### PR TITLE
Polish README for public audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 An on-demand exception tool for a flying club's hangar parking.
 
-The club parks nine aircraft in a deep, stack-style hangar with a single door at the front. There's a standard layout that works for the standard situation — every plane back from its flight at the expected time, no surprise maintenance, no late returns. When that standard situation breaks (a plane comes back late, a maintenance slot moves, two planes need to swap order), someone has to come up with an alternative parking arrangement on the spot. `hangarfit` is the tool that checks whether a proposed alternative is physically valid: no fuselage, wing, or strut collisions; everything fits inside the hangar; the plane scheduled for maintenance ends up at the back where the maintenance bay is. It also renders a top-down PNG so a human can sanity-check the result by eye.
+The club parks nine aircraft in a deep, stack-style hangar with a single door at the front. There's a standard layout that works for the standard situation — every plane back from its flight at the expected time, no surprise maintenance, no late returns. When that standard situation breaks (a plane comes back late, a maintenance slot moves, two planes need to swap order), someone has to come up with an alternative parking arrangement on the spot. `hangarfit` is the tool that checks whether a proposed alternative is physically valid: no fuselage, wing, or strut collisions; everything fits inside the hangar; the plane scheduled for maintenance ends up at the back where the maintenance bay is.
+
+It also renders a top-down PNG so a human can sanity-check the result by eye.
 
 It is not a planner. It does not search for a layout — you hand it one, it tells you whether it works.
 
@@ -22,7 +24,7 @@ These boundaries are deliberate. The collision model is the load-bearing piece; 
 
 ## Status
 
