### PR TITLE
chore(github): add CODEOWNERS, issue templates, and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Catch-all: every PR auto-requests @DocGerd as reviewer.
+# Per the GitFlow rule in CLAUDE.md, @DocGerd is the only approver and merger.
+* @DocGerd

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,74 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly
+title: "[bug] "
+labels: ["bug"]
+
+body:
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: What you did
+      description: Steps to reproduce the issue
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      description: What did happen instead?
+    validations:
+      required: true
+
+  - type: input
+    id: python_version
+    attributes:
+      label: Python version
+      description: Output of `python --version`
+      placeholder: "Python 3.11.2"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "Ubuntu 22.04 / macOS 13.2 / Windows 11"
+    validations:
+      required: true
+
+  - type: input
+    id: hangarfit_version
+    attributes:
+      label: hangarfit version or commit SHA
+      placeholder: "0.1.0 or abc1234"
+    validations:
+      required: true
+
+  - type: textarea
+    id: minimal_reproducer
+    attributes:
+      label: Minimal reproducer (layout YAML, command)
+      description: Optional — a minimal layout YAML or `hangarfit` command that triggers the issue
+      placeholder: |
+        ```yaml
+        # layout.yaml
+        ```
+
+        ```bash
+        hangarfit check layout.yaml --render out.png
+        ```
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Propose a new feature or enhancement
+title: "[feat] "
+labels: ["enhancement"]
+
+body:
+  - type: textarea
+    id: problem_statement
+    attributes:
+      label: Problem statement
+      description: What problem are we solving? What's the user need?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_approach
+    attributes:
+      label: Proposed approach
+      description: How should we solve it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional — any other approaches considered?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,19 @@
+name: Question
+description: Ask a question about hangarfit
+title: "[question] "
+labels: ["question"]
+
+body:
+  - type: textarea
+    id: trying_to_do
+    attributes:
+      label: What are you trying to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried_so_far
+    attributes:
+      label: What have you tried?
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## What
+
+<one-paragraph description>
+
+Closes #<N>
+
+## Checklist
+
+- [ ] Branched from `develop` (or `main` for hotfix)
+- [ ] Tests added/updated and pass locally
+- [ ] No skipped hooks (no `--no-verify`)
+- [ ] CLAUDE.md updated if design assumptions changed
+- [ ] pr-review-toolkit run; all threads resolved
+- [ ] No direct push expected — waiting for review + merge by maintainer


### PR DESCRIPTION
## What

Bundle of three .github/ additions per the memory recommendation (zero file overlap, atomic-revert not useful):

- **CODEOWNERS** (#17): catch-all `* @DocGerd`.
- **Issue templates** (#18): bug / feature / question YAML issue forms + config.yml disabling blank issues.
- **PR template** (#19): GitFlow checklist prefill from CLAUDE.md.

Closes #17
Closes #18
Closes #19

## Checklist

- [x] Branched from \`develop\`
- [x] No code changes (docs/config only) — pytest unaffected
- [x] No skipped hooks