### PR TITLE
Models + loader: Scenario, PlaneConstraint, SolveResult, load_scenario

### DIFF
--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -445,7 +445,7 @@ Tell the user the PR is clean and ready for final review. Do NOT `gh pr merge` f
 
 ### Task B.0: Branch + issue setup
 
-- [ ] **Step 1: Update local develop**
+- [x] **Step 1: Update local develop**
 
 ```bash
 git switch develop
@@ -454,7 +454,7 @@ git pull --ff-only
 
 Expected: `develop` is up to date with Chunk A merged in.
 
-- [ ] **Step 2: Create the issue**
+- [x] **Step 2: Create the issue**
 
 ```bash
 gh issue create \
@@ -482,7 +482,7 @@ EOF
 
 Note the issue number as `#B`.
 
-- [ ] **Step 3: Create the branch**
+- [x] **Step 3: Create the branch**
 
 ```bash
 git switch -c feature/phase2a-scenario-types
@@ -494,7 +494,7 @@ git switch -c feature/phase2a-scenario-types
 - Modify: `src/hangarfit/models.py`
 - Modify: `tests/test_models.py` (or create `tests/test_scenario.py`; both fine — put PlaneConstraint tests with whichever feels right; this plan uses `tests/test_scenario.py`)
 
-- [ ] **Step 1: Write failing tests for `PlaneConstraint`**
+- [x] **Step 1: Write failing tests for `PlaneConstraint`**
 
 Create `tests/test_scenario.py`:
 
@@ -533,13 +533,13 @@ def test_plane_constraint_can_carry_force_on_carts():
     assert c.pin is None
 ```
 
-- [ ] **Step 2: Run, expect failure**
+- [x] **Step 2: Run, expect failure**
 
 Run: `pytest tests/test_scenario.py -v`
 
 Expected: FAIL — `ImportError: cannot import name 'PlaneConstraint'`.
 
-- [ ] **Step 3: Add `PlaneConstraint` to `models.py`**
+- [x] **Step 3: Add `PlaneConstraint` to `models.py`**
 
 Insert the following at the end of `src/hangarfit/models.py` (after `CheckResult`, keeping imports sorted at the top):
 
@@ -557,13 +557,13 @@ class PlaneConstraint:
     force_on_carts: bool | None = None
 ```
 
-- [ ] **Step 4: Run, expect pass**
+- [x] **Step 4: Run, expect pass**
 
 Run: `pytest tests/test_scenario.py -v`
 
 Expected: PASS for all three.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/hangarfit/models.py tests/test_scenario.py
@@ -584,7 +584,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 - Modify: `src/hangarfit/models.py`
 - Modify: `tests/test_scenario.py`
 
-- [ ] **Step 1: Write failing tests for `Scenario` invariants**
+- [x] **Step 1: Write failing tests for `Scenario` invariants**
 
 Append to `tests/test_scenario.py`:
 
@@ -747,13 +747,13 @@ def test_scenario_rejects_pin_and_force_on_carts_disagreement(fleet, hangar):
         )
 ```
 
-- [ ] **Step 2: Run, expect failure**
+- [x] **Step 2: Run, expect failure**
 
 Run: `pytest tests/test_scenario.py -v`
 
 Expected: all new Scenario tests FAIL — `ImportError: cannot import name 'Scenario'`.
 
-- [ ] **Step 3: Implement `Scenario` with all invariant checks**
+- [x] **Step 3: Implement `Scenario` with all invariant checks**
 
 Append to `src/hangarfit/models.py` (after `PlaneConstraint`):
 
@@ -880,19 +880,19 @@ You'll need to add `field` to the imports near the top of `models.py`:
 from dataclasses import dataclass, field
 ```
 
-- [ ] **Step 4: Run, expect pass**
+- [x] **Step 4: Run, expect pass**
 
 Run: `pytest tests/test_scenario.py -v`
 
 Expected: all 9 Scenario tests PASS.
 
-- [ ] **Step 5: Run full suite — no regressions**
+- [x] **Step 5: Run full suite — no regressions**
 
 Run: `pytest -q`
 
 Expected: green.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/hangarfit/models.py tests/test_scenario.py
@@ -918,7 +918,7 @@ EOF
 - Modify: `src/hangarfit/models.py`
 - Modify: `tests/test_scenario.py` (or new file — keep in test_scenario.py for cohesion)
 
-- [ ] **Step 1: Write failing tests for the output types and configs**
+- [x] **Step 1: Write failing tests for the output types and configs**
 
 Append to `tests/test_scenario.py`:
 
@@ -986,13 +986,13 @@ def test_search_config_defaults():
     assert s.heading_sigma_deg == 10.0
 ```
 
-- [ ] **Step 2: Run, expect failure**
+- [x] **Step 2: Run, expect failure**
 
 Run: `pytest tests/test_scenario.py -v -k 'SolveStatus or diagnostics or solve_result or diversity_config or search_config'`
 
 (Mix of test names; substitute as appropriate.) Expected: FAIL with ImportError.
 
-- [ ] **Step 3: Add the remaining types**
+- [x] **Step 3: Add the remaining types**
 
 Append to `src/hangarfit/models.py`:
 
@@ -1044,13 +1044,13 @@ class SearchConfig:
     heading_sigma_deg: float = 10.0
 ```
 
-- [ ] **Step 4: Run, expect pass**
+- [x] **Step 4: Run, expect pass**
 
 Run: `pytest tests/test_scenario.py -v`
 
 Expected: all tests PASS.
 
-- [ ] **Step 5: Run full suite + lint + type check**
+- [x] **Step 5: Run full suite + lint + type check**
 
 ```bash
 pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
@@ -1058,7 +1058,7 @@ pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy s
 
 Expected: all green.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/hangarfit/models.py tests/test_scenario.py
@@ -1090,7 +1090,7 @@ EOF
 - Create: `tests/fixtures/scenario_bad_unknown_plane.yaml`
 - Create: `tests/fixtures/scenario_bad_force_carts_conflict.yaml`
 
-- [ ] **Step 1: Create the fixtures**
+- [x] **Step 1: Create the fixtures**
 
 `tests/fixtures/scenario_minimal.yaml`:
 
@@ -1143,7 +1143,7 @@ constraints:
     force_on_carts: true   # aviat_husky is always_own_gear → contradiction
 ```
 
-- [ ] **Step 2: Write failing tests for `load_scenario`**
+- [x] **Step 2: Write failing tests for `load_scenario`**
 
 Create `tests/test_loader_scenario.py`:
 
@@ -1231,13 +1231,13 @@ def test_load_scenario_missing_fleet_in(tmp_path):
         load_scenario(missing)
 ```
 
-- [ ] **Step 3: Run, expect failure**
+- [x] **Step 3: Run, expect failure**
 
 Run: `pytest tests/test_loader_scenario.py -v`
 
 Expected: all FAIL with `ImportError: cannot import name 'load_scenario'`.
 
