### PR TITLE
docs(CLAUDE.md): refresh Phase 1 status + module map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Stack-like layout: deep, one door at the front. The back-most spot doubles as th
 
 ## The parts model (the most important rule)
 
-> Each aircraft is a list of **parts**. Every part is an oriented rectangle in plan view with a height range `[z_bottom_m, z_top_m]`. Fuselage, wing, and each strut are all parts.
+> Each aircraft is a list of **parts**. Every part is an oriented rectangle in plan view with a height range `[z_bottom_m, z_top_m]`. Fuselage, wing, each strut, and the tail (where modeled) are all parts — the closed set of `PartKind` values lives in `models.py`.
 >
 > **Collision rule**: two parts from different aircraft conflict iff **both** hold:
 >
@@ -131,10 +131,10 @@ Current status of the Phase 1 cut. Only the CLI remains before the first tagged 
 |---|---|---|---|
 | 1 | `data/fleet.yaml` — 9 aircraft, parts model, **placeholder dimensions** flagged with `measured: false` | #3 | ✅ shipped |
 | 2 | `data/hangar.yaml` — hangar dimensions + door + maintenance bay (placeholders) | #3 | ✅ shipped |
-| 3 | `src/hangarfit/collisions.py` — the collision checker (the heart of Phase 1) | #5 | ✅ shipped (PR #28) |
-| 4 | `src/hangarfit/visualize.py` — matplotlib top-down PNG renderer | #6 | ✅ shipped (PR #29) |
+| 3 | `src/hangarfit/collisions.py` — the collision checker (the heart of Phase 1) | #5 | ✅ shipped |
+| 4 | `src/hangarfit/visualize.py` — matplotlib top-down PNG renderer | #6 | ✅ shipped |
 | 5 | `src/hangarfit/cli.py` — `hangarfit check layouts/example.yaml --render out.png` | #7 | ⏳ **next** |
-| 6 | Strut-aware golden-test suite in `tests/test_collisions.py` — same-height wing overlap, high-over-low height-disjoint pass, strut-blocks-nesting, inboard / outboard strut-free nesting, maintenance-bay rule, cart rule, all-9-planes valid layout | #5 | ✅ shipped |
+| 6 | Strut-aware golden-test suite in `tests/test_collisions.py` — same-height wing overlap, high-over-low height-disjoint pass, strut-blocks-nesting, inboard / outboard strut-free nesting, maintenance-bay rule, all-9-planes valid layout (the cart rule is exercised separately at `Layout` construction; see module map) | #5 | ✅ shipped |
 
 The strut-aware golden tests are the canary that the parts model is intact. If they pass, the geometry is trustworthy on the current (placeholder) data.
 
@@ -144,12 +144,12 @@ The strut-aware golden tests are the canary that the parts model is intact. If t
 |---|---|
 | `src/hangarfit/models.py` | Frozen dataclasses + invariants (`Aircraft`, `Hangar`, `Layout`, `Conflict`, `CheckResult`). Cross-reference rules (cart rule, `movement_mode` ↔ `on_carts`, maintenance plane in fleet & placed) are enforced in `Layout.__post_init__`. |
 | `src/hangarfit/loader.py` | YAML → models. Expands the high-level `struts:` block into two mirrored strut `Part`s before constructing `Aircraft`. |
