### PR TITLE
chore(ci): adopt mypy for type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Check formatting with ruff
         run: ruff format --check src/ tests/
 
+      - name: Type-check with mypy
+        run: mypy src/hangarfit
+
       - name: Run tests
         run: pytest --cov=hangarfit --cov-report=xml --cov-report=term-missing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,9 @@ ruff format --check src/ tests/
 ruff check --fix src/ tests/
 ruff format src/ tests/
 
+# Type check
+mypy src/hangarfit/
+
 # CI: GitHub Actions runs `pytest` on Python 3.11 + 3.12 for PRs into
 # develop/main (see .github/workflows/ci.yml). No coverage gate yet.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7.4", "pytest-cov>=4.0", "ruff>=0.7.0"]
+dev = ["pytest>=7.4", "pytest-cov>=4.0", "ruff>=0.7.0", "mypy>=1.0", "types-PyYAML", "types-shapely"]
 
 [project.scripts]
 hangarfit = "hangarfit.cli:main"
@@ -39,3 +39,24 @@ select = ["E", "F", "I", "B", "UP", "SIM"]
 
 [tool.ruff.format]
 # Defaults are fine — quote-style="double", indent-style="space", line-ending="lf".
+
+[tool.mypy]
+python_version = "3.11"
+strict_optional = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+module = "hangarfit.*"
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+ignore_errors = false
+
+# matplotlib ships no PEP 561 stubs; ignore its imports rather than
+# using an unofficial stub package that may not track the 3.x API.
+[[tool.mypy.overrides]]
+module = "matplotlib.*"
+ignore_missing_imports = true

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -332,18 +332,27 @@ def _expand_struts(spec: StrutsSpec, wing: Part) -> list[Part]:
             f"loader requires a strictly positive span"
         )
     midpoint = (spec.fuselage_attach_y_m + spec.wing_attach_y_m) / 2.0
-    common = {
-        "kind": "strut",
-        "length_m": spec.width_m,
-        "width_m": strut_span,
-        "offset_x_m": spec.fuselage_attach_x_m,
-        "angle_deg": 0.0,
-        "z_bottom_m": spec.fuselage_attach_z_m,
-        "z_top_m": wing.z_bottom_m,
-    }
     return [
-        Part(offset_y_m=midpoint, **common),  # right side
-        Part(offset_y_m=-midpoint, **common),  # left side
+        Part(  # right side
+            kind="strut",
+            length_m=spec.width_m,
+            width_m=strut_span,
+            offset_x_m=spec.fuselage_attach_x_m,
+            offset_y_m=midpoint,
+            angle_deg=0.0,
+            z_bottom_m=spec.fuselage_attach_z_m,
+            z_top_m=wing.z_bottom_m,
+        ),
+        Part(  # left side
+            kind="strut",
+            length_m=spec.width_m,
+            width_m=strut_span,
+            offset_x_m=spec.fuselage_attach_x_m,
+            offset_y_m=-midpoint,
+            angle_deg=0.0,
+            z_bottom_m=spec.fuselage_attach_z_m,
+            z_top_m=wing.z_bottom_m,
+        ),
     ]
 
 

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
+from typing import Any
 
 import matplotlib
 
@@ -32,7 +33,7 @@ import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.patches import Polygon as MplPolygon  # noqa: E402
 
 from .geometry import WorldPart, aircraft_parts_world  # noqa: E402
