### PR TITLE
chore(ci): adopt ruff for lint and format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Install
         run: pip install -e ".[dev]"
 
+      - name: Lint with ruff
+        run: ruff check src/ tests/
+
+      - name: Check formatting with ruff
+        run: ruff format --check src/ tests/
+
       - name: Run tests
         run: pytest --cov=hangarfit --cov-report=xml --cov-report=term-missing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,14 @@ pip install -e ".[dev]"
 # Run tests
 pytest
 
+# Lint + format check (CI also runs these)
+ruff check src/ tests/
+ruff format --check src/ tests/
+
+# Auto-fix lint findings and format
+ruff check --fix src/ tests/
+ruff format src/ tests/
+
 # CI: GitHub Actions runs `pytest` on Python 3.11 + 3.12 for PRs into
 # develop/main (see .github/workflows/ci.yml). No coverage gate yet.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7.4", "pytest-cov>=4.0"]
+dev = ["pytest>=7.4", "pytest-cov>=4.0", "ruff>=0.7.0"]
 
 [project.scripts]
 hangarfit = "hangarfit.cli:main"
@@ -29,3 +29,13 @@ where = ["src"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-ra"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "SIM"]
+
+[tool.ruff.format]
+# Defaults are fine — quote-style="double", indent-style="space", line-ending="lf".

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -44,13 +44,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--fleet",
         metavar="PATH",
         default=None,
-        help="Override the fleet data file. Cannot be combined with a layout that already embeds a fleet path.",
+        help="Override the fleet data file. Cannot be combined with a layout that already embeds a fleet path.",  # noqa: E501
     )
     check.add_argument(
         "--hangar",
         metavar="PATH",
         default=None,
-        help="Override the hangar data file. Cannot be combined with a layout that already embeds a hangar path.",
+        help="Override the hangar data file. Cannot be combined with a layout that already embeds a hangar path.",  # noqa: E501
     )
     check.add_argument(
         "--json",

--- a/src/hangarfit/collisions.py
+++ b/src/hangarfit/collisions.py
@@ -45,8 +45,7 @@ from .models import CheckResult, Conflict, Hangar, Layout
 def check(layout: Layout) -> CheckResult:
     """Run all geometric checks and return a :class:`CheckResult`."""
     world_parts: dict[str, list[WorldPart]] = {
-        p.plane_id: aircraft_parts_world(layout.fleet[p.plane_id], p)
-        for p in layout.placements
+        p.plane_id: aircraft_parts_world(layout.fleet[p.plane_id], p) for p in layout.placements
     }
     conflicts: list[Conflict] = []
     conflicts.extend(_hangar_bounds_conflicts(world_parts, layout.hangar))
@@ -92,9 +91,7 @@ def _hangar_bounds_conflicts(
     return out
 
 
-def _first_out_of_bounds_vertex(
-    part: WorldPart, hangar: Hangar
-) -> tuple[float, float] | None:
+def _first_out_of_bounds_vertex(part: WorldPart, hangar: Hangar) -> tuple[float, float] | None:
     """Return ``(x, y)`` of the first vertex of ``part`` outside the
     hangar rectangle, or ``None`` if every vertex is inside."""
     for x, y in list(part.polygon.exterior.coords)[:-1]:
@@ -123,9 +120,7 @@ def _maintenance_conflicts(
     """
     if layout.maintenance_plane is None:
         return []
-    fuselage_parts = [
-        p for p in world_parts[layout.maintenance_plane] if p.kind == "fuselage"
-    ]
+    fuselage_parts = [p for p in world_parts[layout.maintenance_plane] if p.kind == "fuselage"]
     if not fuselage_parts:
         # The :class:`Aircraft` model permits parts of any kind, including
         # zero fuselages. If the designated maintenance plane has no fuselage,
@@ -161,9 +156,7 @@ def _maintenance_conflicts(
     return []
 
 
-def _pairwise_conflicts(
-    world_parts: dict[str, list[WorldPart]], hangar: Hangar
-) -> list[Conflict]:
+def _pairwise_conflicts(world_parts: dict[str, list[WorldPart]], hangar: Hangar) -> list[Conflict]:
     """For every pair of parts from *different* aircraft, emit a conflict
     iff both the plan-view-overlap rule and the z-overlap rule fire.
 

--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -72,8 +72,7 @@ def oriented_rect(
     # Corners in local frame (CCW from front-right): +x is "forward", +y is "left side"
     corners_local = [(hl, -hw), (hl, hw), (-hl, hw), (-hl, -hw)]
     corners_world = [
-        (cx + x * cos_h - y * sin_h, cy + x * sin_h + y * cos_h)
-        for x, y in corners_local
+        (cx + x * cos_h - y * sin_h, cy + x * sin_h + y * cos_h) for x, y in corners_local
     ]
     return Polygon(corners_world)
 
@@ -98,9 +97,7 @@ def polygon_overlap(p1: Polygon, p2: Polygon, clearance: float = 0.0) -> bool:
     error rather than a misconfigured layout.
     """
     if clearance < 0:
-        raise ValueError(
-            f"polygon_overlap: clearance must be non-negative, got {clearance}"
-        )
+        raise ValueError(f"polygon_overlap: clearance must be non-negative, got {clearance}")
     if clearance > 0:
         return p1.distance(p2) < clearance
     return p1.intersects(p2) and not p1.touches(p2)

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -48,8 +48,7 @@ def _to_float(value: Any, field_name: str) -> float:
         return float(value)
     except (TypeError, ValueError) as e:
         raise LoaderError(
-            f"{field_name!r}: expected number, got {value!r} "
-            f"({type(value).__name__})"
+            f"{field_name!r}: expected number, got {value!r} ({type(value).__name__})"
         ) from e
 
 
@@ -106,7 +105,9 @@ def load_hangar(path: Path | str) -> Hangar:
 
     door_data = raw.get("door")
     if not isinstance(door_data, dict):
-        raise LoaderError(f"{path}: 'door' must be a mapping with 'center_x_m' and 'width_m'")
+        raise LoaderError(
+            f"{path}: 'door' must be a mapping with 'center_x_m' and 'width_m'"
+        )
 
     bay_data = raw.get("maintenance_bay")
     if not isinstance(bay_data, dict):
@@ -235,7 +236,9 @@ def _extract_maintenance_plane(raw: dict, path: Path) -> str | None:
 
 def _build_aircraft(entry: Any) -> Aircraft:
     if not isinstance(entry, dict):
-        raise LoaderError(f"aircraft entry must be a mapping, got {type(entry).__name__}")
+        raise LoaderError(
+            f"aircraft entry must be a mapping, got {type(entry).__name__}"
+        )
 
     required = ("id", "name", "wing_position", "gear", "movement_mode")
     for key in required:
@@ -257,7 +260,9 @@ def _build_aircraft(entry: Any) -> Aircraft:
         parts.extend(_expand_struts(spec, wing))
 
     turn_radius_raw = entry.get("turn_radius_m")
-    turn_radius_m = None if turn_radius_raw is None else _to_float(turn_radius_raw, "turn_radius_m")
+    turn_radius_m = (
+        None if turn_radius_raw is None else _to_float(turn_radius_raw, "turn_radius_m")
+    )
 
     return Aircraft(
         id=entry["id"],
@@ -303,9 +308,15 @@ def _build_struts_spec(data: dict[str, Any]) -> StrutsSpec:
         if key not in data:
             raise LoaderError(f"'struts' missing required field {key!r}")
     return StrutsSpec(
-        fuselage_attach_x_m=_to_float(data["fuselage_attach_x_m"], "struts.fuselage_attach_x_m"),
-        fuselage_attach_y_m=_to_float(data["fuselage_attach_y_m"], "struts.fuselage_attach_y_m"),
-        fuselage_attach_z_m=_to_float(data["fuselage_attach_z_m"], "struts.fuselage_attach_z_m"),
+        fuselage_attach_x_m=_to_float(
+            data["fuselage_attach_x_m"], "struts.fuselage_attach_x_m"
+        ),
+        fuselage_attach_y_m=_to_float(
+            data["fuselage_attach_y_m"], "struts.fuselage_attach_y_m"
+        ),
+        fuselage_attach_z_m=_to_float(
+            data["fuselage_attach_z_m"], "struts.fuselage_attach_z_m"
+        ),
         wing_attach_y_m=_to_float(data["wing_attach_y_m"], "struts.wing_attach_y_m"),
         width_m=_to_float(data["width_m"], "struts.width_m"),
     )
@@ -346,7 +357,7 @@ def _expand_struts(spec: StrutsSpec, wing: Part) -> list[Part]:
         "z_top_m": wing.z_bottom_m,
     }
     return [
-        Part(offset_y_m=midpoint, **common),   # right side
+        Part(offset_y_m=midpoint, **common),  # right side
         Part(offset_y_m=-midpoint, **common),  # left side
     ]
 
@@ -375,5 +386,3 @@ def _read_yaml(path: Path) -> Any:
         raise LoaderError(f"file not found: {path}") from e
     except yaml.YAMLError as e:
         raise LoaderError(f"{path}: YAML parse error: {e}") from e
-
-

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -105,9 +105,7 @@ def load_hangar(path: Path | str) -> Hangar:
 
     door_data = raw.get("door")
     if not isinstance(door_data, dict):
-        raise LoaderError(
-            f"{path}: 'door' must be a mapping with 'center_x_m' and 'width_m'"
-        )
+        raise LoaderError(f"{path}: 'door' must be a mapping with 'center_x_m' and 'width_m'")
 
     bay_data = raw.get("maintenance_bay")
     if not isinstance(bay_data, dict):
@@ -224,21 +222,16 @@ def _extract_maintenance_plane(raw: dict, path: Path) -> str | None:
         return None  # explicit `maintenance: ~` → no maintenance plane
     if not isinstance(m, dict):
         raise LoaderError(
-            f"{path}: 'maintenance' must be a mapping with a 'plane' key, "
-            f"got {type(m).__name__}"
+            f"{path}: 'maintenance' must be a mapping with a 'plane' key, got {type(m).__name__}"
         )
     if "plane" not in m:
-        raise LoaderError(
-            f"{path}: 'maintenance' block present but lacks required 'plane' key"
-        )
+        raise LoaderError(f"{path}: 'maintenance' block present but lacks required 'plane' key")
     return m["plane"]
 
 
 def _build_aircraft(entry: Any) -> Aircraft:
     if not isinstance(entry, dict):
-        raise LoaderError(
-            f"aircraft entry must be a mapping, got {type(entry).__name__}"
-        )
+        raise LoaderError(f"aircraft entry must be a mapping, got {type(entry).__name__}")
 
     required = ("id", "name", "wing_position", "gear", "movement_mode")
     for key in required:
@@ -260,9 +253,7 @@ def _build_aircraft(entry: Any) -> Aircraft:
         parts.extend(_expand_struts(spec, wing))
 
     turn_radius_raw = entry.get("turn_radius_m")
-    turn_radius_m = (
-        None if turn_radius_raw is None else _to_float(turn_radius_raw, "turn_radius_m")
-    )
+    turn_radius_m = None if turn_radius_raw is None else _to_float(turn_radius_raw, "turn_radius_m")
 
     return Aircraft(
         id=entry["id"],
@@ -308,15 +299,9 @@ def _build_struts_spec(data: dict[str, Any]) -> StrutsSpec:
         if key not in data:
             raise LoaderError(f"'struts' missing required field {key!r}")
     return StrutsSpec(
-        fuselage_attach_x_m=_to_float(
-            data["fuselage_attach_x_m"], "struts.fuselage_attach_x_m"
-        ),
-        fuselage_attach_y_m=_to_float(
-            data["fuselage_attach_y_m"], "struts.fuselage_attach_y_m"
-        ),
-        fuselage_attach_z_m=_to_float(
-            data["fuselage_attach_z_m"], "struts.fuselage_attach_z_m"
-        ),
+        fuselage_attach_x_m=_to_float(data["fuselage_attach_x_m"], "struts.fuselage_attach_x_m"),
+        fuselage_attach_y_m=_to_float(data["fuselage_attach_y_m"], "struts.fuselage_attach_y_m"),
+        fuselage_attach_z_m=_to_float(data["fuselage_attach_z_m"], "struts.fuselage_attach_z_m"),
         wing_attach_y_m=_to_float(data["wing_attach_y_m"], "struts.wing_attach_y_m"),
         width_m=_to_float(data["width_m"], "struts.width_m"),
     )

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -12,9 +12,10 @@ The full coordinate convention and parts-model collision rule live in
 from __future__ import annotations
 
 import typing
+from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Literal, Mapping
+from typing import Literal
 
 WingPosition = Literal["high", "mid", "low"]
 Gear = Literal["tailwheel", "nosewheel", "monowheel"]
@@ -52,17 +53,12 @@ class Part:
     def __post_init__(self) -> None:
         if self.kind not in _VALID_PART_KINDS:
             raise ValueError(
-                f"Part.kind must be one of {sorted(_VALID_PART_KINDS)}, "
-                f"got {self.kind!r}"
+                f"Part.kind must be one of {sorted(_VALID_PART_KINDS)}, got {self.kind!r}"
             )
         if self.length_m <= 0:
-            raise ValueError(
-                f"Part {self.kind!r}: length_m must be positive, got {self.length_m}"
-            )
+            raise ValueError(f"Part {self.kind!r}: length_m must be positive, got {self.length_m}")
         if self.width_m <= 0:
-            raise ValueError(
-                f"Part {self.kind!r}: width_m must be positive, got {self.width_m}"
-            )
+            raise ValueError(f"Part {self.kind!r}: width_m must be positive, got {self.width_m}")
         if self.z_bottom_m < 0:
             raise ValueError(
                 f"Part {self.kind!r}: z_bottom_m must be non-negative, got {self.z_bottom_m}"
@@ -97,9 +93,7 @@ class StrutsSpec:
 
     def __post_init__(self) -> None:
         if self.width_m <= 0:
-            raise ValueError(
-                f"StrutsSpec: width_m must be positive, got {self.width_m}"
-            )
+            raise ValueError(f"StrutsSpec: width_m must be positive, got {self.width_m}")
         if self.fuselage_attach_y_m < 0:
             raise ValueError(
                 f"StrutsSpec: fuselage_attach_y_m must be non-negative "
@@ -215,9 +209,7 @@ class Door:
         if self.width_m <= 0:
             raise ValueError(f"Door.width_m must be positive, got {self.width_m}")
         if self.center_x_m < 0:
-            raise ValueError(
-                f"Door.center_x_m must be non-negative, got {self.center_x_m}"
-            )
+            raise ValueError(f"Door.center_x_m must be non-negative, got {self.center_x_m}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -228,9 +220,7 @@ class MaintenanceBay:
 
     def __post_init__(self) -> None:
         if self.depth_m <= 0:
-            raise ValueError(
-                f"MaintenanceBay.depth_m must be positive, got {self.depth_m}"
-            )
+            raise ValueError(f"MaintenanceBay.depth_m must be positive, got {self.depth_m}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -254,9 +244,7 @@ class Hangar:
         if self.width_m <= 0:
             raise ValueError(f"Hangar.width_m must be positive, got {self.width_m}")
         if self.clearance_m < 0:
-            raise ValueError(
-                f"Hangar.clearance_m must be non-negative, got {self.clearance_m}"
-            )
+            raise ValueError(f"Hangar.clearance_m must be non-negative, got {self.clearance_m}")
         if self.wing_layer_clearance_m < 0:
             raise ValueError(
                 f"Hangar.wing_layer_clearance_m must be non-negative, "
@@ -362,19 +350,14 @@ class Layout:
         )
         if cart_count > 1:
             raise ValueError(
-                f"At most one cart_eligible plane may have on_carts=True "
-                f"(got {cart_count})"
+                f"At most one cart_eligible plane may have on_carts=True (got {cart_count})"
             )
 
         if self.maintenance_plane is not None:
             if self.maintenance_plane not in self.fleet:
-                raise ValueError(
-                    f"maintenance_plane {self.maintenance_plane!r} not in fleet"
-                )
+                raise ValueError(f"maintenance_plane {self.maintenance_plane!r} not in fleet")
             if self.maintenance_plane not in seen:
-                raise ValueError(
-                    f"maintenance_plane {self.maintenance_plane!r} is not placed"
-                )
+                raise ValueError(f"maintenance_plane {self.maintenance_plane!r} is not placed")
 
         object.__setattr__(self, "fleet", MappingProxyType(dict(self.fleet)))
 
@@ -400,25 +383,19 @@ class Conflict:
         if not self.planes:
             raise ValueError("Conflict.planes must have at least one plane id")
         if len(self.planes) > 2:
-            raise ValueError(
-                f"Conflict.planes must have 1 or 2 entries, got {len(self.planes)}"
-            )
+            raise ValueError(f"Conflict.planes must have 1 or 2 entries, got {len(self.planes)}")
         if any(not pid for pid in self.planes):
-            raise ValueError(
-                f"Conflict.planes entries must be non-empty, got {self.planes}"
-            )
+            raise ValueError(f"Conflict.planes entries must be non-empty, got {self.planes}")
         if len(set(self.planes)) != len(self.planes):
-            raise ValueError(
-                f"Conflict.planes entries must be distinct, got {self.planes}"
-            )
+            raise ValueError(f"Conflict.planes entries must be distinct, got {self.planes}")
 
     @classmethod
-    def single(cls, kind: str, plane: str, detail: str) -> "Conflict":
+    def single(cls, kind: str, plane: str, detail: str) -> Conflict:
         """Factory for a single-aircraft conflict (e.g. ``maintenance_position``)."""
         return cls(kind=kind, planes=(plane,), detail=detail)
 
     @classmethod
-    def pair(cls, kind: str, plane_a: str, plane_b: str, detail: str) -> "Conflict":
+    def pair(cls, kind: str, plane_a: str, plane_b: str, detail: str) -> Conflict:
         """Factory for a pairwise conflict (e.g. ``wing_strut_overlap``)."""
         return cls(kind=kind, planes=(plane_a, plane_b), detail=detail)
 

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -182,9 +182,7 @@ def _draw_hangar(ax, layout: Layout) -> None:
         lw=2,
     )
     ax.plot([0, 0], [0, hangar.length_m], color=_HANGAR_EDGE, lw=2)
-    ax.plot(
-        [hangar.width_m, hangar.width_m], [0, hangar.length_m], color=_HANGAR_EDGE, lw=2
-    )
+    ax.plot([hangar.width_m, hangar.width_m], [0, hangar.length_m], color=_HANGAR_EDGE, lw=2)
 
     # Front wall split around the door — door rendered as a light/dashed
     # gap so it reads as "opening" not "wall I forgot to draw".

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -48,12 +48,12 @@ _FALLBACK_COLOR = "#95a5a6"  # gray
 _CONFLICT_COLOR = "#e74c3c"  # red
 
 _FUSELAGE_ALPHA = 0.9  # near-opaque: two fuselages overlapping is always
-                       # a conflict, no value in seeing through.
-_WING_ALPHA = 0.4      # translucent so stacked wings (z-disjoint nesting,
-                       # case 3 / case 7-8) show their plan-view overlap.
-_STRUT_LINEWIDTH = 1.2 # struts are physically thin (~5 cm × ~1.3 m); a
-                       # filled polygon would be near-invisible at hangar
-                       # scale, so we draw an outline instead.
+# a conflict, no value in seeing through.
+_WING_ALPHA = 0.4  # translucent so stacked wings (z-disjoint nesting,
+# case 3 / case 7-8) show their plan-view overlap.
+_STRUT_LINEWIDTH = 1.2  # struts are physically thin (~5 cm × ~1.3 m); a
+# filled polygon would be near-invisible at hangar
+# scale, so we draw an outline instead.
 
 # Arrow length for the nose-direction marker, in meters. Hardcoded rather
 # than scaling with hangar size: at the fleet's ~6-9 m fuselage scale,
@@ -175,9 +175,16 @@ def _draw_hangar(ax, layout: Layout) -> None:
     )
 
     # Back, left, right walls — solid.
-    ax.plot([0, hangar.width_m], [hangar.length_m, hangar.length_m], color=_HANGAR_EDGE, lw=2)
+    ax.plot(
+        [0, hangar.width_m],
+        [hangar.length_m, hangar.length_m],
+        color=_HANGAR_EDGE,
+        lw=2,
+    )
     ax.plot([0, 0], [0, hangar.length_m], color=_HANGAR_EDGE, lw=2)
-    ax.plot([hangar.width_m, hangar.width_m], [0, hangar.length_m], color=_HANGAR_EDGE, lw=2)
+    ax.plot(
+        [hangar.width_m, hangar.width_m], [0, hangar.length_m], color=_HANGAR_EDGE, lw=2
+    )
 
     # Front wall split around the door — door rendered as a light/dashed
     # gap so it reads as "opening" not "wall I forgot to draw".
@@ -212,14 +219,34 @@ def _draw_part(ax, part: WorldPart, color: str) -> None:
     """
     coords = list(part.polygon.exterior.coords)[:-1]
     if part.kind == "fuselage" or part.kind == "tail":
-        patch = MplPolygon(coords, closed=True, facecolor=color, edgecolor=_HANGAR_EDGE,
-                           alpha=_FUSELAGE_ALPHA, lw=0.5, zorder=2)
+        patch = MplPolygon(
+            coords,
+            closed=True,
+            facecolor=color,
+            edgecolor=_HANGAR_EDGE,
+            alpha=_FUSELAGE_ALPHA,
+            lw=0.5,
+            zorder=2,
+        )
     elif part.kind == "wing":
-        patch = MplPolygon(coords, closed=True, facecolor=color, edgecolor=color,
-                           alpha=_WING_ALPHA, lw=0.5, zorder=1)
+        patch = MplPolygon(
+            coords,
+            closed=True,
+            facecolor=color,
+            edgecolor=color,
+            alpha=_WING_ALPHA,
+            lw=0.5,
+            zorder=1,
+        )
     elif part.kind == "strut":
-        patch = MplPolygon(coords, closed=True, facecolor="none", edgecolor=_HANGAR_EDGE,
-                           lw=_STRUT_LINEWIDTH, zorder=3)
+        patch = MplPolygon(
+            coords,
+            closed=True,
+            facecolor="none",
+            edgecolor=_HANGAR_EDGE,
+            lw=_STRUT_LINEWIDTH,
+            zorder=3,
+        )
     else:
         raise ValueError(
             f"_draw_part: unhandled part kind {part.kind!r}. "
@@ -233,8 +260,10 @@ def _annotate_plane(ax, placement, plane_id: str) -> None:
     dx, dy = nose_direction(placement.heading_deg)
     ax.annotate(
         "",
-        xy=(placement.x_m + dx * _NOSE_ARROW_LENGTH_M,
-            placement.y_m + dy * _NOSE_ARROW_LENGTH_M),
+        xy=(
+            placement.x_m + dx * _NOSE_ARROW_LENGTH_M,
+            placement.y_m + dy * _NOSE_ARROW_LENGTH_M,
+        ),
         xytext=(placement.x_m, placement.y_m),
         arrowprops=dict(arrowstyle="->", color=_HANGAR_EDGE, lw=1),
         zorder=4,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,9 +65,7 @@ class TestCheckHappyPath:
         assert captured.err == ""
 
     def test_check_invalid_layout_returns_1(self, capsys):
-        exit_code = main(
-            ["check", str(FIXTURES_DIR / "invalid_fuselage_wing_overlap.yaml")]
-        )
+        exit_code = main(["check", str(FIXTURES_DIR / "invalid_fuselage_wing_overlap.yaml")])
         assert exit_code == 1
         captured = capsys.readouterr()
         assert captured.out.startswith("invalid:")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,7 +65,9 @@ class TestCheckHappyPath:
         assert captured.err == ""
 
     def test_check_invalid_layout_returns_1(self, capsys):
-        exit_code = main(["check", str(FIXTURES_DIR / "invalid_fuselage_wing_overlap.yaml")])
+        exit_code = main(
+            ["check", str(FIXTURES_DIR / "invalid_fuselage_wing_overlap.yaml")]
+        )
         assert exit_code == 1
         captured = capsys.readouterr()
         assert captured.out.startswith("invalid:")
@@ -193,25 +195,35 @@ class TestFleetHangarOverrides:
         clean = tmp_path / "clean_layout.yaml"
         original = src.read_text(encoding="utf-8")
         stripped = "\n".join(
-            line for line in original.splitlines()
+            line
+            for line in original.splitlines()
             if not (line.startswith("fleet:") or line.startswith("hangar:"))
         )
         clean.write_text(stripped + "\n", encoding="utf-8")
 
-        exit_code = main([
-            "check", str(clean),
-            "--fleet", str(REPO_ROOT / "data" / "fleet.yaml"),
-            "--hangar", str(REPO_ROOT / "data" / "hangar.yaml"),
-        ])
+        exit_code = main(
+            [
+                "check",
+                str(clean),
+                "--fleet",
+                str(REPO_ROOT / "data" / "fleet.yaml"),
+                "--hangar",
+                str(REPO_ROOT / "data" / "hangar.yaml"),
+            ]
+        )
         assert exit_code == 0
         assert capsys.readouterr().out.strip() == "valid"
 
     def test_fleet_override_with_embedded_fleet_errors(self, capsys):
         # Both kwarg and embedded are present — loader rejects this.
-        exit_code = main([
-            "check", str(FIXTURES_DIR / "valid_two_separated.yaml"),
-            "--fleet", str(REPO_ROOT / "data" / "fleet.yaml"),
-        ])
+        exit_code = main(
+            [
+                "check",
+                str(FIXTURES_DIR / "valid_two_separated.yaml"),
+                "--fleet",
+                str(REPO_ROOT / "data" / "fleet.yaml"),
+            ]
+        )
         assert exit_code == 2
         captured = capsys.readouterr()
         assert captured.out == ""

--- a/tests/test_collisions.py
+++ b/tests/test_collisions.py
@@ -104,8 +104,7 @@ class TestPairwiseOverlap:
             f"expected exactly fuselage_fuselage_overlap, got {result.conflicts!r}"
         )
         assert len(result.conflicts) == 1, (
-            f"expected exactly 1 conflict, got {len(result.conflicts)}: "
-            f"{result.conflicts!r}"
+            f"expected exactly 1 conflict, got {len(result.conflicts)}: {result.conflicts!r}"
         )
 
 
@@ -122,9 +121,7 @@ class TestValidLayouts:
 
     def test_case_1_two_high_wings_well_separated(self) -> None:
         result = check(_load("valid_two_separated"))
-        assert result.valid, (
-            f"two-plane layout must be clean, got conflicts: {result.conflicts!r}"
-        )
+        assert result.valid, f"two-plane layout must be clean, got conflicts: {result.conflicts!r}"
 
     def test_case_12_all_nine_planes_valid(self) -> None:
         """Phase 1 acceptance smoke test: all 9 placeholder aircraft fit.
@@ -136,9 +133,7 @@ class TestValidLayouts:
         full rationale.
         """
         result = check(_load("valid_all_nine_planes"))
-        assert result.valid, (
-            f"9-plane layout must be clean, got conflicts: {result.conflicts!r}"
-        )
+        assert result.valid, f"9-plane layout must be clean, got conflicts: {result.conflicts!r}"
 
 
 class TestCartRule:
@@ -173,8 +168,7 @@ class TestStrutCanary:
         assert not result.valid
         kinds = _conflict_kinds(result)
         assert "strut_wing_overlap" in kinds, (
-            f"strut canary failed: expected strut_wing_overlap, "
-            f"got {result.conflicts!r}"
+            f"strut canary failed: expected strut_wing_overlap, got {result.conflicts!r}"
         )
         assert "wing_strut_overlap" not in kinds, (
             f"non-alphabetical kind leaked into conflicts: {result.conflicts!r}"
@@ -183,15 +177,13 @@ class TestStrutCanary:
     def test_case_7_strut_free_right_side_nesting_valid(self) -> None:
         result = check(_load("valid_right_side_nesting"))
         assert result.valid, (
-            f"right-side nesting must be valid (z-disjoint), "
-            f"got conflicts: {result.conflicts!r}"
+            f"right-side nesting must be valid (z-disjoint), got conflicts: {result.conflicts!r}"
         )
 
     def test_case_8_strut_free_left_side_nesting_valid(self) -> None:
         result = check(_load("valid_left_side_nesting"))
         assert result.valid, (
-            f"left-side nesting must be valid (z-disjoint), "
-            f"got conflicts: {result.conflicts!r}"
+            f"left-side nesting must be valid (z-disjoint), got conflicts: {result.conflicts!r}"
         )
 
 
@@ -213,8 +205,7 @@ class TestMaintenancePosition:
         against a future tightening to ``<=``."""
         result = check(_load("valid_maintenance_at_bay_boundary"))
         assert result.valid, (
-            f"maintenance centroid at bay-start y must pass, "
-            f"got conflicts: {result.conflicts!r}"
+            f"maintenance centroid at bay-start y must pass, got conflicts: {result.conflicts!r}"
         )
 
     def test_maintenance_plane_without_fuselage_emits_conflict(self) -> None:

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -80,7 +80,12 @@ class TestOrientedRect:
         """At 45° CCW, a 2×2 square's corner at local (1, -1) maps to world (√2, 0)."""
         rect = oriented_rect(cx=0, cy=0, length=2, width=2, angle_deg=45)
         # Square is symmetric; corners should be at distance √2 along the axes.
-        expected = [(math.sqrt(2), 0), (0, math.sqrt(2)), (-math.sqrt(2), 0), (0, -math.sqrt(2))]
+        expected = [
+            (math.sqrt(2), 0),
+            (0, math.sqrt(2)),
+            (-math.sqrt(2), 0),
+            (0, -math.sqrt(2)),
+        ]
         assert _corners_almost_equal(rect, expected)
 
     def test_area_preserved_under_rotation(self) -> None:
@@ -219,7 +224,9 @@ class TestAircraftPartsWorld:
     def test_heading_zero_nose_maps_to_world_plus_y(self) -> None:
         """At heading 0°, a part at plane-local (u=1, v=0) lands at world (px, py+1)."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
-        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        pl = Placement(
+            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
+        )
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 0.0, tol=1e-6)
@@ -228,7 +235,9 @@ class TestAircraftPartsWorld:
     def test_heading_zero_right_wingtip_maps_to_world_plus_x(self) -> None:
         """At heading 0°, a part at plane-local (u=0, v=1) lands at world (px+1, py)."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
-        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        pl = Placement(
+            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
+        )
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 1.0, tol=1e-6)
@@ -237,7 +246,9 @@ class TestAircraftPartsWorld:
     def test_heading_90_nose_maps_to_world_plus_x(self) -> None:
         """At heading 90°, nose (plane +x) points to world +x."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
-        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=90.0, on_carts=False)
+        pl = Placement(
+            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=90.0, on_carts=False
+        )
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 1.0, tol=1e-6)
@@ -246,7 +257,9 @@ class TestAircraftPartsWorld:
     def test_heading_90_right_wingtip_maps_to_world_minus_y(self) -> None:
         """At heading 90° (nose right), right-wingtip points toward door (world -y)."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
-        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=90.0, on_carts=False)
+        pl = Placement(
+            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=90.0, on_carts=False
+        )
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 0.0, tol=1e-6)
@@ -261,7 +274,9 @@ class TestAircraftPartsWorld:
         right-wingtip case below distinguishes the two.
         """
         ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
-        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False)
+        pl = Placement(
+            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False
+        )
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, SQRT2_2, tol=1e-6)
@@ -279,7 +294,9 @@ class TestAircraftPartsWorld:
         somewhere and the parts model will be silently wrong.
         """
         ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
-        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False)
+        pl = Placement(
+            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False
+        )
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, SQRT2_2, tol=1e-6), f"x expected {SQRT2_2}, got {cx}"
@@ -288,7 +305,9 @@ class TestAircraftPartsWorld:
     def test_placement_offset_applied(self) -> None:
         """Placement translation is applied AFTER the rotation/reflection."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
-        pl = Placement(plane_id="probe", x_m=10.0, y_m=20.0, heading_deg=0.0, on_carts=False)
+        pl = Placement(
+            plane_id="probe", x_m=10.0, y_m=20.0, heading_deg=0.0, on_carts=False
+        )
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 10.0, tol=1e-6)
@@ -306,7 +325,9 @@ class TestAircraftPartsWorld:
         Different in BOTH coordinates — the cleanest single test for the
         wrong-handedness bug."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
-        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=135.0, on_carts=False)
+        pl = Placement(
+            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=135.0, on_carts=False
+        )
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, SQRT2_2, tol=1e-6), f"x expected {SQRT2_2}, got {cx}"
@@ -344,7 +365,7 @@ class TestAircraftPartsWorld:
         part = Part(
             kind="strut",
             length_m=4.0,  # long
-            width_m=0.1,   # thin
+            width_m=0.1,  # thin
             offset_x_m=0.0,
             offset_y_m=0.0,
             angle_deg=90.0,  # rotate CCW 90° within plane-local
@@ -352,20 +373,28 @@ class TestAircraftPartsWorld:
             z_top_m=2.0,
         )
         ac = _aircraft_with_one_part(part)
-        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        pl = Placement(
+            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
+        )
         [world] = aircraft_parts_world(ac, pl)
         # Plane-local: 0.1 wide along +x, 4.0 long along +y (after the 90° rot).
         # World mapping at heading 0°: plane +x → world +y, plane +y → world +x.
         # So in world: long axis (4.0) runs along +x, narrow (0.1) along +y.
         minx, miny, maxx, maxy = world.polygon.bounds
-        assert _almost_equal(maxx - minx, 4.0, tol=1e-6), f"world x-extent: {maxx - minx}"
-        assert _almost_equal(maxy - miny, 0.1, tol=1e-6), f"world y-extent: {maxy - miny}"
+        assert _almost_equal(maxx - minx, 4.0, tol=1e-6), (
+            f"world x-extent: {maxx - minx}"
+        )
+        assert _almost_equal(maxy - miny, 0.1, tol=1e-6), (
+            f"world y-extent: {maxy - miny}"
+        )
 
     def test_heading_minus_90(self) -> None:
         """At heading -90° (nose toward world -x, i.e. left wall), right-wingtip
         points toward world +y (deeper into hangar)."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
-        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=-90.0, on_carts=False)
+        pl = Placement(
+            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=-90.0, on_carts=False
+        )
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 0.0, tol=1e-6)
@@ -419,7 +448,9 @@ class TestWorldPartMetadata:
             measured=False,
             parts=parts,
         )
