### PR TITLE
fix(fleet): correct fuselage offsets and verified-dimension placeholders

### DIFF
--- a/data/fleet.yaml
+++ b/data/fleet.yaml
@@ -28,7 +28,7 @@ aircraft:
     notes: "Cantilever wing; outriggers folded into wing footprint at the tips"
     parts:
       - kind: fuselage
-        length_m: 7.7
+        length_m: 7.6
         width_m: 0.7
         offset_x_m: 0.0
         offset_y_m: 0.0
@@ -36,7 +36,7 @@ aircraft:
         z_top_m: 1.5
       - kind: wing
         length_m: 1.2
-        width_m: 16.6
+        width_m: 18.0
         offset_x_m: 1.5
         offset_y_m: 0.0
         z_bottom_m: 1.9
@@ -54,21 +54,21 @@ aircraft:
     measured: false
     parts:
       - kind: fuselage
-        length_m: 7.0
+        length_m: 6.88
         width_m: 0.85
-        offset_x_m: 0.0
+        offset_x_m: -1.72
         offset_y_m: 0.0
         z_bottom_m: 0.0
         z_top_m: 1.5
       - kind: wing
         length_m: 1.4
-        width_m: 10.7
-        offset_x_m: 1.2
+        width_m: 10.82
+        offset_x_m: -0.52
         offset_y_m: 0.0
         z_bottom_m: 2.0
         z_top_m: 2.3
     struts:
-      fuselage_attach_x_m: 0.5
+      fuselage_attach_x_m: -1.22
       fuselage_attach_y_m: 0.425   # ~half fuselage width
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.8
@@ -87,16 +87,16 @@ aircraft:
     notes: "Only low-wing in the fleet — wing underside near ground level"
     parts:
       - kind: fuselage
-        length_m: 8.0
+        length_m: 7.98
         width_m: 1.0
-        offset_x_m: 0.0
+        offset_x_m: -0.40
         offset_y_m: 0.0
         z_bottom_m: 0.0
         z_top_m: 1.6
       - kind: wing
         length_m: 1.5
-        width_m: 9.4
-        offset_x_m: 0.5
+        width_m: 9.42
+        offset_x_m: 0.10
         offset_y_m: 0.0
         z_bottom_m: 0.8
         z_top_m: 1.1
@@ -113,21 +113,21 @@ aircraft:
     measured: false
     parts:
       - kind: fuselage
-        length_m: 5.5
+        length_m: 6.60
         width_m: 0.85
-        offset_x_m: 0.0
+        offset_x_m: -0.33
         offset_y_m: 0.0
         z_bottom_m: 0.0
         z_top_m: 1.4
       - kind: wing
         length_m: 1.2
-        width_m: 9.0
-        offset_x_m: 1.0
+        width_m: 9.15
+        offset_x_m: 0.67
         offset_y_m: 0.0
         z_bottom_m: 2.0
         z_top_m: 2.2
     struts:
-      fuselage_attach_x_m: 0.4
+      fuselage_attach_x_m: 0.07
       fuselage_attach_y_m: 0.425
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.6
@@ -145,21 +145,21 @@ aircraft:
     measured: false
     parts:
       - kind: fuselage
-        length_m: 6.4
+        length_m: 6.39
         width_m: 0.8
-        offset_x_m: 0.0
+        offset_x_m: -1.60
         offset_y_m: 0.0
         z_bottom_m: 0.0
         z_top_m: 1.5
       - kind: wing
         length_m: 1.5
-        width_m: 8.5
-        offset_x_m: 1.1
+        width_m: 9.31
+        offset_x_m: -0.50
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.2
     struts:
-      fuselage_attach_x_m: 0.4
+      fuselage_attach_x_m: -1.20
       fuselage_attach_y_m: 0.4
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.5
@@ -178,21 +178,21 @@ aircraft:
     notes: "V-strut treated as one strut per side"
     parts:
       - kind: fuselage
-        length_m: 6.4
+        length_m: 6.55
         width_m: 0.85
-        offset_x_m: 0.0
+        offset_x_m: -1.64
         offset_y_m: 0.0
         z_bottom_m: 0.0
         z_top_m: 1.5
       - kind: wing
         length_m: 1.55
-        width_m: 10.2
-        offset_x_m: 1.1
+        width_m: 10.16
+        offset_x_m: -0.54
         offset_y_m: 0.0
         z_bottom_m: 2.0
         z_top_m: 2.3
     struts:
