### PR TITLE
fix(layouts): rewrite default example.yaml as a valid Saturday-morning layout

### DIFF
--- a/layouts/example.yaml
+++ b/layouts/example.yaml
@@ -1,78 +1,80 @@
-# Example candidate layout for the 9-aircraft fleet.
+# Default example layout for hangarfit.
 #
-# This layout loads cleanly and satisfies all loader-level invariants
-# (cart rule, movement-mode-vs-on_carts consistency, maintenance plane
-# in fleet and placed). It is NOT guaranteed to be collision-free —
-# that's what the collision checker (#5) is for. Edit positions once
-# the checker lands and you can iterate.
+# Scenario: Saturday morning. Three of the club's nine aircraft are out
+# (Cessna 140 and 150 doing training flights, FK9 on a pleasure flight),
+# six are home in non-standard positions. Scheibe Falke is in the back
+# for scheduled maintenance.
 #
-# Hangar: 25 m deep × 18 m wide, door centered at x=9 (width 12),
-# maintenance bay = back 9 m (so y > 16 is the bay).
+# This is the canonical smoke test from CLAUDE.md:
 #
-# Coordinate convention (CLAUDE.md): world (0,0) at front-left, +x right
-# along door wall, +y deeper into hangar. heading 0° = nose into hangar.
+#     hangarfit check layouts/example.yaml --render out.png
+#
+# It must produce ``valid`` (exit 0). A clean PNG is the demo output a
+# first-time user sees. If you want to see the conflict-overlay branch
+# of the visualiser, use ``layouts/example_invalid.yaml`` (a deliberately
+# bad layout shipped alongside this file for that purpose).
+#
+# Hangar: 18 m wide × 25 m deep (data/hangar.yaml). Bay = back 9 m
+# (y >= 16). Coordinate convention (CLAUDE.md): world (0, 0) at front-left,
+# +x right along door wall, +y deeper into hangar. heading 0 = nose
+# into hangar.
+#
+# Cart usage: only the three ``always_cart`` planes (scheibe, zlin,
+# wild_thing) are on carts; CTSL is ``cart_eligible`` but parked on its
+# own gear (the "no cart swapping unless necessary" operational rule).
+#
+# Planes not in this layout (out flying):
+#   - cessna_140  (training flight)
+#   - cessna_150  (training flight)
+#   - fk9_mkii    (pleasure flight)
 
 fleet: ../data/fleet.yaml
 hangar: ../data/hangar.yaml
 
 maintenance:
-  plane: cessna_150          # parked in the back maintenance bay
+  plane: scheibe_falke
 
 placements:
-  # Back / maintenance bay
-  - plane: cessna_150
+  # Front-center: small cantilever at the door, easy to roll out first
+  - plane: ctsl
     x_m: 9.0
-    y_m: 21.0
-    heading_deg: 0
-    on_carts: false          # the cart-eligible plane currently on its own gear
+    y_m: 4.0
+    heading_deg: 0.0
+    on_carts: false        # cart_eligible but on own gear
 
-  # Middle row
-  - plane: scheibe_falke
+  # Front lane (y = 8): one strut-braced on the left, fuji
+  # parked sideways on the right
+  - plane: zlin_savage
+    x_m: 5.0
+    y_m: 8.0
+    heading_deg: 0.0
+    on_carts: true         # always_cart
+  - plane: fuji
+    x_m: 13.0
+    y_m: 8.0
+    heading_deg: 90.0      # nose pointing right; low wing threads under
+                           # neighbouring high wings (z-disjoint nesting)
+    on_carts: false        # always_own_gear
+
+  # Mid-center: wild_thing
+  - plane: wild_thing
     x_m: 9.0
     y_m: 13.0
-    heading_deg: 90          # nose right; the 16.6 m wingspan runs along world y
-    on_carts: true           # always_cart
+    heading_deg: 0.0
+    on_carts: true         # always_cart
 
-  # Front row (deeper end of front area)
+  # Just forward of the maintenance bay: husky tucked against the
+  # left wall (its 10.82 m wingspan reaches across to mid-hangar)
   - plane: aviat_husky
-    x_m: 3.0
-    y_m: 8.0
-    heading_deg: 0
-    on_carts: false          # always_own_gear
+    x_m: 6.0
+    y_m: 16.0
+    heading_deg: 0.0
+    on_carts: false        # always_own_gear
 
