### PR TITLE
feat(geometry): primitives + plane-local→world transform (#4)

### DIFF
--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
-import shapely
 from shapely.geometry import Polygon
 
 from .models import Aircraft, PartKind, Placement
@@ -91,7 +90,17 @@ def polygon_overlap(p1: Polygon, p2: Polygon, clearance: float = 0.0) -> bool:
     - ``clearance == 0``: conflict only on **actual area overlap**.
       Polygons that touch at the boundary (Shapely's ``touches``) are
       NOT a conflict — distance is 0 but no interior is shared.
+
+    Raises ``ValueError`` for negative ``clearance`` — there is no
+    sensible "negative clearance" semantic and the upstream
+    :class:`Hangar` already constrains the configured value to
+    non-negative, so a negative value here indicates a programming
+    error rather than a misconfigured layout.
     """
+    if clearance < 0:
+        raise ValueError(
+            f"polygon_overlap: clearance must be non-negative, got {clearance}"
+        )
     if clearance > 0:
         return p1.distance(p2) < clearance
     return p1.intersects(p2) and not p1.touches(p2)
@@ -151,11 +160,13 @@ def aircraft_parts_world(
             angle_deg=part.angle_deg,
         )
         # Apply the plane-local-to-world transform to each vertex.
+        # local_poly.exterior.coords includes the closing-point duplicate;
+        # slice it off so Polygon() doesn't have to de-dup.
         world_coords = [
             (px + u * sin_h + v * cos_h, py + u * cos_h - v * sin_h)
-            for u, v in local_poly.exterior.coords
+            for u, v in list(local_poly.exterior.coords)[:-1]
         ]
-        world_poly = shapely.geometry.Polygon(world_coords)
+        world_poly = Polygon(world_coords)
         world_parts.append(
             WorldPart(
                 polygon=world_poly,

--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -1,0 +1,168 @@
+"""Geometry primitives for hangarfit.
+
+Two distinct angle conventions live in this module and must be kept
+strictly separate:
+
+1. :func:`oriented_rect` uses **standard CCW math rotation** (positive
+   ``angle_deg`` rotates a vector counter-clockwise from world ``+x``
+   toward ``+y``). This is the generic 2D-rectangle builder and has no
+   knowledge of compass headings or plane-local axes.
+
+2. :func:`aircraft_parts_world` uses the **compass-style** transform
+   from plane-local ``(forward, right)`` to world ``(right-along-door,
+   deeper-into-hangar)`` documented in ``CLAUDE.md``. The linear part
+   of this transform has determinant ``−1`` — it is a rotation
+   composed with a reflection, **NOT** a pure rotation.
+
+Mixing the two conventions is the off-by-90° trap of the project.
+Tests must include at least one non-axis-aligned heading (45°) to
+catch any regression — see ``tests/test_geometry.py``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import shapely
+from shapely.geometry import Polygon
+
+from .models import Aircraft, PartKind, Placement
+
+
+@dataclass(frozen=True, slots=True)
+class WorldPart:
+    """A :class:`Part` after the plane-local → world transform.
+
+    The collision checker (#5) iterates over ``WorldPart`` instances:
+    two ``WorldPart``s from different aircraft conflict iff their
+    ``polygon``s are within clearance in plan view AND their z-ranges
+    overlap (see the collision rule in ``CLAUDE.md``).
+    """
+
+    polygon: Polygon
+    z_bottom_m: float
+    z_top_m: float
+    plane_id: str
+    kind: PartKind
+
+
+def oriented_rect(
+    cx: float,
+    cy: float,
+    length: float,
+    width: float,
+    angle_deg: float,
+) -> Polygon:
+    """Build an oriented rectangle as a Shapely ``Polygon``.
+
+    The rectangle is centered at ``(cx, cy)`` with the given dimensions.
+    At ``angle_deg = 0`` the length axis runs along world ``+x`` and the
+    width axis along world ``+y``. Positive ``angle_deg`` rotates the
+    length axis CCW from ``+x`` toward ``+y`` (standard math convention).
+
+    Note: this is a **generic** primitive — it does NOT know about
+    compass headings or plane-local axes. For aircraft transforms see
+    :func:`aircraft_parts_world`.
+    """
+    h = math.radians(angle_deg)
+    cos_h = math.cos(h)
+    sin_h = math.sin(h)
+    hl = length / 2.0
+    hw = width / 2.0
+    # Corners in local frame (CCW from front-right): +x is "forward", +y is "left side"
+    corners_local = [(hl, -hw), (hl, hw), (-hl, hw), (-hl, -hw)]
+    corners_world = [
+        (cx + x * cos_h - y * sin_h, cy + x * sin_h + y * cos_h)
+        for x, y in corners_local
+    ]
+    return Polygon(corners_world)
+
+
+def polygon_overlap(p1: Polygon, p2: Polygon, clearance: float = 0.0) -> bool:
+    """Whether two polygons conflict in plan view, given a clearance buffer.
+
+    - ``clearance > 0``: ``p1`` and ``p2`` conflict iff
+      ``p1.distance(p2) < clearance``. Overlapping polygons (distance 0)
+      always conflict; touching polygons (distance 0) conflict because
+      ``0 < clearance``; truly separated polygons conflict only when
+      closer than the clearance.
+
+    - ``clearance == 0``: conflict only on **actual area overlap**.
+      Polygons that touch at the boundary (Shapely's ``touches``) are
+      NOT a conflict — distance is 0 but no interior is shared.
+    """
+    if clearance > 0:
+        return p1.distance(p2) < clearance
+    return p1.intersects(p2) and not p1.touches(p2)
+
+
+def polygon_overlap_area(p1: Polygon, p2: Polygon) -> float:
+    """Area of the intersection of two polygons (``0.0`` if disjoint).
+
+    Useful for the ``Conflict.detail`` message ("overlap by 0.18 m²").
+    """
+    if not p1.intersects(p2):
+        return 0.0
+    return p1.intersection(p2).area
+
+
+def aircraft_parts_world(
+    aircraft: Aircraft,
+    placement: Placement,
+) -> list[WorldPart]:
+    """Transform every part of an aircraft from plane-local to world coords.
+
+    ``placement.heading_deg`` is the compass-style angle of the nose,
+    measured from world ``+y`` (deeper-into-hangar), CW positive.
+    At ``heading_deg = 0`` the plane's forward direction maps to world
+    ``+y``; at ``heading_deg = 90°`` it maps to world ``+x``.
+
+    The linear transform from plane-local ``(u, v)`` (``+u`` forward,
+    ``+v`` right) to world is:
+
+    .. code-block::
+
+        world_x = placement.x_m + u·sin(h) + v·cos(h)
+        world_y = placement.y_m + u·cos(h) − v·sin(h)
+
+    where ``h = radians(placement.heading_deg)``. The linear part has
+    determinant ``−1`` (rotation composed with reflection), reflecting
+    the (a) CW-positive compass convention vs CCW-positive math, and
+    (b) plane-local ``(forward, right)`` vs world ``(right, deeper)``.
+    See ``CLAUDE.md`` for the full derivation.
+    """
+    h = math.radians(placement.heading_deg)
+    sin_h = math.sin(h)
+    cos_h = math.cos(h)
+    px = placement.x_m
+    py = placement.y_m
+
+    world_parts: list[WorldPart] = []
+    for part in aircraft.parts:
+        # Build the part's polygon in plane-local coordinates. ``angle_deg``
+        # rotates the part within plane-local (standard CCW). This is the
+        # "in plane-local frame, where is the part?" step.
+        local_poly = oriented_rect(
+            cx=part.offset_x_m,
+            cy=part.offset_y_m,
+            length=part.length_m,
+            width=part.width_m,
+            angle_deg=part.angle_deg,
+        )
+        # Apply the plane-local-to-world transform to each vertex.
+        world_coords = [
+            (px + u * sin_h + v * cos_h, py + u * cos_h - v * sin_h)
+            for u, v in local_poly.exterior.coords
+        ]
+        world_poly = shapely.geometry.Polygon(world_coords)
+        world_parts.append(
+            WorldPart(
+                polygon=world_poly,
+                z_bottom_m=part.z_bottom_m,
+                z_top_m=part.z_top_m,
+                plane_id=placement.plane_id,
+                kind=part.kind,
+            )
+        )
+    return world_parts

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,391 @@
+"""Tests for hangarfit.geometry.
+
+The headline tests pin the **off-by-90° / determinant−1 trap** of the
+project: at a non-axis-aligned heading like 45°, the world coordinates
+of plane-local axes must point into the correct quadrants. Tests at
+0°, 90°, 180° alone do NOT catch a wrong-handedness implementation
+(they all happen to look right by symmetry).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from shapely.geometry import Polygon
+
+from hangarfit.geometry import (
+    WorldPart,
+    aircraft_parts_world,
+    oriented_rect,
+    polygon_overlap,
+    polygon_overlap_area,
+)
+from hangarfit.models import Aircraft, Part, Placement
+
+SQRT2_2 = math.sqrt(2) / 2  # ≈ 0.7071...
+
+
+def _sorted_corners(poly: Polygon) -> list[tuple[float, float]]:
+    """Polygon exterior coords sorted lexicographically (and with the
+    closing-point duplicate removed) for stable comparison."""
+    coords = list(poly.exterior.coords)
+    if coords and coords[0] == coords[-1]:
+        coords = coords[:-1]
+    return sorted(coords)
+
+
+def _almost_equal(a: float, b: float, tol: float = 1e-9) -> bool:
+    return abs(a - b) < tol
+
+
+def _corners_almost_equal(
+    poly: Polygon, expected: list[tuple[float, float]], tol: float = 1e-9
+) -> bool:
+    got = _sorted_corners(poly)
+    want = sorted(expected)
+    if len(got) != len(want):
+        return False
+    return all(
+        _almost_equal(gx, wx, tol) and _almost_equal(gy, wy, tol)
+        for (gx, gy), (wx, wy) in zip(got, want)
+    )
+
+
+# ----------------------------------------------------------------------------
+# oriented_rect
+# ----------------------------------------------------------------------------
+
+
+class TestOrientedRect:
+    def test_axis_aligned(self) -> None:
+        """A 10×4 rect centered at origin at angle 0: corners at (±5, ±2)."""
+        rect = oriented_rect(cx=0, cy=0, length=10, width=4, angle_deg=0)
+        expected = [(5, -2), (5, 2), (-5, 2), (-5, -2)]
+        assert _corners_almost_equal(rect, expected)
+
+    def test_translated(self) -> None:
+        rect = oriented_rect(cx=10, cy=20, length=4, width=2, angle_deg=0)
+        expected = [(12, 19), (12, 21), (8, 21), (8, 19)]
+        assert _corners_almost_equal(rect, expected)
+
+    def test_rotated_90(self) -> None:
+        """At 90° CCW, length axis runs along +y, width along -x."""
+        rect = oriented_rect(cx=0, cy=0, length=10, width=4, angle_deg=90)
+        # Corners (rotated): the long axis is now ±5 along y, short ±2 along x
+        expected = [(2, 5), (-2, 5), (-2, -5), (2, -5)]
+        assert _corners_almost_equal(rect, expected)
+
+    def test_rotated_45(self) -> None:
+        """At 45° CCW, a 2×2 square's corner at local (1, -1) maps to world (√2, 0)."""
+        rect = oriented_rect(cx=0, cy=0, length=2, width=2, angle_deg=45)
+        # Square is symmetric; corners should be at distance √2 along the axes.
+        expected = [(math.sqrt(2), 0), (0, math.sqrt(2)), (-math.sqrt(2), 0), (0, -math.sqrt(2))]
+        assert _corners_almost_equal(rect, expected)
+
+    def test_area_preserved_under_rotation(self) -> None:
+        rect0 = oriented_rect(cx=0, cy=0, length=10, width=4, angle_deg=0)
+        rect45 = oriented_rect(cx=0, cy=0, length=10, width=4, angle_deg=45)
+        rect90 = oriented_rect(cx=0, cy=0, length=10, width=4, angle_deg=90)
+        rect_neg = oriented_rect(cx=0, cy=0, length=10, width=4, angle_deg=-30)
+        assert _almost_equal(rect0.area, 40.0)
+        assert _almost_equal(rect45.area, 40.0)
+        assert _almost_equal(rect90.area, 40.0)
+        assert _almost_equal(rect_neg.area, 40.0)
+
+
+# ----------------------------------------------------------------------------
+# polygon_overlap
+# ----------------------------------------------------------------------------
+
+
+class TestPolygonOverlap:
+    def test_disjoint_no_overlap(self) -> None:
+        p1 = oriented_rect(0, 0, 2, 2, 0)
+        p2 = oriented_rect(5, 0, 2, 2, 0)
+        assert polygon_overlap(p1, p2) is False
+
+    def test_overlapping_areas(self) -> None:
+        p1 = oriented_rect(0, 0, 2, 2, 0)
+        p2 = oriented_rect(1, 0, 2, 2, 0)
+        assert polygon_overlap(p1, p2) is True
+
+    def test_clearance_zero_touching_not_a_conflict(self) -> None:
+        """At clearance=0, polygons touching at the boundary do NOT conflict
+        (no interior overlap)."""
+        p1 = oriented_rect(0, 0, 2, 2, 0)
+        p2 = oriented_rect(2, 0, 2, 2, 0)  # share the line x=1
+        assert polygon_overlap(p1, p2, clearance=0.0) is False
+
+    def test_clearance_positive_touching_is_a_conflict(self) -> None:
+        """At clearance>0, polygons exactly touching (distance 0) conflict."""
+        p1 = oriented_rect(0, 0, 2, 2, 0)
+        p2 = oriented_rect(2, 0, 2, 2, 0)
+        assert polygon_overlap(p1, p2, clearance=0.1) is True
+
+    def test_clearance_separates(self) -> None:
+        """Polygons farther apart than clearance do not conflict."""
+        p1 = oriented_rect(0, 0, 2, 2, 0)
+        p2 = oriented_rect(5, 0, 2, 2, 0)  # 3m gap (5-1-1)
+        assert polygon_overlap(p1, p2, clearance=0.3) is False
+
+    def test_clearance_pulls_in(self) -> None:
+        """Polygons just outside clearance: no conflict. Just inside: conflict."""
+        p1 = oriented_rect(0, 0, 2, 2, 0)
+        p2 = oriented_rect(2.5, 0, 2, 2, 0)  # 0.5m gap
+        assert polygon_overlap(p1, p2, clearance=0.3) is False
+        assert polygon_overlap(p1, p2, clearance=0.6) is True
+
+
+class TestPolygonOverlapArea:
+    def test_disjoint(self) -> None:
+        p1 = oriented_rect(0, 0, 2, 2, 0)
+        p2 = oriented_rect(5, 0, 2, 2, 0)
+        assert polygon_overlap_area(p1, p2) == 0.0
+
+    def test_overlapping(self) -> None:
+        p1 = oriented_rect(0, 0, 2, 2, 0)  # area 4, x ∈ [-1, 1]
+        p2 = oriented_rect(1, 0, 2, 2, 0)  # area 4, x ∈ [0, 2]
+        # Intersection: x ∈ [0, 1], y ∈ [-1, 1] → area = 1 * 2 = 2.0
+        assert _almost_equal(polygon_overlap_area(p1, p2), 2.0)
+
+    def test_touching_zero_area(self) -> None:
+        p1 = oriented_rect(0, 0, 2, 2, 0)
+        p2 = oriented_rect(2, 0, 2, 2, 0)
+        assert polygon_overlap_area(p1, p2) == 0.0
+
+
+# ----------------------------------------------------------------------------
+# aircraft_parts_world — the core transform.
+#
+# Per CLAUDE.md the transform is:
+#   world_x = px + u·sin(h) + v·cos(h)
+#   world_y = py + u·cos(h) − v·sin(h)
+# with determinant −1 (rotation + reflection).
+#
+# The 45° tests are the critical regression catches: a textbook CCW
+# rotation matrix would produce the wrong quadrants at h=45 even though
+# 0°/90°/180° still look correct by symmetry.
+# ----------------------------------------------------------------------------
+
+
+def _aircraft_with_one_part(
+    part: Part,
+    *,
+    movement_mode: str = "always_own_gear",
+    turn_radius_m: float | None = 5.0,
+) -> Aircraft:
+    return Aircraft(
+        id="probe",
+        name="Probe",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode=movement_mode,  # type: ignore[arg-type]
+        turn_radius_m=turn_radius_m,
+        measured=False,
+        parts=(part,),
+    )
+
+
+def _point_part(
+    *,
+    offset_x_m: float = 0.0,
+    offset_y_m: float = 0.0,
+    length_m: float = 0.001,
+    width_m: float = 0.001,
+) -> Part:
+    """A tiny rectangle approximating a point at (offset_x, offset_y) plane-local."""
+    return Part(
+        kind="fuselage",
+        length_m=length_m,
+        width_m=width_m,
+        offset_x_m=offset_x_m,
+        offset_y_m=offset_y_m,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=1.0,
+    )
+
+
+class TestAircraftPartsWorld:
+    def test_heading_zero_nose_maps_to_world_plus_y(self) -> None:
+        """At heading 0°, a part at plane-local (u=1, v=0) lands at world (px, py+1)."""
+        ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        [world] = aircraft_parts_world(ac, pl)
+        cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
+        assert _almost_equal(cx, 0.0, tol=1e-6)
+        assert _almost_equal(cy, 1.0, tol=1e-6)
+
+    def test_heading_zero_right_wingtip_maps_to_world_plus_x(self) -> None:
+        """At heading 0°, a part at plane-local (u=0, v=1) lands at world (px+1, py)."""
+        ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        [world] = aircraft_parts_world(ac, pl)
+        cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
+        assert _almost_equal(cx, 1.0, tol=1e-6)
+        assert _almost_equal(cy, 0.0, tol=1e-6)
+
+    def test_heading_90_nose_maps_to_world_plus_x(self) -> None:
+        """At heading 90°, nose (plane +x) points to world +x."""
+        ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=90.0, on_carts=False)
+        [world] = aircraft_parts_world(ac, pl)
+        cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
+        assert _almost_equal(cx, 1.0, tol=1e-6)
+        assert _almost_equal(cy, 0.0, tol=1e-6)
+
+    def test_heading_90_right_wingtip_maps_to_world_minus_y(self) -> None:
+        """At heading 90° (nose right), right-wingtip points toward door (world -y)."""
+        ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=90.0, on_carts=False)
+        [world] = aircraft_parts_world(ac, pl)
+        cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
+        assert _almost_equal(cx, 0.0, tol=1e-6)
+        assert _almost_equal(cy, -1.0, tol=1e-6)
+
+    def test_heading_45_nose_in_plus_x_plus_y_quadrant(self) -> None:
+        """🔬 The off-by-90° regression test.
+
+        At heading 45°, nose should point into the (+x, +y) quadrant.
+        A textbook CCW rotation matrix at 45° would send the forward
+        vector to (cos 45, sin 45) — same direction here — but the
+        right-wingtip case below distinguishes the two.
+        """
+        ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False)
+        [world] = aircraft_parts_world(ac, pl)
+        cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
+        assert _almost_equal(cx, SQRT2_2, tol=1e-6)
+        assert _almost_equal(cy, SQRT2_2, tol=1e-6)
+
+    def test_heading_45_right_wingtip_in_plus_x_minus_y_quadrant(self) -> None:
+        """🔬 The DEFINITIVE off-by-90° / determinant-sign regression.
+
+        A textbook CCW rotation matrix would send plane-local (0, 1) to
+        (-sin 45, cos 45) = (-√2/2, +√2/2) — UPPER-LEFT quadrant.
+        The correct (det=-1) transform sends it to (cos 45, -sin 45)
+        = (+√2/2, -√2/2) — LOWER-RIGHT quadrant (right and toward door).
+
+        If this test fails, the implementation is using a pure rotation
+        somewhere and the parts model will be silently wrong.
+        """
+        ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False)
+        [world] = aircraft_parts_world(ac, pl)
+        cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
+        assert _almost_equal(cx, SQRT2_2, tol=1e-6), f"x expected {SQRT2_2}, got {cx}"
+        assert _almost_equal(cy, -SQRT2_2, tol=1e-6), f"y expected {-SQRT2_2}, got {cy}"
+
+    def test_placement_offset_applied(self) -> None:
+        """Placement translation is applied AFTER the rotation/reflection."""
+        ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
+        pl = Placement(plane_id="probe", x_m=10.0, y_m=20.0, heading_deg=0.0, on_carts=False)
+        [world] = aircraft_parts_world(ac, pl)
+        cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
+        assert _almost_equal(cx, 10.0, tol=1e-6)
+        assert _almost_equal(cy, 21.0, tol=1e-6)  # 20 + 1 (nose forward)
+
+    def test_heading_minus_90(self) -> None:
+        """At heading -90° (nose toward world -x, i.e. left wall), right-wingtip
+        points toward world +y (deeper into hangar)."""
+        ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=-90.0, on_carts=False)
+        [world] = aircraft_parts_world(ac, pl)
+        cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
+        assert _almost_equal(cx, 0.0, tol=1e-6)
+        assert _almost_equal(cy, 1.0, tol=1e-6)
+
+
+class TestWorldPartMetadata:
+    """``aircraft_parts_world`` must preserve every part's metadata
+    untouched — kind, z-range, and plane id."""
+
+    def test_kind_z_range_and_plane_id_preserved(self) -> None:
+        parts = (
+            Part(
+                kind="fuselage",
+                length_m=7.0,
+                width_m=0.8,
+                offset_x_m=0,
+                offset_y_m=0,
+                angle_deg=0,
+                z_bottom_m=0.0,
+                z_top_m=1.5,
+            ),
+            Part(
+                kind="wing",
+                length_m=1.4,
+                width_m=10.0,
+                offset_x_m=1.0,
+                offset_y_m=0,
+                angle_deg=0,
+                z_bottom_m=2.0,
+                z_top_m=2.3,
+            ),
+            Part(
+                kind="strut",
+                length_m=0.05,
+                width_m=1.5,
+                offset_x_m=0.5,
+                offset_y_m=1.0,
+                angle_deg=0,
+                z_bottom_m=0.5,
+                z_top_m=2.0,
+            ),
+        )
+        ac = Aircraft(
+            id="multipart",
+            name="Multipart",
+            wing_position="high",
+            gear="tailwheel",
+            movement_mode="always_own_gear",
+            turn_radius_m=5.0,
+            measured=False,
+            parts=parts,
+        )
+        pl = Placement(plane_id="multipart", x_m=5.0, y_m=10.0, heading_deg=37.0, on_carts=False)
+        worlds = aircraft_parts_world(ac, pl)
+        assert len(worlds) == 3
+        # Order preserved; metadata preserved 1:1 from source parts.
+        for src, dst in zip(parts, worlds):
+            assert dst.kind == src.kind
+            assert dst.z_bottom_m == src.z_bottom_m
+            assert dst.z_top_m == src.z_top_m
+            assert dst.plane_id == "multipart"
+
+
+class TestAircraftPartsWorldOnRealAircraft:
+    """End-to-end: a strut-braced aircraft loaded from the bundled fleet.yaml
+    produces transformed parts whose footprints are inside the expected
+    region of the world frame."""
+
+    def test_husky_at_origin_heading_zero(self) -> None:
+        """A Husky placed at (0, 0) heading 0° should have its fuselage
+        roughly along world +y (nose deeper into hangar)."""
+        from hangarfit.loader import load_fleet
+
+        from pathlib import Path
+
+        fleet = load_fleet(Path(__file__).resolve().parent.parent / "data" / "fleet.yaml")
+        husky = fleet["aviat_husky"]
+        pl = Placement(plane_id="aviat_husky", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        worlds = aircraft_parts_world(husky, pl)
+        # 4 parts: fuselage + wing + 2 struts
+        kinds = [w.kind for w in worlds]
+        assert kinds.count("fuselage") == 1
+        assert kinds.count("wing") == 1
+        assert kinds.count("strut") == 2
+        # Fuselage at heading 0: long axis (length_m=7.0) runs along world y.
+        fuselage = next(w for w in worlds if w.kind == "fuselage")
+        minx, miny, maxx, maxy = fuselage.polygon.bounds
+        # length 7.0 → spans ≈ 7m along y; width 0.85 → spans ≈ 0.85m along x.
+        assert _almost_equal(maxy - miny, 7.0, tol=1e-6)
+        assert _almost_equal(maxx - minx, 0.85, tol=1e-6)
+        # Two struts are mirrored across plane-local +y=0; at heading 0,
+        # plane +y maps to world +x, so the struts mirror across world x=0.
+        struts = [w for w in worlds if w.kind == "strut"]
+        strut_xs = sorted(s.polygon.centroid.x for s in struts)
+        assert _almost_equal(strut_xs[0], -strut_xs[1], tol=1e-6), (
+            f"struts should mirror across world x=0, got centroids at {strut_xs}"
+        )

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -136,6 +136,14 @@ class TestPolygonOverlap:
         assert polygon_overlap(p1, p2, clearance=0.3) is False
         assert polygon_overlap(p1, p2, clearance=0.6) is True
 
+    def test_negative_clearance_rejected(self) -> None:
+        """No sensible 'negative clearance' semantic — raise instead of
+        silently falling through to the clearance=0 branch."""
+        p1 = oriented_rect(0, 0, 2, 2, 0)
+        p2 = oriented_rect(5, 0, 2, 2, 0)
+        with pytest.raises(ValueError, match="clearance must be non-negative"):
+            polygon_overlap(p1, p2, clearance=-0.1)
+
 
 class TestPolygonOverlapArea:
     def test_disjoint(self) -> None:
@@ -285,6 +293,73 @@ class TestAircraftPartsWorld:
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 10.0, tol=1e-6)
         assert _almost_equal(cy, 21.0, tol=1e-6)  # 20 + 1 (nose forward)