-- [ ] **Step 4: Implement `load_scenario`**
+- [x] **Step 4: Implement `load_scenario`**
 
 Add to `src/hangarfit/loader.py`:
 
@@ -1365,13 +1365,13 @@ from .models import (
 )
 ```
 
-- [ ] **Step 5: Run, expect pass**
+- [x] **Step 5: Run, expect pass**
 
 Run: `pytest tests/test_loader_scenario.py -v`
 
 Expected: all 8 tests PASS.
 
-- [ ] **Step 6: Run full suite + lint + type check**
+- [x] **Step 6: Run full suite + lint + type check**
 
 ```bash
 pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
@@ -1379,7 +1379,7 @@ pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy s
 
 Expected: green.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add src/hangarfit/loader.py tests/test_loader_scenario.py tests/fixtures/scenario_*.yaml

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -1404,13 +1404,13 @@ EOF
 
 ### Task B.5: Chunk B wrap-up
 
-- [ ] **Step 1: Push the branch**
+- [x] **Step 1: Push the branch**
 
 ```bash
 git push -u origin feature/phase2a-scenario-types
 ```
 
-- [ ] **Step 2: Open PR (base develop)**
+- [x] **Step 2: Open PR (base develop)**
 
 ```bash
 gh pr create --base develop \
@@ -1439,7 +1439,7 @@ EOF
 )"
 ```
 
-- [ ] **Step 3: Set PR labels via gh api**
+- [x] **Step 3: Set PR labels via gh api**
 
 ```bash
 PR_NUMBER=<from Step 2>

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -1446,7 +1446,7 @@ PR_NUMBER=<from Step 2>
 gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" -f '{"labels":["enhancement"]}'
 ```
 
-- [ ] **Step 4: Run `/pr-review`, resolve threads, hand off**
+- [x] **Step 4: Run `/pr-review`, resolve threads, hand off**
 
 Same flow as Chunk A. Don't merge.
 

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -30,6 +30,8 @@ from .models import (
     MaintenanceBay,
     Part,
     Placement,
+    PlaneConstraint,
+    Scenario,
     StrutsSpec,
 )
 
@@ -210,6 +212,114 @@ def load_layout(
         )
     except ValueError as e:
         raise LoaderError(f"{path}: {e}") from e
+
+
+def load_scenario(
+    path: Path | str,
+    *,
+    fleet: dict[str, Aircraft] | None = None,
+    hangar: Hangar | None = None,
+) -> Scenario:
+    """Load a scenario YAML into a validated :class:`Scenario`.
+
+    Path resolution and override-conflict policy mirror :func:`load_layout`.
+    """
+    path = Path(path)
+    raw = _read_yaml(path)
+    if not isinstance(raw, dict):
+        raise LoaderError(f"{path}: top-level must be a mapping")
+
+    # fleet_in (required) — checked before fleet/hangar are loaded so that
+    # a missing required field is reported as such, rather than as a
+    # downstream "file not found" when the fleet path is bogus.
+    if "fleet_in" not in raw:
+        raise LoaderError(f"{path}: missing required field 'fleet_in'")
+    fleet_in_raw = raw["fleet_in"]
+    if not isinstance(fleet_in_raw, list):
+        raise LoaderError(f"{path}: 'fleet_in' must be a list")
+    fleet_in = tuple(str(x) for x in fleet_in_raw)
+
+    # fleet / hangar — same pattern as load_layout
+    if fleet is None:
+        fleet_ref = raw.get("fleet")
+        if fleet_ref is None:
+            raise LoaderError(
+                f"{path}: 'fleet' field is required when no fleet override is provided"
+            )
+        fleet = load_fleet((path.parent / fleet_ref).resolve())
+    elif "fleet" in raw:
+        raise LoaderError(
+            f"{path}: 'fleet' field is set in YAML but a fleet override was also "
+            f"provided programmatically; remove one to disambiguate"
+        )
+
+    if hangar is None:
+        hangar_ref = raw.get("hangar")
+        if hangar_ref is None:
+            raise LoaderError(
+                f"{path}: 'hangar' field is required when no hangar override is provided"
+            )
+        hangar = load_hangar((path.parent / hangar_ref).resolve())
+    elif "hangar" in raw:
+        raise LoaderError(
+            f"{path}: 'hangar' field is set in YAML but a hangar override was also "
+            f"provided programmatically; remove one to disambiguate"
+        )
+
+    # maintenance (optional, same shape as load_layout)
+    maintenance_plane = _extract_maintenance_plane(raw, path)
+
+    # constraints (optional)
+    constraints_raw = raw.get("constraints") or {}
+    if not isinstance(constraints_raw, dict):
+        raise LoaderError(f"{path}: 'constraints' must be a mapping")
+    constraints: dict[str, PlaneConstraint] = {}
+    for plane_id, cdata in constraints_raw.items():
+        try:
+            constraints[plane_id] = _build_plane_constraint(plane_id, cdata)
+        except (ValueError, KeyError, TypeError, LoaderError) as e:
+            raise LoaderError(f"{path}: constraint {plane_id!r}: {e}") from e
+
+    try:
+        return Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=fleet_in,
+            maintenance_plane=maintenance_plane,
+            constraints=constraints,
+        )
+    except ValueError as e:
+        raise LoaderError(f"{path}: {e}") from e
+
+
+def _build_plane_constraint(plane_id: str, data: Any) -> PlaneConstraint:
+    if not isinstance(data, dict):
+        raise LoaderError(f"must be a mapping, got {type(data).__name__}")
+
+    pin_data = data.get("pin")
+    pin: Placement | None = None
+    if pin_data is not None:
+        if not isinstance(pin_data, dict):
+            raise LoaderError(f"'pin' must be a mapping, got {type(pin_data).__name__}")
+        # pin's plane_id is filled in from the constraint key (the YAML schema
+        # doesn't repeat it — the user already keys it under the plane).
+        required = ("x_m", "y_m", "heading_deg")
+        for key in required:
+            if key not in pin_data:
+                raise LoaderError(f"'pin' missing required field {key!r}")
+        pin = Placement(
+            plane_id=plane_id,
+            x_m=_to_float(pin_data["x_m"], "pin.x_m"),
+            y_m=_to_float(pin_data["y_m"], "pin.y_m"),
+            heading_deg=_to_float(pin_data["heading_deg"], "pin.heading_deg"),
+            on_carts=_to_bool(pin_data.get("on_carts", False), "pin.on_carts"),
+        )
+
+    force_on_carts = data.get("force_on_carts")
+    if force_on_carts is not None:
+        force_on_carts = _to_bool(force_on_carts, "force_on_carts")
+
+    return PlaneConstraint(pin=pin, force_on_carts=force_on_carts)
 
 
 def _extract_maintenance_plane(raw: dict, path: Path) -> str | None:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -222,7 +222,22 @@ def load_scenario(
 ) -> Scenario:
     """Load a scenario YAML into a validated :class:`Scenario`.
 
-    Path resolution and override-conflict policy mirror :func:`load_layout`.
+    Path resolution and override-conflict policy mirror :func:`load_layout`:
+    ``fleet:`` and ``hangar:`` YAML refs are resolved relative to the
+    scenario file's directory (with the absolute-path-overrides-join
+    behaviour of :class:`pathlib.Path`), and passing ``fleet=`` or
+    ``hangar=`` as a kwarg while the YAML *also* sets the corresponding
+    field raises ``LoaderError`` rather than letting one source of truth
+    silently shadow the other.
+
+    Scenario YAML schema:
+
+    ``fleet_in: [plane_id, ...]`` is required and must be non-empty.
+    ``maintenance: {plane: plane_id}`` is optional.
+    ``constraints`` is a mapping of ``plane_id -> {pin?, force_on_carts?}``;
+    see :func:`_build_plane_constraint` for the pin schema (notably:
+    ``pin.plane_id`` is taken from the constraint key, NOT repeated under
+    the pin block).
     """
     path = Path(path)
     raw = _read_yaml(path)