-        pl = Placement(plane_id="multipart", x_m=5.0, y_m=10.0, heading_deg=37.0, on_carts=False)
+        pl = Placement(
+            plane_id="multipart", x_m=5.0, y_m=10.0, heading_deg=37.0, on_carts=False
+        )
         worlds = aircraft_parts_world(ac, pl)
         assert len(worlds) == 3
         # Order preserved; metadata preserved 1:1 from source parts.
@@ -442,9 +473,13 @@ class TestAircraftPartsWorldOnRealAircraft:
 
         from pathlib import Path
 
-        fleet = load_fleet(Path(__file__).resolve().parent.parent / "data" / "fleet.yaml")
+        fleet = load_fleet(
+            Path(__file__).resolve().parent.parent / "data" / "fleet.yaml"
+        )
         husky = fleet["aviat_husky"]
-        pl = Placement(plane_id="aviat_husky", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        pl = Placement(
+            plane_id="aviat_husky", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
+        )
         worlds = aircraft_parts_world(husky, pl)
         # 4 parts: fuselage + wing + 2 struts
         kinds = [w.kind for w in worlds]

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -15,7 +15,6 @@ import pytest
 from shapely.geometry import Polygon
 
 from hangarfit.geometry import (
-    WorldPart,
     aircraft_parts_world,
     oriented_rect,
     polygon_overlap,
@@ -48,7 +47,7 @@ def _corners_almost_equal(
         return False
     return all(
         _almost_equal(gx, wx, tol) and _almost_equal(gy, wy, tol)
-        for (gx, gy), (wx, wy) in zip(got, want)
+        for (gx, gy), (wx, wy) in zip(got, want, strict=False)
     )
 
 
@@ -224,9 +223,7 @@ class TestAircraftPartsWorld:
     def test_heading_zero_nose_maps_to_world_plus_y(self) -> None:
         """At heading 0°, a part at plane-local (u=1, v=0) lands at world (px, py+1)."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
-        pl = Placement(
-            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
-        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 0.0, tol=1e-6)
@@ -235,9 +232,7 @@ class TestAircraftPartsWorld:
     def test_heading_zero_right_wingtip_maps_to_world_plus_x(self) -> None:
         """At heading 0°, a part at plane-local (u=0, v=1) lands at world (px+1, py)."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
-        pl = Placement(
-            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
-        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 1.0, tol=1e-6)
@@ -246,9 +241,7 @@ class TestAircraftPartsWorld:
     def test_heading_90_nose_maps_to_world_plus_x(self) -> None:
         """At heading 90°, nose (plane +x) points to world +x."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
-        pl = Placement(
-            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=90.0, on_carts=False
-        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=90.0, on_carts=False)
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 1.0, tol=1e-6)
@@ -257,9 +250,7 @@ class TestAircraftPartsWorld:
     def test_heading_90_right_wingtip_maps_to_world_minus_y(self) -> None:
         """At heading 90° (nose right), right-wingtip points toward door (world -y)."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
-        pl = Placement(
-            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=90.0, on_carts=False
-        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=90.0, on_carts=False)
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 0.0, tol=1e-6)
@@ -274,9 +265,7 @@ class TestAircraftPartsWorld:
         right-wingtip case below distinguishes the two.
         """
         ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
-        pl = Placement(
-            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False
-        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False)
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, SQRT2_2, tol=1e-6)
@@ -294,9 +283,7 @@ class TestAircraftPartsWorld:
         somewhere and the parts model will be silently wrong.
         """
         ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
-        pl = Placement(
-            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False
-        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False)
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, SQRT2_2, tol=1e-6), f"x expected {SQRT2_2}, got {cx}"
@@ -305,9 +292,7 @@ class TestAircraftPartsWorld:
     def test_placement_offset_applied(self) -> None:
         """Placement translation is applied AFTER the rotation/reflection."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
-        pl = Placement(
-            plane_id="probe", x_m=10.0, y_m=20.0, heading_deg=0.0, on_carts=False
-        )
+        pl = Placement(plane_id="probe", x_m=10.0, y_m=20.0, heading_deg=0.0, on_carts=False)
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 10.0, tol=1e-6)
@@ -325,9 +310,7 @@ class TestAircraftPartsWorld:
         Different in BOTH coordinates — the cleanest single test for the
         wrong-handedness bug."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
-        pl = Placement(
-            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=135.0, on_carts=False
-        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=135.0, on_carts=False)
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, SQRT2_2, tol=1e-6), f"x expected {SQRT2_2}, got {cx}"
@@ -340,9 +323,7 @@ class TestAircraftPartsWorld:
         Pins that we don't normalize heading anywhere upstream and that the
         transform stays consistent across the wrap."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=1.0, offset_y_m=0.0))
-        pl = Placement(
-            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=heading_deg, on_carts=False
-        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=heading_deg, on_carts=False)
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         expected_x = math.sin(math.radians(heading_deg))
@@ -373,28 +354,20 @@ class TestAircraftPartsWorld:
             z_top_m=2.0,
         )
         ac = _aircraft_with_one_part(part)
-        pl = Placement(
-            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
-        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
         [world] = aircraft_parts_world(ac, pl)
         # Plane-local: 0.1 wide along +x, 4.0 long along +y (after the 90° rot).
         # World mapping at heading 0°: plane +x → world +y, plane +y → world +x.
         # So in world: long axis (4.0) runs along +x, narrow (0.1) along +y.
         minx, miny, maxx, maxy = world.polygon.bounds
-        assert _almost_equal(maxx - minx, 4.0, tol=1e-6), (
-            f"world x-extent: {maxx - minx}"
-        )
-        assert _almost_equal(maxy - miny, 0.1, tol=1e-6), (
-            f"world y-extent: {maxy - miny}"
-        )
+        assert _almost_equal(maxx - minx, 4.0, tol=1e-6), f"world x-extent: {maxx - minx}"
+        assert _almost_equal(maxy - miny, 0.1, tol=1e-6), f"world y-extent: {maxy - miny}"
 
     def test_heading_minus_90(self) -> None:
         """At heading -90° (nose toward world -x, i.e. left wall), right-wingtip
         points toward world +y (deeper into hangar)."""
         ac = _aircraft_with_one_part(_point_part(offset_x_m=0.0, offset_y_m=1.0))
-        pl = Placement(
-            plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=-90.0, on_carts=False
-        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=-90.0, on_carts=False)
         [world] = aircraft_parts_world(ac, pl)
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 0.0, tol=1e-6)
@@ -448,13 +421,11 @@ class TestWorldPartMetadata:
             measured=False,
             parts=parts,
         )
-        pl = Placement(
-            plane_id="multipart", x_m=5.0, y_m=10.0, heading_deg=37.0, on_carts=False
-        )
+        pl = Placement(plane_id="multipart", x_m=5.0, y_m=10.0, heading_deg=37.0, on_carts=False)
         worlds = aircraft_parts_world(ac, pl)
         assert len(worlds) == 3
         # Order preserved; metadata preserved 1:1 from source parts.
-        for src, dst in zip(parts, worlds):
+        for src, dst in zip(parts, worlds, strict=True):
             assert dst.kind == src.kind
             assert dst.z_bottom_m == src.z_bottom_m
             assert dst.z_top_m == src.z_top_m
@@ -469,17 +440,13 @@ class TestAircraftPartsWorldOnRealAircraft:
     def test_husky_at_origin_heading_zero(self) -> None:
         """A Husky placed at (0, 0) heading 0° should have its fuselage
         roughly along world +y (nose deeper into hangar)."""
-        from hangarfit.loader import load_fleet
-
         from pathlib import Path
 
-        fleet = load_fleet(
-            Path(__file__).resolve().parent.parent / "data" / "fleet.yaml"
-        )
+        from hangarfit.loader import load_fleet
+
+        fleet = load_fleet(Path(__file__).resolve().parent.parent / "data" / "fleet.yaml")
         husky = fleet["aviat_husky"]
-        pl = Placement(
-            plane_id="aviat_husky", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
-        )
+        pl = Placement(plane_id="aviat_husky", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
         worlds = aircraft_parts_world(husky, pl)
         # 4 parts: fuselage + wing + 2 struts
         kinds = [w.kind for w in worlds]

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -44,9 +44,7 @@ class TestRealDataFiles:
         failure first."""
         assert FLEET_YAML.exists(), f"bundled fleet file missing: {FLEET_YAML}"
         assert HANGAR_YAML.exists(), f"bundled hangar file missing: {HANGAR_YAML}"
-        assert EXAMPLE_LAYOUT.exists(), (
-            f"bundled example layout missing: {EXAMPLE_LAYOUT}"
-        )
+        assert EXAMPLE_LAYOUT.exists(), f"bundled example layout missing: {EXAMPLE_LAYOUT}"
 
     def test_load_fleet(self) -> None:
         fleet = load_fleet(FLEET_YAML)
@@ -77,9 +75,7 @@ class TestRealDataFiles:
         }
         for aid in strut_braced:
             struts = [p for p in fleet[aid].parts if p.kind == "strut"]
