### PR TITLE
feat(loader): YAML loader + placeholder data files (#3)

### DIFF
--- a/data/fleet.yaml
+++ b/data/fleet.yaml
@@ -1,0 +1,290 @@
+# Fleet definitions for the flying club.
+#
+# ALL DIMENSIONS BELOW ARE PLACEHOLDERS — replace with real measurements
+# before trusting any layout the collision checker validates. Every
+# entry has `measured: false` as a grep handle so you can audit what
+# still needs real numbers.
+#
+# Conventions (see CLAUDE.md for the full version):
+# - Plane-local coords: +x = forward (toward nose), +y = right (toward right wingtip)
+# - Origin of plane-local frame = main-gear / cart centroid
+# - Each Part is an oriented rectangle: length_m runs along plane +x,
+#   width_m runs along plane +y
+# - Heights z_bottom_m / z_top_m are above-ground in world coords
+# - struts block (optional) is expanded by the loader into two mirrored
+#   strut Parts; cantilever aircraft omit the block entirely
+
+aircraft:
+  # ----------------------------------------------------------------------------
+  # MOTORGLIDER — cantilever high wing, monowheel + outriggers, always on carts
+  # ----------------------------------------------------------------------------
+  - id: scheibe_falke
+    name: "Scheibe SF-25E Falke"
+    wing_position: high
+    gear: monowheel
+    movement_mode: always_cart
+    turn_radius_m: null
+    measured: false
+    notes: "Cantilever wing; outriggers folded into wing footprint at the tips"
+    parts:
+      - kind: fuselage
+        length_m: 7.7
+        width_m: 0.7
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.2
+        width_m: 16.6
+        offset_x_m: 1.5
+        offset_y_m: 0.0
+        z_bottom_m: 1.9
+        z_top_m: 2.1
+
+  # ----------------------------------------------------------------------------
+  # TAILWHEEL HIGH-WING — strut-braced, always on own gear
+  # ----------------------------------------------------------------------------
+  - id: aviat_husky
+    name: "Aviat Husky A-1"
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.85
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.4
+        width_m: 10.7
+        offset_x_m: 1.2
+        offset_y_m: 0.0
+        z_bottom_m: 2.0
+        z_top_m: 2.3
+    struts:
+      fuselage_attach_x_m: 0.5
+      fuselage_attach_y_m: 0.425   # ~half fuselage width
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.8
+      width_m: 0.05
+
+  # ----------------------------------------------------------------------------
+  # LOW-WING — cantilever, nosewheel, always on own gear. ONLY low-wing in fleet.
+  # ----------------------------------------------------------------------------
+  - id: fuji
+    name: "Fuji FA-200"
+    wing_position: low
+    gear: nosewheel
+    movement_mode: always_own_gear
+    turn_radius_m: 7.0
+    measured: false
+    notes: "Only low-wing in the fleet — wing underside near ground level"
+    parts:
+      - kind: fuselage
+        length_m: 8.0
+        width_m: 1.0
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.6
+      - kind: wing
+        length_m: 1.5
+        width_m: 9.4
+        offset_x_m: 0.5
+        offset_y_m: 0.0
+        z_bottom_m: 0.8
+        z_top_m: 1.1
+
+  # ----------------------------------------------------------------------------
+  # ULTRALIGHT HIGH-WING — strut-braced, always on carts
+  # ----------------------------------------------------------------------------
+  - id: wild_thing
+    name: "Wild Thing"
+    wing_position: high
+    gear: nosewheel
+    movement_mode: always_cart
+    turn_radius_m: null
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 5.5
+        width_m: 0.85
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.4
+      - kind: wing
+        length_m: 1.2
+        width_m: 9.0
+        offset_x_m: 1.0
+        offset_y_m: 0.0
+        z_bottom_m: 2.0
+        z_top_m: 2.2
+    struts:
+      fuselage_attach_x_m: 0.4
+      fuselage_attach_y_m: 0.425
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.6
+      width_m: 0.05
+
+  # ----------------------------------------------------------------------------
+  # TAILWHEEL HIGH-WING — strut-braced, always on carts
+  # ----------------------------------------------------------------------------
+  - id: zlin_savage
+    name: "Zlin Savage"
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_cart
+    turn_radius_m: null
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 6.4
+        width_m: 0.8
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.5
+        width_m: 8.5
+        offset_x_m: 1.1
+        offset_y_m: 0.0
+        z_bottom_m: 1.9
+        z_top_m: 2.2
+    struts:
+      fuselage_attach_x_m: 0.4
+      fuselage_attach_y_m: 0.4
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.5
+      width_m: 0.05
+
+  # ----------------------------------------------------------------------------
+  # CART-ELIGIBLE — high-wing tailwheel, strut-braced (V-strut → one per side)
+  # ----------------------------------------------------------------------------
+  - id: cessna_140
+    name: "Cessna 140"
+    wing_position: high
+    gear: tailwheel
+    movement_mode: cart_eligible
+    turn_radius_m: 5.5
+    measured: false
+    notes: "V-strut treated as one strut per side"
+    parts:
+      - kind: fuselage
+        length_m: 6.4
+        width_m: 0.85
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.55
+        width_m: 10.2
+        offset_x_m: 1.1
+        offset_y_m: 0.0
+        z_bottom_m: 2.0
+        z_top_m: 2.3
+    struts:
+      fuselage_attach_x_m: 0.5
+      fuselage_attach_y_m: 0.425
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.7
+      width_m: 0.05
+
+  # ----------------------------------------------------------------------------
+  # CART-ELIGIBLE — high-wing nosewheel, strut-braced
+  # ----------------------------------------------------------------------------
+  - id: cessna_150
+    name: "Cessna 150"
+    wing_position: high
+    gear: nosewheel
+    movement_mode: cart_eligible
+    turn_radius_m: 4.5
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 7.3
+        width_m: 0.9
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.5
+        width_m: 10.1
+        offset_x_m: 1.1
+        offset_y_m: 0.0
+        z_bottom_m: 2.0
+        z_top_m: 2.3
+    struts:
+      fuselage_attach_x_m: 0.5
+      fuselage_attach_y_m: 0.45
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.8
+      width_m: 0.05
+
+  # ----------------------------------------------------------------------------
+  # CART-ELIGIBLE — high-wing nosewheel, cantilever (no struts)
+  # ----------------------------------------------------------------------------
+  - id: ctsl
+    name: "Flight Design CTSL"
+    wing_position: high
+    gear: nosewheel
+    movement_mode: cart_eligible
+    turn_radius_m: 4.0
+    measured: false
+    notes: "Cantilever wing (no struts)"
+    parts:
+      - kind: fuselage
+        length_m: 6.3
+        width_m: 1.0
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.4
+      - kind: wing
+        length_m: 1.4
+        width_m: 8.6
+        offset_x_m: 1.0
+        offset_y_m: 0.0
+        z_bottom_m: 1.9
+        z_top_m: 2.2
+
+  # ----------------------------------------------------------------------------
+  # CART-ELIGIBLE — high-wing nosewheel, strut-braced
+  # ----------------------------------------------------------------------------
+  - id: fk9_mkii
+    name: "FK9 Mk II"
+    wing_position: high
+    gear: nosewheel
+    movement_mode: cart_eligible
+    turn_radius_m: 4.0
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 6.2
+        width_m: 0.85
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.4
+      - kind: wing
+        length_m: 1.3
+        width_m: 9.0
+        offset_x_m: 1.0
+        offset_y_m: 0.0
+        z_bottom_m: 1.9
+        z_top_m: 2.2
+    struts:
+      fuselage_attach_x_m: 0.4
+      fuselage_attach_y_m: 0.425
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.6
+      width_m: 0.05

--- a/data/hangar.yaml
+++ b/data/hangar.yaml
@@ -1,0 +1,21 @@
+# Hangar floor plan.
+#
+# ALL DIMENSIONS ARE PLACEHOLDERS — replace with real measurements
+# before trusting any layout the collision checker validates.
+#
+# Coordinates: (0, 0) at the front-left corner of the hangar floor,
+# looking down. +x runs right along the door wall, +y runs deeper
+# into the hangar. See CLAUDE.md for the full convention.
+
+length_m: 25.0          # depth from front wall (door side) to back wall
+width_m: 18.0           # left-to-right span
+
+door:
+  center_x_m: 9.0       # door center along the front wall (x axis)
+  width_m: 12.0         # door opening width
+
+maintenance_bay:
+  depth_m: 9.0          # back-most strip that doubles as the maintenance bay
+
+clearance_m: 0.3        # minimum horizontal gap between any two aircraft parts
+wing_layer_clearance_m: 0.2  # minimum vertical gap between two parts at the same XY

--- a/layouts/example.yaml
+++ b/layouts/example.yaml
@@ -1,0 +1,78 @@
+# Example candidate layout for the 9-aircraft fleet.
+#
+# This layout loads cleanly and satisfies all loader-level invariants
+# (cart rule, movement-mode-vs-on_carts consistency, maintenance plane
+# in fleet and placed). It is NOT guaranteed to be collision-free —
+# that's what the collision checker (#5) is for. Edit positions once
+# the checker lands and you can iterate.
+#
+# Hangar: 25 m deep × 18 m wide, door centered at x=9 (width 12),
+# maintenance bay = back 9 m (so y > 16 is the bay).
+#
+# Coordinate convention (CLAUDE.md): world (0,0) at front-left, +x right
+# along door wall, +y deeper into hangar. heading 0° = nose into hangar.
+
+fleet: ../data/fleet.yaml
+hangar: ../data/hangar.yaml
+
+maintenance:
+  plane: cessna_150          # parked in the back maintenance bay
+
+placements:
+  # Back / maintenance bay
+  - plane: cessna_150
+    x_m: 9.0
+    y_m: 21.0
+    heading_deg: 0
+    on_carts: false          # the cart-eligible plane currently on its own gear
+
+  # Middle row
+  - plane: scheibe_falke
+    x_m: 9.0
+    y_m: 13.0
+    heading_deg: 90          # nose right; the 16.6 m wingspan runs along world y
+    on_carts: true           # always_cart
+
+  # Front row (deeper end of front area)
+  - plane: aviat_husky
+    x_m: 3.0
+    y_m: 8.0
+    heading_deg: 0
+    on_carts: false          # always_own_gear
+
+  - plane: fuji
+    x_m: 9.0
+    y_m: 8.0
+    heading_deg: 0
+    on_carts: false          # always_own_gear
+
+  - plane: wild_thing
+    x_m: 15.0
+    y_m: 8.0
+    heading_deg: 0
+    on_carts: true           # always_cart
+
+  # Front-front row (near door)
+  - plane: zlin_savage
+    x_m: 3.0
+    y_m: 3.0
+    heading_deg: 0
+    on_carts: true           # always_cart
+
+  - plane: cessna_140
+    x_m: 7.0
+    y_m: 3.0
+    heading_deg: 0
+    on_carts: true           # the ONE cart_eligible plane on the spare carts
+
+  - plane: ctsl
+    x_m: 11.0
+    y_m: 3.0
+    heading_deg: 0
+    on_carts: false
+
+  - plane: fk9_mkii
+    x_m: 15.0
+    y_m: 3.0
+    heading_deg: 0
+    on_carts: false

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -38,6 +38,33 @@ class LoaderError(Exception):
     """Raised when a YAML file is malformed or fails model validation."""
 
 
+def _to_float(value: Any, field_name: str) -> float:
+    """Coerce a YAML scalar to ``float``, raising ``LoaderError`` with the
+    field name on failure (rather than a bare ``TypeError`` from
+    ``float(None)`` or ``ValueError`` from ``float("abc")``)."""
+    if value is None:
+        raise LoaderError(f"{field_name!r}: expected number, got null")
+    try:
+        return float(value)
+    except (TypeError, ValueError) as e:
+        raise LoaderError(
+            f"{field_name!r}: expected number, got {value!r} "
+            f"({type(value).__name__})"
+        ) from e
+
+
+def _to_bool(value: Any, field_name: str) -> bool:
+    """Coerce a YAML scalar to ``bool`` strictly. Rejects quoted strings
+    (``"true"``, ``"false"``) and any non-bool value — those are the
+    classic YAML silent-flip footgun (``bool("false")`` is ``True``)."""
+    if not isinstance(value, bool):
+        raise LoaderError(
+            f"{field_name!r}: expected boolean (unquoted true/false), "
+            f"got {value!r} ({type(value).__name__})"
+        )
+    return value
+
+
 def load_fleet(path: Path | str) -> dict[str, Aircraft]:
     """Load ``fleet.yaml`` into a dict keyed by :attr:`Aircraft.id`.
 
@@ -59,10 +86,10 @@ def load_fleet(path: Path | str) -> dict[str, Aircraft]:
             raise LoaderError(
                 f"{path}: aircraft entry #{i} must be a mapping, got {type(entry).__name__}"
             )
-        ident = entry.get("id", f"#{i}")
+        ident = entry.get("id", f"#{i}") if isinstance(entry, dict) else f"#{i}"
         try:
             aircraft = _build_aircraft(entry)
-        except (ValueError, KeyError, LoaderError) as e:
+        except (ValueError, KeyError, TypeError, LoaderError) as e:
             raise LoaderError(f"{path}: aircraft {ident!r}: {e}") from e
         if aircraft.id in fleet:
             raise LoaderError(f"{path}: duplicate aircraft id {aircraft.id!r}")
@@ -96,15 +123,19 @@ def load_hangar(path: Path | str) -> Hangar:
 
     try:
         return Hangar(
-            length_m=float(raw["length_m"]),
-            width_m=float(raw["width_m"]),
+            length_m=_to_float(raw["length_m"], "length_m"),
+            width_m=_to_float(raw["width_m"], "width_m"),
             door=Door(
-                center_x_m=float(door_data["center_x_m"]),
-                width_m=float(door_data["width_m"]),
+                center_x_m=_to_float(door_data["center_x_m"], "door.center_x_m"),
+                width_m=_to_float(door_data["width_m"], "door.width_m"),
             ),
-            maintenance_bay=MaintenanceBay(depth_m=float(bay_data["depth_m"])),
-            clearance_m=float(raw.get("clearance_m", 0.3)),
-            wing_layer_clearance_m=float(raw.get("wing_layer_clearance_m", 0.2)),
+            maintenance_bay=MaintenanceBay(
+                depth_m=_to_float(bay_data["depth_m"], "maintenance_bay.depth_m")
+            ),
+            clearance_m=_to_float(raw.get("clearance_m", 0.3), "clearance_m"),
+            wing_layer_clearance_m=_to_float(
+                raw.get("wing_layer_clearance_m", 0.2), "wing_layer_clearance_m"
+            ),
         )
     except (ValueError, TypeError) as e:
         raise LoaderError(f"{path}: {e}") from e
@@ -118,10 +149,17 @@ def load_layout(
 ) -> Layout:
     """Load a layout YAML.
 
-    If ``fleet`` and ``hangar`` are provided, the YAML's ``fleet:`` and
-    ``hangar:`` fields are ignored. Otherwise, those fields are
-    interpreted as paths **relative to the layout YAML's parent
-    directory** and loaded.
+    Path resolution: when the YAML supplies ``fleet:`` / ``hangar:``,
+    those values are joined to the layout YAML's parent directory.
+    Absolute paths in those fields override the join (pathlib's
+    behavior — passing an absolute right-hand side to ``/`` discards
+    the left), which is occasionally useful but also a footgun; prefer
+    repo-relative paths.
+
+    Conflict policy: if ``fleet`` / ``hangar`` overrides are supplied
+    as kwargs **and** the YAML also has those fields, the loader
+    raises :class:`LoaderError`. We refuse to silently let one source
+    of truth shadow the other.
     """
     path = Path(path)
     raw = _read_yaml(path)
@@ -135,6 +173,11 @@ def load_layout(
                 f"{path}: 'fleet' field is required when no fleet override is provided"
             )
         fleet = load_fleet((path.parent / fleet_ref).resolve())
+    elif "fleet" in raw:
+        raise LoaderError(
+            f"{path}: 'fleet' field is set in YAML but a fleet override was also "
+            f"provided programmatically; remove one to disambiguate"
+        )
 
     if hangar is None:
         hangar_ref = raw.get("hangar")
@@ -143,18 +186,21 @@ def load_layout(
                 f"{path}: 'hangar' field is required when no hangar override is provided"
             )
         hangar = load_hangar((path.parent / hangar_ref).resolve())
+    elif "hangar" in raw:
+        raise LoaderError(
+            f"{path}: 'hangar' field is set in YAML but a hangar override was also "
+            f"provided programmatically; remove one to disambiguate"
+        )
 
     placements_data = raw.get("placements", [])
     if not isinstance(placements_data, list):
         raise LoaderError(f"{path}: 'placements' must be a list")
     try:
         placements = tuple(_build_placement(p) for p in placements_data)
-    except (ValueError, KeyError, TypeError) as e:
+    except (ValueError, KeyError, TypeError, LoaderError) as e:
         raise LoaderError(f"{path}: placement: {e}") from e
 
-    maintenance_plane: str | None = None
-    if isinstance(raw.get("maintenance"), dict):
-        maintenance_plane = raw["maintenance"].get("plane")
+    maintenance_plane = _extract_maintenance_plane(raw, path)
 
     try:
         return Layout(
@@ -167,7 +213,35 @@ def load_layout(
         raise LoaderError(f"{path}: {e}") from e
 
 
-def _build_aircraft(entry: dict[str, Any]) -> Aircraft:
+def _extract_maintenance_plane(raw: dict, path: Path) -> str | None:
+    """Pull ``maintenance_plane`` from the layout YAML, rejecting common
+    typos (``maintenance: cessna_150`` with no nested ``plane:`` key)."""
+    if "maintenance" not in raw:
+        return None
+    m = raw["maintenance"]
+    if m is None:
+        return None  # explicit `maintenance: ~` → no maintenance plane
+    if not isinstance(m, dict):
+        raise LoaderError(
+            f"{path}: 'maintenance' must be a mapping with a 'plane' key, "
+            f"got {type(m).__name__}"
+        )
+    if "plane" not in m:
+        raise LoaderError(
+            f"{path}: 'maintenance' block present but lacks required 'plane' key"
+        )
+    return m["plane"]
+
+
+def _build_aircraft(entry: Any) -> Aircraft:
+    if not isinstance(entry, dict):
+        raise LoaderError(f"aircraft entry must be a mapping, got {type(entry).__name__}")
+
+    required = ("id", "name", "wing_position", "gear", "movement_mode")
+    for key in required:
+        if key not in entry:
+            raise LoaderError(f"missing required field {key!r}")
+
     parts_data = entry.get("parts")
     if not isinstance(parts_data, list) or not parts_data:
         raise LoaderError("'parts' must be a non-empty list")
@@ -182,14 +256,17 @@ def _build_aircraft(entry: dict[str, Any]) -> Aircraft:
             raise LoaderError("'struts' block requires a part of kind 'wing'")
         parts.extend(_expand_struts(spec, wing))
 
+    turn_radius_raw = entry.get("turn_radius_m")
+    turn_radius_m = None if turn_radius_raw is None else _to_float(turn_radius_raw, "turn_radius_m")
+
     return Aircraft(
         id=entry["id"],
         name=entry["name"],
         wing_position=entry["wing_position"],
         gear=entry["gear"],
         movement_mode=entry["movement_mode"],
-        turn_radius_m=entry.get("turn_radius_m"),
-        measured=bool(entry.get("measured", False)),
+        turn_radius_m=turn_radius_m,
+        measured=_to_bool(entry.get("measured", False), "measured"),
         parts=tuple(parts),
         notes=entry.get("notes", ""),
     )
@@ -204,13 +281,13 @@ def _build_part(data: Any, index: int) -> Part:
             raise LoaderError(f"parts[{index}] missing required field {key!r}")
     return Part(
         kind=data["kind"],
-        length_m=float(data["length_m"]),
-        width_m=float(data["width_m"]),
-        offset_x_m=float(data.get("offset_x_m", 0.0)),
-        offset_y_m=float(data.get("offset_y_m", 0.0)),
-        angle_deg=float(data.get("angle_deg", 0.0)),
-        z_bottom_m=float(data["z_bottom_m"]),
-        z_top_m=float(data["z_top_m"]),
+        length_m=_to_float(data["length_m"], f"parts[{index}].length_m"),
+        width_m=_to_float(data["width_m"], f"parts[{index}].width_m"),
+        offset_x_m=_to_float(data.get("offset_x_m", 0.0), f"parts[{index}].offset_x_m"),
+        offset_y_m=_to_float(data.get("offset_y_m", 0.0), f"parts[{index}].offset_y_m"),
+        angle_deg=_to_float(data.get("angle_deg", 0.0), f"parts[{index}].angle_deg"),
+        z_bottom_m=_to_float(data["z_bottom_m"], f"parts[{index}].z_bottom_m"),
+        z_top_m=_to_float(data["z_top_m"], f"parts[{index}].z_top_m"),
     )
 
 
@@ -226,11 +303,11 @@ def _build_struts_spec(data: dict[str, Any]) -> StrutsSpec:
         if key not in data:
             raise LoaderError(f"'struts' missing required field {key!r}")
     return StrutsSpec(
-        fuselage_attach_x_m=float(data["fuselage_attach_x_m"]),
-        fuselage_attach_y_m=float(data["fuselage_attach_y_m"]),
-        fuselage_attach_z_m=float(data["fuselage_attach_z_m"]),
-        wing_attach_y_m=float(data["wing_attach_y_m"]),
-        width_m=float(data["width_m"]),
+        fuselage_attach_x_m=_to_float(data["fuselage_attach_x_m"], "struts.fuselage_attach_x_m"),
+        fuselage_attach_y_m=_to_float(data["fuselage_attach_y_m"], "struts.fuselage_attach_y_m"),
+        fuselage_attach_z_m=_to_float(data["fuselage_attach_z_m"], "struts.fuselage_attach_z_m"),
+        wing_attach_y_m=_to_float(data["wing_attach_y_m"], "struts.wing_attach_y_m"),
+        width_m=_to_float(data["width_m"], "struts.width_m"),
     )
 
 
@@ -283,10 +360,10 @@ def _build_placement(data: Any) -> Placement:
             raise LoaderError(f"placement missing required field {key!r}")
     return Placement(
         plane_id=data["plane"],
-        x_m=float(data["x_m"]),
-        y_m=float(data["y_m"]),
-        heading_deg=float(data["heading_deg"]),
-        on_carts=bool(data.get("on_carts", False)),
+        x_m=_to_float(data["x_m"], "x_m"),
+        y_m=_to_float(data["y_m"], "y_m"),
+        heading_deg=_to_float(data["heading_deg"], "heading_deg"),
+        on_carts=_to_bool(data.get("on_carts", False), "on_carts"),
     )
 
 

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -1,0 +1,302 @@
+"""YAML → typed-model loader for hangarfit.
+
+Thin adapter layer between user-authored YAML files and the dataclasses
+in :mod:`hangarfit.models`. The loader's main job, besides translating
+types, is **error message quality** — a 250-line ``fleet.yaml`` is
+miserable to debug if errors only say "ValueError on line ?". Every
+exception raised here is a :class:`LoaderError` with the file path
+and (where it makes sense) the aircraft id or field name prepended.
+
+The loader also performs the one piece of build-time geometry that
+makes the parts-model schema readable: it expands each strut-braced
+aircraft's high-level ``struts:`` block into two mirrored strut
+:class:`~hangarfit.models.Part` instances. After loading, the
+aircraft's ``parts`` tuple is the single source of truth for geometry
+— there is no separate ``struts`` field on the :class:`Aircraft`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .models import (
+    Aircraft,
+    Door,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    Placement,
+    StrutsSpec,
+)
+
+
+class LoaderError(Exception):
+    """Raised when a YAML file is malformed or fails model validation."""
+
+
+def load_fleet(path: Path | str) -> dict[str, Aircraft]:
+    """Load ``fleet.yaml`` into a dict keyed by :attr:`Aircraft.id`.
+
+    Expands the optional ``struts:`` block on each aircraft into
+    mirrored strut Parts (one per side), folded into the final
+    ``parts`` tuple.
+    """
+    path = Path(path)
+    raw = _read_yaml(path)
+    if not isinstance(raw, dict) or "aircraft" not in raw:
+        raise LoaderError(f"{path}: top-level mapping must contain 'aircraft' list")
+    aircraft_list = raw["aircraft"]
+    if not isinstance(aircraft_list, list):
+        raise LoaderError(f"{path}: 'aircraft' must be a list")
+
+    fleet: dict[str, Aircraft] = {}
+    for i, entry in enumerate(aircraft_list):
+        if not isinstance(entry, dict):
+            raise LoaderError(
+                f"{path}: aircraft entry #{i} must be a mapping, got {type(entry).__name__}"
+            )
+        ident = entry.get("id", f"#{i}")
+        try:
+            aircraft = _build_aircraft(entry)
+        except (ValueError, KeyError, LoaderError) as e:
+            raise LoaderError(f"{path}: aircraft {ident!r}: {e}") from e
+        if aircraft.id in fleet:
+            raise LoaderError(f"{path}: duplicate aircraft id {aircraft.id!r}")
+        fleet[aircraft.id] = aircraft
+    return fleet
+
+
+def load_hangar(path: Path | str) -> Hangar:
+    """Load ``hangar.yaml`` into a :class:`Hangar`."""
+    path = Path(path)
+    raw = _read_yaml(path)
+    if not isinstance(raw, dict):
+        raise LoaderError(f"{path}: top-level must be a mapping")
+
+    door_data = raw.get("door")
+    if not isinstance(door_data, dict):
+        raise LoaderError(f"{path}: 'door' must be a mapping with 'center_x_m' and 'width_m'")
+
+    bay_data = raw.get("maintenance_bay")
+    if not isinstance(bay_data, dict):
+        raise LoaderError(f"{path}: 'maintenance_bay' must be a mapping with 'depth_m'")
+
+    for key in ("length_m", "width_m"):
+        if key not in raw:
+            raise LoaderError(f"{path}: missing required field {key!r}")
+    for key in ("center_x_m", "width_m"):
+        if key not in door_data:
+            raise LoaderError(f"{path}: missing required field 'door.{key}'")
+    if "depth_m" not in bay_data:
+        raise LoaderError(f"{path}: missing required field 'maintenance_bay.depth_m'")
+
+    try:
+        return Hangar(
+            length_m=float(raw["length_m"]),
+            width_m=float(raw["width_m"]),
+            door=Door(
+                center_x_m=float(door_data["center_x_m"]),
+                width_m=float(door_data["width_m"]),
+            ),
+            maintenance_bay=MaintenanceBay(depth_m=float(bay_data["depth_m"])),
+            clearance_m=float(raw.get("clearance_m", 0.3)),
+            wing_layer_clearance_m=float(raw.get("wing_layer_clearance_m", 0.2)),
+        )
+    except (ValueError, TypeError) as e:
+        raise LoaderError(f"{path}: {e}") from e
+
+
+def load_layout(
+    path: Path | str,
+    *,
+    fleet: dict[str, Aircraft] | None = None,
+    hangar: Hangar | None = None,
+) -> Layout:
+    """Load a layout YAML.
+
+    If ``fleet`` and ``hangar`` are provided, the YAML's ``fleet:`` and
+    ``hangar:`` fields are ignored. Otherwise, those fields are
+    interpreted as paths **relative to the layout YAML's parent
+    directory** and loaded.
+    """
+    path = Path(path)
+    raw = _read_yaml(path)
+    if not isinstance(raw, dict):
+        raise LoaderError(f"{path}: top-level must be a mapping")
+
+    if fleet is None:
+        fleet_ref = raw.get("fleet")
+        if fleet_ref is None:
+            raise LoaderError(
+                f"{path}: 'fleet' field is required when no fleet override is provided"
+            )
+        fleet = load_fleet((path.parent / fleet_ref).resolve())
+
+    if hangar is None:
+        hangar_ref = raw.get("hangar")
+        if hangar_ref is None:
+            raise LoaderError(
+                f"{path}: 'hangar' field is required when no hangar override is provided"
+            )
+        hangar = load_hangar((path.parent / hangar_ref).resolve())
+
+    placements_data = raw.get("placements", [])
+    if not isinstance(placements_data, list):
+        raise LoaderError(f"{path}: 'placements' must be a list")
+    try:
+        placements = tuple(_build_placement(p) for p in placements_data)
+    except (ValueError, KeyError, TypeError) as e:
+        raise LoaderError(f"{path}: placement: {e}") from e
+
+    maintenance_plane: str | None = None
+    if isinstance(raw.get("maintenance"), dict):
+        maintenance_plane = raw["maintenance"].get("plane")
+
+    try:
+        return Layout(
+            fleet=fleet,
+            hangar=hangar,
+            placements=placements,
+            maintenance_plane=maintenance_plane,
+        )
+    except ValueError as e:
+        raise LoaderError(f"{path}: {e}") from e
+
+
+def _build_aircraft(entry: dict[str, Any]) -> Aircraft:
+    parts_data = entry.get("parts")
+    if not isinstance(parts_data, list) or not parts_data:
+        raise LoaderError("'parts' must be a non-empty list")
+    parts = [_build_part(p, i) for i, p in enumerate(parts_data)]
+
+    if "struts" in entry:
+        if not isinstance(entry["struts"], dict):
+            raise LoaderError("'struts' must be a mapping")
+        spec = _build_struts_spec(entry["struts"])
+        wing = next((p for p in parts if p.kind == "wing"), None)
+        if wing is None:
+            raise LoaderError("'struts' block requires a part of kind 'wing'")
+        parts.extend(_expand_struts(spec, wing))
+
+    return Aircraft(
+        id=entry["id"],
+        name=entry["name"],
+        wing_position=entry["wing_position"],
+        gear=entry["gear"],
+        movement_mode=entry["movement_mode"],
+        turn_radius_m=entry.get("turn_radius_m"),
+        measured=bool(entry.get("measured", False)),
+        parts=tuple(parts),
+        notes=entry.get("notes", ""),
+    )
+
+
+def _build_part(data: Any, index: int) -> Part:
+    if not isinstance(data, dict):
+        raise LoaderError(f"parts[{index}] must be a mapping")
+    required = ("kind", "length_m", "width_m", "z_bottom_m", "z_top_m")
+    for key in required:
+        if key not in data:
+            raise LoaderError(f"parts[{index}] missing required field {key!r}")
+    return Part(
+        kind=data["kind"],
+        length_m=float(data["length_m"]),
+        width_m=float(data["width_m"]),
+        offset_x_m=float(data.get("offset_x_m", 0.0)),
+        offset_y_m=float(data.get("offset_y_m", 0.0)),
+        angle_deg=float(data.get("angle_deg", 0.0)),
+        z_bottom_m=float(data["z_bottom_m"]),
+        z_top_m=float(data["z_top_m"]),
+    )
+
+
+def _build_struts_spec(data: dict[str, Any]) -> StrutsSpec:
+    required = (
+        "fuselage_attach_x_m",
+        "fuselage_attach_y_m",
+        "fuselage_attach_z_m",
+        "wing_attach_y_m",
+        "width_m",
+    )
+    for key in required:
+        if key not in data:
+            raise LoaderError(f"'struts' missing required field {key!r}")
+    return StrutsSpec(
+        fuselage_attach_x_m=float(data["fuselage_attach_x_m"]),
+        fuselage_attach_y_m=float(data["fuselage_attach_y_m"]),
+        fuselage_attach_z_m=float(data["fuselage_attach_z_m"]),
+        wing_attach_y_m=float(data["wing_attach_y_m"]),
+        width_m=float(data["width_m"]),
+    )
+
+
+def _expand_struts(spec: StrutsSpec, wing: Part) -> list[Part]:
+    """Build two mirrored strut Parts from a StrutsSpec + wing.
+
+    Each strut is modelled in plan view as a thin oriented rectangle
+    running outboard from the fuselage attach (y = ``fuselage_attach_y_m``)
+    to the wing attach (y = ``wing_attach_y_m``), at the same x as the
+    fuselage attach point. The strut's z-range is
+    ``[fuselage_attach_z_m, wing.z_bottom_m]`` — i.e. from the lower
+    fuselage attach point up to the wing underside.
+    """
+    if wing.z_bottom_m <= spec.fuselage_attach_z_m:
+        raise LoaderError(
+            f"strut z_top (wing.z_bottom_m={wing.z_bottom_m}) must be above "
+            f"strut z_bottom (fuselage_attach_z_m={spec.fuselage_attach_z_m}). "
+            f"Struts only make sense when the wing is above the fuselage attach point."
+        )
+    strut_span = spec.wing_attach_y_m - spec.fuselage_attach_y_m
+    if strut_span <= 0:
+        raise LoaderError(
+            f"strut would have zero outboard span "
+            f"(wing_attach_y_m={spec.wing_attach_y_m}, "
+            f"fuselage_attach_y_m={spec.fuselage_attach_y_m}); "
+            f"loader requires a strictly positive span"
+        )
+    midpoint = (spec.fuselage_attach_y_m + spec.wing_attach_y_m) / 2.0
+    common = {
+        "kind": "strut",
+        "length_m": spec.width_m,
+        "width_m": strut_span,
+        "offset_x_m": spec.fuselage_attach_x_m,
+        "angle_deg": 0.0,
+        "z_bottom_m": spec.fuselage_attach_z_m,
+        "z_top_m": wing.z_bottom_m,
+    }
+    return [
+        Part(offset_y_m=midpoint, **common),   # right side
+        Part(offset_y_m=-midpoint, **common),  # left side
+    ]
+
+
+def _build_placement(data: Any) -> Placement:
+    if not isinstance(data, dict):
+        raise LoaderError(f"placement must be a mapping, got {type(data).__name__}")
+    required = ("plane", "x_m", "y_m", "heading_deg")
+    for key in required:
+        if key not in data:
+            raise LoaderError(f"placement missing required field {key!r}")
+    return Placement(
+        plane_id=data["plane"],
+        x_m=float(data["x_m"]),
+        y_m=float(data["y_m"]),
+        heading_deg=float(data["heading_deg"]),
+        on_carts=bool(data.get("on_carts", False)),
+    )
+
+
+def _read_yaml(path: Path) -> Any:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError as e:
+        raise LoaderError(f"file not found: {path}") from e
+    except yaml.YAMLError as e:
+        raise LoaderError(f"{path}: YAML parse error: {e}") from e
+
+

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -22,6 +22,9 @@ MovementMode = Literal["always_cart", "always_own_gear", "cart_eligible"]
 PartKind = Literal["fuselage", "wing", "strut", "tail"]
 
 _VALID_PART_KINDS = frozenset(typing.get_args(PartKind))
+_VALID_WING_POSITIONS = frozenset(typing.get_args(WingPosition))
+_VALID_GEARS = frozenset(typing.get_args(Gear))
+_VALID_MOVEMENT_MODES = frozenset(typing.get_args(MovementMode))
 
 
 @dataclass(frozen=True, slots=True)
@@ -155,6 +158,21 @@ class Aircraft:
             raise ValueError(f"Aircraft {self.id!r}: name must be non-empty")
         if not self.parts:
             raise ValueError(f"Aircraft {self.id!r}: parts must be non-empty")
+        if self.wing_position not in _VALID_WING_POSITIONS:
+            raise ValueError(
+                f"Aircraft {self.id!r}: wing_position must be one of "
+                f"{sorted(_VALID_WING_POSITIONS)}, got {self.wing_position!r}"
+            )
+        if self.gear not in _VALID_GEARS:
+            raise ValueError(
+                f"Aircraft {self.id!r}: gear must be one of "
+                f"{sorted(_VALID_GEARS)}, got {self.gear!r}"
+            )
+        if self.movement_mode not in _VALID_MOVEMENT_MODES:
+            raise ValueError(
+                f"Aircraft {self.id!r}: movement_mode must be one of "
+                f"{sorted(_VALID_MOVEMENT_MODES)}, got {self.movement_mode!r}"
+            )
         if self.movement_mode != "always_cart":
             if self.turn_radius_m is None:
                 raise ValueError(

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,614 @@
+"""Tests for hangarfit.loader.
+
+The loader's main job, besides type translation, is **error message
+quality** when YAML edits go wrong. Most tests focus on the failure
+paths: which YAML problem produces which LoaderError text.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hangarfit.loader import (
+    LoaderError,
+    load_fleet,
+    load_hangar,
+    load_layout,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FLEET_YAML = REPO_ROOT / "data" / "fleet.yaml"
+HANGAR_YAML = REPO_ROOT / "data" / "hangar.yaml"
+EXAMPLE_LAYOUT = REPO_ROOT / "layouts" / "example.yaml"
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# ----------------------------------------------------------------------------
+# Happy-path: load the real bundled data files.
+# ----------------------------------------------------------------------------
+
+
+class TestRealDataFiles:
+    """Loading the actual data/ and layouts/ files in the repo."""
+
+    def test_load_fleet(self) -> None:
+        fleet = load_fleet(FLEET_YAML)
+        assert set(fleet) == {
+            "scheibe_falke",
+            "aviat_husky",
+            "fuji",
+            "wild_thing",
+            "zlin_savage",
+            "cessna_140",
+            "cessna_150",
+            "ctsl",
+            "fk9_mkii",
+        }
+        # Every fleet aircraft's id matches its dict key
+        for k, a in fleet.items():
+            assert a.id == k
+
+    def test_strut_braced_planes_have_two_strut_parts_each(self) -> None:
+        fleet = load_fleet(FLEET_YAML)
+        strut_braced = {
+            "aviat_husky",
+            "wild_thing",
+            "zlin_savage",
+            "cessna_140",
+            "cessna_150",
+            "fk9_mkii",
+        }
+        for aid in strut_braced:
+            struts = [p for p in fleet[aid].parts if p.kind == "strut"]
+            assert len(struts) == 2, f"{aid} should have 2 strut parts, got {len(struts)}"
+
+    def test_cantilever_planes_have_no_strut_parts(self) -> None:
+        fleet = load_fleet(FLEET_YAML)
+        cantilever = {"scheibe_falke", "fuji", "ctsl"}
+        for aid in cantilever:
+            assert all(p.kind != "strut" for p in fleet[aid].parts), (
+                f"{aid} (cantilever) should have no strut parts"
+            )
+
+    def test_expanded_struts_are_mirrored(self) -> None:
+        """For each strut-braced plane, the two strut parts should have
+        equal-and-opposite offset_y_m (mirrored across the y=0 plane)."""
+        fleet = load_fleet(FLEET_YAML)
+        for aid in ("aviat_husky", "cessna_150", "fk9_mkii"):
+            struts = [p for p in fleet[aid].parts if p.kind == "strut"]
+            assert len(struts) == 2
+            ys = sorted(p.offset_y_m for p in struts)
+            assert ys[0] == -ys[1], f"{aid}: strut offsets not mirrored: {ys}"
+            assert ys[1] > 0, f"{aid}: at least one strut should be on +y side"
+
+    def test_strut_z_range_uses_wing_z_bottom(self) -> None:
+        """Strut z_top should equal the wing's z_bottom_m for each plane."""
+        fleet = load_fleet(FLEET_YAML)
+        for aid, a in fleet.items():
+            wing = next((p for p in a.parts if p.kind == "wing"), None)
+            struts = [p for p in a.parts if p.kind == "strut"]
+            if not struts:
+                continue
+            assert wing is not None
+            for s in struts:
+                assert s.z_top_m == wing.z_bottom_m, (
+                    f"{aid} strut z_top={s.z_top_m} != wing z_bottom={wing.z_bottom_m}"
+                )
+
+    def test_all_placeholders_flagged(self) -> None:
+        """Every aircraft in the bundled fleet.yaml should be flagged as
+        unmeasured — a regression guard so we notice if someone forgets
+        to flip a flag when adding real measurements."""
+        fleet = load_fleet(FLEET_YAML)
+        for aid, a in fleet.items():
+            assert a.measured is False, f"{aid}: bundled data should be measured: false"
+
+    def test_load_hangar(self) -> None:
+        hangar = load_hangar(HANGAR_YAML)
+        assert hangar.length_m == 25.0
+        assert hangar.width_m == 18.0
+        assert hangar.door.center_x_m == 9.0
+        assert hangar.maintenance_bay.depth_m == 9.0
+
+    def test_load_example_layout(self) -> None:
+        layout = load_layout(EXAMPLE_LAYOUT)
+        assert len(layout.placements) == 9
+        assert layout.maintenance_plane == "cessna_150"
+
+
+# ----------------------------------------------------------------------------
+# File-level loader errors.
+# ----------------------------------------------------------------------------
+
+
+class TestFleetLoaderErrors:
+    def test_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(LoaderError, match="file not found"):
+            load_fleet(tmp_path / "nonexistent.yaml")
+
+    def test_malformed_yaml(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "bad.yaml", "aircraft: [unclosed")
+        with pytest.raises(LoaderError, match="YAML parse error"):
+            load_fleet(path)
+
+    def test_missing_top_level_aircraft(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "f.yaml", "fleet: []\n")
+        with pytest.raises(LoaderError, match="must contain 'aircraft'"):
+            load_fleet(path)
+
+    def test_aircraft_not_a_list(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "f.yaml", "aircraft: not_a_list\n")
+        with pytest.raises(LoaderError, match="'aircraft' must be a list"):
+            load_fleet(path)
+
+    def test_duplicate_aircraft_id(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "f.yaml",
+            _fleet_yaml(_aircraft_entry("foo"), _aircraft_entry("foo")),
+        )
+        with pytest.raises(LoaderError, match="duplicate aircraft id 'foo'"):
+            load_fleet(path)
+
+    def test_aircraft_missing_parts(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: foo
+    name: Foo
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+""",
+        )
+        with pytest.raises(LoaderError, match="aircraft 'foo': 'parts' must be a non-empty list"):
+            load_fleet(path)
+
+    def test_part_missing_required_field(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: foo
+    name: Foo
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+""",
+        )
+        with pytest.raises(LoaderError, match="missing required field 'width_m'"):
+            load_fleet(path)
+
+    def test_invalid_part_kind_propagated_from_model(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: foo
+    name: Foo
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    parts:
+      - kind: fueslage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+""",
+        )
+        with pytest.raises(LoaderError, match="kind must be one of"):
+            load_fleet(path)
+
+    def test_model_validation_error_includes_aircraft_id(self, tmp_path: Path) -> None:
+        """Aircraft.__post_init__ ValueError should be re-raised as LoaderError
+        with the aircraft id prepended for navigation."""
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: bad_husky
+    name: Bad Husky
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    # turn_radius_m missing — required for always_own_gear
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+""",
+        )
+        with pytest.raises(LoaderError, match="aircraft 'bad_husky'.*turn_radius_m is required"):
+            load_fleet(path)
+
+
+# ----------------------------------------------------------------------------
+# Strut expansion.
+# ----------------------------------------------------------------------------
+
+
+class TestStrutExpansion:
+    def test_struts_without_wing_part_rejected(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: weird
+    name: Weird
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+    struts:
+      fuselage_attach_x_m: 0.5
+      fuselage_attach_y_m: 0.4
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.8
+      width_m: 0.05
+""",
+        )
+        with pytest.raises(LoaderError, match="requires a part of kind 'wing'"):
+            load_fleet(path)
+
+    def test_struts_with_low_wing_rejected(self, tmp_path: Path) -> None:
+        """A wing whose z_bottom is below or equal to the strut's fuselage
+        attach height makes no geometric sense — the strut would point
+        downward. Loader catches it with a clear message."""
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: low_wing_with_struts
+    name: Bogus
+    wing_position: low
+    gear: nosewheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.5
+        width_m: 9.0
+        z_bottom_m: 0.4
+        z_top_m: 0.6
+    struts:
+      fuselage_attach_x_m: 0.5
+      fuselage_attach_y_m: 0.4
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.8
+      width_m: 0.05
+""",
+        )
+        with pytest.raises(LoaderError, match="Struts only make sense when the wing is above"):
+            load_fleet(path)
+
+    def test_strut_span_must_be_positive(self, tmp_path: Path) -> None:
+        """StrutsSpec allows wing_attach_y_m == fuselage_attach_y_m (degenerate
+        boundary), but the loader requires strict span > 0 to build a usable Part."""
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: degenerate
+    name: Degenerate
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.5
+        width_m: 9.0
+        z_bottom_m: 2.0
+        z_top_m: 2.3
+    struts:
+      fuselage_attach_x_m: 0.5
+      fuselage_attach_y_m: 0.8
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 0.8
+      width_m: 0.05
+""",
+        )
+        with pytest.raises(LoaderError, match="zero outboard span"):
+            load_fleet(path)
+
+
+# ----------------------------------------------------------------------------
+# Hangar loader.
+# ----------------------------------------------------------------------------
+
+
+class TestHangarLoaderErrors:
+    def test_missing_length(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "h.yaml",
+            """
+width_m: 18.0
+door: {center_x_m: 9, width_m: 12}
+maintenance_bay: {depth_m: 9}
+""",
+        )
+        with pytest.raises(LoaderError, match="missing required field 'length_m'"):
+            load_hangar(path)
+
+    def test_missing_door_block(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "h.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+maintenance_bay: {depth_m: 9}
+""",
+        )
+        with pytest.raises(LoaderError, match="'door' must be a mapping"):
+            load_hangar(path)
+
+    def test_missing_door_center_x(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "h.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {width_m: 12}
+maintenance_bay: {depth_m: 9}
+""",
+        )
+        with pytest.raises(LoaderError, match="missing required field 'door.center_x_m'"):
+            load_hangar(path)
+
+    def test_door_does_not_fit_propagates_from_model(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "h.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 1.0, width_m: 12.0}
+maintenance_bay: {depth_m: 9}
+""",
+        )
+        with pytest.raises(LoaderError, match="doesn't fit in hangar width"):
+            load_hangar(path)
+
+    def test_clearance_defaults_applied(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "h.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 9.0, width_m: 12.0}
+maintenance_bay: {depth_m: 9}
+""",
+        )
+        h = load_hangar(path)
+        assert h.clearance_m == 0.3
+        assert h.wing_layer_clearance_m == 0.2
+
+
+# ----------------------------------------------------------------------------
+# Layout loader: path resolution + cross-reference errors.
+# ----------------------------------------------------------------------------
+
+
+class TestLayoutLoader:
+    def _minimal_fleet_and_hangar(self, dir_: Path) -> tuple[Path, Path]:
+        fleet = _write(
+            dir_ / "fleet.yaml",
+            _minimal_aircraft_yaml("foo", movement_mode="always_own_gear", turn_radius_m=5.0),
+        )
+        hangar = _write(
+            dir_ / "hangar.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 9.0, width_m: 12.0}
+maintenance_bay: {depth_m: 9}
+""",
+        )
+        return fleet, hangar
+
+    def test_happy_path(self, tmp_path: Path) -> None:
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - plane: foo
+    x_m: 5.0
+    y_m: 5.0
+    heading_deg: 0
+    on_carts: false
+""",
+        )
+        layout = load_layout(layout_path)
+        assert len(layout.placements) == 1
+        assert layout.placements[0].plane_id == "foo"
+
+    def test_unknown_plane_reference_propagates(self, tmp_path: Path) -> None:
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - plane: ghost
+    x_m: 5.0
+    y_m: 5.0
+    heading_deg: 0
+""",
+        )
+        with pytest.raises(LoaderError, match="unknown plane_id 'ghost'"):
+            load_layout(layout_path)
+
+    def test_cart_rule_violation_propagates(self, tmp_path: Path) -> None:
+        # Two cart_eligible planes, both on_carts=true
+        _write(
+            tmp_path / "fleet.yaml",
+            _fleet_yaml(
+                _aircraft_entry("a", movement_mode="cart_eligible", turn_radius_m=4.0),
+                _aircraft_entry("b", movement_mode="cart_eligible", turn_radius_m=4.0),
+            ),
+        )
+        _write(
+            tmp_path / "hangar.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 9.0, width_m: 12.0}
+maintenance_bay: {depth_m: 9}
+""",
+        )
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: a, x_m: 5, y_m: 5, heading_deg: 0, on_carts: true}
+  - {plane: b, x_m: 10, y_m: 5, heading_deg: 0, on_carts: true}
+""",
+        )
+        with pytest.raises(LoaderError, match="At most one cart_eligible"):
+            load_layout(layout_path)
+
+    def test_fleet_and_hangar_overrides(self, tmp_path: Path) -> None:
+        """When fleet/hangar are supplied as args, the YAML's references are ignored."""
+        fleet_path, hangar_path = self._minimal_fleet_and_hangar(tmp_path)
+        # Layout YAML references nonexistent files — they should be ignored.
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: does-not-exist.yaml
+hangar: also-does-not-exist.yaml
+placements:
+  - {plane: foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+""",
+        )
+        layout = load_layout(
+            layout_path,
+            fleet=load_fleet(fleet_path),
+            hangar=load_hangar(hangar_path),
+        )
+        assert "foo" in layout.fleet
+
+    def test_layout_missing_fleet_ref(self, tmp_path: Path) -> None:
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+hangar: hangar.yaml
+placements: []
+""",
+        )
+        with pytest.raises(LoaderError, match="'fleet' field is required"):
+            load_layout(layout_path)
+
+    def test_layout_missing_hangar_ref(self, tmp_path: Path) -> None:
+        _write(tmp_path / "fleet.yaml", _minimal_aircraft_yaml("foo", movement_mode="always_own_gear", turn_radius_m=5.0))
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+placements: []
+""",
+        )
+        with pytest.raises(LoaderError, match="'hangar' field is required"):
+            load_layout(layout_path)
+
+    def test_placement_missing_required_field(self, tmp_path: Path) -> None:
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: foo, x_m: 5, y_m: 5}
+""",
+        )
+        with pytest.raises(LoaderError, match="missing required field 'heading_deg'"):
+            load_layout(layout_path)
+
+
+# ----------------------------------------------------------------------------
+# YAML helpers
+# ----------------------------------------------------------------------------
+
+
+def _aircraft_entry(
+    plane_id: str,
+    *,
+    movement_mode: str = "always_own_gear",
+    turn_radius_m: float | None = 5.0,
+) -> str:
+    """One aircraft entry for a fleet YAML (no top-level 'aircraft:' key).
+    Compose multiple entries via :func:`_fleet_yaml`."""
+    radius_yaml = (
+        f"turn_radius_m: {turn_radius_m}" if turn_radius_m is not None else "turn_radius_m: null"
+    )
+    return f"""\
+  - id: {plane_id}
+    name: "Plane {plane_id}"
+    wing_position: high
+    gear: tailwheel
+    movement_mode: {movement_mode}
+    {radius_yaml}
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.5
+        width_m: 9.0
+        z_bottom_m: 2.0
+        z_top_m: 2.3
+"""
+
+
+def _fleet_yaml(*entries: str) -> str:
+    """Wrap one or more aircraft entries in a fleet YAML document."""
+    return "aircraft:\n" + "".join(entries)
+
+
+def _minimal_aircraft_yaml(
+    plane_id: str,
+    *,
+    movement_mode: str = "always_own_gear",
+    turn_radius_m: float | None = 5.0,
+) -> str:
+    """Convenience: build a complete single-aircraft fleet YAML."""
+    return _fleet_yaml(_aircraft_entry(plane_id, movement_mode=movement_mode, turn_radius_m=turn_radius_m))

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -37,6 +37,15 @@ def _write(path: Path, text: str) -> Path:
 class TestRealDataFiles:
     """Loading the actual data/ and layouts/ files in the repo."""
 