@@ -269,8 +284,14 @@ def load_scenario(
     # maintenance (optional, same shape as load_layout)
     maintenance_plane = _extract_maintenance_plane(raw, path)
 
-    # constraints (optional)
-    constraints_raw = raw.get("constraints") or {}
+    # constraints (optional). `or {}` is wrong here — it collapses every
+    # falsy YAML value (including `constraints: []` or `constraints: 0`)
+    # to `{}` before the isinstance check, silently treating shape bugs
+    # as "no constraints". Use explicit None-handling so the isinstance
+    # check actually fires for non-dict shapes.
+    constraints_raw = raw.get("constraints", {})
+    if constraints_raw is None:  # explicit YAML null: `constraints:`
+        constraints_raw = {}
     if not isinstance(constraints_raw, dict):
         raise LoaderError(f"{path}: 'constraints' must be a mapping")
     constraints: dict[str, PlaneConstraint] = {}
@@ -293,6 +314,34 @@ def load_scenario(
 
 
 def _build_plane_constraint(plane_id: str, data: Any) -> PlaneConstraint:
+    """Build a :class:`PlaneConstraint` from one entry in a scenario YAML
+    ``constraints:`` block.
+
+    YAML schema accepted:
+
+    .. code-block:: yaml
+
+        constraints:
+          <plane_id>:
+            pin: { x_m: <float>, y_m: <float>, heading_deg: <float>, on_carts: <bool> }
+            force_on_carts: <bool>
+
+    Both ``pin`` and ``force_on_carts`` are optional. Omitting both
+    yields a "free" constraint (the solver may place the plane anywhere
+    within physical / cart-rule limits).
+
+    **Implicit ``pin.plane_id``** — the loader fills :attr:`Placement.plane_id`
+    from the constraint key, so authors don't repeat the plane id under
+    the ``pin`` block. The Scenario invariant
+    ``pin.plane_id == constraint key`` only matters when constructing
+    :class:`Scenario` directly in Python.
+
+    **Required ``pin.on_carts``** — there is no sensible default, so the
+    YAML must spell it out explicitly. ``always_cart`` and
+    ``always_own_gear`` planes have a single legal value;
+    ``cart_eligible`` planes have two and a silent default would silently
+    pick the wrong one for users who didn't mean it.
+    """
     if not isinstance(data, dict):
         raise LoaderError(f"must be a mapping, got {type(data).__name__}")
 
@@ -303,7 +352,7 @@ def _build_plane_constraint(plane_id: str, data: Any) -> PlaneConstraint:
             raise LoaderError(f"'pin' must be a mapping, got {type(pin_data).__name__}")
         # pin's plane_id is filled in from the constraint key (the YAML schema
         # doesn't repeat it — the user already keys it under the plane).
-        required = ("x_m", "y_m", "heading_deg")
+        required = ("x_m", "y_m", "heading_deg", "on_carts")
         for key in required:
             if key not in pin_data:
                 raise LoaderError(f"'pin' missing required field {key!r}")
@@ -312,7 +361,7 @@ def _build_plane_constraint(plane_id: str, data: Any) -> PlaneConstraint:
             x_m=_to_float(pin_data["x_m"], "pin.x_m"),
             y_m=_to_float(pin_data["y_m"], "pin.y_m"),
             heading_deg=_to_float(pin_data["heading_deg"], "pin.heading_deg"),
-            on_carts=_to_bool(pin_data.get("on_carts", False), "pin.on_carts"),
+            on_carts=_to_bool(pin_data["on_carts"], "pin.on_carts"),
         )
 
     force_on_carts = data.get("force_on_carts")

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -554,3 +554,50 @@ class Scenario:
         # constraints is also frozen-ish via MappingProxyType, ensure it is
         if not isinstance(self.constraints, MappingProxyType):
             object.__setattr__(self, "constraints", MappingProxyType(dict(self.constraints)))
+
+
+SolveStatus = Literal[
+    "found",
+    "found_partial",
+    "exhausted_budget",
+    "trivially_infeasible",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SolverDiagnostics:
+    """Per-solve diagnostic information."""
+
+    restarts_attempted: int
+    wall_time_s: float
+    best_partial: CheckResult | None
+    best_partial_layout: Layout | None
+    seed: int
+
+
+@dataclass(frozen=True, slots=True)
+class SolveResult:
+    """Public output of solver.solve()."""
+
+    status: SolveStatus
+    layouts: tuple[Layout, ...]
+    diagnostics: SolverDiagnostics
+
+
+@dataclass(frozen=True, slots=True)
+class DiversityConfig:
+    """Diversity-filter thresholds (see spec §4.6)."""
+
+    min_planes_moved: int = 2
+    position_threshold_m: float = 0.5
+    heading_threshold_deg: float = 30.0
+
+
+@dataclass(frozen=True, slots=True)
+class SearchConfig:
+    """Solver hyperparameters (see spec §4.3, §4.5). v1 defaults are guesses."""
+
+    candidates_per_iter: int = 8
+    k_stall: int = 50
+    pos_sigma_m: float = 0.5
+    heading_sigma_deg: float = 10.0

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import math
 import typing
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Literal
 
@@ -446,3 +446,111 @@ class PlaneConstraint:
 
     pin: Placement | None = None
     force_on_carts: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Scenario:
+    """Solver input for Phase 2a.
+
+    Cross-reference invariants validated in __post_init__:
+
+    - every fleet_in id exists in fleet
+    - maintenance_plane (if set) is in fleet_in
+    - constraints.keys() ⊆ set(fleet_in)
+    - for each (plane_id, constraint): constraint.pin.plane_id == plane_id (if pin set)
+    - force_on_carts is consistent with movement_mode:
+        force_on_carts=True  → plane must NOT be always_own_gear
+        force_on_carts=False → plane must NOT be always_cart
+    - pin.on_carts is consistent with movement_mode (same rules)
+    - if both a pin and force_on_carts are set, their on_carts must agree
+    - fleet dict is wrapped in MappingProxyType (same pattern as Layout)
+
+    See spec §3.2 for the rationale.
+    """
+
+    fleet: Mapping[str, Aircraft]
+    hangar: Hangar
+    fleet_in: tuple[str, ...]
+    maintenance_plane: str | None = None
+    constraints: Mapping[str, PlaneConstraint] = field(default_factory=lambda: MappingProxyType({}))
+
+    def __post_init__(self) -> None:
+        # fleet_in must be non-empty (otherwise there's nothing to solve;
+        # downstream helpers like the sum-of-areas infeasibility check
+        # also do `fleet_in[0]` which would IndexError on empty input).
+        if not self.fleet_in:
+            raise ValueError("Scenario.fleet_in must be non-empty")
+
+        # fleet_in references real planes
+        for pid in self.fleet_in:
+            if pid not in self.fleet:
+                raise ValueError(
+                    f"Scenario.fleet_in references unknown plane {pid!r}; "
+                    f"fleet has: {sorted(self.fleet)}"
+                )
+
+        fleet_in_set = set(self.fleet_in)
+
+        # maintenance_plane in fleet_in
+        if self.maintenance_plane is not None and self.maintenance_plane not in fleet_in_set:
+            raise ValueError(
+                f"Scenario.maintenance_plane {self.maintenance_plane!r} must be in fleet_in"
+            )
+
+        # constraint keys ⊆ fleet_in
+        for key in self.constraints:
+            if key not in fleet_in_set:
+                raise ValueError(f"Scenario.constraints has key {key!r} not in fleet_in")
+
+        # per-constraint validation
+        for plane_id, constraint in self.constraints.items():
+            plane = self.fleet[plane_id]
+
+            if constraint.pin is not None:
+                if constraint.pin.plane_id != plane_id:
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].pin.plane_id is "
+                        f"{constraint.pin.plane_id!r}; must equal the constraint key"
+                    )
+
+                # pin.on_carts consistency with movement_mode
+                if plane.movement_mode == "always_cart" and not constraint.pin.on_carts:
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].pin.on_carts=False "
+                        f"contradicts movement_mode={plane.movement_mode!r}"
+                    )
+                if plane.movement_mode == "always_own_gear" and constraint.pin.on_carts:
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].pin.on_carts=True "
+                        f"contradicts movement_mode={plane.movement_mode!r}"
+                    )
+
+            if constraint.force_on_carts is not None:
+                # force_on_carts consistency with movement_mode
+                if constraint.force_on_carts is True and plane.movement_mode == "always_own_gear":
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].force_on_carts=True "
+                        f"contradicts movement_mode={plane.movement_mode!r}"
+                    )
+                if constraint.force_on_carts is False and plane.movement_mode == "always_cart":
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].force_on_carts=False "
+                        f"contradicts movement_mode={plane.movement_mode!r}"
+                    )
+
+            # pin and force_on_carts must agree if both set
+            if (
+                constraint.pin is not None
+                and constraint.force_on_carts is not None
+                and constraint.pin.on_carts != constraint.force_on_carts
+            ):
+                raise ValueError(
+                    f"Scenario.constraints[{plane_id!r}]: pin.on_carts="
+                    f"{constraint.pin.on_carts} and force_on_carts="
+                    f"{constraint.force_on_carts} disagree (contradictory)"
+                )
+
+        object.__setattr__(self, "fleet", MappingProxyType(dict(self.fleet)))
+        # constraints is also frozen-ish via MappingProxyType, ensure it is
+        if not isinstance(self.constraints, MappingProxyType):
+            object.__setattr__(self, "constraints", MappingProxyType(dict(self.constraints)))

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -433,3 +433,16 @@ class CheckResult:
     @property
     def valid(self) -> bool:
         return len(self.conflicts) == 0
