### PR TITLE
chore(mcp): drop context7 MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,12 +1,5 @@
 {
   "mcpServers": {
-    "context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@2.3.0"],
-      "env": {
-        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
-      }
-    },
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,25 +220,22 @@ The `.claude/` directory holds team-shared Claude Code settings (currently: a Po
 
 | Server | Transport | Purpose |
 |---|---|---|
-| `context7` | stdio (`npx @upstash/context7-mcp@2.3.0`) | Live shapely 2.x and matplotlib API lookups. `shapely>=2.0,<3` is pinned in `pyproject.toml`; training-data docs may be stale. |
 | `github` | HTTP (`https://api.githubcopilot.com/mcp/`) | Issue / PR / release inspection from Claude; complements the existing `gh` CLI. |
 
 **Canonical upstream references (verify before editing `.mcp.json`):**
-- Context7: https://context7.com/docs/resources/all-clients
 - GitHub MCP: https://github.com/github/github-mcp-server
 
 If a URL or env-var name in `.mcp.json` ever stops working, check these first.
 
 ### Auth requirements
 
-- **Context7** — API key is optional (public free tier has rate limits). For higher limits, set `CONTEXT7_API_KEY` in your shell environment. Get a free key at https://context7.com/dashboard.
 - **GitHub MCP** — Requires `GITHUB_PERSONAL_ACCESS_TOKEN` in your shell environment. Minimum permissions depend on which PAT type you create:
   - **Classic PAT:** `repo` + `read:org` scopes are sufficient for read operations; add `write:discussion` if you want Claude to create issues or PRs via the MCP server rather than `gh`.
   - **Fine-grained PAT:** Repository permissions `Contents: Read`, `Issues: Read`, `Pull requests: Read`; plus Organization permissions `Members: Read` for org-level lookups. Add the corresponding `Write` levels for create operations. Fine-grained PATs use different UI checkboxes from classic — the scope names above are classic-only.
 
 ### Verifying the servers loaded
 
-After cloning and running `claude`, use the `/mcp` command. Both `context7` and `github` should appear with status **connected**. If a server shows **failed**, check that the relevant env var is set and that `npx` (a recent Node LTS, `node --version` ≥ 18 is safe) is on your PATH.
+After cloning and running `claude`, use the `/mcp` command. The `github` server should appear with status **connected**. If it shows **failed**, check that `GITHUB_PERSONAL_ACCESS_TOKEN` is set in your shell environment.
 
 ---
 


### PR DESCRIPTION
## What

Drops the `context7` MCP server from `.mcp.json` and removes references from `CLAUDE.md`. Reason: requires a `CONTEXT7_API_KEY` env var (public free tier rate-limits hard), which doubles onboarding friction on top of the `GITHUB_PERSONAL_ACCESS_TOKEN` already needed for the `github` MCP server.

Closes #66

## Checklist

- [x] Branched from `develop`
- [x] No code changes (config + docs only)
- [x] `.mcp.json` still valid JSON
- [x] No remaining references to context7 in files