### PR TITLE
CI: GitHub Actions workflow (pytest matrix 3.11+3.12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    name: test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  # Only run CI on PRs into integration/release branches — not cross-feature PRs.
   pull_request:
     branches: [develop, main]
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # hangarfit
 
+![CI](https://github.com/DocGerd/hangarfit/actions/workflows/ci.yml/badge.svg?branch=develop)
+
 An on-demand exception tool for a flying club's hangar parking.
 
 The club parks nine aircraft in a deep, stack-style hangar with a single door at the front. There's a standard layout that works for the standard situation — every plane back from its flight at the expected time, no surprise maintenance, no late returns. When that standard situation breaks (a plane comes back late, a maintenance slot moves, two planes need to swap order), someone has to come up with an alternative parking arrangement on the spot. `hangarfit` is the tool that checks whether a proposed alternative is physically valid: no fuselage, wing, or strut collisions; everything fits inside the hangar; the plane scheduled for maintenance ends up at the back where the maintenance bay is.


### PR DESCRIPTION
## Summary

Closes #15

Adds `.github/workflows/ci.yml` — the **first CI workflow on the repo**, triggering on the first PR and first use of free GitHub Actions minutes since the public flip.

Runs `pytest` on every `pull_request` targeting `develop` or `main`, and on every direct push to those branches, across Python 3.11 and 3.12 in parallel.

Also adds a CI status badge to `README.md` (below the `# hangarfit` heading, pointing at the `develop` branch).

## Design choices

| Choice | Rationale |
|---|---|
| **Matrix: 3.11 + 3.12** | `requires-python = ">=3.11"` covers both; running both surfaces regressions on either. Python 3.13 deferred — shapely/matplotlib sometimes lag on new releases. |
| **`fail-fast: false`** | Both Python versions always report; one failure doesn't suppress the other's result. |
| **Pinned major versions** (`@v4`, `@v5`) | Stable, auditable — never silently picks up breaking upstream changes. |
| **`permissions: contents: read`** | Minimal token scope: CI only reads code, no write access needed. |
| **`concurrency` block** | Cancels superseded PR runs when you push twice in quick succession (saves runner minutes). Push-to-branch runs (`develop`/`main`) always run to completion (`cancel-in-progress` is `false` for `push` events). |
| **`cache: pip` + `cache-dependency-path: pyproject.toml`** | setup-python's built-in pip cache, keyed on the manifest. Re-resolves deps only when `pyproject.toml` changes. |
| **Linux only** | No concrete cross-platform requirement yet; Windows/macOS runners cost more minutes and add noise. Add when there's a real reason. |
| **No lint/typecheck/coverage** | Single-purpose PR. Those are separate issues per the project plan. |

## Status-check names for branch protection (#16)

The two check names GitHub will register (needed for branch-protection config in issue #16):

- `test (Python 3.11)`
- `test (Python 3.12)`

## Note on issue #15 vs. this PR

Issue #15 specifies Python 3.12 only and `pytest -q`. This PR uses a 3.11+3.12 matrix and bare `pytest` (which already has `-ra` via `addopts` in `pyproject.toml`). Both choices follow the more detailed implementation spec provided; the matrix catches regressions on the oldest supported Python version. The reviewer should confirm this is the intended scope.