+
+
+@dataclass(frozen=True, slots=True)
+class PlaneConstraint:
+    """Per-plane HARD constraints for a Scenario.
+
+    All fields optional — a constraint with everything None means 'free'
+    (the solver may place the plane anywhere within physical / cart-rule
+    limits). See spec §3.2 for the rationale.
+    """
+
+    pin: Placement | None = None
+    force_on_carts: bool | None = None

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -454,6 +454,8 @@ class Scenario:
 
     Cross-reference invariants validated in __post_init__:
 
+    - fleet_in is non-empty
+    - fleet_in has no duplicate entries
     - every fleet_in id exists in fleet
     - maintenance_plane (if set) is in fleet_in
     - constraints.keys() ⊆ set(fleet_in)
@@ -463,7 +465,7 @@ class Scenario:
         force_on_carts=False → plane must NOT be always_cart
     - pin.on_carts is consistent with movement_mode (same rules)
     - if both a pin and force_on_carts are set, their on_carts must agree
-    - fleet dict is wrapped in MappingProxyType (same pattern as Layout)
+    - fleet and constraints are wrapped in MappingProxyType (same pattern as Layout)
 
     See spec §3.2 for the rationale.
     """
@@ -480,6 +482,11 @@ class Scenario:
         # also do `fleet_in[0]` which would IndexError on empty input).
         if not self.fleet_in:
             raise ValueError("Scenario.fleet_in must be non-empty")
+
+        # fleet_in has no duplicates (one Husky can't park in two places).
+        # Mirror of the placements seen-set check in Layout.__post_init__.
+        if len(set(self.fleet_in)) != len(self.fleet_in):
+            raise ValueError(f"Scenario.fleet_in has duplicate entries: {self.fleet_in}")
 
         # fleet_in references real planes
         for pid in self.fleet_in:
@@ -551,9 +558,11 @@ class Scenario:
                 )
 
         object.__setattr__(self, "fleet", MappingProxyType(dict(self.fleet)))
-        # constraints is also frozen-ish via MappingProxyType, ensure it is
-        if not isinstance(self.constraints, MappingProxyType):
-            object.__setattr__(self, "constraints", MappingProxyType(dict(self.constraints)))
+        # Always copy+wrap constraints — mirrors the unconditional pattern on
+        # fleet above (and on Layout.fleet). Skipping the copy when the caller
+        # passes a pre-wrapped MappingProxyType would let the caller leak
+        # mutations through their retained reference to the underlying dict.
+        object.__setattr__(self, "constraints", MappingProxyType(dict(self.constraints)))
 
 
 SolveStatus = Literal[
@@ -566,7 +575,18 @@ SolveStatus = Literal[
 
 @dataclass(frozen=True, slots=True)
 class SolverDiagnostics:
-    """Per-solve diagnostic information."""
+    """Per-solve diagnostic information.
+
+    ``best_partial`` and ``best_partial_layout`` are a fused pair — the
+    lowest-conflict :class:`CheckResult` seen and the matching
+    :class:`Layout` so it can be rendered. They MUST both be set or both
+    be ``None``; carrying one without the other is a self-inconsistent
+    state that would crash downstream rendering (Chunk F's CLI).
+
+    ``seed`` is the *actually-used* seed — ``None`` resolved to entropy
+    on entry to :func:`hangarfit.solver.solve` is recorded here so a run
+    can be replayed exactly.
+    """
 
     restarts_attempted: int
     wall_time_s: float
@@ -574,14 +594,46 @@ class SolverDiagnostics:
     best_partial_layout: Layout | None
     seed: int
 
+    def __post_init__(self) -> None:
+        if (self.best_partial is None) != (self.best_partial_layout is None):
+            raise ValueError(
+                "SolverDiagnostics.best_partial and best_partial_layout must "
+                "both be set or both be None"
+            )
+        if self.restarts_attempted < 0:
+            raise ValueError(
+                f"SolverDiagnostics.restarts_attempted must be >= 0, got {self.restarts_attempted}"
+            )
+        if not math.isfinite(self.wall_time_s) or self.wall_time_s < 0.0:
+            raise ValueError(
+                f"SolverDiagnostics.wall_time_s must be finite and >= 0, got {self.wall_time_s!r}"
+            )
+
 
 @dataclass(frozen=True, slots=True)
 class SolveResult:
-    """Public output of solver.solve()."""
+    """Public output of :func:`hangarfit.solver.solve`.
+
+    ``layouts`` is 0..K valid Layouts, with K matching the caller's
+    ``alternatives`` request. The ``status`` field disambiguates partial
+    runs (see spec §4.7); status and ``layouts`` emptiness must agree:
+
+    - ``"found"`` / ``"found_partial"`` → at least one layout
+    - ``"exhausted_budget"`` / ``"trivially_infeasible"`` → zero layouts
+    """
 
     status: SolveStatus
     layouts: tuple[Layout, ...]
     diagnostics: SolverDiagnostics
+
+    def __post_init__(self) -> None:
+        if self.status in ("found", "found_partial") and not self.layouts:
+            raise ValueError(f"SolveResult.status={self.status!r} requires at least one layout")
+        if self.status in ("exhausted_budget", "trivially_infeasible") and self.layouts:
+            raise ValueError(
+                f"SolveResult.status={self.status!r} must have empty layouts, "
+                f"got {len(self.layouts)}"
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -592,12 +644,53 @@ class DiversityConfig:
     position_threshold_m: float = 0.5
     heading_threshold_deg: float = 30.0
 
+    def __post_init__(self) -> None:
+        if self.min_planes_moved < 1:
+            raise ValueError(
+                f"DiversityConfig.min_planes_moved must be >= 1 "
+                f"(zero makes diversity vacuous), got {self.min_planes_moved}"
+            )
+        if self.position_threshold_m <= 0.0:
+            raise ValueError(
+                f"DiversityConfig.position_threshold_m must be positive, "
+                f"got {self.position_threshold_m}"
+            )
+        if not (0.0 <= self.heading_threshold_deg <= 180.0):
+            raise ValueError(
+                f"DiversityConfig.heading_threshold_deg must be in [0, 180] "
+                f"(shorter arc), got {self.heading_threshold_deg}"
+            )
+
 
 @dataclass(frozen=True, slots=True)
 class SearchConfig:
-    """Solver hyperparameters (see spec §4.3, §4.5). v1 defaults are guesses."""
+    """Solver hyperparameters (see spec §4.3, §4.5).
+
+    v1 defaults are guesses; tune with real data.
+    """
 
     candidates_per_iter: int = 8
     k_stall: int = 50
     pos_sigma_m: float = 0.5
     heading_sigma_deg: float = 10.0
+
+    def __post_init__(self) -> None:
+        if self.candidates_per_iter < 1:
+            raise ValueError(
+                f"SearchConfig.candidates_per_iter must be >= 1 "
+                f"(descent picks one per iter), got {self.candidates_per_iter}"
+            )
+        if self.k_stall < 1:
+            raise ValueError(
+                f"SearchConfig.k_stall must be >= 1 "
+                f"(zero would restart on every iter), got {self.k_stall}"
+            )
+        if self.pos_sigma_m <= 0.0:
+            raise ValueError(
+                f"SearchConfig.pos_sigma_m must be positive "
+                f"(zero freezes the trajectory), got {self.pos_sigma_m}"
+            )
+        if self.heading_sigma_deg <= 0.0:
+            raise ValueError(
+                f"SearchConfig.heading_sigma_deg must be positive, got {self.heading_sigma_deg}"
+            )

--- a/tests/fixtures/scenario_bad_force_carts_conflict.yaml
+++ b/tests/fixtures/scenario_bad_force_carts_conflict.yaml
@@ -1,0 +1,10 @@
+# Invalid: force_on_carts=true on an always_own_gear airframe. The
+# Husky has tundra tires and no cart geometry; the constraint
+# contradicts its movement_mode.
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [aviat_husky]
+constraints:
+  aviat_husky:
+    force_on_carts: true   # aviat_husky is always_own_gear → contradiction

--- a/tests/fixtures/scenario_bad_unknown_plane.yaml
+++ b/tests/fixtures/scenario_bad_unknown_plane.yaml
@@ -1,0 +1,6 @@
+# Invalid: fleet_in references a plane id that doesn't exist in the
+# fleet. Scenario.__post_init__ rejects this.
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [aviat_husky, not_a_real_plane]

--- a/tests/fixtures/scenario_minimal.yaml
+++ b/tests/fixtures/scenario_minimal.yaml
@@ -1,0 +1,6 @@
+# Minimal valid scenario: two planes, no constraints, no maintenance.
+# Used to exercise the load_scenario happy path.
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [aviat_husky, ctsl]

--- a/tests/fixtures/scenario_with_force_carts.yaml
+++ b/tests/fixtures/scenario_with_force_carts.yaml
@@ -1,0 +1,9 @@
+# Scenario with a force_on_carts constraint on a cart_eligible plane
+# (cessna_140 is one of the four cart_eligible airframes).
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [cessna_140, ctsl]
+constraints:
+  cessna_140:
+    force_on_carts: true

--- a/tests/fixtures/scenario_with_pin.yaml
+++ b/tests/fixtures/scenario_with_pin.yaml
@@ -1,0 +1,12 @@
+# Scenario with a pin constraint and a maintenance plane. Pin's plane_id
+# is implicit from the constraint key (the loader fills it in from the
+# key, so YAML authors don't repeat the plane id under the pin block).
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [aviat_husky, ctsl, fuji]
+maintenance:
+  plane: fuji
+constraints:
+  aviat_husky:
+    pin: { x_m: 2.1, y_m: 14.3, heading_deg: 0.0, on_carts: false }

--- a/tests/test_loader_scenario.py
+++ b/tests/test_loader_scenario.py
@@ -1,0 +1,78 @@
+"""Tests for hangarfit.loader.load_scenario."""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.loader import LoaderError
+
+
+def test_load_scenario_minimal():
+    from hangarfit.loader import load_scenario
+
+    s = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    assert s.fleet_in == ("aviat_husky", "ctsl")
+    assert s.maintenance_plane is None
+    assert s.constraints == {}
+
+
+def test_load_scenario_with_pin():
+    from hangarfit.loader import load_scenario
+
+    s = load_scenario("tests/fixtures/scenario_with_pin.yaml")
+    assert s.maintenance_plane == "fuji"
+    assert "aviat_husky" in s.constraints
+    pin = s.constraints["aviat_husky"].pin
+    assert pin is not None
+    assert pin.plane_id == "aviat_husky"  # filled in by loader
+    assert pin.x_m == 2.1
+    assert pin.heading_deg == 0.0
+    assert pin.on_carts is False
+
+
+def test_load_scenario_with_force_carts():
+    from hangarfit.loader import load_scenario
+
+    s = load_scenario("tests/fixtures/scenario_with_force_carts.yaml")
+    assert s.constraints["cessna_140"].force_on_carts is True
+
+
+def test_load_scenario_rejects_unknown_plane():
+    from hangarfit.loader import load_scenario
+
+    with pytest.raises(LoaderError, match="unknown plane"):
+        load_scenario("tests/fixtures/scenario_bad_unknown_plane.yaml")
+
+
+def test_load_scenario_rejects_force_carts_conflict():
+    from hangarfit.loader import load_scenario
+
+    with pytest.raises(LoaderError, match="movement_mode"):
+        load_scenario("tests/fixtures/scenario_bad_force_carts_conflict.yaml")
+
+
+def test_load_scenario_rejects_double_fleet_source(tmp_path):
+    """If YAML embeds `fleet:` AND a fleet override is passed, raise."""
+    from hangarfit.loader import load_fleet, load_scenario
+
+    fleet_obj = load_fleet("data/fleet.yaml")
+    with pytest.raises(LoaderError, match="fleet"):
+        load_scenario("tests/fixtures/scenario_minimal.yaml", fleet=fleet_obj)
+
+
+def test_load_scenario_yaml_parse_error(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("not: valid: yaml: at: all:\n  - [")
+    with pytest.raises(LoaderError, match="YAML parse error"):
+        load_scenario(bad)
+
+
+def test_load_scenario_missing_fleet_in(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    missing = tmp_path / "missing.yaml"
+    missing.write_text("fleet: ../../data/fleet.yaml\nhangar: ../../data/hangar.yaml\n")
+    with pytest.raises(LoaderError, match="fleet_in"):
+        load_scenario(missing)

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+
+from hangarfit.loader import load_fleet, load_hangar
 from hangarfit.models import (
     Placement,
     PlaneConstraint,
@@ -27,3 +30,175 @@ def test_plane_constraint_can_carry_force_on_carts():
     c = PlaneConstraint(force_on_carts=True)
     assert c.force_on_carts is True
     assert c.pin is None
+
+
+# ── Scenario ────────────────────────────────────────────────────────────
+
+# Helpers: build a minimal in-memory fleet + hangar for Scenario tests.
+# We use the real data files rather than synthesizing fakes so that the
+# tests also exercise the loader path indirectly.
+
+
+@pytest.fixture
+def fleet():
+    return load_fleet("data/fleet.yaml")
+
+
+@pytest.fixture
+def hangar():
+    return load_hangar("data/hangar.yaml")
+
+
+def test_scenario_smoke_construct_minimal(fleet, hangar):
+    """Minimal valid scenario constructs cleanly."""
+    from hangarfit.models import Scenario
+
+    s = Scenario(
+        fleet=fleet,
+        hangar=hangar,
+        fleet_in=("aviat_husky", "ctsl"),
+        maintenance_plane=None,
+    )
+    assert s.fleet_in == ("aviat_husky", "ctsl")
+    assert s.maintenance_plane is None
+    assert s.constraints == {}  # MappingProxyType, but == {} works
+
+
+def test_scenario_rejects_empty_fleet_in(fleet, hangar):
+    """Empty fleet_in is nonsense — nothing to solve; downstream solver
+    helpers also assume at least one plane (e.g., fleet_in[0])."""
+    from hangarfit.models import Scenario
+
+    with pytest.raises(ValueError, match="non-empty"):
+        Scenario(fleet=fleet, hangar=hangar, fleet_in=())
+
+
+def test_scenario_rejects_unknown_plane_in_fleet_in(fleet, hangar):
+    from hangarfit.models import Scenario
+
+    with pytest.raises(ValueError, match="unknown plane"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("not_a_real_plane",),
+        )
+
+
+def test_scenario_rejects_maintenance_plane_not_in_fleet_in(fleet, hangar):
+    from hangarfit.models import Scenario
+
+    with pytest.raises(ValueError, match="maintenance_plane"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("aviat_husky",),
+            maintenance_plane="ctsl",  # not in fleet_in
+        )
+
+
+def test_scenario_rejects_constraint_key_not_in_fleet_in(fleet, hangar):
+    from hangarfit.models import PlaneConstraint, Scenario
+
+    with pytest.raises(ValueError, match="constraint"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("aviat_husky",),
+            constraints={"ctsl": PlaneConstraint(force_on_carts=True)},
+        )
+
+
+def test_scenario_rejects_pin_plane_id_mismatch(fleet, hangar):
+    from hangarfit.models import Placement, PlaneConstraint, Scenario
+
+    with pytest.raises(ValueError, match="plane_id"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("aviat_husky", "ctsl"),
+            constraints={
+                "aviat_husky": PlaneConstraint(
+                    pin=Placement(
+                        plane_id="ctsl",  # mismatch — should be "aviat_husky"
+                        x_m=2.0,
+                        y_m=2.0,
+                        heading_deg=0.0,
+                        on_carts=False,
+                    )
+                )
+            },
+        )
+
+
+def test_scenario_rejects_force_on_carts_true_for_always_own_gear(fleet, hangar):
+    """force_on_carts=True is illegal for an always_own_gear plane (Husky)."""
+    from hangarfit.models import PlaneConstraint, Scenario
+
+    with pytest.raises(ValueError, match="movement_mode"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("aviat_husky",),
+            constraints={"aviat_husky": PlaneConstraint(force_on_carts=True)},
+        )
+
+
+def test_scenario_rejects_force_on_carts_false_for_always_cart(fleet, hangar):
+    """force_on_carts=False is illegal for an always_cart plane (Falke)."""
+    from hangarfit.models import PlaneConstraint, Scenario
+
+    with pytest.raises(ValueError, match="movement_mode"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("scheibe_falke",),
+            constraints={"scheibe_falke": PlaneConstraint(force_on_carts=False)},
+        )
+
+
+def test_scenario_rejects_pin_on_carts_inconsistent_with_movement_mode(fleet, hangar):
+    """A pin whose on_carts violates the plane's movement_mode is invalid."""
+    from hangarfit.models import Placement, PlaneConstraint, Scenario
+
+    # Falke is always_cart — a pin with on_carts=False is illegal.
+    with pytest.raises(ValueError, match="movement_mode"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("scheibe_falke",),
+            constraints={
+                "scheibe_falke": PlaneConstraint(
+                    pin=Placement(
+                        plane_id="scheibe_falke",
+                        x_m=2.0,
+                        y_m=2.0,
+                        heading_deg=0.0,
+                        on_carts=False,  # illegal for always_cart
+                    )
+                )
+            },
+        )
+
+
+def test_scenario_rejects_pin_and_force_on_carts_disagreement(fleet, hangar):
+    """If both pin and force_on_carts are set, their on_carts must agree."""
+    from hangarfit.models import Placement, PlaneConstraint, Scenario
+
+    with pytest.raises(ValueError, match="disagree|contradict"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("cessna_140",),  # cart_eligible — both states are valid
+            constraints={
+                "cessna_140": PlaneConstraint(
+                    pin=Placement(
+                        plane_id="cessna_140",
+                        x_m=2.0,
+                        y_m=2.0,
+                        heading_deg=0.0,
+                        on_carts=True,
+                    ),
+                    force_on_carts=False,  # contradicts the pin's on_carts
+                )
+            },
+        )

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from types import MappingProxyType
+
 import pytest
 
 from hangarfit.loader import load_fleet, load_hangar
 from hangarfit.models import (
     Placement,
     PlaneConstraint,
+    Scenario,
 )
 
 # ── PlaneConstraint ─────────────────────────────────────────────────────
@@ -156,10 +159,8 @@ def test_scenario_rejects_force_on_carts_false_for_always_cart(fleet, hangar):
         )
 
 