+    def test_bundled_data_files_exist(self) -> None:
+        """Sentinel: if a bundled data file is renamed/deleted, every other
+        test in this class will produce a confusing 'file not found' error.
+        This test surfaces that scenario with a clearly intent-revealing
+        failure first."""
+        assert FLEET_YAML.exists(), f"bundled fleet file missing: {FLEET_YAML}"
+        assert HANGAR_YAML.exists(), f"bundled hangar file missing: {HANGAR_YAML}"
+        assert EXAMPLE_LAYOUT.exists(), f"bundled example layout missing: {EXAMPLE_LAYOUT}"
+
     def test_load_fleet(self) -> None:
         fleet = load_fleet(FLEET_YAML)
         assert set(fleet) == {
@@ -104,10 +113,33 @@ class TestRealDataFiles:
     def test_all_placeholders_flagged(self) -> None:
         """Every aircraft in the bundled fleet.yaml should be flagged as
         unmeasured — a regression guard so we notice if someone forgets
-        to flip a flag when adding real measurements."""
+        to flip a flag when adding real measurements.
+
+        Tripwire: when the first aircraft actually gets measured, this
+        test should be flipped (assert per-aircraft expected state)
+        rather than deleted."""
         fleet = load_fleet(FLEET_YAML)
         for aid, a in fleet.items():
             assert a.measured is False, f"{aid}: bundled data should be measured: false"
+
+    def test_representative_values_pinned(self) -> None:
+        """One representative dimension per aircraft (pinned). Guards
+        against silent edits to fleet.yaml values that wouldn't fail
+        any other test (count/shape/property tests would all still pass
+        if e.g. the Husky's wingspan were typo'd from 10.7 to 1.07)."""
+        fleet = load_fleet(FLEET_YAML)
+        # Wingspan = width_m of the wing part.
+        wing_widths = {
+            aid: next(p.width_m for p in a.parts if p.kind == "wing")
+            for aid, a in fleet.items()
+        }
+        # Loose ballpark check: every wingspan in [4, 20] m (sanity range
+        # for the fleet). A decimal-point typo (10.7 → 1.07) is caught.
+        for aid, w in wing_widths.items():
+            assert 4.0 < w < 20.0, f"{aid}: wingspan {w} m is outside sanity range"
+        # And pin a couple of specific values so single-plane edits surface.
+        assert wing_widths["scheibe_falke"] == 16.6
+        assert wing_widths["fuji"] == 9.4
 
     def test_load_hangar(self) -> None:
         hangar = load_hangar(HANGAR_YAML)
@@ -212,6 +244,135 @@ aircraft:
         with pytest.raises(LoaderError, match="kind must be one of"):
             load_fleet(path)
 
+    def test_aircraft_entry_not_a_mapping(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - just_a_string
+""",
+        )
+        with pytest.raises(LoaderError, match="must be a mapping"):
+            load_fleet(path)
+
+    def test_aircraft_missing_top_level_field(self, tmp_path: Path) -> None:
+        """An aircraft entry missing 'name' (or any other top-level required
+        field) should produce a clear 'missing required field' message,
+        not a bare quoted KeyError."""
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: foo
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+""",
+        )
+        with pytest.raises(LoaderError, match="missing required field 'name'"):
+            load_fleet(path)
+
+    def test_aircraft_missing_id_uses_fallback(self, tmp_path: Path) -> None:
+        """When the aircraft entry has no 'id', the loader uses '#<index>'
+        as the identifier in the wrapped error message."""
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - name: Anonymous
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+""",
+        )
+        with pytest.raises(LoaderError, match="aircraft '#0'.*missing required field 'id'"):
+            load_fleet(path)
+
+    def test_null_numeric_field_clear_error(self, tmp_path: Path) -> None:
+        """`length_m:` (YAML null) used to leak as TypeError; now caught."""
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: foo
+    name: Foo
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    parts:
+      - kind: fuselage
+        length_m:
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+""",
+        )
+        with pytest.raises(LoaderError, match="'parts\\[0\\].length_m'.*expected number, got null"):
+            load_fleet(path)
+
+    def test_quoted_bool_for_measured_rejected(self, tmp_path: Path) -> None:
+        """`measured: "false"` (quoted) would silently be True via bool()."""
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: foo
+    name: Foo
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    measured: "false"
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+""",
+        )
+        with pytest.raises(LoaderError, match="'measured': expected boolean"):
+            load_fleet(path)
+
+    def test_invalid_movement_mode_caught(self, tmp_path: Path) -> None:
+        """Typo in movement_mode used to leak silently past the Layout cart
+        rule (Aircraft.__post_init__ now validates the Literal set)."""
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: foo
+    name: Foo
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_carts
+    turn_radius_m: 5.0
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+""",
+        )
+        with pytest.raises(LoaderError, match="movement_mode must be one of"):
+            load_fleet(path)
+
     def test_model_validation_error_includes_aircraft_id(self, tmp_path: Path) -> None:
         """Aircraft.__post_init__ ValueError should be re-raised as LoaderError
         with the aircraft id prepended for navigation."""
@@ -307,6 +468,50 @@ aircraft:
         with pytest.raises(LoaderError, match="Struts only make sense when the wing is above"):
             load_fleet(path)
 
+    def test_first_wing_part_drives_strut_z_top(self, tmp_path: Path) -> None:
+        """If an aircraft has multiple wing parts (unusual: split-wing, twin
+        booms), the strut z_top is inferred from the FIRST wing part. Pin
+        this behavior so refactoring to last-wins or raising would surface."""
+        path = _write(
+            tmp_path / "f.yaml",
+            """
+aircraft:
+  - id: split_wing
+    name: Split Wing
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    parts:
+      - kind: wing
+        length_m: 1.5
+        width_m: 5.0
+        z_bottom_m: 2.0
+        z_top_m: 2.3
+      - kind: wing
+        length_m: 1.5
+        width_m: 5.0
+        z_bottom_m: 2.5
+        z_top_m: 2.8
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+    struts:
+      fuselage_attach_x_m: 0.5
+      fuselage_attach_y_m: 0.4
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.8
+      width_m: 0.05
+""",
+        )
+        fleet = load_fleet(path)
+        struts = [p for p in fleet["split_wing"].parts if p.kind == "strut"]
+        assert len(struts) == 2
+        # First wing (z_bottom=2.0) wins, NOT the second wing (z_bottom=2.5).
+        assert all(s.z_top_m == 2.0 for s in struts)
+
     def test_strut_span_must_be_positive(self, tmp_path: Path) -> None:
         """StrutsSpec allows wing_attach_y_m == fuselage_attach_y_m (degenerate
         boundary), but the loader requires strict span > 0 to build a usable Part."""
@@ -397,6 +602,36 @@ maintenance_bay: {depth_m: 9}
 """,
         )
         with pytest.raises(LoaderError, match="doesn't fit in hangar width"):