-            assert len(struts) == 2, (
-                f"{aid} should have 2 strut parts, got {len(struts)}"
-            )
+            assert len(struts) == 2, f"{aid} should have 2 strut parts, got {len(struts)}"
 
     def test_cantilever_planes_have_no_strut_parts(self) -> None:
         fleet = load_fleet(FLEET_YAML)
@@ -134,8 +130,7 @@ class TestRealDataFiles:
         fleet = load_fleet(FLEET_YAML)
         # Wingspan = width_m of the wing part.
         wing_widths = {
-            aid: next(p.width_m for p in a.parts if p.kind == "wing")
-            for aid, a in fleet.items()
+            aid: next(p.width_m for p in a.parts if p.kind == "wing") for aid, a in fleet.items()
         }
         # Loose ballpark check: every wingspan in [4, 20] m (sanity range
         # for the fleet). A decimal-point typo (10.7 → 1.07) is caught.
@@ -206,9 +201,7 @@ aircraft:
     turn_radius_m: 5.0
 """,
         )
-        with pytest.raises(
-            LoaderError, match="aircraft 'foo': 'parts' must be a non-empty list"
-        ):
+        with pytest.raises(LoaderError, match="aircraft 'foo': 'parts' must be a non-empty list"):
             load_fleet(path)
 
     def test_part_missing_required_field(self, tmp_path: Path) -> None:
@@ -307,9 +300,7 @@ aircraft:
         z_top_m: 1.5
 """,
         )