-def test_scenario_rejects_pin_on_carts_inconsistent_with_movement_mode(fleet, hangar):
+def test_scenario_rejects_pin_on_carts_false_for_always_cart(fleet, hangar):
     """A pin whose on_carts violates the plane's movement_mode is invalid."""
-    from hangarfit.models import Placement, PlaneConstraint, Scenario
-
     # Falke is always_cart — a pin with on_carts=False is illegal.
     with pytest.raises(ValueError, match="movement_mode"):
         Scenario(
@@ -177,6 +178,91 @@ def test_scenario_rejects_pin_on_carts_inconsistent_with_movement_mode(fleet, ha
                     )
                 )
             },
+        )
+
+
+def test_scenario_rejects_pin_on_carts_true_for_always_own_gear(fleet, hangar):
+    """The symmetric half of the always_cart case: on_carts=True on a Husky
+    (always_own_gear) is illegal. Pinned as a separate test so a refactor
+    consolidating the two pin checks can't silently delete one half."""
+    with pytest.raises(ValueError, match="movement_mode"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("aviat_husky",),  # always_own_gear
+            constraints={
+                "aviat_husky": PlaneConstraint(
+                    pin=Placement(
+                        plane_id="aviat_husky",
+                        x_m=2.0,
+                        y_m=2.0,
+                        heading_deg=0.0,
+                        on_carts=True,  # illegal for always_own_gear
+                    )
+                )
+            },
+        )
+
+
+def test_scenario_accepts_pin_and_force_on_carts_agreeing(fleet, hangar):
+    """Positive counterpart to the disagreement test: pin.on_carts and
+    force_on_carts both set to the same value should construct cleanly.
+
+    Pins the agreement-is-fine contract — a refactor that made the
+    disagreement check fire unconditionally (whenever both are set) would
+    silently break a legitimate use case, but the disagreement-only test
+    above would still pass. This test catches it."""
+    s = Scenario(
+        fleet=fleet,
+        hangar=hangar,
+        fleet_in=("cessna_140",),
+        constraints={
+            "cessna_140": PlaneConstraint(
+                pin=Placement(
+                    plane_id="cessna_140",
+                    x_m=2.0,
+                    y_m=2.0,
+                    heading_deg=0.0,
+                    on_carts=True,
+                ),
+                force_on_carts=True,
+            )
+        },
+    )
+    assert s.constraints["cessna_140"].force_on_carts is True
+
+
+def test_scenario_fleet_is_mapping_proxy(fleet, hangar):
+    """Pin the immutability wrap on Scenario.fleet — a refactor that
+    drops the object.__setattr__ in __post_init__ would silently regress
+    the docstring-promised immutability."""
+    s = Scenario(fleet=fleet, hangar=hangar, fleet_in=("aviat_husky",))
+    assert isinstance(s.fleet, MappingProxyType)
+    with pytest.raises(TypeError):
+        s.fleet["x"] = None  # type: ignore[index]
+
+
+def test_scenario_constraints_is_mapping_proxy(fleet, hangar):
+    """Pin the immutability wrap on Scenario.constraints — same risk as
+    test_scenario_fleet_is_mapping_proxy."""
+    s = Scenario(
+        fleet=fleet,
+        hangar=hangar,
+        fleet_in=("aviat_husky",),
+        constraints={"aviat_husky": PlaneConstraint()},
+    )
+    assert isinstance(s.constraints, MappingProxyType)
+    with pytest.raises(TypeError):
+        s.constraints["x"] = PlaneConstraint()  # type: ignore[index]
+
+
+def test_scenario_rejects_duplicate_fleet_in(fleet, hangar):
+    """One plane can't park in two places — fleet_in must have no duplicates."""
+    with pytest.raises(ValueError, match="duplicate"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("aviat_husky", "aviat_husky"),
         )
 
 