+            load_hangar(path)
+
+    def test_top_level_not_a_mapping(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "h.yaml", "- a\n- b\n")
+        with pytest.raises(LoaderError, match="top-level must be a mapping"):
+            load_hangar(path)
+
+    def test_missing_maintenance_bay_block(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "h.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 9, width_m: 12}
+""",
+        )
+        with pytest.raises(LoaderError, match="'maintenance_bay' must be a mapping"):
+            load_hangar(path)
+
+    def test_missing_maintenance_bay_depth(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "h.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 9, width_m: 12}
+maintenance_bay: {}
+""",
+        )
+        with pytest.raises(LoaderError, match="missing required field 'maintenance_bay.depth_m'"):
             load_hangar(path)
 
     def test_clearance_defaults_applied(self, tmp_path: Path) -> None:
@@ -504,14 +739,13 @@ placements:
             load_layout(layout_path)
 
     def test_fleet_and_hangar_overrides(self, tmp_path: Path) -> None:
-        """When fleet/hangar are supplied as args, the YAML's references are ignored."""
+        """When fleet/hangar are supplied as args AND the YAML omits those
+        fields, the overrides are used. (When BOTH are present, the loader
+        refuses to disambiguate — see test_override_and_yaml_ref_conflict_*.)"""
         fleet_path, hangar_path = self._minimal_fleet_and_hangar(tmp_path)