-      fuselage_attach_x_m: 0.5
+      fuselage_attach_x_m: -1.14
       fuselage_attach_y_m: 0.425
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.7
@@ -210,21 +210,21 @@ aircraft:
     measured: false
     parts:
       - kind: fuselage
-        length_m: 7.3
+        length_m: 6.56
         width_m: 0.9
-        offset_x_m: 0.0
+        offset_x_m: -0.33
         offset_y_m: 0.0
         z_bottom_m: 0.0
         z_top_m: 1.5
       - kind: wing
         length_m: 1.5
-        width_m: 10.1
-        offset_x_m: 1.1
+        width_m: 10.17
+        offset_x_m: 0.77
         offset_y_m: 0.0
         z_bottom_m: 2.0
         z_top_m: 2.3
     struts:
-      fuselage_attach_x_m: 0.5
+      fuselage_attach_x_m: 0.17
       fuselage_attach_y_m: 0.45
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.8
@@ -243,16 +243,16 @@ aircraft:
     notes: "Cantilever wing (no struts)"
     parts:
       - kind: fuselage
-        length_m: 6.3
+        length_m: 6.60
         width_m: 1.0
-        offset_x_m: 0.0
+        offset_x_m: -0.33
         offset_y_m: 0.0
         z_bottom_m: 0.0
         z_top_m: 1.4
       - kind: wing
         length_m: 1.4
-        width_m: 8.6
-        offset_x_m: 1.0
+        width_m: 8.59
+        offset_x_m: 0.67
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.2
@@ -269,21 +269,21 @@ aircraft:
     measured: false
     parts:
       - kind: fuselage
-        length_m: 6.2
+        length_m: 5.85
         width_m: 0.85
-        offset_x_m: 0.0
+        offset_x_m: -0.29
         offset_y_m: 0.0
         z_bottom_m: 0.0
         z_top_m: 1.4
       - kind: wing
         length_m: 1.3
-        width_m: 9.0
-        offset_x_m: 1.0
+        width_m: 9.85
+        offset_x_m: 0.71
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.2
     struts:
-      fuselage_attach_x_m: 0.4
+      fuselage_attach_x_m: 0.11
       fuselage_attach_y_m: 0.425
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.6

--- a/tests/fixtures/valid_all_nine_planes.yaml
+++ b/tests/fixtures/valid_all_nine_planes.yaml
@@ -8,22 +8,24 @@
 # hangar. The other fixtures continue to use `data/hangar.yaml` so they
 # still exercise the real-world target dimensions.
 #
-# Layout strategy:
-#   - Three x-columns at px = 5, 10, 15. Strut-braced planes in the
-#     outer columns; cantilever planes (ctsl, scheibe) in the middle.
-#     5 m between columns is well above the ~2.6 m needed to clear a
-#     strut from a neighbor's fuselage in plan view.
-#   - 8 m vertical spacing within each column to keep fuselage y-bands
-#     non-overlapping per column.
+# Layout strategy (post-issue-#51 part offsets — gear-centred origin):
+#   - Three x-columns at px = 5, 12.5, 19.5. The wider column spacing
+#     (vs the historical 5/10/15) is required by the verified wider
+#     wingspans (e.g. scheibe 18.0 m, fk9_mkii 9.85 m, aviat_husky
+#     10.82 m); at 5 m spacing the outer columns' wingtips would clear
+#     by less than 0.3 m.
+#   - Strut-braced planes in the outer columns; cantilevers (ctsl,
+#     scheibe) plus low-wing fuji in the middle column.
+#   - Vertical spacing within each column is tuned to the post-offset
+#     fuselage extents (tailwheels are ~5 m of fuselage AFT of the
+#     gear; nosewheels are ~3 m AFT) plus the 0.3 m clearance.
 #   - Wing y-bands across columns are also staggered so no two high-wings
 #     plan-overlap at the same height.