-from .models import CheckResult, Layout, WingPosition  # noqa: E402
+from .models import CheckResult, Layout, Placement, WingPosition  # noqa: E402
 
 _WING_COLORS: dict[WingPosition, str] = {
     "high": "#3498db",  # blue
@@ -157,7 +158,7 @@ def nose_direction(heading_deg: float) -> tuple[float, float]:
     return (math.sin(h), math.cos(h))
 
 
-def _draw_hangar(ax, layout: Layout) -> None:
+def _draw_hangar(ax: Any, layout: Layout) -> None:
     """Hangar rectangle with a gap in the front wall for the door and a
     shaded back strip for the maintenance bay."""
     hangar = layout.hangar
@@ -191,7 +192,7 @@ def _draw_hangar(ax, layout: Layout) -> None:
     ax.plot([door_left, door_right], [0, 0], color=_DOOR_EDGE, lw=1, linestyle=":")
 
 
-def _draw_aircraft(ax, layout: Layout) -> None:
+def _draw_aircraft(ax: Any, layout: Layout) -> None:
     """Draw each placed plane as its world parts, color-keyed by wing position."""
     for placement in layout.placements:
         aircraft = layout.fleet[placement.plane_id]
@@ -202,7 +203,7 @@ def _draw_aircraft(ax, layout: Layout) -> None:
         _annotate_plane(ax, placement, aircraft.id)
 
 
-def _draw_part(ax, part: WorldPart, color: str) -> None:
+def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
     """Render a single world part. Fuselage is near-opaque (two fuselages
     overlapping is always a conflict; no value in seeing through), wing
     translucent (so stacked wings show their plan-view overlap visually),
@@ -253,7 +254,7 @@ def _draw_part(ax, part: WorldPart, color: str) -> None:
     ax.add_patch(patch)
 
 
-def _annotate_plane(ax, placement, plane_id: str) -> None:
+def _annotate_plane(ax: Any, placement: Placement, plane_id: str) -> None:
     """Plane id label + a short arrow showing the nose direction."""
     dx, dy = nose_direction(placement.heading_deg)
     ax.annotate(
@@ -278,7 +279,7 @@ def _annotate_plane(ax, placement, plane_id: str) -> None:
     )
 
 
-def _draw_conflict_overlay(ax, layout: Layout, check_result: CheckResult) -> None:
+def _draw_conflict_overlay(ax: Any, layout: Layout, check_result: CheckResult) -> None:
     """Redraw every part of every plane named in any conflict, in red,
     with a thicker edge so the conflict reads at a glance."""
     conflicting_planes: set[str] = set()
@@ -301,7 +302,7 @@ def _draw_conflict_overlay(ax, layout: Layout, check_result: CheckResult) -> Non
             ax.add_patch(patch)
 
 
-def _finalize_axes(ax, layout: Layout, title: str | None) -> None:
+def _finalize_axes(ax: Any, layout: Layout, title: str | None) -> None:
     """Equal-aspect axes, hangar-sized view, sensible labels, optional title.
 
     The y-axis is inverted so the door (y = 0) renders at the *top* of


### PR DESCRIPTION
## What

Adopts \`mypy\` as the type checker for \`src/hangarfit/\`. Strict on src, low-ceremony on tests.

- \`[tool.mypy]\` config in pyproject.toml: \`strict_optional\`, \`warn_unused_ignores\`, \`warn_redundant_casts\`; per-module \`disallow_untyped_defs = true\` for \`hangarfit.*\`.
- \`mypy>=1.0\`, \`types-PyYAML\`, \`types-shapely\` added to dev deps.
- Targeted \`ignore_missing_imports = true\` for \`matplotlib.*\` (no official PEP 561 stubs; unofficial packages incomplete for 3.x API).
- New CI step \`mypy src/hangarfit\` between ruff and tests (same fail-fast ordering).
- CLAUDE.md "Useful commands" extended with the mypy invocation.

**Annotation changes** (no logic changes anywhere):

- \`loader.py\` \`_expand_struts\`: replaced \`**common\` dict-unpack into \`Part()\` with explicit keyword args — mypy correctly flagged \`dict[str, object]\` as incompatible with the \`Part\` positional literal types. The expansion is semantically identical; the dict was a DRY convenience that mypy can't see through.
- \`visualize.py\`: annotated six private functions that take a matplotlib \`Axes\` as \`ax: Any\` (the type is \`matplotlib.axes.Axes\`, unavailable without stubs); imported \`Placement\` to give \`_annotate_plane\` a precise \`placement: Placement\` annotation rather than \`Any\`.

\`geometry.py\` received **no changes** — the determinant-−1 transform invariant is untouched.

Precondition for #27 (pre-commit hooks) per the dependency edge.

Closes #57

## Checklist

- [x] Branched from \`develop\`
- [x] \`mypy src/hangarfit\` clean (Success: no issues found in 7 source files)
- [x] \`pytest\` still green (244 tests)
- [x] \`ruff check\` / \`ruff format --check\` still pass
- [x] No logic changes in \`geometry.py\` — annotations only