-| `src/hangarfit/geometry.py` | Plane-local → world transform (the determinant‑−1 trap lives here) and `aircraft_parts_world()`. |
-| `src/hangarfit/collisions.py` | The `check(layout)` entry point. Enforces hangar bounds, maintenance-bay position (centroid of designated plane's fuselage parts is in the back strip), and pairwise parts overlap. **Not here:** the cart rule (already enforced upstream in `Layout`). |
-| `src/hangarfit/visualize.py` | Top-down PNG renderer. Calls `matplotlib.use("Agg", force=True)` so it runs headless in CI / pytest. Conflict parts are overdrawn in red when a `CheckResult` is passed. |
+| `src/hangarfit/geometry.py` | Plane-local → world transform (the determinant −1 trap lives here) and `aircraft_parts_world()`. |
+| `src/hangarfit/collisions.py` | The `check(layout)` entry point. Enforces hangar bounds, maintenance-bay position (centroid of the designated plane's fuselage parts is in the back strip; if that plane has no fuselage parts, an explicit `maintenance_no_fuselage` conflict is emitted rather than silently passing), and pairwise parts overlap. **Not here:** the cart rule (already enforced upstream in `Layout`). |
+| `src/hangarfit/visualize.py` | Top-down PNG renderer. Forces a headless matplotlib backend at import time so it runs in CI / pytest without a display server. When a `CheckResult` is passed, validates that its conflicts reference only planes from the layout, then overdraws the conflicting parts in red. |
 | `src/hangarfit/cli.py` | **Not yet shipped — issue #7.** |
 | `tests/fixtures/*.yaml` | One YAML per scenario, `valid_*` / `invalid_*` naming. Add new collision regressions by dropping in a fixture, not by writing geometry literals in Python. |
-| `tests/fixtures/test_hangar_large.yaml` | Test-only larger hangar (30 × 25 m). Used by `valid_all_nine_planes.yaml` because the placeholder fleet's strut bracing forces ~2.6 m of x-clearance between strut-braced planes whose fuselage y-bands overlap — which doesn't fit in the placeholder 18 × 25 hangar. This is a placeholder-dimension artifact, not a checker bug. Will go away once real measurements arrive. See the file header for full reasoning. |
+| `tests/fixtures/test_hangar_large.yaml` | Test-only larger hangar (30 × 25 m, length × width). Used by `valid_all_nine_planes.yaml` because the placeholder fleet's strut bracing forces ~2.6 m of x-clearance between strut-braced planes whose fuselage y-bands overlap — which doesn't fit in the placeholder 25 × 18 m hangar (see `data/hangar.yaml`). This is a placeholder-dimension artifact, not a checker bug. Will go away once real measurements arrive. See the fixture header for full reasoning. |
 
 ### Out of scope for Phase 1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,9 @@ The door is a **visual marker only**. All aircraft parts must fit fully inside t
 
 ### Default clearances
 
-Both clearances will be configurable in `data/hangar.yaml` once that file lands in #3.
+Both clearances are configurable in `data/hangar.yaml` (`Hangar.clearance_m`, `Hangar.wing_layer_clearance_m`).
 
-| Clearance | Default | Planned key in `hangar.yaml` |
+| Clearance | Default | Key in `hangar.yaml` |
 |---|---|---|
 | Horizontal | 0.30 m | `clearance_m` |
 | Vertical | 0.20 m | `wing_layer_clearance_m` |
@@ -125,14 +125,31 @@ Both clearances will be configurable in `data/hangar.yaml` once that file lands 
 
 ## Phase 1 deliverables
 
-The list below is the **target shape** of the Phase 1 cut. Most of these files do not exist yet — each will land in its own PR per the issue plan.
+Current status of the Phase 1 cut. Only the CLI remains before the first tagged release (`release/0.1.0`).
 
-1. `data/fleet.yaml` — 9 aircraft, parts model, **placeholder dimensions** flagged with `measured: false`. (#3)
-2. `data/hangar.yaml` — hangar dimensions + door + maintenance bay (placeholders). (#3)
-3. `src/hangarfit/collisions.py` — the collision checker (the heart of Phase 1). (#5)
-4. `src/hangarfit/visualize.py` — matplotlib top-down PNG renderer. (#6)
-5. `src/hangarfit/cli.py` — `hangarfit check layouts/example.yaml --render out.png`. (#7)
-6. **Strut-aware golden-test suite** in `tests/test_collisions.py` — the canary that the parts model is intact. Cases include same-height wing overlap, high-over-low height-disjoint pass, the strut-blocks-nesting case, inboard / outboard strut-free nesting, the maintenance-bay rule, the cart rule, and the all-9-planes valid layout. (#5)
+| # | Deliverable | Issue | Status |
+|---|---|---|---|
+| 1 | `data/fleet.yaml` — 9 aircraft, parts model, **placeholder dimensions** flagged with `measured: false` | #3 | ✅ shipped |
+| 2 | `data/hangar.yaml` — hangar dimensions + door + maintenance bay (placeholders) | #3 | ✅ shipped |
+| 3 | `src/hangarfit/collisions.py` — the collision checker (the heart of Phase 1) | #5 | ✅ shipped (PR #28) |
+| 4 | `src/hangarfit/visualize.py` — matplotlib top-down PNG renderer | #6 | ✅ shipped (PR #29) |
+| 5 | `src/hangarfit/cli.py` — `hangarfit check layouts/example.yaml --render out.png` | #7 | ⏳ **next** |
+| 6 | Strut-aware golden-test suite in `tests/test_collisions.py` — same-height wing overlap, high-over-low height-disjoint pass, strut-blocks-nesting, inboard / outboard strut-free nesting, maintenance-bay rule, cart rule, all-9-planes valid layout | #5 | ✅ shipped |
+
+The strut-aware golden tests are the canary that the parts model is intact. If they pass, the geometry is trustworthy on the current (placeholder) data.
+
+## Where things live (module map)
+
+| File | Responsibility |
+|---|---|
+| `src/hangarfit/models.py` | Frozen dataclasses + invariants (`Aircraft`, `Hangar`, `Layout`, `Conflict`, `CheckResult`). Cross-reference rules (cart rule, `movement_mode` ↔ `on_carts`, maintenance plane in fleet & placed) are enforced in `Layout.__post_init__`. |
+| `src/hangarfit/loader.py` | YAML → models. Expands the high-level `struts:` block into two mirrored strut `Part`s before constructing `Aircraft`. |
+| `src/hangarfit/geometry.py` | Plane-local → world transform (the determinant‑−1 trap lives here) and `aircraft_parts_world()`. |
+| `src/hangarfit/collisions.py` | The `check(layout)` entry point. Enforces hangar bounds, maintenance-bay position (centroid of designated plane's fuselage parts is in the back strip), and pairwise parts overlap. **Not here:** the cart rule (already enforced upstream in `Layout`). |
+| `src/hangarfit/visualize.py` | Top-down PNG renderer. Calls `matplotlib.use("Agg", force=True)` so it runs headless in CI / pytest. Conflict parts are overdrawn in red when a `CheckResult` is passed. |
+| `src/hangarfit/cli.py` | **Not yet shipped — issue #7.** |
+| `tests/fixtures/*.yaml` | One YAML per scenario, `valid_*` / `invalid_*` naming. Add new collision regressions by dropping in a fixture, not by writing geometry literals in Python. |
+| `tests/fixtures/test_hangar_large.yaml` | Test-only larger hangar (30 × 25 m). Used by `valid_all_nine_planes.yaml` because the placeholder fleet's strut bracing forces ~2.6 m of x-clearance between strut-braced planes whose fuselage y-bands overlap — which doesn't fit in the placeholder 18 × 25 hangar. This is a placeholder-dimension artifact, not a checker bug. Will go away once real measurements arrive. See the file header for full reasoning. |
 
 ### Out of scope for Phase 1
 
@@ -213,6 +230,9 @@ pip install -e ".[dev]"
 
 # Run tests
 pytest
+
+# CI: GitHub Actions runs `pytest` on Python 3.11 + 3.12 for PRs into
+# develop/main (see .github/workflows/ci.yml). No coverage gate yet.
 
 # Phase 1 acceptance smoke test (once CLI lands)
 hangarfit check layouts/example.yaml --render out.png


### PR DESCRIPTION
Closes #33.

## Summary

- Drop stale "once #3 lands" / "doesn't exist yet" wording in **Default clearances** and **Phase 1 deliverables**; replace the latter with a current-status table (only #7 / CLI outstanding).
- Add a new **"Where things live" module map** so a fresh Claude session can locate the heading transform, collision check, loader, and renderer by filename without grepping. Includes the `tests/fixtures/test_hangar_large.yaml` case-12 workaround (placeholder-dimension artifact, not a checker bug) which was previously only documented in the fixture header.
- Two-line CI note under **Useful commands** pointing at `.github/workflows/ci.yml` (Python 3.11 + 3.12 matrix).

## Deliberately not touched

- The coordinate-transform section. That's the most load-bearing prose in the file (the determinant‑−1 reflection trap + the 45° canonical test); editing it would risk losing the trap-doc for no current-state gain.
- No `tail` PartKind reference (no aircraft uses one yet — would be aspirational).
- No LICENSE / Apache-2.0 mention (README territory).

## Test plan

- [x] CLAUDE.md renders cleanly end-to-end (no broken section boundaries, table formatting OK).
- [x] Module map's claims are sourced from the current code: `geometry.py` (transform), `collisions.py` (the four invariants + cart-rule-not-here note), `visualize.py` (`matplotlib.use("Agg", force=True)`), `models.py` (`Layout.__post_init__` cross-ref rules), `tests/fixtures/test_hangar_large.yaml` (case 12 reasoning lifted from the fixture header).
- [x] No code changes — docs-only PR, no tests to run.