@@ -231,25 +317,101 @@ def test_solver_diagnostics_construct():
     assert d.restarts_attempted == 47
 
 
-def test_solve_result_construct():
+def test_solver_diagnostics_rejects_partial_pairing():
+    """best_partial and best_partial_layout are a fused pair — both-or-neither."""
+    from hangarfit.models import CheckResult, SolverDiagnostics
+
+    with pytest.raises(ValueError, match="best_partial"):
+        SolverDiagnostics(
+            restarts_attempted=0,
+            wall_time_s=0.0,
+            best_partial=CheckResult(),  # Some
+            best_partial_layout=None,  # None — mismatched
+            seed=42,
+        )
+
+
+def test_solver_diagnostics_rejects_negative_restarts():
+    from hangarfit.models import SolverDiagnostics
+
+    with pytest.raises(ValueError, match=">= 0"):
+        SolverDiagnostics(
+            restarts_attempted=-1,
+            wall_time_s=0.0,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=42,
+        )
+
+
+def test_solver_diagnostics_rejects_negative_wall_time():
+    from hangarfit.models import SolverDiagnostics
+
+    with pytest.raises(ValueError, match="wall_time_s"):
+        SolverDiagnostics(
+            restarts_attempted=0,
+            wall_time_s=-0.1,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=42,
+        )
+
+
+def test_solve_result_construct_empty_for_infeasible():
+    """Status=trivially_infeasible MUST have empty layouts."""
     from hangarfit.models import (
         SolverDiagnostics,
         SolveResult,
     )
 