-  - plane: fuji
+  # Maintenance bay (back): the motorglider sits along the back wall,
+  # its 18 m wingspan exactly spanning the hangar width
+  - plane: scheibe_falke
     x_m: 9.0
-    y_m: 8.0
-    heading_deg: 0
-    on_carts: false          # always_own_gear
-
-  - plane: wild_thing
-    x_m: 15.0
-    y_m: 8.0
-    heading_deg: 0
-    on_carts: true           # always_cart
-
-  # Front-front row (near door)
-  - plane: zlin_savage
-    x_m: 3.0
-    y_m: 3.0
-    heading_deg: 0
-    on_carts: true           # always_cart
-
-  - plane: cessna_140
-    x_m: 7.0
-    y_m: 3.0
-    heading_deg: 0
-    on_carts: true           # the ONE cart_eligible plane on the spare carts
-
-  - plane: ctsl
-    x_m: 11.0
-    y_m: 3.0
-    heading_deg: 0
-    on_carts: false
-
-  - plane: fk9_mkii
-    x_m: 15.0
-    y_m: 3.0
-    heading_deg: 0
-    on_carts: false
+    y_m: 20.5
+    heading_deg: 0.0
+    on_carts: true         # always_cart

--- a/layouts/example_invalid.yaml
+++ b/layouts/example_invalid.yaml
@@ -1,0 +1,52 @@
+# Deliberately invalid example — drives the conflict-overlay demo.
+#
+# Run:
+#     hangarfit check layouts/example_invalid.yaml --render bad.png
+#
+# Expected: ``invalid: 4 conflicts``, exit 1, and a PNG with each
+# conflicting plane outlined in red. Exercises three different
+# conflict kinds:
+#
+#   - hangar_bounds   — aviat_husky's left wingtip pokes past x=0
+#   - wing_wing_overlap — aviat_husky's wing overlaps cessna_140's wing
+#     in plan view AND at the same height (~2 m)
+#   - strut_wing_overlap — the same wing-wing situation also brings each
+#     plane's wing close to the other's strut
+#
+# Companion to the all-valid ``layouts/example.yaml``. If you only want
+# the demo of a clean PNG, run the default example instead.
+#
+# Hangar: 18 m wide × 25 m deep (data/hangar.yaml). Coordinate
+# convention: (0, 0) front-left, +x right along door, +y deeper.
+
+fleet: ../data/fleet.yaml
+hangar: ../data/hangar.yaml
+
+maintenance:
+  plane: scheibe_falke
+
+placements:
+  # Husky too far left — its 10.82 m wingspan reaches past x=0
+  - plane: aviat_husky
+    x_m: 4.0
+    y_m: 8.0
+    heading_deg: 0.0
+    on_carts: false
+
+  # Cessna 140 placed only 6 m to husky's right — their wings overlap
+  # in plan view and at the same height (~2 m), so the checker fires
+  # both wing_wing_overlap and strut_wing_overlap
+  - plane: cessna_140
+    x_m: 10.0
+    y_m: 8.0
+    heading_deg: 0.0
+    on_carts: true         # the single cart_eligible plane on carts
+
+  # Maintenance plane in the bay — placed correctly (no conflict here);
+  # this is just to satisfy the Layout invariant that the designated
+  # maintenance plane is also placed
+  - plane: scheibe_falke
+    x_m: 9.0
+    y_m: 18.0
+    heading_deg: 0.0
+    on_carts: true

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,30 @@ class TestCheckHappyPath:
         assert captured.out.strip() == "valid"
         assert captured.err == ""
 
+    def test_default_example_layout_is_valid(self, capsys):
+        """The canonical smoke test from CLAUDE.md must produce ``valid``.
+
+        ``hangarfit check layouts/example.yaml`` is the first thing a new
+        contributor runs after cloning. If this regresses, the default
+        user experience is "the algorithm looks broken" — even when the
+        checker itself is fine. Pin it.
+        """
+        exit_code = main(["check", str(REPO_ROOT / "layouts" / "example.yaml")])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "valid"
+        assert captured.err == ""
+
+    def test_default_example_invalid_layout_lists_conflicts(self, capsys):
+        """The companion ``layouts/example_invalid.yaml`` must exit 1 and
+        produce at least one conflict — it's the demo for the red-overlay
+        rendering and the JSON conflicts list."""
+        exit_code = main(["check", str(REPO_ROOT / "layouts" / "example_invalid.yaml")])
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert captured.out.startswith("invalid:")
+        assert captured.err == ""
+
     def test_check_invalid_layout_returns_1(self, capsys):
         exit_code = main(["check", str(FIXTURES_DIR / "invalid_fuselage_wing_overlap.yaml")])
         assert exit_code == 1

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -150,8 +150,10 @@ class TestRealDataFiles:
 
     def test_load_example_layout(self) -> None:
         layout = load_layout(EXAMPLE_LAYOUT)
