### PR TITLE
chore(ci): add CodeQL workflow for Python

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,6 @@ jobs:
         uses: github/codeql-action/init@f411752efdf656cb71aa17b755b22c890960da1d  # v3.35.5
         with:
           languages: python
-          queries: default
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@f411752efdf656cb71aa17b755b22c890960da1d  # v3.35.5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@f411752efdf656cb71aa17b755b22c890960da1d  # v3.35.5
+        with:
+          languages: python
+          queries: default
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@f411752efdf656cb71aa17b755b22c890960da1d  # v3.35.5
+        with:
+          category: "/language:python"


### PR DESCRIPTION
## What

Adds .github/workflows/codeql.yml — CodeQL static analysis on push to develop/main, PRs into develop, and a weekly cron. Python-only, default queries (informational mode, no PR-blocking).

Actions pinned to commit SHAs from day one — preempts #53.

Closes #23

## Checklist

- [x] Branched from `develop`
- [x] No code changes
- [x] Actions pinned to SHA