### PR TITLE
CheckResult: add total_penetration_m2 populated by collisions.check()

### DIFF
--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -418,13 +418,13 @@ gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" -f '{"labels":["enha
 
 (Milestone assignment optional — leave blank unless a Phase 2 milestone exists.)
 
-- [ ] **Step 4: Run the PR review skill**
+- [x] **Step 4: Run the PR review skill**
 
 In your Claude Code session, invoke: `/pr-review` (or the `pr-review-toolkit:review-pr` skill).
 
 Convert each finding into a review thread on the diff via `gh api .../pulls/<n>/comments`. Resolve each thread by fixing the code (preferred) or replying with rationale. If the changes were non-trivial, re-run `/pr-review`.
 
-- [ ] **Step 5: Hand off to user for approval and merge**
+- [x] **Step 5: Hand off to user for approval and merge**
 
 Tell the user the PR is clean and ready for final review. Do NOT `gh pr merge` from Claude.
 

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -216,13 +216,13 @@ EOF
 - Modify: `src/hangarfit/collisions.py` (compute + accumulate at the conflict site)
 - Modify: `tests/test_collisions.py` (assertion on populated value)
 
-- [ ] **Step 1: Read the existing `check()` implementation**
+- [x] **Step 1: Read the existing `check()` implementation**
 
 Run: `head -100 src/hangarfit/collisions.py`
 
 Then read the full file to locate the pairwise sweep where conflicts are emitted. Identify the line where the conflict's two `Part` polygons are in scope (likely just before the `Conflict.pair(...)` factory call). The penetration accumulation goes at that same site so we don't need to recompute the polygons.
 
-- [ ] **Step 2: Write the failing test**
+- [x] **Step 2: Write the failing test**
 
 Add to `tests/test_collisions.py`:
 
@@ -278,13 +278,13 @@ def test_check_total_penetration_excludes_single_plane_conflicts(tmp_path):
 
 **Note on fixture names:** `invalid_two_planes_wing_overlap.yaml` and `invalid_plane_out_of_bounds.yaml` are illustrative — substitute the exact fixture filenames present in `tests/fixtures/`. Verify with `ls tests/fixtures/invalid_*` and pick fixtures whose names match these semantics. If none match exactly, pick the closest and adjust the test names accordingly. Do NOT add new fixtures in this chunk — that's Chunk G's job.
 
-- [ ] **Step 3: Run the new tests, expect failure**
+- [x] **Step 3: Run the new tests, expect failure**
 
 Run: `pytest tests/test_collisions.py::test_check_populates_total_penetration_for_overlapping_wings tests/test_collisions.py::test_check_total_penetration_is_zero_for_valid_layout tests/test_collisions.py::test_check_total_penetration_excludes_single_plane_conflicts -v`
 
 Expected: the populated-penetration test FAILs with `Expected non-zero penetration ... got 0.0`. The other two PASS (default 0.0 already satisfies them).
 
-- [ ] **Step 4: Implement the penetration accumulator in `collisions.check()`**
+- [x] **Step 4: Implement the penetration accumulator in `collisions.check()`**
 
 In `src/hangarfit/collisions.py`:
 