-        with pytest.raises(
-            LoaderError, match="aircraft '#0'.*missing required field 'id'"
-        ):
+        with pytest.raises(LoaderError, match="aircraft '#0'.*missing required field 'id'"):
             load_fleet(path)
 
     def test_null_numeric_field_clear_error(self, tmp_path: Path) -> None:
@@ -332,9 +323,7 @@ aircraft:
         z_top_m: 1.5
 """,
         )
-        with pytest.raises(
-            LoaderError, match="'parts\\[0\\].length_m'.*expected number, got null"
-        ):
+        with pytest.raises(LoaderError, match="'parts\\[0\\].length_m'.*expected number, got null"):
             load_fleet(path)
 
     def test_quoted_bool_for_measured_rejected(self, tmp_path: Path) -> None:
@@ -406,9 +395,7 @@ aircraft:
         z_top_m: 1.5
 """,
         )
-        with pytest.raises(
-            LoaderError, match="aircraft 'bad_husky'.*turn_radius_m is required"
-        ):
+        with pytest.raises(LoaderError, match="aircraft 'bad_husky'.*turn_radius_m is required"):
             load_fleet(path)
 
 
@@ -479,9 +466,7 @@ aircraft:
       width_m: 0.05
 """,
         )
-        with pytest.raises(
-            LoaderError, match="Struts only make sense when the wing is above"
-        ):
+        with pytest.raises(LoaderError, match="Struts only make sense when the wing is above"):
             load_fleet(path)
 
     def test_first_wing_part_drives_strut_z_top(self, tmp_path: Path) -> None:
@@ -604,9 +589,7 @@ door: {width_m: 12}
 maintenance_bay: {depth_m: 9}
 """,
         )