-Pre-release. Phase 1 is in active development — the data model, loader, geometry primitives, collision checker, and visualizer have landed; the CLI is the last piece before the first tagged cut. All aircraft and hangar dimensions in `data/` are placeholders pending real measurement and are flagged as such in the YAML; collision-checker output on the current data is illustrative, not authoritative.
+Pre-release. Phase 1 is in active development; the CLI is the last piece before the first tagged cut. All dimensions in `data/` are placeholders pending real measurement and are flagged as such in the YAML; collision-checker output on the current data is illustrative, not authoritative.
 
 Follow progress in [GitHub Issues](https://github.com/DocGerd/hangarfit/issues) and milestones.
 
@@ -36,13 +38,13 @@ pip install -e ".[dev]"
 
 This installs the package in editable mode along with the test dependencies (`pytest`).
 
-## Smoke test
+## Run the tests
 
 ```bash
 pytest
 ```
 
-The test suite includes a strut-aware golden set for the collision checker (same-height wing overlap, high-over-low height-disjoint pass, strut-blocks-nesting, the maintenance-bay rule, the cart rule, and an all-nine-planes valid layout). If those pass, the geometry is intact.
+The test suite includes a strut-aware golden set for the collision checker covering the height-layer rule, the strut-blocks-nesting case, the maintenance-bay rule, the cart rule, and an all-nine-planes valid layout. If those pass, the geometry is intact.
 
 The end-to-end CLI (`hangarfit check layouts/example.yaml --render out.png`) is tracked in issue #7 and not yet shipped.
 
@@ -57,10 +59,8 @@ tests/              # pytest suite, including strut-aware collision golden tests
 
 ## More depth
 
-[`CLAUDE.md`](CLAUDE.md) is the durable project spec: the fleet (nine aircraft, mix of high-wing strut-braced, high-wing cantilever, and one low-wing), the parts-based collision rule, the coordinate convention (including the non-obvious heading transform), and the Phase 1 deliverables list. Read it before contributing anything geometric.
-
-A `CONTRIBUTING.md` will land alongside the public release.
+[`CLAUDE.md`](CLAUDE.md) is the durable project spec: the fleet (nine aircraft, mostly high-wing, with one low-wing), the parts-based collision rule, the coordinate convention (including the non-obvious heading transform), and the Phase 1 deliverables list. Read it before contributing anything geometric.
 
 ## License
 
-Apache-2.0. See [`LICENSE`](LICENSE).
+Licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,46 +1,66 @@
 # hangarfit
 
-Helper tool for arranging the flying club fleet in a stack-style hangar when the standard layout doesn't work. **On-demand exception tool**, not a daily ops system.
+An on-demand exception tool for a flying club's hangar parking.
 
-Given a hand-authored candidate layout (in YAML), `hangarfit`:
+The club parks nine aircraft in a deep, stack-style hangar with a single door at the front. There's a standard layout that works for the standard situation — every plane back from its flight at the expected time, no surprise maintenance, no late returns. When that standard situation breaks (a plane comes back late, a maintenance slot moves, two planes need to swap order), someone has to come up with an alternative parking arrangement on the spot. `hangarfit` is the tool that checks whether a proposed alternative is physically valid: no fuselage, wing, or strut collisions; everything fits inside the hangar; the plane scheduled for maintenance ends up at the back where the maintenance bay is. It also renders a top-down PNG so a human can sanity-check the result by eye.
 
-1. checks whether the layout is **physically valid** (no fuselage / wing / strut collisions, fits in the hangar, maintenance plane in the right spot), and
-2. **renders** a top-down PNG so a human can eyeball it.
+It is not a planner. It does not search for a layout — you hand it one, it tells you whether it works.
 
-A planner / search algorithm is **out of scope for Phase 1**. Phase 1 builds the substrate (data model, collision checker, visualizer) that any future planner will sit on top of.
+## Scope
+
+**Phase 1 (current focus).** Build the substrate: an aircraft + hangar data model, a parts-based collision checker, a matplotlib top-down visualizer, and a CLI that ties them together. Phase 1 is about getting the geometry right — once the collision rule is trustworthy, anything downstream can be built on top of it.
+
+**Explicitly out of scope for Phase 1:**
+
+- No planner, search, or optimization — you provide the candidate layout.
+- No movement-sequence planning (no "in what order do I roll planes out and back in to reach this layout").
+- No tracking of hangar state across runs.
+- No GUI or web frontend.
+- No handling of late arrivals as a live event stream.
+
+These boundaries are deliberate. The collision model is the load-bearing piece; layering search on top of a wobbly geometry foundation would compound errors.
 
 ## Status
 
-Phase 1 in active development. See [GitHub Issues](https://github.com/DocGerd/hangarfit/issues) and milestones.
+Pre-release. Phase 1 is in active development — the data model, loader, geometry primitives, collision checker, and visualizer have landed; the CLI is the last piece before the first tagged cut. All aircraft and hangar dimensions in `data/` are placeholders pending real measurement and are flagged as such in the YAML; collision-checker output on the current data is illustrative, not authoritative.
 
-## Quickstart
+Follow progress in [GitHub Issues](https://github.com/DocGerd/hangarfit/issues) and milestones.
 
-What works today (after merging the scaffolding PR):
+## Install
+
+Requires Python 3.11 or newer.
 
 ```bash
 pip install -e ".[dev]"
-pytest                              # currently collects 0 tests
 ```
 
-The full end-to-end loop will work once milestone `v0.3.0` ships the CLI:
+This installs the package in editable mode along with the test dependencies (`pytest`).
+
+## Smoke test
 
 ```bash
-hangarfit check layouts/example.yaml --render out.png   # ← lands in #7
+pytest
 ```
 
-## Project layout (target — most files land in later milestones)
+The test suite includes a strut-aware golden set for the collision checker (same-height wing overlap, high-over-low height-disjoint pass, strut-blocks-nesting, the maintenance-bay rule, the cart rule, and an all-nine-planes valid layout). If those pass, the geometry is intact.
+
+The end-to-end CLI (`hangarfit check layouts/example.yaml --render out.png`) is tracked in issue #7 and not yet shipped.
+
+## Project layout
 
 ```
-src/hangarfit/      # Python package (models, loader, geometry, collisions, visualize, cli)
-data/               # fleet.yaml, hangar.yaml — measured-once club data
-layouts/            # hand-authored candidate layouts (one .yaml per scenario)
-tests/              # pytest suite, including the strut-aware collision golden tests
+src/hangarfit/      # models, loader, geometry, collisions, visualize (CLI pending)
+data/               # fleet.yaml, hangar.yaml — placeholder measurements
+layouts/            # hand-authored candidate layouts, one YAML per scenario
+tests/              # pytest suite, including strut-aware collision golden tests
 ```
 
-## Workflow
+## More depth
 
-This repo uses GitFlow with PR-driven review. See [`CLAUDE.md`](CLAUDE.md) for the full workflow and project context.
+[`CLAUDE.md`](CLAUDE.md) is the durable project spec: the fleet (nine aircraft, mix of high-wing strut-braced, high-wing cantilever, and one low-wing), the parts-based collision rule, the coordinate convention (including the non-obvious heading transform), and the Phase 1 deliverables list. Read it before contributing anything geometric.
+
+A `CONTRIBUTING.md` will land alongside the public release.
 
 ## License
 
-MIT
+Apache-2.0. See [`LICENSE`](LICENSE).


### PR DESCRIPTION
Closes #14.

Rewrites `README.md` for a cold visitor arriving from a search result or
a link, rather than someone already inside the project. The structural
shift: lead with the concrete problem (flying club, stack-style hangar,
planes don't always come back on time), state Phase 1 scope **and**
non-goals explicitly (no planner, no GUI, no movement-sequence
planning), and drop the stale `hangarfit check ...` quickstart since
the CLI is still in flight (#7).

## Notable choices

- **License = Apache-2.0** per the going-public plan, even though
  `pyproject.toml` still says `MIT`. Per the issue brief that
  realignment is owned by sibling PR #13 (the `LICENSE` file);
  whichever PR merges second, the README text is fine either way.
- **No CI badge** yet — issue #15 owns the workflow and will add the
  badge in that PR; adding it here would 404.
- **No visualizer screenshot** — placeholder dimensions in `data/`
  aren't representative.

## Scope

`README.md` only. No code or other doc changes.