### PR TITLE
Solver: solve() signature + pre-search infeasibility checks

### DIFF
--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -1971,7 +1971,7 @@ EOF
 
 ### Task C.4: Pre-search infeasibility check 3 — pin self-collision
 
-- [ ] **Step 1: Create the fixture**
+- [x] **Step 1: Create the fixture**
 
 `tests/fixtures/solve_infeasible_pins_clash.yaml`:
 
@@ -1986,7 +1986,7 @@ constraints:
     pin: { x_m: 5.0, y_m: 5.0, heading_deg: 0.0, on_carts: false }   # exact same spot
 ```
 
-- [ ] **Step 2: Write failing test**
+- [x] **Step 2: Write failing test**
 
 Append:
 
@@ -2011,13 +2011,13 @@ def test_solve_trivially_infeasible_when_pins_clash():
     )
 ```
 
-- [ ] **Step 3: Run, expect failure**
+- [x] **Step 3: Run, expect failure**
 
 Run: `pytest tests/test_solver_infeasibility.py::test_solve_trivially_infeasible_when_pins_clash -v`
 
 Expected: FAIL.
 
-- [ ] **Step 4: Implement check #3**
+- [x] **Step 4: Implement check #3**
 
 In `_check_trivially_infeasible`, after check #2:
 
@@ -2062,13 +2062,13 @@ In `_check_trivially_infeasible`, after check #2:
             return pin_check
 ```
 
-- [ ] **Step 5: Run, expect pass**
+- [x] **Step 5: Run, expect pass**
 
 Run: `pytest tests/test_solver_infeasibility.py -v`
 
 Expected: all PASS.
 
-- [ ] **Step 6: Run full suite + lint + type check**
+- [x] **Step 6: Run full suite + lint + type check**
 
 ```bash
 pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
@@ -2076,7 +2076,7 @@ pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy s
 
 Expected: green.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_infeasibility.py tests/fixtures/solve_infeasible_pins_clash.yaml

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -1468,7 +1468,7 @@ Same flow as Chunk A. Don't merge.
 
 ### Task C.0: Branch + issue setup
 
-- [ ] **Step 1: Update develop, create branch**
+- [x] **Step 1: Update develop, create branch**
 
 ```bash
 git switch develop
@@ -1476,7 +1476,7 @@ git pull --ff-only
 git switch -c feature/phase2a-solver-skeleton
 ```
 
-- [ ] **Step 2: Create the issue**
+- [x] **Step 2: Create the issue** (issue #86)
 
 ```bash
 gh issue create \
@@ -1507,7 +1507,7 @@ Note issue number as `#C`.
 - Create: `tests/test_solver_infeasibility.py`
 - Create: `tests/fixtures/solve_feasible_smoke.yaml`
 
-- [ ] **Step 1: Create the feasible smoke fixture**
+- [x] **Step 1: Create the feasible smoke fixture**
 
 `tests/fixtures/solve_feasible_smoke.yaml`:
 
@@ -1519,7 +1519,7 @@ fleet_in: [aviat_husky]
 
 (Single plane, small footprint, large hangar — definitely feasible.)
 
-- [ ] **Step 2: Write the failing smoke test**
+- [x] **Step 2: Write the failing smoke test**
 
 Create `tests/test_solver_infeasibility.py`:
 
@@ -1560,13 +1560,13 @@ def test_solve_resolves_none_seed_to_entropy():
     assert r.diagnostics.seed != 0  # entropy is essentially always nonzero
 ```
 
-- [ ] **Step 3: Run, expect failure**
+- [x] **Step 3: Run, expect failure**
 
 Run: `pytest tests/test_solver_infeasibility.py -v`
 
 Expected: FAIL with `ModuleNotFoundError: No module named 'hangarfit.solver'`.
 
-- [ ] **Step 4: Create the minimal `solver.py`**
+- [x] **Step 4: Create the minimal `solver.py`**
 
 Create `src/hangarfit/solver.py`:
 
@@ -1640,13 +1640,13 @@ def solve(
     )
 ```
 
-- [ ] **Step 5: Run, expect pass**
+- [x] **Step 5: Run, expect pass**
 
 Run: `pytest tests/test_solver_infeasibility.py -v`
 
 Expected: both PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_infeasibility.py tests/fixtures/solve_feasible_smoke.yaml

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -2101,7 +2101,7 @@ EOF
 
 ### Task C.5: Chunk C wrap-up
 
-- [ ] **Step 1: Push, open PR, set metadata, run review, hand off**
+- [x] **Step 1: Push, open PR, set metadata, run review, hand off** (PR #87, label set via `gh api -X PATCH` with `--input -` JSON body. The plan's `-f '{...}'` form is malformed — `-f` takes one `key=value` per flag, not a JSON object. Used `echo '{"labels":["enhancement"]}' | gh api -X PATCH ".../issues/87" --input -` instead.)
 
 ```bash
 git push -u origin feature/phase2a-solver-skeleton

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -413,7 +413,7 @@ Per memory `feedback_pr_metadata.md`, `gh pr edit` is broken in this repo. Use `
 
 ```bash
 PR_NUMBER=<the PR number from Step 2>
-gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" -f '{"labels":["enhancement"]}'
+echo '{"labels":["enhancement"]}' | gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" --input -
 ```
 
 (Milestone assignment optional — leave blank unless a Phase 2 milestone exists.)
@@ -1443,7 +1443,7 @@ EOF
 
 ```bash
 PR_NUMBER=<from Step 2>
-gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" -f '{"labels":["enhancement"]}'
+echo '{"labels":["enhancement"]}' | gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" --input -
 ```
 
 - [x] **Step 4: Run `/pr-review`, resolve threads, hand off**
@@ -2131,7 +2131,7 @@ Closes #C
 EOF
 )"
 PR_NUMBER=<from above>
-gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" -f '{"labels":["enhancement"]}'
+echo '{"labels":["enhancement"]}' | gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" --input -
 ```
 
 Run `/pr-review`, resolve threads, hand off.
@@ -3056,7 +3056,7 @@ EOF
 )"
 
 PR_NUMBER=<from above>
-gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" -f '{"labels":["enhancement"]}'
+echo '{"labels":["enhancement"]}' | gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR_NUMBER" --input -
 ```
 
 Run `/pr-review`, resolve, hand off.

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -1675,7 +1675,7 @@ EOF
 
 **Note:** "plane bbox > hangar" requires a fixture where some plane's max-extent bbox literally exceeds the hangar's larger dimension. Since the real `data/fleet.yaml` planes all fit in `data/hangar.yaml`, we'll synthesize a tiny test-only hangar. (Actually, the Falke's 18 m wing fits in `data/hangar.yaml`'s 25 m length already. Use a 10×10 m fixture hangar so the Falke clearly doesn't fit.)
 