-    r = SolveResult(
-        status="found",
-        layouts=(),
-        diagnostics=SolverDiagnostics(
-            restarts_attempted=0,
-            wall_time_s=0.0,
-            best_partial=None,
-            best_partial_layout=None,
-            seed=42,
-        ),
+    diag = SolverDiagnostics(
+        restarts_attempted=0,
+        wall_time_s=0.0,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=42,
     )
-    assert r.status == "found"
+    r = SolveResult(status="trivially_infeasible", layouts=(), diagnostics=diag)
+    assert r.status == "trivially_infeasible"
     assert r.layouts == ()
+
+
+def test_solve_result_rejects_found_with_empty_layouts():
+    """Status=found with empty layouts is self-inconsistent."""
+    from hangarfit.models import (
+        SolverDiagnostics,
+        SolveResult,
+    )
+
+    diag = SolverDiagnostics(
+        restarts_attempted=0,
+        wall_time_s=0.0,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=42,
+    )
+    with pytest.raises(ValueError, match="requires at least one layout"):
+        SolveResult(status="found", layouts=(), diagnostics=diag)
+
+
+def test_solve_result_rejects_infeasible_with_layouts(fleet, hangar):
+    """Status=trivially_infeasible with non-empty layouts is self-inconsistent."""
+    from hangarfit.models import (
+        Layout,
+        SolverDiagnostics,
+        SolveResult,
+    )
+
+    diag = SolverDiagnostics(
+        restarts_attempted=0,
+        wall_time_s=0.0,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=42,
+    )
+    empty_layout = Layout(fleet=fleet, hangar=hangar, placements=())
+    with pytest.raises(ValueError, match="must have empty layouts"):
+        SolveResult(status="trivially_infeasible", layouts=(empty_layout,), diagnostics=diag)
 
 
 # ── DiversityConfig / SearchConfig ──────────────────────────────────────

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -1,0 +1,29 @@
+"""Tests for the Scenario / PlaneConstraint dataclasses in models.py."""
+
+from __future__ import annotations
+
+from hangarfit.models import (
+    Placement,
+    PlaneConstraint,
+)
+
+# ── PlaneConstraint ─────────────────────────────────────────────────────
+
+
+def test_plane_constraint_default_is_free():
+    """A constraint with no fields set means 'free'."""
+    c = PlaneConstraint()
+    assert c.pin is None
+    assert c.force_on_carts is None
+
+
+def test_plane_constraint_can_carry_pin():
+    p = Placement(plane_id="aviat_husky", x_m=2.1, y_m=14.3, heading_deg=0.0, on_carts=False)
+    c = PlaneConstraint(pin=p)
+    assert c.pin == p
+
+
+def test_plane_constraint_can_carry_force_on_carts():
+    c = PlaneConstraint(force_on_carts=True)
+    assert c.force_on_carts is True
+    assert c.pin is None

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -202,3 +202,73 @@ def test_scenario_rejects_pin_and_force_on_carts_disagreement(fleet, hangar):
                 )
             },
         )