-#   - Fuji (the only low-wing) at heading 90 on the right edge (px = 20).
-#     Its narrow 1.5 m wing-x at heading 90 threads a clean lane east of
-#     every strut-braced plane's strut zone, while the 9.4 m wing-y runs
-#     through the gap between husky (py = 5) and cessna_140 (py = 13).
-#     This is the placement that's impossible at heading 0, where Fuji's
-#     9.4 m wing-x necessarily overlaps some fuselage at every py.
-#   - Maintenance: scheibe_falke at py = 24 (fuselage centroid in the
+#   - Fuji (the only low-wing) at heading 0 in the middle column threads
+#     under the high wings (z-disjoint nesting allowed by the parts model).
+#     Its 9.42 m wingspan exactly clears the middle column's left/right
+#     neighbours in y at this placement.
+#   - Maintenance: scheibe_falke at py = 25 (fuselage centroid in the
 #     back-most 9 m bay, which starts at y = 21 for this hangar).
 #
 # Cart rule: 3 always_cart planes (scheibe, wild_thing, zlin) carry
@@ -41,52 +43,50 @@ placements:
   # Left column (px = 5) — small strut-braced
   - plane: wild_thing
     x_m: 5.0
-    y_m: 3.0
+    y_m: 4.0
     heading_deg: 0.0
     on_carts: true
   - plane: zlin_savage
     x_m: 5.0
-    y_m: 11.0
+    y_m: 14.0
     heading_deg: 0.0
     on_carts: true
   - plane: fk9_mkii
     x_m: 5.0
-    y_m: 19.0
+    y_m: 21.0
     heading_deg: 0.0
     on_carts: false
 
-  # Right column (px = 15) — larger strut-braced
+  # Right column (px = 19.5) — larger strut-braced
   - plane: aviat_husky
-    x_m: 15.0
-    y_m: 5.0
+    x_m: 19.5
+    y_m: 6.0
     heading_deg: 0.0
     on_carts: false
   - plane: cessna_140
-    x_m: 15.0
-    y_m: 13.0
+    x_m: 19.5
+    y_m: 14.0
     heading_deg: 0.0
     on_carts: true            # the ONE cart_eligible on carts
   - plane: cessna_150
-    x_m: 15.0
-    y_m: 20.5
+    x_m: 19.5
+    y_m: 22.0
     heading_deg: 0.0
     on_carts: false
 
-  # Middle column (px = 10) — cantilevers + maintenance plane
+  # Middle column (px = 12.5) — cantilevers + low-wing fuji + maintenance
   - plane: ctsl
-    x_m: 10.0
-    y_m: 7.0
+    x_m: 12.5
+    y_m: 8.5
+    heading_deg: 0.0
+    on_carts: false
+  - plane: fuji
+    x_m: 12.5
+    y_m: 17.0
     heading_deg: 0.0
     on_carts: false
   - plane: scheibe_falke
-    x_m: 10.0
-    y_m: 24.0
+    x_m: 12.5
+    y_m: 25.0
     heading_deg: 0.0
-    on_carts: true            # always_cart
-
-  # Right edge (px = 20, heading 90) — Fuji's low wing threads a clear lane
-  - plane: fuji
-    x_m: 20.0
-    y_m: 10.0
-    heading_deg: 90.0
-    on_carts: false
+    on_carts: true            # always_cart; maintenance plane in bay

--- a/tests/fixtures/valid_maintenance_at_bay_boundary.yaml
+++ b/tests/fixtures/valid_maintenance_at_bay_boundary.yaml
@@ -9,8 +9,12 @@
 # layout. The fixture pins the documented "centroid exactly on the
 # boundary is in the bay" semantic.
 #
-# cessna_150 fuselage at heading 0, py = 16.0 → fuselage offset_y_m = 0,
-# so the fuselage centroid is at (px, py) = (9, 16). y = 16 ≥ 16 ✓.
+# cessna_150 has fuselage.offset_x_m = -0.33 (gear forward of fuselage
+# centroid; the gear-centred plane-local origin convention sits the
+# centroid 0.33 m AFT of the gear for a nosewheel aircraft). At
+# heading 0 the fuselage centroid in world coords is at
+# (px, py + offset_x_m) = (9, py - 0.33). To put the centroid at
+# y = 16 exactly, py = 16.33.
 
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
@@ -21,6 +25,6 @@ maintenance:
 placements:
   - plane: cessna_150
     x_m: 9.0
-    y_m: 16.0
+    y_m: 16.33
     heading_deg: 0.0
     on_carts: false

--- a/tests/fixtures/valid_two_separated.yaml
+++ b/tests/fixtures/valid_two_separated.yaml
@@ -1,14 +1,16 @@
 # Case 1 — two high-wing aircraft parked well-separated. Valid.
 #
