### PR TITLE
chore(ci): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    labels: ["dependencies", "ci"]


### PR DESCRIPTION
## What

Adds .github/dependabot.yml so dependency bumps land as PRs automatically. pip weekly (Monday), github-actions monthly, both labeled `dependencies`.

Closes #22

## Checklist

- [x] Branched from `develop`
- [x] No code changes
- [x] No skipped hooks