-        with pytest.raises(
-            LoaderError, match="missing required field 'door.center_x_m'"
-        ):
+        with pytest.raises(LoaderError, match="missing required field 'door.center_x_m'"):
             load_hangar(path)
 
     def test_door_does_not_fit_propagates_from_model(self, tmp_path: Path) -> None:
@@ -649,9 +632,7 @@ door: {center_x_m: 9, width_m: 12}
 maintenance_bay: {}
 """,
         )
-        with pytest.raises(
-            LoaderError, match="missing required field 'maintenance_bay.depth_m'"
-        ):
+        with pytest.raises(LoaderError, match="missing required field 'maintenance_bay.depth_m'"):
             load_hangar(path)
 
     def test_clearance_defaults_applied(self, tmp_path: Path) -> None:
@@ -678,9 +659,7 @@ class TestLayoutLoader:
     def _minimal_fleet_and_hangar(self, dir_: Path) -> tuple[Path, Path]:
         fleet = _write(
             dir_ / "fleet.yaml",
-            _minimal_aircraft_yaml(
-                "foo", movement_mode="always_own_gear", turn_radius_m=5.0
-            ),
+            _minimal_aircraft_yaml("foo", movement_mode="always_own_gear", turn_radius_m=5.0),
         )
         hangar = _write(
             dir_ / "hangar.yaml",
@@ -793,9 +772,7 @@ placements: []
     def test_layout_missing_hangar_ref(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "fleet.yaml",
-            _minimal_aircraft_yaml(
-                "foo", movement_mode="always_own_gear", turn_radius_m=5.0
-            ),
+            _minimal_aircraft_yaml("foo", movement_mode="always_own_gear", turn_radius_m=5.0),
         )
         layout_path = _write(
             tmp_path / "layout.yaml",
@@ -916,9 +893,7 @@ hangar: hangar.yaml
 placements: []
 """,
         )