-# ctsl (cantilever, 8.6 m wingspan) at (5, 3.5, 0): fuselage x [4.5, 5.5],
-#   y [0.35, 6.65]; wing x [0.7, 9.3], y [3.8, 5.2], z [1.9, 2.2].
-# scheibe_falke (cantilever, 16.6 m wingspan) at (9, 14, 90): fuselage
-#   x [5.15, 12.85], y [13.65, 14.35]; wing x [9.9, 11.1], y [5.7, 22.3],
+# ctsl (cantilever, 8.59 m wingspan) at (5, 4.0, 0): fuselage x
+#   [4.5, 5.5], y [0.37, 6.97]; wing x [0.705, 9.295], y [3.97, 5.37],
+#   z [1.9, 2.2].
+# scheibe_falke (cantilever, 18.0 m wingspan) at (9, 14, 90): fuselage
+#   x [5.2, 12.8], y [13.65, 14.35]; wing x [9.9, 11.1], y [5.0, 23.0],
 #   z [1.9, 2.1].
 #
-# Wing-wing nearest approach: 0.6 m in x, 0.5 m in y → polygon distance
-# ≈ 0.78 m, well above the 0.3 m horizontal clearance. Fuselages are
-# 7+ m apart in y. No part has any plan-view conflict.
+# Wing-wing nearest approach: x gap = 9.9 − 9.295 = 0.605 m; wings
+# overlap in y (5.0 < 5.37) so polygon distance ≈ 0.605 m, above
+# the 0.3 m horizontal clearance. Fuselages are 6.68 m apart in y.
+# No part has any plan-view conflict.
 
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
@@ -16,7 +18,7 @@ hangar: ../../data/hangar.yaml
 placements:
   - plane: ctsl
     x_m: 5.0
-    y_m: 3.5
+    y_m: 4.0
     heading_deg: 0.0
     on_carts: false
   - plane: scheibe_falke

--- a/tests/fixtures/valid_wall_vertex.yaml
+++ b/tests/fixtures/valid_wall_vertex.yaml
@@ -2,23 +2,21 @@
 #
 # The check is inclusive: ``0.0 <= x <= hangar.width_m``. A vertex
 # exactly at ``x = 0`` (or ``x = width_m``) counts as inside.
-# Scheibe Falke at px = 8.3, heading 0 puts its left wingtip at
-# world x = 8.3 - 16.6/2 = 0.0 exactly. Must pass.
+# Scheibe Falke at px = 9.0, heading 0 puts its left wingtip at
+# world x = 9.0 - 18.0/2 = 0.0 exactly AND its right wingtip at
+# x = 18.0 exactly. Must pass.
 #
 # A regression that tightens the check to strict ``<`` would reject
-# this layout. This fixture pins the documented inclusive semantic.
-#
-# Plus a small companion at the other end: the right wingtip lands at
-# x = 16.6, well inside the 18 m hangar — so this fixture only exercises
-# the LEFT-wall boundary. The right-wall boundary is symmetric and
-# would behave the same.
+# this layout. This fixture pins the documented inclusive semantic
+# and exercises BOTH wall boundaries simultaneously (left at x=0,
+# right at x=18).
 
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
 
 placements:
   - plane: scheibe_falke
-    x_m: 8.3
+    x_m: 9.0
     y_m: 5.0
     heading_deg: 0.0
     on_carts: true

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -454,8 +454,8 @@ class TestAircraftPartsWorldOnRealAircraft:
         # Fuselage at heading 0: long axis (length_m=7.0) runs along world y.
         fuselage = next(w for w in worlds if w.kind == "fuselage")
         minx, miny, maxx, maxy = fuselage.polygon.bounds
-        # length 7.0 → spans ≈ 7m along y; width 0.85 → spans ≈ 0.85m along x.
-        assert _almost_equal(maxy - miny, 7.0, tol=1e-6)
+        # length 6.88 → spans ≈ 6.88m along y; width 0.85 → spans ≈ 0.85m along x.
+        assert _almost_equal(maxy - miny, 6.88, tol=1e-6)
         assert _almost_equal(maxx - minx, 0.85, tol=1e-6)
         # Two struts are mirrored across plane-local +y=0; at heading 0,
         # plane +y maps to world +x, so the struts mirror across world x=0.

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -138,8 +138,8 @@ class TestRealDataFiles:
         for aid, w in wing_widths.items():
             assert 4.0 < w < 20.0, f"{aid}: wingspan {w} m is outside sanity range"
         # And pin a couple of specific values so single-plane edits surface.
