### PR TITLE
feat(models): data model dataclasses (#2)

### DIFF
--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1,0 +1,335 @@
+"""Pure data models for hangarfit.
+
+No I/O, no business logic. Every type here is a frozen dataclass with
+slots, validates its invariants in ``__post_init__``, and uses tuples
+instead of lists where collections appear (so the whole graph is
+effectively immutable after construction).
+
+The full coordinate convention and parts-model collision rule live in
+``CLAUDE.md`` at the repo root — this module just encodes the types.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+WingPosition = Literal["high", "mid", "low"]
+Gear = Literal["tailwheel", "nosewheel", "monowheel"]
+MovementMode = Literal["always_cart", "always_own_gear", "cart_eligible"]
+
+
+@dataclass(frozen=True, slots=True)
+class Part:
+    """One oriented rectangle in plane-local coordinates with a height range.
+
+    The universal collision unit. Fuselage, wing, and each strut are all
+    represented as ``Part`` instances. See ``CLAUDE.md`` for the
+    plane-local coordinate convention (``+x`` forward, ``+y`` right).
+    """
+
+    kind: str
+    length_m: float
+    width_m: float
+    offset_x_m: float
+    offset_y_m: float
+    angle_deg: float
+    z_bottom_m: float
+    z_top_m: float
+
+    def __post_init__(self) -> None:
+        if not self.kind:
+            raise ValueError("Part.kind must be non-empty")
+        if self.length_m <= 0:
+            raise ValueError(
+                f"Part {self.kind!r}: length_m must be positive, got {self.length_m}"
+            )
+        if self.width_m <= 0:
+            raise ValueError(
+                f"Part {self.kind!r}: width_m must be positive, got {self.width_m}"
+            )
+        if self.z_bottom_m < 0:
+            raise ValueError(
+                f"Part {self.kind!r}: z_bottom_m must be non-negative, got {self.z_bottom_m}"
+            )
+        if self.z_top_m <= self.z_bottom_m:
+            raise ValueError(
+                f"Part {self.kind!r}: z_top_m must exceed z_bottom_m, "
+                f"got z_bottom={self.z_bottom_m}, z_top={self.z_top_m}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class StrutsSpec:
+    """Convenience block describing a strut-braced aircraft's struts.
+
+    The loader / geometry layer expands one ``StrutsSpec`` into two
+    mirrored strut ``Part`` instances (one per side). Stored on
+    ``Aircraft.struts`` only for aircraft that actually have struts;
+    cantilever aircraft leave it ``None``.
+
+    The geometry: each strut runs from a fuselage attach point at
+    height ``fuselage_attach_z_m`` outward and upward to a wing attach
+    point at offset ``wing_attach_y_m`` (measured along the half-span)
+    at the wing's underside height.
+    """
+
+    fuselage_attach_x_m: float
+    fuselage_attach_y_m: float
+    fuselage_attach_z_m: float
+    wing_attach_y_m: float
+    width_m: float
+
+    def __post_init__(self) -> None:
+        if self.width_m <= 0:
+            raise ValueError(
+                f"StrutsSpec: width_m must be positive, got {self.width_m}"
+            )
+        if self.fuselage_attach_y_m < 0:
+            raise ValueError(
+                f"StrutsSpec: fuselage_attach_y_m must be non-negative "
+                f"(outboard distance at fuselage side), got {self.fuselage_attach_y_m}"
+            )
+        if self.fuselage_attach_z_m < 0:
+            raise ValueError(
+                f"StrutsSpec: fuselage_attach_z_m must be non-negative, "
+                f"got {self.fuselage_attach_z_m}"
+            )
+        if self.wing_attach_y_m <= 0:
+            raise ValueError(
+                f"StrutsSpec: wing_attach_y_m must be positive "
+                f"(outboard distance on the wing), got {self.wing_attach_y_m}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class Aircraft:
+    """One plane in the fleet.
+
+    ``parts`` is the primary geometric data — the collision checker
+    sees nothing else. ``struts`` is a convenience that gets expanded
+    into mirrored strut ``Part`` instances by the loader; if present,
+    the resulting strut parts are also included in ``parts`` after
+    expansion.
+
+    ``turn_radius_m`` is required for any non-``always_cart`` aircraft
+    (the future planner needs it for Dubins-style motion).
+    """
+
+    id: str
+    name: str
+    wing_position: WingPosition
+    gear: Gear
+    movement_mode: MovementMode
+    turn_radius_m: float | None
+    measured: bool
+    parts: tuple[Part, ...]
+    struts: StrutsSpec | None = None
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("Aircraft.id must be non-empty")
+        if not self.name:
+            raise ValueError(f"Aircraft {self.id!r}: name must be non-empty")
+        if not self.parts:
+            raise ValueError(f"Aircraft {self.id!r}: parts must be non-empty")
+        if self.movement_mode != "always_cart":
+            if self.turn_radius_m is None:
+                raise ValueError(
+                    f"Aircraft {self.id!r}: turn_radius_m is required when "
+                    f"movement_mode={self.movement_mode!r}"
+                )
+            if self.turn_radius_m <= 0:
+                raise ValueError(
+                    f"Aircraft {self.id!r}: turn_radius_m must be positive, "
+                    f"got {self.turn_radius_m}"
+                )
+
+    @property
+    def is_cart_eligible(self) -> bool:
+        return self.movement_mode == "cart_eligible"
+
+
+@dataclass(frozen=True, slots=True)
+class Door:
+    center_x_m: float
+    width_m: float
+
+    def __post_init__(self) -> None:
+        if self.width_m <= 0:
+            raise ValueError(f"Door.width_m must be positive, got {self.width_m}")
+        if self.center_x_m < 0:
+            raise ValueError(
+                f"Door.center_x_m must be non-negative, got {self.center_x_m}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class MaintenanceBay:
+    """The back-most strip of the hangar that doubles as the maintenance bay."""
+
+    depth_m: float
+
+    def __post_init__(self) -> None:
+        if self.depth_m <= 0:
+            raise ValueError(
+                f"MaintenanceBay.depth_m must be positive, got {self.depth_m}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class Hangar:
+    """The hangar floor plan.
+
+    Coordinates: ``(0, 0)`` at the front-left corner, ``+x`` along the
+    door wall, ``+y`` deeper into the hangar. See ``CLAUDE.md``.
+    """
+
+    length_m: float
+    width_m: float
+    door: Door
+    maintenance_bay: MaintenanceBay
+    clearance_m: float
+    wing_layer_clearance_m: float
+
+    def __post_init__(self) -> None:
+        if self.length_m <= 0:
+            raise ValueError(f"Hangar.length_m must be positive, got {self.length_m}")
+        if self.width_m <= 0:
+            raise ValueError(f"Hangar.width_m must be positive, got {self.width_m}")
+        if self.clearance_m < 0:
+            raise ValueError(
+                f"Hangar.clearance_m must be non-negative, got {self.clearance_m}"
+            )
+        if self.wing_layer_clearance_m < 0:
+            raise ValueError(
+                f"Hangar.wing_layer_clearance_m must be non-negative, "
+                f"got {self.wing_layer_clearance_m}"
+            )
+        door_left = self.door.center_x_m - self.door.width_m / 2
+        door_right = self.door.center_x_m + self.door.width_m / 2
+        if door_left < 0 or door_right > self.width_m:
+            raise ValueError(
+                f"Door (center={self.door.center_x_m}, width={self.door.width_m}) "
+                f"doesn't fit in hangar width {self.width_m}"
+            )
+        if self.maintenance_bay.depth_m > self.length_m:
+            raise ValueError(
+                f"MaintenanceBay.depth_m={self.maintenance_bay.depth_m} "
+                f"exceeds Hangar.length_m={self.length_m}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class Placement:
+    """A single aircraft's position and orientation in the hangar."""
+
+    plane_id: str
+    x_m: float
+    y_m: float
+    heading_deg: float
+    on_carts: bool
+
+    def __post_init__(self) -> None:
+        if not self.plane_id:
+            raise ValueError("Placement.plane_id must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class Layout:
+    """A complete candidate layout: hangar + fleet + placements.
+
+    Validates cross-reference invariants between placements and the
+    fleet (unknown IDs, duplicates, cart rule, movement-mode
+    consistency, maintenance plane placement).
+    """
+
+    fleet: dict[str, Aircraft]
+    hangar: Hangar
+    placements: tuple[Placement, ...]
+    maintenance_plane: str | None = None
+
+    def __post_init__(self) -> None:
+        seen: set[str] = set()
+        for p in self.placements:
+            if p.plane_id not in self.fleet:
+                raise ValueError(
+                    f"Placement references unknown plane_id {p.plane_id!r} "
+                    f"(fleet has: {sorted(self.fleet)})"
+                )
+            if p.plane_id in seen:
+                raise ValueError(f"Duplicate placement for plane_id {p.plane_id!r}")
+            seen.add(p.plane_id)
+
+            plane = self.fleet[p.plane_id]
+            if plane.movement_mode == "always_cart" and not p.on_carts:
+                raise ValueError(
+                    f"Placement for {p.plane_id!r}: must have on_carts=True "
+                    f"(movement_mode=always_cart)"
+                )
+            if plane.movement_mode == "always_own_gear" and p.on_carts:
+                raise ValueError(
+                    f"Placement for {p.plane_id!r}: must have on_carts=False "
+                    f"(movement_mode=always_own_gear)"
+                )
+
+        cart_count = sum(
+            1
+            for p in self.placements
+            if p.on_carts and self.fleet[p.plane_id].movement_mode == "cart_eligible"
+        )
+        if cart_count > 1:
+            raise ValueError(
+                f"At most one cart_eligible plane may have on_carts=True "
+                f"(got {cart_count})"
+            )
+
+        if self.maintenance_plane is not None:
+            if self.maintenance_plane not in self.fleet:
+                raise ValueError(
+                    f"maintenance_plane {self.maintenance_plane!r} not in fleet"
+                )
+            if self.maintenance_plane not in seen:
+                raise ValueError(
+                    f"maintenance_plane {self.maintenance_plane!r} is not placed"
+                )
+
+
+@dataclass(frozen=True, slots=True)
+class Conflict:
+    """One reason a layout is invalid.
+
+    ``planes`` carries 1 or 2 aircraft IDs depending on the rule that
+    fired (layout-wide rules like ``maintenance_position`` cite one
+    plane; pairwise rules like ``wing_strut_overlap`` cite two).
+    """
+
+    kind: str
+    planes: tuple[str, ...]
+    detail: str
+
+    def __post_init__(self) -> None:
+        if not self.kind:
+            raise ValueError("Conflict.kind must be non-empty")
+        if not self.planes:
+            raise ValueError("Conflict.planes must have at least one plane id")
+        if len(self.planes) > 2:
+            raise ValueError(
+                f"Conflict.planes must have 1 or 2 entries, got {len(self.planes)}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class CheckResult:
+    """Result of running the collision checker against a Layout.
+
+    ``valid`` is a derived property — there is no way to construct a
+    ``CheckResult`` that claims to be valid while carrying conflicts.
+    """
+
+    conflicts: tuple[Conflict, ...] = ()
+
+    @property
+    def valid(self) -> bool:
+        return len(self.conflicts) == 0

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -11,12 +11,17 @@ The full coordinate convention and parts-model collision rule live in
 
 from __future__ import annotations
 
+import typing
 from dataclasses import dataclass
-from typing import Literal
+from types import MappingProxyType
+from typing import Literal, Mapping
 
 WingPosition = Literal["high", "mid", "low"]
 Gear = Literal["tailwheel", "nosewheel", "monowheel"]
 MovementMode = Literal["always_cart", "always_own_gear", "cart_eligible"]
+PartKind = Literal["fuselage", "wing", "strut", "tail"]
+
+_VALID_PART_KINDS = frozenset(typing.get_args(PartKind))
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,9 +31,13 @@ class Part:
     The universal collision unit. Fuselage, wing, and each strut are all
     represented as ``Part`` instances. See ``CLAUDE.md`` for the
     plane-local coordinate convention (``+x`` forward, ``+y`` right).
+
+    ``kind`` is closed: ``"fuselage" | "wing" | "strut" | "tail"``. New
+    kinds must be added to ``PartKind`` and the matching ``_VALID_PART_KINDS``
+    set above; the collision checker and visualizer key off these values.
     """
 
-    kind: str
+    kind: PartKind
     length_m: float
     width_m: float
     offset_x_m: float
@@ -38,8 +47,11 @@ class Part:
     z_top_m: float
 
     def __post_init__(self) -> None:
-        if not self.kind:
-            raise ValueError("Part.kind must be non-empty")
+        if self.kind not in _VALID_PART_KINDS:
+            raise ValueError(
+                f"Part.kind must be one of {sorted(_VALID_PART_KINDS)}, "
+                f"got {self.kind!r}"
+            )
         if self.length_m <= 0:
             raise ValueError(
                 f"Part {self.kind!r}: length_m must be positive, got {self.length_m}"
@@ -100,20 +112,30 @@ class StrutsSpec:
                 f"StrutsSpec: wing_attach_y_m must be positive "
                 f"(outboard distance on the wing), got {self.wing_attach_y_m}"
             )
+        if self.wing_attach_y_m < self.fuselage_attach_y_m:
+            raise ValueError(
+                f"StrutsSpec: wing_attach_y_m ({self.wing_attach_y_m}) must be "
+                f">= fuselage_attach_y_m ({self.fuselage_attach_y_m}); a strut "
+                f"must run outward, not inward through the fuselage"
+            )
 
 
 @dataclass(frozen=True, slots=True)
 class Aircraft:
     """One plane in the fleet.
 
-    ``parts`` is the primary geometric data — the collision checker
-    sees nothing else. ``struts`` is a convenience that gets expanded
-    into mirrored strut ``Part`` instances by the loader; if present,
-    the resulting strut parts are also included in ``parts`` after
-    expansion.
+    ``parts`` is the single source of truth for geometry — the collision
+    checker and visualizer key off it directly. There is **no** ``struts``
+    field on the constructed ``Aircraft``: ``StrutsSpec`` is a transient
+    YAML-schema-only type that the loader (#3) expands into mirrored
+    strut ``Part`` instances and folds into ``parts`` before constructing
+    the ``Aircraft``. This keeps the parts model the unambiguous canonical
+    geometric representation (no risk of strut volume being double-counted
+    once from ``struts`` and again from a strut ``Part``).
 
     ``turn_radius_m`` is required for any non-``always_cart`` aircraft
-    (the future planner needs it for Dubins-style motion).
+    (the future Dubins-path planner needs it for own-gear motion).
+    For ``always_cart`` it may be ``None`` (or any value — it is ignored).
     """
 
     id: str
@@ -124,7 +146,6 @@ class Aircraft:
     turn_radius_m: float | None
     measured: bool
     parts: tuple[Part, ...]
-    struts: StrutsSpec | None = None
     notes: str = ""
 
     def __post_init__(self) -> None:
@@ -149,6 +170,22 @@ class Aircraft:
     @property
     def is_cart_eligible(self) -> bool:
         return self.movement_mode == "cart_eligible"
+
+    def required_turn_radius_m(self) -> float:
+        """Return ``turn_radius_m`` narrowed to ``float`` (never ``None``).
+
+        Use when calling code statically knows the aircraft is not
+        ``always_cart`` and therefore must have a turn radius (Dubins
+        planner, etc.). Raises ``AssertionError`` if the invariant has
+        been broken (which ``__post_init__`` should prevent).
+        """
+        if self.turn_radius_m is None:
+            raise AssertionError(
+                f"Aircraft {self.id!r}: turn_radius_m is None "
+                f"(movement_mode={self.movement_mode!r}); caller assumed "
+                f"a turn radius was available."
+            )
+        return self.turn_radius_m
 
 
 @dataclass(frozen=True, slots=True)
@@ -214,10 +251,11 @@ class Hangar:
                 f"Door (center={self.door.center_x_m}, width={self.door.width_m}) "
                 f"doesn't fit in hangar width {self.width_m}"
             )
-        if self.maintenance_bay.depth_m > self.length_m:
+        if self.maintenance_bay.depth_m >= self.length_m:
             raise ValueError(
                 f"MaintenanceBay.depth_m={self.maintenance_bay.depth_m} "
-                f"exceeds Hangar.length_m={self.length_m}"
+                f"must be strictly less than Hangar.length_m={self.length_m} "
+                f"(otherwise no non-bay parking area remains)"
             )
 
 
@@ -240,17 +278,42 @@ class Placement:
 class Layout:
     """A complete candidate layout: hangar + fleet + placements.
 
-    Validates cross-reference invariants between placements and the
-    fleet (unknown IDs, duplicates, cart rule, movement-mode
-    consistency, maintenance plane placement).
+    Validates **cross-reference invariants** between placements and the
+    fleet:
+
+    - every placement's ``plane_id`` exists in ``fleet``,
+    - the fleet dict's keys equal their ``Aircraft.id`` (no key/id drift),
+    - no duplicate placements,
+    - the cart rule (at most one ``cart_eligible`` plane on carts),
+    - ``always_cart`` ↔ ``on_carts=True`` consistency,
+    - ``always_own_gear`` ↔ ``on_carts=False`` consistency,
+    - the maintenance plane (if set) is in the fleet and is placed.
+
+    The maintenance plane's **position** rule ("must be parked in the
+    back-most strip of the hangar") is *not* enforced here — it depends
+    on placement geometry and the hangar's maintenance-bay depth, so it
+    lives in the collision checker (#5) alongside the other geometric
+    rules.
+
+    On construction, ``fleet`` is wrapped in ``MappingProxyType`` so
+    that the cross-reference invariants stay valid for the lifetime of
+    the ``Layout`` (a plain ``dict`` field, even on a frozen dataclass,
+    can be mutated through ``layout.fleet["x"] = …``).
     """
 
-    fleet: dict[str, Aircraft]
+    fleet: Mapping[str, Aircraft]
     hangar: Hangar
     placements: tuple[Placement, ...]
     maintenance_plane: str | None = None
 
     def __post_init__(self) -> None:
+        for k, a in self.fleet.items():
+            if a.id != k:
+                raise ValueError(
+                    f"fleet key {k!r} does not match its Aircraft.id "
+                    f"({a.id!r}); fleet keys must equal their aircraft id"
+                )
+
         seen: set[str] = set()
         for p in self.placements:
             if p.plane_id not in self.fleet:
@@ -295,14 +358,18 @@ class Layout:
                     f"maintenance_plane {self.maintenance_plane!r} is not placed"
                 )
 
+        object.__setattr__(self, "fleet", MappingProxyType(dict(self.fleet)))
+
 
 @dataclass(frozen=True, slots=True)
 class Conflict:
     """One reason a layout is invalid.
 
-    ``planes`` carries 1 or 2 aircraft IDs depending on the rule that
-    fired (layout-wide rules like ``maintenance_position`` cite one
-    plane; pairwise rules like ``wing_strut_overlap`` cite two).
+    ``planes`` carries 1 or 2 *distinct, non-empty* aircraft IDs
+    depending on the rule that fired (layout-wide rules like
+    ``maintenance_position`` cite one plane; pairwise rules like
+    ``wing_strut_overlap`` cite two). Use ``Conflict.single()`` /
+    ``Conflict.pair()`` at call sites to make the arity explicit.
     """
 
     kind: str
@@ -318,6 +385,24 @@ class Conflict:
             raise ValueError(
                 f"Conflict.planes must have 1 or 2 entries, got {len(self.planes)}"
             )
+        if any(not pid for pid in self.planes):
+            raise ValueError(
+                f"Conflict.planes entries must be non-empty, got {self.planes}"
+            )
+        if len(set(self.planes)) != len(self.planes):
+            raise ValueError(
+                f"Conflict.planes entries must be distinct, got {self.planes}"
+            )
+
+    @classmethod
+    def single(cls, kind: str, plane: str, detail: str) -> "Conflict":
+        """Factory for a single-aircraft conflict (e.g. ``maintenance_position``)."""
+        return cls(kind=kind, planes=(plane,), detail=detail)
+
+    @classmethod
+    def pair(cls, kind: str, plane_a: str, plane_b: str, detail: str) -> "Conflict":
+        """Factory for a pairwise conflict (e.g. ``wing_strut_overlap``)."""
+        return cls(kind=kind, planes=(plane_a, plane_b), detail=detail)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,517 @@
+"""Tests for hangarfit.models — construction, validation, immutability."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from hangarfit.models import (
+    Aircraft,
+    CheckResult,
+    Conflict,
+    Door,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    Placement,
+    StrutsSpec,
+)
+
+
+def _ok_part(
+    kind: str = "fuselage",
+    *,
+    length_m: float = 7.0,
+    width_m: float = 0.8,
+    z_bottom_m: float = 0.0,
+    z_top_m: float = 1.4,
+) -> Part:
+    return Part(
+        kind=kind,
+        length_m=length_m,
+        width_m=width_m,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=z_bottom_m,
+        z_top_m=z_top_m,
+    )
+
+
+def _ok_aircraft(
+    plane_id: str = "test_plane",
+    *,
+    movement_mode: str = "always_own_gear",
+    turn_radius_m: float | None = 5.0,
+    struts: StrutsSpec | None = None,
+) -> Aircraft:
+    return Aircraft(
+        id=plane_id,
+        name=f"Test Plane {plane_id}",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode=movement_mode,  # type: ignore[arg-type]
+        turn_radius_m=turn_radius_m,
+        measured=False,
+        parts=(_ok_part(),),
+        struts=struts,
+    )
+
+
+def _ok_hangar() -> Hangar:
+    return Hangar(
+        length_m=25.0,
+        width_m=18.0,
+        door=Door(center_x_m=9.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(depth_m=9.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.2,
+    )
+
+
+class TestPart:
+    def test_valid_construction(self) -> None:
+        p = _ok_part()
+        assert p.kind == "fuselage"
+        assert p.z_top_m > p.z_bottom_m
+
+    def test_empty_kind_rejected(self) -> None:
+        with pytest.raises(ValueError, match="kind must be non-empty"):
+            _ok_part(kind="")
+
+    @pytest.mark.parametrize("length_m", [0.0, -1.0])
+    def test_non_positive_length_rejected(self, length_m: float) -> None:
+        with pytest.raises(ValueError, match="length_m must be positive"):
+            _ok_part(length_m=length_m)
+
+    @pytest.mark.parametrize("width_m", [0.0, -0.5])
+    def test_non_positive_width_rejected(self, width_m: float) -> None:
+        with pytest.raises(ValueError, match="width_m must be positive"):
+            _ok_part(width_m=width_m)
+
+    def test_negative_z_bottom_rejected(self) -> None:
+        with pytest.raises(ValueError, match="z_bottom_m must be non-negative"):
+            _ok_part(z_bottom_m=-0.1, z_top_m=1.0)
+
+    @pytest.mark.parametrize(
+        "z_bottom_m, z_top_m",
+        [(1.0, 1.0), (2.0, 1.5)],
+    )
+    def test_z_top_must_exceed_z_bottom(
+        self, z_bottom_m: float, z_top_m: float
+    ) -> None:
+        with pytest.raises(ValueError, match="z_top_m must exceed z_bottom_m"):
+            _ok_part(z_bottom_m=z_bottom_m, z_top_m=z_top_m)
+
+
+class TestStrutsSpec:
+    def test_valid_construction(self) -> None:
+        s = StrutsSpec(
+            fuselage_attach_x_m=0.5,
+            fuselage_attach_y_m=0.4,
+            fuselage_attach_z_m=0.5,
+            wing_attach_y_m=1.8,
+            width_m=0.05,
+        )
+        assert s.width_m == 0.05
+
+    def test_zero_width_rejected(self) -> None:
+        with pytest.raises(ValueError, match="width_m must be positive"):
+            StrutsSpec(
+                fuselage_attach_x_m=0.0,
+                fuselage_attach_y_m=0.4,
+                fuselage_attach_z_m=0.5,
+                wing_attach_y_m=1.8,
+                width_m=0.0,
+            )
+
+    def test_zero_wing_attach_rejected(self) -> None:
+        with pytest.raises(ValueError, match="wing_attach_y_m must be positive"):
+            StrutsSpec(
+                fuselage_attach_x_m=0.0,
+                fuselage_attach_y_m=0.4,
+                fuselage_attach_z_m=0.5,
+                wing_attach_y_m=0.0,
+                width_m=0.05,
+            )
+
+    def test_negative_fuselage_attach_y_rejected(self) -> None:
+        with pytest.raises(ValueError, match="fuselage_attach_y_m must be non-negative"):
+            StrutsSpec(
+                fuselage_attach_x_m=0.0,
+                fuselage_attach_y_m=-0.1,
+                fuselage_attach_z_m=0.5,
+                wing_attach_y_m=1.8,
+                width_m=0.05,
+            )
+
+    def test_negative_fuselage_attach_z_rejected(self) -> None:
+        with pytest.raises(ValueError, match="fuselage_attach_z_m must be non-negative"):
+            StrutsSpec(
+                fuselage_attach_x_m=0.0,
+                fuselage_attach_y_m=0.4,
+                fuselage_attach_z_m=-0.1,
+                wing_attach_y_m=1.8,
+                width_m=0.05,
+            )
+
+
+class TestAircraft:
+    def test_valid_own_gear_construction(self) -> None:
+        a = _ok_aircraft(movement_mode="always_own_gear", turn_radius_m=5.0)
+        assert a.turn_radius_m == 5.0
+        assert a.is_cart_eligible is False
+
+    def test_valid_always_cart_no_turn_radius(self) -> None:
+        a = _ok_aircraft(movement_mode="always_cart", turn_radius_m=None)
+        assert a.turn_radius_m is None
+        assert a.is_cart_eligible is False
+
+    def test_cart_eligible_flag(self) -> None:
+        a = _ok_aircraft(movement_mode="cart_eligible", turn_radius_m=4.0)
+        assert a.is_cart_eligible is True
+
+    def test_empty_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="id must be non-empty"):
+            _ok_aircraft(plane_id="")
+
+    def test_empty_name_rejected(self) -> None:
+        with pytest.raises(ValueError, match="name must be non-empty"):
+            Aircraft(
+                id="x",
+                name="",
+                wing_position="high",
+                gear="tailwheel",
+                movement_mode="always_cart",
+                turn_radius_m=None,
+                measured=False,
+                parts=(_ok_part(),),
+            )
+
+    def test_empty_parts_rejected(self) -> None:
+        with pytest.raises(ValueError, match="parts must be non-empty"):
+            Aircraft(
+                id="x",
+                name="x",
+                wing_position="high",
+                gear="tailwheel",
+                movement_mode="always_cart",
+                turn_radius_m=None,
+                measured=False,
+                parts=(),
+            )
+
+    def test_own_gear_requires_turn_radius(self) -> None:
+        with pytest.raises(ValueError, match="turn_radius_m is required"):
+            _ok_aircraft(movement_mode="always_own_gear", turn_radius_m=None)
+
+    def test_cart_eligible_requires_turn_radius(self) -> None:
+        with pytest.raises(ValueError, match="turn_radius_m is required"):
+            _ok_aircraft(movement_mode="cart_eligible", turn_radius_m=None)
+
+    @pytest.mark.parametrize("turn_radius_m", [0.0, -1.0])
+    def test_non_positive_turn_radius_rejected(self, turn_radius_m: float) -> None:
+        with pytest.raises(ValueError, match="turn_radius_m must be positive"):
+            _ok_aircraft(movement_mode="always_own_gear", turn_radius_m=turn_radius_m)
+
+
+class TestDoor:
+    def test_valid_construction(self) -> None:
+        d = Door(center_x_m=9.0, width_m=12.0)
+        assert d.width_m == 12.0
+
+    def test_zero_width_rejected(self) -> None:
+        with pytest.raises(ValueError, match="width_m must be positive"):
+            Door(center_x_m=9.0, width_m=0.0)
+
+    def test_negative_center_rejected(self) -> None:
+        with pytest.raises(ValueError, match="center_x_m must be non-negative"):
+            Door(center_x_m=-1.0, width_m=12.0)
+
+
+class TestMaintenanceBay:
+    def test_valid_construction(self) -> None:
+        m = MaintenanceBay(depth_m=9.0)
+        assert m.depth_m == 9.0
+
+    @pytest.mark.parametrize("depth_m", [0.0, -1.0])
+    def test_non_positive_depth_rejected(self, depth_m: float) -> None:
+        with pytest.raises(ValueError, match="depth_m must be positive"):
+            MaintenanceBay(depth_m=depth_m)
+
+
+class TestHangar:
+    def test_valid_construction(self) -> None:
+        h = _ok_hangar()
+        assert h.length_m == 25.0
+
+    @pytest.mark.parametrize("length_m", [0.0, -5.0])
+    def test_non_positive_length_rejected(self, length_m: float) -> None:
+        with pytest.raises(ValueError, match="length_m must be positive"):
+            Hangar(
+                length_m=length_m,
+                width_m=18.0,
+                door=Door(center_x_m=9.0, width_m=12.0),
+                maintenance_bay=MaintenanceBay(depth_m=9.0),
+                clearance_m=0.3,
+                wing_layer_clearance_m=0.2,
+            )
+
+    def test_negative_clearance_rejected(self) -> None:
+        with pytest.raises(ValueError, match="clearance_m must be non-negative"):
+            Hangar(
+                length_m=25.0,
+                width_m=18.0,
+                door=Door(center_x_m=9.0, width_m=12.0),
+                maintenance_bay=MaintenanceBay(depth_m=9.0),
+                clearance_m=-0.1,
+                wing_layer_clearance_m=0.2,
+            )
+
+    def test_zero_clearance_allowed(self) -> None:
+        h = Hangar(
+            length_m=25.0,
+            width_m=18.0,
+            door=Door(center_x_m=9.0, width_m=12.0),
+            maintenance_bay=MaintenanceBay(depth_m=9.0),
+            clearance_m=0.0,
+            wing_layer_clearance_m=0.0,
+        )
+        assert h.clearance_m == 0.0
+
+    def test_door_overflows_left(self) -> None:
+        with pytest.raises(ValueError, match="doesn't fit in hangar width"):
+            Hangar(
+                length_m=25.0,
+                width_m=18.0,
+                door=Door(center_x_m=4.0, width_m=12.0),  # left edge at -2
+                maintenance_bay=MaintenanceBay(depth_m=9.0),
+                clearance_m=0.3,
+                wing_layer_clearance_m=0.2,
+            )
+
+    def test_door_overflows_right(self) -> None:
+        with pytest.raises(ValueError, match="doesn't fit in hangar width"):
+            Hangar(
+                length_m=25.0,
+                width_m=18.0,
+                door=Door(center_x_m=15.0, width_m=12.0),  # right edge at 21
+                maintenance_bay=MaintenanceBay(depth_m=9.0),
+                clearance_m=0.3,
+                wing_layer_clearance_m=0.2,
+            )
+
+    def test_maintenance_bay_too_deep(self) -> None:
+        with pytest.raises(ValueError, match="exceeds Hangar.length_m"):
+            Hangar(
+                length_m=25.0,
+                width_m=18.0,
+                door=Door(center_x_m=9.0, width_m=12.0),
+                maintenance_bay=MaintenanceBay(depth_m=30.0),
+                clearance_m=0.3,
+                wing_layer_clearance_m=0.2,
+            )
+
+
+class TestPlacement:
+    def test_valid_construction(self) -> None:
+        p = Placement(plane_id="x", x_m=1.0, y_m=2.0, heading_deg=45.0, on_carts=False)
+        assert p.heading_deg == 45.0
+
+    def test_empty_plane_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="plane_id must be non-empty"):
+            Placement(plane_id="", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+
+
+class TestLayout:
+    def _fleet_of(self, *aircraft: Aircraft) -> dict[str, Aircraft]:
+        return {a.id: a for a in aircraft}
+
+    def test_valid_construction(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="always_own_gear", turn_radius_m=5.0)
+        layout = Layout(
+            fleet=self._fleet_of(a),
+            hangar=_ok_hangar(),
+            placements=(
+                Placement(plane_id="foo", x_m=5.0, y_m=10.0, heading_deg=0.0, on_carts=False),
+            ),
+        )
+        assert layout.maintenance_plane is None
+        assert len(layout.placements) == 1
+
+    def test_unknown_plane_id_rejected(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="always_own_gear", turn_radius_m=5.0)
+        with pytest.raises(ValueError, match="unknown plane_id 'bar'"):
+            Layout(
+                fleet=self._fleet_of(a),
+                hangar=_ok_hangar(),
+                placements=(
+                    Placement(plane_id="bar", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                ),
+            )
+
+    def test_duplicate_placement_rejected(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="always_own_gear", turn_radius_m=5.0)
+        with pytest.raises(ValueError, match="Duplicate placement"):
+            Layout(
+                fleet=self._fleet_of(a),
+                hangar=_ok_hangar(),
+                placements=(
+                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                    Placement(plane_id="foo", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),
+                ),
+            )
+
+    def test_always_cart_requires_on_carts_true(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="always_cart", turn_radius_m=None)
+        with pytest.raises(ValueError, match="must have on_carts=True"):
+            Layout(
+                fleet=self._fleet_of(a),
+                hangar=_ok_hangar(),
+                placements=(
+                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                ),
+            )
+
+    def test_always_own_gear_rejects_on_carts_true(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="always_own_gear", turn_radius_m=5.0)
+        with pytest.raises(ValueError, match="must have on_carts=False"):
+            Layout(
+                fleet=self._fleet_of(a),
+                hangar=_ok_hangar(),
+                placements=(
+                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                ),
+            )
+
+    def test_cart_rule_allows_one_cart_eligible_on_carts(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="cart_eligible", turn_radius_m=4.0)
+        b = _ok_aircraft("bar", movement_mode="cart_eligible", turn_radius_m=4.0)
+        layout = Layout(
+            fleet=self._fleet_of(a, b),
+            hangar=_ok_hangar(),
+            placements=(
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                Placement(plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),
+            ),
+        )
+        assert len(layout.placements) == 2
+
+    def test_cart_rule_rejects_two_cart_eligible_on_carts(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="cart_eligible", turn_radius_m=4.0)
+        b = _ok_aircraft("bar", movement_mode="cart_eligible", turn_radius_m=4.0)
+        with pytest.raises(ValueError, match="At most one cart_eligible"):
+            Layout(
+                fleet=self._fleet_of(a, b),
+                hangar=_ok_hangar(),
+                placements=(
+                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                    Placement(plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=True),
+                ),
+            )
+
+    def test_maintenance_plane_must_be_in_fleet(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="always_own_gear", turn_radius_m=5.0)
+        with pytest.raises(ValueError, match="not in fleet"):
+            Layout(
+                fleet=self._fleet_of(a),
+                hangar=_ok_hangar(),
+                placements=(
+                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                ),
+                maintenance_plane="ghost",
+            )
+
+    def test_maintenance_plane_must_be_placed(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="always_own_gear", turn_radius_m=5.0)
+        b = _ok_aircraft("bar", movement_mode="always_own_gear", turn_radius_m=5.0)
+        with pytest.raises(ValueError, match="is not placed"):
+            Layout(
+                fleet=self._fleet_of(a, b),
+                hangar=_ok_hangar(),
+                placements=(
+                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                ),
+                maintenance_plane="bar",
+            )
+
+
+class TestConflict:
+    def test_one_plane_conflict(self) -> None:
+        c = Conflict(kind="maintenance_position", planes=("foo",), detail="not in back zone")
+        assert len(c.planes) == 1
+
+    def test_two_plane_conflict(self) -> None:
+        c = Conflict(
+            kind="wing_strut_overlap",
+            planes=("cessna_150", "aviat_husky"),
+            detail="wing crosses right strut",
+        )
+        assert len(c.planes) == 2
+
+    def test_empty_kind_rejected(self) -> None:
+        with pytest.raises(ValueError, match="kind must be non-empty"):
+            Conflict(kind="", planes=("foo",), detail="x")
+
+    def test_empty_planes_rejected(self) -> None:
+        with pytest.raises(ValueError, match="at least one plane id"):
+            Conflict(kind="x", planes=(), detail="x")
+
+    def test_too_many_planes_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must have 1 or 2 entries"):
+            Conflict(kind="x", planes=("a", "b", "c"), detail="x")
+
+
+class TestCheckResult:
+    def test_empty_is_valid(self) -> None:
+        r = CheckResult()
+        assert r.valid is True
+        assert r.conflicts == ()
+
+    def test_with_conflict_is_invalid(self) -> None:
+        c = Conflict(kind="x", planes=("foo",), detail="x")
+        r = CheckResult(conflicts=(c,))
+        assert r.valid is False
+        assert len(r.conflicts) == 1
+
+    def test_valid_tracks_conflicts_addition(self) -> None:
+        c1 = Conflict(kind="x", planes=("foo",), detail="x")
+        c2 = Conflict(kind="y", planes=("bar", "baz"), detail="y")
+        r0 = CheckResult()
+        r1 = CheckResult(conflicts=(c1,))
+        r2 = CheckResult(conflicts=(c1, c2))
+        assert (r0.valid, r1.valid, r2.valid) == (True, False, False)
+        assert (len(r0.conflicts), len(r1.conflicts), len(r2.conflicts)) == (0, 1, 2)
+
+
+class TestFrozenBehavior:
+    """Cross-cutting: every public dataclass should be frozen."""
+
+    def test_part_is_frozen(self) -> None:
+        p = _ok_part()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            p.kind = "wing"  # type: ignore[misc]
+
+    def test_aircraft_is_frozen(self) -> None:
+        a = _ok_aircraft()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            a.measured = True  # type: ignore[misc]
+
+    def test_hangar_is_frozen(self) -> None:
+        h = _ok_hangar()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            h.length_m = 30.0  # type: ignore[misc]
+
+    def test_layout_is_frozen(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="always_own_gear", turn_radius_m=5.0)
+        layout = Layout(
+            fleet={a.id: a},
+            hangar=_ok_hangar(),
+            placements=(
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+            ),
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            layout.maintenance_plane = "foo"  # type: ignore[misc]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,7 +45,6 @@ def _ok_aircraft(
     *,
     movement_mode: str = "always_own_gear",
     turn_radius_m: float | None = 5.0,
-    struts: StrutsSpec | None = None,
 ) -> Aircraft:
     return Aircraft(
         id=plane_id,
@@ -56,7 +55,6 @@ def _ok_aircraft(
         turn_radius_m=turn_radius_m,
         measured=False,
         parts=(_ok_part(),),
-        struts=struts,
     )
 
 
@@ -77,9 +75,15 @@ class TestPart:
         assert p.kind == "fuselage"
         assert p.z_top_m > p.z_bottom_m
 
-    def test_empty_kind_rejected(self) -> None:
-        with pytest.raises(ValueError, match="kind must be non-empty"):
-            _ok_part(kind="")
+    @pytest.mark.parametrize("kind", ["", "fueslage", "Wing", "engine", "rotor"])
+    def test_invalid_kind_rejected(self, kind: str) -> None:
+        with pytest.raises(ValueError, match="Part.kind must be one of"):
+            _ok_part(kind=kind)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("kind", ["fuselage", "wing", "strut", "tail"])
+    def test_all_valid_kinds_accepted(self, kind: str) -> None:
+        p = _ok_part(kind=kind)  # type: ignore[arg-type]
+        assert p.kind == kind
 
     @pytest.mark.parametrize("length_m", [0.0, -1.0])
     def test_non_positive_length_rejected(self, length_m: float) -> None:
@@ -157,6 +161,28 @@ class TestStrutsSpec:
                 width_m=0.05,
             )
 
+    def test_wing_attach_inboard_of_fuselage_rejected(self) -> None:
+        """A strut must run outward; wing attach inside the fuselage attach is impossible."""
+        with pytest.raises(ValueError, match="must be >="):
+            StrutsSpec(
+                fuselage_attach_x_m=0.0,
+                fuselage_attach_y_m=0.8,
+                fuselage_attach_z_m=0.5,
+                wing_attach_y_m=0.4,  # inboard of fuselage attach — impossible
+                width_m=0.05,
+            )
+
+    def test_wing_attach_equal_to_fuselage_attach_allowed(self) -> None:
+        """Degenerate but legal: strut runs vertically (no outward component)."""
+        s = StrutsSpec(
+            fuselage_attach_x_m=0.0,
+            fuselage_attach_y_m=0.8,
+            fuselage_attach_z_m=0.5,
+            wing_attach_y_m=0.8,
+            width_m=0.05,
+        )
+        assert s.wing_attach_y_m == s.fuselage_attach_y_m
+
 
 class TestAircraft:
     def test_valid_own_gear_construction(self) -> None:
@@ -211,10 +237,37 @@ class TestAircraft:
         with pytest.raises(ValueError, match="turn_radius_m is required"):
             _ok_aircraft(movement_mode="cart_eligible", turn_radius_m=None)
 
-    @pytest.mark.parametrize("turn_radius_m", [0.0, -1.0])
-    def test_non_positive_turn_radius_rejected(self, turn_radius_m: float) -> None:
+    @pytest.mark.parametrize(
+        "movement_mode, turn_radius_m",
+        [
+            ("always_own_gear", 0.0),
+            ("always_own_gear", -1.0),
+            ("cart_eligible", 0.0),
+            ("cart_eligible", -2.0),
+        ],
+    )
+    def test_non_positive_turn_radius_rejected(
+        self, movement_mode: str, turn_radius_m: float
+    ) -> None:
         with pytest.raises(ValueError, match="turn_radius_m must be positive"):
-            _ok_aircraft(movement_mode="always_own_gear", turn_radius_m=turn_radius_m)
+            _ok_aircraft(movement_mode=movement_mode, turn_radius_m=turn_radius_m)
+
+    def test_always_cart_ignores_turn_radius_value(self) -> None:
+        """always_cart short-circuits turn_radius validation; even a nonsensical
+        value is accepted because turn_radius is meaningless for cart-only planes.
+        Pinning this asymmetry intentionally so a refactor of the conditional
+        doesn't silently change behavior."""
+        a = _ok_aircraft(movement_mode="always_cart", turn_radius_m=-5.0)
+        assert a.turn_radius_m == -5.0
+
+    def test_required_turn_radius_m_returns_float(self) -> None:
+        a = _ok_aircraft(movement_mode="always_own_gear", turn_radius_m=5.5)
+        assert a.required_turn_radius_m() == 5.5
+
+    def test_required_turn_radius_m_raises_when_none(self) -> None:
+        a = _ok_aircraft(movement_mode="always_cart", turn_radius_m=None)
+        with pytest.raises(AssertionError, match="turn_radius_m is None"):
+            a.required_turn_radius_m()
 
 
 class TestDoor:
@@ -254,6 +307,18 @@ class TestHangar:
                 length_m=length_m,
                 width_m=18.0,
                 door=Door(center_x_m=9.0, width_m=12.0),
+                maintenance_bay=MaintenanceBay(depth_m=9.0),
+                clearance_m=0.3,
+                wing_layer_clearance_m=0.2,
+            )
+
+    @pytest.mark.parametrize("width_m", [0.0, -3.0])
+    def test_non_positive_width_rejected(self, width_m: float) -> None:
+        with pytest.raises(ValueError, match="width_m must be positive"):
+            Hangar(
+                length_m=25.0,
+                width_m=width_m,
+                door=Door(center_x_m=9.0, width_m=12.0) if width_m > 12 else Door(center_x_m=1.0, width_m=0.5),
                 maintenance_bay=MaintenanceBay(depth_m=9.0),
                 clearance_m=0.3,
                 wing_layer_clearance_m=0.2,
@@ -304,7 +369,7 @@ class TestHangar:
             )
 
     def test_maintenance_bay_too_deep(self) -> None:
-        with pytest.raises(ValueError, match="exceeds Hangar.length_m"):
+        with pytest.raises(ValueError, match="must be strictly less than"):
             Hangar(
                 length_m=25.0,
                 width_m=18.0,
@@ -313,6 +378,42 @@ class TestHangar:
                 clearance_m=0.3,
                 wing_layer_clearance_m=0.2,
             )
+
+    def test_maintenance_bay_equal_to_length_rejected(self) -> None:
+        """Bay-depth == hangar-length leaves zero parking area; rejected."""
+        with pytest.raises(ValueError, match="must be strictly less than"):
+            Hangar(
+                length_m=25.0,
+                width_m=18.0,
+                door=Door(center_x_m=9.0, width_m=12.0),
+                maintenance_bay=MaintenanceBay(depth_m=25.0),
+                clearance_m=0.3,
+                wing_layer_clearance_m=0.2,
+            )
+
+    def test_door_flush_with_left_wall_allowed(self) -> None:
+        """Door's left edge exactly at x=0 is a legal boundary."""
+        h = Hangar(
+            length_m=25.0,
+            width_m=18.0,
+            door=Door(center_x_m=6.0, width_m=12.0),
+            maintenance_bay=MaintenanceBay(depth_m=9.0),
+            clearance_m=0.3,
+            wing_layer_clearance_m=0.2,
+        )
+        assert h.door.center_x_m == 6.0
+
+    def test_door_flush_with_right_wall_allowed(self) -> None:
+        """Door's right edge exactly at x=width_m is a legal boundary."""
+        h = Hangar(
+            length_m=25.0,
+            width_m=18.0,
+            door=Door(center_x_m=12.0, width_m=12.0),
+            maintenance_bay=MaintenanceBay(depth_m=9.0),
+            clearance_m=0.3,
+            wing_layer_clearance_m=0.2,
+        )
+        assert h.door.center_x_m == 12.0
 
 
 class TestPlacement:
@@ -437,6 +538,95 @@ class TestLayout:
                 maintenance_plane="bar",
             )
 
+    def test_maintenance_plane_happy_path(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="always_own_gear", turn_radius_m=5.0)
+        layout = Layout(
+            fleet=self._fleet_of(a),
+            hangar=_ok_hangar(),
+            placements=(
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+            ),
+            maintenance_plane="foo",
+        )
+        assert layout.maintenance_plane == "foo"
+
+    def test_fleet_key_must_match_aircraft_id(self) -> None:
+        a = _ok_aircraft("real_id", movement_mode="always_own_gear", turn_radius_m=5.0)
+        with pytest.raises(ValueError, match="does not match its Aircraft.id"):
+            Layout(
+                fleet={"wrong_key": a},
+                hangar=_ok_hangar(),
+                placements=(),
+            )
+
+    def test_fleet_is_read_only_after_construction(self) -> None:
+        """Layout.__post_init__ wraps fleet in MappingProxyType so that
+        cross-reference invariants stay valid for the object's lifetime."""
+        a = _ok_aircraft("foo", movement_mode="always_own_gear", turn_radius_m=5.0)
+        layout = Layout(
+            fleet=self._fleet_of(a),
+            hangar=_ok_hangar(),
+            placements=(
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+            ),
+        )
+        with pytest.raises(TypeError):
+            layout.fleet["foo"] = a  # type: ignore[index]
+        with pytest.raises(TypeError):
+            del layout.fleet["foo"]  # type: ignore[attr-defined]
+
+    def test_fleet_caller_mutation_does_not_leak(self) -> None:
+        """The dict the caller passes in is copied before being wrapped, so
+        post-construction mutations to the caller's dict don't leak."""
+        a = _ok_aircraft("foo", movement_mode="always_own_gear", turn_radius_m=5.0)
+        caller_dict = self._fleet_of(a)
+        layout = Layout(
+            fleet=caller_dict,
+            hangar=_ok_hangar(),
+            placements=(
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+            ),
+        )
+        del caller_dict["foo"]
+        assert "foo" in layout.fleet
+
+    def test_always_cart_planes_do_not_count_against_cart_limit(self) -> None:
+        """Two always_cart + one cart_eligible on carts must be allowed:
+        the limit is 'at most one cart_eligible on carts', not 'at most
+        one anything on carts'."""
+        a = _ok_aircraft("a", movement_mode="always_cart", turn_radius_m=None)
+        b = _ok_aircraft("b", movement_mode="always_cart", turn_radius_m=None)
+        c = _ok_aircraft("c", movement_mode="cart_eligible", turn_radius_m=4.0)
+        layout = Layout(
+            fleet=self._fleet_of(a, b, c),
+            hangar=_ok_hangar(),
+            placements=(
+                Placement(plane_id="a", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                Placement(plane_id="b", x_m=2.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                Placement(plane_id="c", x_m=4.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+            ),
+        )
+        assert len(layout.placements) == 3
+
+    def test_cart_rule_allows_zero_cart_eligible_on_carts(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="cart_eligible", turn_radius_m=4.0)
+        b = _ok_aircraft("bar", movement_mode="cart_eligible", turn_radius_m=4.0)
+        layout = Layout(
+            fleet=self._fleet_of(a, b),
+            hangar=_ok_hangar(),
+            placements=(
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                Placement(plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),
+            ),
+        )
+        assert len(layout.placements) == 2
+
+    def test_empty_layout_valid(self) -> None:
+        """A Layout with an empty fleet and no placements is legal (degenerate)."""
+        layout = Layout(fleet={}, hangar=_ok_hangar(), placements=())
+        assert layout.placements == ()
+        assert len(layout.fleet) == 0
+
 
 class TestConflict:
     def test_one_plane_conflict(self) -> None:
@@ -463,6 +653,34 @@ class TestConflict:
         with pytest.raises(ValueError, match="must have 1 or 2 entries"):
             Conflict(kind="x", planes=("a", "b", "c"), detail="x")
 
+    def test_empty_plane_id_in_planes_rejected(self) -> None:
+        with pytest.raises(ValueError, match="entries must be non-empty"):
+            Conflict(kind="x", planes=("foo", ""), detail="x")
+
+    def test_duplicate_planes_rejected(self) -> None:
+        """A pairwise conflict can't list the same plane on both sides."""
+        with pytest.raises(ValueError, match="must be distinct"):
+            Conflict(kind="x", planes=("foo", "foo"), detail="x")
+
+    def test_single_factory(self) -> None:
+        c = Conflict.single(kind="maintenance_position", plane="foo", detail="x")
+        assert c.kind == "maintenance_position"
+        assert c.planes == ("foo",)
+
+    def test_pair_factory(self) -> None:
+        c = Conflict.pair(
+            kind="wing_strut_overlap",
+            plane_a="foo",
+            plane_b="bar",
+            detail="x",
+        )
+        assert c.planes == ("foo", "bar")
+
+    def test_pair_factory_rejects_self_pair(self) -> None:
+        """Factory still goes through __post_init__, so the distinct check fires."""
+        with pytest.raises(ValueError, match="must be distinct"):
+            Conflict.pair(kind="x", plane_a="foo", plane_b="foo", detail="x")
+
 
 class TestCheckResult:
     def test_empty_is_valid(self) -> None:
@@ -475,15 +693,6 @@ class TestCheckResult:
         r = CheckResult(conflicts=(c,))
         assert r.valid is False
         assert len(r.conflicts) == 1
-
-    def test_valid_tracks_conflicts_addition(self) -> None:
-        c1 = Conflict(kind="x", planes=("foo",), detail="x")
-        c2 = Conflict(kind="y", planes=("bar", "baz"), detail="y")
-        r0 = CheckResult()
-        r1 = CheckResult(conflicts=(c1,))
-        r2 = CheckResult(conflicts=(c1, c2))
-        assert (r0.valid, r1.valid, r2.valid) == (True, False, False)
-        assert (len(r0.conflicts), len(r1.conflicts), len(r2.conflicts)) == (0, 1, 2)
 
 
 class TestFrozenBehavior:


### PR DESCRIPTION
Closes #2.

Adds the pure data model layer that the rest of Phase 1 builds against. No I/O, no logic — every type is a frozen dataclass with slots, validates invariants in `__post_init__`, and uses tuples for collection fields.

## Types

| Type | Purpose |
|---|---|
| `Part` | Universal collision unit — oriented rect in plane-local coords + `[z_bottom, z_top]` |
| `StrutsSpec` | Convenience block; loader/geometry (#3/#4) expand into mirrored strut Parts |
| `Aircraft` | id, name, wing_position, gear, movement_mode, turn_radius_m, parts, struts |
| `Door`, `MaintenanceBay`, `Hangar` | Hangar floor plan + clearances |
| `Placement` | aircraft position + heading + on_carts (world coords) |
| `Layout` | hangar + fleet + placements, validates cross-references |
| `Conflict`, `CheckResult` | Collision checker output types |

## Design notes

- **Frozen + slots everywhere.** Catches accidental mutation bugs, saves memory, blocks typo'd attribute additions (`layout.placments = ...` raises).
- **Cross-reference invariants live in `Layout.__post_init__`** (not deferred to the loader): unknown plane refs, duplicate placements, the cart rule (at most one `cart_eligible` on carts), `always_cart` ↔ `on_carts=True` consistency, `always_own_gear` ↔ `on_carts=False` consistency, maintenance plane membership and placement. The loader in #3 becomes a thin adapter.
- **`CheckResult.valid` is a derived property**, not a separate field. Constructor is `CheckResult(conflicts=...)`. Prevents the inconsistent state where `valid=True` ships alongside non-empty `conflicts`. The issue body wrote `CheckResult(valid, conflicts)` as the sig — this PR honors the semantics (exposes both `valid` and `conflicts`) but tightens the data integrity.
- **`Aircraft.turn_radius_m` is required** for any non-`always_cart` movement mode (the future planner needs it for Dubins paths on both `always_own_gear` and `cart_eligible` planes when not on carts).

## Verification

```
$ pytest tests/test_models.py
============================== 61 passed in 0.05s ==============================
```

Coverage:

- Every public type's happy-path construction.
- Every `__post_init__` validation branch (length/width/z-range invalid, missing turn_radius for own-gear/cart-eligible, door doesn't fit, maintenance bay too deep, unknown plane refs, duplicate placements, cart rule violation, movement-mode-vs-on_carts mismatches, maintenance plane not placed, conflict shape violations).
- Frozen behavior on `Part`, `Aircraft`, `Hangar`, `Layout` (cross-cutting).

## Workflow follow-up after merge

1. `pr-review` runs after this PR is opened.
2. Findings (if any) become PR review threads, get resolved in a follow-up commit.
3. When clean, ready for your final review.

Milestone: `v0.1.0 — Foundation`. Depends on #1 (now merged).