### PR TITLE
chore(ci): pin Actions to commit SHAs in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip


### PR DESCRIPTION
## What

Pins `actions/checkout` and `actions/setup-python` in `.github/workflows/ci.yml` to commit SHAs with the version tag preserved as a trailing comment. Dependabot (#22) uses the tag comment to auto-bump.

Matches the pattern set by PR #63 (CodeQL) which already pins from day one. Aligns with OpenSSF Scorecard's `Pinned-Dependencies` check (relevant to #54).

Closes #53

## Checklist

- [x] Branched from `develop`
- [x] No code changes — workflow YAML only
- [x] Both SHA + trailing tag comment present on every `uses:` line