### PR TITLE
Phase 2a: static layout solver — design + implementation plan (docs)

### DIFF
--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -1,0 +1,3636 @@
+# Phase 2a Static Layout Solver — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the static layout solver designed in `docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md` — a `solve()` library function + `hangarfit solve` CLI subcommand that takes a `Scenario` (fleet subset + maintenance plane + per-plane constraints) and returns up to K diverse valid `Layout`s.
+
+**Architecture:** One Phase 1 extension (`CheckResult.total_penetration_m2` + `collisions.check()` populates it), one new solver module (`src/hangarfit/solver.py`, ~600 LoC: random-restart hill climb with min-conflicts descent + edit-count diversity filter), additions to `models.py` (7 new dataclasses + 1 Literal), one new loader function (`load_scenario`), one new CLI subcommand (`hangarfit solve`), and 12+ fixture YAMLs.
+
+**Tech Stack:** Python 3.11+, frozen dataclasses w/ slots, `random.Random` for sampling, `secrets.randbits` for seed resolution, shapely (already a dep) for penetration-area computation, argparse for CLI, pytest + caplog + tmp_path for tests.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md`. Section references throughout this plan (§3.2, §4.4, etc.) point into the spec.
+
+---
+
+## Plan structure & GitFlow
+
+The work splits into **7 sequential chunks**, each landing as one PR into `develop`. Per CLAUDE.md GitFlow:
+
+- One GitHub issue per chunk (created at the start of the chunk).
+- Each chunk's branch is `feature/<slug>` cut off `develop` *after* the previous chunk's PR is merged (so each chunk inherits the previous chunk's changes from `develop`).
+- After all task checkboxes in a chunk are green and tests pass, open the PR, run `/pr-review` (the `pr-review-toolkit:review-pr` skill), convert findings into review threads, resolve them, then hand off to the user for final approval and merge.
+
+| # | Chunk | Branch | Issue title | What this PR delivers |
+|---|---|---|---|---|
+| A | Phase 1 surgery (penetration depth) | `feature/phase2a-checkresult-penetration` | "CheckResult: add `total_penetration_m2` populated by `collisions.check()`" | Phase 1 scoring substrate for the solver. |
+| B | Scenario types + `load_scenario` | `feature/phase2a-scenario-types` | "Models + loader: `Scenario`, `PlaneConstraint`, `SolveResult`, `load_scenario`" | Pure-data plumbing. No behavior. |
+| C | Solver skeleton + infeasibility checks | `feature/phase2a-solver-skeleton` | "Solver: `solve()` signature + pre-search infeasibility checks" | `trivially_infeasible` works; feasible inputs return placeholder `exhausted_budget`. |
+| D | Search engine MVP (single layout) | `feature/phase2a-solver-search-engine` | "Solver: random-restart hill climb with min-conflicts descent (alternatives=1)" | Real solving for `alternatives=1`. |
+| E | K-diversity + termination | `feature/phase2a-solver-diversity` | "Solver: K-diverse alternatives + termination + diagnostics" | Full library feature for `alternatives ≥ 1`. |
+| F | CLI subcommand | `feature/phase2a-cli-solve` | "CLI: `hangarfit solve` subcommand" | `hangarfit solve` end-to-end. |
+| G | Comprehensive fixture matrix + determinism canaries | `feature/phase2a-fixture-coverage` | "Tests: full v1 fixture matrix + determinism canary set" | All §6.5 fixtures + §6.3 canary tests. |
+
+**Why sequential, not parallel?** Each chunk uses types/functions added in the previous one. PR2 imports types from PR1; PR3 imports types from PR2; etc. Trying to parallelize means juggling cross-branch merges that obscure review — not worth it for one engineer.
+
+**Working directory.** All commands assume cwd is the repo root (`/home/pkuhn/hangarfit`). No worktrees needed — sequential branch checkouts are simpler.
+
+**Acceptance for "chunk done":** all checkboxes ticked, `pytest` green on the chunk's branch, `ruff check src/ tests/` and `ruff format --check src/ tests/` and `mypy src/hangarfit/` all clean, `/pr-review` findings all resolved, user has approved and merged the PR to develop.
+
+---
+
+## Chunk A (PR1): Phase 1 surgery — penetration depth
+
+**Goal:** `CheckResult` gains `total_penetration_m2: float = 0.0` (default keeps existing fixtures green); `collisions.check()` populates it by summing `intersection().area` over pairwise conflicts.
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (add one field to `CheckResult`)
+- Modify: `src/hangarfit/collisions.py` (compute + sum overlap area at the conflict site)
+- Modify: `tests/test_collisions.py` (new assertions on the new field)
+- Modify: `tests/test_models.py` (CheckResult default-value test)
+
+### Task A.0: Branch + issue setup
+
+- [ ] **Step 1: Create the GitHub issue**
+
+Run:
+
+```bash
+gh issue create \
+  --title "CheckResult: add total_penetration_m2 populated by collisions.check()" \
+  --assignee DocGerd \
+  --label enhancement \
+  --body "$(cat <<'EOF'
+## Motivation
+
+Phase 2a (static layout solver, spec at \`docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md\` §7) uses a hierarchical scoring function \`(conflict_count, total_penetration_m2)\` for its descent step. The secondary key breaks plateaus in the integer-conflict-count metric and gives the search a smooth gradient signal even when the count is tied.
+
+This issue ships the Phase 1 substrate change required to unblock Phase 2a's solver. After this lands, \`CheckResult\` carries the new field and \`collisions.check()\` populates it; no caller is required to use it.
+
+## Scope
+
+- Add \`total_penetration_m2: float = 0.0\` to \`CheckResult\` (backward-compatible default).
+- Have \`collisions.check()\` compute the overlap area between conflicting Part polygons via shapely \`intersection().area\` and sum across all pairwise conflicts. Single-plane conflicts (\`Conflict.planes\` length 1) contribute 0.
+- Update tests that construct \`CheckResult\` literally; ensure the default-value path still passes existing assertions.
+
+## Out of scope
+
+- JSON output: \`hangarfit.check/v1\` schema is NOT changed. The new field is internal-use-only; a future v1.1 of the schema could expose it but this PR does not.
+- Solver itself (later PRs in the Phase 2a chain).
+EOF
+)"
+```
+
+Expected: prints the issue URL. Note the issue number (call it \`#A\` below) for the PR body.
+
+- [ ] **Step 2: Create the branch off the latest `develop`**
+
+```bash
+git switch develop
+git pull --ff-only
+git switch -c feature/phase2a-checkresult-penetration
+```
+
+Expected: confirms switch + reports "Switched to a new branch ..."
+
+### Task A.1: Extend `CheckResult` with the new field
+
+**Files:**
+- Modify: `src/hangarfit/models.py:404-415` (the `CheckResult` definition)
+- Modify: `tests/test_models.py` (add default-value test)
+
+- [ ] **Step 1: Write the failing test for the new field default**
+
+Add to `tests/test_models.py`:
+
+```python
+def test_check_result_default_total_penetration_is_zero():
+    """Default-constructed CheckResult has total_penetration_m2 == 0.0."""
+    from hangarfit.models import CheckResult
+
+    result = CheckResult()
+    assert result.total_penetration_m2 == 0.0
+    assert result.valid is True
+
+
+def test_check_result_total_penetration_field_is_kept():
+    """Explicit penetration value is preserved."""
+    from hangarfit.models import CheckResult
+
+    result = CheckResult(total_penetration_m2=2.5)
+    assert result.total_penetration_m2 == 2.5
+    assert result.valid is True  # still derived from conflicts, not from penetration
+```
+
+- [ ] **Step 2: Run the new tests, expect failure**
+
+Run: `pytest tests/test_models.py::test_check_result_default_total_penetration_is_zero tests/test_models.py::test_check_result_total_penetration_field_is_kept -v`
+
+Expected: both FAIL with `TypeError: ... got an unexpected keyword argument 'total_penetration_m2'` (or similar — the field doesn't exist yet).
+
+- [ ] **Step 3: Add the field to `CheckResult`**
+
+In `src/hangarfit/models.py`, find the `CheckResult` dataclass (around line 404). Modify it from:
+
+```python
+@dataclass(frozen=True, slots=True)
+class CheckResult:
+    """Result of running the collision checker against a Layout.
+
+    ``valid`` is a derived property — there is no way to construct a
+    ``CheckResult`` that claims to be valid while carrying conflicts.
+    """
+
+    conflicts: tuple[Conflict, ...] = ()
+
+    @property
+    def valid(self) -> bool:
+        return len(self.conflicts) == 0
+```
+
+To:
+
+```python
+@dataclass(frozen=True, slots=True)
+class CheckResult:
+    """Result of running the collision checker against a Layout.
+
+    ``valid`` is a derived property — there is no way to construct a
+    ``CheckResult`` that claims to be valid while carrying conflicts.
+
+    ``total_penetration_m2`` is the summed shapely-``intersection().area``
+    across pairwise conflicts (length-2 ``Conflict.planes``) — used by
+    the Phase 2a solver as a smooth secondary scoring key to break
+    plateaus in the integer ``len(conflicts)`` metric. Single-plane
+    conflicts (``maintenance_position``, ``maintenance_no_fuselage``,
+    ``hangar_bounds``) contribute 0. The validity contract is unchanged:
+    ``valid`` is still derived from ``conflicts`` only.
+    """
+
+    conflicts: tuple[Conflict, ...] = ()
+    total_penetration_m2: float = 0.0
+
+    @property
+    def valid(self) -> bool:
+        return len(self.conflicts) == 0
+```
+
+- [ ] **Step 4: Run the same tests, expect pass**
+
+Run: `pytest tests/test_models.py::test_check_result_default_total_penetration_is_zero tests/test_models.py::test_check_result_total_penetration_field_is_kept -v`
+
+Expected: both PASS.
+
+- [ ] **Step 5: Run the full test suite to confirm no regressions**
+
+Run: `pytest -q`
+
+Expected: all existing tests still pass. (The default value ensures literal `CheckResult()` constructors elsewhere still work; the new field is invisible to consumers that don't ask for it.)
+
+- [ ] **Step 6: Commit the field extension**
+
+```bash
+git add src/hangarfit/models.py tests/test_models.py
+git commit -m "$(cat <<'EOF'
+models: add CheckResult.total_penetration_m2 (default 0.0)
+
+Phase 1 substrate change for Phase 2a's hierarchical scoring function
+(see docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md §7.1).
+Backward-compatible default — existing CheckResult() constructors and
+fixture-based tests are unaffected.
+
+This commit only adds the field; collisions.check() is updated to
+populate it in the next commit.
+
+Refs #A
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+(Replace `#A` with the actual issue number from Step 1 of Task A.0.)
+
+### Task A.2: Populate `total_penetration_m2` in `collisions.check()`
+
+**Files:**
+- Modify: `src/hangarfit/collisions.py` (compute + accumulate at the conflict site)
+- Modify: `tests/test_collisions.py` (assertion on populated value)
+
+- [ ] **Step 1: Read the existing `check()` implementation**
+
+Run: `head -100 src/hangarfit/collisions.py`
+
+Then read the full file to locate the pairwise sweep where conflicts are emitted. Identify the line where the conflict's two `Part` polygons are in scope (likely just before the `Conflict.pair(...)` factory call). The penetration accumulation goes at that same site so we don't need to recompute the polygons.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `tests/test_collisions.py`:
+
+```python
+def test_check_populates_total_penetration_for_overlapping_wings(tmp_path):
+    """Two planes whose wings overlap in plan view should produce a
+    non-zero total_penetration_m2 equal to the sum of intersection areas."""
+    from hangarfit.collisions import check
+    from hangarfit.loader import load_layout
+
+    # Use an existing invalid fixture that has wing-wing overlap.
+    # The fixture lives in tests/fixtures/; pick one that the existing
+    # test_collisions suite already uses for wing overlap.
+    fixture_path = "tests/fixtures/invalid_two_planes_wing_overlap.yaml"
+    layout = load_layout(fixture_path)
+    result = check(layout)
+
+    assert not result.valid
+    assert result.total_penetration_m2 > 0.0, (
+        f"Expected non-zero penetration for overlapping wings; "
+        f"got {result.total_penetration_m2}"
+    )
+
+
+def test_check_total_penetration_is_zero_for_valid_layout(tmp_path):
+    """Valid layouts have total_penetration_m2 == 0.0 by construction."""
+    from hangarfit.collisions import check
+    from hangarfit.loader import load_layout
+
+    layout = load_layout("layouts/example.yaml")
+    result = check(layout)
+
+    assert result.valid
+    assert result.total_penetration_m2 == 0.0
+
+
+def test_check_total_penetration_excludes_single_plane_conflicts(tmp_path):
+    """Single-plane conflicts (hangar_bounds, maintenance_position) contribute 0."""
+    from hangarfit.collisions import check
+    from hangarfit.loader import load_layout
+
+    # Use an existing fixture where a single plane is out of bounds but
+    # no two planes overlap (so all conflicts are single-plane).
+    fixture_path = "tests/fixtures/invalid_plane_out_of_bounds.yaml"
+    layout = load_layout(fixture_path)
+    result = check(layout)
+
+    assert not result.valid
+    # Every conflict here is single-plane (hangar_bounds).
+    assert all(len(c.planes) == 1 for c in result.conflicts)
+    assert result.total_penetration_m2 == 0.0
+```
+
+**Note on fixture names:** `invalid_two_planes_wing_overlap.yaml` and `invalid_plane_out_of_bounds.yaml` are illustrative — substitute the exact fixture filenames present in `tests/fixtures/`. Verify with `ls tests/fixtures/invalid_*` and pick fixtures whose names match these semantics. If none match exactly, pick the closest and adjust the test names accordingly. Do NOT add new fixtures in this chunk — that's Chunk G's job.
+
+- [ ] **Step 3: Run the new tests, expect failure**
+
+Run: `pytest tests/test_collisions.py::test_check_populates_total_penetration_for_overlapping_wings tests/test_collisions.py::test_check_total_penetration_is_zero_for_valid_layout tests/test_collisions.py::test_check_total_penetration_excludes_single_plane_conflicts -v`
+
+Expected: the populated-penetration test FAILs with `Expected non-zero penetration ... got 0.0`. The other two PASS (default 0.0 already satisfies them).
+
+- [ ] **Step 4: Implement the penetration accumulator in `collisions.check()`**
+
+In `src/hangarfit/collisions.py`:
+
+1. At the top of `check()`, initialize a local accumulator: `total_penetration_m2 = 0.0`.
+2. Locate the inner loop where pairwise part-conflicts are detected. The two conflicting shapely polygons are in scope at the conflict site (computed for the `distance` test). Immediately after deciding "this is a conflict," but before constructing the `Conflict`, accumulate:
+
+   ```python
+   total_penetration_m2 += polygon_a.intersection(polygon_b).area
+   ```
+
+   Use the same `polygon_a` and `polygon_b` already used for the distance check — do not recompute.
+
+3. At the end of `check()`, pass the accumulator to the `CheckResult` constructor:
+
+   ```python
+   return CheckResult(
+       conflicts=tuple(conflicts),
+       total_penetration_m2=total_penetration_m2,
+   )
+   ```
+
+**Implementation note:** if the existing code uses `polygon_a.distance(polygon_b) < clearance_m` to decide whether to emit a conflict, `intersection().area` correctly returns 0 when the polygons don't actually overlap (distance > 0 but within clearance). That's fine: clearance-only conflicts contribute 0 to penetration, which is consistent with the spec ("penetration depth" means actual overlap, not clearance violation). The spec calls this out implicitly via the "two planes overlapping" framing of §4.4.
+
+If preferred, an even safer formulation is:
+
+```python
+if polygon_a.intersects(polygon_b):
+    total_penetration_m2 += polygon_a.intersection(polygon_b).area
+```
+
+`polygon_a.intersects(polygon_b)` is a cheap boolean and avoids constructing an empty `intersection()` for clearance-only conflicts. Use this form.
+
+- [ ] **Step 5: Run the new tests, expect pass**
+
+Run: `pytest tests/test_collisions.py::test_check_populates_total_penetration_for_overlapping_wings tests/test_collisions.py::test_check_total_penetration_is_zero_for_valid_layout tests/test_collisions.py::test_check_total_penetration_excludes_single_plane_conflicts -v`
+
+Expected: all three PASS.
+
+- [ ] **Step 6: Run the full test suite to confirm no regressions**
+
+Run: `pytest -q`
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 7: Run lint + format + type check**
+
+```bash
+ruff check src/ tests/
+ruff format --check src/ tests/
+mypy src/hangarfit/
+```
+
+Expected: all three pass with no errors. If `ruff format --check` reports differences, run `ruff format src/ tests/` and re-stage. If `mypy` complains about `intersection().area` typing, add a `# type: ignore[union-attr]` only if shapely's stubs are the issue — but first try just running it; recent shapely usually types correctly.
+
+- [ ] **Step 8: Commit the check() implementation**
+
+```bash
+git add src/hangarfit/collisions.py tests/test_collisions.py
+git commit -m "$(cat <<'EOF'
+collisions: populate CheckResult.total_penetration_m2
+
+Sums shapely intersection().area across pairwise conflicts inside
+check()'s existing sweep — the conflicting Part polygons are already
+in scope at the conflict site, so no extra geometry work is done
+beyond one intersection per conflict pair.
+
+Single-plane conflicts (hangar_bounds, maintenance_position,
+maintenance_no_fuselage) contribute 0 to the sum: they describe "a
+plane in the wrong place" rather than "two planes overlapping" and
+have no second polygon to intersect against.
+
+Refs #A
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task A.3: Chunk A wrap-up — push, PR, review
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin feature/phase2a-checkresult-penetration`
+
+Expected: branch pushed, tracking set up.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --base develop \
+  --title "CheckResult: add total_penetration_m2 populated by collisions.check()" \
+  --assignee DocGerd \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds \`CheckResult.total_penetration_m2: float = 0.0\` (backward-compatible default).
+- \`collisions.check()\` populates it by summing shapely \`intersection().area\` across pairwise conflicts. Single-plane conflicts contribute 0.
+- Existing JSON schema (\`hangarfit.check/v1\`) is unchanged — the new field is internal-use-only.
+
+Phase 1 substrate change required by Phase 2a's hierarchical scoring function. See \`docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md\` §7.
+
+Closes #A
+
+## Test plan
+
+- [x] \`pytest -q\` — full suite green
+- [x] \`ruff check src/ tests/\`
+- [x] \`ruff format --check src/ tests/\`
+- [x] \`mypy src/hangarfit/\`
+- [x] New tests added for: default value, populated value on wing overlap, zero on valid layout, zero on single-plane-only conflicts
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+(Replace `#A` with the actual issue number.)
+
+Expected: prints the PR URL.
+
+- [ ] **Step 3: Set PR metadata via gh api (label + milestone)**
+
+Per memory `feedback_pr_metadata.md`, `gh pr edit` is broken in this repo. Use `gh api -X PATCH` to set labels and (optionally) milestone:
+
+```bash
+PR_NUMBER=<the PR number from Step 2>
+gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" -f '{"labels":["enhancement"]}'
+```
+
+(Milestone assignment optional — leave blank unless a Phase 2 milestone exists.)
+
+- [ ] **Step 4: Run the PR review skill**
+
+In your Claude Code session, invoke: `/pr-review` (or the `pr-review-toolkit:review-pr` skill).
+
+Convert each finding into a review thread on the diff via `gh api .../pulls/<n>/comments`. Resolve each thread by fixing the code (preferred) or replying with rationale. If the changes were non-trivial, re-run `/pr-review`.
+
+- [ ] **Step 5: Hand off to user for approval and merge**
+
+Tell the user the PR is clean and ready for final review. Do NOT `gh pr merge` from Claude.
+
+**Chunk A done when:** PR is merged into `develop` by the user.
+
+---
+
+## Chunk B (PR2): Scenario types + `load_scenario`
+
+**Goal:** All new dataclasses from §3.2 live in `models.py`; `loader.load_scenario` parses scenario YAML into a validated `Scenario`. No solver behavior yet.
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (add `PlaneConstraint`, `Scenario`, `SolveStatus`, `SolverDiagnostics`, `SolveResult`, `DiversityConfig`, `SearchConfig`)
+- Modify: `src/hangarfit/loader.py` (add `load_scenario`)
+- Create: `tests/test_scenario.py` (Scenario invariant tests)
+- Create: `tests/test_loader_scenario.py` (load_scenario behavior tests)
+- Create: `tests/fixtures/scenario_*.yaml` (a handful of scenario fixtures for loader tests)
+
+### Task B.0: Branch + issue setup
+
+- [ ] **Step 1: Update local develop**
+
+```bash
+git switch develop
+git pull --ff-only
+```
+
+Expected: `develop` is up to date with Chunk A merged in.
+
+- [ ] **Step 2: Create the issue**
+
+```bash
+gh issue create \
+  --title "Models + loader: Scenario, PlaneConstraint, SolveResult, load_scenario" \
+  --assignee DocGerd \
+  --label enhancement \
+  --body "$(cat <<'EOF'
+## Motivation
+
+Phase 2a solver input/output types. Pure data plumbing; no behavior. See \`docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md\` §3.
+
+## Scope
+
+- Add to \`models.py\`: \`PlaneConstraint\`, \`Scenario\`, \`SolveStatus\` (Literal), \`SolverDiagnostics\`, \`SolveResult\`, \`DiversityConfig\`, \`SearchConfig\` — all frozen + slots, with \`__post_init__\` invariant checks per spec §3.2.
+- Add to \`loader.py\`: \`load_scenario(path, *, fleet=None, hangar=None) -> Scenario\` — mirrors \`load_layout\` (same conflict policy, same path-resolution rules).
+- Add scenario YAML fixtures + loader tests.
+
+## Out of scope
+
+- Solver itself (Chunk C onwards).
+- CLI subcommand (Chunk F).
+EOF
+)"
+```
+
+Note the issue number as `#B`.
+
+- [ ] **Step 3: Create the branch**
+
+```bash
+git switch -c feature/phase2a-scenario-types
+```
+
+### Task B.1: Add `PlaneConstraint` to `models.py`
+
+**Files:**
+- Modify: `src/hangarfit/models.py`
+- Modify: `tests/test_models.py` (or create `tests/test_scenario.py`; both fine — put PlaneConstraint tests with whichever feels right; this plan uses `tests/test_scenario.py`)
+
+- [ ] **Step 1: Write failing tests for `PlaneConstraint`**
+
+Create `tests/test_scenario.py`:
+
+```python
+"""Tests for the Scenario / PlaneConstraint dataclasses in models.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.models import (
+    PlaneConstraint,
+    Placement,
+)
+
+
+# ── PlaneConstraint ─────────────────────────────────────────────────────
+
+
+def test_plane_constraint_default_is_free():
+    """A constraint with no fields set means 'free'."""
+    c = PlaneConstraint()
+    assert c.pin is None
+    assert c.force_on_carts is None
+
+
+def test_plane_constraint_can_carry_pin():
+    p = Placement(plane_id="husky", x_m=2.1, y_m=14.3, heading_deg=0.0, on_carts=False)
+    c = PlaneConstraint(pin=p)
+    assert c.pin == p
+
+
+def test_plane_constraint_can_carry_force_on_carts():
+    c = PlaneConstraint(force_on_carts=True)
+    assert c.force_on_carts is True
+    assert c.pin is None
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pytest tests/test_scenario.py -v`
+
+Expected: FAIL — `ImportError: cannot import name 'PlaneConstraint'`.
+
+- [ ] **Step 3: Add `PlaneConstraint` to `models.py`**
+
+Insert the following at the end of `src/hangarfit/models.py` (after `CheckResult`, keeping imports sorted at the top):
+
+```python
+@dataclass(frozen=True, slots=True)
+class PlaneConstraint:
+    """Per-plane HARD constraints for a Scenario.
+
+    All fields optional — a constraint with everything None means 'free'
+    (the solver may place the plane anywhere within physical / cart-rule
+    limits). See spec §3.2 for the rationale.
+    """
+
+    pin: Placement | None = None
+    force_on_carts: bool | None = None
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pytest tests/test_scenario.py -v`
+
+Expected: PASS for all three.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_scenario.py
+git commit -m "models: add PlaneConstraint dataclass
+
+Per-plane hard constraints for the upcoming Scenario type:
+- pin (Placement | None) — locks plane to exact placement
+- force_on_carts (bool | None) — locks cart-mode
+
+Refs #B
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+### Task B.2: Add `Scenario` to `models.py` with full invariant checks
+
+**Files:**
+- Modify: `src/hangarfit/models.py`
+- Modify: `tests/test_scenario.py`
+
+- [ ] **Step 1: Write failing tests for `Scenario` invariants**
+
+Append to `tests/test_scenario.py`:
+
+```python
+# ── Scenario ────────────────────────────────────────────────────────────
+
+# Helpers: build a minimal in-memory fleet + hangar for Scenario tests.
+# We use the real data files rather than synthesizing fakes so that the
+# tests also exercise the loader path indirectly.
+
+from hangarfit.loader import load_fleet, load_hangar
+
+
+@pytest.fixture
+def fleet():
+    return load_fleet("data/fleet.yaml")
+
+
+@pytest.fixture
+def hangar():
+    return load_hangar("data/hangar.yaml")
+
+
+def test_scenario_smoke_construct_minimal(fleet, hangar):
+    """Minimal valid scenario constructs cleanly."""
+    from hangarfit.models import Scenario
+
+    s = Scenario(
+        fleet=fleet,
+        hangar=hangar,
+        fleet_in=("husky", "ctsl"),
+        maintenance_plane=None,
+    )
+    assert s.fleet_in == ("husky", "ctsl")
+    assert s.maintenance_plane is None
+    assert s.constraints == {}  # MappingProxyType, but == {} works
+
+
+def test_scenario_rejects_unknown_plane_in_fleet_in(fleet, hangar):
+    from hangarfit.models import Scenario
+
+    with pytest.raises(ValueError, match="unknown plane"):
+        Scenario(
+            fleet=fleet, hangar=hangar,
+            fleet_in=("not_a_real_plane",),
+        )
+
+
+def test_scenario_rejects_maintenance_plane_not_in_fleet_in(fleet, hangar):
+    from hangarfit.models import Scenario
+
+    with pytest.raises(ValueError, match="maintenance_plane"):
+        Scenario(
+            fleet=fleet, hangar=hangar,
+            fleet_in=("husky",),
+            maintenance_plane="ctsl",  # not in fleet_in
+        )
+
+
+def test_scenario_rejects_constraint_key_not_in_fleet_in(fleet, hangar):
+    from hangarfit.models import Scenario, PlaneConstraint
+
+    with pytest.raises(ValueError, match="constraint"):
+        Scenario(
+            fleet=fleet, hangar=hangar,
+            fleet_in=("husky",),
+            constraints={"ctsl": PlaneConstraint(force_on_carts=True)},
+        )
+
+
+def test_scenario_rejects_pin_plane_id_mismatch(fleet, hangar):
+    from hangarfit.models import Scenario, PlaneConstraint, Placement
+
+    with pytest.raises(ValueError, match="plane_id"):
+        Scenario(
+            fleet=fleet, hangar=hangar,
+            fleet_in=("husky", "ctsl"),
+            constraints={
+                "husky": PlaneConstraint(
+                    pin=Placement(
+                        plane_id="ctsl",  # mismatch — should be "husky"
+                        x_m=2.0, y_m=2.0, heading_deg=0.0, on_carts=False,
+                    )
+                )
+            },
+        )
+
+
+def test_scenario_rejects_force_on_carts_true_for_always_own_gear(fleet, hangar):
+    """force_on_carts=True is illegal for an always_own_gear plane (Husky)."""
+    from hangarfit.models import Scenario, PlaneConstraint
+
+    with pytest.raises(ValueError, match="movement_mode"):
+        Scenario(
+            fleet=fleet, hangar=hangar,
+            fleet_in=("husky",),
+            constraints={"husky": PlaneConstraint(force_on_carts=True)},
+        )
+
+
+def test_scenario_rejects_force_on_carts_false_for_always_cart(fleet, hangar):
+    """force_on_carts=False is illegal for an always_cart plane (Falke)."""
+    from hangarfit.models import Scenario, PlaneConstraint
+
+    with pytest.raises(ValueError, match="movement_mode"):
+        Scenario(
+            fleet=fleet, hangar=hangar,
+            fleet_in=("scheibe_falke",),
+            constraints={"scheibe_falke": PlaneConstraint(force_on_carts=False)},
+        )
+
+
+def test_scenario_rejects_pin_on_carts_inconsistent_with_movement_mode(fleet, hangar):
+    """A pin whose on_carts violates the plane's movement_mode is invalid."""
+    from hangarfit.models import Scenario, PlaneConstraint, Placement
+
+    # Falke is always_cart — a pin with on_carts=False is illegal.
+    with pytest.raises(ValueError, match="movement_mode"):
+        Scenario(
+            fleet=fleet, hangar=hangar,
+            fleet_in=("scheibe_falke",),
+            constraints={
+                "scheibe_falke": PlaneConstraint(
+                    pin=Placement(
+                        plane_id="scheibe_falke",
+                        x_m=2.0, y_m=2.0, heading_deg=0.0,
+                        on_carts=False,  # illegal for always_cart
+                    )
+                )
+            },
+        )
+
+
+def test_scenario_rejects_pin_and_force_on_carts_disagreement(fleet, hangar):
+    """If both pin and force_on_carts are set, their on_carts must agree."""
+    from hangarfit.models import Scenario, PlaneConstraint, Placement
+
+    with pytest.raises(ValueError, match="disagree|contradict"):
+        Scenario(
+            fleet=fleet, hangar=hangar,
+            fleet_in=("cessna_140",),  # cart_eligible — both states are valid
+            constraints={
+                "cessna_140": PlaneConstraint(
+                    pin=Placement(
+                        plane_id="cessna_140",
+                        x_m=2.0, y_m=2.0, heading_deg=0.0, on_carts=True,
+                    ),
+                    force_on_carts=False,  # contradicts the pin's on_carts
+                )
+            },
+        )
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pytest tests/test_scenario.py -v`
+
+Expected: all new Scenario tests FAIL — `ImportError: cannot import name 'Scenario'`.
+
+- [ ] **Step 3: Implement `Scenario` with all invariant checks**
+
+Append to `src/hangarfit/models.py` (after `PlaneConstraint`):
+
+```python
+@dataclass(frozen=True, slots=True)
+class Scenario:
+    """Solver input for Phase 2a.
+
+    Cross-reference invariants validated in __post_init__:
+
+    - every fleet_in id exists in fleet
+    - maintenance_plane (if set) is in fleet_in
+    - constraints.keys() ⊆ set(fleet_in)
+    - for each (plane_id, constraint): constraint.pin.plane_id == plane_id (if pin set)
+    - force_on_carts is consistent with movement_mode:
+        force_on_carts=True  → plane must NOT be always_own_gear
+        force_on_carts=False → plane must NOT be always_cart
+    - pin.on_carts is consistent with movement_mode (same rules)
+    - if both a pin and force_on_carts are set, their on_carts must agree
+    - fleet dict is wrapped in MappingProxyType (same pattern as Layout)
+
+    See spec §3.2 for the rationale.
+    """
+
+    fleet: Mapping[str, Aircraft]
+    hangar: Hangar
+    fleet_in: tuple[str, ...]
+    maintenance_plane: str | None = None
+    constraints: Mapping[str, PlaneConstraint] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+
+    def __post_init__(self) -> None:
+        # fleet_in references real planes
+        for pid in self.fleet_in:
+            if pid not in self.fleet:
+                raise ValueError(
+                    f"Scenario.fleet_in references unknown plane {pid!r}; "
+                    f"fleet has: {sorted(self.fleet)}"
+                )
+
+        fleet_in_set = set(self.fleet_in)
+
+        # maintenance_plane in fleet_in
+        if self.maintenance_plane is not None:
+            if self.maintenance_plane not in fleet_in_set:
+                raise ValueError(
+                    f"Scenario.maintenance_plane {self.maintenance_plane!r} "
+                    f"must be in fleet_in"
+                )
+
+        # constraint keys ⊆ fleet_in
+        for key in self.constraints:
+            if key not in fleet_in_set:
+                raise ValueError(
+                    f"Scenario.constraints has key {key!r} not in fleet_in"
+                )
+
+        # per-constraint validation
+        for plane_id, constraint in self.constraints.items():
+            plane = self.fleet[plane_id]
+
+            if constraint.pin is not None:
+                if constraint.pin.plane_id != plane_id:
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].pin.plane_id is "
+                        f"{constraint.pin.plane_id!r}; must equal the constraint key"
+                    )
+
+                # pin.on_carts consistency with movement_mode
+                if plane.movement_mode == "always_cart" and not constraint.pin.on_carts:
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].pin.on_carts=False "
+                        f"contradicts movement_mode={plane.movement_mode!r}"
+                    )
+                if plane.movement_mode == "always_own_gear" and constraint.pin.on_carts:
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].pin.on_carts=True "
+                        f"contradicts movement_mode={plane.movement_mode!r}"
+                    )
+
+            if constraint.force_on_carts is not None:
+                # force_on_carts consistency with movement_mode
+                if constraint.force_on_carts is True and plane.movement_mode == "always_own_gear":
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].force_on_carts=True "
+                        f"contradicts movement_mode={plane.movement_mode!r}"
+                    )
+                if constraint.force_on_carts is False and plane.movement_mode == "always_cart":
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].force_on_carts=False "
+                        f"contradicts movement_mode={plane.movement_mode!r}"
+                    )
+
+            # pin and force_on_carts must agree if both set
+            if (
+                constraint.pin is not None
+                and constraint.force_on_carts is not None
+                and constraint.pin.on_carts != constraint.force_on_carts
+            ):
+                raise ValueError(
+                    f"Scenario.constraints[{plane_id!r}]: pin.on_carts="
+                    f"{constraint.pin.on_carts} and force_on_carts="
+                    f"{constraint.force_on_carts} disagree (contradictory)"
+                )
+
+        object.__setattr__(self, "fleet", MappingProxyType(dict(self.fleet)))
+        # constraints is also frozen-ish via MappingProxyType, ensure it is
+        if not isinstance(self.constraints, MappingProxyType):
+            object.__setattr__(
+                self, "constraints", MappingProxyType(dict(self.constraints))
+            )
+```
+
+You'll need to add `field` to the imports near the top of `models.py`:
+
+```python
+from dataclasses import dataclass, field
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pytest tests/test_scenario.py -v`
+
+Expected: all 9 Scenario tests PASS.
+
+- [ ] **Step 5: Run full suite — no regressions**
+
+Run: `pytest -q`
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_scenario.py
+git commit -m "$(cat <<'EOF'
+models: add Scenario dataclass with full invariant validation
+
+Per spec §3.2, Scenario carries fleet_in + maintenance_plane +
+per-plane constraints, and validates 8 invariants in __post_init__:
+unknown planes, maintenance_plane ∉ fleet_in, constraint keys ⊄
+fleet_in, pin.plane_id mismatch, pin.on_carts vs movement_mode (×2),
+force_on_carts vs movement_mode (×2), pin+force_on_carts disagreement.
+
+Refs #B
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task B.3: Add `SolveStatus`, `SolverDiagnostics`, `SolveResult`, `DiversityConfig`, `SearchConfig`
+
+**Files:**
+- Modify: `src/hangarfit/models.py`
+- Modify: `tests/test_scenario.py` (or new file — keep in test_scenario.py for cohesion)
+
+- [ ] **Step 1: Write failing tests for the output types and configs**
+
+Append to `tests/test_scenario.py`:
+
+```python
+# ── SolveStatus / SolverDiagnostics / SolveResult ───────────────────────
+
+
+def test_solve_status_literal_values():
+    """SolveStatus must be exactly these four strings."""
+    import typing
+    from hangarfit.models import SolveStatus
+
+    values = set(typing.get_args(SolveStatus))
+    assert values == {"found", "found_partial", "exhausted_budget", "trivially_infeasible"}
+
+
+def test_solver_diagnostics_construct():
+    from hangarfit.models import SolverDiagnostics
+
+    d = SolverDiagnostics(
+        restarts_attempted=47,
+        wall_time_s=4.2,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=42,
+    )
+    assert d.seed == 42
+    assert d.restarts_attempted == 47
+
+
+def test_solve_result_construct():
+    from hangarfit.models import SolveResult, SolverDiagnostics
+
+    r = SolveResult(
+        status="found",
+        layouts=(),
+        diagnostics=SolverDiagnostics(
+            restarts_attempted=0, wall_time_s=0.0,
+            best_partial=None, best_partial_layout=None, seed=42,
+        ),
+    )
+    assert r.status == "found"
+    assert r.layouts == ()
+
+
+# ── DiversityConfig / SearchConfig ──────────────────────────────────────
+
+
+def test_diversity_config_defaults():
+    from hangarfit.models import DiversityConfig
+
+    d = DiversityConfig()
+    assert d.min_planes_moved == 2
+    assert d.position_threshold_m == 0.5
+    assert d.heading_threshold_deg == 30.0
+
+
+def test_search_config_defaults():
+    from hangarfit.models import SearchConfig
+
+    s = SearchConfig()
+    assert s.candidates_per_iter == 8
+    assert s.k_stall == 50
+    assert s.pos_sigma_m == 0.5
+    assert s.heading_sigma_deg == 10.0
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pytest tests/test_scenario.py -v -k 'SolveStatus or diagnostics or solve_result or diversity_config or search_config'`
+
+(Mix of test names; substitute as appropriate.) Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Add the remaining types**
+
+Append to `src/hangarfit/models.py`:
+
+```python
+SolveStatus = Literal[
+    "found",
+    "found_partial",
+    "exhausted_budget",
+    "trivially_infeasible",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SolverDiagnostics:
+    """Per-solve diagnostic information."""
+
+    restarts_attempted: int
+    wall_time_s: float
+    best_partial: CheckResult | None
+    best_partial_layout: Layout | None
+    seed: int
+
+
+@dataclass(frozen=True, slots=True)
+class SolveResult:
+    """Public output of solver.solve()."""
+
+    status: SolveStatus
+    layouts: tuple[Layout, ...]
+    diagnostics: SolverDiagnostics
+
+
+@dataclass(frozen=True, slots=True)
+class DiversityConfig:
+    """Diversity-filter thresholds (see spec §4.6)."""
+
+    min_planes_moved: int = 2
+    position_threshold_m: float = 0.5
+    heading_threshold_deg: float = 30.0
+
+
+@dataclass(frozen=True, slots=True)
+class SearchConfig:
+    """Solver hyperparameters (see spec §4.3, §4.5). v1 defaults are guesses."""
+
+    candidates_per_iter: int = 8
+    k_stall: int = 50
+    pos_sigma_m: float = 0.5
+    heading_sigma_deg: float = 10.0
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pytest tests/test_scenario.py -v`
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Run full suite + lint + type check**
+
+```bash
+pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_scenario.py
+git commit -m "$(cat <<'EOF'
+models: add SolveStatus, SolverDiagnostics, SolveResult, DiversityConfig, SearchConfig
+
+Remainder of the Phase 2a public type surface (per spec §3.2):
+- SolveStatus: Literal["found","found_partial","exhausted_budget","trivially_infeasible"]
+- SolverDiagnostics: restarts_attempted, wall_time_s, best_partial(_layout), seed
+- SolveResult: status + layouts + diagnostics
+- DiversityConfig: edit-count thresholds (M=2, 0.5m, 30°)
+- SearchConfig: hyperparameters (N=8, K_stall=50, sigmas)
+
+Refs #B
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task B.4: Add `load_scenario` to `loader.py`
+
+**Files:**
+- Modify: `src/hangarfit/loader.py`
+- Create: `tests/test_loader_scenario.py`
+- Create: `tests/fixtures/scenario_minimal.yaml`
+- Create: `tests/fixtures/scenario_with_pin.yaml`
+- Create: `tests/fixtures/scenario_with_force_carts.yaml`
+- Create: `tests/fixtures/scenario_bad_unknown_plane.yaml`
+- Create: `tests/fixtures/scenario_bad_force_carts_conflict.yaml`
+
+- [ ] **Step 1: Create the fixtures**
+
+`tests/fixtures/scenario_minimal.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [husky, ctsl]
+```
+
+`tests/fixtures/scenario_with_pin.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [husky, ctsl, fuji]
+maintenance:
+  plane: fuji
+constraints:
+  husky:
+    pin: { x_m: 2.1, y_m: 14.3, heading_deg: 0.0, on_carts: false }
+```
+
+`tests/fixtures/scenario_with_force_carts.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [cessna_140, ctsl]
+constraints:
+  cessna_140:
+    force_on_carts: true
+```
+
+`tests/fixtures/scenario_bad_unknown_plane.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [husky, not_a_real_plane]
+```
+
+`tests/fixtures/scenario_bad_force_carts_conflict.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [husky]
+constraints:
+  husky:
+    force_on_carts: true   # husky is always_own_gear → contradiction
+```
+
+- [ ] **Step 2: Write failing tests for `load_scenario`**
+
+Create `tests/test_loader_scenario.py`:
+
+```python
+"""Tests for hangarfit.loader.load_scenario."""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.loader import LoaderError
+
+
+def test_load_scenario_minimal():
+    from hangarfit.loader import load_scenario
+
+    s = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    assert s.fleet_in == ("husky", "ctsl")
+    assert s.maintenance_plane is None
+    assert s.constraints == {}
+
+
+def test_load_scenario_with_pin():
+    from hangarfit.loader import load_scenario
+
+    s = load_scenario("tests/fixtures/scenario_with_pin.yaml")
+    assert s.maintenance_plane == "fuji"
+    assert "husky" in s.constraints
+    pin = s.constraints["husky"].pin
+    assert pin is not None
+    assert pin.plane_id == "husky"  # filled in by loader
+    assert pin.x_m == 2.1
+    assert pin.heading_deg == 0.0
+    assert pin.on_carts is False
+
+
+def test_load_scenario_with_force_carts():
+    from hangarfit.loader import load_scenario
+
+    s = load_scenario("tests/fixtures/scenario_with_force_carts.yaml")
+    assert s.constraints["cessna_140"].force_on_carts is True
+
+
+def test_load_scenario_rejects_unknown_plane():
+    from hangarfit.loader import load_scenario
+
+    with pytest.raises(LoaderError, match="unknown plane"):
+        load_scenario("tests/fixtures/scenario_bad_unknown_plane.yaml")
+
+
+def test_load_scenario_rejects_force_carts_conflict():
+    from hangarfit.loader import load_scenario
+
+    with pytest.raises(LoaderError, match="movement_mode"):
+        load_scenario("tests/fixtures/scenario_bad_force_carts_conflict.yaml")
+
+
+def test_load_scenario_rejects_double_fleet_source(tmp_path):
+    """If YAML embeds `fleet:` AND a fleet override is passed, raise."""
+    from hangarfit.loader import load_scenario, load_fleet
+
+    fleet_obj = load_fleet("data/fleet.yaml")
+    with pytest.raises(LoaderError, match="fleet"):
+        load_scenario("tests/fixtures/scenario_minimal.yaml", fleet=fleet_obj)
+
+
+def test_load_scenario_yaml_parse_error(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("not: valid: yaml: at: all:\n  - [")
+    with pytest.raises(LoaderError, match="YAML parse error"):
+        load_scenario(bad)
+
+
+def test_load_scenario_missing_fleet_in(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    missing = tmp_path / "missing.yaml"
+    missing.write_text(
+        "fleet: ../../data/fleet.yaml\n"
+        "hangar: ../../data/hangar.yaml\n"
+    )
+    with pytest.raises(LoaderError, match="fleet_in"):
+        load_scenario(missing)
+```
+
+- [ ] **Step 3: Run, expect failure**
+
+Run: `pytest tests/test_loader_scenario.py -v`
+
+Expected: all FAIL with `ImportError: cannot import name 'load_scenario'`.
+
+- [ ] **Step 4: Implement `load_scenario`**
+
+Add to `src/hangarfit/loader.py`:
+
+```python
+def load_scenario(
+    path: Path | str,
+    *,
+    fleet: dict[str, Aircraft] | None = None,
+    hangar: Hangar | None = None,
+) -> Scenario:
+    """Load a scenario YAML into a validated :class:`Scenario`.
+
+    Path resolution and override-conflict policy mirror :func:`load_layout`.
+    """
+    path = Path(path)
+    raw = _read_yaml(path)
+    if not isinstance(raw, dict):
+        raise LoaderError(f"{path}: top-level must be a mapping")
+
+    # fleet / hangar — same pattern as load_layout
+    if fleet is None:
+        fleet_ref = raw.get("fleet")
+        if fleet_ref is None:
+            raise LoaderError(
+                f"{path}: 'fleet' field is required when no fleet override is provided"
+            )
+        fleet = load_fleet((path.parent / fleet_ref).resolve())
+    elif "fleet" in raw:
+        raise LoaderError(
+            f"{path}: 'fleet' field is set in YAML but a fleet override was also "
+            f"provided programmatically; remove one to disambiguate"
+        )
+
+    if hangar is None:
+        hangar_ref = raw.get("hangar")
+        if hangar_ref is None:
+            raise LoaderError(
+                f"{path}: 'hangar' field is required when no hangar override is provided"
+            )
+        hangar = load_hangar((path.parent / hangar_ref).resolve())
+    elif "hangar" in raw:
+        raise LoaderError(
+            f"{path}: 'hangar' field is set in YAML but a hangar override was also "
+            f"provided programmatically; remove one to disambiguate"
+        )
+
+    # fleet_in (required)
+    if "fleet_in" not in raw:
+        raise LoaderError(f"{path}: missing required field 'fleet_in'")
+    fleet_in_raw = raw["fleet_in"]
+    if not isinstance(fleet_in_raw, list):
+        raise LoaderError(f"{path}: 'fleet_in' must be a list")
+    fleet_in = tuple(str(x) for x in fleet_in_raw)
+
+    # maintenance (optional, same shape as load_layout)
+    maintenance_plane = _extract_maintenance_plane(raw, path)
+
+    # constraints (optional)
+    constraints_raw = raw.get("constraints") or {}
+    if not isinstance(constraints_raw, dict):
+        raise LoaderError(f"{path}: 'constraints' must be a mapping")
+    constraints: dict[str, PlaneConstraint] = {}
+    for plane_id, cdata in constraints_raw.items():
+        try:
+            constraints[plane_id] = _build_plane_constraint(plane_id, cdata)
+        except (ValueError, KeyError, TypeError, LoaderError) as e:
+            raise LoaderError(f"{path}: constraint {plane_id!r}: {e}") from e
+
+    try:
+        return Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=fleet_in,
+            maintenance_plane=maintenance_plane,
+            constraints=constraints,
+        )
+    except ValueError as e:
+        raise LoaderError(f"{path}: {e}") from e
+
+
+def _build_plane_constraint(plane_id: str, data: Any) -> PlaneConstraint:
+    if not isinstance(data, dict):
+        raise LoaderError(f"must be a mapping, got {type(data).__name__}")
+
+    pin_data = data.get("pin")
+    pin: Placement | None = None
+    if pin_data is not None:
+        if not isinstance(pin_data, dict):
+            raise LoaderError(f"'pin' must be a mapping, got {type(pin_data).__name__}")
+        # pin's plane_id is filled in from the constraint key (the YAML schema
+        # doesn't repeat it — the user already keys it under the plane).
+        required = ("x_m", "y_m", "heading_deg")
+        for key in required:
+            if key not in pin_data:
+                raise LoaderError(f"'pin' missing required field {key!r}")
+        pin = Placement(
+            plane_id=plane_id,
+            x_m=_to_float(pin_data["x_m"], "pin.x_m"),
+            y_m=_to_float(pin_data["y_m"], "pin.y_m"),
+            heading_deg=_to_float(pin_data["heading_deg"], "pin.heading_deg"),
+            on_carts=_to_bool(pin_data.get("on_carts", False), "pin.on_carts"),
+        )
+
+    force_on_carts = data.get("force_on_carts")
+    if force_on_carts is not None:
+        force_on_carts = _to_bool(force_on_carts, "force_on_carts")
+
+    return PlaneConstraint(pin=pin, force_on_carts=force_on_carts)
+```
+
+Add the missing imports to the top of `loader.py`:
+
+```python
+from .models import (
+    Aircraft,
+    Door,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    PlaneConstraint,   # NEW
+    Placement,
+    Scenario,          # NEW
+    StrutsSpec,
+)
+```
+
+- [ ] **Step 5: Run, expect pass**
+
+Run: `pytest tests/test_loader_scenario.py -v`
+
+Expected: all 8 tests PASS.
+
+- [ ] **Step 6: Run full suite + lint + type check**
+
+```bash
+pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
+```
+
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader_scenario.py tests/fixtures/scenario_*.yaml
+git commit -m "$(cat <<'EOF'
+loader: add load_scenario(path, *, fleet=None, hangar=None) -> Scenario
+
+Mirrors load_layout: YAML→Scenario translation with path resolution,
+strict coercion, override-conflict refusal. Per-plane constraints
+(pin + force_on_carts) are built from the YAML constraint mapping
+under each plane_id key; pin.plane_id is filled in from the key.
+
+Includes 5 new YAML fixtures (3 valid scenarios, 2 invalid) and 8
+loader tests covering happy paths and rejection of invariant
+violations.
+
+Refs #B
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task B.5: Chunk B wrap-up
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feature/phase2a-scenario-types
+```
+
+- [ ] **Step 2: Open PR (base develop)**
+
+```bash
+gh pr create --base develop \
+  --title "Models + loader: Scenario, PlaneConstraint, SolveResult, load_scenario" \
+  --assignee DocGerd \
+  --body "$(cat <<'EOF'
+## Summary
+
+- 7 new dataclasses in models.py: PlaneConstraint, Scenario, SolverDiagnostics, SolveResult, DiversityConfig, SearchConfig (plus SolveStatus Literal)
+- load_scenario in loader.py (mirrors load_layout's contract)
+- 5 new YAML fixtures (3 valid scenarios, 2 invalid) + 17 new tests across test_scenario.py and test_loader_scenario.py
+
+Pure data plumbing — no behavior change. The solver itself lands in subsequent PRs.
+
+Closes #B
+
+## Test plan
+
+- [x] \`pytest -q\` — full suite green
+- [x] \`ruff check src/ tests/\` / \`ruff format --check\` / \`mypy src/hangarfit/\`
+- [x] All 9 Scenario invariants tested (unknown plane, maintenance_plane ∉ fleet_in, constraint key ∉ fleet_in, pin.plane_id mismatch, pin.on_carts vs movement_mode ×2, force_on_carts vs movement_mode ×2, pin+force disagreement)
+- [x] load_scenario tested for happy paths, missing fields, double-source refusal, YAML parse errors
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Set PR labels via gh api**
+
+```bash
+PR_NUMBER=<from Step 2>
+gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" -f '{"labels":["enhancement"]}'
+```
+
+- [ ] **Step 4: Run `/pr-review`, resolve threads, hand off**
+
+Same flow as Chunk A. Don't merge.
+
+**Chunk B done when:** PR merged to develop.
+
+---
+
+## Chunk C (PR3): Solver skeleton + pre-search infeasibility checks
+
+**Goal:** `src/hangarfit/solver.py` exists with `solve()`. For any infeasible-at-load-time scenario, returns `status="trivially_infeasible"`. For any feasible-looking scenario, returns `status="exhausted_budget"` immediately with `wall_time_s ≈ 0`, `layouts=()`, `best_partial=None`. This is intentional: the actual search lands in Chunk D.
+
+**Files:**
+- Create: `src/hangarfit/solver.py` (~150 LoC for this chunk)
+- Create: `tests/test_solver_infeasibility.py`
+- Create: `tests/fixtures/solve_infeasible_pins_clash.yaml`
+- Create: `tests/fixtures/solve_infeasible_too_big.yaml`
+- Create: `tests/fixtures/solve_infeasible_plane_too_big.yaml` (per-plane bbox > hangar)
+- Create: `tests/fixtures/solve_feasible_smoke.yaml` (minimal feasible — returns exhausted_budget placeholder)
+
+### Task C.0: Branch + issue setup
+
+- [ ] **Step 1: Update develop, create branch**
+
+```bash
+git switch develop
+git pull --ff-only
+git switch -c feature/phase2a-solver-skeleton
+```
+
+- [ ] **Step 2: Create the issue**
+
+```bash
+gh issue create \
+  --title "Solver: solve() signature + pre-search infeasibility checks" \
+  --assignee DocGerd \
+  --label enhancement \
+  --body "$(cat <<'EOF'
+## Motivation
+
+First slice of \`src/hangarfit/solver.py\`. Wires up the public \`solve()\` API and implements the three pre-search infeasibility checks from spec §4.1 (per-plane bbox vs hangar, Σ areas vs hangar, pin self-collision). Does NOT yet implement actual search — feasible scenarios short-circuit to \`exhausted_budget\` placeholder.
+
+Splitting this from the search engine keeps both PRs small and reviewable.
+
+## Out of scope
+
+- Initial placement, descent, restart, diversity — Chunks D and E.
+- CLI — Chunk F.
+EOF
+)"
+```
+
+Note issue number as `#C`.
+
+### Task C.1: Create `solver.py` with `solve()` signature returning placeholder
+
+**Files:**
+- Create: `src/hangarfit/solver.py`
+- Create: `tests/test_solver_infeasibility.py`
+- Create: `tests/fixtures/solve_feasible_smoke.yaml`
+
+- [ ] **Step 1: Create the feasible smoke fixture**
+
+`tests/fixtures/solve_feasible_smoke.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [husky]
+```
+
+(Single plane, small footprint, large hangar — definitely feasible.)
+
+- [ ] **Step 2: Write the failing smoke test**
+
+Create `tests/test_solver_infeasibility.py`:
+
+```python
+"""Tests for solver.solve() — pre-search infeasibility + smoke."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_solve_feasible_smoke_returns_exhausted_budget_placeholder():
+    """Until Chunk D lands, any feasible scenario returns exhausted_budget."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    r = solve(s, budget_s=0.1, seed=42)
+
+    # Chunk C placeholder: no search yet, so feasible inputs return
+    # exhausted_budget immediately.
+    assert r.status == "exhausted_budget"
+    assert r.layouts == ()
+    assert r.diagnostics.seed == 42
+    assert r.diagnostics.wall_time_s < 1.0
+    # best_partial is None at this stage (no search means no partial)
+    assert r.diagnostics.best_partial is None
+
+
+def test_solve_resolves_none_seed_to_entropy():
+    """seed=None resolves to a random int and is recorded in diagnostics."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    r = solve(s, budget_s=0.1, seed=None)
+    assert isinstance(r.diagnostics.seed, int)
+    assert r.diagnostics.seed != 0  # entropy is essentially always nonzero
+```
+
+- [ ] **Step 3: Run, expect failure**
+
+Run: `pytest tests/test_solver_infeasibility.py -v`
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'hangarfit.solver'`.
+
+- [ ] **Step 4: Create the minimal `solver.py`**
+
+Create `src/hangarfit/solver.py`:
+
+```python
+"""Phase 2a static layout solver.
+
+See ``docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md``
+for the full design. This module is built incrementally across multiple PRs;
+the current implementation supports:
+
+- pre-search infeasibility detection (§4.1)  [Chunk C]
+- random-restart hill climb with min-conflicts descent (§4.2-§4.4)  [Chunk D]
+- K-diverse alternatives + termination (§4.5-§4.7)  [Chunk E]
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+import random as _random_module
+
+from hangarfit.models import (
+    DiversityConfig,
+    Scenario,
+    SearchConfig,
+    SolveResult,
+    SolverDiagnostics,
+)
+
+
+def solve(
+    scenario: Scenario,
+    *,
+    budget_s: float = 30.0,
+    alternatives: int = 1,
+    seed: int | None = None,
+    diversity: DiversityConfig | None = None,
+    search: SearchConfig | None = None,
+) -> SolveResult:
+    """Solve a Scenario into up to ``alternatives`` diverse valid Layouts.
+
+    See spec §3.3 for the contract.
+    """
+    if diversity is None:
+        diversity = DiversityConfig()
+    if search is None:
+        search = SearchConfig()
+
+    # Resolve seed
+    resolved_seed = seed if seed is not None else secrets.randbits(32)
+    rng = _random_module.Random(resolved_seed)
+    del rng  # not used in Chunk C — placeholder
+
+    start = time.monotonic()
+
+    # Chunk C: actual search not yet implemented — short-circuit to
+    # exhausted_budget for any feasible scenario. The infeasibility
+    # checks added below replace this short-circuit for infeasible cases.
+    elapsed = time.monotonic() - start
+
+    return SolveResult(
+        status="exhausted_budget",
+        layouts=(),
+        diagnostics=SolverDiagnostics(
+            restarts_attempted=0,
+            wall_time_s=elapsed,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=resolved_seed,
+        ),
+    )
+```
+
+- [ ] **Step 5: Run, expect pass**
+
+Run: `pytest tests/test_solver_infeasibility.py -v`
+
+Expected: both PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_infeasibility.py tests/fixtures/solve_feasible_smoke.yaml
+git commit -m "$(cat <<'EOF'
+solver: create solver.py with solve() signature returning placeholder
+
+First skeleton commit of src/hangarfit/solver.py. The public solve()
+signature is wired up; seed resolution + diagnostics population work
+correctly. Actual search is not yet implemented — any feasible
+scenario returns status=exhausted_budget with empty layouts. The
+infeasibility checks in §4.1 land in the next commit.
+
+Refs #C
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task C.2: Pre-search infeasibility check 1 — per-plane bbox > hangar
+
+**Files:**
+- Modify: `src/hangarfit/solver.py`
+- Modify: `tests/test_solver_infeasibility.py`
+- Create: `tests/fixtures/solve_infeasible_plane_too_big.yaml`
+
+**Note:** "plane bbox > hangar" requires a fixture where some plane's max-extent bbox literally exceeds the hangar's larger dimension. Since the real `data/fleet.yaml` planes all fit in `data/hangar.yaml`, we'll synthesize a tiny test-only hangar. (Actually, the Falke's 18 m wing fits in `data/hangar.yaml`'s 25 m length already. Use a 10×10 m fixture hangar so the Falke clearly doesn't fit.)
+
+- [ ] **Step 1: Create the test-only hangar and scenario fixtures**
+
+`tests/fixtures/test_hangar_tiny.yaml` (only if it doesn't exist; check first with `ls tests/fixtures/test_hangar*`):
+
+```yaml
+length_m: 10.0
+width_m: 8.0
+door:
+  center_x_m: 4.0
+  width_m: 5.0
+maintenance_bay:
+  depth_m: 1.0
+clearance_m: 0.3
+wing_layer_clearance_m: 0.2
+```
+
+`tests/fixtures/solve_infeasible_plane_too_big.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ./test_hangar_tiny.yaml
+fleet_in: [scheibe_falke]   # 18 m wingspan, won't fit in 10x8 m
+```
+
+- [ ] **Step 2: Write failing test**
+
+Append to `tests/test_solver_infeasibility.py`:
+
+```python
+def test_solve_trivially_infeasible_when_plane_too_big_for_hangar():
+    """A plane whose bbox exceeds hangar dims → trivially_infeasible."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_infeasible_plane_too_big.yaml")
+    r = solve(s, budget_s=5.0, seed=42)
+
+    assert r.status == "trivially_infeasible"
+    assert r.layouts == ()
+    # Pre-search check must short-circuit fast (no actual search).
+    assert r.diagnostics.wall_time_s < 0.5
+    assert r.diagnostics.restarts_attempted == 0
+```
+
+- [ ] **Step 3: Run, expect failure**
+
+Run: `pytest tests/test_solver_infeasibility.py::test_solve_trivially_infeasible_when_plane_too_big_for_hangar -v`
+
+Expected: FAIL — status is `exhausted_budget` instead of `trivially_infeasible`.
+
+- [ ] **Step 4: Implement check #1 in `solver.py`**
+
+In `src/hangarfit/solver.py`, insert a helper function and a check call inside `solve()` before the short-circuit return. After the `del rng` line, before `start = time.monotonic()`:
+
+```python
+    # ── Pre-search infeasibility checks (§4.1) ──────────────────────────
+    start = time.monotonic()
+
+    infeasible_reason = _check_trivially_infeasible(scenario)
+    if infeasible_reason is not None:
+        return SolveResult(
+            status="trivially_infeasible",
+            layouts=(),
+            diagnostics=SolverDiagnostics(
+                restarts_attempted=0,
+                wall_time_s=time.monotonic() - start,
+                best_partial=infeasible_reason,   # CheckResult-shaped for pin-collision case
+                best_partial_layout=None,
+                seed=resolved_seed,
+            ),
+        )
+
+    elapsed = time.monotonic() - start
+    # Chunk C: actual search not yet implemented (continues below)
+```
+
+(Delete the original `start = time.monotonic()` and `elapsed = ...` lines below, since they're now folded into the new block.)
+
+Then add the helper at module scope:
+
+```python
+from hangarfit.models import (
+    CheckResult,
+    Conflict,
+    DiversityConfig,
+    Layout,
+    Scenario,
+    SearchConfig,
+    SolveResult,
+    SolverDiagnostics,
+)
+
+
+def _check_trivially_infeasible(scenario: Scenario) -> CheckResult | None:
+    """Run the three literal-impossibility checks from spec §4.1.
+
+    Returns a CheckResult-shaped diagnostic if the scenario is infeasible,
+    else None. CheckResult is reused here so the caller can hand it to
+    diagnostics.best_partial uniformly.
+    """
+    # Check 1: per-plane bbox vs hangar
+    for pid in scenario.fleet_in:
+        plane = scenario.fleet[pid]
+        length, width = _plane_max_extent(plane)
+        max_hangar = max(scenario.hangar.length_m, scenario.hangar.width_m)
+        if length > max_hangar or width > max_hangar:
+            return CheckResult(
+                conflicts=(
+                    Conflict.single(
+                        kind="trivially_infeasible_plane_too_big",
+                        plane=pid,
+                        detail=(
+                            f"plane bbox {length:.1f}x{width:.1f} m exceeds "
+                            f"hangar max dimension {max_hangar:.1f} m"
+                        ),
+                    ),
+                ),
+                total_penetration_m2=0.0,
+            )
+
+    # Checks 2 and 3 land in Tasks C.3 and C.4.
+    return None
+
+
+def _plane_max_extent(plane) -> tuple[float, float]:
+    """Return (max_length_m, max_width_m) over all of the plane's Parts.
+
+    Computes a coarse plane-local bounding box: takes the maximum of
+    (length_m, width_m) across all Parts. This is an over-approximation
+    (a plane's outline is not necessarily the union of its part bboxes
+    rotated together) but is correct for the literal-infeasibility check:
+    if even one part exceeds the hangar, the plane cannot fit.
+
+    Returns the max length and max width separately so the caller can
+    compare each to the relevant hangar dimension.
+    """
+    max_length = max(p.length_m for p in plane.parts)
+    max_width = max(p.width_m for p in plane.parts)
+    return max_length, max_width
+```
+
+Note: also add `field`, `Layout`, `CheckResult`, `Conflict` to the imports of `solver.py` if not already present.
+
+- [ ] **Step 5: Run, expect pass**
+
+Run: `pytest tests/test_solver_infeasibility.py -v`
+
+Expected: all PASS, including the new plane-too-big test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_infeasibility.py tests/fixtures/test_hangar_tiny.yaml tests/fixtures/solve_infeasible_plane_too_big.yaml
+git commit -m "$(cat <<'EOF'
+solver: implement infeasibility check #1 (per-plane bbox > hangar)
+
+First of three literal-impossibility checks per spec §4.1. A plane
+whose max-extent bounding box exceeds the hangar's larger dimension
+in either direction cannot fit at any orientation — solver returns
+trivially_infeasible with a synthetic Conflict naming the offending
+plane.
+
+Fixture uses a tiny test-only hangar (10x8 m) with the Falke (18 m
+wing) to make the infeasibility unambiguous.
+
+Refs #C
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task C.3: Pre-search infeasibility check 2 — Σ areas > hangar
+
+- [ ] **Step 1: Create the fixture**
+
+`tests/fixtures/solve_infeasible_too_big.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [scheibe_falke, aviat_husky, fuji, wild_thing, zlin_savage, cessna_140, cessna_150, ctsl, fk9_mkii]
+```
+
+(All 9 planes in the placeholder hangar — known too small per memory `project_case12_hangar_workaround`.)
+
+- [ ] **Step 2: Write the failing test**
+
+Append:
+
+```python
+def test_solve_trivially_infeasible_when_sum_areas_exceeds_hangar():
+    """All 9 planes in the placeholder hangar → sum of bbox areas > hangar floor."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_infeasible_too_big.yaml")
+    r = solve(s, budget_s=5.0, seed=42)
+
+    assert r.status == "trivially_infeasible"
+    assert r.diagnostics.wall_time_s < 0.5
+    # The diagnostic should mention "sum" or "area" so the user can tell
+    # WHICH infeasibility check fired.
+    bp = r.diagnostics.best_partial
+    assert bp is not None
+    assert any("area" in c.detail.lower() or "footprint" in c.detail.lower()
+               for c in bp.conflicts)
+```
+
+- [ ] **Step 3: Run, expect failure**
+
+Run: `pytest tests/test_solver_infeasibility.py::test_solve_trivially_infeasible_when_sum_areas_exceeds_hangar -v`
+
+Expected: FAIL. The placeholder hangar (25 × 18 = 450 m²) may or may not actually exceed Σ areas of all 9 planes — verify first by hand-summing from `data/fleet.yaml`. If sum < 450 m², adjust the fixture (use `test_hangar_tiny.yaml` as the hangar instead) so the assertion holds.
+
+- [ ] **Step 4: Implement check #2**
+
+In `_check_trivially_infeasible`, after check #1:
+
+```python
+    # Check 2: Σ bbox areas vs hangar floor area
+    total_area = 0.0
+    for pid in scenario.fleet_in:
+        plane = scenario.fleet[pid]
+        length, width = _plane_max_extent(plane)
+        total_area += length * width
+    hangar_area = scenario.hangar.length_m * scenario.hangar.width_m
+    if total_area > hangar_area:
+        return CheckResult(
+            conflicts=(
+                Conflict.single(
+                    kind="trivially_infeasible_sum_areas",
+                    plane=scenario.fleet_in[0],   # the conflict's "plane" field is
+                                                  # cosmetic here — see detail
+                    detail=(
+                        f"fleet footprint Σ areas {total_area:.1f} m² exceeds "
+                        f"hangar floor area {hangar_area:.1f} m²"
+                    ),
+                ),
+            ),
+            total_penetration_m2=0.0,
+        )
+```
+
+(Note: the synthetic Conflict picks an arbitrary plane for `planes`; the real information is in `detail`. The spec acknowledges that single-plane vs sum-aggregate conflicts use the same `Conflict` shape.)
+
+- [ ] **Step 5: Run, expect pass**
+
+Run: `pytest tests/test_solver_infeasibility.py -v`
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_infeasibility.py tests/fixtures/solve_infeasible_too_big.yaml
+git commit -m "$(cat <<'EOF'
+solver: implement infeasibility check #2 (Σ areas > hangar)
+
+Second of three pre-search checks. Sum of per-plane max-extent bbox
+areas compared to hangar.length_m × hangar.width_m; if larger, the
+fleet cannot fit at any rotation or clearance. No margin per spec §4.1
+— this is a literal-impossibility check, not a fuzzy heuristic.
+
+Refs #C
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task C.4: Pre-search infeasibility check 3 — pin self-collision
+
+- [ ] **Step 1: Create the fixture**
+
+`tests/fixtures/solve_infeasible_pins_clash.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [husky, ctsl]
+constraints:
+  husky:
+    pin: { x_m: 5.0, y_m: 5.0, heading_deg: 0.0, on_carts: false }
+  ctsl:
+    pin: { x_m: 5.0, y_m: 5.0, heading_deg: 0.0, on_carts: false }   # exact same spot
+```
+
+- [ ] **Step 2: Write failing test**
+
+Append:
+
+```python
+def test_solve_trivially_infeasible_when_pins_clash():
+    """Two pins overlapping at the same coordinates → trivially_infeasible."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_infeasible_pins_clash.yaml")
+    r = solve(s, budget_s=5.0, seed=42)
+
+    assert r.status == "trivially_infeasible"
+    assert r.diagnostics.wall_time_s < 0.5
+    # The best_partial's conflicts should include the pin pair
+    bp = r.diagnostics.best_partial
+    assert bp is not None
+    # At least one conflict must reference both pinned planes
+    refs = [set(c.planes) for c in bp.conflicts if len(c.planes) == 2]
+    assert any({"husky", "ctsl"} == r for r in refs), (
+        f"Expected a pairwise conflict between husky and ctsl, got {refs}"
+    )
+```
+
+- [ ] **Step 3: Run, expect failure**
+
+Run: `pytest tests/test_solver_infeasibility.py::test_solve_trivially_infeasible_when_pins_clash -v`
+
+Expected: FAIL.
+
+- [ ] **Step 4: Implement check #3**
+
+In `_check_trivially_infeasible`, after check #2:
+
+```python
+    # Check 3: pin self-collision (build a pin-only Layout and run check())
+    from hangarfit.collisions import check as check_layout
+
+    pinned_placements = []
+    for pid in scenario.fleet_in:
+        constraint = scenario.constraints.get(pid)
+        if constraint is not None and constraint.pin is not None:
+            pinned_placements.append(constraint.pin)
+
+    if pinned_placements:
+        # Build a Layout containing ONLY the pinned planes.
+        # maintenance_plane=None to bypass Layout's "maintenance must be placed"
+        # invariant; we're only checking pin-vs-pin and pin-vs-hangar here.
+        try:
+            pin_only_layout = Layout(
+                fleet=scenario.fleet,
+                hangar=scenario.hangar,
+                placements=tuple(pinned_placements),
+                maintenance_plane=None,
+            )
+        except ValueError as e:
+            # This means the pins themselves violated a Layout invariant
+            # (cart rule, movement_mode mismatch, etc.) — should have been
+            # caught by Scenario.__post_init__, but defend anyway.
+            return CheckResult(
+                conflicts=(
+                    Conflict.single(
+                        kind="trivially_infeasible_pin_invariant",
+                        plane=pinned_placements[0].plane_id,
+                        detail=f"pin set violates Layout invariant: {e}",
+                    ),
+                ),
+                total_penetration_m2=0.0,
+            )
+
+        pin_check = check_layout(pin_only_layout)
+        if not pin_check.valid:
+            return pin_check
+```
+
+- [ ] **Step 5: Run, expect pass**
+
+Run: `pytest tests/test_solver_infeasibility.py -v`
+
+Expected: all PASS.
+
+- [ ] **Step 6: Run full suite + lint + type check**
+
+```bash
+pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
+```
+
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_infeasibility.py tests/fixtures/solve_infeasible_pins_clash.yaml
+git commit -m "$(cat <<'EOF'
+solver: implement infeasibility check #3 (pin self-collision)
+
+Third pre-search check: build a Layout containing only the pinned
+planes (with maintenance_plane=None to bypass the placed-maintenance
+invariant) and run collisions.check() on it. Any conflict — pin-vs-pin
+overlap, pin out of hangar bounds — means the scenario is provably
+infeasible regardless of how unpinned planes are placed.
+
+Reuses the existing check() output as the trivially_infeasible
+diagnostic so the user sees exactly which pins clash and where.
+
+Refs #C
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task C.5: Chunk C wrap-up
+
+- [ ] **Step 1: Push, open PR, set metadata, run review, hand off**
+
+```bash
+git push -u origin feature/phase2a-solver-skeleton
+gh pr create --base develop \
+  --title "Solver: solve() signature + pre-search infeasibility checks" \
+  --assignee DocGerd \
+  --body "$(cat <<'EOF'
+## Summary
+
+- New module \`src/hangarfit/solver.py\` with public \`solve()\` signature
+- Three literal-impossibility pre-search checks per spec §4.1:
+  1. per-plane bbox > hangar dims → \`trivially_infeasible\`
+  2. Σ bbox areas > hangar floor area → \`trivially_infeasible\`
+  3. pin self-collision via \`collisions.check()\` on a pin-only Layout → \`trivially_infeasible\`
+- Any feasible scenario short-circuits to \`exhausted_budget\` for now (real search lands in next PR).
+- Diagnostics populated correctly (seed, wall_time_s, best_partial).
+
+Closes #C
+
+## Test plan
+
+- [x] \`pytest -q\` — full suite green
+- [x] lint + format + mypy
+- [x] 5 new tests covering: feasible smoke, seed resolution, plane-too-big, sum-areas-too-big, pins-clash
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+PR_NUMBER=<from above>
+gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" -f '{"labels":["enhancement"]}'
+```
+
+Run `/pr-review`, resolve threads, hand off.
+
+**Chunk C done when:** PR merged to develop.
+
+---
+
+## Chunk D (PR4): Search engine MVP — random-restart hill climb (alternatives=1)
+
+**Goal:** Real solving for `alternatives=1`. RR-MC with min-conflicts descent, hierarchical scoring `(conflict_count, total_penetration_m2)`, cart-assignment round-robin, restart on K_stall. No diversity filter yet (that's Chunk E). Returns `status="found"` with one valid Layout when search succeeds, or `status="exhausted_budget"` with `best_partial` when it doesn't.
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` (~400 LoC added)
+- Create: `tests/test_solver_search.py`
+- Create: `tests/fixtures/solve_trivial_single_plane.yaml`
+- Create: `tests/fixtures/solve_fresh_six_planes.yaml`
+
+### Task D.0: Branch + issue
+
+- [ ] **Step 1: Branch + issue**
+
+```bash
+git switch develop
+git pull --ff-only
+git switch -c feature/phase2a-solver-search-engine
+
+gh issue create \
+  --title "Solver: random-restart hill climb with min-conflicts descent (alternatives=1)" \
+  --assignee DocGerd \
+  --label enhancement \
+  --body "..."
+```
+
+Issue body: explain that this lands the actual search engine (initial placement + cart round-robin + descent + scoring + restart). Reference spec §4.2-§4.5.
+
+Note as `#D`.
+
+### Task D.1: Implement initial placement helpers
+
+**Goal:** Helper functions to sample initial `Placement`s for each plane.
+
+- [ ] **Step 1: Write failing test for `_initial_placement_for_plane`**
+
+Add `tests/test_solver_search.py`:
+
+```python
+"""Tests for solver.py — search engine (Chunks D & E)."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+
+def test_initial_placement_for_pinned_plane_returns_the_pin():
+    """If a plane is pinned, its initial placement IS the pin (no sampling)."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import PlaneConstraint, Placement
+    from hangarfit.solver import _initial_placement_for_plane
+
+    s = load_scenario("tests/fixtures/scenario_with_pin.yaml")
+    rng = random.Random(42)
+    pin = s.constraints["husky"].pin
+    assert pin is not None
+
+    result = _initial_placement_for_plane(
+        plane_id="husky", scenario=s, rng=rng, on_carts=pin.on_carts,
+    )
+    assert result == pin
+
+
+def test_initial_placement_for_free_plane_is_within_hangar():
+    """Free planes get random (x,y) inside hangar bounds, any heading."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _initial_placement_for_plane
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    rng = random.Random(42)
+    p = _initial_placement_for_plane(
+        plane_id="husky", scenario=s, rng=rng, on_carts=False,
+    )
+    assert p.plane_id == "husky"
+    assert 0.0 <= p.x_m <= s.hangar.width_m
+    assert 0.0 <= p.y_m <= s.hangar.length_m
+    assert 0.0 <= p.heading_deg < 360.0
+
+
+def test_initial_placement_for_maintenance_biases_to_back_strip():
+    """The maintenance plane's initial y is inside the maintenance bay."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _initial_placement_for_plane
+
+    s = load_scenario("tests/fixtures/scenario_with_pin.yaml")
+    # In scenario_with_pin, maintenance_plane is fuji (not pinned).
+    rng = random.Random(42)
+    p = _initial_placement_for_plane(
+        plane_id="fuji", scenario=s, rng=rng, on_carts=False,
+        bias_to_maintenance_bay=True,
+    )
+    bay_y_start = s.hangar.length_m - s.hangar.maintenance_bay.depth_m
+    assert bay_y_start <= p.y_m <= s.hangar.length_m
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pytest tests/test_solver_search.py::test_initial_placement_for_pinned_plane_returns_the_pin tests/test_solver_search.py::test_initial_placement_for_free_plane_is_within_hangar tests/test_solver_search.py::test_initial_placement_for_maintenance_biases_to_back_strip -v`
+
+Expected: all FAIL — `_initial_placement_for_plane` doesn't exist.
+
+- [ ] **Step 3: Implement `_initial_placement_for_plane`**
+
+Add to `src/hangarfit/solver.py`:
+
+```python
+def _initial_placement_for_plane(
+    *,
+    plane_id: str,
+    scenario: Scenario,
+    rng: _random_module.Random,
+    on_carts: bool,
+    bias_to_maintenance_bay: bool = False,
+) -> Placement:
+    """Sample an initial Placement for one plane.
+
+    - If pinned → return the pin verbatim.
+    - If bias_to_maintenance_bay → (x,y) uniform in the back bay strip.
+    - Otherwise → (x,y) uniform inside hangar (with bbox margin), heading uniform on [0, 360).
+    """
+    constraint = scenario.constraints.get(plane_id)
+    if constraint is not None and constraint.pin is not None:
+        return constraint.pin
+
+    hangar = scenario.hangar
+    plane = scenario.fleet[plane_id]
+    max_length, max_width = _plane_max_extent(plane)
+    margin_x = max(max_length, max_width) / 2
+    margin_y = margin_x
+
+    if bias_to_maintenance_bay:
+        bay_depth = hangar.maintenance_bay.depth_m
+        y_lo = max(margin_y, hangar.length_m - bay_depth)
+        y_hi = hangar.length_m - margin_y
+    else:
+        y_lo = margin_y
+        y_hi = hangar.length_m - margin_y
+
+    x_lo = margin_x
+    x_hi = hangar.width_m - margin_x
+
+    # If margins eat the entire hangar (very tiny hangar / very big plane),
+    # fall back to placing at the center — the infeasibility checks should
+    # have rejected this case, but defend in code.
+    if x_hi <= x_lo:
+        x = hangar.width_m / 2
+    else:
+        x = rng.uniform(x_lo, x_hi)
+    if y_hi <= y_lo:
+        y = hangar.length_m / 2
+    else:
+        y = rng.uniform(y_lo, y_hi)
+
+    heading = rng.uniform(0.0, 360.0)
+
+    return Placement(
+        plane_id=plane_id,
+        x_m=x,
+        y_m=y,
+        heading_deg=heading,
+        on_carts=on_carts,
+    )
+```
+
+Add `Placement` to the imports (top of `solver.py`).
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pytest tests/test_solver_search.py -v -k 'initial_placement'`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_search.py
+git commit -m "solver: implement _initial_placement_for_plane helper
+
+Per spec §4.2: pinned planes return the pin verbatim; maintenance
+planes (with bias=True) sample (x,y) in the back bay strip; free
+planes sample uniformly inside hangar bounds (with a bbox-derived
+margin) and uniform heading on [0, 360°).
+
+Refs #D"
+```
+
+### Task D.2: Implement cart-assignment round-robin
+
+- [ ] **Step 1: Write failing test**
+
+Append:
+
+```python
+def test_cart_buckets_enumerates_unlocked_cart_eligibles_plus_none():
+    """With C unlocked cart_eligible planes, there should be C+1 buckets."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _enumerate_cart_buckets
+
+    # Use a scenario with 2 cart_eligible planes, neither locked.
+    s = load_scenario("tests/fixtures/scenario_with_force_carts.yaml")
+    # cessna_140 is cart_eligible but locked on_carts=True
+    # ctsl is cart_eligible and unlocked
+    # → buckets = [{}, {"ctsl"}]  (cessna_140 is forced — it's separate from the round-robin)
+    buckets = _enumerate_cart_buckets(s)
+    assert len(buckets) == 2
+    assert set() in buckets  # the "no-one" bucket
+    assert {"ctsl"} in buckets
+
+
+def test_cart_bucket_for_restart_is_deterministic_round_robin():
+    """Restart index R selects bucket R % len(buckets)."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _enumerate_cart_buckets, _cart_bucket_for_restart
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    buckets = _enumerate_cart_buckets(s)
+    if len(buckets) > 0:
+        # First few restarts should cycle through buckets
+        for i in range(2 * len(buckets)):
+            chosen = _cart_bucket_for_restart(buckets, restart_index=i)
+            assert chosen == buckets[i % len(buckets)]
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Expected: ImportError.
+
+- [ ] **Step 3: Implement**
+
+In `solver.py`:
+
+```python
+def _enumerate_cart_buckets(scenario: Scenario) -> list[frozenset[str]]:
+    """Enumerate the cart-assignment buckets to round-robin over.
+
+    Per spec §4.2: cart_eligible planes that are NOT locked by
+    force_on_carts/pin can be on or off carts. With C such planes,
+    the buckets are: the empty set + {plane_i} for each — totaling C+1.
+
+    Locked cart_eligible planes (force_on_carts=True or a pin with
+    on_carts=True) bypass round-robin — their on_carts state is fixed.
+    The cart-rule (at-most-one cart_eligible on_carts) is enforced
+    holistically by Layout.__post_init__ later.
+    """
+    free_cart_eligibles: list[str] = []
+    for pid in scenario.fleet_in:
+        plane = scenario.fleet[pid]
+        if not plane.is_cart_eligible:
+            continue
+        constraint = scenario.constraints.get(pid)
+        if constraint is not None:
+            if constraint.force_on_carts is not None:
+                continue  # locked
+            if constraint.pin is not None and constraint.pin.on_carts:
+                continue  # pinned on carts
+        free_cart_eligibles.append(pid)
+
+    buckets: list[frozenset[str]] = [frozenset()]
+    for pid in free_cart_eligibles:
+        buckets.append(frozenset({pid}))
+    return buckets
+
+
+def _cart_bucket_for_restart(
+    buckets: list[frozenset[str]], *, restart_index: int
+) -> frozenset[str]:
+    """Pick bucket round-robin."""
+    if not buckets:
+        return frozenset()
+    return buckets[restart_index % len(buckets)]
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pytest tests/test_solver_search.py -v -k 'cart'`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_search.py
+git commit -m "solver: implement cart-assignment round-robin enumeration
+
+_enumerate_cart_buckets returns C+1 buckets (empty + each unlocked
+cart_eligible singleton); _cart_bucket_for_restart selects bucket
+restart_index % len(buckets). Round-robin guarantees every cart
+configuration is sampled within a small restart budget.
+
+Refs #D"
+```
+
+### Task D.3: Implement scoring `_score()`
+
+- [ ] **Step 1: Failing test**
+
+Append:
+
+```python
+def test_score_valid_layout_is_zero_zero():
+    from hangarfit.loader import load_layout
+    from hangarfit.solver import _score
+
+    layout = load_layout("layouts/example.yaml")
+    s = _score(layout)
+    assert s == (0, 0.0)
+
+
+def test_score_invalid_layout_is_positive():
+    from hangarfit.loader import load_layout
+    from hangarfit.solver import _score
+
+    # Use an existing invalid-overlap fixture; substitute filename if needed.
+    layout = load_layout("layouts/example_invalid.yaml")
+    s = _score(layout)
+    count, penetration = s
+    assert count > 0
+    assert penetration >= 0.0  # could be 0 if all conflicts are single-plane
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Expected: ImportError on `_score`.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _score(layout: Layout) -> tuple[int, float]:
+    """Hierarchical scoring: (conflict_count, total_penetration_m2). Lower wins."""
+    from hangarfit.collisions import check as check_layout
+    result = check_layout(layout)
+    return (len(result.conflicts), result.total_penetration_m2)
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+```bash
+pytest tests/test_solver_search.py::test_score_valid_layout_is_zero_zero tests/test_solver_search.py::test_score_invalid_layout_is_positive -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_search.py
+git commit -m "solver: implement _score(layout) → (count, penetration_m2)
+
+Hierarchical scoring per spec §4.4. Wraps collisions.check() and
+returns (len(conflicts), total_penetration_m2) for lex comparison.
+
+Refs #D"
+```
+
+### Task D.4: Implement perturbation + descent step
+
+- [ ] **Step 1: Failing test**
+
+This is harder to TDD finely; the best functional test is "descent from a perturbation should not increase score." Append:
+
+```python
+def test_perturb_plane_returns_valid_placement_within_hangar():
+    """Perturbation outputs are within hangar bounds and on [0, 360°)."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import Placement
+    from hangarfit.solver import _perturb_plane, SearchConfig
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    rng = random.Random(42)
+    current = Placement(plane_id="husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    config = SearchConfig()  # defaults
+
+    # Generate many perturbations; all must be inside hangar bounds.
+    for _ in range(50):
+        cand = _perturb_plane(
+            current=current, scenario=s, rng=rng, search=config, large_jump=False,
+        )
+        assert cand.plane_id == "husky"
+        assert 0.0 <= cand.x_m <= s.hangar.width_m
+        assert 0.0 <= cand.y_m <= s.hangar.length_m
+        assert 0.0 <= cand.heading_deg < 360.0
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Expected: ImportError.
+
+- [ ] **Step 3: Implement perturbation**
+
+```python
+def _perturb_plane(
+    *,
+    current: Placement,
+    scenario: Scenario,
+    rng: _random_module.Random,
+    search: SearchConfig,
+    large_jump: bool,
+) -> Placement:
+    """One candidate perturbation for the given plane.
+
+    `large_jump=True` re-samples (x,y) and heading globally; `False` does
+    a small Gaussian nudge. The 180° heading-flip variant is handled by
+    the caller (`_descent_step`) as a third variant.
+    """
+    hangar = scenario.hangar
+    plane = scenario.fleet[current.plane_id]
+    max_length, max_width = _plane_max_extent(plane)
+    margin = max(max_length, max_width) / 2
+
+    if large_jump:
+        x_lo, x_hi = margin, hangar.width_m - margin
+        y_lo, y_hi = margin, hangar.length_m - margin
+        if x_hi <= x_lo:
+            x = hangar.width_m / 2
+        else:
+            x = rng.uniform(x_lo, x_hi)
+        if y_hi <= y_lo:
+            y = hangar.length_m / 2
+        else:
+            y = rng.uniform(y_lo, y_hi)
+        heading = rng.uniform(0.0, 360.0)
+    else:
+        dx = rng.gauss(0.0, search.pos_sigma_m)
+        dy = rng.gauss(0.0, search.pos_sigma_m)
+        dh = rng.gauss(0.0, search.heading_sigma_deg)
+        # Clamp to hangar bounds (margin-protected)
+        x = max(margin, min(hangar.width_m - margin, current.x_m + dx))
+        y = max(margin, min(hangar.length_m - margin, current.y_m + dy))
+        heading = (current.heading_deg + dh) % 360.0
+
+    return Placement(
+        plane_id=current.plane_id,
+        x_m=x,
+        y_m=y,
+        heading_deg=heading,
+        on_carts=current.on_carts,
+    )
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+```bash
+pytest tests/test_solver_search.py::test_perturb_plane_returns_valid_placement_within_hangar -v
+```
+
+- [ ] **Step 5: Implement `_descent_step`**
+
+This is the orchestrator that runs one min-conflicts iteration. Add:
+
+```python
+def _descent_step(
+    *,
+    placements: dict[str, Placement],
+    scenario: Scenario,
+    rng: _random_module.Random,
+    search: SearchConfig,
+    current_score: tuple[int, float],
+    pinned_planes: frozenset[str],
+) -> tuple[dict[str, Placement], tuple[int, float], bool] | None:
+    """Run one min-conflicts iteration.
+
+    Returns (new_placements, new_score, accepted) where `accepted` is True
+    iff the new score was strictly better OR equal (greedy ≤).
+    Returns None if the trajectory should restart (all conflicts involve
+    only pinned planes, i.e. unsolvable from this configuration).
+    """
+    # Build current Layout from placements (uses Layout invariants — free check)
+    current_layout = Layout(
+        fleet=scenario.fleet,
+        hangar=scenario.hangar,
+        placements=tuple(placements[pid] for pid in scenario.fleet_in),
+        maintenance_plane=scenario.maintenance_plane,
+    )
+
+    from hangarfit.collisions import check as check_layout
+    current_result = check_layout(current_layout)
+
+    # Build conflicting-plane set (excluding pinned)
+    conflicting = set()
+    for c in current_result.conflicts:
+        for pid in c.planes:
+            if pid not in pinned_planes:
+                conflicting.add(pid)
+    if not conflicting:
+        return None  # restart — all conflicts are on pinned planes
+
+    target = rng.choice(sorted(conflicting))
+
+    # Generate N candidate perturbations: 6 small + 1 large + 1 flip
+    candidates: list[Placement] = []
+    n_small = max(0, search.candidates_per_iter - 2)
+    for _ in range(n_small):
+        candidates.append(_perturb_plane(
+            current=placements[target], scenario=scenario, rng=rng,
+            search=search, large_jump=False,
+        ))
+    candidates.append(_perturb_plane(
+        current=placements[target], scenario=scenario, rng=rng,
+        search=search, large_jump=True,
+    ))
+    flipped = Placement(
+        plane_id=target,
+        x_m=placements[target].x_m,
+        y_m=placements[target].y_m,
+        heading_deg=(placements[target].heading_deg + 180.0) % 360.0,
+        on_carts=placements[target].on_carts,
+    )
+    candidates.append(flipped)
+
+    # Score each candidate
+    best_score = current_score
+    best_placements = placements
+    best_cand = None
+    best_disp = float("inf")
+    for cand in candidates:
+        trial = dict(placements)
+        trial[target] = cand
+        try:
+            trial_layout = Layout(
+                fleet=scenario.fleet,
+                hangar=scenario.hangar,
+                placements=tuple(trial[pid] for pid in scenario.fleet_in),
+                maintenance_plane=scenario.maintenance_plane,
+            )
+        except ValueError:
+            # Layout invariant violated (cart rule, etc.) — skip this candidate
+            continue
+        s = _score(trial_layout)
+        disp = ((cand.x_m - placements[target].x_m) ** 2
+                + (cand.y_m - placements[target].y_m) ** 2) ** 0.5
+        if (s < best_score) or (s == best_score and disp < best_disp):
+            best_score = s
+            best_placements = trial
+            best_cand = cand
+            best_disp = disp
+
+    if best_cand is None or best_score > current_score:
+        # No improvement — reject
+        return placements, current_score, False
+    if best_score <= current_score:
+        return best_placements, best_score, True
+    return placements, current_score, False
+```
+
+- [ ] **Step 6: Commit (partial; integration test in next task)**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_search.py
+git commit -m "solver: implement _perturb_plane and _descent_step
+
+Perturbation generates one candidate move (Gaussian nudge or large
+jump) for the named plane. Descent step picks a conflicting plane,
+samples N=8 candidates (6 small + 1 large + 1 180° flip), and accepts
+the best-scoring one if score is ≤ current (greedy plateau-traversal).
+
+Refs #D"
+```
+
+### Task D.5: Implement the restart loop + `_run_trajectory`
+
+- [ ] **Step 1: Write the integration test (solve a trivial single-plane scenario)**
+
+Append:
+
+```python
+def test_solve_finds_layout_for_trivial_single_plane(tmp_path):
+    """A single plane in a large hangar must be found quickly."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+    from hangarfit.collisions import check
+
+    s = load_scenario("tests/fixtures/solve_trivial_single_plane.yaml")
+    r = solve(s, budget_s=5.0, alternatives=1, seed=42)
+
+    assert r.status == "found"
+    assert len(r.layouts) == 1
+    assert check(r.layouts[0]).valid
+```
+
+You'll need `tests/fixtures/solve_trivial_single_plane.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ./test_hangar_large.yaml  # the existing 30×25 fixture
+fleet_in: [husky]
+```
+
+(Confirm `test_hangar_large.yaml` exists in `tests/fixtures/` per CLAUDE.md module map. It does.)
+
+- [ ] **Step 2: Run, expect failure**
+
+Expected: solver still returns `exhausted_budget` (no search loop yet).
+
+- [ ] **Step 3: Implement the trajectory + restart loop**
+
+Replace the Chunk C placeholder in `solve()` (the line that returns `exhausted_budget` for feasible scenarios) with the actual search:
+
+```python
+    # ── Real search (RR-MC) ────────────────────────────────────────────
+    pinned_planes = frozenset(
+        pid for pid in scenario.fleet_in
+        if pid in scenario.constraints and scenario.constraints[pid].pin is not None
+    )
+    cart_buckets = _enumerate_cart_buckets(scenario)
+
+    best_partial_score: tuple[int, float] = (float("inf"), float("inf"))   # type: ignore[assignment]
+    best_partial_layout: Layout | None = None
+    accepted_layouts: list[Layout] = []
+    restart_index = 0
+
+    while time.monotonic() - start < budget_s:
+        cart_bucket = _cart_bucket_for_restart(cart_buckets, restart_index=restart_index)
+        try:
+            placements = _initial_placements(
+                scenario=scenario, rng=rng, cart_bucket=cart_bucket,
+            )
+        except _LayoutBuildFailure:
+            restart_index += 1
+            continue
+
+        # Initial score
+        try:
+            initial_layout = Layout(
+                fleet=scenario.fleet, hangar=scenario.hangar,
+                placements=tuple(placements[pid] for pid in scenario.fleet_in),
+                maintenance_plane=scenario.maintenance_plane,
+            )
+        except ValueError:
+            restart_index += 1
+            continue
+        current_score = _score(initial_layout)
+        last_improved = 0
+
+        for iter_count in range(10000):  # large outer cap; real exit via stall or success
+            if time.monotonic() - start >= budget_s:
+                break
+            if current_score == (0, 0.0):
+                # Valid! Accept (no diversity filter yet in Chunk D — just take it)
+                accepted_layouts.append(Layout(
+                    fleet=scenario.fleet, hangar=scenario.hangar,
+                    placements=tuple(placements[pid] for pid in scenario.fleet_in),
+                    maintenance_plane=scenario.maintenance_plane,
+                ))
+                break  # found one; outer loop terminates because alternatives=1
+
+            step_result = _descent_step(
+                placements=placements, scenario=scenario, rng=rng,
+                search=search, current_score=current_score,
+                pinned_planes=pinned_planes,
+            )
+            if step_result is None:
+                break  # restart (all conflicts on pinned planes)
+            placements, new_score, accepted = step_result
+            if new_score < current_score:
+                last_improved = iter_count
+            current_score = new_score
+            if iter_count - last_improved >= search.k_stall:
+                break  # stall — restart
+
+            # Track best partial
+            if current_score < best_partial_score:
+                best_partial_score = current_score
+                best_partial_layout = Layout(
+                    fleet=scenario.fleet, hangar=scenario.hangar,
+                    placements=tuple(placements[pid] for pid in scenario.fleet_in),
+                    maintenance_plane=scenario.maintenance_plane,
+                )
+
+        restart_index += 1
+        if len(accepted_layouts) >= alternatives:
+            break
+
+    elapsed = time.monotonic() - start
+
+    if accepted_layouts:
+        from hangarfit.collisions import check as check_layout
+        status = "found" if len(accepted_layouts) >= alternatives else "found_partial"
+        return SolveResult(
+            status=status,
+            layouts=tuple(accepted_layouts),
+            diagnostics=SolverDiagnostics(
+                restarts_attempted=restart_index,
+                wall_time_s=elapsed,
+                best_partial=None,
+                best_partial_layout=None,
+                seed=resolved_seed,
+            ),
+        )
+    else:
+        from hangarfit.collisions import check as check_layout
+        bp = check_layout(best_partial_layout) if best_partial_layout is not None else None
+        return SolveResult(
+            status="exhausted_budget",
+            layouts=(),
+            diagnostics=SolverDiagnostics(
+                restarts_attempted=restart_index,
+                wall_time_s=elapsed,
+                best_partial=bp,
+                best_partial_layout=best_partial_layout,
+                seed=resolved_seed,
+            ),
+        )
+```
+
+You'll need the helper `_initial_placements` and the exception class:
+
+```python
+class _LayoutBuildFailure(Exception):
+    """Raised when initial placement can't satisfy basic invariants (e.g. cart rule)."""
+
+
+def _initial_placements(
+    *,
+    scenario: Scenario,
+    rng: _random_module.Random,
+    cart_bucket: frozenset[str],
+) -> dict[str, Placement]:
+    """Sample initial placements for every plane in fleet_in.
+
+    cart_bucket: the set of cart_eligible planes that should be on_carts
+    (max one element per spec; the empty set means no carts).
+    """
+    placements: dict[str, Placement] = {}
+    for pid in scenario.fleet_in:
+        plane = scenario.fleet[pid]
+        constraint = scenario.constraints.get(pid)
+
+        # Decide on_carts
+        if constraint is not None and constraint.force_on_carts is not None:
+            on_carts = constraint.force_on_carts
+        elif constraint is not None and constraint.pin is not None:
+            on_carts = constraint.pin.on_carts
+        elif plane.movement_mode == "always_cart":
+            on_carts = True
+        elif plane.movement_mode == "always_own_gear":
+            on_carts = False
+        else:  # cart_eligible
+            on_carts = pid in cart_bucket
+
+        bias = (scenario.maintenance_plane == pid
+                and (constraint is None or constraint.pin is None))
+
+        placements[pid] = _initial_placement_for_plane(
+            plane_id=pid, scenario=scenario, rng=rng,
+            on_carts=on_carts, bias_to_maintenance_bay=bias,
+        )
+
+    return placements
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+```bash
+pytest tests/test_solver_search.py::test_solve_finds_layout_for_trivial_single_plane -v
+```
+
+Expected: PASS (one plane in 30×25 m hangar is trivially solvable in << 5s).
+
+- [ ] **Step 5: Add the six-plane fresh fixture + test**
+
+`tests/fixtures/solve_fresh_six_planes.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [husky, fuji, ctsl, scheibe_falke, fk9_mkii, cessna_140]
+maintenance:
+  plane: scheibe_falke
+```
+
+Append test:
+
+```python
+def test_solve_finds_layout_for_fresh_six_planes():
+    """6 planes in placeholder hangar — should be findable within budget."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+    from hangarfit.collisions import check
+
+    s = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    r = solve(s, budget_s=5.0, alternatives=1, seed=42)
+
+    if r.status == "exhausted_budget":
+        pytest.skip(
+            f"Search didn't find a layout for 6 planes in 5s with seed=42 "
+            f"(restarts={r.diagnostics.restarts_attempted}). This is acceptable "
+            f"behavior — the placeholder hangar is tight. Increase budget or "
+            f"retune SearchConfig if this becomes a pattern."
+        )
+
+    assert r.status == "found"
+    assert len(r.layouts) == 1
+    assert check(r.layouts[0]).valid
+```
+
+(`pytest.skip` is intentional: if the placeholder hangar is too tight for 5s to find a solution at seed=42, that's a property of the data, not a bug. Real measurements will likely fix this.)
+
+- [ ] **Step 6: Run + lint + type check**
+
+```bash
+pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
+```
+
+Expected: green.
+
+- [ ] **Step 7: Commit + push + PR**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_search.py tests/fixtures/solve_trivial_single_plane.yaml tests/fixtures/solve_fresh_six_planes.yaml
+git commit -m "$(cat <<'EOF'
+solver: implement RR-MC search engine (alternatives=1)
+
+Real search lands here:
+- _initial_placements: sample placement for every plane (pinned →
+  verbatim, maintenance → biased to bay, free → uniform), with
+  cart-assignment chosen from the round-robin bucket.
+- restart loop: cycles cart buckets, runs _descent_step until score
+  hits (0, 0.0) OR k_stall iterations without improvement OR conflicts
+  all on pinned planes.
+- best-partial tracking: keep the lowest-score layout seen for
+  diagnostics.
+
+For alternatives=1, returns "found" with one valid Layout when the
+search succeeds; "exhausted_budget" with best_partial otherwise.
+
+K-diversity, the diversity filter, and the diversity-impossible warning
+land in Chunk E (PR5).
+
+Refs #D
+EOF
+)"
+
+git push -u origin feature/phase2a-solver-search-engine
+
+gh pr create --base develop \
+  --title "Solver: random-restart hill climb with min-conflicts descent (alternatives=1)" \
+  --assignee DocGerd \
+  --body "$(cat <<'EOF'
+## Summary
+
+Implements the RR-MC search engine for the static layout solver:
+- Initial placement (§4.2): pinned → pin verbatim; maintenance → bay-biased; free → uniform
+- Cart round-robin (§4.2): C+1 buckets cycled per restart for guaranteed coverage
+- Descent step (§4.3): min-conflicts — pick a conflicting plane, sample N=8 candidates (6 Gauss + 1 jump + 1 180° flip), accept best-of-N with score ≤ current
+- Restart trigger (§4.5): k_stall=50 iters without improvement OR conflicts-on-pinned-only
+- Best-partial tracking for diagnostics
+
+Returns \`status="found"\` with one valid Layout for \`alternatives=1\` when search succeeds. K-diverse alternatives land in next PR.
+
+Closes #D
+EOF
+)"
+
+PR_NUMBER=<from above>
+gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" -f '{"labels":["enhancement"]}'
+```
+
+Run `/pr-review`, resolve, hand off.
+
+**Chunk D done when:** PR merged.
+
+---
+
+## Chunk E (PR5): K-diversity + termination + diagnostics
+
+**Goal:** Full feature for `alternatives ≥ 1`. Adds diversity filter, termination logic that distinguishes `found` / `found_partial` / `exhausted_budget`, and the diversity-impossible warning.
+
+**Files:**
+- Modify: `src/hangarfit/solver.py`
+- Modify: `tests/test_solver_search.py` (new tests for diversity)
+- Create: `tests/fixtures/solve_fresh_alternatives_three.yaml`
+- Create: `tests/fixtures/solve_diversity_impossible_warn.yaml`
+
+### Task E.0: Branch + issue
+
+```bash
+git switch develop && git pull --ff-only
+git switch -c feature/phase2a-solver-diversity
+gh issue create --title "Solver: K-diverse alternatives + termination + diagnostics" ...
+```
+
+Note issue as `#E`.
+
+### Task E.1: Implement the diversity filter (`_is_diverse_enough`)
+
+- [ ] **Step 1: Failing test**
+
+Append to `tests/test_solver_search.py`:
+
+```python
+def test_diversity_filter_rejects_near_duplicate():
+    """Two layouts with no planes moved enough should fail diversity."""
+    from hangarfit.models import Layout, Placement, DiversityConfig
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.solver import _is_diverse_enough
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+    p1 = Placement(plane_id="husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
+    L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))  # identical
+
+    diversity = DiversityConfig()  # defaults: M=2, 0.5m, 30°
+    assert not _is_diverse_enough(L2, [L1], diversity)
+
+
+def test_diversity_filter_accepts_meaningfully_different():
+    from hangarfit.models import Layout, Placement, DiversityConfig
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.solver import _is_diverse_enough
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+    p1 = Placement(plane_id="husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
+
+    # L2: both planes moved by > 0.5 m
+    p1b = Placement(plane_id="husky", x_m=8.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2b = Placement(plane_id="ctsl", x_m=13.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1b, p2b))
+
+    diversity = DiversityConfig()
+    assert _is_diverse_enough(L2, [L1], diversity)
+
+
+def test_diversity_heading_uses_short_arc():
+    """0° and 359° should be 1° apart, not 359°."""
+    from hangarfit.models import Layout, Placement, DiversityConfig
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.solver import _is_diverse_enough
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+    p1 = Placement(plane_id="husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
+
+    p1b = Placement(plane_id="husky", x_m=5.0, y_m=5.0, heading_deg=359.0, on_carts=False)
+    p2b = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1b, p2b))
+
+    diversity = DiversityConfig()
+    # heading_threshold_deg=30 — 1° gap is less than 30°, so this is NOT diverse.
+    assert not _is_diverse_enough(L2, [L1], diversity)
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+- [ ] **Step 3: Implement**
+
+```python
+def _heading_delta_short_arc(a: float, b: float) -> float:
+    """Shortest angular distance on the circle, in degrees."""
+    d = abs(a - b) % 360.0
+    return min(d, 360.0 - d)
+
+
+def _is_diverse_enough(
+    candidate: Layout,
+    accepted: list[Layout],
+    diversity: DiversityConfig,
+) -> bool:
+    """Return True iff candidate differs from EVERY accepted layout by at
+    least min_planes_moved planes (per the position/heading thresholds)."""
+    cand_by_id = {p.plane_id: p for p in candidate.placements}
+    for L in accepted:
+        L_by_id = {p.plane_id: p for p in L.placements}
+        n_moved = 0
+        for pid, cand_p in cand_by_id.items():
+            ref = L_by_id.get(pid)
+            if ref is None:
+                # Plane not in the reference layout — count as moved
+                n_moved += 1
+                continue
+            pos_delta = ((cand_p.x_m - ref.x_m) ** 2
+                         + (cand_p.y_m - ref.y_m) ** 2) ** 0.5
+            head_delta = _heading_delta_short_arc(cand_p.heading_deg, ref.heading_deg)
+            if (pos_delta >= diversity.position_threshold_m
+                    or head_delta >= diversity.heading_threshold_deg):
+                n_moved += 1
+        if n_moved < diversity.min_planes_moved:
+            return False  # too similar to this accepted layout
+    return True
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_search.py
+git commit -m "solver: implement _is_diverse_enough + _heading_delta_short_arc
+
+Per spec §4.6: edit-count diversity (M=2 planes moved ≥ 0.5m OR ≥ 30°).
+Heading delta uses min(|a-b|, 360-|a-b|) so 0° and 359° are 1° apart.
+
+Refs #E"
+```
+
+### Task E.2: Wire the diversity filter into the search loop
+
+- [ ] **Step 1: Add failing test for K=3 alternatives**
+
+`tests/fixtures/solve_fresh_alternatives_three.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ./test_hangar_large.yaml
+fleet_in: [husky, fuji, ctsl]
+```
+
+Append test:
+
+```python
+def test_solve_returns_k_diverse_alternatives():
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve, _is_diverse_enough
+    from hangarfit.models import DiversityConfig
+
+    s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    r = solve(s, budget_s=10.0, alternatives=3, seed=42)
+
+    if r.status == "exhausted_budget":
+        pytest.skip("Search didn't find K=3 within budget; acceptable on placeholder data.")
+    assert r.status in {"found", "found_partial"}
+    assert 1 <= len(r.layouts) <= 3
+    # Each pair must be diverse
+    div = DiversityConfig()
+    for i, L_i in enumerate(r.layouts):
+        for j, L_j in enumerate(r.layouts):
+            if i == j:
+                continue
+            others = [L_j]
+            assert _is_diverse_enough(L_i, others, div), (
+                f"layouts[{i}] and layouts[{j}] are not diverse from each other"
+            )
+```
+
+- [ ] **Step 2: Update `solve()` to use the diversity filter on accept**
+
+In the inner loop of `solve()`, replace:
+
+```python
+            if current_score == (0, 0.0):
+                # Valid! Accept (no diversity filter yet in Chunk D — just take it)
+                accepted_layouts.append(Layout(...))
+                break
+```
+
+With:
+
+```python
+            if current_score == (0, 0.0):
+                candidate_layout = Layout(
+                    fleet=scenario.fleet, hangar=scenario.hangar,
+                    placements=tuple(placements[pid] for pid in scenario.fleet_in),
+                    maintenance_plane=scenario.maintenance_plane,
+                )
+                if _is_diverse_enough(candidate_layout, accepted_layouts, diversity):
+                    accepted_layouts.append(candidate_layout)
+                # Whether accepted or not, restart to try for a different basin.
+                break
+```
+
+- [ ] **Step 3: Run, expect pass**
+
+```bash
+pytest tests/test_solver_search.py::test_solve_returns_k_diverse_alternatives -v
+```
+
+(May skip on placeholder data; that's fine.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_search.py tests/fixtures/solve_fresh_alternatives_three.yaml
+git commit -m "solver: gate accept-into-pool on diversity filter
+
+When a trajectory finds a valid layout, only add it to accepted_layouts
+if _is_diverse_enough vs the existing pool. Either way, restart to
+explore other basins.
+
+Refs #E"
+```
+
+### Task E.3: Implement diversity-impossible warning
+
+- [ ] **Step 1: Failing test**
+
+`tests/fixtures/solve_diversity_impossible_warn.yaml`:
+
+```yaml
+fleet: ../../data/fleet.yaml
+hangar: ./test_hangar_large.yaml
+fleet_in: [husky, ctsl, fuji]
+constraints:
+  husky:
+    pin: { x_m: 5.0, y_m: 5.0, heading_deg: 0.0, on_carts: false }
+  ctsl:
+    pin: { x_m: 15.0, y_m: 10.0, heading_deg: 0.0, on_carts: false }
+```
+
+(2 of 3 planes pinned; `min_planes_moved=2` requires moving 2 of the 1 unpinned plane → impossible.)
+
+Append test:
+
+```python
+def test_solve_emits_diversity_impossible_warning(caplog):
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+    import logging
+
+    s = load_scenario("tests/fixtures/solve_diversity_impossible_warn.yaml")
+    with caplog.at_level(logging.WARNING):
+        r = solve(s, budget_s=5.0, alternatives=3, seed=42)
+
+    # At least one warning about diversity impossibility
+    assert any("achievable" in rec.message.lower() or "diversity" in rec.message.lower()
+               for rec in caplog.records), (
+        f"Expected diversity-impossible warning; got messages: "
+        f"{[r.message for r in caplog.records]}"
+    )
+    # Should be found_partial (one layout found) or found (if K=1 matters)
+    assert r.status in {"found_partial", "found", "exhausted_budget"}
+    assert len(r.layouts) <= 1
+```
+
+- [ ] **Step 2: Implement the check at solve() entry**
+
+Near the top of `solve()` (after seed resolution, before pre-search infeasibility):
+
+```python
+    import logging
+    _logger = logging.getLogger(__name__)
+
+    free_planes = sum(
+        1 for pid in scenario.fleet_in
+        if scenario.constraints.get(pid) is None
+        or scenario.constraints[pid].pin is None
+    )
+    if alternatives > 1 and free_planes < diversity.min_planes_moved:
+        _logger.warning(
+            "requested %d alternatives but only 1 is achievable "
+            "(%d of %d planes are pinned). Expect status=found_partial.",
+            alternatives,
+            len(scenario.fleet_in) - free_planes,
+            len(scenario.fleet_in),
+        )
+```
+
+(Move the `import logging` and logger setup to module top in clean form.)
+
+- [ ] **Step 3: Run, expect pass**
+
+```bash
+pytest tests/test_solver_search.py::test_solve_emits_diversity_impossible_warning -v
+```
+
+- [ ] **Step 4: Commit, push, PR**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_search.py tests/fixtures/solve_diversity_impossible_warn.yaml
+git commit -m "solver: warn when diversity is mathematically impossible
+
+If fleet_in − pinned < min_planes_moved AND alternatives > 1, log a
+warning at solve() entry. Search continues normally; the natural
+outcome is found_partial with one layout. Spec §4.6 deliberately
+avoids mutating target K to keep the API semantics clean.
+
+Refs #E"
+
+git push -u origin feature/phase2a-solver-diversity
+gh pr create --base develop \
+  --title "Solver: K-diverse alternatives + termination + diagnostics" ...
+```
+
+Run `/pr-review`, hand off.
+
+**Chunk E done when:** PR merged.
+
+---
+
+## Chunk F (PR6): CLI subcommand `hangarfit solve`
+
+**Goal:** End-to-end CLI subcommand wired up. JSON output, --render with `{i}`, --write-yaml, --strict-k, all per spec §5.
+
+**Files:**
+- Modify: `src/hangarfit/cli.py`
+- Create: `tests/test_cli_solve.py`
+
+### Task F.0: Branch + issue
+
+```bash
+git switch develop && git pull --ff-only
+git switch -c feature/phase2a-cli-solve
+gh issue create --title "CLI: hangarfit solve subcommand" ...
+```
+
+Note as `#F`.
+
+### Task F.1: Add the `solve` subparser
+
+- [ ] **Step 1: Test that `hangarfit solve --help` works**
+
+Add `tests/test_cli_solve.py`:
+
+```python
+"""Tests for the `hangarfit solve` subcommand."""
+
+from __future__ import annotations
+
+import json
+import pytest
+
+from hangarfit.cli import main, build_parser
+
+
+def test_solve_subcommand_in_parser():
+    parser = build_parser()
+    # Argparse should accept "solve" as a subcommand without error
+    args = parser.parse_args(["solve", "tests/fixtures/solve_feasible_smoke.yaml"])
+    assert args.cmd == "solve"
+    assert args.scenario == "tests/fixtures/solve_feasible_smoke.yaml"
+
+
+def test_solve_subcommand_default_flags():
+    parser = build_parser()
+    args = parser.parse_args(["solve", "tests/fixtures/solve_feasible_smoke.yaml"])
+    assert args.budget == 30.0
+    assert args.alternatives == 1
+    assert args.seed is None
+    assert args.render is None
+    assert args.write_yaml is None
+    assert args.strict_k is False
+    assert args.json is False
+```
+
+- [ ] **Step 2: Extend `cli.py`'s `build_parser`**
+
+In `src/hangarfit/cli.py`, inside `build_parser()`, after the `check` subparser block, add:
+
+```python
+    solve = sub.add_parser("solve", help="Solve a scenario to a valid layout.")
+    solve.add_argument("scenario", help="Path to the scenario YAML.")
+    solve.add_argument(
+        "--budget", type=float, default=30.0, metavar="SEC",
+        help="Wall-clock budget in seconds (default: 30).",
+    )
+    solve.add_argument(
+        "--alternatives", type=int, default=1, metavar="N",
+        help="Number of diverse alternative layouts (default: 1).",
+    )
+    solve.add_argument(
+        "--seed", type=int, default=None, metavar="S",
+        help="RNG seed (default: None → resolved from system entropy).",
+    )
+    solve.add_argument(
+        "--render", default=None, metavar="PATTERN",
+        help="Write top-down PNG(s). Must contain '{i}' if --alternatives > 1.",
+    )
+    solve.add_argument(
+        "--write-yaml", default=None, metavar="PATTERN", dest="write_yaml",
+        help="Write layout YAML(s). Must contain '{i}' if --alternatives > 1.",
+    )
+    solve.add_argument(
+        "--strict-k", action="store_true", dest="strict_k",
+        help="Exit 1 if status=found_partial (default: exit 0 unless 0 valid).",
+    )
+    solve.add_argument(
+        "--json", action="store_true", dest="json",
+        help="Emit JSON on stdout (schema: hangarfit.solve/v1).",
+    )
+    solve.add_argument("--fleet", default=None, metavar="PATH")
+    solve.add_argument("--hangar", default=None, metavar="PATH")
+```
+
+Also extend `main()` to dispatch:
+
+```python
+    if args.cmd == "check":
+        return cmd_check(args)
+    if args.cmd == "solve":
+        return cmd_solve(args)
+```
+
+- [ ] **Step 3: Stub `cmd_solve`**
+
+```python
+def cmd_solve(args: argparse.Namespace) -> int:
+    """Run the `solve` subcommand. See spec §5."""
+    raise NotImplementedError("Task F.2 wires this up.")
+```
+
+- [ ] **Step 4: Run, expect pass on parser tests**
+
+```bash
+pytest tests/test_cli_solve.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/cli.py tests/test_cli_solve.py
+git commit -m "cli: scaffold solve subcommand parser (no behavior yet)
+
+Refs #F"
+```
+
+### Task F.2-F.6: Wire cmd_solve handler in incremental commits
+
+For each of the following, follow TDD:
+- Write failing test (`test_solve_smoke_returns_exit_0_for_found`, `test_solve_json_emits_schema`, `test_solve_render_pattern_must_contain_braces_when_k_gt_1`, `test_solve_write_yaml_creates_files`, `test_solve_strict_k_flips_exit_for_found_partial`)
+- Implement the corresponding code path in `cmd_solve`
+- Run, see pass
+- Commit
+
+The full `cmd_solve` body, all features wired:
+
+```python
+def cmd_solve(args: argparse.Namespace) -> int:
+    """Run the `solve` subcommand. See spec §5."""
+    from hangarfit.loader import load_scenario, LoaderError, load_fleet, load_hangar
+    from hangarfit.solver import solve
+
+    # Validate --render / --write-yaml PATTERN early if K>1
+    if args.alternatives > 1:
+        for flag_name, pattern in (("--render", args.render), ("--write-yaml", args.write_yaml)):
+            if pattern is not None and "{i}" not in pattern:
+                print(
+                    f"error: {flag_name} PATTERN must contain '{{i}}' "
+                    f"when --alternatives > 1 (got: {pattern!r})",
+                    file=sys.stderr,
+                )
+                return 2
+
+    try:
+        fleet_override = load_fleet(args.fleet) if args.fleet is not None else None
+        hangar_override = load_hangar(args.hangar) if args.hangar is not None else None
+        scenario = load_scenario(args.scenario, fleet=fleet_override, hangar=hangar_override)
+    except LoaderError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    result = solve(
+        scenario, budget_s=args.budget,
+        alternatives=args.alternatives, seed=args.seed,
+    )
+
+    # Emit human or JSON
+    if args.json:
+        _emit_solve_json(args.scenario, result)
+    else:
+        _emit_solve_human(result, alternatives=args.alternatives)
+
+    # Renders / YAML writes
+    try:
+        if args.render is not None:
+            _write_renders(result, args.render)
+        if args.write_yaml is not None:
+            _write_yamls(result, args.write_yaml)
+    except OSError as e:
+        print(f"error: write failed: {e}", file=sys.stderr)
+        return 2
+
+    # Exit code
+    if not result.layouts:
+        return 1
+    if result.status == "found_partial" and args.strict_k:
+        return 1
+    return 0
+```
+
+Plus the helpers `_emit_solve_human`, `_emit_solve_json`, `_write_renders`, `_write_yamls` (each ~10–20 LoC).
+
+For each helper, follow the same TDD discipline.
+
+- [ ] **Step 1 (consolidated): TDD each cmd_solve helper, commit each**
+
+Recommended commit cadence:
+- `cli: implement cmd_solve dispatch + LoaderError handling`
+- `cli: implement _emit_solve_human (human stdout)`
+- `cli: implement _emit_solve_json (hangarfit.solve/v1 schema)`
+- `cli: implement _write_renders with {i} substitution`
+- `cli: implement _write_yamls`
+- `cli: implement --strict-k exit code translation`
+
+(The exact split is up to the implementer; this many commits keeps each diff small and reviewable.)
+
+- [ ] **Step 2: Final wrap — full test suite + lint + PR**
+
+```bash
+pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
+
+git push -u origin feature/phase2a-cli-solve
+gh pr create --base develop \
+  --title "CLI: hangarfit solve subcommand" ...
+```
+
+Run `/pr-review`, hand off.
+
+**Chunk F done when:** PR merged.
+
+---
+
+## Chunk G (PR7): Comprehensive fixture matrix + determinism canaries
+
+**Goal:** All §6.5 fixtures land + the §6.3 determinism canary set.
+
+**Files:**
+- Create the remaining fixtures (`solve_pinned_one_plane`, `solve_repair_minimal_edit`, `solve_force_carts_lock`, `solve_force_carts_conflict`, `solve_maintenance_bay_required`, `solve_all_nine_large_hangar`)
+- Create `tests/test_solver_canaries.py` for determinism
+- Modify `tests/test_solver_search.py` to add per-fixture tests
+
+### Task G.0: Branch + issue
+
+```bash
+git switch develop && git pull --ff-only
+git switch -c feature/phase2a-fixture-coverage
+gh issue create --title "Tests: full v1 fixture matrix + determinism canary set" ...
+```
+
+Note as `#G`.
+
+### Task G.1-G.6: One commit per fixture + its test
+
+For each of these, follow the same TDD discipline:
+
+| Fixture YAML | Test | Expected outcome |
+|---|---|---|
+| `solve_pinned_one_plane.yaml` | 6 planes, husky pinned | `found`, pinned plane unchanged |
+| `solve_repair_minimal_edit.yaml` | 6 planes, 5 pinned to baseline | `found`, only unpinned plane differs from baseline |
+| `solve_force_carts_lock.yaml` | cessna_140 forced on_carts=True | `found`, returned layout respects lock |
+| `solve_force_carts_conflict.yaml` | always_cart plane forced on_carts=False | `LoaderError` |
+| `solve_maintenance_bay_required.yaml` | maintenance plane set, no pin | `found`, maintenance plane centroid in bay strip |
+| `solve_all_nine_large_hangar.yaml` | all 9 planes + test_hangar_large | `found` |
+
+For each, write the fixture, then a test that asserts the expected outcome, then commit (e.g., `tests: add solve_pinned_one_plane fixture + test`).
+
+### Task G.7: Determinism canary tests
+
+- [ ] **Step 1: Add canary tests**
+
+Create `tests/test_solver_canaries.py`:
+
+```python
+"""Determinism canary tests for the static layout solver.
+
+These tests verify that solve(scenario, seed=42) returns an IDENTICAL
+SolveResult across runs. They are intentionally fragile — any
+deliberate algorithm change requires updating them. That's the point:
+loud signal on accidental determinism breaks (e.g., dict iteration
+ordering, set ordering, unseeded random).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.loader import load_scenario
+from hangarfit.solver import solve
+
+
+CANARY_FIXTURES = [
+    "tests/fixtures/solve_trivial_single_plane.yaml",
+    "tests/fixtures/solve_pinned_one_plane.yaml",
+    "tests/fixtures/solve_fresh_six_planes.yaml",
+]
+
+
+@pytest.mark.parametrize("fixture", CANARY_FIXTURES)
+def test_solve_deterministic_given_seed(fixture):
+    s = load_scenario(fixture)
+    r1 = solve(s, budget_s=5.0, seed=42)
+    s2 = load_scenario(fixture)
+    r2 = solve(s2, budget_s=5.0, seed=42)
+    assert r1.status == r2.status
+    assert r1.layouts == r2.layouts
+    # diagnostics.wall_time_s naturally varies; don't compare it
+    assert r1.diagnostics.seed == r2.diagnostics.seed
+    assert r1.diagnostics.restarts_attempted == r2.diagnostics.restarts_attempted
+```
+
+- [ ] **Step 2: Run, expect pass**
+
+```bash
+pytest tests/test_solver_canaries.py -v
+```
+
+If any canary test fails, it means there's a non-determinism source in the solver (likely set / dict iteration order, or an unseeded `random` call). Find and fix it — common culprits: `set()` ordering, `dict.items()` ordering (Python 3.7+ guarantees insertion order, but not "deterministic across processes"), `os.urandom()` used directly instead of via the seeded `rng`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_solver_canaries.py
+git commit -m "tests: add determinism canary suite
+
+Asserts solve(scenario, seed=42) returns identical SolveResult across
+runs for 3 canary fixtures. Intentionally fragile — deliberate
+algorithm changes require updating expected outputs. Catches
+accidental non-determinism (set ordering, unseeded random, etc.).
+
+Refs #G"
+```
+
+### Task G.8: Final wrap
+
+- [ ] **Step 1: Full test suite + lint + type check + PR**
+
+```bash
+pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
+
+git push -u origin feature/phase2a-fixture-coverage
+gh pr create --base develop \
+  --title "Tests: full v1 fixture matrix + determinism canary set" ...
+```
+
+Run `/pr-review`, hand off.
+
+**Chunk G done when:** PR merged. **Phase 2a is then SHIPPED.**
+
+---
+
+## Post-implementation
+
+Once all 7 chunks are merged:
+
+1. **Tag a milestone close.** If a Phase 2a or v0.5.0 milestone exists, close it. If not, optionally create one retroactively and close it for traceability.
+2. **Update CLAUDE.md.** Add a brief note under "Where things live" mentioning `solver.py`. Move "No planner / search / optimization" out of the Phase 1 out-of-scope list and replace with the actual Phase 2 scope picture.
+3. **Update README.md.** Add a usage section for `hangarfit solve`.
+4. **Update memory.** Mark Phase 2a complete in `project_phase1_progress.md` (rename appropriately) or create `project_phase2_progress.md`.
+
+These are not part of this plan's chunks — they're follow-up housekeeping after the last PR merges.

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -520,7 +520,7 @@ def test_plane_constraint_default_is_free():
 
 
 def test_plane_constraint_can_carry_pin():
-    p = Placement(plane_id="husky", x_m=2.1, y_m=14.3, heading_deg=0.0, on_carts=False)
+    p = Placement(plane_id="aviat_husky", x_m=2.1, y_m=14.3, heading_deg=0.0, on_carts=False)
     c = PlaneConstraint(pin=p)
     assert c.pin == p
 
@@ -613,10 +613,10 @@ def test_scenario_smoke_construct_minimal(fleet, hangar):
     s = Scenario(
         fleet=fleet,
         hangar=hangar,
-        fleet_in=("husky", "ctsl"),
+        fleet_in=("aviat_husky", "ctsl"),
         maintenance_plane=None,
     )
-    assert s.fleet_in == ("husky", "ctsl")
+    assert s.fleet_in == ("aviat_husky", "ctsl")
     assert s.maintenance_plane is None
     assert s.constraints == {}  # MappingProxyType, but == {} works
 
@@ -637,7 +637,7 @@ def test_scenario_rejects_maintenance_plane_not_in_fleet_in(fleet, hangar):
     with pytest.raises(ValueError, match="maintenance_plane"):
         Scenario(
             fleet=fleet, hangar=hangar,
-            fleet_in=("husky",),
+            fleet_in=("aviat_husky",),
             maintenance_plane="ctsl",  # not in fleet_in
         )
 
@@ -648,7 +648,7 @@ def test_scenario_rejects_constraint_key_not_in_fleet_in(fleet, hangar):
     with pytest.raises(ValueError, match="constraint"):
         Scenario(
             fleet=fleet, hangar=hangar,
-            fleet_in=("husky",),
+            fleet_in=("aviat_husky",),
             constraints={"ctsl": PlaneConstraint(force_on_carts=True)},
         )
 
@@ -659,11 +659,11 @@ def test_scenario_rejects_pin_plane_id_mismatch(fleet, hangar):
     with pytest.raises(ValueError, match="plane_id"):
         Scenario(
             fleet=fleet, hangar=hangar,
-            fleet_in=("husky", "ctsl"),
+            fleet_in=("aviat_husky", "ctsl"),
             constraints={
-                "husky": PlaneConstraint(
+                "aviat_husky": PlaneConstraint(
                     pin=Placement(
-                        plane_id="ctsl",  # mismatch — should be "husky"
+                        plane_id="ctsl",  # mismatch — should be "aviat_husky"
                         x_m=2.0, y_m=2.0, heading_deg=0.0, on_carts=False,
                     )
                 )
@@ -678,8 +678,8 @@ def test_scenario_rejects_force_on_carts_true_for_always_own_gear(fleet, hangar)
     with pytest.raises(ValueError, match="movement_mode"):
         Scenario(
             fleet=fleet, hangar=hangar,
-            fleet_in=("husky",),
-            constraints={"husky": PlaneConstraint(force_on_carts=True)},
+            fleet_in=("aviat_husky",),
+            constraints={"aviat_husky": PlaneConstraint(force_on_carts=True)},
         )
 
 
@@ -1080,7 +1080,7 @@ EOF
 ```yaml
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
-fleet_in: [husky, ctsl]
+fleet_in: [aviat_husky, ctsl]
 ```
 
 `tests/fixtures/scenario_with_pin.yaml`:
@@ -1088,11 +1088,11 @@ fleet_in: [husky, ctsl]
 ```yaml
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
-fleet_in: [husky, ctsl, fuji]
+fleet_in: [aviat_husky, ctsl, fuji]
 maintenance:
   plane: fuji
 constraints:
-  husky:
+  aviat_husky:
     pin: { x_m: 2.1, y_m: 14.3, heading_deg: 0.0, on_carts: false }
 ```
 
@@ -1112,7 +1112,7 @@ constraints:
 ```yaml
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
-fleet_in: [husky, not_a_real_plane]
+fleet_in: [aviat_husky, not_a_real_plane]
 ```
 
 `tests/fixtures/scenario_bad_force_carts_conflict.yaml`:
@@ -1120,10 +1120,10 @@ fleet_in: [husky, not_a_real_plane]
 ```yaml
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
-fleet_in: [husky]
+fleet_in: [aviat_husky]
 constraints:
-  husky:
-    force_on_carts: true   # husky is always_own_gear → contradiction
+  aviat_husky:
+    force_on_carts: true   # aviat_husky is always_own_gear → contradiction
 ```
 
 - [ ] **Step 2: Write failing tests for `load_scenario`**
@@ -1144,7 +1144,7 @@ def test_load_scenario_minimal():
     from hangarfit.loader import load_scenario
 
     s = load_scenario("tests/fixtures/scenario_minimal.yaml")
-    assert s.fleet_in == ("husky", "ctsl")
+    assert s.fleet_in == ("aviat_husky", "ctsl")
     assert s.maintenance_plane is None
     assert s.constraints == {}
 
@@ -1154,10 +1154,10 @@ def test_load_scenario_with_pin():
 
     s = load_scenario("tests/fixtures/scenario_with_pin.yaml")
     assert s.maintenance_plane == "fuji"
-    assert "husky" in s.constraints
-    pin = s.constraints["husky"].pin
+    assert "aviat_husky" in s.constraints
+    pin = s.constraints["aviat_husky"].pin
     assert pin is not None
-    assert pin.plane_id == "husky"  # filled in by loader
+    assert pin.plane_id == "aviat_husky"  # filled in by loader
     assert pin.x_m == 2.1
     assert pin.heading_deg == 0.0
     assert pin.on_carts is False
@@ -1497,7 +1497,7 @@ Note issue number as `#C`.
 ```yaml
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
-fleet_in: [husky]
+fleet_in: [aviat_husky]
 ```
 
 (Single plane, small footprint, large hangar — definitely feasible.)
@@ -1785,14 +1785,25 @@ def _check_trivially_infeasible(scenario: Scenario) -> CheckResult | None:
 def _plane_max_extent(plane) -> tuple[float, float]:
     """Return (max_length_m, max_width_m) over all of the plane's Parts.
 
-    Computes a coarse plane-local bounding box: takes the maximum of
-    (length_m, width_m) across all Parts. This is an over-approximation
-    (a plane's outline is not necessarily the union of its part bboxes
-    rotated together) but is correct for the literal-infeasibility check:
-    if even one part exceeds the hangar, the plane cannot fit.
+    Takes the maximum `length_m` and maximum `width_m` across all
+    parts. This is a **lower bound** on the plane's true plane-local
+    outline — it IGNORES per-part offsets (`Part.offset_x_m`,
+    `Part.offset_y_m`), so a plane whose individual parts each fit
+    but whose offsets push the combined outline outside will pass
+    this check (false negative).
 
-    Returns the max length and max width separately so the caller can
-    compare each to the relevant hangar dimension.
+    That's an acceptable trade-off for the literal-infeasibility gate
+    (Chunk C check #1): false negatives don't cause incorrect
+    rejection — they just defer to the actual search, which detects
+    the failure via `collisions.check()`. What this function CANNOT
+    produce is a false positive: if even one part's bbox dimension
+    exceeds `max(hangar.length_m, hangar.width_m)`, the plane
+    provably cannot fit at any heading, regardless of offsets.
+
+    Returns max length and max width as separate values; the caller
+    compares both against `max(hangar.length_m, hangar.width_m)` to
+    catch rotation-aware infeasibility (either bbox dim can become
+    the deep one).
     """
     max_length = max(p.length_m for p in plane.parts)
     max_width = max(p.width_m for p in plane.parts)
@@ -1938,9 +1949,9 @@ EOF
 ```yaml
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
-fleet_in: [husky, ctsl]
+fleet_in: [aviat_husky, ctsl]
 constraints:
-  husky:
+  aviat_husky:
     pin: { x_m: 5.0, y_m: 5.0, heading_deg: 0.0, on_carts: false }
   ctsl:
     pin: { x_m: 5.0, y_m: 5.0, heading_deg: 0.0, on_carts: false }   # exact same spot
@@ -1966,8 +1977,8 @@ def test_solve_trivially_infeasible_when_pins_clash():
     assert bp is not None
     # At least one conflict must reference both pinned planes
     refs = [set(c.planes) for c in bp.conflicts if len(c.planes) == 2]
-    assert any({"husky", "ctsl"} == r for r in refs), (
-        f"Expected a pairwise conflict between husky and ctsl, got {refs}"
+    assert any({"aviat_husky", "ctsl"} == r for r in refs), (
+        f"Expected a pairwise conflict between aviat_husky and ctsl, got {refs}"
     )
 ```
 
@@ -2156,11 +2167,11 @@ def test_initial_placement_for_pinned_plane_returns_the_pin():
 
     s = load_scenario("tests/fixtures/scenario_with_pin.yaml")
     rng = random.Random(42)
-    pin = s.constraints["husky"].pin
+    pin = s.constraints["aviat_husky"].pin
     assert pin is not None
 
     result = _initial_placement_for_plane(
-        plane_id="husky", scenario=s, rng=rng, on_carts=pin.on_carts,
+        plane_id="aviat_husky", scenario=s, rng=rng, on_carts=pin.on_carts,
     )
     assert result == pin
 
@@ -2173,9 +2184,9 @@ def test_initial_placement_for_free_plane_is_within_hangar():
     s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
     rng = random.Random(42)
     p = _initial_placement_for_plane(
-        plane_id="husky", scenario=s, rng=rng, on_carts=False,
+        plane_id="aviat_husky", scenario=s, rng=rng, on_carts=False,
     )
-    assert p.plane_id == "husky"
+    assert p.plane_id == "aviat_husky"
     assert 0.0 <= p.x_m <= s.hangar.width_m
     assert 0.0 <= p.y_m <= s.hangar.length_m
     assert 0.0 <= p.heading_deg < 360.0
@@ -2255,7 +2266,10 @@ def _initial_placement_for_plane(
     else:
         y = rng.uniform(y_lo, y_hi)
 
-    heading = rng.uniform(0.0, 360.0)
+    # rng.random() returns [0.0, 1.0); multiplying by 360 keeps the
+    # exclusive upper bound (avoids the rng.uniform(0, 360) inclusive-
+    # endpoint pitfall — see test assertion `heading_deg < 360.0`).
+    heading = rng.random() * 360.0
 
     return Placement(
         plane_id=plane_id,
@@ -2295,20 +2309,39 @@ Refs #D"
 Append:
 
 ```python
-def test_cart_buckets_enumerates_unlocked_cart_eligibles_plus_none():
-    """With C unlocked cart_eligible planes, there should be C+1 buckets."""
+def test_cart_buckets_collapses_when_another_cart_eligible_is_force_locked_on():
+    """When another cart_eligible is force_on_carts=True, the at-most-one
+    cart-rule slot is taken — singletons for others would be infeasible."""
     from hangarfit.loader import load_scenario
     from hangarfit.solver import _enumerate_cart_buckets
 
-    # Use a scenario with 2 cart_eligible planes, neither locked.
+    # scenario_with_force_carts.yaml locks cessna_140 on_carts=True.
+    # ctsl is also cart_eligible and unlocked.
+    # Naive enumeration would emit [frozenset(), frozenset({"ctsl"})], but
+    # the singleton bucket pairs ctsl-on-carts WITH cessna_140-already-on-carts,
+    # which violates Layout's at-most-one-cart_eligible-on-carts rule.
+    # Correct behavior: only the empty bucket is feasible.
     s = load_scenario("tests/fixtures/scenario_with_force_carts.yaml")
-    # cessna_140 is cart_eligible but locked on_carts=True
-    # ctsl is cart_eligible and unlocked
-    # → buckets = [{}, {"ctsl"}]  (cessna_140 is forced — it's separate from the round-robin)
     buckets = _enumerate_cart_buckets(s)
-    assert len(buckets) == 2
-    assert set() in buckets  # the "no-one" bucket
-    assert {"ctsl"} in buckets
+    assert buckets == [frozenset()]
+
+
+def test_cart_buckets_enumerates_unlocked_cart_eligibles_plus_none():
+    """With C unlocked cart_eligible planes AND none pre-committed-on-carts,
+    there should be C+1 buckets."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _enumerate_cart_buckets
+
+    # solve_fresh_six_planes scenario includes ctsl, cessna_140, fk9_mkii
+    # (3 cart_eligibles, none locked). Expected: 4 buckets.
+    s = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    buckets = _enumerate_cart_buckets(s)
+    assert len(buckets) == 4
+    assert frozenset() in buckets
+    cart_eligibles = {pid for pid in s.fleet_in
+                      if s.fleet[pid].is_cart_eligible}
+    for pid in cart_eligibles:
+        assert frozenset({pid}) in buckets
 
 
 def test_cart_bucket_for_restart_is_deterministic_round_robin():
@@ -2338,30 +2371,56 @@ def _enumerate_cart_buckets(scenario: Scenario) -> list[frozenset[str]]:
     """Enumerate the cart-assignment buckets to round-robin over.
 
     Per spec §4.2: cart_eligible planes that are NOT locked by
-    force_on_carts/pin can be on or off carts. With C such planes,
-    the buckets are: the empty set + {plane_i} for each — totaling C+1.
+    force_on_carts/pin can be on or off carts. With C such planes
+    and NO pre-committed cart_eligible-on-carts plane, the buckets
+    are: the empty set + {plane_i} for each — totaling C+1.
 
-    Locked cart_eligible planes (force_on_carts=True or a pin with
-    on_carts=True) bypass round-robin — their on_carts state is fixed.
-    The cart-rule (at-most-one cart_eligible on_carts) is enforced
-    holistically by Layout.__post_init__ later.
+    Locked cart_eligible planes (force_on_carts=True, or any pin —
+    which sets on_carts as part of the placement) bypass round-robin;
+    their on_carts state is fixed. The cart-rule (at-most-one
+    cart_eligible on_carts) is enforced holistically by
+    Layout.__post_init__ later.
+
+    **IMPORTANT — pre-committed cart-on-carts case:** if any
+    cart_eligible plane is committed to `on_carts=True` by a
+    constraint (force_on_carts=True OR pin.on_carts=True), then the
+    "at most one cart_eligible on carts" slot is already taken. In
+    that case the ONLY valid bucket is the empty set — singleton
+    buckets for OTHER unlocked cart_eligibles would put a second
+    plane on carts and violate the rule, wasting restart budget on
+    guaranteed-infeasible configurations. We exclude singletons in
+    that case.
+
+    Note: a pin with `on_carts=False` also locks the plane (it can't
+    appear in any bucket), but doesn't consume the on-carts slot —
+    so other unlocked cart_eligibles can still be enumerated as
+    singletons.
     """
     free_cart_eligibles: list[str] = []
+    has_committed_cart_eligible_on_carts = False
     for pid in scenario.fleet_in:
         plane = scenario.fleet[pid]
         if not plane.is_cart_eligible:
             continue
         constraint = scenario.constraints.get(pid)
         if constraint is not None:
+            if constraint.pin is not None:
+                # Any pin locks the plane out of round-robin. If the pin
+                # puts it on carts, the on-carts slot is consumed.
+                if constraint.pin.on_carts:
+                    has_committed_cart_eligible_on_carts = True
+                continue
             if constraint.force_on_carts is not None:
-                continue  # locked
-            if constraint.pin is not None and constraint.pin.on_carts:
-                continue  # pinned on carts
+                # force_on_carts=True consumes the on-carts slot.
+                if constraint.force_on_carts:
+                    has_committed_cart_eligible_on_carts = True
+                continue
         free_cart_eligibles.append(pid)
 
     buckets: list[frozenset[str]] = [frozenset()]
-    for pid in free_cart_eligibles:
-        buckets.append(frozenset({pid}))
+    if not has_committed_cart_eligible_on_carts:
+        for pid in free_cart_eligibles:
+            buckets.append(frozenset({pid}))
     return buckets
 
 
@@ -2387,9 +2446,12 @@ git add src/hangarfit/solver.py tests/test_solver_search.py
 git commit -m "solver: implement cart-assignment round-robin enumeration
 
 _enumerate_cart_buckets returns C+1 buckets (empty + each unlocked
-cart_eligible singleton); _cart_bucket_for_restart selects bucket
-restart_index % len(buckets). Round-robin guarantees every cart
-configuration is sampled within a small restart budget.
+cart_eligible singleton) when no cart_eligible is pre-committed on
+carts; collapses to [frozenset()] when one IS pre-committed (so the
+at-most-one cart-rule slot stays satisfied). _cart_bucket_for_restart
+selects bucket restart_index % len(buckets). Round-robin guarantees
+every feasible cart configuration is sampled within a small restart
+budget without wasting restarts on guaranteed-infeasible pairings.
 
 Refs #D"
 ```
@@ -2469,7 +2531,7 @@ def test_perturb_plane_returns_valid_placement_within_hangar():
 
     s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
     rng = random.Random(42)
-    current = Placement(plane_id="husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    current = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
     config = SearchConfig()  # defaults
 
     # Generate many perturbations; all must be inside hangar bounds.
@@ -2477,7 +2539,7 @@ def test_perturb_plane_returns_valid_placement_within_hangar():
         cand = _perturb_plane(
             current=current, scenario=s, rng=rng, search=config, large_jump=False,
         )
-        assert cand.plane_id == "husky"
+        assert cand.plane_id == "aviat_husky"
         assert 0.0 <= cand.x_m <= s.hangar.width_m
         assert 0.0 <= cand.y_m <= s.hangar.length_m
         assert 0.0 <= cand.heading_deg < 360.0
@@ -2520,7 +2582,8 @@ def _perturb_plane(
             y = hangar.length_m / 2
         else:
             y = rng.uniform(y_lo, y_hi)
-        heading = rng.uniform(0.0, 360.0)
+        # Exclusive upper bound — see _initial_placement_for_plane note.
+        heading = rng.random() * 360.0
     else:
         dx = rng.gauss(0.0, search.pos_sigma_m)
         dy = rng.gauss(0.0, search.pos_sigma_m)
@@ -2684,7 +2747,7 @@ You'll need `tests/fixtures/solve_trivial_single_plane.yaml`:
 ```yaml
 fleet: ../../data/fleet.yaml
 hangar: ./test_hangar_large.yaml  # the existing 30×25 fixture
-fleet_in: [husky]
+fleet_in: [aviat_husky]
 ```
 
 (Confirm `test_hangar_large.yaml` exists in `tests/fixtures/` per CLAUDE.md module map. It does.)
@@ -2858,14 +2921,23 @@ pytest tests/test_solver_search.py::test_solve_finds_layout_for_trivial_single_p
 
 Expected: PASS (one plane in 30×25 m hangar is trivially solvable in << 5s).
 
-- [ ] **Step 5: Add the six-plane fresh fixture + test**
+- [ ] **Step 5: Delete the Chunk C placeholder smoke test**
+
+In Chunk C (Task C.1), we wrote `test_solve_feasible_smoke_returns_exhausted_budget_placeholder` to verify the solver's Chunk-C-era short-circuit behavior. That short-circuit no longer exists after Step 3 of this task — feasible scenarios now actually run the search and (for the smoke fixture: a single plane in a large hangar) succeed with `status="found"`. The placeholder assertion `assert r.status == "exhausted_budget"` is wrong from this commit onwards.
+
+Open `tests/test_solver_infeasibility.py` and **delete** the function `test_solve_feasible_smoke_returns_exhausted_budget_placeholder` entirely. The companion `test_solve_resolves_none_seed_to_entropy` stays — it only checks seed handling, not status, and remains valid.
+
+Run: `pytest tests/test_solver_infeasibility.py -v`
+Expected: only `test_solve_resolves_none_seed_to_entropy` and the three `trivially_infeasible_*` tests run; all PASS.
+
+- [ ] **Step 6: Add the six-plane fresh fixture + test**
 
 `tests/fixtures/solve_fresh_six_planes.yaml`:
 
 ```yaml
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
-fleet_in: [husky, fuji, ctsl, scheibe_falke, fk9_mkii, cessna_140]
+fleet_in: [aviat_husky, fuji, ctsl, scheibe_falke, fk9_mkii, cessna_140]
 maintenance:
   plane: scheibe_falke
 ```
@@ -2897,7 +2969,7 @@ def test_solve_finds_layout_for_fresh_six_planes():
 
 (`pytest.skip` is intentional: if the placeholder hangar is too tight for 5s to find a solution at seed=42, that's a property of the data, not a bug. Real measurements will likely fix this.)
 
-- [ ] **Step 6: Run + lint + type check**
+- [ ] **Step 7: Run + lint + type check**
 
 ```bash
 pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
@@ -2905,10 +2977,10 @@ pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy s
 
 Expected: green.
 
-- [ ] **Step 7: Commit + push + PR**
+- [ ] **Step 8: Commit + push + PR**
 
 ```bash
-git add src/hangarfit/solver.py tests/test_solver_search.py tests/fixtures/solve_trivial_single_plane.yaml tests/fixtures/solve_fresh_six_planes.yaml
+git add src/hangarfit/solver.py tests/test_solver_infeasibility.py tests/test_solver_search.py tests/fixtures/solve_trivial_single_plane.yaml tests/fixtures/solve_fresh_six_planes.yaml
 git commit -m "$(cat <<'EOF'
 solver: implement RR-MC search engine (alternatives=1)
 
@@ -2998,7 +3070,7 @@ def test_diversity_filter_rejects_near_duplicate():
 
     fleet = load_fleet("data/fleet.yaml")
     hangar = load_hangar("data/hangar.yaml")
-    p1 = Placement(plane_id="husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p1 = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
     p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
     L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
     L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))  # identical
@@ -3014,12 +3086,12 @@ def test_diversity_filter_accepts_meaningfully_different():
 
     fleet = load_fleet("data/fleet.yaml")
     hangar = load_hangar("data/hangar.yaml")
-    p1 = Placement(plane_id="husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p1 = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
     p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
     L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
 
     # L2: both planes moved by > 0.5 m
-    p1b = Placement(plane_id="husky", x_m=8.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p1b = Placement(plane_id="aviat_husky", x_m=8.0, y_m=5.0, heading_deg=0.0, on_carts=False)
     p2b = Placement(plane_id="ctsl", x_m=13.0, y_m=10.0, heading_deg=0.0, on_carts=False)
     L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1b, p2b))
 
@@ -3035,11 +3107,11 @@ def test_diversity_heading_uses_short_arc():
 
     fleet = load_fleet("data/fleet.yaml")
     hangar = load_hangar("data/hangar.yaml")
-    p1 = Placement(plane_id="husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p1 = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
     p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
     L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
 
-    p1b = Placement(plane_id="husky", x_m=5.0, y_m=5.0, heading_deg=359.0, on_carts=False)
+    p1b = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=359.0, on_carts=False)
     p2b = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
     L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1b, p2b))
 
@@ -3110,7 +3182,7 @@ Refs #E"
 ```yaml
 fleet: ../../data/fleet.yaml
 hangar: ./test_hangar_large.yaml
-fleet_in: [husky, fuji, ctsl]
+fleet_in: [aviat_husky, fuji, ctsl]
 ```
 
 Append test:
@@ -3196,9 +3268,9 @@ Refs #E"
 ```yaml
 fleet: ../../data/fleet.yaml
 hangar: ./test_hangar_large.yaml
-fleet_in: [husky, ctsl, fuji]
+fleet_in: [aviat_husky, ctsl, fuji]
 constraints:
-  husky:
+  aviat_husky:
     pin: { x_m: 5.0, y_m: 5.0, heading_deg: 0.0, on_carts: false }
   ctsl:
     pin: { x_m: 15.0, y_m: 10.0, heading_deg: 0.0, on_carts: false }
@@ -3531,7 +3603,7 @@ For each of these, follow the same TDD discipline:
 
 | Fixture YAML | Test | Expected outcome |
 |---|---|---|
-| `solve_pinned_one_plane.yaml` | 6 planes, husky pinned | `found`, pinned plane unchanged |
+| `solve_pinned_one_plane.yaml` | 6 planes, aviat_husky pinned | `found`, pinned plane unchanged |
 | `solve_repair_minimal_edit.yaml` | 6 planes, 5 pinned to baseline | `found`, only unpinned plane differs from baseline |
 | `solve_force_carts_lock.yaml` | cessna_140 forced on_carts=True | `found`, returned layout respects lock |
 | `solve_force_carts_conflict.yaml` | always_cart plane forced on_carts=False | `LoaderError` |

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -289,15 +289,24 @@ Expected: the populated-penetration test FAILs with `Expected non-zero penetrati
 In `src/hangarfit/collisions.py`:
 
 1. At the top of `check()`, initialize a local accumulator: `total_penetration_m2 = 0.0`.
-2. Locate the inner loop where pairwise part-conflicts are detected. The two conflicting shapely polygons are in scope at the conflict site (computed for the `distance` test). Immediately after deciding "this is a conflict," but before constructing the `Conflict`, accumulate:
+
+2. Extend the existing imports from `.geometry` to include `polygon_overlap_area` — it's already exported at `src/hangarfit/geometry.py:106-113` and does exactly the `intersects + intersection().area` work we need, returning 0 cleanly when the polygons don't overlap (clearance-only conflicts contribute 0 to penetration, consistent with spec §4.4's "two planes overlapping" framing).
+
+   Current `collisions.py` imports from geometry typically look like:
+   ```python
+   from .geometry import WorldPart, aircraft_parts_world, polygon_overlap
+   ```
+   Add `polygon_overlap_area` to that list.
+
+3. Locate the inner loop where pairwise part-conflicts are detected. The two conflicting shapely polygons are in scope at the conflict site (already computed for the `distance` test). Immediately after deciding "this is a conflict," but before constructing the `Conflict`, accumulate using the shared helper:
 
    ```python
-   total_penetration_m2 += polygon_a.intersection(polygon_b).area
+   total_penetration_m2 += polygon_overlap_area(polygon_a, polygon_b)
    ```
 
-   Use the same `polygon_a` and `polygon_b` already used for the distance check — do not recompute.
+   Reuses `polygon_a` and `polygon_b` from the distance check — no recomputation.
 
-3. At the end of `check()`, pass the accumulator to the `CheckResult` constructor:
+4. At the end of `check()`, pass the accumulator to the `CheckResult` constructor:
 
    ```python
    return CheckResult(
@@ -306,16 +315,9 @@ In `src/hangarfit/collisions.py`:
    )
    ```
 
-**Implementation note:** if the existing code uses `polygon_a.distance(polygon_b) < clearance_m` to decide whether to emit a conflict, `intersection().area` correctly returns 0 when the polygons don't actually overlap (distance > 0 but within clearance). That's fine: clearance-only conflicts contribute 0 to penetration, which is consistent with the spec ("penetration depth" means actual overlap, not clearance violation). The spec calls this out implicitly via the "two planes overlapping" framing of §4.4.
-
-If preferred, an even safer formulation is:
-
-```python
-if polygon_a.intersects(polygon_b):
-    total_penetration_m2 += polygon_a.intersection(polygon_b).area
-```
-
-`polygon_a.intersects(polygon_b)` is a cheap boolean and avoids constructing an empty `intersection()` for clearance-only conflicts. Use this form.
+**Why use `polygon_overlap_area` rather than inline `intersects + intersection().area`?** Two reasons:
+1. **DRY** — the helper exists and is already used elsewhere in the codebase.
+2. **Consistency** — its return value (0.0 when the polygons don't intersect) matches our semantic ("penetration depth" means actual overlap, not clearance violation) without needing inline `if intersects` guards.
 
 - [ ] **Step 5: Run the new tests, expect pass**
 
@@ -621,6 +623,15 @@ def test_scenario_smoke_construct_minimal(fleet, hangar):
     assert s.constraints == {}  # MappingProxyType, but == {} works
 
 
+def test_scenario_rejects_empty_fleet_in(fleet, hangar):
+    """Empty fleet_in is nonsense — nothing to solve; downstream solver
+    helpers also assume at least one plane (e.g., fleet_in[0])."""
+    from hangarfit.models import Scenario
+
+    with pytest.raises(ValueError, match="non-empty"):
+        Scenario(fleet=fleet, hangar=hangar, fleet_in=())
+
+
 def test_scenario_rejects_unknown_plane_in_fleet_in(fleet, hangar):
     from hangarfit.models import Scenario
 
@@ -776,6 +787,12 @@ class Scenario:
     )
 
     def __post_init__(self) -> None:
+        # fleet_in must be non-empty (otherwise there's nothing to solve;
+        # downstream helpers like the sum-of-areas infeasibility check
+        # also do `fleet_in[0]` which would IndexError on empty input).
+        if not self.fleet_in:
+            raise ValueError("Scenario.fleet_in must be non-empty")
+
         # fleet_in references real planes
         for pid in self.fleet_in:
             if pid not in self.fleet:
@@ -1698,7 +1715,7 @@ def test_solve_trivially_infeasible_when_plane_too_big_for_hangar():
     assert r.status == "trivially_infeasible"
     assert r.layouts == ()
     # Pre-search check must short-circuit fast (no actual search).
-    assert r.diagnostics.wall_time_s < 0.5
+    assert r.diagnostics.wall_time_s < 5.0  # well below the 30 s default budget
     assert r.diagnostics.restarts_attempted == 0
 ```
 
@@ -1869,7 +1886,7 @@ def test_solve_trivially_infeasible_when_sum_areas_exceeds_hangar():
     r = solve(s, budget_s=5.0, seed=42)
 
     assert r.status == "trivially_infeasible"
-    assert r.diagnostics.wall_time_s < 0.5
+    assert r.diagnostics.wall_time_s < 5.0  # well below the 30 s default budget
     # The diagnostic should mention "sum" or "area" so the user can tell
     # WHICH infeasibility check fired.
     bp = r.diagnostics.best_partial
@@ -1971,7 +1988,7 @@ def test_solve_trivially_infeasible_when_pins_clash():
     r = solve(s, budget_s=5.0, seed=42)
 
     assert r.status == "trivially_infeasible"
-    assert r.diagnostics.wall_time_s < 0.5
+    assert r.diagnostics.wall_time_s < 5.0  # well below the 30 s default budget
     # The best_partial's conflicts should include the pin pair
     bp = r.diagnostics.best_partial
     assert bp is not None
@@ -2699,12 +2716,13 @@ def _descent_step(
             best_cand = cand
             best_disp = disp
 
-    if best_cand is None or best_score > current_score:
-        # No improvement — reject
+    # By construction the loop only updates best_score when the new
+    # candidate's score is ≤ best_score (which starts at current_score),
+    # so best_score ≤ current_score whenever best_cand is not None. No
+    # need to re-test that — just dispatch on whether anything improved.
+    if best_cand is None:
         return placements, current_score, False
-    if best_score <= current_score:
-        return best_placements, best_score, True
-    return placements, current_score, False
+    return best_placements, best_score, True
 ```
 
 - [ ] **Step 6: Commit (partial; integration test in next task)**
@@ -3649,11 +3667,16 @@ def test_solve_deterministic_given_seed(fixture):
     r1 = solve(s, budget_s=5.0, seed=42)
     s2 = load_scenario(fixture)
     r2 = solve(s2, budget_s=5.0, seed=42)
+    # Status, layouts, and seed must match bit-for-bit across runs.
     assert r1.status == r2.status
     assert r1.layouts == r2.layouts
-    # diagnostics.wall_time_s naturally varies; don't compare it
     assert r1.diagnostics.seed == r2.diagnostics.seed
-    assert r1.diagnostics.restarts_attempted == r2.diagnostics.restarts_attempted
+    # NOT asserted: diagnostics.wall_time_s and diagnostics.restarts_attempted.
+    # Both depend on machine speed and the wall-clock-based budget cutoff —
+    # a faster run completes more restarts within the same 5.0 s budget.
+    # The deterministic-layout assertion above is enough to catch any
+    # accidental non-determinism (unseeded random, set/dict ordering, etc.):
+    # different RNG state → different layouts.
 ```
 
 - [ ] **Step 2: Run, expect pass**

--- a/docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md
+++ b/docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md
@@ -1,0 +1,552 @@
+# Phase 2a — Static layout solver, design
+
+**Status:** draft 2026-05-22 (awaiting review)
+**Tracks:** (to be assigned to a new issue once spec is approved) — first slice of Phase 2 ("planner / search / optimization") that CLAUDE.md flagged as out of scope for Phase 1.
+**Author:** Claude (Opus 4.7), brainstormed with @DocGerd
+**Depends on:** [#79 — real Herrenteich hangar dimensions](https://github.com/DocGerd/hangarfit/issues/79) (not a hard blocker for implementation, but a hard blocker for trusting solver outputs against operational reality).
+
+A solver that takes a *fleet subset + hard constraints* and returns *up to K diverse valid layouts*, built on top of the Phase 1 collision substrate. Covers both **fresh-layout** ("fit these planes") and **minimal-edit repair** ("baseline broke, fix it") via the same engine — repair is implemented as pinning the unchanged planes.
+
+---
+
+## 1. Goals & non-goals
+
+**Goals**
+
+- One library function `solver.solve(scenario)` and one CLI subcommand `hangarfit solve` that turn a `Scenario` (fleet subset + maintenance plane + per-plane constraints) into a `SolveResult` (up to K diverse `Layout`s plus diagnostics).
+- Fresh-layout mode and minimal-edit repair mode share the same search engine; repair is just "pin everything that didn't change."
+- Continuous placement (any `x_m`, `y_m`, any `heading_deg`) — no grid, no axis-aligned restriction.
+- Honest failure modes: when the solver gives up, the user gets `status`, `best_partial`, and the conflict list, not a black-box "didn't work."
+- Reproducible given a seed.
+- Tests use the existing fixture-driven pattern; no new test infrastructure.
+
+**Non-goals (Phase 2a)**
+
+- **No move-sequence planning** (Phase 2b's territory). 2a returns end-state layouts; it doesn't reason about pulling planes out the door.
+- **No cross-run hangar state persistence** (Phase 2c).
+- **No soft constraints / preferences** — only hard constraints (pin, force_on_carts, maintenance plane).
+- **No region constraints** or **heading-only locks** without position locks. Pin is the only positional constraint primitive; richer constraint language is a v1.1+ addition.
+- **No completeness guarantee.** When the solver returns "no layout found in budget," that is a *probabilistic* claim, not a proof of infeasibility — except for the three `trivially_infeasible` cases enumerated in §4.1, which are literal impossibilities.
+- **No CLI flag for `SearchConfig` hyperparameters** (`N`, `K_stall`, perturbation thresholds) — those are programmatic only, exposed via the `solve()` kwarg. Surfacing them on the CLI is v1.1.
+- **No structured min-conflicts moves** that use the conflict's separation axis as a direction. Requires extending `Conflict` to carry penetration geometry — a Phase 1 surgery deferred to v1.1.
+
+---
+
+## 2. Summary of design decisions
+
+A high-level index of the choices the spec encodes. Sections 3–6 contain the full adversarial review of each.
+
+| # | Decision | Choice | Confidence |
+|---|---|---|---|
+| 1 | Scenario shape | Fresh + repair dispatched by input; repair = "pin everything unchanged" | high |
+| 2 | Placement model | Continuous `(x, y)` + any `heading_deg` | high |
+| 3 | Constraint set | Standard: maintenance plane, per-plane `pin` (full Placement), per-plane `force_on_carts` | high |
+| 4 | Output cardinality | Up to K diverse alternatives (`--alternatives N`, default 1) | high |
+| 5 | Diversity metric | Edit-count: ≥2 planes moved >0.5 m OR >30° between any two accepted layouts | high |
+| 6 | Algorithm family | Random-restart hill climbing with min-conflicts descent (RR-MC) | high |
+| 7 | Scoring function | Hierarchical `(conflict_count, total_penetration_m2)` | medium-high (requires Phase 1 `CheckResult` extension — see §7) |
+| 8 | Cart assignment | Round-robin over `{no-carts, plane_i-on-carts}` buckets across restarts | high |
+| 9 | Pre-search infeasibility | Three literal-impossibility checks (per-plane bbox > hangar, Σ areas > hangar, pin self-collision via `check()`) | high |
+| 10 | `--render` PATTERN with K>1 | Require `{i}` placeholder; loud failure if absent | medium-high |
+| 11 | Exit code for `found_partial` | Default 0 (forgiving); `--strict-k` flag opts into exit 1 | high |
+| 12 | Layout YAML output | `--write-yaml PATTERN` flag (parallel to `--render`) | high |
+| 13 | Testing | Fixture-driven (`tests/fixtures/solve_*.yaml`), 12-fixture v1 matrix, `pytest.mark.slow` for long tests | high |
+| 14 | Determinism | Bit-for-bit on a small "canary" fixture subset; outcome-equality everywhere else | medium-high |
+
+---
+
+## 3. Types and module layout (Section A)
+
+### 3.1 New module
+
+`src/hangarfit/solver.py` — public `solve()` entry point + internal RR-MC search loop + diversity filter. Flat module, no `solver/` package (matches Phase 1 convention of `loader.py`, `geometry.py`, `collisions.py`, etc.).
+
+### 3.2 New types in `models.py`
+
+All frozen + slots; `__post_init__` invariant checks (matches Phase 1 style).
+
+```python
+@dataclass(frozen=True, slots=True)
+class PlaneConstraint:
+    """Per-plane HARD constraints for a Scenario.
+
+    All fields optional — a constraint with everything None means 'free'.
+    """
+    pin: Placement | None = None              # locks plane to exact placement
+    force_on_carts: bool | None = None         # True / False / None (unrestricted)
+
+
+@dataclass(frozen=True, slots=True)
+class Scenario:
+    """Solver input.
+
+    Cross-reference invariants validated in __post_init__:
+    - every fleet_in id exists in fleet
+    - maintenance_plane (if set) is in fleet_in
+    - constraints.keys() ⊆ set(fleet_in)
+    - for each (plane_id, constraint): constraint.pin.plane_id == plane_id (if pin set)
+    - force_on_carts is consistent with movement_mode:
+        force_on_carts=True  → plane must NOT be always_own_gear
+        force_on_carts=False → plane must NOT be always_cart
+    - pin.on_carts is consistent with movement_mode (same rules — a pin sets all of
+      x_m / y_m / heading_deg / on_carts, so its on_carts must match the plane's mode)
+    - if both a pin and force_on_carts are set for the same plane, they must agree
+      on on_carts (otherwise the constraint set is self-contradictory)
+    - fleet dict is wrapped in MappingProxyType (same pattern as Layout)
+
+    Default-value note (implementation): the `constraints` default below is shown as
+    a literal `MappingProxyType({})` for readability, but the actual implementation
+    must use `dataclasses.field(default_factory=lambda: MappingProxyType({}))` to
+    avoid sharing the same proxy instance across all default-constructed Scenarios.
+    """
+    fleet: Mapping[str, Aircraft]
+    hangar: Hangar
+    fleet_in: tuple[str, ...]
+    maintenance_plane: str | None = None
+    constraints: Mapping[str, PlaneConstraint] = MappingProxyType({})
+
+
+SolveStatus = Literal[
+    "found",                 # all K alternatives found
+    "found_partial",         # 1 ≤ found < K within budget
+    "exhausted_budget",      # 0 valid layouts; best_partial available
+    "trivially_infeasible",  # provably no solution per §4.1
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SolverDiagnostics:
+    restarts_attempted: int
+    wall_time_s: float
+    best_partial: CheckResult | None       # lowest-conflict CheckResult seen
+    best_partial_layout: Layout | None     # the matching Layout (so it can be rendered)
+    seed: int                              # actually-used seed (None resolved to entropy)
+
+
+@dataclass(frozen=True, slots=True)
+class SolveResult:
+    status: SolveStatus
+    layouts: tuple[Layout, ...]            # 0..K elements
+    diagnostics: SolverDiagnostics
+
+
+@dataclass(frozen=True, slots=True)
+class DiversityConfig:
+    min_planes_moved: int = 2
+    position_threshold_m: float = 0.5
+    heading_threshold_deg: float = 30.0
+
+
+@dataclass(frozen=True, slots=True)
+class SearchConfig:
+    """Solver hyperparameters. v1 defaults are guesses; tune with real data."""
+    candidates_per_iter: int = 8
+    k_stall: int = 50
+    pos_sigma_m: float = 0.5
+    heading_sigma_deg: float = 10.0
+```
+
+### 3.3 Public API
+
+```python
+def solve(
+    scenario: Scenario,
+    *,
+    budget_s: float = 30.0,
+    alternatives: int = 1,
+    seed: int | None = None,
+    diversity: DiversityConfig = DiversityConfig(),
+    search: SearchConfig = SearchConfig(),
+) -> SolveResult: ...
+```
+
+**Note:** `strict_k` is a CLI-only concept (it controls exit-code translation from
+`SolveResult.status`). The library API does not need it — callers inspect
+`result.status` directly and decide how to react. The CLI implements `--strict-k`
+by mapping `found_partial → exit 1` after calling `solve()` with no extra flag.
+
+**Default-factory note (implementation):** the `diversity` and `search` defaults shown above as `DiversityConfig()` / `SearchConfig()` are literal calls for readability. Both Configs are frozen + slots + immutable, so sharing a single default instance across calls is *theoretically* safe. The implementation may use either (a) `None` sentinels resolved at function entry, or (b) `field(default_factory=...)` if the kwargs are wrapped in a dataclass — both are fine; whichever keeps the linter quiet wins.
+
+### 3.4 Loader extension
+
+`loader.py` gains `load_scenario(path, *, fleet=None, hangar=None) -> Scenario` — mirrors `load_layout` exactly (same conflict policy: refuse if both YAML-embedded ref and programmatic override are supplied; same path-resolution rules).
+
+Scenario YAML schema:
+
+```yaml
+fleet: ../data/fleet.yaml
+hangar: ../data/hangar.yaml
+fleet_in: [husky, fuji, ctsl, falke, fk9_mkii, cessna_140]
+maintenance:
+  plane: falke
+constraints:
+  husky:
+    pin: { x_m: 2.1, y_m: 14.3, heading_deg: 0, on_carts: false }
+  cessna_140:
+    force_on_carts: true
+```
+
+### 3.5 Reuse of Phase 1 invariants
+
+The solver builds a candidate `Layout` from `Scenario + (placements it sampled)` on every iteration. `Layout.__post_init__` then validates cross-reference invariants (cart rule, movement_mode consistency, fleet/placement key match, maintenance plane in fleet) for **free** — the solver doesn't re-encode those rules; it relies on the existing dataclass to throw `ValueError` if it ever proposes something illegal. This means a bug in the solver that violates the cart rule can never produce a returned `Layout` — `Layout.__post_init__` rejects it first.
+
+---
+
+## 4. Algorithm internals (Section B)
+
+The algorithm family is **RR-MC**: many independent random-initialized trajectories, each performing min-conflicts greedy descent until either (a) a valid layout is found and added to the alternatives pool, or (b) the trajectory plateaus and is restarted. The full alternatives reasoning + adversarial review is preserved here because the user explicitly values seeing the decisions survive scrutiny (see [[feedback_adversarial_design_review]] in author memory).
+
+### 4.1 Pre-search infeasibility checks
+
+Before the first restart, run three literal-impossibility tests in order. If any fires, return `SolveResult(status="trivially_infeasible", layouts=(), diagnostics=...)`.
+
+1. **Per-plane bounding box vs. hangar.** For each plane in `fleet_in`, compute its axis-aligned plane-local bbox (max extent over all `Parts`); reject if `bbox.length > hangar.length_m` *or* `bbox.width > hangar.length_m` (using `length_m` for both because the plane can be rotated). Catches typos like a 200 m wingspan.
+2. **Σ areas vs. hangar floor area.** Sum each plane's bbox area; reject if `> hangar.length_m × hangar.width_m`. (No margin — only flag *literal* infeasibility.)
+3. **Pin self-collision.** Build a `Layout` containing only the pinned planes (skipping all unpinned ones); call `collisions.check()`. Any conflict → infeasible, return the conflict list as `diagnostics.best_partial` so the user sees which two pins clash, or which pin lies outside the hangar (caught as a `hangar_bounds` conflict).
+
+   **Important construction detail:** the pin-only Layout is built with `maintenance_plane=None` regardless of the scenario's `maintenance_plane`. `Layout.__post_init__` enforces "maintenance_plane is placed if set" — but at this stage we're skipping all unpinned planes, so the maintenance plane (if not itself pinned) would be missing and trigger that invariant. The pre-search check is *only* about pin-vs-pin self-collision and pin-vs-hangar bounds; maintenance-position is irrelevant here (no maintenance plane → no maintenance-position rule).
+
+**Decisions challenged.** Original design had a 0.95 margin on step 2 ("Σ areas > 0.95 × hangar area"). Adversarial review rejected the magic number — false positives are worse than missing a soft "probably won't fit" warning, since step 2 is a *defensible* check only when it represents a literal impossibility. The 0.95 was a heuristic without empirical backing; dropped.
+
+### 4.2 Initial placement (per restart)
+
+For each plane in `fleet_in`:
+
+- **Pinned planes** → placement is `constraint.pin` verbatim. Never moves during the trajectory.
+- **Maintenance plane** (if not pinned) → biased initial: `(x_m, y_m)` uniform in the back maintenance-bay strip (depth = `hangar.maintenance_bay.depth_m`), `heading_deg` uniform on `[0°, 360°)`.
+- **Other free planes** → `(x_m, y_m)` uniform inside the hangar interior with a margin equal to the plane's max-extent bbox / 2 (to reduce initial bounds violations), `heading_deg` uniform on `[0°, 360°)`.
+
+**Cart assignment is fixed at restart time, round-robin** over the unlocked buckets. With C cart_eligible planes that are not locked by `force_on_carts`, the buckets are `{none, plane_1_on_carts, plane_2_on_carts, …, plane_C_on_carts}` — i.e., `C + 1` buckets. Restart number R picks bucket `R mod (C+1)`. Round-robin guarantees every cart configuration is sampled at least once within a small restart budget, beating the random-per-restart alternative (which can leave buckets unsampled).
+
+**Decisions challenged.** Original design had **random** per-restart cart picks. Adversarial review changed to **round-robin** for guaranteed coverage at the same compute cost. Maintenance-plane biased initial survived: alternatives ("no bias", "auto-pin maintenance to bay center", "pin + heading-only search") all lose either flexibility or impose unwarranted structure.
+
+### 4.3 Descent step (min-conflicts perturbation)
+
+Given a current candidate layout with `score > (0, 0)`:
+
+1. Build the conflicting-plane set `S = (⋃ c.planes for c in check_result.conflicts) − pinned_planes`. If `S` is empty → trajectory is stuck (all conflicts involve only pinned planes, which can't move); abort restart.
+2. Pick one plane from `S` uniformly at random.
+3. Generate `N = candidates_per_iter` candidate perturbations for that plane (default `N = 8`):
+   - **6 small Gaussian nudges**: `(dx, dy) ~ N(0, pos_sigma_m)`, `dh ~ N(0, heading_sigma_deg)`.
+   - **1 large jump**: re-sample `(x_m, y_m)` uniformly over the hangar (with the same margin as initial placement); `heading_deg` uniform on `[0°, 360°)`.
+   - **1 heading-only 180° flip**: keep `(x_m, y_m)`, set `heading_deg = current + 180°`. Domain heuristic for "nose-wrong-way" cases.
+4. For each candidate, build a tentative `Layout` (cart assignment unchanged) and score it via `_score(layout)` (§4.4). Select the candidate with the lowest `score`. Tie-break by **smallest displacement** from the current state (smooth trajectory).
+5. Accept iff `new_score ≤ current_score` (greedy `≤` allows plateau traversal — strict `<` is too aggressive on integer-valued conflict counts).
+
+**Decisions challenged.** The perturbation mix (`6 + 1 + 1`) is a heuristic; alternatives include "8 Gaussian only" (too local), "4 + 4" (more exploration, more noise), "structured moves from conflict geometry" (more principled but requires `Conflict.penetration_axis` — deferred to v1.1). Default `N = 8` is a guess; should be tuned with measured `check()` cost. The 180° flip is a domain bet that may never fire usefully — harmless if it doesn't.
+
+### 4.4 Scoring function
+
+`_score(layout: Layout) -> tuple[int, float]` returns `(conflict_count, total_penetration_m2)`.
+
+- **Primary key** `conflict_count = len(check_result.conflicts)`. Integer.
+- **Secondary key** `total_penetration_m2 = sum over conflicts of overlap_area(part_a, part_b)`. Computed via shapely `polygon.intersection(other).area` for each pairwise conflict. Conflicts that reference only a single plane (per `Conflict.planes` having length 1 — currently `maintenance_position`, `maintenance_no_fuselage`, `hangar_bounds`) contribute 0 to the sum: they describe a different kind of invalid (a plane in the wrong place rather than two planes overlapping) and have no second polygon to intersect against.
+- Lexicographic comparison: lower-`conflict_count` wins; ties broken by lower-`total_penetration_m2`.
+- `score == (0, 0.0)` means valid.
+
+**Phase 1 surgery required** (see §7): extend `CheckResult` with `total_penetration_m2: float = 0.0` (backward-compatible default) and have `collisions.check()` populate it.
+
+**Decisions challenged.** The original spec used pure conflict count for v1 simplicity, with a deferred-instrumentation plan to upgrade if plateau pathology showed up in real data. Adversarial review surfaced that integer-count metrics are well-known to plateau on packing problems — the cost of `(count, depth)` is modest (small Phase 1 extension; one shapely call per conflict) and the algorithmic gain is real (smooth secondary signal for descent direction). User chose hierarchical.
+
+### 4.5 Restart trigger
+
+Restart the current trajectory whenever any of:
+
+- `score == (0, 0.0)` → valid! Pass to the diversity filter (§4.6), then restart fresh.
+- `k_stall = 50` consecutive iterations without `score` strictly decreasing (in lexicographic order).
+- Conflicting-plane set `S` is empty (all conflicts involve pinned planes only — locally unsolvable).
+
+Pin assignments survive across restarts; everything else re-randomizes.
+
+### 4.6 Diversity filter
+
+When a trajectory yields a valid layout `L`:
+
+- For each already-accepted layout `L'` in `accepted_layouts`:
+  - `n_moved(L, L') := |{ plane p : ||L[p].xy − L'[p].xy|| ≥ position_threshold_m  OR  |L[p].heading − L'[p].heading| (normalized to [0, 180°]) ≥ heading_threshold_deg }|`
+  - If `n_moved(L, L') < min_planes_moved` for any `L'` → `L` is too similar; **reject** (don't add).
+- Else → accept; append to `accepted_layouts`.
+- If `len(accepted_layouts) == alternatives` → terminate search; return `status="found"`.
+
+**Heading delta normalization**: `min(|a − b|, 360 − |a − b|)` — i.e., the shorter arc, so that `0°` and `359°` are 1° apart, not 359° apart.
+
+**Diversity-impossible detection.** If `(|fleet_in| − |pinned_planes|) < min_planes_moved` AND `alternatives > 1`, the user cannot mathematically get more than one accepted layout: every candidate `L'` after the first will share too many planes with `L` to pass the `n_moved ≥ min_planes_moved` test. Solver logs a warning at `solve()` entry (`"requested K alternatives but only 1 is achievable (M of N planes pinned)"`) but does **not** mutate the target `K` — search runs to budget, and the natural outcome is `found_partial` with one accepted layout. This is honest and avoids the API question of "what does it mean if the solver returned `found` for K=3 but actually only found 1 because it downgraded?"
+
+### 4.7 Termination
+
+Search ends when EITHER:
+
+- `len(accepted_layouts) == alternatives` → `status = "found"`.
+- Wall time exceeds `budget_s` → `status` derived from accepted count:
+  - 0 accepted → `"exhausted_budget"` (diagnostics carries best partial).
+  - `0 < n < alternatives` → `"found_partial"`.
+  - `n == alternatives` → `"found"` (we hit budget exactly while filling — equivalent to the first condition by milliseconds).
+
+### 4.8 Reproducibility
+
+`solver.py` instantiates one `random.Random(seed)`. Every sampling decision (initial placement, perturbation, candidate selection, restart bucket index) pulls from it. `seed=None` resolves to `secrets.randbits(32)` at `solve()` entry; the resolved seed is recorded in `SolverDiagnostics.seed`.
+
+Cart-assignment round-robin uses a non-random counter (the restart index) — it's deterministic by construction.
+
+---
+
+## 5. CLI surface (Section C)
+
+### 5.1 Subcommand
+
+```
+hangarfit solve SCENARIO
+                [--budget SEC]
+                [--alternatives N]
+                [--seed S]
+                [--render PATTERN]
+                [--write-yaml PATTERN]
+                [--strict-k]
+                [--json]
+                [--fleet PATH]
+                [--hangar PATH]
+```
+
+- `SCENARIO` — positional, required. Path to the scenario YAML.
+- `--budget SEC` — float seconds, default 30.0. Wall-clock budget for the whole solve.
+- `--alternatives N` — int, default 1. K diverse layouts to return (see §4.6).
+- `--seed S` — int, optional. None resolves to entropy; resolved value recorded in diagnostics.
+- `--render PATTERN` — write top-down PNGs. **Must contain `{i}` placeholder** if `--alternatives > 1`; loud error otherwise. For K=1, `{i}` is optional (substituted with `1` if present).
+- `--write-yaml PATTERN` — write a layout YAML per returned layout. Same `{i}` placeholder rule.
+- `--strict-k` — if `found_partial`, exit 1 instead of 0. Default off.
+- `--json` — switch human stdout to JSON (schema `hangarfit.solve/v1`).
+- `--fleet`, `--hangar` — same semantics as `check`'s overrides: refuse if scenario YAML also embeds the ref.
+
+### 5.2 Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Found ≥ 1 valid layout (`status` in `{"found", "found_partial"}`). `--strict-k` makes `found_partial` → 1. |
+| 1 | No valid layout found (`status` in `{"exhausted_budget", "trivially_infeasible"}`). |
+| 2 | Loader / usage error (LoaderError, argparse error, IO error during render/yaml write). |
+
+`--strict-k` only flips 0→1 for `found_partial`. `found` stays 0; `exhausted_budget` / `trivially_infeasible` stay 1.
+
+### 5.3 Stdout (human)
+
+```
+$ hangarfit solve scenario.yaml --alternatives 3 --render out_{i}.png
+Found 3 layouts in 4.2s (seed=42, 47 restarts).
+  #1: 6 planes placed; 0 conflicts; score=(0, 0.0)
+  #2: 5 of 6 planes shifted vs #1 (avg shift 2.1 m)
+  #3: 6 of 6 planes shifted vs #1 (avg shift 3.4 m), 5 of 6 vs #2
+Wrote out_1.png, out_2.png, out_3.png
+```
+
+For `exhausted_budget`:
+
+```
+$ hangarfit solve scenario.yaml --budget 5
+No valid layout found in 5.0s (seed=2731415, 12 restarts).
+Best partial had 2 conflicts:
+  - wing_wing_overlap [husky, ctsl]: closest distance 0.04 m (threshold 0.30 m)
+  - hangar_bounds [falke]: extends 1.20 m past back wall
+Hint: increase --budget, or relax pins.
+```
+
+For `trivially_infeasible`:
+
+```
+$ hangarfit solve scenario.yaml
+Trivially infeasible: fleet footprint exceeds hangar floor area.
+  Σ plane bbox areas: 412.3 m²
+  hangar floor area:  450.0 m²
+  utilization:        91.6% (effective max with clearances: ~85%)
+```
+
+### 5.4 Stdout (JSON, schema `hangarfit.solve/v1`)
+
+```json
+{
+  "schema": "hangarfit.solve/v1",
+  "scenario": "scenario.yaml",
+  "status": "found",
+  "layouts": [
+    {
+      "placements": [
+        { "plane": "husky", "x_m": 2.1, "y_m": 14.3, "heading_deg": 0.0, "on_carts": false },
+        ...
+      ],
+      "maintenance_plane": "falke"
+    },
+    ...
+  ],
+  "diagnostics": {
+    "restarts_attempted": 47,
+    "wall_time_s": 4.211,
+    "seed": 42,
+    "best_partial": null,
+    "best_partial_layout": null
+  }
+}
+```
+
+`best_partial` and `best_partial_layout` are populated only for non-found statuses. The `best_partial` payload mirrors `hangarfit.check/v1`'s `conflicts` structure.
+
+### 5.5 Loader behavior (`load_scenario`)
+
+| Step | Behavior |
+|---|---|
+| YAML parse error | `LoaderError(f"{path}: YAML parse error: ...")` — same as Phase 1 |
+| Missing required key (`fleet_in`, `maintenance`, etc.) | `LoaderError(f"{path}: missing required field 'X'")` |
+| `fleet:` / `hangar:` both embedded and overridden | `LoaderError` — refuse to silently choose one |
+| Path resolution for `fleet:` / `hangar:` | Resolved relative to scenario YAML's parent directory (same as `load_layout`) |
+| `Scenario.__post_init__` raises `ValueError` | Wrap in `LoaderError(f"{path}: {e}")` |
+
+Strict coercion via existing `_to_float` / `_to_bool` for all scalar fields.
+
+### 5.6 Error handling matrix
+
+| Trigger | Where caught | User sees | Exit |
+|---|---|---|---|
+| Invalid YAML | `LoaderError` from `load_scenario` | `error: <path>: YAML parse error: ...` | 2 |
+| Unknown plane_id in `fleet_in` | `Scenario.__post_init__` → `LoaderError` | `error: <path>: fleet_in references unknown plane 'X'` | 2 |
+| Pin outside hangar | Pre-search check (§4.1.3); status `trivially_infeasible` | `Trivially infeasible: pin for plane 'X' is outside hangar` | 1 |
+| Two pins clash | Same as above | `Trivially infeasible: pins for 'X' and 'Y' overlap` | 1 |
+| Diversity impossible | Logged warning at solve() entry; search continues to budget | `Warning: requested 3 alternatives but only 1 is achievable (5 of 6 planes pinned). Expect status=found_partial.` | 0 (or 1 with `--strict-k`) |
+| Budget exhausted, 0 valid | Status `exhausted_budget`, `best_partial` populated | Conflict list from best partial | 1 |
+| Budget exhausted, partial K | Status `found_partial` | Layouts written, summary noted | 0 (or 1 with `--strict-k`) |
+| Render IO error | `OSError` caught in `cmd_solve` | `error: render failed: ...` | 2 |
+| `--render` PATTERN lacks `{i}` and K>1 | argparse-level check or early validation in `cmd_solve` | `error: --render PATTERN must contain '{i}' when --alternatives > 1` | 2 |
+
+---
+
+## 6. Testing strategy (Section D)
+
+### 6.1 Fixture format
+
+YAML fixtures in `tests/fixtures/`, naming convention `solve_<class>_<slug>.yaml` paralleling existing `valid_*` / `invalid_*` layout fixtures. New fixture classes: `solve_fresh_*`, `solve_repair_*`, `solve_infeasible_*`, `solve_pinned_*`, `solve_cart_*`. Authored via the existing `/new-fixture` scaffolding skill.
+
+### 6.2 Property assertions (every fixture test)
+
+Every solve test asserts:
+
+1. `result.status` matches the expected enum value.
+2. For every layout in `result.layouts`, `collisions.check(layout).valid is True`. (Re-checking via Phase 1 is the independent validation that solver correctness rests on.)
+3. `result.diagnostics.seed` is populated (`isinstance(int)`, not None).
+4. If `result.status in {"exhausted_budget", "trivially_infeasible"}`: `result.diagnostics.best_partial is not None`.
+5. If `len(result.layouts) > 1`: every pair `(L_i, L_j)` satisfies the diversity rule (`n_moved >= min_planes_moved`).
+6. If `result.status == "trivially_infeasible"`: `result.diagnostics.wall_time_s < 0.5` (pre-search check ran, no actual search burned).
+
+### 6.3 Determinism
+
+A small canary fixture subset (3–5 scenarios) is tested for **bit-for-bit equality** across runs with the same seed: `solve(s, seed=42) == solve(s, seed=42)`. The canary set is explicitly fragile — any deliberate algorithm tweak requires updating the expected outputs, which is correct behavior (loud signal on accidental determinism breaks).
+
+Outcome-equality (same status, same K modulo ordering) is asserted on the broader fixture matrix where bit-for-bit would be too brittle.
+
+### 6.4 CI budget
+
+Default per-fixture solve budget = **5 seconds**. Acceptable: 12 fixtures × 5 s = 60 s for the solver suite. Any test that needs > 5 s gets `@pytest.mark.slow` and is excluded from CI default (run on demand via `pytest -m slow`).
+
+### 6.5 v1 fixture matrix
+
+| Fixture slug | Scenario summary | Expected outcome |
+|---|---|---|
+| `solve_trivial_single_plane` | 1 plane, no constraints, large hangar | `found`, K=1 |
+| `solve_fresh_six_planes` | 6 planes, maintenance plane set | `found`, K=1 |
+| `solve_fresh_alternatives_three` | 6 planes, `alternatives=3` | `found`, K=3, mutual diversity |
+| `solve_pinned_one_plane` | 6 planes, 1 pinned | `found`, pinned unchanged |
+| `solve_repair_minimal_edit` | 6 planes, 5 pinned to baseline | `found`, only the unpinned plane is in a different position vs. baseline |
+| `solve_infeasible_pins_clash` | 2 pins overlapping | `trivially_infeasible`, diagnostic names clashing pair |
+| `solve_infeasible_too_big` | 9 planes in placeholder hangar | `trivially_infeasible` via Σ areas |
+| `solve_force_carts_lock` | Cessna 140 forced `on_carts: true` | `found`, returned layout respects lock |
+| `solve_force_carts_conflict` | `always_cart` plane forced `on_carts: false` | `LoaderError` at scenario load |
+| `solve_diversity_impossible_warn` | 5 of 6 pinned, `alternatives=3` | `found_partial` K=1, warning emitted (capture via `caplog`) |
+| `solve_maintenance_bay_required` | Maintenance plane set, no pin | `found`, maintenance plane centroid in bay strip |
+| `solve_all_nine_large_hangar` | All 9 + `test_hangar_large.yaml` | `found`, valid |
+
+12 fixtures. New regressions drop in as fixtures #13, #14, … exactly like Phase 1.
+
+### 6.6 What is NOT in v1 tests
+
+Explicitly out of scope: performance regression tests (CI noise too high), stochastic robustness (run-with-`seed=None` × N), multi-process / threading, visual PNG regression, Hypothesis-style generated scenarios. All deferred to future work as concrete needs surface.
+
+---
+
+## 7. Phase 1 changes required
+
+**Module touched:** `src/hangarfit/models.py`, `src/hangarfit/collisions.py`.
+
+### 7.1 `CheckResult` extension
+
+Add one field, default 0.0:
+
+```python
+@dataclass(frozen=True, slots=True)
+class CheckResult:
+    conflicts: tuple[Conflict, ...] = ()
+    total_penetration_m2: float = 0.0
+
+    @property
+    def valid(self) -> bool:
+        return len(self.conflicts) == 0
+```
+
+`valid` continues to be derived from `conflicts`. `total_penetration_m2` is informational only — the existing validity contract is unchanged.
+
+### 7.2 `collisions.check()` populates penetration
+
+For each conflict with two planes (`len(c.planes) == 2`), compute the overlap area between the two specific conflicting `Part` polygons via shapely `polygon.intersection(other).area` and add it to the running sum. Conflicts with a single plane (`len(c.planes) == 1` — currently `maintenance_position`, `maintenance_no_fuselage`, `hangar_bounds`) contribute 0 to the sum: they describe "a plane in the wrong place" rather than "two planes overlapping" and have no second polygon to intersect against. The total is stored in `CheckResult.total_penetration_m2`.
+
+The implementation must remember **which `Part` polygons** were the conflicting pair for each pairwise conflict, since `Conflict.planes` only records the *aircraft* IDs, not which specific parts overlapped. Easiest path: during the pairwise sweep in `check()`, when a conflict fires, the two `Part` polygons are already in scope — accumulate `intersection.area` at the same site, before constructing the `Conflict`.
+
+### 7.3 JSON schema backward compatibility
+
+`hangarfit.check/v1` schema currently emits `{ "valid": bool, "conflicts": [...] }`. The new field is *not* emitted by default (zero changes to existing JSON output); a follow-up v1.1 of the schema could surface it if needed. New solver JSON schema (`hangarfit.solve/v1`) uses the field internally for scoring but doesn't expose it in user output (would only confuse).
+
+### 7.4 Performance cost
+
+Adds `O(|conflicts|)` shapely intersection-area calls per `check()`. Shapely is already in the dependency set and intersection-area is fast (microseconds for the polygon sizes here). No measurable cost expected for the typical 0–10 conflicts per call.
+
+### 7.5 Test impact
+
+Existing Phase 1 `check()` fixture tests that assert exact `CheckResult` equality will still pass because the default `total_penetration_m2=0.0` matches their `CheckResult()` constructors. Tests that construct `CheckResult` manually (golden tests in `test_collisions.py`) may need to add the new field — backward-compatible default minimizes churn.
+
+---
+
+## 8. Open questions and dependencies
+
+| Item | Status | Impact |
+|---|---|---|
+| Real Herrenteich hangar dimensions (issue #79) | Open | Solver outputs are illustrative until this lands — but implementation can proceed against placeholders. |
+| Real aircraft measurements (every `measured: false` in fleet.yaml) | Open | Same as above. |
+| `SearchConfig` hyperparameter defaults (N=8, K_stall=50, sigmas) | Guess | Tune empirically once we have a few real scenarios solved. v1 ships the guesses; v1.1 may revise. |
+| Budget default (30 s) | Guess | Same. |
+| `DiversityConfig` defaults (M=2, 0.5 m, 30°) | Guess | Operator feedback once solver is in use. |
+
+---
+
+## 9. Out of scope (v1.1+ candidates)
+
+- **Structured min-conflicts moves.** Use the conflict's penetration axis as a direction for perturbations. Requires extending `Conflict` to carry an axis vector. Higher-quality moves; better convergence on hard scenarios.
+- **Soft constraints / preferences.** Quality metrics like "minimize depth of plane X" (for early-rollout-tomorrow scenarios). Layered on top of `(count, penetration)` scoring as a tertiary key.
+- **Region constraints.** Per-plane rectangle "must be inside this box."
+- **Heading-only locks** (without position pin).
+- **Adjacency / non-adjacency constraints.**
+- **CLI flags for `SearchConfig` hyperparameters.**
+- **Hypothesis-style property tests** with a `Scenario` generator.
+
+These all sit on top of v1 without requiring v1 changes — additive.
+
+---
+
+## 10. Implementation sequencing (to be detailed by `superpowers:writing-plans` skill)
+
+Anticipated rough ordering — the writing-plans skill will produce the actual checklist:
+
+1. Phase 1 surgery — extend `CheckResult` + `collisions.check()` for penetration depth (§7).
+2. New types in `models.py` — `PlaneConstraint`, `Scenario`, `SolveStatus`, `SolverDiagnostics`, `SolveResult`, `DiversityConfig`, `SearchConfig`.
+3. `loader.load_scenario` + YAML schema tests.
+4. `solver.py` skeleton: `solve()` signature, pre-search infeasibility checks (§4.1), short-circuit returns.
+5. Initial placement (§4.2) + cart-assignment round-robin.
+6. Descent step + scoring (§4.3, §4.4).
+7. Restart trigger + diversity filter (§4.5, §4.6).
+8. Termination + diagnostics population (§4.7).
+9. CLI subcommand `hangarfit solve` (§5).
+10. v1 fixture matrix (§6.5).
+11. Determinism canary fixtures (§6.3).

--- a/docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md
+++ b/docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md
@@ -176,11 +176,11 @@ Scenario YAML schema:
 ```yaml
 fleet: ../data/fleet.yaml
 hangar: ../data/hangar.yaml
-fleet_in: [husky, fuji, ctsl, falke, fk9_mkii, cessna_140]
+fleet_in: [aviat_husky, fuji, ctsl, scheibe_falke, fk9_mkii, cessna_140]
 maintenance:
-  plane: falke
+  plane: scheibe_falke
 constraints:
-  husky:
+  aviat_husky:
     pin: { x_m: 2.1, y_m: 14.3, heading_deg: 0, on_carts: false }
   cessna_140:
     force_on_carts: true
@@ -200,7 +200,7 @@ The algorithm family is **RR-MC**: many independent random-initialized trajector
 
 Before the first restart, run three literal-impossibility tests in order. If any fires, return `SolveResult(status="trivially_infeasible", layouts=(), diagnostics=...)`.
 
-1. **Per-plane bounding box vs. hangar.** For each plane in `fleet_in`, compute its axis-aligned plane-local bbox (max extent over all `Parts`); reject if `bbox.length > hangar.length_m` *or* `bbox.width > hangar.length_m` (using `length_m` for both because the plane can be rotated). Catches typos like a 200 m wingspan.
+1. **Per-plane bounding box vs. hangar.** For each plane in `fleet_in`, compute a coarse plane-local bbox by taking the maximum `length_m` and maximum `width_m` over all of the plane's `Parts` (ignoring per-part offsets — see §7.1 / §10.3 for why this is a *lower bound* on the true outline, which is safe as a literal-infeasibility gate but not as a tight feasibility check). Then reject if `bbox_length > max(hangar.length_m, hangar.width_m)` *or* `bbox_width > max(hangar.length_m, hangar.width_m)` — using `max(...)` for both because the plane can be rotated into either orientation. Catches typos like a 200 m wingspan.
 2. **Σ areas vs. hangar floor area.** Sum each plane's bbox area; reject if `> hangar.length_m × hangar.width_m`. (No margin — only flag *literal* infeasibility.)
 3. **Pin self-collision.** Build a `Layout` containing only the pinned planes (skipping all unpinned ones); call `collisions.check()`. Any conflict → infeasible, return the conflict list as `diagnostics.best_partial` so the user sees which two pins clash, or which pin lies outside the hangar (caught as a `hangar_bounds` conflict).
 
@@ -344,8 +344,8 @@ For `exhausted_budget`:
 $ hangarfit solve scenario.yaml --budget 5
 No valid layout found in 5.0s (seed=2731415, 12 restarts).
 Best partial had 2 conflicts:
-  - wing_wing_overlap [husky, ctsl]: closest distance 0.04 m (threshold 0.30 m)
-  - hangar_bounds [falke]: extends 1.20 m past back wall
+  - wing_wing_overlap [aviat_husky, ctsl]: closest distance 0.04 m (threshold 0.30 m)
+  - hangar_bounds [scheibe_falke]: extends 1.20 m past back wall
 Hint: increase --budget, or relax pins.
 ```
 
@@ -369,10 +369,10 @@ Trivially infeasible: fleet footprint exceeds hangar floor area.
   "layouts": [
     {
       "placements": [
-        { "plane": "husky", "x_m": 2.1, "y_m": 14.3, "heading_deg": 0.0, "on_carts": false },
+        { "plane": "aviat_husky", "x_m": 2.1, "y_m": 14.3, "heading_deg": 0.0, "on_carts": false },
         ...
       ],
-      "maintenance_plane": "falke"
+      "maintenance_plane": "scheibe_falke"
     },
     ...
   ],


### PR DESCRIPTION
## Summary

Lands the design + implementation plan for the Phase 2a static layout solver as docs-only artifacts under \`docs/superpowers/\`. No code changes; pure documentation.

- **Spec** (`docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md`, 552 lines): designs a solver that takes a fleet subset + hard constraints and returns up to K diverse valid layouts via random-restart hill climbing with min-conflicts descent. Includes adversarial decision review per @DocGerd's review-style preference.
- **Plan** (`docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md`, 3636 lines): 7 sequential chunks (A through G), one PR per chunk, with bite-sized TDD steps and exact code snippets per task.

## Key design choices (full justification in spec §2 + §3-6)

- **Scoring**: hierarchical `(conflict_count, total_penetration_m2)`. Requires a small Phase 1 extension to `CheckResult` — this lands as chunk A.
- **Algorithm**: RR-MC (random-restart + min-conflicts descent). Approach 2 (SA) and 3 (greedy backtracking) were considered and explicitly rejected in the spec.
- **Cart assignment**: round-robin per restart (changed from initial "random" proposal during adversarial review).
- **Pre-search infeasibility**: three literal-impossibility checks; no fuzzy heuristics (the 0.95 area-margin was dropped during review).
- **Diversity**: edit-count (≥2 planes moved >0.5 m OR >30°).
- **CLI**: `hangarfit solve SCENARIO [--budget] [--alternatives N] [--render {i}.png] [--write-yaml {i}.yaml] [--strict-k] [--json]`.

## What's NOT in this PR

- No code. Implementation lands across 7 follow-up PRs per the plan (chunks A-G).
- No new fixtures yet. They're created as their owning chunk lands.

## Related

Closes #80
Depends on #79 (real Herrenteich hangar dims — needed to validate solver outputs against operational reality, but not a hard blocker for implementation against placeholders)

## Test plan

- [x] Pre-commit hooks pass on both files (trim, EOF, large-files, merge-conflicts)
- [ ] Comment-analyzer subagent review (in /pr-review run) — spec + plan have a lot of prose; comment-analyzer is the right specialist for verifying clarity and that claims in the docs reflect the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)