@@ -319,19 +319,19 @@ In `src/hangarfit/collisions.py`:
 1. **DRY** — the helper exists and is already used elsewhere in the codebase.
 2. **Consistency** — its return value (0.0 when the polygons don't intersect) matches our semantic ("penetration depth" means actual overlap, not clearance violation) without needing inline `if intersects` guards.
 
-- [ ] **Step 5: Run the new tests, expect pass**
+- [x] **Step 5: Run the new tests, expect pass**
 
 Run: `pytest tests/test_collisions.py::test_check_populates_total_penetration_for_overlapping_wings tests/test_collisions.py::test_check_total_penetration_is_zero_for_valid_layout tests/test_collisions.py::test_check_total_penetration_excludes_single_plane_conflicts -v`
 
 Expected: all three PASS.
 
-- [ ] **Step 6: Run the full test suite to confirm no regressions**
+- [x] **Step 6: Run the full test suite to confirm no regressions**
 
 Run: `pytest -q`
 
 Expected: all existing tests still pass.
 
-- [ ] **Step 7: Run lint + format + type check**
+- [x] **Step 7: Run lint + format + type check**
 
 ```bash
 ruff check src/ tests/
@@ -341,7 +341,7 @@ mypy src/hangarfit/
 
 Expected: all three pass with no errors. If `ruff format --check` reports differences, run `ruff format src/ tests/` and re-stage. If `mypy` complains about `intersection().area` typing, add a `# type: ignore[union-attr]` only if shapely's stubs are the issue — but first try just running it; recent shapely usually types correctly.
 
-- [ ] **Step 8: Commit the check() implementation**
+- [x] **Step 8: Commit the check() implementation**
 
 ```bash
 git add src/hangarfit/collisions.py tests/test_collisions.py

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -50,7 +50,7 @@ The work splits into **7 sequential chunks**, each landing as one PR into `devel
 
 ### Task A.0: Branch + issue setup
 
-- [ ] **Step 1: Create the GitHub issue**
+- [x] **Step 1: Create the GitHub issue**
 
 Run:
 
@@ -82,7 +82,7 @@ EOF
 
 Expected: prints the issue URL. Note the issue number (call it \`#A\` below) for the PR body.
 
-- [ ] **Step 2: Create the branch off the latest `develop`**
+- [x] **Step 2: Create the branch off the latest `develop`**
 
 ```bash
 git switch develop
@@ -98,7 +98,7 @@ Expected: confirms switch + reports "Switched to a new branch ..."
 - Modify: `src/hangarfit/models.py:404-415` (the `CheckResult` definition)
 - Modify: `tests/test_models.py` (add default-value test)
 
-- [ ] **Step 1: Write the failing test for the new field default**
+- [x] **Step 1: Write the failing test for the new field default**
 
 Add to `tests/test_models.py`:
 
@@ -121,13 +121,13 @@ def test_check_result_total_penetration_field_is_kept():
     assert result.valid is True  # still derived from conflicts, not from penetration
 ```
 
-- [ ] **Step 2: Run the new tests, expect failure**
+- [x] **Step 2: Run the new tests, expect failure**
 
 Run: `pytest tests/test_models.py::test_check_result_default_total_penetration_is_zero tests/test_models.py::test_check_result_total_penetration_field_is_kept -v`
 
 Expected: both FAIL with `TypeError: ... got an unexpected keyword argument 'total_penetration_m2'` (or similar — the field doesn't exist yet).
 
-- [ ] **Step 3: Add the field to `CheckResult`**
+- [x] **Step 3: Add the field to `CheckResult`**
 
 In `src/hangarfit/models.py`, find the `CheckResult` dataclass (around line 404). Modify it from:
 
@@ -174,19 +174,19 @@ class CheckResult:
         return len(self.conflicts) == 0
 ```
 
-- [ ] **Step 4: Run the same tests, expect pass**
+- [x] **Step 4: Run the same tests, expect pass**
 
 Run: `pytest tests/test_models.py::test_check_result_default_total_penetration_is_zero tests/test_models.py::test_check_result_total_penetration_field_is_kept -v`
 
 Expected: both PASS.
 
-- [ ] **Step 5: Run the full test suite to confirm no regressions**
+- [x] **Step 5: Run the full test suite to confirm no regressions**
 
 Run: `pytest -q`
 
 Expected: all existing tests still pass. (The default value ensures literal `CheckResult()` constructors elsewhere still work; the new field is invisible to consumers that don't ask for it.)
 
-- [ ] **Step 6: Commit the field extension**
+- [x] **Step 6: Commit the field extension**
 
 ```bash
 git add src/hangarfit/models.py tests/test_models.py

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -367,13 +367,13 @@ EOF
 
 ### Task A.3: Chunk A wrap-up — push, PR, review
 
-- [ ] **Step 1: Push the branch**
+- [x] **Step 1: Push the branch**
 
 Run: `git push -u origin feature/phase2a-checkresult-penetration`
 
 Expected: branch pushed, tracking set up.
 
-- [ ] **Step 2: Open the PR**
+- [x] **Step 2: Open the PR**
 
 ```bash
 gh pr create --base develop \
@@ -407,7 +407,7 @@ EOF
 
 Expected: prints the PR URL.
 
-- [ ] **Step 3: Set PR metadata via gh api (label + milestone)**
+- [x] **Step 3: Set PR metadata via gh api (label + milestone)**
 
 Per memory `feedback_pr_metadata.md`, `gh pr edit` is broken in this repo. Use `gh api -X PATCH` to set labels and (optionally) milestone:
 

--- a/src/hangarfit/collisions.py
+++ b/src/hangarfit/collisions.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 from shapely.ops import unary_union
 
-from .geometry import WorldPart, aircraft_parts_world, polygon_overlap
+from .geometry import WorldPart, aircraft_parts_world, polygon_overlap, polygon_overlap_area
 from .models import CheckResult, Conflict, Hangar, Layout
 
 
@@ -50,8 +50,12 @@ def check(layout: Layout) -> CheckResult:
     conflicts: list[Conflict] = []
     conflicts.extend(_hangar_bounds_conflicts(world_parts, layout.hangar))
     conflicts.extend(_maintenance_conflicts(world_parts, layout))
-    conflicts.extend(_pairwise_conflicts(world_parts, layout.hangar))
-    return CheckResult(conflicts=tuple(conflicts))
+    pairwise, total_penetration_m2 = _pairwise_conflicts(world_parts, layout.hangar)
+    conflicts.extend(pairwise)
+    return CheckResult(
+        conflicts=tuple(conflicts),
+        total_penetration_m2=total_penetration_m2,
+    )
 
 
 def _hangar_bounds_conflicts(
@@ -156,7 +160,9 @@ def _maintenance_conflicts(
     return []
 
 
-def _pairwise_conflicts(world_parts: dict[str, list[WorldPart]], hangar: Hangar) -> list[Conflict]:
+def _pairwise_conflicts(
+    world_parts: dict[str, list[WorldPart]], hangar: Hangar
+) -> tuple[list[Conflict], float]:
     """For every pair of parts from *different* aircraft, emit a conflict
     iff both the plan-view-overlap rule and the z-overlap rule fire.
 
@@ -183,8 +189,18 @@ def _pairwise_conflicts(world_parts: dict[str, list[WorldPart]], hangar: Hangar)
     is the intended shape — these are two distinct geometric collisions
     (one per physical strut), not a duplicate. The ``detail`` strings
     differ via their z-ranges and the gap computation.
+
+    Returns a ``(conflicts, total_penetration_m2)`` tuple. The second
+    component accumulates the shapely ``intersection().area`` (via
+    :func:`hangarfit.geometry.polygon_overlap_area`) of every pairwise
+    conflict — used as Phase 2a's secondary scoring key to break
+    plateaus in the integer conflict-count metric. Clearance-only
+    conflicts (polygons within ``clearance_m`` but not actually
+    intersecting) contribute 0, matching the spec's "two planes
+    overlapping" framing.
     """
     out: list[Conflict] = []
+    total_penetration_m2 = 0.0
     ids = list(world_parts.keys())
     for i in range(len(ids)):
         for j in range(i + 1, len(ids)):
@@ -193,7 +209,8 @@ def _pairwise_conflicts(world_parts: dict[str, list[WorldPart]], hangar: Hangar)
                 for pb in world_parts[b_id]:
                     if _parts_conflict(pa, pb, hangar):
                         out.append(_build_pairwise_conflict(pa, pb, a_id, b_id, hangar))
-    return out
+                        total_penetration_m2 += polygon_overlap_area(pa.polygon, pb.polygon)
+    return out, total_penetration_m2
 
 
 def _parts_conflict(pa: WorldPart, pb: WorldPart, hangar: Hangar) -> bool:

--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -106,7 +106,10 @@ def polygon_overlap(p1: Polygon, p2: Polygon, clearance: float = 0.0) -> bool:
 def polygon_overlap_area(p1: Polygon, p2: Polygon) -> float:
     """Area of the intersection of two polygons (``0.0`` if disjoint).
 
-    Useful for the ``Conflict.detail`` message ("overlap by 0.18 m²").
+    Used by :func:`hangarfit.collisions._pairwise_conflicts` to accumulate
+    :attr:`hangarfit.models.CheckResult.total_penetration_m2` (Phase 2a's
+    secondary scoring key) — and historically to format the
+    ``Conflict.detail`` "overlap by 0.18 m²" message.
     """
     if not p1.intersects(p2):
         return 0.0

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -11,6 +11,7 @@ The full coordinate convention and parts-model collision rule live in
 
 from __future__ import annotations
 
+import math
 import typing
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -418,6 +419,16 @@ class CheckResult:
 
     conflicts: tuple[Conflict, ...] = ()
     total_penetration_m2: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.total_penetration_m2):
+            raise ValueError(
+                f"total_penetration_m2 must be finite, got {self.total_penetration_m2!r}"
+            )
+        if self.total_penetration_m2 < 0.0:
+            raise ValueError(
+                f"total_penetration_m2 must be >= 0.0, got {self.total_penetration_m2}"
+            )
 
     @property
     def valid(self) -> bool:

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -406,9 +406,18 @@ class CheckResult:
 
     ``valid`` is a derived property — there is no way to construct a
     ``CheckResult`` that claims to be valid while carrying conflicts.
+
+    ``total_penetration_m2`` is the summed shapely-``intersection().area``
+    across pairwise conflicts (length-2 ``Conflict.planes``) — used by
+    the Phase 2a solver as a smooth secondary scoring key to break
+    plateaus in the integer ``len(conflicts)`` metric. Single-plane
+    conflicts (``maintenance_position``, ``maintenance_no_fuselage``,
+    ``hangar_bounds``) contribute 0. The validity contract is unchanged:
+    ``valid`` is still derived from ``conflicts`` only.
     """
 
     conflicts: tuple[Conflict, ...] = ()
+    total_penetration_m2: float = 0.0
 
     @property
     def valid(self) -> bool:

--- a/tests/test_collisions.py
+++ b/tests/test_collisions.py
@@ -271,33 +271,50 @@ class TestMaintenancePosition:
         )
 
 
-def test_check_populates_total_penetration_for_overlapping_wings():
-    """Two planes whose wings overlap in plan view should produce a
-    non-zero total_penetration_m2 equal to the sum of intersection areas."""
-    layout = _load("invalid_wing_wing_same_height")
-    result = check(layout)
+class TestTotalPenetration:
+    """Behavioral tests for ``CheckResult.total_penetration_m2``.
 
-    assert not result.valid
-    assert result.total_penetration_m2 > 0.0, (
-        f"Expected non-zero penetration for overlapping wings; got {result.total_penetration_m2}"
-    )
+    Penetration is the summed shapely ``intersection().area`` across pairwise
+    conflicts, used by the Phase 2a solver as a smooth tie-breaker on top of
+    the integer conflict count. These tests pin:
 
+    1. the exact value for a single-pair overlap (axis-aligned, deterministic),
+    2. the sum semantic across multiple pair-collisions in one layout,
+    3. the zero-on-valid-layout contract,
+    4. the "single-plane conflicts contribute 0" rule from
+       :func:`hangarfit.collisions._pairwise_conflicts`'s docstring.
+    """
 
-def test_check_total_penetration_is_zero_for_valid_layout():
-    """Valid layouts have total_penetration_m2 == 0.0 by construction."""
-    layout = load_layout(Path(__file__).resolve().parent.parent / "layouts" / "example.yaml")
-    result = check(layout)
+    def test_exact_value_for_single_wing_wing_overlap(self) -> None:
+        layout = _load("invalid_wing_wing_same_height")
+        result = check(layout)
 
-    assert result.valid
-    assert result.total_penetration_m2 == 0.0
+        assert not result.valid
+        assert result.total_penetration_m2 == pytest.approx(4.0373, abs=1e-4)
 
+    def test_sums_across_multiple_pair_conflicts(self) -> None:
+        """3 pairwise conflicts in ``invalid_strut_blocks_nesting`` should
+        sum to the deterministic 1.4305 m² total — pins the ``+=``
+        accumulator semantic against future refactors to ``=``, ``max``,
+        or ``mean``."""
+        layout = _load("invalid_strut_blocks_nesting")
+        result = check(layout)
 
-def test_check_total_penetration_excludes_single_plane_conflicts():
-    """Single-plane conflicts (hangar_bounds, maintenance_position) contribute 0."""
-    layout = _load("invalid_hangar_bounds")
-    result = check(layout)
+        assert len(result.conflicts) == 3
+        assert result.total_penetration_m2 == pytest.approx(1.4305, abs=1e-4)
 
-    assert not result.valid
-    # Every conflict here is single-plane (hangar_bounds).
-    assert all(len(c.planes) == 1 for c in result.conflicts)
-    assert result.total_penetration_m2 == 0.0
+    def test_zero_for_valid_layout(self) -> None:
+        layout = _load("valid_two_separated")
+        result = check(layout)
+
+        assert result.valid
+        assert result.total_penetration_m2 == 0.0
+
+    def test_single_plane_conflicts_contribute_zero(self) -> None:
+        layout = _load("invalid_hangar_bounds")
+        result = check(layout)
+
+        assert not result.valid
+        # Every conflict here is single-plane (hangar_bounds).
+        assert all(len(c.planes) == 1 for c in result.conflicts)
+        assert result.total_penetration_m2 == 0.0

--- a/tests/test_collisions.py
+++ b/tests/test_collisions.py
@@ -269,3 +269,35 @@ class TestMaintenancePosition:
         assert "maintenance_no_fuselage" in _conflict_kinds(result), (
             f"expected maintenance_no_fuselage conflict, got {result.conflicts!r}"
         )
+
+
+def test_check_populates_total_penetration_for_overlapping_wings():
+    """Two planes whose wings overlap in plan view should produce a
+    non-zero total_penetration_m2 equal to the sum of intersection areas."""
+    layout = _load("invalid_wing_wing_same_height")
+    result = check(layout)
+
+    assert not result.valid
+    assert result.total_penetration_m2 > 0.0, (
+        f"Expected non-zero penetration for overlapping wings; got {result.total_penetration_m2}"
+    )
+
+
+def test_check_total_penetration_is_zero_for_valid_layout():
+    """Valid layouts have total_penetration_m2 == 0.0 by construction."""
+    layout = load_layout(Path(__file__).resolve().parent.parent / "layouts" / "example.yaml")
+    result = check(layout)
+
+    assert result.valid
+    assert result.total_penetration_m2 == 0.0
+
+
+def test_check_total_penetration_excludes_single_plane_conflicts():
+    """Single-plane conflicts (hangar_bounds, maintenance_position) contribute 0."""
+    layout = _load("invalid_hangar_bounds")
+    result = check(layout)
+
+    assert not result.valid
+    # Every conflict here is single-plane (hangar_bounds).
+    assert all(len(c.planes) == 1 for c in result.conflicts)
+    assert result.total_penetration_m2 == 0.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -774,23 +774,27 @@ class TestCheckResult:
         assert r.valid is False
         assert len(r.conflicts) == 1
 
+    def test_default_total_penetration_is_zero(self) -> None:
+        """Default-constructed CheckResult has total_penetration_m2 == 0.0."""
+        result = CheckResult()
+        assert result.total_penetration_m2 == 0.0
+        assert result.valid is True
 
-def test_check_result_default_total_penetration_is_zero():
-    """Default-constructed CheckResult has total_penetration_m2 == 0.0."""
-    from hangarfit.models import CheckResult
+    def test_total_penetration_field_is_independent_of_validity(self) -> None:
+        """Explicit penetration is preserved; validity is conflict-derived only."""
+        result = CheckResult(total_penetration_m2=2.5)
+        assert result.total_penetration_m2 == 2.5
+        assert result.valid is True  # derived from conflicts, not penetration
 
-    result = CheckResult()
-    assert result.total_penetration_m2 == 0.0
-    assert result.valid is True
+    def test_total_penetration_rejects_nan(self) -> None:
+        """NaN would silently corrupt Phase 2a's lexicographic sort key."""
+        with pytest.raises(ValueError, match="must be finite"):
+            CheckResult(total_penetration_m2=float("nan"))
 
-
-def test_check_result_total_penetration_field_is_kept():
-    """Explicit penetration value is preserved."""
-    from hangarfit.models import CheckResult
-
-    result = CheckResult(total_penetration_m2=2.5)
-    assert result.total_penetration_m2 == 2.5
-    assert result.valid is True  # still derived from conflicts, not from penetration
+    def test_total_penetration_rejects_negative(self) -> None:
+        """A summed area is non-negative by construction; reject anything else."""
+        with pytest.raises(ValueError, match="must be >= 0.0"):
+            CheckResult(total_penetration_m2=-0.1)
 
 
 class TestFrozenBehavior:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -775,6 +775,24 @@ class TestCheckResult:
         assert len(r.conflicts) == 1
 
 
+def test_check_result_default_total_penetration_is_zero():
+    """Default-constructed CheckResult has total_penetration_m2 == 0.0."""
+    from hangarfit.models import CheckResult
+
+    result = CheckResult()
+    assert result.total_penetration_m2 == 0.0
+    assert result.valid is True
+
+
+def test_check_result_total_penetration_field_is_kept():
+    """Explicit penetration value is preserved."""
+    from hangarfit.models import CheckResult
+
+    result = CheckResult(total_penetration_m2=2.5)
+    assert result.total_penetration_m2 == 2.5
+    assert result.valid is True  # still derived from conflicts, not from penetration
+
+
 class TestFrozenBehavior:
     """Cross-cutting: every public dataclass should be frozen."""
 


### PR DESCRIPTION
## Summary

- Adds `CheckResult.total_penetration_m2: float = 0.0` (backward-compatible default).
- `collisions.check()` populates it by summing shapely `intersection().area` across pairwise conflicts. Single-plane conflicts contribute 0.
- Existing JSON schema (`hangarfit.check/v1`) is unchanged — the new field is internal-use-only.

Phase 1 substrate change required by Phase 2a's hierarchical scoring function. See `docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md` §7.

Closes #82

## Test plan

- [x] `pytest -q` — full suite green
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`
- [x] `mypy src/hangarfit/`
- [x] New tests added for: default value, populated value on wing overlap, zero on valid layout, zero on single-plane-only conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)