### PR TITLE
feat(claude-config): add .mcp.json with Context7 + GitHub MCP defaults

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "context7": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@latest"],
+      "args": ["-y", "@upstash/context7-mcp@2.3.0"],
       "env": {
         "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"],
+      "env": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
+      }
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,21 +215,29 @@ The `.claude/` directory holds team-shared Claude Code settings (currently: a Po
 
 ## MCP servers
 
-`.mcp.json` at the repo root declares two project-scoped MCP servers so every contributor gets them automatically on a fresh clone — no per-user setup step.
+`.mcp.json` at the repo root declares two project-scoped MCP servers so every contributor gets them automatically on a fresh clone — no per-user setup step. See also [.claude/README.md](.claude/README.md) for the broader Claude Code config ecosystem in this repo.
 
 | Server | Transport | Purpose |
 |---|---|---|
-| `context7` | stdio (`npx @upstash/context7-mcp@latest`) | Live shapely 2.x and matplotlib API lookups. `shapely>=2.0,<3` is pinned in `pyproject.toml`; training-data docs may be stale. |
+| `context7` | stdio (`npx @upstash/context7-mcp@2.3.0`) | Live shapely 2.x and matplotlib API lookups. `shapely>=2.0,<3` is pinned in `pyproject.toml`; training-data docs may be stale. |
 | `github` | HTTP (`https://api.githubcopilot.com/mcp/`) | Issue / PR / release inspection from Claude; complements the existing `gh` CLI. |
+
+**Canonical upstream references (verify before editing `.mcp.json`):**
+- Context7: https://context7.com/docs/resources/all-clients
+- GitHub MCP: https://github.com/github/github-mcp-server
+
+If a URL or env-var name in `.mcp.json` ever stops working, check these first.
 
 ### Auth requirements
 
 - **Context7** — API key is optional (public free tier has rate limits). For higher limits, set `CONTEXT7_API_KEY` in your shell environment. Get a free key at https://context7.com/dashboard.
-- **GitHub MCP** — Requires `GITHUB_PERSONAL_ACCESS_TOKEN` in your shell environment. A classic PAT (or fine-grained PAT) with `repo` + `read:org` scopes is sufficient for read operations; add `write` scopes if you want Claude to create issues / PRs via the MCP server rather than `gh`.
+- **GitHub MCP** — Requires `GITHUB_PERSONAL_ACCESS_TOKEN` in your shell environment. Minimum permissions depend on which PAT type you create:
+  - **Classic PAT:** `repo` + `read:org` scopes are sufficient for read operations; add `write:discussion` if you want Claude to create issues or PRs via the MCP server rather than `gh`.
+  - **Fine-grained PAT:** Repository permissions `Contents: Read`, `Issues: Read`, `Pull requests: Read`; plus Organization permissions `Members: Read` for org-level lookups. Add the corresponding `Write` levels for create operations. Fine-grained PATs use different UI checkboxes from classic — the scope names above are classic-only.
 
 ### Verifying the servers loaded
 
-After cloning and running `claude`, use the `/mcp` command. Both `context7` and `github` should appear with status **connected**. If a server shows **failed**, check that the relevant env var is set and that `npx` (Node ≥18) is on your PATH.
+After cloning and running `claude`, use the `/mcp` command. Both `context7` and `github` should appear with status **connected**. If a server shows **failed**, check that the relevant env var is set and that `npx` (a recent Node LTS, `node --version` ≥ 18 is safe) is on your PATH.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,26 @@ The `.claude/` directory holds team-shared Claude Code settings (currently: a Po
 
 ---
 
+## MCP servers
+
+`.mcp.json` at the repo root declares two project-scoped MCP servers so every contributor gets them automatically on a fresh clone — no per-user setup step.
+
+| Server | Transport | Purpose |
+|---|---|---|
+| `context7` | stdio (`npx @upstash/context7-mcp@latest`) | Live shapely 2.x and matplotlib API lookups. `shapely>=2.0,<3` is pinned in `pyproject.toml`; training-data docs may be stale. |
+| `github` | HTTP (`https://api.githubcopilot.com/mcp/`) | Issue / PR / release inspection from Claude; complements the existing `gh` CLI. |
+
+### Auth requirements
+
+- **Context7** — API key is optional (public free tier has rate limits). For higher limits, set `CONTEXT7_API_KEY` in your shell environment. Get a free key at https://context7.com/dashboard.
+- **GitHub MCP** — Requires `GITHUB_PERSONAL_ACCESS_TOKEN` in your shell environment. A classic PAT (or fine-grained PAT) with `repo` + `read:org` scopes is sufficient for read operations; add `write` scopes if you want Claude to create issues / PRs via the MCP server rather than `gh`.
+
+### Verifying the servers loaded
+
+After cloning and running `claude`, use the `/mcp` command. Both `context7` and `github` should appear with status **connected**. If a server shows **failed**, check that the relevant env var is set and that `npx` (Node ≥18) is on your PATH.
+
+---
+
 ## Worktrees
 
 Allowed but not the default. Use only when two feature branches need parallel work (e.g., long-running test suite while writing the visualizer). For sequential issue flow, plain branch checkout is simpler.


### PR DESCRIPTION
## Summary

- Adds `.mcp.json` at repo root declaring two project-scoped MCP servers: **Context7** (shapely/matplotlib live docs) and **GitHub MCP** (issue/PR/release inspection).
- Updates `CLAUDE.md` with a new "MCP servers" subsection documenting purpose, auth requirements (`CONTEXT7_API_KEY` optional; `GITHUB_PERSONAL_ACCESS_TOKEN` required), and how to verify both servers loaded via `/mcp`.
- No Python source modified; all 242 tests pass.

Closes #39

## How upstream references were verified

**Context7** — Consulted https://context7.com/docs/resources/all-clients (canonical all-clients setup guide). The guide confirms: transport is **stdio** via `npx -y @upstash/context7-mcp@latest`; `CONTEXT7_API_KEY` is optional (public free tier with rate limits; higher limits require a free key from https://context7.com/dashboard). The `env` block uses `${CONTEXT7_API_KEY}` so contributors without a key get the free tier automatically.

**GitHub MCP** — Consulted https://github.com/github/github-mcp-server README. The remote server is **HTTP** at `https://api.githubcopilot.com/mcp/`; authentication is via `Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}`. This is the official recommended configuration for project-scoped Claude Code `.mcp.json` files.

Both entries use `${VAR}` env-var references only — no secrets, no absolute paths, no user-specific values.

## Test plan

- [ ] Fresh clone + `claude` session → run `/mcp` → both `context7` and `github` appear with status **connected**
- [ ] Context7: ask Claude to look up `shapely.affinity.rotate` → returns current shapely 2.x docs
- [ ] GitHub MCP: ask Claude to list open issues in DocGerd/hangarfit → returns issue list
- [ ] Contributor without `CONTEXT7_API_KEY` set → Context7 still connects (free tier); no hard failure
- [ ] `pytest -q` → 242 passed (verified locally)
- [ ] `python -m json.tool .mcp.json` → valid JSON (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)