### PR TITLE
chore: project scaffolding (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,5 @@ coverage.xml
 .DS_Store
 
 # Project artifacts
-out.png
-*.local.yaml
+out*.png
+*.local.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Test / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.cache/
+nosetests.xml
+coverage.xml
+
+# Type checkers
+.mypy_cache/
+.pyre/
+.ruff_cache/
+
+# IDE / editor
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Project artifacts
+out.png
+*.local.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,12 @@ Stack-like layout: deep, one door at the front. The back-most spot doubles as th
 
 > Each aircraft is a list of **parts**. Every part is an oriented rectangle in plan view with a height range `[z_bottom_m, z_top_m]`. Fuselage, wing, and each strut are all parts.
 >
-> **Collision rule**: two parts from different planes conflict iff their 2D polygons overlap (with horizontal clearance) AND their z-ranges overlap (with vertical clearance).
+> **Collision rule**: two parts from different aircraft conflict iff **both** hold:
+>
+> 1. **In plan view**: `polygon_a.distance(polygon_b) < clearance_m` (the closest distance between the polygons is less than the horizontal clearance).
+> 2. **In height**: the gap between `[z_bottom_a, z_top_a]` and `[z_bottom_b, z_top_b]` is less than `wing_layer_clearance_m` (treating overlap as a gap of 0).
+>
+> Parts of the *same* aircraft are never checked against each other (a Husky's wing and its own strut "overlap" by design).
 
 This is the single most important geometric rule in the project. Every future feature sits on top of it. If the parts model or the collision rule is wrong, every downstream layout will be wrong.
 
@@ -86,7 +91,22 @@ For strut-braced planes, `fleet.yaml` accepts a high-level `struts:` block that 
 - `+x` = forward (toward nose).
 - `+y` = right (toward right wingtip).
 
-**The transform**: at `heading_deg = 0`, plane `+x` should map to world `+y` (nose deeper into hangar). So the plane-local-to-world rotation is `(heading_deg - 90°)`, not `heading_deg`. **This is the off-by-90° trap of the project** — tests must include a non-90°-aligned heading (e.g., 45°) to catch any regression.
+**The transform** (plane-local → world). `heading_deg` is the **compass-style angle of the nose**, measured from world `+y` (the "deeper into hangar" direction), CW positive. Concretely:
+
+- At `heading_deg = 0`, the nose vector in world coords is `(0, 1)`.
+- At `heading_deg = 90°`, the nose vector is `(1, 0)`.
+- At `heading_deg = 45°`, the nose vector is `(√2/2, √2/2)` — pointing into the (+x, +y) quadrant.
+
+A part with plane-local offset `(u, v)` (u forward, v right) at placement `(px, py, heading)` lands at:
+
+```
+world_x = px + u·sin(heading) + v·cos(heading)
+world_y = py + u·cos(heading) − v·sin(heading)
+```
+
+Equivalently, the linear part is `[[sin h, cos h], [cos h, −sin h]]` applied to `(u, v)`. **This matrix has determinant −1** — it is a rotation **composed with a reflection**, not a pure rotation. Two ways to land here: (a) compass headings rotate CW while standard math angles rotate CCW (one sign flip), and (b) the plane-local right-handed-feeling axes (forward, right) end up describing a left-handed mapping when laid against the (right-along-door, deeper-into-hangar) world frame (a second sign flip).
+
+**Do NOT** drop in a textbook CCW rotation matrix `[[cos α, −sin α], [sin α, cos α]]` and call it done — the result will be silently wrong, and worse, will *look* correct in tests at headings 0°, 90°, 180° because those are the symmetric cases. Tests must include at least one **non-axis-aligned heading** (45° is canonical) to catch any regression: at heading 45° the nose vector should be `(√2/2, √2/2)`, and a plane-local part at `(u=0, v=1)` (one meter to the right of plane origin) should land at world `(√2/2, −√2/2)` — right and toward the door, never up and into the hangar.
 
 ### Door model in Phase 1
 
@@ -94,21 +114,25 @@ The door is a **visual marker only**. All aircraft parts must fit fully inside t
 
 ### Default clearances
 
-| Clearance | Default | Configurable in |
+Both clearances will be configurable in `data/hangar.yaml` once that file lands in #3.
+
+| Clearance | Default | Planned key in `hangar.yaml` |
 |---|---|---|
-| Horizontal | 0.30 m | `data/hangar.yaml` → `clearance_m` |
-| Vertical | 0.20 m | `data/hangar.yaml` → `wing_layer_clearance_m` |
+| Horizontal | 0.30 m | `clearance_m` |
+| Vertical | 0.20 m | `wing_layer_clearance_m` |
 
 ---
 
 ## Phase 1 deliverables
 
-1. `data/fleet.yaml` — 9 aircraft, parts model, **placeholder dimensions** flagged with `measured: false`.
-2. `data/hangar.yaml` — hangar dimensions + door + maintenance bay (placeholders).
-3. `src/hangarfit/collisions.py` — the collision checker (the heart of Phase 1).
-4. `src/hangarfit/visualize.py` — matplotlib top-down PNG renderer.
-5. `src/hangarfit/cli.py` — `hangarfit check layouts/example.yaml --render out.png`.
-6. **12 golden tests** in `tests/test_collisions.py` covering all conflict types, including the strut-aware cases (the canary that the parts model is intact).
+The list below is the **target shape** of the Phase 1 cut. Most of these files do not exist yet — each will land in its own PR per the issue plan.
+
+1. `data/fleet.yaml` — 9 aircraft, parts model, **placeholder dimensions** flagged with `measured: false`. (#3)
+2. `data/hangar.yaml` — hangar dimensions + door + maintenance bay (placeholders). (#3)
+3. `src/hangarfit/collisions.py` — the collision checker (the heart of Phase 1). (#5)
+4. `src/hangarfit/visualize.py` — matplotlib top-down PNG renderer. (#6)
+5. `src/hangarfit/cli.py` — `hangarfit check layouts/example.yaml --render out.png`. (#7)
+6. **Strut-aware golden-test suite** in `tests/test_collisions.py` — the canary that the parts model is intact. Cases include same-height wing overlap, high-over-low height-disjoint pass, the strut-blocks-nesting case, inboard / outboard strut-free nesting, the maintenance-bay rule, the cart rule, and the all-9-planes valid layout. (#5)
 
 ### Out of scope for Phase 1
 
@@ -128,7 +152,7 @@ The door is a **visual marker only**. All aircraft parts must fit fully inside t
 
 | Branch | Purpose | Direct push allowed? |
 |---|---|---|
-| `main` | Production / release-tagged. | **No** (single empty bootstrap commit excepted) |
+| `main` | Production / release-tagged. | **No** |
 | `develop` | Integration; default branch on GitHub. | No, only via PR from `feature/*` |
 | `feature/<slug>` | One per issue; off `develop`. | Yes (Claude works here) |
 | `release/<version>` | Cut from `develop`, PR'd into both `main` and `develop`. | No, only via PR |
@@ -154,12 +178,13 @@ The door is a **visual marker only**. All aircraft parts must fit fully inside t
 
 ## Subagents
 
-Use the best-fitted model for the task.
+Use the best-fitted model for the task. The model class to pick is "as much reasoning as the work needs" — heavy for novel design and deep review, lighter for mechanical work.
 
-- **`pr-review-toolkit:code-reviewer`** (Sonnet 4.6) — main PR review pass on every PR.
-- **`pr-review-toolkit:silent-failure-hunter`** (Sonnet) — for PRs touching loader or collision code.
-- **`pr-review-toolkit:type-design-analyzer`** (Sonnet) — when `models.py` changes.
-- **`feature-dev:code-architect`** (Opus 4.7) — only for genuinely novel design decisions, not routine implementation.
+- **`pr-review-toolkit:code-reviewer`** — main PR review pass on every PR.
+- **`pr-review-toolkit:comment-analyzer`** — for PRs that meaningfully change docs (README, CLAUDE.md, docstrings).
+- **`pr-review-toolkit:silent-failure-hunter`** — for PRs touching loader or collision code.
+- **`pr-review-toolkit:type-design-analyzer`** — when `models.py` changes.
+- **`feature-dev:code-architect`** — only for genuinely novel design decisions, not routine implementation.
 
 Most coding goes direct in-session. Subagent dispatch is for review work and isolated heavy lifts.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,201 @@
+# Project context — hangarfit
+
+This file is the durable context for the project. Read it first in any new session.
+
+---
+
+## What this project is
+
+`hangarfit` is an **on-demand exception tool** for a flying club: when the standard hangar parking layout breaks (delayed return, surprise maintenance, etc.), it helps find *a* valid alternative arrangement.
+
+The tool checks whether a hand-authored candidate layout is physically valid (no fuselage / wing / strut collisions, fits in the hangar, maintenance plane in the right spot) and renders a top-down PNG so a human can eyeball it.
+
+**Phase 1 scope** (the current focus): build the substrate — aircraft data model, hangar model, collision checker, visualizer, CLI. **No planner / search / optimization** in Phase 1.
+
+---
+
+## The fleet (9 aircraft)
+
+| ID | Name | Wing | Gear | Movement mode | Wing strut? | Notes |
+|---|---|---|---|---|---|---|
+| `scheibe_falke` | Scheibe SF-25E Falke | High | Monowheel + outriggers | `always_cart` | No (cantilever) | Outriggers folded into wing footprint |
+| `aviat_husky` | Aviat Husky A-1 | High | Tailwheel | `always_own_gear` | **Yes** | |
+| `fuji` | Fuji FA-200 | **Low** | Nosewheel | `always_own_gear` | No (cantilever) | The only low-wing |
+| `wild_thing` | Wild Thing | High | Nosewheel | `always_cart` | **Yes** | |
+| `zlin_savage` | Zlin Savage | High | Tailwheel | `always_cart` | **Yes** | |
+| `cessna_140` | Cessna 140 | High | Tailwheel | `cart_eligible` | **Yes** | V-strut treated as one strut per side |
+| `cessna_150` | Cessna 150 | High | Nosewheel | `cart_eligible` | **Yes** | |
+| `ctsl` | Flight Design CTSL | High | Nosewheel | `cart_eligible` | No (cantilever) | |
+| `fk9_mkii` | FK9 Mk II | High | Nosewheel | `cart_eligible` | **Yes** | |
+
+**Cart rule**: of the 4 `cart_eligible` planes, **at most one** uses the spare carts at a time. Cart mounting is operationally free — the algorithm can pick any cart assignment.
+
+**Motion (relevant for the future planner, not Phase 1 collision)**:
+- On carts: holonomic (any direction, including sideways).
+- On own gear: non-holonomic (Dubins-path-style curves bounded by turn radius).
+
+---
+
+## The hangar
+
+Stack-like layout: deep, one door at the front. The back-most spot doubles as the **maintenance bay** (curtained off when in use); a plane scheduled for maintenance must already be parked at the back. All dimensions in `data/hangar.yaml` are **placeholders** until real measurements are taken.
+
+---
+
+## The parts model (the most important rule)
+
+> Each aircraft is a list of **parts**. Every part is an oriented rectangle in plan view with a height range `[z_bottom_m, z_top_m]`. Fuselage, wing, and each strut are all parts.
+>
+> **Collision rule**: two parts from different planes conflict iff their 2D polygons overlap (with horizontal clearance) AND their z-ranges overlap (with vertical clearance).
+
+This is the single most important geometric rule in the project. Every future feature sits on top of it. If the parts model or the collision rule is wrong, every downstream layout will be wrong.
+
+### Why parts (and not a single bounding box)?
+
+- A single bbox can't represent the legality of a **high-wing's wingtip overlapping a low-wing's fuselage area in plan view**: the heights differ, so it's fine, but a flat bbox would mark it as a collision.
+- **Wing struts** (on Husky, Wild Thing, Zlin Savage, both Cessnas, FK9) occupy a thin column from lower fuselage out to the underside of the wing. The "wing volume" of a strut-braced plane is NOT free — another plane's wing can't nest through where the strut lives. The parts model expresses this directly; a bbox model cannot.
+
+### YAML convenience: the `struts:` block
+
+For strut-braced planes, `fleet.yaml` accepts a high-level `struts:` block that the loader expands into two mirrored strut `Part`s (one per side). This keeps the YAML readable while still funneling into the uniform parts model internally.
+
+---
+
+## Coordinate convention
+
+**Hangar (world) coordinates**: origin at the front-left corner, looking down.
+
+```
+       +x ->
+  +---[door]-------+
+  |                |
+  | y (deeper)     |
+  v                |
+  |                |
+  +----------------+
+```
+
+- `+x` runs right along the door wall.
+- `+y` runs deeper into the hangar.
+- **Heading 0°** = nose pointing toward `+y` (deeper into hangar).
+- **Heading 90°** = nose toward `+x` (right).
+
+**Plane-local coordinates** (used in `fleet.yaml` part offsets):
+
+- Origin = plane reference point (main-gear / cart centroid).
+- `+x` = forward (toward nose).
+- `+y` = right (toward right wingtip).
+
+**The transform**: at `heading_deg = 0`, plane `+x` should map to world `+y` (nose deeper into hangar). So the plane-local-to-world rotation is `(heading_deg - 90°)`, not `heading_deg`. **This is the off-by-90° trap of the project** — tests must include a non-90°-aligned heading (e.g., 45°) to catch any regression.
+
+### Door model in Phase 1
+
+The door is a **visual marker only**. All aircraft parts must fit fully inside the hangar rectangle for the layout to be considered valid. The door is rendered as a gap in the front wall by the visualizer but doesn't affect collision logic.
+
+### Default clearances
+
+| Clearance | Default | Configurable in |
+|---|---|---|
+| Horizontal | 0.30 m | `data/hangar.yaml` → `clearance_m` |
+| Vertical | 0.20 m | `data/hangar.yaml` → `wing_layer_clearance_m` |
+
+---
+
+## Phase 1 deliverables
+
+1. `data/fleet.yaml` — 9 aircraft, parts model, **placeholder dimensions** flagged with `measured: false`.
+2. `data/hangar.yaml` — hangar dimensions + door + maintenance bay (placeholders).
+3. `src/hangarfit/collisions.py` — the collision checker (the heart of Phase 1).
+4. `src/hangarfit/visualize.py` — matplotlib top-down PNG renderer.
+5. `src/hangarfit/cli.py` — `hangarfit check layouts/example.yaml --render out.png`.
+6. **12 golden tests** in `tests/test_collisions.py` covering all conflict types, including the strut-aware cases (the canary that the parts model is intact).
+
+### Out of scope for Phase 1
+
+- No planner / search / optimization.
+- No movement-sequence planning (no "Tower of Hanoi" reshuffling).
+- No tracking of current hangar state across runs.
+- No GUI / web frontend.
+- No handling of late arrivals.
+
+---
+
+## Development workflow
+
+**Strict GitFlow + issue-driven + PR-review on every change. The user is the only approver and merger.**
+
+### Branching
+
+| Branch | Purpose | Direct push allowed? |
+|---|---|---|
+| `main` | Production / release-tagged. | **No** (single empty bootstrap commit excepted) |
+| `develop` | Integration; default branch on GitHub. | No, only via PR from `feature/*` |
+| `feature/<slug>` | One per issue; off `develop`. | Yes (Claude works here) |
+| `release/<version>` | Cut from `develop`, PR'd into both `main` and `develop`. | No, only via PR |
+| `hotfix/<slug>` | Only if needed; off `main`. | No, only via PR |
+
+### Per-PR process
+
+1. Branch `feature/<slug>` off `develop`. Work, commit.
+2. Open PR with `gh pr create` — base `develop`, body includes `Closes #N`.
+3. Invoke `/pr-review` (or the `pr-review-toolkit:review-pr` skill).
+4. Convert each finding into a **review thread on the diff** (via `gh pr review` line comments / `gh api .../pulls/<n>/comments`). Findings never live only in chat.
+5. Resolve every thread: fix the code (preferred) or reply with rationale, then mark resolved.
+6. If the changes were non-trivial, re-run the review.
+7. Tell the user the PR is **clean and ready for final review**. The user approves and merges. **Never `gh pr merge` from Claude.**
+
+### Issues
+
+- Every change is tracked by a GitHub issue. No code without an issue.
+- Issues are organized into milestones (one milestone = one releasable cut).
+- PR bodies link to issues with `Closes #N` / `Fixes #N` (the body, not the title — only body syntax auto-closes).
+
+---
+
+## Subagents
+
+Use the best-fitted model for the task.
+
+- **`pr-review-toolkit:code-reviewer`** (Sonnet 4.6) — main PR review pass on every PR.
+- **`pr-review-toolkit:silent-failure-hunter`** (Sonnet) — for PRs touching loader or collision code.
+- **`pr-review-toolkit:type-design-analyzer`** (Sonnet) — when `models.py` changes.
+- **`feature-dev:code-architect`** (Opus 4.7) — only for genuinely novel design decisions, not routine implementation.
+
+Most coding goes direct in-session. Subagent dispatch is for review work and isolated heavy lifts.
+
+---
+
+## Worktrees
+
+Allowed but not the default. Use only when two feature branches need parallel work (e.g., long-running test suite while writing the visualizer). For sequential issue flow, plain branch checkout is simpler.
+
+---
+
+## Open questions / TBD before trusting output
+
+- **Real measurements** for every aircraft (`measured: false` in `fleet.yaml`). All current dimensions are eyeballed placeholders.
+- **Real hangar measurements** (`data/hangar.yaml`) — length, width, door position and width, maintenance bay depth.
+
+The collision checker will run on placeholder data, but until the measurements are real, the output is illustrative only.
+
+---
+
+## Useful commands
+
+```bash
+# Install
+pip install -e ".[dev]"
+
+# Run tests
+pytest
+
+# Phase 1 acceptance smoke test (once CLI lands)
+hangarfit check layouts/example.yaml --render out.png
+
+# GitFlow loops
+git switch develop && git pull
+git switch -c feature/<slug>
+# ... work ...
+git push -u origin feature/<slug>
+gh pr create --base develop --title "..." --body "Closes #N ..."
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# hangarfit
+
+Helper tool for arranging the flying club fleet in a stack-style hangar when the standard layout doesn't work. **On-demand exception tool**, not a daily ops system.
+
+Given a hand-authored candidate layout (in YAML), `hangarfit`:
+
+1. checks whether the layout is **physically valid** (no fuselage / wing / strut collisions, fits in the hangar, maintenance plane in the right spot), and
+2. **renders** a top-down PNG so a human can eyeball it.
+
+A planner / search algorithm is **out of scope for Phase 1**. Phase 1 builds the substrate (data model, collision checker, visualizer) that any future planner will sit on top of.
+
+## Status
+
+Phase 1 in active development. See [GitHub Issues](https://github.com/DocGerd/hangarfit/issues) and milestones.
+
+## Quickstart (Phase 1 placeholder — not all components exist yet)
+
+```bash
+pip install -e ".[dev]"
+pytest
+hangarfit check layouts/example.yaml --render out.png
+```
+
+End-to-end usage examples will land with the CLI in milestone `v0.3.0`.
+
+## Project layout
+
+```
+src/hangarfit/      # Python package (models, loader, geometry, collisions, visualize, cli)
+data/               # fleet.yaml, hangar.yaml — measured-once club data
+layouts/            # hand-authored candidate layouts (one .yaml per scenario)
+tests/              # pytest suite, including the 12 collision golden tests
+```
+
+## Workflow
+
+This repo uses GitFlow with PR-driven review. See [`CLAUDE.md`](CLAUDE.md) for the full workflow and project context.
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -13,23 +13,28 @@ A planner / search algorithm is **out of scope for Phase 1**. Phase 1 builds the
 
 Phase 1 in active development. See [GitHub Issues](https://github.com/DocGerd/hangarfit/issues) and milestones.
 
-## Quickstart (Phase 1 placeholder — not all components exist yet)
+## Quickstart
+
+What works today (after merging the scaffolding PR):
 
 ```bash
 pip install -e ".[dev]"
-pytest
-hangarfit check layouts/example.yaml --render out.png
+pytest                              # currently collects 0 tests
 ```
 
-End-to-end usage examples will land with the CLI in milestone `v0.3.0`.
+The full end-to-end loop will work once milestone `v0.3.0` ships the CLI:
 
-## Project layout
+```bash
+hangarfit check layouts/example.yaml --render out.png   # ← lands in #7
+```
+
+## Project layout (target — most files land in later milestones)
 
 ```
 src/hangarfit/      # Python package (models, loader, geometry, collisions, visualize, cli)
 data/               # fleet.yaml, hangar.yaml — measured-once club data
 layouts/            # hand-authored candidate layouts (one .yaml per scenario)
-tests/              # pytest suite, including the 12 collision golden tests
+tests/              # pytest suite, including the strut-aware collision golden tests
 ```
 
 ## Workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hangarfit"
+version = "0.0.1"
+description = "Helper tool for arranging the flying club fleet in a stack-style hangar — collision checker + visualizer (Phase 1)."
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{ name = "Patrick Kuhn" }]
+license = { text = "MIT" }
+dependencies = [
+  "pyyaml>=6.0",
+  "shapely>=2.0",
+  "matplotlib>=3.8",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.4"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "Patrick Kuhn" }]
 license = { text = "MIT" }
 dependencies = [
   "pyyaml>=6.0",
-  "shapely>=2.0",
+  "shapely>=2.0,<3",
   "matplotlib>=3.8",
 ]
 

--- a/src/hangarfit/__init__.py
+++ b/src/hangarfit/__init__.py
@@ -1,0 +1,3 @@
+"""Hangar arrangement helper for a flying club fleet."""
+
+__version__ = "0.0.1"


### PR DESCRIPTION
Closes #1.

Bootstraps the Python package, project structure, and durable project context.

## What's in this PR

| File | Purpose |
|---|---|
| `pyproject.toml` | Python 3.11+, deps `pyyaml`/`shapely`/`matplotlib`, dev dep `pytest`, pytest config |
| `src/hangarfit/__init__.py` | Package marker with `__version__ = "0.0.1"` |
| `tests/__init__.py` | Empty (so pytest discovers `tests/` as a package) |
| `README.md` | Project purpose + quickstart placeholder |
| `.gitignore` | Python + project artifacts (`.venv/`, `out.png`, `*.local.yaml`, etc.) |
| `CLAUDE.md` | Durable project context: fleet, hangar, parts model, coords, workflow |

## Verification

```
$ uv venv .venv && uv pip install -e ".[dev]"
... installs cleanly
$ .venv/bin/pytest
collected 0 items
no tests ran in 0.00s
```

So `pip install -e .` works and `pytest` discovers `tests/` correctly (no tests yet, but the framework is wired).

## Notes / deviations

- **No `[project.scripts]` entry yet**: the `hangarfit` console-script entry lands in #7 alongside `src/hangarfit/cli.py`. Adding it here would point at a non-existent module and emit a warning on every `pip install -e .`.
- **`data/`, `layouts/`, `tests/fixtures/` are not committed yet**: empty directories aren't tracked by git, and they'll get content in #3 (loader + data) and #5 (collision fixtures).
- **Bootstrap commit on `main`** and **`develop` creation + default branch switch** were done before this branch was cut (the one-time exception to "no direct pushes" called out in the issue scope).

## Workflow follow-up after merge

1. `pr-review` will run after this PR is opened.
2. Findings (if any) become PR review threads, get resolved.
3. When clean, ready for your final review.

Milestone: `v0.1.0 — Foundation`.