### PR TITLE
chore(ci): measure coverage with pytest-cov + Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,11 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run tests
-        run: pytest
+        run: pytest --cov=hangarfit --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5.5.4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # hangarfit
 
 ![CI](https://github.com/DocGerd/hangarfit/actions/workflows/ci.yml/badge.svg?branch=develop)
+[![codecov](https://codecov.io/gh/DocGerd/hangarfit/branch/develop/graph/badge.svg)](https://codecov.io/gh/DocGerd/hangarfit)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/DocGerd/hangarfit/badge)](https://securityscorecards.dev/viewer/?uri=github.com/DocGerd/hangarfit)
 
 An on-demand exception tool for a flying club's hangar parking.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7.4"]
+dev = ["pytest>=7.4", "pytest-cov>=4.0"]
 
 [project.scripts]
 hangarfit = "hangarfit.cli:main"


### PR DESCRIPTION
## What

Adds coverage measurement (`pytest-cov`) and Codecov upload to CI. README gets a Codecov badge next to the existing CI badge.

- Codecov free OSS path: no token, `fail_ci_if_error: false` so an outage doesn't break CI.
- `codecov/codecov-action` pinned to a commit SHA per the project pattern (#68).
- Measurement only — no `fail_under=X` gate. That's deferred to a follow-up once we know the natural floor.

Closes #55

## Checklist

- [x] Branched from `develop`
- [x] `pytest --cov=hangarfit --cov-report=xml --cov-report=term-missing` passes locally
- [x] `coverage.xml` produced
- [x] Codecov action pinned to SHA