-        assert len(layout.placements) == 9
-        assert layout.maintenance_plane == "cessna_150"
+        # The default example is the Saturday-morning scenario: 6 planes
+        # at home, 3 out flying. See layouts/example.yaml for context.
+        assert len(layout.placements) == 6
+        assert layout.maintenance_plane == "scheibe_falke"
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #49.

## What

`layouts/example.yaml` was hand-authored under the pre-#51 origin convention and packed all 9 aircraft side-by-side in the 18×25 m placeholder hangar — geometrically impossible. Running the canonical smoke test (`hangarfit check layouts/example.yaml --render out.png`) produced 27+ conflicts and a visually chaotic PNG, giving first-run users the misleading impression that the checker itself was broken.

## How

Rewritten as a realistic exception-tool scenario: a Saturday morning with **6 planes at home** and **3 out flying** (Cessna 140, Cessna 150, FK9). The hangar genuinely cannot fit all 9 placeholder aircraft at once — the verified wingspans (e.g. scheibe 18 m, husky 10.8 m) plus the clearance budget exceed what 18 m of door width can accommodate, regardless of heading combinations. The exception-tool framing matches the actual purpose of `hangarfit` (find an alternative arrangement when the standard layout breaks), so "some planes are out" is the right shape for the default example, not a workaround.

### Layout decisions

- Single center column for the three high-wing aircraft (`ctsl`, `wild_thing`, `aviat_husky`) plus the maintenance plane (`scheibe_falke`).
- `zlin_savage` at the left side, `fuji` at the right side at heading 90 — `fuji`'s narrow heading-90 footprint clears the center column and its low wing nests at a different z from the high wings.
- `aviat_husky` tucked at `x = 6` just forward of the bay, its 10.8 m wingspan reaching across to mid-hangar.
- Only the three `always_cart` planes (scheibe, zlin, wild_thing) are on carts; `ctsl` is `cart_eligible` but on its own gear — the "no cart swapping unless necessary" operational principle.

## Companion: `example_invalid.yaml`

Ships alongside the valid default to keep a one-command demo of the red-overlay rendering. Exercises three different conflict kinds (`hangar_bounds`, `wing_wing_overlap`, `strut_wing_overlap`) in a minimal 3-plane layout.

## Tests

- `tests/test_cli.py::test_default_example_layout_is_valid` — pins the smoke contract (exit 0, stdout `valid`). Regressions in either the fleet data or the example will surface here before they ship.
- `tests/test_cli.py::test_default_example_invalid_layout_lists_conflicts` — pins the invalid sibling (exit 1, conflict lines on stdout).
- `tests/test_loader.py::test_load_example_layout` updated for the new placement count and maintenance plane (6 planes, `scheibe_falke`).

**244 passing** (was 242 + 2 new CLI tests).

## Verification

```
$ hangarfit check layouts/example.yaml --render out.png
valid
(exit 0)

$ hangarfit check layouts/example_invalid.yaml --render bad.png
invalid: 4 conflicts
  - hangar_bounds [aviat_husky]: ...
  - wing_wing_overlap [aviat_husky, cessna_140]: ...
  - strut_wing_overlap [aviat_husky, cessna_140]: ...
  - strut_wing_overlap [aviat_husky, cessna_140]: ...
(exit 1)
```

## Acceptance criteria (from #49)

- [x] `hangarfit check layouts/example.yaml --render out.png` exits 0.
- [x] No `hangar_bounds`, `*_overlap`, or `maintenance_*` conflicts.
- [x] Only `always_cart` planes are on carts (no discretionary `cart_eligible` cart use).
- [x] Ship `layouts/example_invalid.yaml` as the conflict-overlay demo.
- [x] Smoke test added to `tests/test_cli.py` asserting the default example is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