-        with pytest.raises(
-            LoaderError, match="'fleet' field is set in YAML but a fleet override"
-        ):
+        with pytest.raises(LoaderError, match="'fleet' field is set in YAML but a fleet override"):
             load_layout(layout_path, fleet=load_fleet(fleet_path))
 
     def test_override_and_yaml_ref_conflict_for_hangar(self, tmp_path: Path) -> None:
@@ -965,9 +940,7 @@ def _aircraft_entry(
     """One aircraft entry for a fleet YAML (no top-level 'aircraft:' key).
     Compose multiple entries via :func:`_fleet_yaml`."""
     radius_yaml = (
-        f"turn_radius_m: {turn_radius_m}"
-        if turn_radius_m is not None
-        else "turn_radius_m: null"
+        f"turn_radius_m: {turn_radius_m}" if turn_radius_m is not None else "turn_radius_m: null"
     )
     return f"""\
   - id: {plane_id}
@@ -1004,7 +977,5 @@ def _minimal_aircraft_yaml(
 ) -> str:
     """Convenience: build a complete single-aircraft fleet YAML."""
     return _fleet_yaml(
-        _aircraft_entry(
-            plane_id, movement_mode=movement_mode, turn_radius_m=turn_radius_m
-        )
+        _aircraft_entry(plane_id, movement_mode=movement_mode, turn_radius_m=turn_radius_m)
     )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -44,7 +44,9 @@ class TestRealDataFiles:
         failure first."""
         assert FLEET_YAML.exists(), f"bundled fleet file missing: {FLEET_YAML}"
         assert HANGAR_YAML.exists(), f"bundled hangar file missing: {HANGAR_YAML}"
-        assert EXAMPLE_LAYOUT.exists(), f"bundled example layout missing: {EXAMPLE_LAYOUT}"
+        assert EXAMPLE_LAYOUT.exists(), (
+            f"bundled example layout missing: {EXAMPLE_LAYOUT}"
+        )
 
     def test_load_fleet(self) -> None:
         fleet = load_fleet(FLEET_YAML)
@@ -75,7 +77,9 @@ class TestRealDataFiles:
         }
         for aid in strut_braced:
             struts = [p for p in fleet[aid].parts if p.kind == "strut"]
-            assert len(struts) == 2, f"{aid} should have 2 strut parts, got {len(struts)}"
+            assert len(struts) == 2, (
+                f"{aid} should have 2 strut parts, got {len(struts)}"
+            )
 
     def test_cantilever_planes_have_no_strut_parts(self) -> None:
         fleet = load_fleet(FLEET_YAML)
@@ -202,7 +206,9 @@ aircraft:
     turn_radius_m: 5.0
 """,
         )
-        with pytest.raises(LoaderError, match="aircraft 'foo': 'parts' must be a non-empty list"):
+        with pytest.raises(
+            LoaderError, match="aircraft 'foo': 'parts' must be a non-empty list"
+        ):
             load_fleet(path)
 
     def test_part_missing_required_field(self, tmp_path: Path) -> None:
@@ -301,7 +307,9 @@ aircraft:
         z_top_m: 1.5
 """,
         )
-        with pytest.raises(LoaderError, match="aircraft '#0'.*missing required field 'id'"):
+        with pytest.raises(
+            LoaderError, match="aircraft '#0'.*missing required field 'id'"
+        ):
             load_fleet(path)
 
     def test_null_numeric_field_clear_error(self, tmp_path: Path) -> None:
@@ -324,7 +332,9 @@ aircraft:
         z_top_m: 1.5
 """,
         )
-        with pytest.raises(LoaderError, match="'parts\\[0\\].length_m'.*expected number, got null"):
+        with pytest.raises(
+            LoaderError, match="'parts\\[0\\].length_m'.*expected number, got null"
+        ):
             load_fleet(path)
 
     def test_quoted_bool_for_measured_rejected(self, tmp_path: Path) -> None:
@@ -396,7 +406,9 @@ aircraft:
         z_top_m: 1.5
 """,
         )
-        with pytest.raises(LoaderError, match="aircraft 'bad_husky'.*turn_radius_m is required"):
+        with pytest.raises(
+            LoaderError, match="aircraft 'bad_husky'.*turn_radius_m is required"
+        ):
             load_fleet(path)
 
 
@@ -467,7 +479,9 @@ aircraft:
       width_m: 0.05
 """,
         )
-        with pytest.raises(LoaderError, match="Struts only make sense when the wing is above"):
+        with pytest.raises(
+            LoaderError, match="Struts only make sense when the wing is above"
+        ):
             load_fleet(path)
 
     def test_first_wing_part_drives_strut_z_top(self, tmp_path: Path) -> None:
@@ -590,7 +604,9 @@ door: {width_m: 12}
 maintenance_bay: {depth_m: 9}
 """,
         )
-        with pytest.raises(LoaderError, match="missing required field 'door.center_x_m'"):
+        with pytest.raises(
+            LoaderError, match="missing required field 'door.center_x_m'"
+        ):
             load_hangar(path)
 
     def test_door_does_not_fit_propagates_from_model(self, tmp_path: Path) -> None:
@@ -633,7 +649,9 @@ door: {center_x_m: 9, width_m: 12}
 maintenance_bay: {}
 """,
         )
-        with pytest.raises(LoaderError, match="missing required field 'maintenance_bay.depth_m'"):
+        with pytest.raises(
+            LoaderError, match="missing required field 'maintenance_bay.depth_m'"
+        ):
             load_hangar(path)
 
     def test_clearance_defaults_applied(self, tmp_path: Path) -> None:
@@ -660,7 +678,9 @@ class TestLayoutLoader:
     def _minimal_fleet_and_hangar(self, dir_: Path) -> tuple[Path, Path]:
         fleet = _write(
             dir_ / "fleet.yaml",
-            _minimal_aircraft_yaml("foo", movement_mode="always_own_gear", turn_radius_m=5.0),
+            _minimal_aircraft_yaml(
+                "foo", movement_mode="always_own_gear", turn_radius_m=5.0
+            ),
         )
         hangar = _write(
             dir_ / "hangar.yaml",
@@ -771,7 +791,12 @@ placements: []
             load_layout(layout_path)
 
     def test_layout_missing_hangar_ref(self, tmp_path: Path) -> None:
-        _write(tmp_path / "fleet.yaml", _minimal_aircraft_yaml("foo", movement_mode="always_own_gear", turn_radius_m=5.0))
+        _write(
+            tmp_path / "fleet.yaml",
+            _minimal_aircraft_yaml(
+                "foo", movement_mode="always_own_gear", turn_radius_m=5.0
+            ),
+        )
         layout_path = _write(
             tmp_path / "layout.yaml",
             """