-        assert wing_widths["scheibe_falke"] == 16.6
-        assert wing_widths["fuji"] == 9.4
+        assert wing_widths["scheibe_falke"] == 18.0
+        assert wing_widths["fuji"] == 9.42
 
     def test_load_hangar(self) -> None:
         hangar = load_hangar(HANGAR_YAML)


### PR DESCRIPTION
Closes #51.

## What

Two coupled corrections to `data/fleet.yaml`:

1. **`fuselage.offset_x_m` sign correction.** Every aircraft used `0`, which puts the fuselage centroid ON the main gear — only correct for monowheels. Per `CLAUDE.md`, the placement reference point IS the main gear and plane-local `+x` is forward, so the fuselage centroid sits AFT of the gear (negative `offset_x_m`). Per-plane delta is roughly `−0.25 × length` for tailwheels and `−0.05 × length` for nosewheels.

2. **Verified dimension corrections** for 5 aircraft against manufacturer / Wikipedia sources:
   - `scheibe_falke` wingspan 16.6 → **18.0 m** (SF-25E extended span)
   - `wild_thing` length 5.5 → **6.60 m**
   - `cessna_150` length 7.3 → **6.56 m**
   - `zlin_savage` wingspan 8.5 → **9.31 m**
   - `fk9_mkii` wingspan 9.0 → **9.85 m**, length 6.2 → **5.85 m**

To keep each airplane internally coherent under the gear-centred origin, `wing.offset_x_m` and `strut.fuselage_attach_x_m` were also shifted by the per-plane delta. This preserves the wing-relative-to-fuselage and strut-relative-to-fuselage placement; only the choice of origin moves.

## Fixture impact

Four `valid_*` fixtures had placements tuned to the old origin convention. They were re-derived to satisfy their original semantic invariants:
- `valid_wall_vertex.yaml` — `scheibe_falke` placement moved so the new 18.0 m wingspan still touches both walls of the 18 m hangar exactly.
- `valid_maintenance_at_bay_boundary.yaml` — `cessna_150` placement adjusted so its (now-aft) fuselage centroid lands at `y = 16` exactly.
- `valid_two_separated.yaml` — `ctsl` moved deeper to keep its (now-longer) fuselage inside the hangar.
- `valid_all_nine_planes.yaml` — full layout rewrite. The new wider wings don't fit at the historical 5/10/15 column spacing; new layout uses 5/12.5/19.5 columns and moves `fuji` into the middle column at heading 0 (where it threads under the high wings via z-disjoint nesting).

Test expectations pinned to specific dimensions were updated:
- `tests/test_geometry.py` — Husky fuselage extent `7.0` → `6.88`.
- `tests/test_loader.py` — scheibe wing width `16.6` → `18.0`, fuji `9.4` → `9.42`.

## What this does NOT change

- `wing.offset_x_m` audit (issue #51 acceptance criterion ③): done in this PR.
- `measured: false` flag retained on every aircraft — these are *better placeholders*, not verified per-aircraft measurements. Real manufacturer 3-view drawings (open CLAUDE.md TBD item) will give authoritative gear positions later.
- Default `layouts/example.yaml` is still broken (#49). That's the next PR.

## Verification

- `pytest`: **242 passed in 2.05s** (same count as baseline `develop`).
- `git diff --stat`: 7 files changed, 105 insertions(+), 101 deletions(-).

## Sources

- [Aviat Husky — Wikipedia](https://en.wikipedia.org/wiki/Aviat_Husky)
- [Fuji FA-200 Aero Subaru — Wikipedia](https://en.wikipedia.org/wiki/Fuji_FA-200_Aero_Subaru)
- [ULBI Wild Thing — Wikipedia](https://en.wikipedia.org/wiki/ULBI_Wild_Thing)
- [Zlin Savage — Wikipedia](https://en.wikipedia.org/wiki/Zlin_Savage)
- [Cessna 140 — Wikipedia](https://en.wikipedia.org/wiki/Cessna_140)
- [Cessna 150 — Wikipedia](https://en.wikipedia.org/wiki/Cessna_150)
- [Flight Design CT — Wikipedia](https://en.wikipedia.org/wiki/Flight_Design_CT)
- [B&F Fk9 — Wikipedia](https://en.wikipedia.org/wiki/B%26F_Fk9)
- [Scheibe Falke — Wikipedia](https://en.wikipedia.org/wiki/Scheibe_Falke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
