### PR TITLE
chore: back-merge v0.1.0 into develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hangarfit"
-version = "0.0.1"
+version = "0.1.0"
 description = "Helper tool for arranging the flying club fleet in a stack-style hangar — collision checker + visualizer (Phase 1)."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Back-merge v0.1.0 into develop

Merges the release/0.1.0 branch back into develop to keep the branches in sync after the release.

This PR should be merged **AFTER** the main release PR (#46) is merged and the v0.1.0 tag is pushed.

Cut with /release-cut.