@@ -874,7 +899,9 @@ maintenance:
   comment: forgot the plane key
 """,
         )
-        with pytest.raises(LoaderError, match="'maintenance' block present but lacks required 'plane'"):
+        with pytest.raises(
+            LoaderError, match="'maintenance' block present but lacks required 'plane'"
+        ):
             load_layout(layout_path)
 
     def test_override_and_yaml_ref_conflict_for_fleet(self, tmp_path: Path) -> None:
@@ -889,7 +916,9 @@ hangar: hangar.yaml
 placements: []
 """,
         )
-        with pytest.raises(LoaderError, match="'fleet' field is set in YAML but a fleet override"):
+        with pytest.raises(
+            LoaderError, match="'fleet' field is set in YAML but a fleet override"
+        ):
             load_layout(layout_path, fleet=load_fleet(fleet_path))
 
     def test_override_and_yaml_ref_conflict_for_hangar(self, tmp_path: Path) -> None:
@@ -902,7 +931,9 @@ hangar: hangar.yaml
 placements: []
 """,
         )
-        with pytest.raises(LoaderError, match="'hangar' field is set in YAML but a hangar override"):
+        with pytest.raises(
+            LoaderError, match="'hangar' field is set in YAML but a hangar override"
+        ):
             load_layout(layout_path, hangar=load_hangar(hangar_path))
 
     def test_helper_composition_yields_two_aircraft(self, tmp_path: Path) -> None:
@@ -934,7 +965,9 @@ def _aircraft_entry(
     """One aircraft entry for a fleet YAML (no top-level 'aircraft:' key).
     Compose multiple entries via :func:`_fleet_yaml`."""
     radius_yaml = (
-        f"turn_radius_m: {turn_radius_m}" if turn_radius_m is not None else "turn_radius_m: null"
+        f"turn_radius_m: {turn_radius_m}"
+        if turn_radius_m is not None
+        else "turn_radius_m: null"
     )
     return f"""\
   - id: {plane_id}
@@ -970,4 +1003,8 @@ def _minimal_aircraft_yaml(
     turn_radius_m: float | None = 5.0,
 ) -> str:
     """Convenience: build a complete single-aircraft fleet YAML."""
-    return _fleet_yaml(_aircraft_entry(plane_id, movement_mode=movement_mode, turn_radius_m=turn_radius_m))
+    return _fleet_yaml(
+        _aircraft_entry(
+            plane_id, movement_mode=movement_mode, turn_radius_m=turn_radius_m
+        )
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -142,7 +142,9 @@ class TestStrutsSpec:
             )
 
     def test_negative_fuselage_attach_y_rejected(self) -> None:
-        with pytest.raises(ValueError, match="fuselage_attach_y_m must be non-negative"):
+        with pytest.raises(
+            ValueError, match="fuselage_attach_y_m must be non-negative"
+        ):
             StrutsSpec(
                 fuselage_attach_x_m=0.0,
                 fuselage_attach_y_m=-0.1,
@@ -152,7 +154,9 @@ class TestStrutsSpec:
             )
 
     def test_negative_fuselage_attach_z_rejected(self) -> None:
-        with pytest.raises(ValueError, match="fuselage_attach_z_m must be non-negative"):
+        with pytest.raises(
+            ValueError, match="fuselage_attach_z_m must be non-negative"
+        ):
             StrutsSpec(
                 fuselage_attach_x_m=0.0,
                 fuselage_attach_y_m=0.4,
@@ -362,7 +366,9 @@ class TestHangar:
             Hangar(
                 length_m=25.0,
                 width_m=width_m,
-                door=Door(center_x_m=9.0, width_m=12.0) if width_m > 12 else Door(center_x_m=1.0, width_m=0.5),
+                door=Door(center_x_m=9.0, width_m=12.0)
+                if width_m > 12
+                else Door(center_x_m=1.0, width_m=0.5),
                 maintenance_bay=MaintenanceBay(depth_m=9.0),
                 clearance_m=0.3,
                 wing_layer_clearance_m=0.2,
@@ -480,7 +486,9 @@ class TestLayout:
             fleet=self._fleet_of(a),
             hangar=_ok_hangar(),
             placements=(
-                Placement(plane_id="foo", x_m=5.0, y_m=10.0, heading_deg=0.0, on_carts=False),
+                Placement(
+                    plane_id="foo", x_m=5.0, y_m=10.0, heading_deg=0.0, on_carts=False
+                ),
             ),
         )
         assert layout.maintenance_plane is None
@@ -493,7 +501,13 @@ class TestLayout:
                 fleet=self._fleet_of(a),
                 hangar=_ok_hangar(),
                 placements=(
-                    Placement(plane_id="bar", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                    Placement(
+                        plane_id="bar",
+                        x_m=0.0,
+                        y_m=0.0,
+                        heading_deg=0.0,
+                        on_carts=False,
+                    ),
                 ),
             )
 
@@ -504,8 +518,20 @@ class TestLayout:
                 fleet=self._fleet_of(a),
                 hangar=_ok_hangar(),
                 placements=(
-                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
-                    Placement(plane_id="foo", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),
+                    Placement(
+                        plane_id="foo",
+                        x_m=0.0,
+                        y_m=0.0,
+                        heading_deg=0.0,
+                        on_carts=False,
+                    ),
+                    Placement(
+                        plane_id="foo",
+                        x_m=5.0,
+                        y_m=5.0,
+                        heading_deg=0.0,
+                        on_carts=False,
+                    ),
                 ),
             )
 
@@ -516,7 +542,13 @@ class TestLayout:
                 fleet=self._fleet_of(a),
                 hangar=_ok_hangar(),
                 placements=(
-                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                    Placement(
+                        plane_id="foo",
+                        x_m=0.0,
+                        y_m=0.0,
+                        heading_deg=0.0,
+                        on_carts=False,
+                    ),
                 ),
             )
 
@@ -527,7 +559,9 @@ class TestLayout:
                 fleet=self._fleet_of(a),
                 hangar=_ok_hangar(),
                 placements=(
-                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                    Placement(
+                        plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True
+                    ),
                 ),
             )
 
@@ -538,8 +572,12 @@ class TestLayout:
             fleet=self._fleet_of(a, b),
             hangar=_ok_hangar(),
             placements=(
-                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
-                Placement(plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),
+                Placement(
+                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True
+                ),
+                Placement(
+                    plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False
+                ),
             ),
         )
         assert len(layout.placements) == 2
@@ -552,8 +590,12 @@ class TestLayout:
                 fleet=self._fleet_of(a, b),
                 hangar=_ok_hangar(),
                 placements=(
-                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
-                    Placement(plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=True),
+                    Placement(
+                        plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True
+                    ),
+                    Placement(
+                        plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=True
+                    ),
                 ),
             )
 
@@ -564,7 +606,13 @@ class TestLayout:
                 fleet=self._fleet_of(a),
                 hangar=_ok_hangar(),
                 placements=(
-                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                    Placement(
+                        plane_id="foo",
+                        x_m=0.0,
+                        y_m=0.0,
+                        heading_deg=0.0,
+                        on_carts=False,
+                    ),
                 ),
                 maintenance_plane="ghost",
             )
@@ -577,7 +625,13 @@ class TestLayout:
                 fleet=self._fleet_of(a, b),
                 hangar=_ok_hangar(),
                 placements=(
-                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                    Placement(
+                        plane_id="foo",
+                        x_m=0.0,
+                        y_m=0.0,
+                        heading_deg=0.0,
+                        on_carts=False,
+                    ),
                 ),
                 maintenance_plane="bar",
             )
@@ -588,7 +642,9 @@ class TestLayout:
             fleet=self._fleet_of(a),
             hangar=_ok_hangar(),
             placements=(
-                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                Placement(
+                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
+                ),
             ),
             maintenance_plane="foo",
         )
@@ -611,7 +667,9 @@ class TestLayout:
             fleet=self._fleet_of(a),
             hangar=_ok_hangar(),
             placements=(
-                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                Placement(
+                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
+                ),
             ),
         )
         with pytest.raises(TypeError):
@@ -628,7 +686,9 @@ class TestLayout:
             fleet=caller_dict,
             hangar=_ok_hangar(),
             placements=(
-                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                Placement(
+                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
+                ),
             ),
         )
         del caller_dict["foo"]