+
+    def test_heading_135_nose_distinguishes_correct_from_ccw(self) -> None:
+        """🔬 Bonus regression: at heading 135°, the NOSE itself
+        distinguishes the correct transform from a textbook CCW rotation
+        — unlike at heading 45° where sin(45°) == cos(45°) makes the two
+        formulations coincide on the nose vector. At 135°:
+
+          correct: nose → (sin 135°, cos 135°) = (+√2/2, -√2/2)
+          CCW:     nose → (cos 135°, sin 135°) = (-√2/2, +√2/2)
+
+        Different in BOTH coordinates — the cleanest single test for the
+        wrong-handedness bug."""
+        ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=135.0, on_carts=False)
+        [world] = aircraft_parts_world(ac, pl)
+        cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
+        assert _almost_equal(cx, SQRT2_2, tol=1e-6), f"x expected {SQRT2_2}, got {cx}"
+        assert _almost_equal(cy, -SQRT2_2, tol=1e-6), f"y expected {-SQRT2_2}, got {cy}"
+
+    @pytest.mark.parametrize("heading_deg", [180.0, 360.0, 720.0, -360.0])
+    def test_heading_wraparound_works(self, heading_deg: float) -> None:
+        """Heading values outside [-180, 180] or multiples of 360° should
+        produce the expected forward direction (sin/cos handle wrap natively).
+        Pins that we don't normalize heading anywhere upstream and that the
+        transform stays consistent across the wrap."""
+        ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
+        pl = Placement(
+            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=heading_deg, on_carts=False
+        )
+        [world] = aircraft_parts_world(ac, pl)
+        cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
+        expected_x = math.sin(math.radians(heading_deg))
+        expected_y = math.cos(math.radians(heading_deg))
+        assert _almost_equal(cx, expected_x, tol=1e-6)
+        assert _almost_equal(cy, expected_y, tol=1e-6)
+
+    def test_part_angle_deg_composed_with_world_transform(self) -> None:
+        """🔬 Coverage gap caught in PR #11 review: every other test uses
+        ``angle_deg=0``. This test exercises the composition of
+        (in-plane-local rotation) ∘ (world transform).
+
+        Setup: a thin rectangle at plane-local origin with ``angle_deg=90``
+        (rotated CCW 90° within plane-local) — so its long axis now runs
+        along plane-local +y instead of +x. At placement heading 0°, the
+        plane-local axes map as plane +x → world +y, plane +y → world +x.
+        So the rectangle's long axis (now along plane +y) should run
+        along world +x.
+        """
+        part = Part(
+            kind="strut",
+            length_m=4.0,  # long
+            width_m=0.1,   # thin
+            offset_x_m=0.0,
+            offset_y_m=0.0,
+            angle_deg=90.0,  # rotate CCW 90° within plane-local
+            z_bottom_m=0.5,
+            z_top_m=2.0,
+        )
+        ac = _aircraft_with_one_part(part)
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        [world] = aircraft_parts_world(ac, pl)
+        # Plane-local: 0.1 wide along +x, 4.0 long along +y (after the 90° rot).
+        # World mapping at heading 0°: plane +x → world +y, plane +y → world +x.
+        # So in world: long axis (4.0) runs along +x, narrow (0.1) along +y.
+        minx, miny, maxx, maxy = world.polygon.bounds
+        assert _almost_equal(maxx - minx, 4.0, tol=1e-6), f"world x-extent: {maxx - minx}"
+        assert _almost_equal(maxy - miny, 0.1, tol=1e-6), f"world y-extent: {maxy - miny}"
 
     def test_heading_minus_90(self) -> None:
         """At heading -90° (nose toward world -x, i.e. left wall), right-wingtip


### PR DESCRIPTION
Closes #4.

Geometric primitives + the plane-local→world transform that the collision checker (#5) will iterate over. This is the file where the off-by-90° trap of the project lives, so the tests are deliberately heavy on the regression-catching side.

## What's in this PR

- `src/hangarfit/geometry.py` (~150 LOC):
  - `oriented_rect(cx, cy, length, width, angle_deg) -> shapely.Polygon` — generic 2D rectangle builder, **standard CCW rotation**.
  - `polygon_overlap(p1, p2, clearance=0.0) -> bool` — split semantics: `clearance > 0` uses `distance < clearance` (touching counts as conflict); `clearance == 0` uses `intersects and not touches` (true area overlap only).
  - `polygon_overlap_area(p1, p2) -> float` — for `Conflict.detail` ("overlap by 0.18 m²").
  - `aircraft_parts_world(aircraft, placement) -> list[WorldPart]` — the **compass-style transform with determinant −1** from CLAUDE.md.
  - `WorldPart` dataclass (frozen+slots) wrapping `(polygon, z_bottom_m, z_top_m, plane_id, kind)`.

- `tests/test_geometry.py` (~390 LOC, 24 tests).

## Key design decision: two separate angle conventions

`geometry.py` has TWO distinct angle interpretations that must stay separate:

1. **`oriented_rect`** uses standard CCW math rotation. It's a generic primitive with no aircraft awareness.
2. **`aircraft_parts_world`** uses the compass-style transform documented in `CLAUDE.md`:

   ```
   world_x = placement.x_m + u·sin(h) + v·cos(h)
   world_y = placement.y_m + u·cos(h) − v·sin(h)
   ```

   The linear part has **determinant −1** (rotation composed with reflection), because (a) compass headings rotate CW while math rotations rotate CCW (one sign flip), and (b) the plane-local `(forward, right)` axes against the world `(right, deeper)` frame are a left-handed mapping (second sign flip).

Mixing the two is the off-by-90° trap of the project — every collision check produced by `aircraft_parts_world` would be silently wrong. The tests catch this directly.

## The headline regression tests

The critical test in this PR is `test_heading_45_right_wingtip_in_plus_x_minus_y_quadrant`:

> At heading 45°, a plane-local part at `(u=0, v=1)` (one meter to the right of plane origin) MUST land at world `(+√2/2, −√2/2)` — into the **lower-right quadrant** (+x, −y), meaning "right along the door wall and toward the door."
>
> A textbook CCW rotation matrix at any angle would send the right-wingtip into the upper-left quadrant `(−√2/2, +√2/2)` instead. If this test ever passes a wrong-handedness implementation, the entire collision checker is silently wrong.

The 0° and 90° tests don't catch this — they happen to look correct by symmetry. The 45° test is mandatory.

## What's NOT in this PR

- **`expand_struts` is in `loader.py`**, not here. When `Aircraft.struts` was dropped from the model in #9 (review feedback), strut expansion became a build-time YAML→Parts conversion, and the loader is its natural home. Geometry stays a clean primitives module.
- The collision checker (#5), which will consume `WorldPart` and iterate pairs of them.

## Verification

```
$ pytest
=================== 184 passed in 0.40s ===================
```

| Test class | What it covers |
|---|---|
| `TestOrientedRect` | Axis-aligned, translated, rotated 45°/90°, area preserved under rotation |
| `TestPolygonOverlap` | Disjoint, area-overlap, touching at clearance 0 vs >0, gap just inside/outside clearance |
| `TestPolygonOverlapArea` | Disjoint, overlapping, touching (zero area) |
| `TestAircraftPartsWorld` | 0°, 90°, -90° (axis-aligned cases); **45° nose AND 45° right-wingtip** (the off-by-90° catches); placement translation applied |
| `TestWorldPartMetadata` | kind / z-range / plane_id preserved 1:1 from source parts |
| `TestAircraftPartsWorldOnRealAircraft` | End-to-end: load the Husky from `data/fleet.yaml`, place at origin heading 0°, verify fuselage long-axis runs along world y and the two struts mirror across world x=0 |

## Workflow follow-up

1. `pr-review` runs after this PR is opened.
2. Findings (if any) become PR review threads, get resolved in a follow-up commit.
3. When clean, ready for your final review.

Milestone: `v0.2.0 — Collision substrate`. Depends on #2 (merged). Unblocks #5 once merged.