+
+
+# ── SolveStatus / SolverDiagnostics / SolveResult ───────────────────────
+
+
+def test_solve_status_literal_values():
+    """SolveStatus must be exactly these four strings."""
+    import typing
+
+    from hangarfit.models import SolveStatus
+
+    values = set(typing.get_args(SolveStatus))
+    assert values == {"found", "found_partial", "exhausted_budget", "trivially_infeasible"}
+
+
+def test_solver_diagnostics_construct():
+    from hangarfit.models import SolverDiagnostics
+
+    d = SolverDiagnostics(
+        restarts_attempted=47,
+        wall_time_s=4.2,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=42,
+    )
+    assert d.seed == 42
+    assert d.restarts_attempted == 47
+
+
+def test_solve_result_construct():
+    from hangarfit.models import (
+        SolverDiagnostics,
+        SolveResult,
+    )
+
+    r = SolveResult(
+        status="found",
+        layouts=(),
+        diagnostics=SolverDiagnostics(
+            restarts_attempted=0,
+            wall_time_s=0.0,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=42,
+        ),
+    )
+    assert r.status == "found"
+    assert r.layouts == ()
+
+
+# ── DiversityConfig / SearchConfig ──────────────────────────────────────
+
+
+def test_diversity_config_defaults():
+    from hangarfit.models import DiversityConfig
+
+    d = DiversityConfig()
+    assert d.min_planes_moved == 2
+    assert d.position_threshold_m == 0.5
+    assert d.heading_threshold_deg == 30.0
+
+
+def test_search_config_defaults():
+    from hangarfit.models import SearchConfig
+
+    s = SearchConfig()
+    assert s.candidates_per_iter == 8
+    assert s.k_stall == 50
+    assert s.pos_sigma_m == 0.5
+    assert s.heading_sigma_deg == 10.0


### PR DESCRIPTION
## Summary

- 7 new dataclasses in models.py: PlaneConstraint, Scenario, SolverDiagnostics, SolveResult, DiversityConfig, SearchConfig (plus SolveStatus Literal)
- load_scenario in loader.py (mirrors load_layout's contract)
- 5 new YAML fixtures (3 valid scenarios, 2 invalid) + 18 new tests across test_scenario.py and test_loader_scenario.py

Pure data plumbing — no behavior change. The solver itself lands in subsequent PRs.

Closes #84

## Test plan

- [x] `pytest -q` — full suite green (278 passed; 252 baseline + 26 new)
- [x] `ruff check src/ tests/` / `ruff format --check` / `mypy src/hangarfit/`
- [x] All 9 Scenario invariants tested (unknown plane, maintenance_plane in fleet_in, constraint key in fleet_in, pin.plane_id mismatch, pin.on_carts vs movement_mode x2, force_on_carts vs movement_mode x2, pin+force disagreement)
- [x] load_scenario tested for happy paths, missing fields, double-source refusal, YAML parse errors

## Notes for review

One small divergence from the merged plan: the `'fleet_in' required` check fires before fleet/hangar are resolved/loaded, so a missing required field is reported as such rather than masked by a downstream "file not found". The plan's `test_load_scenario_missing_fleet_in` implicitly requires this ordering — see commit body of dbd08a9 for details.

Generated with Claude Code (https://claude.com/claude-code)