@@ -645,9 +705,15 @@ class TestLayout:
             fleet=self._fleet_of(a, b, c),
             hangar=_ok_hangar(),
             placements=(
-                Placement(plane_id="a", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
-                Placement(plane_id="b", x_m=2.0, y_m=0.0, heading_deg=0.0, on_carts=True),
-                Placement(plane_id="c", x_m=4.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                Placement(
+                    plane_id="a", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True
+                ),
+                Placement(
+                    plane_id="b", x_m=2.0, y_m=0.0, heading_deg=0.0, on_carts=True
+                ),
+                Placement(
+                    plane_id="c", x_m=4.0, y_m=0.0, heading_deg=0.0, on_carts=True
+                ),
             ),
         )
         assert len(layout.placements) == 3
@@ -659,8 +725,12 @@ class TestLayout:
             fleet=self._fleet_of(a, b),
             hangar=_ok_hangar(),
             placements=(
-                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
-                Placement(plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),
+                Placement(
+                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
+                ),
+                Placement(
+                    plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False
+                ),
             ),
         )
         assert len(layout.placements) == 2
@@ -674,7 +744,9 @@ class TestLayout:
 
 class TestConflict:
     def test_one_plane_conflict(self) -> None:
-        c = Conflict(kind="maintenance_position", planes=("foo",), detail="not in back zone")
+        c = Conflict(
+            kind="maintenance_position", planes=("foo",), detail="not in back zone"
+        )
         assert len(c.planes) == 1
 
     def test_two_plane_conflict(self) -> None:
@@ -763,7 +835,9 @@ class TestFrozenBehavior:
             fleet={a.id: a},
             hangar=_ok_hangar(),
             placements=(
-                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                Placement(
+                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
+                ),
             ),
         )
         with pytest.raises(dataclasses.FrozenInstanceError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -103,9 +103,7 @@ class TestPart:
         "z_bottom_m, z_top_m",
         [(1.0, 1.0), (2.0, 1.5)],
     )
-    def test_z_top_must_exceed_z_bottom(
-        self, z_bottom_m: float, z_top_m: float
-    ) -> None:
+    def test_z_top_must_exceed_z_bottom(self, z_bottom_m: float, z_top_m: float) -> None:
         with pytest.raises(ValueError, match="z_top_m must exceed z_bottom_m"):
             _ok_part(z_bottom_m=z_bottom_m, z_top_m=z_top_m)
 
@@ -142,9 +140,7 @@ class TestStrutsSpec:
             )
 
     def test_negative_fuselage_attach_y_rejected(self) -> None:
-        with pytest.raises(
-            ValueError, match="fuselage_attach_y_m must be non-negative"
-        ):
+        with pytest.raises(ValueError, match="fuselage_attach_y_m must be non-negative"):
             StrutsSpec(
                 fuselage_attach_x_m=0.0,
                 fuselage_attach_y_m=-0.1,
@@ -154,9 +150,7 @@ class TestStrutsSpec:
             )
 
     def test_negative_fuselage_attach_z_rejected(self) -> None:
-        with pytest.raises(
-            ValueError, match="fuselage_attach_z_m must be non-negative"
-        ):
+        with pytest.raises(ValueError, match="fuselage_attach_z_m must be non-negative"):
             StrutsSpec(
                 fuselage_attach_x_m=0.0,
                 fuselage_attach_y_m=0.4,
@@ -486,9 +480,7 @@ class TestLayout:
             fleet=self._fleet_of(a),
             hangar=_ok_hangar(),
             placements=(
-                Placement(
-                    plane_id="foo", x_m=5.0, y_m=10.0, heading_deg=0.0, on_carts=False
-                ),
+                Placement(plane_id="foo", x_m=5.0, y_m=10.0, heading_deg=0.0, on_carts=False),
             ),
         )
         assert layout.maintenance_plane is None
@@ -559,9 +551,7 @@ class TestLayout:
                 fleet=self._fleet_of(a),
                 hangar=_ok_hangar(),
                 placements=(
-                    Placement(
-                        plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True
-                    ),
+                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
                 ),
             )
 
@@ -572,12 +562,8 @@ class TestLayout:
             fleet=self._fleet_of(a, b),
             hangar=_ok_hangar(),
             placements=(
-                Placement(
-                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True
-                ),
-                Placement(
-                    plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False
-                ),
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                Placement(plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),
             ),
         )
         assert len(layout.placements) == 2
@@ -590,12 +576,8 @@ class TestLayout:
                 fleet=self._fleet_of(a, b),
                 hangar=_ok_hangar(),
                 placements=(
-                    Placement(
-                        plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True
-                    ),
-                    Placement(
-                        plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=True
-                    ),
+                    Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                    Placement(plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=True),
                 ),
             )
 
@@ -642,9 +624,7 @@ class TestLayout:
             fleet=self._fleet_of(a),
             hangar=_ok_hangar(),
             placements=(
-                Placement(
-                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
-                ),
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
             ),
             maintenance_plane="foo",
         )
@@ -667,9 +647,7 @@ class TestLayout:
             fleet=self._fleet_of(a),
             hangar=_ok_hangar(),
             placements=(
-                Placement(
-                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
-                ),
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
             ),
         )
         with pytest.raises(TypeError):
@@ -686,9 +664,7 @@ class TestLayout:
             fleet=caller_dict,
             hangar=_ok_hangar(),
             placements=(
-                Placement(
-                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
-                ),
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
             ),
         )
         del caller_dict["foo"]
@@ -705,15 +681,9 @@ class TestLayout:
             fleet=self._fleet_of(a, b, c),
             hangar=_ok_hangar(),
             placements=(
-                Placement(
-                    plane_id="a", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True
-                ),
-                Placement(
-                    plane_id="b", x_m=2.0, y_m=0.0, heading_deg=0.0, on_carts=True
-                ),
-                Placement(
-                    plane_id="c", x_m=4.0, y_m=0.0, heading_deg=0.0, on_carts=True
-                ),
+                Placement(plane_id="a", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                Placement(plane_id="b", x_m=2.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                Placement(plane_id="c", x_m=4.0, y_m=0.0, heading_deg=0.0, on_carts=True),
             ),
         )
         assert len(layout.placements) == 3
@@ -725,12 +695,8 @@ class TestLayout:
             fleet=self._fleet_of(a, b),
             hangar=_ok_hangar(),
             placements=(
-                Placement(
-                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
-                ),
-                Placement(
-                    plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False
-                ),
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+                Placement(plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),
             ),
         )
         assert len(layout.placements) == 2
@@ -744,9 +710,7 @@ class TestLayout:
 
 class TestConflict:
     def test_one_plane_conflict(self) -> None:
-        c = Conflict(
-            kind="maintenance_position", planes=("foo",), detail="not in back zone"
-        )
+        c = Conflict(kind="maintenance_position", planes=("foo",), detail="not in back zone")
         assert len(c.planes) == 1
 
     def test_two_plane_conflict(self) -> None:
@@ -835,9 +799,7 @@ class TestFrozenBehavior:
             fleet={a.id: a},
             hangar=_ok_hangar(),
             placements=(
-                Placement(
-                    plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False
-                ),
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
             ),
         )
         with pytest.raises(dataclasses.FrozenInstanceError):

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -197,9 +197,7 @@ class TestRendererValidatesInputs:
     for a malformed input is the precise failure mode this tool exists
     to prevent."""
 
-    def test_check_result_with_unknown_plane_id_rejected(
-        self, tmp_path: Path
-    ) -> None:
+    def test_check_result_with_unknown_plane_id_rejected(self, tmp_path: Path) -> None:
         """If the caller hands the renderer a CheckResult that references
         a plane not in the layout (e.g., a CheckResult from a different
         layout), reject loudly rather than rendering a clean PNG."""


### PR DESCRIPTION
## What

Adopts \`ruff\` as the project's single tool for Python linting and formatting. Two-commit structure for reviewability:

1. **Formatting pass** — \`ruff format src/ tests/\` applied across the codebase. No logic changes. Reviewable as pure whitespace/quote-style diff.
2. **Config + CI wiring + docs** — adds \`[tool.ruff]\` and \`[tool.ruff.lint]\` blocks to \`pyproject.toml\` (\`select = ["E", "F", "I", "B", "UP", "SIM"]\`), adds \`ruff>=0.7.0\` to dev deps, adds \`ruff check\` and \`ruff format --check\` steps to CI, documents the local commands in CLAUDE.md.

Lint findings fixed in commit 2:
- **UP035** \`src/hangarfit/models.py\`: \`Mapping\` moved from \`typing\` to \`collections.abc\` (auto-fixed)
- **UP037** \`src/hangarfit/models.py\` (×2): Removed unnecessary forward-reference quotes from \`-> "Conflict"\` return annotations (auto-fixed; safe because \`from __future__ import annotations\` is already present)
- **F401** \`tests/test_geometry.py\`: Removed unused \`WorldPart\` import (auto-fixed)
- **I001** \`tests/test_geometry.py\`: Reordered local imports in an inline import block (auto-fixed)
- **B905** \`tests/test_geometry.py\` (×2): Added \`strict=\` parameter to \`zip()\` calls (\`strict=False\` for the length-guarded helper; \`strict=True\` for the 1:1 parts/worlds iterator)
- **E501** \`src/hangarfit/cli.py\` (×2): \`# noqa: E501\` on \`help=\` string literals that cannot be wrapped without degrading argparse output

Precondition for #27 (pre-commit hooks) per the dependency edge.

Closes #56

## Checklist

- [x] Branched from \`develop\`
- [x] \`pytest\` still green (244 passed)
- [x] \`ruff check src/ tests/\` clean
- [x] \`ruff format --check src/ tests/\` clean
- [x] No skipped hooks