-- [ ] **Step 1: Create the test-only hangar and scenario fixtures**
+- [x] **Step 1: Create the test-only hangar and scenario fixtures**
 
 `tests/fixtures/test_hangar_tiny.yaml` (only if it doesn't exist; check first with `ls tests/fixtures/test_hangar*`):
 
@@ -1699,7 +1699,7 @@ hangar: ./test_hangar_tiny.yaml
 fleet_in: [scheibe_falke]   # 18 m wingspan, won't fit in 10x8 m
 ```
 
-- [ ] **Step 2: Write failing test**
+- [x] **Step 2: Write failing test**
 
 Append to `tests/test_solver_infeasibility.py`:
 
@@ -1719,13 +1719,23 @@ def test_solve_trivially_infeasible_when_plane_too_big_for_hangar():
     assert r.diagnostics.restarts_attempted == 0
 ```
 
-- [ ] **Step 3: Run, expect failure**
+- [x] **Step 3: Run, expect failure**
 
 Run: `pytest tests/test_solver_infeasibility.py::test_solve_trivially_infeasible_when_plane_too_big_for_hangar -v`
 
 Expected: FAIL — status is `exhausted_budget` instead of `trivially_infeasible`.
 
-- [ ] **Step 4: Implement check #1 in `solver.py`**
+- [x] **Step 4: Implement check #1 in `solver.py`**
+
+**Deviation note (Chunk B re-baseline):** Chunk B added a fused-pair
+invariant to `SolverDiagnostics` requiring `best_partial` and
+`best_partial_layout` to both be set or both be None. The plan's
+literal "`best_partial_layout=None`" alongside `best_partial=<CheckResult>`
+violates this. Resolution: `_check_trivially_infeasible` now returns
+`tuple[CheckResult, Layout] | None`; checks #1 and #2 pair the synthetic
+CheckResult with a placement-less Layout via a new `_empty_layout`
+helper, check #3 pairs the CheckResult with the pin-only Layout that
+detected the conflict.
 
 In `src/hangarfit/solver.py`, insert a helper function and a check call inside `solve()` before the short-circuit return. After the `del rng` line, before `start = time.monotonic()`:
 
@@ -1829,13 +1839,13 @@ def _plane_max_extent(plane) -> tuple[float, float]:
 
 Note: also add `field`, `Layout`, `CheckResult`, `Conflict` to the imports of `solver.py` if not already present.
 
-- [ ] **Step 5: Run, expect pass**
+- [x] **Step 5: Run, expect pass**
 
 Run: `pytest tests/test_solver_infeasibility.py -v`
 
 Expected: all PASS, including the new plane-too-big test.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_infeasibility.py tests/fixtures/test_hangar_tiny.yaml tests/fixtures/solve_infeasible_plane_too_big.yaml

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -1870,7 +1870,7 @@ EOF
 
 ### Task C.3: Pre-search infeasibility check 2 — Σ areas > hangar
 
-- [ ] **Step 1: Create the fixture**
+- [x] **Step 1: Create the fixture**
 
 `tests/fixtures/solve_infeasible_too_big.yaml`:
 
@@ -1882,7 +1882,7 @@ fleet_in: [scheibe_falke, aviat_husky, fuji, wild_thing, zlin_savage, cessna_140
 
 (All 9 planes in the placeholder hangar — known too small per memory `project_case12_hangar_workaround`.)
 
-- [ ] **Step 2: Write the failing test**
+- [x] **Step 2: Write the failing test**
 
 Append:
 
@@ -1905,13 +1905,15 @@ def test_solve_trivially_infeasible_when_sum_areas_exceeds_hangar():
                for c in bp.conflicts)
 ```
 
-- [ ] **Step 3: Run, expect failure**
+- [x] **Step 3: Run, expect failure**
 
 Run: `pytest tests/test_solver_infeasibility.py::test_solve_trivially_infeasible_when_sum_areas_exceeds_hangar -v`
 
 Expected: FAIL. The placeholder hangar (25 × 18 = 450 m²) may or may not actually exceed Σ areas of all 9 planes — verify first by hand-summing from `data/fleet.yaml`. If sum < 450 m², adjust the fixture (use `test_hangar_tiny.yaml` as the hangar instead) so the assertion holds.
 
-- [ ] **Step 4: Implement check #2**
+(Verified: 9-plane Σ ≈ 653.8 m² > 450 m². Placeholder hangar is fine.)
+
+- [x] **Step 4: Implement check #2**
 
 In `_check_trivially_infeasible`, after check #1:
 
@@ -1942,13 +1944,13 @@ In `_check_trivially_infeasible`, after check #1:
 
 (Note: the synthetic Conflict picks an arbitrary plane for `planes`; the real information is in `detail`. The spec acknowledges that single-plane vs sum-aggregate conflicts use the same `Conflict` shape.)
 
-- [ ] **Step 5: Run, expect pass**
+- [x] **Step 5: Run, expect pass**
 
 Run: `pytest tests/test_solver_infeasibility.py -v`
 
 Expected: green.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_infeasibility.py tests/fixtures/solve_infeasible_too_big.yaml

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -47,10 +47,13 @@ def solve(
     if search is None:
         search = SearchConfig()
 
-    # Resolve seed
+    # Resolve seed. Validate eagerly — a bad seed would raise here, at
+    # solve() entry, instead of 30 s into Chunk D's search loop. The rng
+    # itself will be re-created when search lands; the construction here
+    # is deliberately preserved (don't "clean it up" as dead code).
     resolved_seed = seed if seed is not None else secrets.randbits(32)
     rng = _random_module.Random(resolved_seed)
-    del rng  # not used in Chunk C — placeholder
+    del rng
 
     # ── Pre-search infeasibility checks (§4.1) ──────────────────────────
     start = time.monotonic()
@@ -160,6 +163,35 @@ def _check_trivially_infeasible(
             pinned_placements.append(constraint.pin)
 
     if pinned_placements:
+        # The cart rule (at most one cart_eligible plane on carts at a
+        # time) is enforced by Layout.__post_init__ but NOT by
+        # Scenario.__post_init__ — that's a cross-pin invariant Scenario
+        # currently doesn't check. Guard explicitly here so we can return
+        # a sharp `pin_cart_rule` conflict instead of silently absorbing
+        # a generic Layout `ValueError`. Morally this check belongs in
+        # Scenario; a follow-up could migrate it to Scenario.__post_init__
+        # so every caller (not just solve()) benefits.
+        cart_eligible_on_carts = sum(
+            1
+            for p in pinned_placements
+            if p.on_carts and scenario.fleet[p.plane_id].movement_mode == "cart_eligible"
+        )
+        if cart_eligible_on_carts > 1:
+            check = CheckResult(
+                conflicts=(
+                    Conflict.single(
+                        kind="trivially_infeasible_pin_cart_rule",
+                        plane=pinned_placements[0].plane_id,
+                        detail=(
+                            f"{cart_eligible_on_carts} cart_eligible pins on "
+                            f"carts (cart rule allows at most 1)"
+                        ),
+                    ),
+                ),
+                total_penetration_m2=0.0,
+            )
+            return check, _empty_layout(scenario)
+
         # Build a Layout containing ONLY the pinned planes.
         # maintenance_plane=None to bypass Layout's "maintenance must be placed"
         # invariant; we're only checking pin-vs-pin and pin-vs-hangar here.
@@ -167,29 +199,18 @@ def _check_trivially_infeasible(
         # only about pin-vs-pin self-collision and pin-vs-hangar bounds; the
         # maintenance-position rule is not in scope at this stage because no
         # maintenance plane is set.)
-        try:
-            pin_only_layout = Layout(
-                fleet=scenario.fleet,
-                hangar=scenario.hangar,
-                placements=tuple(pinned_placements),
-                maintenance_plane=None,
-            )
-        except ValueError as e:
-            # This means the pins themselves violated a Layout invariant
-            # (cart rule, movement_mode mismatch, etc.) — should have been
-            # caught by Scenario.__post_init__, but defend anyway. There is
-            # no Layout to attach, so we fall back to the empty Layout.
-            check = CheckResult(
-                conflicts=(
-                    Conflict.single(
-                        kind="trivially_infeasible_pin_invariant",
-                        plane=pinned_placements[0].plane_id,
-                        detail=f"pin set violates Layout invariant: {e}",
-                    ),
-                ),
-                total_penetration_m2=0.0,
-            )
-            return check, _empty_layout(scenario)
+        # No try/except: every remaining Layout invariant that could fire
+        # here is either structurally impossible given pin-only construction
+        # or already caught by Scenario.__post_init__ (pin.plane_id mismatch,
+        # pin.on_carts vs movement_mode). A genuinely unexpected ValueError
+        # should propagate as a bug, not get silently re-wrapped as a pin
+        # infeasibility.
+        pin_only_layout = Layout(
+            fleet=scenario.fleet,
+            hangar=scenario.hangar,
+            placements=tuple(pinned_placements),
+            maintenance_plane=None,
+        )
 
         pin_check = check_layout(pin_only_layout)
         if not pin_check.valid:

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -16,7 +16,11 @@ import secrets
 import time
 
 from hangarfit.models import (
+    Aircraft,
+    CheckResult,
+    Conflict,
     DiversityConfig,
+    Layout,
     Scenario,
     SearchConfig,
     SolverDiagnostics,
@@ -47,13 +51,28 @@ def solve(
     rng = _random_module.Random(resolved_seed)
     del rng  # not used in Chunk C — placeholder
 
+    # ── Pre-search infeasibility checks (§4.1) ──────────────────────────
     start = time.monotonic()
 
-    # Chunk C: actual search not yet implemented — short-circuit to
-    # exhausted_budget for any feasible scenario. The infeasibility
-    # checks added below replace this short-circuit for infeasible cases.
+    infeasible = _check_trivially_infeasible(scenario)
+    if infeasible is not None:
+        bad_check, bad_layout = infeasible
+        return SolveResult(
+            status="trivially_infeasible",
+            layouts=(),
+            diagnostics=SolverDiagnostics(
+                restarts_attempted=0,
+                wall_time_s=time.monotonic() - start,
+                best_partial=bad_check,
+                best_partial_layout=bad_layout,
+                seed=resolved_seed,
+            ),
+        )
+
     elapsed = time.monotonic() - start
 
+    # Chunk C: actual search not yet implemented — short-circuit to
+    # exhausted_budget for any feasible scenario.
     return SolveResult(
         status="exhausted_budget",
         layouts=(),
@@ -64,4 +83,95 @@ def solve(
             best_partial_layout=None,
             seed=resolved_seed,
         ),
+    )
+
+
+def _check_trivially_infeasible(
+    scenario: Scenario,
+) -> tuple[CheckResult, Layout] | None:
+    """Run the three literal-impossibility checks from spec §4.1.
+
+    Returns ``(check_result, layout)`` if the scenario is provably
+    infeasible (the caller plugs both into
+    :class:`SolverDiagnostics`); else ``None``.
+
+    The Layout is paired with the CheckResult because
+    :class:`SolverDiagnostics` requires ``best_partial`` and
+    ``best_partial_layout`` to both be set or both be ``None``. For
+    checks #1 and #2 (no candidate placements exist yet), the paired
+    Layout is the "empty" Layout — same fleet and hangar as the
+    scenario, with no placements and no maintenance plane. For check #3
+    it is the pin-only Layout that was used to detect the conflict.
+    """
+    # Check 1: per-plane bbox vs hangar
+    for pid in scenario.fleet_in:
+        plane = scenario.fleet[pid]
+        length, width = _plane_max_extent(plane)
+        max_hangar = max(scenario.hangar.length_m, scenario.hangar.width_m)
+        if length > max_hangar or width > max_hangar:
+            check = CheckResult(
+                conflicts=(
+                    Conflict.single(
+                        kind="trivially_infeasible_plane_too_big",
+                        plane=pid,
+                        detail=(
+                            f"plane bbox {length:.1f}x{width:.1f} m exceeds "
+                            f"hangar max dimension {max_hangar:.1f} m"
+                        ),
+                    ),
+                ),
+                total_penetration_m2=0.0,
+            )
+            return check, _empty_layout(scenario)
+
+    # Checks 2 and 3 land in Tasks C.3 and C.4.
+    return None
+
+
+def _plane_max_extent(plane: Aircraft) -> tuple[float, float]:
+    """Return (max_length_m, max_width_m) over all of the plane's Parts.
+
+    Takes the maximum ``length_m`` and maximum ``width_m`` across all
+    parts. This is a **lower bound** on the plane's true plane-local
+    outline — it IGNORES per-part offsets (``Part.offset_x_m``,
+    ``Part.offset_y_m``), so a plane whose individual parts each fit
+    but whose offsets push the combined outline outside will pass
+    this check (false negative).
+
+    That's an acceptable trade-off for the literal-infeasibility gate
+    (Chunk C check #1): false negatives don't cause incorrect
+    rejection — they just defer to the actual search, which detects
+    the failure via ``collisions.check()``. What this function CANNOT
+    produce is a false positive: if even one part's bbox dimension
+    exceeds ``max(hangar.length_m, hangar.width_m)``, the plane
+    provably cannot fit at any heading, regardless of offsets.
+
+    Returns max length and max width as separate values; the caller
+    compares both against ``max(hangar.length_m, hangar.width_m)`` to
+    catch rotation-aware infeasibility (either bbox dim can become
+    the deep one).
+    """
+    max_length = max(p.length_m for p in plane.parts)
+    max_width = max(p.width_m for p in plane.parts)
+    return max_length, max_width
+
+
+def _empty_layout(scenario: Scenario) -> Layout:
+    """Build a placement-less Layout for pairing with a synthetic CheckResult.
+
+    Checks #1 and #2 of :func:`_check_trivially_infeasible` reject the
+    scenario before any placements have been sampled. There is no real
+    Layout to attach to the diagnostic CheckResult, but
+    :class:`SolverDiagnostics` requires ``best_partial`` and
+    ``best_partial_layout`` to be a fused pair. An empty Layout —
+    same fleet and hangar, no placements, no maintenance plane — is
+    the natural "we never got far enough to place anything" stand-in
+    and satisfies ``Layout.__post_init__`` (which only mandates that
+    a non-None ``maintenance_plane`` be placed).
+    """
+    return Layout(
+        fleet=scenario.fleet,
+        hangar=scenario.hangar,
+        placements=(),
+        maintenance_plane=None,
     )

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -15,6 +15,7 @@ import random as _random_module
 import secrets
 import time
 
+from hangarfit.collisions import check as check_layout
 from hangarfit.models import (
     Aircraft,
     CheckResult,
@@ -151,7 +152,49 @@ def _check_trivially_infeasible(
         )
         return check, _empty_layout(scenario)
 
-    # Check 3 lands in Task C.4.
+    # Check 3: pin self-collision (build a pin-only Layout and run check())
+    pinned_placements = []
+    for pid in scenario.fleet_in:
+        constraint = scenario.constraints.get(pid)
+        if constraint is not None and constraint.pin is not None:
+            pinned_placements.append(constraint.pin)
+
+    if pinned_placements:
+        # Build a Layout containing ONLY the pinned planes.
+        # maintenance_plane=None to bypass Layout's "maintenance must be placed"
+        # invariant; we're only checking pin-vs-pin and pin-vs-hangar here.
+        # (Spec §4.1 step 3 spells this out explicitly: the pre-search check is
+        # only about pin-vs-pin self-collision and pin-vs-hangar bounds; the
+        # maintenance-position rule is not in scope at this stage because no
+        # maintenance plane is set.)
+        try:
+            pin_only_layout = Layout(
+                fleet=scenario.fleet,
+                hangar=scenario.hangar,
+                placements=tuple(pinned_placements),
+                maintenance_plane=None,
+            )
+        except ValueError as e:
+            # This means the pins themselves violated a Layout invariant
+            # (cart rule, movement_mode mismatch, etc.) — should have been
+            # caught by Scenario.__post_init__, but defend anyway. There is
+            # no Layout to attach, so we fall back to the empty Layout.
+            check = CheckResult(
+                conflicts=(
+                    Conflict.single(
+                        kind="trivially_infeasible_pin_invariant",
+                        plane=pinned_placements[0].plane_id,
+                        detail=f"pin set violates Layout invariant: {e}",
+                    ),
+                ),
+                total_penetration_m2=0.0,
+            )
+            return check, _empty_layout(scenario)
+
+        pin_check = check_layout(pin_only_layout)
+        if not pin_check.valid:
+            return pin_check, pin_only_layout
+
     return None
 
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -1,0 +1,67 @@
+"""Phase 2a static layout solver.
+
+See ``docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md``
+for the full design. This module is built incrementally across multiple PRs;
+the current implementation supports:
+
+- pre-search infeasibility detection (§4.1)  [Chunk C]
+- random-restart hill climb with min-conflicts descent (§4.2-§4.4)  [Chunk D]
+- K-diverse alternatives + termination (§4.5-§4.7)  [Chunk E]
+"""
+
+from __future__ import annotations
+
+import random as _random_module
+import secrets
+import time
+
+from hangarfit.models import (
+    DiversityConfig,
+    Scenario,
+    SearchConfig,
+    SolverDiagnostics,
+    SolveResult,
+)
+
+
+def solve(
+    scenario: Scenario,
+    *,
+    budget_s: float = 30.0,
+    alternatives: int = 1,
+    seed: int | None = None,
+    diversity: DiversityConfig | None = None,
+    search: SearchConfig | None = None,
+) -> SolveResult:
+    """Solve a Scenario into up to ``alternatives`` diverse valid Layouts.
+
+    See spec §3.3 for the contract.
+    """
+    if diversity is None:
+        diversity = DiversityConfig()
+    if search is None:
+        search = SearchConfig()
+
+    # Resolve seed
+    resolved_seed = seed if seed is not None else secrets.randbits(32)
+    rng = _random_module.Random(resolved_seed)
+    del rng  # not used in Chunk C — placeholder
+
+    start = time.monotonic()
+
+    # Chunk C: actual search not yet implemented — short-circuit to
+    # exhausted_budget for any feasible scenario. The infeasibility
+    # checks added below replace this short-circuit for infeasible cases.
+    elapsed = time.monotonic() - start
+
+    return SolveResult(
+        status="exhausted_budget",
+        layouts=(),
+        diagnostics=SolverDiagnostics(
+            restarts_attempted=0,
+            wall_time_s=elapsed,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=resolved_seed,
+        ),
+    )

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -124,7 +124,34 @@ def _check_trivially_infeasible(
             )
             return check, _empty_layout(scenario)
 
-    # Checks 2 and 3 land in Tasks C.3 and C.4.
+    # Check 2: Σ bbox areas vs hangar floor area
+    total_area = 0.0
+    for pid in scenario.fleet_in:
+        plane = scenario.fleet[pid]
+        length, width = _plane_max_extent(plane)
+        total_area += length * width
+    hangar_area = scenario.hangar.length_m * scenario.hangar.width_m
+    if total_area > hangar_area:
+        check = CheckResult(
+            conflicts=(
+                Conflict.single(
+                    kind="trivially_infeasible_sum_areas",
+                    # The conflict's `planes` field is cosmetic here — single-plane
+                    # arity is required by Conflict.__post_init__ but the real
+                    # information is in `detail`. Pick the first plane in
+                    # fleet_in deterministically.
+                    plane=scenario.fleet_in[0],
+                    detail=(
+                        f"fleet footprint Σ areas {total_area:.1f} m² exceeds "
+                        f"hangar floor area {hangar_area:.1f} m²"
+                    ),
+                ),
+            ),
+            total_penetration_m2=0.0,
+        )
+        return check, _empty_layout(scenario)
+
+    # Check 3 lands in Task C.4.
     return None
 
 

--- a/tests/fixtures/solve_feasible_smoke.yaml
+++ b/tests/fixtures/solve_feasible_smoke.yaml
@@ -1,0 +1,3 @@
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [aviat_husky]

--- a/tests/fixtures/solve_feasible_smoke.yaml
+++ b/tests/fixtures/solve_feasible_smoke.yaml
@@ -1,3 +1,12 @@
+# Single Husky in the default placeholder hangar — must remain feasible
+# (no infeasibility check fires) so the solver's exhausted_budget
+# placeholder path is exercised by Chunk C's smoke test.
+#
+# Do NOT bloat this scenario without re-checking feasibility — adding
+# more planes can trip check #2 (Σ areas) under the placeholder hangar
+# dims; see CLAUDE.md's "Placeholder hangar can't fit the full fleet"
+# note.
+
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
 fleet_in: [aviat_husky]

--- a/tests/fixtures/solve_infeasible_pins_clash.yaml
+++ b/tests/fixtures/solve_infeasible_pins_clash.yaml
@@ -1,0 +1,8 @@
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [aviat_husky, ctsl]
+constraints:
+  aviat_husky:
+    pin: { x_m: 5.0, y_m: 5.0, heading_deg: 0.0, on_carts: false }
+  ctsl:
+    pin: { x_m: 5.0, y_m: 5.0, heading_deg: 0.0, on_carts: false }   # exact same spot

--- a/tests/fixtures/solve_infeasible_pins_clash.yaml
+++ b/tests/fixtures/solve_infeasible_pins_clash.yaml
@@ -1,3 +1,11 @@
+# Two pins at exactly the same coordinates — pins collide in plan view
+# and at the same z-band, so the pin-only Layout fails
+# collisions.check() before the solver's search ever starts.
+#
+# Used to pin solver check #3 (pin self-collision, spec §4.1.3). The
+# planes (Husky + CTSL) are chosen so neither carries a maintenance
+# requirement and both can validly be pinned with on_carts=false.
+
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
 fleet_in: [aviat_husky, ctsl]

--- a/tests/fixtures/solve_infeasible_plane_too_big.yaml
+++ b/tests/fixtures/solve_infeasible_plane_too_big.yaml
@@ -1,0 +1,3 @@
+fleet: ../../data/fleet.yaml
+hangar: ./test_hangar_tiny.yaml
+fleet_in: [scheibe_falke]   # 18 m wingspan, won't fit in 10x8 m

--- a/tests/fixtures/solve_infeasible_plane_too_big.yaml
+++ b/tests/fixtures/solve_infeasible_plane_too_big.yaml
@@ -1,3 +1,14 @@
+# Single Scheibe Falke (18 m wingspan) in the test-only tiny hangar
+# (10×8 m). Pins solver check #1 (per-plane bbox > max hangar dim,
+# spec §4.1.1).
+#
+# Note: this fixture ALSO satisfies check #2 (Σ areas: a single Falke's
+# bbox area exceeds the tiny hangar's 80 m² floor). Because the solver
+# evaluates the three checks in order, check #1 fires first — the
+# test_solve_trivially_infeasible_when_plane_too_big_for_hangar test
+# asserts the resulting conflict.kind == "trivially_infeasible_plane_too_big"
+# explicitly, which also pins first-match-wins ordering.
+
 fleet: ../../data/fleet.yaml
 hangar: ./test_hangar_tiny.yaml
-fleet_in: [scheibe_falke]   # 18 m wingspan, won't fit in 10x8 m
+fleet_in: [scheibe_falke]

--- a/tests/fixtures/solve_infeasible_too_big.yaml
+++ b/tests/fixtures/solve_infeasible_too_big.yaml
@@ -1,0 +1,3 @@
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [scheibe_falke, aviat_husky, fuji, wild_thing, zlin_savage, cessna_140, cessna_150, ctsl, fk9_mkii]

--- a/tests/fixtures/solve_infeasible_too_big.yaml
+++ b/tests/fixtures/solve_infeasible_too_big.yaml
@@ -1,3 +1,13 @@
+# All 9 planes in the placeholder hangar. The placeholder 25×18 hangar
+# is known too-tight to fit the full fleet (see CLAUDE.md's
+# "Placeholder hangar can't fit the full fleet" note + the Σ-areas
+# arithmetic). Used to pin solver check #2 (Σ bbox areas > hangar
+# floor, spec §4.1.2).
+#
+# Will start passing once real hangar measurements land (issue #79) —
+# at which point a different fixture will be needed to keep check #2's
+# regression test exercised.
+
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
 fleet_in: [scheibe_falke, aviat_husky, fuji, wild_thing, zlin_savage, cessna_140, cessna_150, ctsl, fk9_mkii]

--- a/tests/fixtures/solve_infeasible_two_cart_pins.yaml
+++ b/tests/fixtures/solve_infeasible_two_cart_pins.yaml
@@ -1,0 +1,19 @@
+# Two cart_eligible planes both pinned with on_carts=true.
+#
+# The Phase 1 cart rule says: at most one cart_eligible plane may use the
+# spare carts at a time (Layout.__post_init__ enforces it). Scenario does
+# NOT enforce this cross-pin rule today — it only validates each pin's
+# on_carts against its own plane's movement_mode. That gap is exactly the
+# case the solver's check #3 has to catch separately, with its own kind
+# trivially_infeasible_pin_cart_rule.
+#
+# Used by test_solve_trivially_infeasible_when_two_cart_eligible_pins_on_carts.
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [cessna_140, ctsl]
+constraints:
+  cessna_140:
+    pin: { x_m: 3.0, y_m: 5.0, heading_deg: 0.0, on_carts: true }
+  ctsl:
+    pin: { x_m: 8.0, y_m: 5.0, heading_deg: 0.0, on_carts: true }

--- a/tests/fixtures/test_hangar_tiny.yaml
+++ b/tests/fixtures/test_hangar_tiny.yaml
@@ -1,0 +1,9 @@
+length_m: 10.0
+width_m: 8.0
+door:
+  center_x_m: 4.0
+  width_m: 5.0
+maintenance_bay:
+  depth_m: 1.0
+clearance_m: 0.3
+wing_layer_clearance_m: 0.2

--- a/tests/fixtures/test_hangar_tiny.yaml
+++ b/tests/fixtures/test_hangar_tiny.yaml
@@ -1,3 +1,17 @@
+# Test-only hangar — much smaller than the placeholder in data/hangar.yaml.
+#
+# Used by solve_infeasible_plane_too_big.yaml to force the solver's check #1
+# (per-plane bbox > hangar dims, spec §4.1.1) to fire on scheibe_falke
+# (18 m wingspan). The placeholder 25×18 hangar can't trigger check #1
+# because no plane in the fleet has any individual part dimension
+# exceeding 25 m, so a smaller hangar is necessary.
+#
+# Dimensions chosen so that max(length, width) = 10 m is well below the
+# 18 m wingspan of the Scheibe Falke, while still satisfying the
+# door / maintenance_bay invariants. Do NOT use this fixture for any test
+# that needs a feasible layout — by design, no plane in the fleet can
+# meaningfully fit here.
+
 length_m: 10.0
 width_m: 8.0
 door:

--- a/tests/test_solver_infeasibility.py
+++ b/tests/test_solver_infeasibility.py
@@ -30,3 +30,18 @@ def test_solve_resolves_none_seed_to_entropy():
     r = solve(s, budget_s=0.1, seed=None)
     assert isinstance(r.diagnostics.seed, int)
     assert r.diagnostics.seed != 0  # entropy is essentially always nonzero
+
+
+def test_solve_trivially_infeasible_when_plane_too_big_for_hangar():
+    """A plane whose bbox exceeds hangar dims → trivially_infeasible."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_infeasible_plane_too_big.yaml")
+    r = solve(s, budget_s=5.0, seed=42)
+
+    assert r.status == "trivially_infeasible"
+    assert r.layouts == ()
+    # Pre-search check must short-circuit fast (no actual search).
+    assert r.diagnostics.wall_time_s < 5.0  # well below the 30 s default budget
+    assert r.diagnostics.restarts_attempted == 0

--- a/tests/test_solver_infeasibility.py
+++ b/tests/test_solver_infeasibility.py
@@ -62,3 +62,23 @@ def test_solve_trivially_infeasible_when_sum_areas_exceeds_hangar():
     bp = r.diagnostics.best_partial
     assert bp is not None
     assert any("area" in c.detail.lower() or "footprint" in c.detail.lower() for c in bp.conflicts)
+
+
+def test_solve_trivially_infeasible_when_pins_clash():
+    """Two pins overlapping at the same coordinates → trivially_infeasible."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_infeasible_pins_clash.yaml")
+    r = solve(s, budget_s=5.0, seed=42)
+
+    assert r.status == "trivially_infeasible"
+    assert r.diagnostics.wall_time_s < 5.0  # well below the 30 s default budget
+    # The best_partial's conflicts should include the pin pair
+    bp = r.diagnostics.best_partial
+    assert bp is not None
+    # At least one conflict must reference both pinned planes
+    refs = [set(c.planes) for c in bp.conflicts if len(c.planes) == 2]
+    assert any({"aviat_husky", "ctsl"} == r for r in refs), (
+        f"Expected a pairwise conflict between aviat_husky and ctsl, got {refs}"
+    )

--- a/tests/test_solver_infeasibility.py
+++ b/tests/test_solver_infeasibility.py
@@ -16,9 +16,14 @@ def test_solve_feasible_smoke_returns_exhausted_budget_placeholder():
     assert r.status == "exhausted_budget"
     assert r.layouts == ()
     assert r.diagnostics.seed == 42
-    assert r.diagnostics.wall_time_s < 1.0
-    # best_partial is None at this stage (no search means no partial)
+    # Placeholder path: O(parts) infeasibility scan only. Should be
+    # microseconds, not seconds. Tight bound catches accidental
+    # invocation of real search work.
+    assert 0.0 <= r.diagnostics.wall_time_s < 0.1
+    assert r.diagnostics.restarts_attempted == 0
+    # best_partial pair: both must be None for exhausted_budget placeholder.
     assert r.diagnostics.best_partial is None
+    assert r.diagnostics.best_partial_layout is None
 
 
 def test_solve_resolves_none_seed_to_entropy():
@@ -32,6 +37,24 @@ def test_solve_resolves_none_seed_to_entropy():
     assert r.diagnostics.seed != 0  # entropy is essentially always nonzero
 
 
+def test_solve_none_seed_produces_different_seeds_across_calls():
+    """Spec §4.8 contract: seed=None draws fresh entropy each call.
+
+    Pin the actual entropy property — not just \"nonzero\". A regression
+    that hardcoded `resolved_seed = 1` when seed is None would pass the
+    previous test but fail this one.
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    seeds = {solve(s, budget_s=0.1, seed=None).diagnostics.seed for _ in range(5)}
+    # 32-bit entropy → birthday-paradox collision probability across 5
+    # draws is ~5.8e-9. Require at least 4 distinct values to give a
+    # huge margin while still pinning the contract.
+    assert len(seeds) >= 4, f"Expected fresh entropy per call, got seeds={seeds}"
+
+
 def test_solve_trivially_infeasible_when_plane_too_big_for_hangar():
     """A plane whose bbox exceeds hangar dims → trivially_infeasible."""
     from hangarfit.loader import load_scenario
@@ -43,8 +66,15 @@ def test_solve_trivially_infeasible_when_plane_too_big_for_hangar():
     assert r.status == "trivially_infeasible"
     assert r.layouts == ()
     # Pre-search check must short-circuit fast (no actual search).
-    assert r.diagnostics.wall_time_s < 5.0  # well below the 30 s default budget
+    assert 0.0 <= r.diagnostics.wall_time_s < 0.1
     assert r.diagnostics.restarts_attempted == 0
+    # best_partial + best_partial_layout must be paired (both Some).
+    bp = r.diagnostics.best_partial
+    assert bp is not None
+    assert r.diagnostics.best_partial_layout is not None
+    # The fixture is also a check #2 candidate (Σ areas) — pinning the
+    # specific kind also pins first-match-wins ordering of the 3 checks.
+    assert bp.conflicts[0].kind == "trivially_infeasible_plane_too_big"
 
 
 def test_solve_trivially_infeasible_when_sum_areas_exceeds_hangar():
@@ -56,12 +86,14 @@ def test_solve_trivially_infeasible_when_sum_areas_exceeds_hangar():
     r = solve(s, budget_s=5.0, seed=42)
 
     assert r.status == "trivially_infeasible"
-    assert r.diagnostics.wall_time_s < 5.0  # well below the 30 s default budget
-    # The diagnostic should mention "sum" or "area" so the user can tell
-    # WHICH infeasibility check fired.
+    assert 0.0 <= r.diagnostics.wall_time_s < 0.1
+    assert r.diagnostics.restarts_attempted == 0
     bp = r.diagnostics.best_partial
     assert bp is not None
-    assert any("area" in c.detail.lower() or "footprint" in c.detail.lower() for c in bp.conflicts)
+    assert r.diagnostics.best_partial_layout is not None
+    # Pin the structured kind (downstream consumers branch on this,
+    # not the detail string).
+    assert bp.conflicts[0].kind == "trivially_infeasible_sum_areas"
 
 
 def test_solve_trivially_infeasible_when_pins_clash():
@@ -73,12 +105,36 @@ def test_solve_trivially_infeasible_when_pins_clash():
     r = solve(s, budget_s=5.0, seed=42)
 
     assert r.status == "trivially_infeasible"
-    assert r.diagnostics.wall_time_s < 5.0  # well below the 30 s default budget
-    # The best_partial's conflicts should include the pin pair
+    assert 0.0 <= r.diagnostics.wall_time_s < 0.1
+    assert r.diagnostics.restarts_attempted == 0
+    # best_partial + best_partial_layout must be paired (both Some).
     bp = r.diagnostics.best_partial
     assert bp is not None
-    # At least one conflict must reference both pinned planes
+    assert r.diagnostics.best_partial_layout is not None
+    # At least one conflict must reference both pinned planes.
     refs = [set(c.planes) for c in bp.conflicts if len(c.planes) == 2]
     assert any({"aviat_husky", "ctsl"} == r for r in refs), (
         f"Expected a pairwise conflict between aviat_husky and ctsl, got {refs}"
     )
+
+
+def test_solve_trivially_infeasible_when_two_cart_eligible_pins_on_carts():
+    """Two cart_eligible planes both pinned with on_carts=True violates the
+    cart rule (at most one cart_eligible on carts at a time).
+
+    This is the case the broad `try/except ValueError` around the pin-only
+    Layout was defending — now replaced with an explicit upstream check
+    that emits a sharper conflict kind. The pre-check fires BEFORE
+    Layout construction, so any other ValueError from Layout propagates
+    loudly (no longer silently absorbed as a generic "pin invariant").
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_infeasible_two_cart_pins.yaml")
+    r = solve(s, budget_s=5.0, seed=42)
+
+    assert r.status == "trivially_infeasible"
+    bp = r.diagnostics.best_partial
+    assert bp is not None
+    assert bp.conflicts[0].kind == "trivially_infeasible_pin_cart_rule"

--- a/tests/test_solver_infeasibility.py
+++ b/tests/test_solver_infeasibility.py
@@ -45,3 +45,20 @@ def test_solve_trivially_infeasible_when_plane_too_big_for_hangar():
     # Pre-search check must short-circuit fast (no actual search).
     assert r.diagnostics.wall_time_s < 5.0  # well below the 30 s default budget
     assert r.diagnostics.restarts_attempted == 0
+
+
+def test_solve_trivially_infeasible_when_sum_areas_exceeds_hangar():
+    """All 9 planes in the placeholder hangar → sum of bbox areas > hangar floor."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_infeasible_too_big.yaml")
+    r = solve(s, budget_s=5.0, seed=42)
+
+    assert r.status == "trivially_infeasible"
+    assert r.diagnostics.wall_time_s < 5.0  # well below the 30 s default budget
+    # The diagnostic should mention "sum" or "area" so the user can tell
+    # WHICH infeasibility check fired.
+    bp = r.diagnostics.best_partial
+    assert bp is not None
+    assert any("area" in c.detail.lower() or "footprint" in c.detail.lower() for c in bp.conflicts)

--- a/tests/test_solver_infeasibility.py
+++ b/tests/test_solver_infeasibility.py
@@ -1,0 +1,32 @@
+"""Tests for solver.solve() — pre-search infeasibility + smoke."""
+
+from __future__ import annotations
+
+
+def test_solve_feasible_smoke_returns_exhausted_budget_placeholder():
+    """Until Chunk D lands, any feasible scenario returns exhausted_budget."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    r = solve(s, budget_s=0.1, seed=42)
+
+    # Chunk C placeholder: no search yet, so feasible inputs return
+    # exhausted_budget immediately.
+    assert r.status == "exhausted_budget"
+    assert r.layouts == ()
+    assert r.diagnostics.seed == 42
+    assert r.diagnostics.wall_time_s < 1.0
+    # best_partial is None at this stage (no search means no partial)
+    assert r.diagnostics.best_partial is None
+
+
+def test_solve_resolves_none_seed_to_entropy():
+    """seed=None resolves to a random int and is recorded in diagnostics."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    r = solve(s, budget_s=0.1, seed=None)
+    assert isinstance(r.diagnostics.seed, int)
+    assert r.diagnostics.seed != 0  # entropy is essentially always nonzero


### PR DESCRIPTION
## Summary

- New module `src/hangarfit/solver.py` with public `solve()` signature
- Three literal-impossibility pre-search checks per spec §4.1:
  1. per-plane bbox > hangar dims → `trivially_infeasible`
  2. Σ bbox areas > hangar floor area → `trivially_infeasible`
  3. pin self-collision via `collisions.check()` on a pin-only Layout → `trivially_infeasible`
- Any feasible scenario short-circuits to `exhausted_budget` for now (real search lands in next PR).
- Diagnostics populated correctly (seed, wall_time_s, best_partial / best_partial_layout fused pair).

## Deviation from plan (Chunk B re-baseline)

Chunk B's review pass added a fused-pair invariant to `SolverDiagnostics`:
`best_partial` and `best_partial_layout` must both be set or both be None.
The plan's literal `best_partial_layout=None` alongside a non-None
`best_partial` would now raise.

Resolution: `_check_trivially_infeasible` returns `tuple[CheckResult, Layout] | None`.
For checks #1 and #2 (no candidate placements exist yet), the paired Layout
is built by a new `_empty_layout` helper — same fleet + hangar, no placements,
no maintenance plane (legal under `Layout.__post_init__`). For check #3 the
paired Layout is the pin-only Layout that produced the conflict, so downstream
rendering can visualize the clashing pins.

Closes #86

## Test plan

- [x] `pytest -q` — 293 tests green (288 baseline + 5 new)
- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [x] `mypy src/hangarfit/` clean
- [x] 5 new tests covering: feasible smoke, seed resolution, plane-too-big, sum-areas-too-big, pins-clash

🤖 Generated with [Claude Code](https://claude.com/claude-code)