-        # Layout YAML references nonexistent files — they should be ignored.
         layout_path = _write(
             tmp_path / "layout.yaml",
             """
-fleet: does-not-exist.yaml
-hangar: also-does-not-exist.yaml
 placements:
   - {plane: foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
 """,
@@ -559,6 +793,129 @@ placements:
         )
         with pytest.raises(LoaderError, match="missing required field 'heading_deg'"):
             load_layout(layout_path)
+
+    def test_top_level_not_a_mapping(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "layout.yaml", "- a\n- b\n")
+        with pytest.raises(LoaderError, match="top-level must be a mapping"):
+            load_layout(path)
+
+    def test_placements_not_a_list(self, tmp_path: Path) -> None:
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements: not_a_list
+""",
+        )
+        with pytest.raises(LoaderError, match="'placements' must be a list"):
+            load_layout(layout_path)
+
+    def test_placement_entry_not_a_mapping(self, tmp_path: Path) -> None:
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - just_a_string
+""",
+        )
+        with pytest.raises(LoaderError, match="placement.*must be a mapping"):
+            load_layout(layout_path)
+
+    def test_quoted_bool_for_on_carts_rejected(self, tmp_path: Path) -> None:
+        """The canonical YAML footgun: `on_carts: "false"` (quoted) used to
+        silently become True via bool('false')."""
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: "false"}
+""",
+        )
+        with pytest.raises(LoaderError, match="'on_carts': expected boolean"):
+            load_layout(layout_path)
+
+    def test_maintenance_shorthand_rejected(self, tmp_path: Path) -> None:
+        """Typo `maintenance: cessna_150` (no nested `plane:` key) used to
+        silently produce maintenance_plane=None."""
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+maintenance: foo
+""",
+        )
+        with pytest.raises(LoaderError, match="'maintenance' must be a mapping"):
+            load_layout(layout_path)
+
+    def test_maintenance_block_missing_plane_key(self, tmp_path: Path) -> None:
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+maintenance:
+  comment: forgot the plane key
+""",
+        )
+        with pytest.raises(LoaderError, match="'maintenance' block present but lacks required 'plane'"):
+            load_layout(layout_path)
+
+    def test_override_and_yaml_ref_conflict_for_fleet(self, tmp_path: Path) -> None:
+        """If the layout YAML has `fleet:` AND the caller passes a fleet
+        override, the loader refuses to silently shadow one with the other."""
+        fleet_path, hangar_path = self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements: []
+""",
+        )
+        with pytest.raises(LoaderError, match="'fleet' field is set in YAML but a fleet override"):
+            load_layout(layout_path, fleet=load_fleet(fleet_path))
+
+    def test_override_and_yaml_ref_conflict_for_hangar(self, tmp_path: Path) -> None:
+        fleet_path, hangar_path = self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements: []
+""",
+        )
+        with pytest.raises(LoaderError, match="'hangar' field is set in YAML but a hangar override"):
+            load_layout(layout_path, hangar=load_hangar(hangar_path))
+
+    def test_helper_composition_yields_two_aircraft(self, tmp_path: Path) -> None:
+        """Pin the helper composition: `_fleet_yaml(entry_a, entry_b)`
+        produces a fleet with TWO aircraft (PyYAML's last-key-wins
+        regression would have produced one — the original bug)."""
+        path = _write(
+            tmp_path / "f.yaml",
+            _fleet_yaml(
+                _aircraft_entry("a"),
+                _aircraft_entry("b"),
+            ),
+        )
+        fleet = load_fleet(path)
+        assert set(fleet) == {"a", "b"}
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -269,6 +269,50 @@ class TestAircraft:
         with pytest.raises(AssertionError, match="turn_radius_m is None"):
             a.required_turn_radius_m()
 
+    @pytest.mark.parametrize("wing_position", ["", "middle", "High", "MID", "bottom"])
+    def test_invalid_wing_position_rejected(self, wing_position: str) -> None:
+        with pytest.raises(ValueError, match="wing_position must be one of"):
+            Aircraft(
+                id="x",
+                name="X",
+                wing_position=wing_position,  # type: ignore[arg-type]
+                gear="tailwheel",
+                movement_mode="always_cart",
+                turn_radius_m=None,
+                measured=False,
+                parts=(_ok_part(),),
+            )
+
+    @pytest.mark.parametrize("gear", ["", "skis", "Tailwheel", "floats", "TRICYCLE"])
+    def test_invalid_gear_rejected(self, gear: str) -> None:
+        with pytest.raises(ValueError, match="gear must be one of"):
+            Aircraft(
+                id="x",
+                name="X",
+                wing_position="high",
+                gear=gear,  # type: ignore[arg-type]
+                movement_mode="always_cart",
+                turn_radius_m=None,
+                measured=False,
+                parts=(_ok_part(),),
+            )
+
+    @pytest.mark.parametrize(
+        "movement_mode", ["", "always_carts", "OWN_GEAR", "cart-eligible", "anywhere"]
+    )
+    def test_invalid_movement_mode_rejected(self, movement_mode: str) -> None:
+        with pytest.raises(ValueError, match="movement_mode must be one of"):
+            Aircraft(
+                id="x",
+                name="X",
+                wing_position="high",
+                gear="tailwheel",
+                movement_mode=movement_mode,  # type: ignore[arg-type]
+                turn_radius_m=5.0,
+                measured=False,
+                parts=(_ok_part(),),
+            )
+
 
 class TestDoor:
     def test_valid_construction(self) -> None:


### PR DESCRIPTION
Closes #3.

The YAML schema, the loader that converts it into typed models, and the actual data files (all placeholder dimensions, all flagged `measured: false`).

## What's in this PR

| File | Purpose |
|---|---|
| `src/hangarfit/loader.py` | `load_fleet` / `load_hangar` / `load_layout` + `LoaderError` |
| `data/fleet.yaml` | 9 aircraft with placeholder dimensions |
| `data/hangar.yaml` | placeholder 25 m × 18 m hangar |
| `layouts/example.yaml` | hand-authored 9-plane candidate layout |
| `tests/test_loader.py` | 32 tests |

## Design notes

- **Strut expansion lives here** (in the loader), not in `geometry.py`. The loader takes each strut-braced aircraft's `struts:` block and expands it into two mirrored strut `Part`s before the `Aircraft` is constructed. After loading, the aircraft's `parts` tuple is the single source of truth for geometry — no separate `struts` field on `Aircraft` (per the design landed in #9).
- **Strut `z_top` is inferred from the wing's `z_bottom_m`** — there's no separate `wing_underside_m` field to keep in sync. Edit the wing's `z_bottom_m` and the strut updates automatically. Low-wing planes with a `struts:` block are rejected by the loader (wing underside would be at or below the fuselage attach height, making the strut z-range degenerate).
- **Error messages are the loader's main job.** Every `ValueError` from `__post_init__` is wrapped in a `LoaderError` with the file path and the aircraft id (or field name) prepended, so users can navigate a 250-line `fleet.yaml` when something breaks.
- **Layout YAML's `fleet:` and `hangar:` references** are interpreted as paths **relative to the layout YAML's parent directory** (standard "paths in config are relative to the config" idiom). The CLI in #7 will get `--fleet`/`--hangar` overrides for the case where the layout YAML is in an unusual location — `load_layout` already accepts those as kwargs.
- **`Aircraft.required_turn_radius_m()` accessor** from #9 is unused so far — it's there for the future Dubins planner. Loader populates `turn_radius_m` as `None` for `always_cart` planes (or as given for the others).

## Schema decisions baked into the data files

- **9 aircraft, dimensions are placeholders.** All entries have `measured: false` so you can grep that flag when real measurements arrive.
- **Strut-braced planes (6 of 9):** Husky, Wild Thing, Zlin Savage, Cessna 140, Cessna 150, FK9 Mk II. Cantilever (3): Falke, Fuji, CTSL.
- **Movement modes:** 3 `always_cart` (Falke, Wild Thing, Zlin Savage), 2 `always_own_gear` (Husky, Fuji), 4 `cart_eligible` (Cessnas, CTSL, FK9).
- **Coordinate convention** (plane-local): `+x` forward, `+y` right; origin at main-gear / cart centroid. World convention as in `CLAUDE.md`.

## Verification

```
$ pytest
================== 124 passed in 0.17s ==================
```

| Test class | What it covers |
|---|---|
| `TestRealDataFiles` | Loading the bundled `data/` and `layouts/` files end-to-end |
| `TestFleetLoaderErrors` | File not found, malformed YAML, missing top-level / fields, duplicate ids, model-validation propagation |
| `TestStrutExpansion` | Missing wing, low wing, zero span — and that real fleet.yaml produces 2 mirrored strut Parts with z_top = wing.z_bottom |
| `TestHangarLoaderErrors` | Missing fields, door doesn't fit (propagated from `Hangar.__post_init__`), default clearances |
| `TestLayoutLoader` | Path resolution, override args, unknown plane refs, cart-rule propagation, missing fleet/hangar refs |

Manual smoke load (from python REPL):

```
>>> from hangarfit.loader import load_fleet, load_layout
>>> fleet = load_fleet('data/fleet.yaml')
>>> len(fleet); sum(1 for a in fleet.values() for p in a.parts if p.kind == 'strut')
9
12   # 6 strut-braced planes × 2 strut parts each
>>> load_layout('layouts/example.yaml').maintenance_plane
'cessna_150'
```

## Workflow follow-up

1. `pr-review` runs after this PR is opened.
2. Findings (if any) become PR review threads, get resolved in a follow-up commit.
3. When clean, ready for your final review.

Milestone: `v0.1.0 — Foundation`. Depends on #2 (merged).

## Deferred / outstanding

- The `pyproject.toml` package-data question from PR #8 (whether `data/` ships as package-data or stays external) is **still deferred**. This PR treats `data/` as repo-only example data; the CLI in #7 will take explicit `--fleet` / `--hangar` flags. If you want `hangarfit check ...` to default to bundled data when no flags given, that's a future PR.
- Strut geometry is **simplified**: each strut is modelled as a thin rectangle running purely outboard in plan view (no forward sweep). Real Cessna struts have some forward sweep, but for placeholder data this approximation is fine. Refine in a future PR if real measurements show it matters.