### PR TITLE
chore(ci): add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,32 @@ review.
 
 ---
 
+## First-time setup
+
+1. Install dev dependencies:
+   ```bash
+   pip install -e ".[dev]"
+   ```
+2. Install the pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
+
+After this, every `git commit` runs the configured hooks (whitespace, YAML,
+ruff lint, ruff format) automatically. A failing hook blocks the commit — fix
+the issue, then re-commit. If you understand the risk and need to bypass the
+hooks for a single commit, you can use `git commit --no-verify` (the repo's
+`CLAUDE.md` notes that Claude-driven commits never skip hooks; humans have the
+override at their discretion).
+
+To run the hooks across the whole repo manually:
+
+```bash
+pre-commit run --all-files
+```
+
+---
+
 ## Issues first
 
 Every change — bug fix, feature, docs update — starts with a GitHub issue. No


### PR DESCRIPTION
## What

Adds `.pre-commit-config.yaml` so contributors get the same lint/format checks locally that CI already enforces.

- Stdlib hooks: `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-added-large-files`, `check-merge-conflict`.
- ruff hooks: `ruff` (with `--fix`) + `ruff-format`. Versions track the ruff in `pyproject.toml` dev deps (#74).
- No mypy hook — mypy stays CI-only (slower; needs proper module resolution). Same reasoning as why pytest is CI-only.
- `CONTRIBUTING.md` extended with a "First-time setup" subsection: `pre-commit install` is the one extra command per fresh clone.

Closes #27 — and closes out the "Going public" milestone hardening tranche.

## Checklist

- [x] Branched from `develop`
- [x] `pre-commit run --all-files` clean
- [x] `pytest` still green
- [x] `ruff check` / `ruff format --check` still clean
- [x] `mypy src/hangarfit` still clean
- [x] No skipped hooks