### PR TITLE
Solver: random-restart hill climb with min-conflicts descent (alternatives=1)

### DIFF
--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -2152,7 +2152,7 @@ Run `/pr-review`, resolve threads, hand off.
 
 ### Task D.0: Branch + issue
 
-- [ ] **Step 1: Branch + issue**
+- [x] **Step 1: Branch + issue**
 
 ```bash
 git switch develop
@@ -2174,7 +2174,7 @@ Note as `#D`.
 
 **Goal:** Helper functions to sample initial `Placement`s for each plane.
 
-- [ ] **Step 1: Write failing test for `_initial_placement_for_plane`**
+- [x] **Step 1: Write failing test for `_initial_placement_for_plane`**
 
 Add `tests/test_solver_search.py`:
 
@@ -2237,13 +2237,13 @@ def test_initial_placement_for_maintenance_biases_to_back_strip():
     assert bay_y_start <= p.y_m <= s.hangar.length_m
 ```
 
-- [ ] **Step 2: Run, expect failure**
+- [x] **Step 2: Run, expect failure**
 
 Run: `pytest tests/test_solver_search.py::test_initial_placement_for_pinned_plane_returns_the_pin tests/test_solver_search.py::test_initial_placement_for_free_plane_is_within_hangar tests/test_solver_search.py::test_initial_placement_for_maintenance_biases_to_back_strip -v`
 
 Expected: all FAIL — `_initial_placement_for_plane` doesn't exist.
 
-- [ ] **Step 3: Implement `_initial_placement_for_plane`**
+- [x] **Step 3: Implement `_initial_placement_for_plane`**
 
 Add to `src/hangarfit/solver.py`:
 
@@ -2311,13 +2311,13 @@ def _initial_placement_for_plane(
 
 Add `Placement` to the imports (top of `solver.py`).
 
-- [ ] **Step 4: Run, expect pass**
+- [x] **Step 4: Run, expect pass**
 
 Run: `pytest tests/test_solver_search.py -v -k 'initial_placement'`
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_search.py

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -2333,7 +2333,7 @@ Refs #D"
 
 ### Task D.2: Implement cart-assignment round-robin
 
-- [ ] **Step 1: Write failing test**
+- [x] **Step 1: Write failing test**
 
 Append:
 
@@ -2387,11 +2387,11 @@ def test_cart_bucket_for_restart_is_deterministic_round_robin():
             assert chosen == buckets[i % len(buckets)]
 ```
 
-- [ ] **Step 2: Run, expect failure**
+- [x] **Step 2: Run, expect failure**
 
 Expected: ImportError.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `solver.py`:
 
@@ -2462,13 +2462,13 @@ def _cart_bucket_for_restart(
     return buckets[restart_index % len(buckets)]
 ```
 
-- [ ] **Step 4: Run, expect pass**
+- [x] **Step 4: Run, expect pass**
 
 Run: `pytest tests/test_solver_search.py -v -k 'cart'`
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_search.py

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -2547,7 +2547,7 @@ Refs #D"
 
 ### Task D.4: Implement perturbation + descent step
 
-- [ ] **Step 1: Failing test**
+- [x] **Step 1: Failing test**
 
 This is harder to TDD finely; the best functional test is "descent from a perturbation should not increase score." Append:
 
@@ -2574,11 +2574,11 @@ def test_perturb_plane_returns_valid_placement_within_hangar():
         assert 0.0 <= cand.heading_deg < 360.0
 ```
 
-- [ ] **Step 2: Run, expect failure**
+- [x] **Step 2: Run, expect failure**
 
 Expected: ImportError.
 
-- [ ] **Step 3: Implement perturbation**
+- [x] **Step 3: Implement perturbation**
 
 ```python
 def _perturb_plane(
@@ -2631,13 +2631,13 @@ def _perturb_plane(
     )
 ```
 
-- [ ] **Step 4: Run, expect pass**
+- [x] **Step 4: Run, expect pass**
 
 ```bash
 pytest tests/test_solver_search.py::test_perturb_plane_returns_valid_placement_within_hangar -v
 ```
 
-- [ ] **Step 5: Implement `_descent_step`**
+- [x] **Step 5: Implement `_descent_step`**
 
 This is the orchestrator that runs one min-conflicts iteration. Add:
 
@@ -2737,7 +2737,7 @@ def _descent_step(
     return best_placements, best_score, True
 ```
 
-- [ ] **Step 6: Commit (partial; integration test in next task)**
+- [x] **Step 6: Commit (partial; integration test in next task)**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_search.py

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -2753,7 +2753,7 @@ Refs #D"
 
 ### Task D.5: Implement the restart loop + `_run_trajectory`
 
-- [ ] **Step 1: Write the integration test (solve a trivial single-plane scenario)**
+- [x] **Step 1: Write the integration test (solve a trivial single-plane scenario)**
 
 Append:
 
@@ -2782,11 +2782,11 @@ fleet_in: [aviat_husky]
 
 (Confirm `test_hangar_large.yaml` exists in `tests/fixtures/` per CLAUDE.md module map. It does.)
 
-- [ ] **Step 2: Run, expect failure**
+- [x] **Step 2: Run, expect failure**
 
 Expected: solver still returns `exhausted_budget` (no search loop yet).
 
-- [ ] **Step 3: Implement the trajectory + restart loop**
+- [x] **Step 3: Implement the trajectory + restart loop**
 
 Replace the Chunk C placeholder in `solve()` (the line that returns `exhausted_budget` for feasible scenarios) with the actual search:
 
@@ -2943,7 +2943,7 @@ def _initial_placements(
     return placements
 ```
 
-- [ ] **Step 4: Run, expect pass**
+- [x] **Step 4: Run, expect pass**
 
 ```bash
 pytest tests/test_solver_search.py::test_solve_finds_layout_for_trivial_single_plane -v
@@ -2951,7 +2951,7 @@ pytest tests/test_solver_search.py::test_solve_finds_layout_for_trivial_single_p
 
 Expected: PASS (one plane in 30×25 m hangar is trivially solvable in << 5s).
 
-- [ ] **Step 5: Delete the Chunk C placeholder smoke test**
+- [x] **Step 5: Delete the Chunk C placeholder smoke test**
 
 In Chunk C (Task C.1), we wrote `test_solve_feasible_smoke_returns_exhausted_budget_placeholder` to verify the solver's Chunk-C-era short-circuit behavior. That short-circuit no longer exists after Step 3 of this task — feasible scenarios now actually run the search and (for the smoke fixture: a single plane in a large hangar) succeed with `status="found"`. The placeholder assertion `assert r.status == "exhausted_budget"` is wrong from this commit onwards.
 
@@ -2960,7 +2960,7 @@ Open `tests/test_solver_infeasibility.py` and **delete** the function `test_solv
 Run: `pytest tests/test_solver_infeasibility.py -v`
 Expected: only `test_solve_resolves_none_seed_to_entropy` and the three `trivially_infeasible_*` tests run; all PASS.
 
-- [ ] **Step 6: Add the six-plane fresh fixture + test**
+- [x] **Step 6: Add the six-plane fresh fixture + test**
 
 `tests/fixtures/solve_fresh_six_planes.yaml`:
 
@@ -2999,7 +2999,7 @@ def test_solve_finds_layout_for_fresh_six_planes():
 
 (`pytest.skip` is intentional: if the placeholder hangar is too tight for 5s to find a solution at seed=42, that's a property of the data, not a bug. Real measurements will likely fix this.)
 
-- [ ] **Step 7: Run + lint + type check**
+- [x] **Step 7: Run + lint + type check**
 
 ```bash
 pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
@@ -3007,7 +3007,7 @@ pytest -q && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy s
 
 Expected: green.
 
-- [ ] **Step 8: Commit + push + PR**
+- [x] **Step 8: Commit + push + PR**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_infeasibility.py tests/test_solver_search.py tests/fixtures/solve_trivial_single_plane.yaml tests/fixtures/solve_fresh_six_planes.yaml

--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -2487,7 +2487,7 @@ Refs #D"
 
 ### Task D.3: Implement scoring `_score()`
 
-- [ ] **Step 1: Failing test**
+- [x] **Step 1: Failing test**
 
 Append:
 
@@ -2513,11 +2513,11 @@ def test_score_invalid_layout_is_positive():
     assert penetration >= 0.0  # could be 0 if all conflicts are single-plane
 ```
 
-- [ ] **Step 2: Run, expect failure**
+- [x] **Step 2: Run, expect failure**
 
 Expected: ImportError on `_score`.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```python
 def _score(layout: Layout) -> tuple[int, float]:
@@ -2527,13 +2527,13 @@ def _score(layout: Layout) -> tuple[int, float]:
     return (len(result.conflicts), result.total_penetration_m2)
 ```
 
-- [ ] **Step 4: Run, expect pass**
+- [x] **Step 4: Run, expect pass**
 
 ```bash
 pytest tests/test_solver_search.py::test_score_valid_layout_is_zero_zero tests/test_solver_search.py::test_score_invalid_layout_is_positive -v
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_search.py

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import random as _random_module
 import secrets
+import sys
 import time
 
 from hangarfit.collisions import check as check_layout
@@ -89,7 +90,11 @@ def solve(
     )
     cart_buckets = _enumerate_cart_buckets(scenario)
 
-    best_partial_score: tuple[float, float] = (float("inf"), float("inf"))
+    # Type matches `_score`'s return (`tuple[int, float]`). `sys.maxsize`
+    # is the sentinel int that compares strictly greater than any plausible
+    # `len(conflicts)`; pairing with `inf` for the float keeps Python's
+    # natural tuple lex-compare unambiguous.
+    best_partial_score: tuple[int, float] = (sys.maxsize, float("inf"))
     best_partial_layout: Layout | None = None
     accepted_layouts: list[Layout] = []
     restart_index = 0
@@ -102,18 +107,22 @@ def solve(
             restart_index += 1
             continue
 
-        # Initial Layout build — catches cart-rule violations and any
-        # other cross-reference invariant from Layout.__post_init__.
-        try:
-            initial_layout = Layout(
-                fleet=scenario.fleet,
-                hangar=scenario.hangar,
-                placements=tuple(placements[pid] for pid in scenario.fleet_in),
-                maintenance_plane=scenario.maintenance_plane,
-            )
-        except ValueError:
-            restart_index += 1
-            continue
+        # Initial Layout build.
+        #
+        # No try/except: under current invariants, NO Layout.__post_init__
+        # ValueError is reachable here. `_enumerate_cart_buckets` already
+        # filters bucket assignments that would violate the cart rule;
+        # Scenario invariants enforce pin/on_carts/movement_mode consistency;
+        # placements are over `scenario.fleet_in` (no duplicates, all in
+        # fleet); the maintenance plane is in placements by construction.
+        # Any ValueError here would mean a real bug — let it propagate as
+        # one rather than burn the budget on silent restart absorption.
+        initial_layout = Layout(
+            fleet=scenario.fleet,
+            hangar=scenario.hangar,
+            placements=tuple(placements[pid] for pid in scenario.fleet_in),
+            maintenance_plane=scenario.maintenance_plane,
+        )
         current_score = _score(initial_layout)
         # Track the initial layout as a best-partial candidate too — it
         # may be the lowest-score thing we see in this trajectory.
@@ -305,23 +314,37 @@ def _check_trivially_infeasible(
             return check, _empty_layout(scenario)
 
         # Build a Layout containing ONLY the pinned planes.
-        # maintenance_plane=None to bypass Layout's "maintenance must be placed"
-        # invariant; we're only checking pin-vs-pin and pin-vs-hangar here.
-        # (Spec §4.1 step 3 spells this out explicitly: the pre-search check is
-        # only about pin-vs-pin self-collision and pin-vs-hangar bounds; the
-        # maintenance-position rule is not in scope at this stage because no
-        # maintenance plane is set.)
+        #
+        # ``maintenance_plane`` is set on the pin-only Layout iff the
+        # maintenance plane is itself pinned. This lets `collisions.check()`
+        # fire the maintenance_position rule on a pinned-out-of-bay
+        # maintenance plane — without it, that case would silently slip
+        # past pre-search and burn the entire solve() budget in the
+        # trajectory loop (every restart would hit the same conflict on
+        # the pinned plane, `_descent_step` would return None, restart
+        # again, ad infinitum until budget).
+        #
+        # If the maintenance plane is NOT pinned, we leave maintenance
+        # off the pin-only Layout — its position will be sampled freely
+        # during search, so pre-search has nothing to check.
+        #
         # No try/except: every remaining Layout invariant that could fire
         # here is either structurally impossible given pin-only construction
         # or already caught by Scenario.__post_init__ (pin.plane_id mismatch,
         # pin.on_carts vs movement_mode). A genuinely unexpected ValueError
         # should propagate as a bug, not get silently re-wrapped as a pin
         # infeasibility.
+        maintenance_pinned = (
+            scenario.maintenance_plane is not None
+            and scenario.maintenance_plane in scenario.constraints
+            and scenario.constraints[scenario.maintenance_plane].pin is not None
+        )
+        maint_for_check = scenario.maintenance_plane if maintenance_pinned else None
         pin_only_layout = Layout(
             fleet=scenario.fleet,
             hangar=scenario.hangar,
             placements=tuple(pinned_placements),
-            maintenance_plane=None,
+            maintenance_plane=maint_for_check,
         )
 
         pin_check = check_layout(pin_only_layout)
@@ -628,8 +651,12 @@ def _descent_step(
     """Run one min-conflicts iteration (spec §4.3).
 
     Returns ``(new_placements, new_score, accepted)`` where ``accepted``
-    is ``True`` iff the new score was strictly better OR equal (greedy
-    ``≤`` allows plateau traversal). Returns ``None`` if the trajectory
+    is ``True`` whenever any candidate beat the (score, displacement)
+    tracker — *including* the pure-displacement tiebreaker case where
+    score didn't change but a closer move was preferred. Caller's
+    "score improved" check at ``solve()``'s descent loop reads the
+    score directly (``new_score < current_score``) and does not depend
+    on this flag's exact semantic. Returns ``None`` if the trajectory
     should restart (all conflicts involve only pinned planes — locally
     unsolvable).
 
@@ -709,6 +736,14 @@ def _descent_step(
 
     # Score each candidate. Tie-break by displacement from the current
     # state (encourages smooth trajectories — spec §4.3 step 4).
+    #
+    # Implicit policy note: the 180°-flip candidate has displacement
+    # exactly 0 (it doesn't move position), which beats any Gaussian
+    # nudge's strictly-positive displacement when scores tie. Effect:
+    # heading-only changes are preferred over position+heading changes
+    # on tie. This matches "smallest motion wins" and is desirable for
+    # local optima escape, but it's an implicit choice — don't
+    # accidentally invert it.
     best_score = current_score
     best_placements = placements
     best_cand: Placement | None = None

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -311,6 +311,69 @@ def _initial_placement_for_plane(
     )
 
 
+def _enumerate_cart_buckets(scenario: Scenario) -> list[frozenset[str]]:
+    """Enumerate the cart-assignment buckets to round-robin over (spec §4.2).
+
+    Returns ``C + 1`` buckets — the empty set plus a singleton for each
+    unlocked ``cart_eligible`` plane — when no cart_eligible plane is
+    pre-committed to ``on_carts=True``. If one IS pre-committed (by
+    ``force_on_carts=True`` or a pin with ``on_carts=True``), the
+    at-most-one cart-rule slot is already taken; the only feasible
+    bucket is ``[frozenset()]``, because any singleton would put a
+    second cart_eligible plane on carts and violate the rule.
+
+    Locked cart_eligible planes (any pin, or ``force_on_carts`` set)
+    bypass round-robin: their ``on_carts`` state is fixed by the
+    constraint. The cart rule is enforced holistically by
+    ``Layout.__post_init__`` later — this enumeration just avoids
+    wasting restart budget on guaranteed-infeasible configurations.
+
+    Note: a pin with ``on_carts=False`` also locks the plane (so it
+    can't appear in any bucket) but does NOT consume the on-carts slot
+    — other unlocked cart_eligibles can still be enumerated as
+    singletons.
+
+    Iteration is over ``scenario.fleet_in`` (a tuple), not
+    ``scenario.fleet`` (a ``MappingProxyType``-wrapped dict view) — so
+    bucket ordering is deterministic by construction.
+    """
+    free_cart_eligibles: list[str] = []
+    has_committed_cart_eligible_on_carts = False
+    for pid in scenario.fleet_in:
+        plane = scenario.fleet[pid]
+        if not plane.is_cart_eligible:
+            continue
+        constraint = scenario.constraints.get(pid)
+        if constraint is not None:
+            if constraint.pin is not None:
+                # Any pin locks the plane out of round-robin. If the pin
+                # puts it on carts, the on-carts slot is consumed.
+                if constraint.pin.on_carts:
+                    has_committed_cart_eligible_on_carts = True
+                continue
+            if constraint.force_on_carts is not None:
+                # force_on_carts=True consumes the on-carts slot.
+                if constraint.force_on_carts:
+                    has_committed_cart_eligible_on_carts = True
+                continue
+        free_cart_eligibles.append(pid)
+
+    buckets: list[frozenset[str]] = [frozenset()]
+    if not has_committed_cart_eligible_on_carts:
+        for pid in free_cart_eligibles:
+            buckets.append(frozenset({pid}))
+    return buckets
+
+
+def _cart_bucket_for_restart(
+    buckets: list[frozenset[str]], *, restart_index: int
+) -> frozenset[str]:
+    """Pick the cart-assignment bucket for the given restart (round-robin)."""
+    if not buckets:
+        return frozenset()
+    return buckets[restart_index % len(buckets)]
+
+
 def _empty_layout(scenario: Scenario) -> Layout:
     """Build a placement-less Layout for pairing with a synthetic CheckResult.
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -311,6 +311,20 @@ def _initial_placement_for_plane(
     )
 
 
+def _score(layout: Layout) -> tuple[int, float]:
+    """Hierarchical scoring (spec §4.4): ``(conflict_count, total_penetration_m2)``.
+
+    Lower wins. Tuples compare lexicographically: a lower conflict count
+    beats any penetration; ties on count are broken by lower penetration.
+    ``(0, 0.0)`` means the layout is valid.
+
+    Uses the module-level :func:`check_layout` import (no per-call import
+    indirection inside the descent loop).
+    """
+    result = check_layout(layout)
+    return (len(result.conflicts), result.total_penetration_m2)
+
+
 def _enumerate_cart_buckets(scenario: Scenario) -> list[frozenset[str]]:
     """Enumerate the cart-assignment buckets to round-robin over (spec §4.2).
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -388,6 +388,189 @@ def _cart_bucket_for_restart(
     return buckets[restart_index % len(buckets)]
 
 
+def _perturb_plane(
+    *,
+    current: Placement,
+    scenario: Scenario,
+    rng: _random_module.Random,
+    search: SearchConfig,
+    large_jump: bool,
+) -> Placement:
+    """One candidate perturbation for the named plane (spec §4.3).
+
+    - ``large_jump=True`` re-samples ``(x, y)`` and ``heading_deg``
+      globally (uniform inside hangar with bbox margin; heading uniform
+      on ``[0, 360°)``).
+    - ``large_jump=False`` does a small Gaussian nudge: ``(dx, dy)`` ~
+      ``N(0, pos_sigma_m)`` and ``dh`` ~ ``N(0, heading_sigma_deg)``,
+      clamped to hangar bounds (margin-protected).
+
+    The 180° heading-flip variant is handled by the caller
+    (:func:`_descent_step`) as a third variant.
+
+    ``on_carts`` is preserved from ``current`` — the cart assignment is
+    fixed at restart time (spec §4.2) and never perturbed within a
+    trajectory.
+    """
+    hangar = scenario.hangar
+    plane = scenario.fleet[current.plane_id]
+    max_length, max_width = _plane_max_extent(plane)
+    margin = max(max_length, max_width) / 2
+
+    if large_jump:
+        x_lo, x_hi = margin, hangar.width_m - margin
+        y_lo, y_hi = margin, hangar.length_m - margin
+        x = hangar.width_m / 2 if x_hi <= x_lo else rng.uniform(x_lo, x_hi)
+        y = hangar.length_m / 2 if y_hi <= y_lo else rng.uniform(y_lo, y_hi)
+        # Exclusive upper bound — see _initial_placement_for_plane note.
+        heading = rng.random() * 360.0
+    else:
+        dx = rng.gauss(0.0, search.pos_sigma_m)
+        dy = rng.gauss(0.0, search.pos_sigma_m)
+        dh = rng.gauss(0.0, search.heading_sigma_deg)
+        # Clamp to hangar bounds (margin-protected)
+        x = max(margin, min(hangar.width_m - margin, current.x_m + dx))
+        y = max(margin, min(hangar.length_m - margin, current.y_m + dy))
+        heading = (current.heading_deg + dh) % 360.0
+
+    return Placement(
+        plane_id=current.plane_id,
+        x_m=x,
+        y_m=y,
+        heading_deg=heading,
+        on_carts=current.on_carts,
+    )
+
+
+def _descent_step(
+    *,
+    placements: dict[str, Placement],
+    scenario: Scenario,
+    rng: _random_module.Random,
+    search: SearchConfig,
+    current_score: tuple[int, float],
+    pinned_planes: frozenset[str],
+) -> tuple[dict[str, Placement], tuple[int, float], bool] | None:
+    """Run one min-conflicts iteration (spec §4.3).
+
+    Returns ``(new_placements, new_score, accepted)`` where ``accepted``
+    is ``True`` iff the new score was strictly better OR equal (greedy
+    ``≤`` allows plateau traversal). Returns ``None`` if the trajectory
+    should restart (all conflicts involve only pinned planes — locally
+    unsolvable).
+
+    Algorithm per spec §4.3:
+
+    1. Build a Layout from ``placements`` and score it (free invariant
+       check — ``Layout.__post_init__`` rejects cart-rule violations,
+       so this also screens for those).
+    2. Take the conflicting-plane set ``S = (⋃ c.planes) − pinned``. If
+       empty → return ``None`` (trajectory stuck).
+    3. Pick one plane from ``S`` uniformly at random.
+    4. Generate ``N = candidates_per_iter`` candidates for that plane:
+       ``N - 2`` small Gaussian nudges, 1 large jump, 1 180° flip.
+    5. Score each candidate's tentative Layout; pick the best (lowest)
+       score. Ties broken by smallest displacement from the current
+       state (smooth trajectory).
+    6. Return the winning placements (greedy ≤; updates whenever the
+       loop body sets ``best_cand``).
+
+    Candidates whose tentative Layout violates a ``Layout`` invariant
+    (e.g. cart rule) raise ``ValueError`` from
+    ``Layout.__post_init__`` and are skipped.
+    """
+    # Build current Layout from placements (uses Layout invariants — free check)
+    current_layout = Layout(
+        fleet=scenario.fleet,
+        hangar=scenario.hangar,
+        placements=tuple(placements[pid] for pid in scenario.fleet_in),
+        maintenance_plane=scenario.maintenance_plane,
+    )
+
+    current_result = check_layout(current_layout)
+
+    # Build conflicting-plane set (excluding pinned). `sorted()` later
+    # ensures `rng.choice` sees a deterministic ordering — set iteration
+    # order would otherwise leak into RNG state.
+    conflicting: set[str] = set()
+    for c in current_result.conflicts:
+        for pid in c.planes:
+            if pid not in pinned_planes:
+                conflicting.add(pid)
+    if not conflicting:
+        return None  # restart — all conflicts are on pinned planes
+
+    target = rng.choice(sorted(conflicting))
+
+    # Generate N candidate perturbations: (N-2) small + 1 large + 1 flip
+    candidates: list[Placement] = []
+    n_small = max(0, search.candidates_per_iter - 2)
+    for _ in range(n_small):
+        candidates.append(
+            _perturb_plane(
+                current=placements[target],
+                scenario=scenario,
+                rng=rng,
+                search=search,
+                large_jump=False,
+            )
+        )
+    candidates.append(
+        _perturb_plane(
+            current=placements[target],
+            scenario=scenario,
+            rng=rng,
+            search=search,
+            large_jump=True,
+        )
+    )
+    flipped = Placement(
+        plane_id=target,
+        x_m=placements[target].x_m,
+        y_m=placements[target].y_m,
+        heading_deg=(placements[target].heading_deg + 180.0) % 360.0,
+        on_carts=placements[target].on_carts,
+    )
+    candidates.append(flipped)
+
+    # Score each candidate. Tie-break by displacement from the current
+    # state (encourages smooth trajectories — spec §4.3 step 4).
+    best_score = current_score
+    best_placements = placements
+    best_cand: Placement | None = None
+    best_disp = float("inf")
+    for cand in candidates:
+        trial = dict(placements)
+        trial[target] = cand
+        try:
+            trial_layout = Layout(
+                fleet=scenario.fleet,
+                hangar=scenario.hangar,
+                placements=tuple(trial[pid] for pid in scenario.fleet_in),
+                maintenance_plane=scenario.maintenance_plane,
+            )
+        except ValueError:
+            # Layout invariant violated (cart rule, etc.) — skip this candidate
+            continue
+        s = _score(trial_layout)
+        disp = (
+            (cand.x_m - placements[target].x_m) ** 2 + (cand.y_m - placements[target].y_m) ** 2
+        ) ** 0.5
+        if (s < best_score) or (s == best_score and disp < best_disp):
+            best_score = s
+            best_placements = trial
+            best_cand = cand
+            best_disp = disp
+
+    # By construction the loop only updates best_score when the new
+    # candidate's score is ≤ best_score (which starts at current_score),
+    # so best_score ≤ current_score whenever best_cand is not None. No
+    # need to re-test that — just dispatch on whether anything improved.
+    if best_cand is None:
+        return placements, current_score, False
+    return best_placements, best_score, True
+
+
 def _empty_layout(scenario: Scenario) -> Layout:
     """Build a placement-less Layout for pairing with a synthetic CheckResult.
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -22,6 +22,7 @@ from hangarfit.models import (
     Conflict,
     DiversityConfig,
     Layout,
+    Placement,
     Scenario,
     SearchConfig,
     SolverDiagnostics,
@@ -245,6 +246,69 @@ def _plane_max_extent(plane: Aircraft) -> tuple[float, float]:
     max_length = max(p.length_m for p in plane.parts)
     max_width = max(p.width_m for p in plane.parts)
     return max_length, max_width
+
+
+def _initial_placement_for_plane(
+    *,
+    plane_id: str,
+    scenario: Scenario,
+    rng: _random_module.Random,
+    on_carts: bool,
+    bias_to_maintenance_bay: bool = False,
+) -> Placement:
+    """Sample an initial :class:`Placement` for one plane (spec §4.2).
+
+    - If pinned → return the pin verbatim.
+    - If ``bias_to_maintenance_bay`` → ``(x, y)`` uniform in the back bay strip.
+    - Otherwise → ``(x, y)`` uniform inside hangar (with bbox-derived margin),
+      ``heading_deg`` uniform on ``[0, 360°)``.
+
+    The margin equals ``max(max_length, max_width) / 2`` so the placement
+    bounding box is unlikely to immediately violate the hangar bounds at any
+    heading. ``rng.random() * 360.0`` (NOT ``rng.uniform(0, 360)``) is used
+    so the upper bound stays exclusive — required by the
+    ``heading_deg < 360.0`` test assertion and matching the spec's
+    ``[0°, 360°)`` interval.
+    """
+    constraint = scenario.constraints.get(plane_id)
+    if constraint is not None and constraint.pin is not None:
+        return constraint.pin
+
+    hangar = scenario.hangar
+    plane = scenario.fleet[plane_id]
+    max_length, max_width = _plane_max_extent(plane)
+    margin_x = max(max_length, max_width) / 2
+    margin_y = margin_x
+
+    if bias_to_maintenance_bay:
+        bay_depth = hangar.maintenance_bay.depth_m
+        y_lo = max(margin_y, hangar.length_m - bay_depth)
+        y_hi = hangar.length_m - margin_y
+    else:
+        y_lo = margin_y
+        y_hi = hangar.length_m - margin_y
+
+    x_lo = margin_x
+    x_hi = hangar.width_m - margin_x
+
+    # If margins eat the entire hangar (very tiny hangar / very big plane),
+    # fall back to placing at the centre — the infeasibility checks should
+    # have rejected this case, but defend in code.
+    x = hangar.width_m / 2 if x_hi <= x_lo else rng.uniform(x_lo, x_hi)
+    y = hangar.length_m / 2 if y_hi <= y_lo else rng.uniform(y_lo, y_hi)
+
+    # rng.random() returns [0.0, 1.0); multiplying by 360 keeps the
+    # exclusive upper bound (avoids the rng.uniform(0, 360) inclusive-
+    # endpoint pitfall — see test assertion `heading_deg < 360.0`).
+    heading = rng.random() * 360.0
+
+    return Placement(
+        plane_id=plane_id,
+        x_m=x,
+        y_m=y,
+        heading_deg=heading,
+        on_carts=on_carts,
+    )
 
 
 def _empty_layout(scenario: Scenario) -> Layout:

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -27,6 +27,7 @@ from hangarfit.models import (
     SearchConfig,
     SolverDiagnostics,
     SolveResult,
+    SolveStatus,
 )
 
 
@@ -47,14 +48,20 @@ def solve(
         diversity = DiversityConfig()
     if search is None:
         search = SearchConfig()
+    # `diversity` is accepted in the signature for forward compatibility
+    # with Chunk E (K-diversity filter); the alternatives=1 path in this
+    # chunk never consults it. Reference it once so static analysis
+    # doesn't flag it as unused without obscuring intent.
+    _ = diversity
 
     # Resolve seed. Validate eagerly — a bad seed would raise here, at
-    # solve() entry, instead of 30 s into Chunk D's search loop. The rng
-    # itself will be re-created when search lands; the construction here
-    # is deliberately preserved (don't "clean it up" as dead code).
+    # solve() entry, instead of 30 s into the search loop. ONE
+    # random.Random instance drives every sampling decision (spec §4.8):
+    # initial placement, perturbation, candidate selection, conflict-
+    # plane pick. Cart-bucket round-robin uses the non-random restart
+    # index, so it's deterministic by construction.
     resolved_seed = seed if seed is not None else secrets.randbits(32)
     rng = _random_module.Random(resolved_seed)
-    del rng
 
     # ── Pre-search infeasibility checks (§4.1) ──────────────────────────
     start = time.monotonic()
@@ -74,18 +81,122 @@ def solve(
             ),
         )
 
+    # ── Real search (RR-MC, spec §4.2-§4.5) ─────────────────────────────
+    pinned_planes = frozenset(
+        pid
+        for pid in scenario.fleet_in
+        if pid in scenario.constraints and scenario.constraints[pid].pin is not None
+    )
+    cart_buckets = _enumerate_cart_buckets(scenario)
+
+    best_partial_score: tuple[float, float] = (float("inf"), float("inf"))
+    best_partial_layout: Layout | None = None
+    accepted_layouts: list[Layout] = []
+    restart_index = 0
+
+    while time.monotonic() - start < budget_s:
+        cart_bucket = _cart_bucket_for_restart(cart_buckets, restart_index=restart_index)
+        try:
+            placements = _initial_placements(scenario=scenario, rng=rng, cart_bucket=cart_bucket)
+        except _LayoutBuildFailure:
+            restart_index += 1
+            continue
+
+        # Initial Layout build — catches cart-rule violations and any
+        # other cross-reference invariant from Layout.__post_init__.
+        try:
+            initial_layout = Layout(
+                fleet=scenario.fleet,
+                hangar=scenario.hangar,
+                placements=tuple(placements[pid] for pid in scenario.fleet_in),
+                maintenance_plane=scenario.maintenance_plane,
+            )
+        except ValueError:
+            restart_index += 1
+            continue
+        current_score = _score(initial_layout)
+        # Track the initial layout as a best-partial candidate too — it
+        # may be the lowest-score thing we see in this trajectory.
+        if current_score < best_partial_score:
+            best_partial_score = current_score
+            best_partial_layout = initial_layout
+        last_improved = 0
+
+        for iter_count in range(10000):  # large outer cap; real exit via stall/success
+            if time.monotonic() - start >= budget_s:
+                break
+            if current_score == (0, 0.0):
+                # Valid! Accept (no diversity filter yet in Chunk D — just take it)
+                accepted_layouts.append(
+                    Layout(
+                        fleet=scenario.fleet,
+                        hangar=scenario.hangar,
+                        placements=tuple(placements[pid] for pid in scenario.fleet_in),
+                        maintenance_plane=scenario.maintenance_plane,
+                    )
+                )
+                break  # found one; outer loop terminates because alternatives=1
+
+            step_result = _descent_step(
+                placements=placements,
+                scenario=scenario,
+                rng=rng,
+                search=search,
+                current_score=current_score,
+                pinned_planes=pinned_planes,
+            )
+            if step_result is None:
+                break  # restart (all conflicts on pinned planes)
+            placements, new_score, _accepted = step_result
+            if new_score < current_score:
+                last_improved = iter_count
+            current_score = new_score
+
+            # Track best partial AFTER the move (lowest-score Layout ever seen)
+            if current_score < best_partial_score:
+                best_partial_score = current_score
+                best_partial_layout = Layout(
+                    fleet=scenario.fleet,
+                    hangar=scenario.hangar,
+                    placements=tuple(placements[pid] for pid in scenario.fleet_in),
+                    maintenance_plane=scenario.maintenance_plane,
+                )
+
+            if iter_count - last_improved >= search.k_stall:
+                break  # stall — restart
+
+        restart_index += 1
+        if len(accepted_layouts) >= alternatives:
+            break
+
     elapsed = time.monotonic() - start
 
-    # Chunk C: actual search not yet implemented — short-circuit to
-    # exhausted_budget for any feasible scenario.
+    if accepted_layouts:
+        # alternatives=1 in Chunk D — found_partial cannot fire (we break
+        # the outer loop as soon as len(accepted) >= alternatives), but
+        # keep the branch shape so Chunk E's K-diversity addition is a
+        # one-liner.
+        status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
+        return SolveResult(
+            status=status,
+            layouts=tuple(accepted_layouts),
+            diagnostics=SolverDiagnostics(
+                restarts_attempted=restart_index,
+                wall_time_s=elapsed,
+                best_partial=None,
+                best_partial_layout=None,
+                seed=resolved_seed,
+            ),
+        )
+    bp = check_layout(best_partial_layout) if best_partial_layout is not None else None
     return SolveResult(
         status="exhausted_budget",
         layouts=(),
         diagnostics=SolverDiagnostics(
-            restarts_attempted=0,
+            restarts_attempted=restart_index,
             wall_time_s=elapsed,
-            best_partial=None,
-            best_partial_layout=None,
+            best_partial=bp,
+            best_partial_layout=best_partial_layout,
             seed=resolved_seed,
         ),
     )
@@ -248,6 +359,17 @@ def _plane_max_extent(plane: Aircraft) -> tuple[float, float]:
     return max_length, max_width
 
 
+class _LayoutBuildFailure(Exception):
+    """Raised when initial placement can't satisfy basic invariants.
+
+    Used by :func:`_initial_placements` to signal a sample-error that
+    should trigger a restart (vs. crashing the solver). Currently the
+    helper never raises — every constraint case is handled inline — but
+    the type is retained so future invariant-aware sampling can fail
+    sharply without leaking ``ValueError`` from the search loop.
+    """
+
+
 def _initial_placement_for_plane(
     *,
     plane_id: str,
@@ -323,6 +445,58 @@ def _score(layout: Layout) -> tuple[int, float]:
     """
     result = check_layout(layout)
     return (len(result.conflicts), result.total_penetration_m2)
+
+
+def _initial_placements(
+    *,
+    scenario: Scenario,
+    rng: _random_module.Random,
+    cart_bucket: frozenset[str],
+) -> dict[str, Placement]:
+    """Sample initial placements for every plane in ``fleet_in``.
+
+    ``cart_bucket`` is the set of cart_eligible planes that should be
+    ``on_carts=True`` for this restart (at most one element per the
+    enumeration in :func:`_enumerate_cart_buckets`). Per-plane
+    ``on_carts`` resolution:
+
+    1. ``constraint.force_on_carts`` (if set) — highest priority.
+    2. ``constraint.pin.on_carts`` (if pinned).
+    3. Plane's ``movement_mode`` for always_cart / always_own_gear.
+    4. Membership in ``cart_bucket`` for cart_eligible planes.
+
+    The maintenance plane gets the bay-bias unless it's pinned (a pin
+    already fixes its position; biasing would be a no-op since the pin
+    is returned verbatim).
+    """
+    placements: dict[str, Placement] = {}
+    for pid in scenario.fleet_in:
+        plane = scenario.fleet[pid]
+        constraint = scenario.constraints.get(pid)
+
+        # Decide on_carts (priority order: force_on_carts > pin > movement_mode > bucket)
+        if constraint is not None and constraint.force_on_carts is not None:
+            on_carts = constraint.force_on_carts
+        elif constraint is not None and constraint.pin is not None:
+            on_carts = constraint.pin.on_carts
+        elif plane.movement_mode == "always_cart":
+            on_carts = True
+        elif plane.movement_mode == "always_own_gear":
+            on_carts = False
+        else:  # cart_eligible
+            on_carts = pid in cart_bucket
+
+        bias = scenario.maintenance_plane == pid and (constraint is None or constraint.pin is None)
+
+        placements[pid] = _initial_placement_for_plane(
+            plane_id=pid,
+            scenario=scenario,
+            rng=rng,
+            on_carts=on_carts,
+            bias_to_maintenance_bay=bias,
+        )
+
+    return placements
 
 
 def _enumerate_cart_buckets(scenario: Scenario) -> list[frozenset[str]]:

--- a/tests/fixtures/solve_fresh_six_planes.yaml
+++ b/tests/fixtures/solve_fresh_six_planes.yaml
@@ -2,8 +2,16 @@
 #
 # Includes 3 cart_eligible planes (ctsl, cessna_140, fk9_mkii) so the
 # cart-assignment round-robin has C+1 = 4 buckets to cycle through.
-# Maintenance plane is scheibe_falke (its monowheel + outriggers footprint
-# is the smallest, easiest to fit in the back bay).
+# Maintenance plane is wild_thing — its bbox is small enough to leave
+# headroom for the rest of the fleet.
+#
+# Aircraft choice tuned for the placeholder hangar's tight Σ-area
+# budget: the 25 × 18 m floor is 450 m², so the fleet bbox sum has to
+# stay under that. scheibe_falke's 18 m wing alone burns 137 m² and was
+# rejected by the trivially_infeasible Σ-areas check (#2). The six
+# below sum to ~391 m², leaving ~59 m² of headroom — feasible but
+# nontrivial, which is exactly the regime the search-engine end-to-end
+# test wants to exercise.
 #
 # Used by tests/test_solver_search.py for two purposes:
 #   - cart-bucket enumeration count (must yield exactly 4 buckets)
@@ -12,6 +20,6 @@
 
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
-fleet_in: [aviat_husky, fuji, ctsl, scheibe_falke, fk9_mkii, cessna_140]
+fleet_in: [aviat_husky, fuji, ctsl, wild_thing, fk9_mkii, cessna_140]
 maintenance:
-  plane: scheibe_falke
+  plane: wild_thing

--- a/tests/fixtures/solve_fresh_six_planes.yaml
+++ b/tests/fixtures/solve_fresh_six_planes.yaml
@@ -1,0 +1,17 @@
+# Fresh-layout solver test: 6 planes in the default placeholder hangar.
+#
+# Includes 3 cart_eligible planes (ctsl, cessna_140, fk9_mkii) so the
+# cart-assignment round-robin has C+1 = 4 buckets to cycle through.
+# Maintenance plane is scheibe_falke (its monowheel + outriggers footprint
+# is the smallest, easiest to fit in the back bay).
+#
+# Used by tests/test_solver_search.py for two purposes:
+#   - cart-bucket enumeration count (must yield exactly 4 buckets)
+#   - end-to-end solve() smoke (may exhaust budget on tight hangar;
+#     test skips rather than fails in that case)
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [aviat_husky, fuji, ctsl, scheibe_falke, fk9_mkii, cessna_140]
+maintenance:
+  plane: scheibe_falke

--- a/tests/fixtures/solve_infeasible_maint_pin_outside_bay.yaml
+++ b/tests/fixtures/solve_infeasible_maint_pin_outside_bay.yaml
@@ -1,0 +1,25 @@
+# Maintenance plane pinned outside the back maintenance bay.
+#
+# Regression fixture for the silent-failure path identified in PR #89's
+# review: a user who pins the maintenance plane to a position outside
+# the back strip would have burned the entire solve() budget on infinite
+# restarts (every iteration hit `maintenance_position` on a pinned plane,
+# which filters out of the descent's conflicting-plane set, restart, ...).
+#
+# After the fix, pre-search check #3 builds the pin-only Layout with
+# `maintenance_plane=<pinned-id>` so collisions.check() fires
+# maintenance_position pre-search → trivially_infeasible with a sharp
+# diagnostic conflict.
+#
+# Falke is the maintenance plane (always_cart). Pinned at y=2.0 m
+# (near the door, NOT in the back maintenance bay which lives at the
+# far end of the placeholder hangar).
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [scheibe_falke, aviat_husky]
+maintenance:
+  plane: scheibe_falke
+constraints:
+  scheibe_falke:
+    pin: { x_m: 12.5, y_m: 2.0, heading_deg: 0.0, on_carts: true }

--- a/tests/fixtures/solve_trivial_single_plane.yaml
+++ b/tests/fixtures/solve_trivial_single_plane.yaml
@@ -1,0 +1,11 @@
+# Trivial solver smoke: one plane in the 30×25 m test hangar.
+#
+# This is the smallest possible "search actually does something" scenario.
+# A single Husky in a hangar that's significantly larger than its bbox
+# must be findable in < 1 s on any halfway-functional implementation.
+# Used by tests/test_solver_search.py::test_solve_finds_layout_for_trivial_single_plane
+# as the canary for Chunk D's end-to-end search.
+
+fleet: ../../data/fleet.yaml
+hangar: ./test_hangar_large.yaml
+fleet_in: [aviat_husky]

--- a/tests/test_solver_infeasibility.py
+++ b/tests/test_solver_infeasibility.py
@@ -115,3 +115,38 @@ def test_solve_trivially_infeasible_when_two_cart_eligible_pins_on_carts():
     bp = r.diagnostics.best_partial
     assert bp is not None
     assert bp.conflicts[0].kind == "trivially_infeasible_pin_cart_rule"
+
+
+def test_solve_trivially_infeasible_when_maintenance_pin_outside_bay():
+    """Maintenance plane pinned outside the back maintenance bay.
+
+    Regression test for the silent-failure path identified in PR #89:
+    pre-search check #3 now includes the maintenance_position rule when
+    the maintenance plane is itself pinned. Without the fix, this case
+    would slip past pre-search and burn the entire solve() budget on
+    infinite restarts.
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_infeasible_maint_pin_outside_bay.yaml")
+    r = solve(s, budget_s=5.0, seed=42)
+
+    # Must fire trivially_infeasible (pre-search), NOT exhausted_budget.
+    assert r.status == "trivially_infeasible", (
+        f"Expected pre-search rejection; got {r.status} after "
+        f"{r.diagnostics.restarts_attempted} restarts (silent-failure regression?)"
+    )
+    # Wall time should be ~zero — no real search ran.
+    assert r.diagnostics.wall_time_s < 0.5
+    assert r.diagnostics.restarts_attempted == 0
+    bp = r.diagnostics.best_partial
+    assert bp is not None
+    # The fired conflict is maintenance_position (one of collisions.py's
+    # standard kinds), not one of the solver's synthetic
+    # "trivially_infeasible_*" kinds. That's fine — what matters is that
+    # the user gets a SHARP signal pre-search rather than a generic
+    # exhausted_budget.
+    assert any("maintenance" in c.kind for c in bp.conflicts), (
+        f"Expected a maintenance-related conflict, got {[c.kind for c in bp.conflicts]}"
+    )

--- a/tests/test_solver_infeasibility.py
+++ b/tests/test_solver_infeasibility.py
@@ -3,29 +3,6 @@
 from __future__ import annotations
 
 
-def test_solve_feasible_smoke_returns_exhausted_budget_placeholder():
-    """Until Chunk D lands, any feasible scenario returns exhausted_budget."""
-    from hangarfit.loader import load_scenario
-    from hangarfit.solver import solve
-
-    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
-    r = solve(s, budget_s=0.1, seed=42)
-
-    # Chunk C placeholder: no search yet, so feasible inputs return
-    # exhausted_budget immediately.
-    assert r.status == "exhausted_budget"
-    assert r.layouts == ()
-    assert r.diagnostics.seed == 42
-    # Placeholder path: O(parts) infeasibility scan only. Should be
-    # microseconds, not seconds. Tight bound catches accidental
-    # invocation of real search work.
-    assert 0.0 <= r.diagnostics.wall_time_s < 0.1
-    assert r.diagnostics.restarts_attempted == 0
-    # best_partial pair: both must be None for exhausted_budget placeholder.
-    assert r.diagnostics.best_partial is None
-    assert r.diagnostics.best_partial_layout is None
-
-
 def test_solve_resolves_none_seed_to_entropy():
     """seed=None resolves to a random int and is recorded in diagnostics."""
     from hangarfit.loader import load_scenario

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import random
 
+import pytest
+
 
 def test_initial_placement_for_pinned_plane_returns_the_pin():
     """If a plane is pinned, its initial placement IS the pin (no sampling)."""
@@ -155,3 +157,71 @@ def test_perturb_plane_returns_valid_placement_within_hangar():
         assert 0.0 <= cand.x_m <= s.hangar.width_m
         assert 0.0 <= cand.y_m <= s.hangar.length_m
         assert 0.0 <= cand.heading_deg < 360.0
+
+
+def test_solve_finds_layout_for_trivial_single_plane():
+    """A single plane in a large hangar must be found quickly."""
+    from hangarfit.collisions import check
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_trivial_single_plane.yaml")
+    r = solve(s, budget_s=5.0, alternatives=1, seed=42)
+
+    assert r.status == "found"
+    assert len(r.layouts) == 1
+    assert check(r.layouts[0]).valid
+
+
+def test_solve_finds_layout_for_fresh_six_planes():
+    """6 planes in placeholder hangar — should be findable within budget."""
+    from hangarfit.collisions import check
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    r = solve(s, budget_s=5.0, alternatives=1, seed=42)
+
+    if r.status == "exhausted_budget":
+        pytest.skip(
+            f"Search didn't find a layout for 6 planes in 5s with seed=42 "
+            f"(restarts={r.diagnostics.restarts_attempted}). This is acceptable "
+            f"behavior — the placeholder hangar is tight. Increase budget or "
+            f"retune SearchConfig if this becomes a pattern."
+        )
+
+    assert r.status == "found"
+    assert len(r.layouts) == 1
+    assert check(r.layouts[0]).valid
+
+
+def test_solve_is_deterministic_for_same_seed():
+    """seed=42 → identical SolveResult across calls.
+
+    The spec §4.8 contract is "one Random(seed) drives every sampling
+    decision". This is the canary that the RNG is actually threaded
+    through every branch — set/dict iteration, time.time() reads, and
+    other nondeterminism would surface here as a flake.
+
+    Compares SolveResults via their layouts' placements (the layouts'
+    fleet dicts are MappingProxyType-wrapped copies, so Layout equality
+    requires deep-equality on dicts which works but is heavy — comparing
+    placements directly is sharper).
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_trivial_single_plane.yaml")
+    r1 = solve(s, budget_s=5.0, alternatives=1, seed=42)
+    r2 = solve(s, budget_s=5.0, alternatives=1, seed=42)
+
+    assert r1.status == r2.status
+    assert r1.diagnostics.seed == r2.diagnostics.seed == 42
+    assert r1.diagnostics.restarts_attempted == r2.diagnostics.restarts_attempted
+    # Compare actual layout placements element-wise — Layout's fleet is
+    # wrapped in MappingProxyType so direct equality would compare proxy
+    # identity in some corner cases.
+    assert len(r1.layouts) == len(r2.layouts)
+    for la, lb in zip(r1.layouts, r2.layouts, strict=True):
+        assert la.placements == lb.placements
+        assert la.maintenance_plane == lb.maintenance_plane

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -108,3 +108,24 @@ def test_cart_bucket_for_restart_is_deterministic_round_robin():
         for i in range(2 * len(buckets)):
             chosen = _cart_bucket_for_restart(buckets, restart_index=i)
             assert chosen == buckets[i % len(buckets)]
+
+
+def test_score_valid_layout_is_zero_zero():
+    from hangarfit.loader import load_layout
+    from hangarfit.solver import _score
+
+    layout = load_layout("layouts/example.yaml")
+    s = _score(layout)
+    assert s == (0, 0.0)
+
+
+def test_score_invalid_layout_is_positive():
+    from hangarfit.loader import load_layout
+    from hangarfit.solver import _score
+
+    # Use an existing invalid-overlap fixture; substitute filename if needed.
+    layout = load_layout("layouts/example_invalid.yaml")
+    s = _score(layout)
+    count, penetration = s
+    assert count > 0
+    assert penetration >= 0.0  # could be 0 if all conflicts are single-plane

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -129,3 +129,29 @@ def test_score_invalid_layout_is_positive():
     count, penetration = s
     assert count > 0
     assert penetration >= 0.0  # could be 0 if all conflicts are single-plane
+
+
+def test_perturb_plane_returns_valid_placement_within_hangar():
+    """Perturbation outputs are within hangar bounds and on [0, 360°)."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import Placement
+    from hangarfit.solver import SearchConfig, _perturb_plane
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    rng = random.Random(42)
+    current = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    config = SearchConfig()  # defaults
+
+    # Generate many perturbations; all must be inside hangar bounds.
+    for _ in range(50):
+        cand = _perturb_plane(
+            current=current,
+            scenario=s,
+            rng=rng,
+            search=config,
+            large_jump=False,
+        )
+        assert cand.plane_id == "aviat_husky"
+        assert 0.0 <= cand.x_m <= s.hangar.width_m
+        assert 0.0 <= cand.y_m <= s.hangar.length_m
+        assert 0.0 <= cand.heading_deg < 360.0

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -1,0 +1,62 @@
+"""Tests for solver.py — search engine (Chunks D & E)."""
+
+from __future__ import annotations
+
+import random
+
+
+def test_initial_placement_for_pinned_plane_returns_the_pin():
+    """If a plane is pinned, its initial placement IS the pin (no sampling)."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _initial_placement_for_plane
+
+    s = load_scenario("tests/fixtures/scenario_with_pin.yaml")
+    rng = random.Random(42)
+    pin = s.constraints["aviat_husky"].pin
+    assert pin is not None
+
+    result = _initial_placement_for_plane(
+        plane_id="aviat_husky",
+        scenario=s,
+        rng=rng,
+        on_carts=pin.on_carts,
+    )
+    assert result == pin
+
+
+def test_initial_placement_for_free_plane_is_within_hangar():
+    """Free planes get random (x,y) inside hangar bounds, any heading."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _initial_placement_for_plane
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    rng = random.Random(42)
+    p = _initial_placement_for_plane(
+        plane_id="aviat_husky",
+        scenario=s,
+        rng=rng,
+        on_carts=False,
+    )
+    assert p.plane_id == "aviat_husky"
+    assert 0.0 <= p.x_m <= s.hangar.width_m
+    assert 0.0 <= p.y_m <= s.hangar.length_m
+    assert 0.0 <= p.heading_deg < 360.0
+
+
+def test_initial_placement_for_maintenance_biases_to_back_strip():
+    """The maintenance plane's initial y is inside the maintenance bay."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _initial_placement_for_plane
+
+    s = load_scenario("tests/fixtures/scenario_with_pin.yaml")
+    # In scenario_with_pin, maintenance_plane is fuji (not pinned).
+    rng = random.Random(42)
+    p = _initial_placement_for_plane(
+        plane_id="fuji",
+        scenario=s,
+        rng=rng,
+        on_carts=False,
+        bias_to_maintenance_bay=True,
+    )
+    bay_y_start = s.hangar.length_m - s.hangar.maintenance_bay.depth_m
+    assert bay_y_start <= p.y_m <= s.hangar.length_m

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -60,3 +60,51 @@ def test_initial_placement_for_maintenance_biases_to_back_strip():
     )
     bay_y_start = s.hangar.length_m - s.hangar.maintenance_bay.depth_m
     assert bay_y_start <= p.y_m <= s.hangar.length_m
+
+
+def test_cart_buckets_collapses_when_another_cart_eligible_is_force_locked_on():
+    """When another cart_eligible is force_on_carts=True, the at-most-one
+    cart-rule slot is taken — singletons for others would be infeasible."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _enumerate_cart_buckets
+
+    # scenario_with_force_carts.yaml locks cessna_140 on_carts=True.
+    # ctsl is also cart_eligible and unlocked.
+    # Naive enumeration would emit [frozenset(), frozenset({"ctsl"})], but
+    # the singleton bucket pairs ctsl-on-carts WITH cessna_140-already-on-carts,
+    # which violates Layout's at-most-one-cart_eligible-on-carts rule.
+    # Correct behavior: only the empty bucket is feasible.
+    s = load_scenario("tests/fixtures/scenario_with_force_carts.yaml")
+    buckets = _enumerate_cart_buckets(s)
+    assert buckets == [frozenset()]
+
+
+def test_cart_buckets_enumerates_unlocked_cart_eligibles_plus_none():
+    """With C unlocked cart_eligible planes AND none pre-committed-on-carts,
+    there should be C+1 buckets."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _enumerate_cart_buckets
+
+    # solve_fresh_six_planes scenario includes ctsl, cessna_140, fk9_mkii
+    # (3 cart_eligibles, none locked). Expected: 4 buckets.
+    s = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    buckets = _enumerate_cart_buckets(s)
+    assert len(buckets) == 4
+    assert frozenset() in buckets
+    cart_eligibles = {pid for pid in s.fleet_in if s.fleet[pid].is_cart_eligible}
+    for pid in cart_eligibles:
+        assert frozenset({pid}) in buckets
+
+
+def test_cart_bucket_for_restart_is_deterministic_round_robin():
+    """Restart index R selects bucket R % len(buckets)."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _cart_bucket_for_restart, _enumerate_cart_buckets
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    buckets = _enumerate_cart_buckets(s)
+    if len(buckets) > 0:
+        # First few restarts should cycle through buckets
+        for i in range(2 * len(buckets)):
+            chosen = _cart_bucket_for_restart(buckets, restart_index=i)
+            assert chosen == buckets[i % len(buckets)]

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -125,12 +125,40 @@ def test_score_invalid_layout_is_positive():
     from hangarfit.loader import load_layout
     from hangarfit.solver import _score
 
-    # Use an existing invalid-overlap fixture; substitute filename if needed.
+    # layouts/example_invalid.yaml is documented in CLAUDE.md as
+    # exercising 3 conflict kinds (hangar_bounds + wing_wing_overlap +
+    # strut_wing_overlap). At least the wing/wing and strut/wing
+    # conflicts produce real overlap area, so penetration is strictly
+    # positive — vacuous `>= 0.0` would mask a regression that
+    # accidentally returned 0.0 for every conflict.
     layout = load_layout("layouts/example_invalid.yaml")
     s = _score(layout)
     count, penetration = s
-    assert count > 0
-    assert penetration >= 0.0  # could be 0 if all conflicts are single-plane
+    assert count >= 3, f"expected ≥3 conflicts in example_invalid; got {count}"
+    assert penetration > 0.0, f"expected positive penetration area; got {penetration}"
+
+
+def test_score_lex_ordering_matches_spec():
+    """Hierarchical scoring: lower conflict-count wins over lower penetration.
+
+    `(2, 999.0) < (3, 0.0)` because 2 < 3. The descent loop's progress
+    depends on this lex compare; a subtle inversion would silently
+    degrade search quality.
+    """
+    from hangarfit.solver import _score  # noqa: F401  (imported for namespace)
+
+    # Build scores directly — no need to load fixtures here.
+    assert (2, 999.0) < (3, 0.0)
+    assert (2, 0.5) > (2, 0.4)
+    assert (0, 0.0) < (1, 0.0)
+    # Sanity: _score returns exactly tuple[int, float]
+    from hangarfit.loader import load_layout
+    from hangarfit.solver import _score as score_fn
+
+    score = score_fn(load_layout("layouts/example.yaml"))
+    assert isinstance(score, tuple)
+    assert isinstance(score[0], int)
+    assert isinstance(score[1], float)
 
 
 def test_perturb_plane_returns_valid_placement_within_hangar():
@@ -157,6 +185,69 @@ def test_perturb_plane_returns_valid_placement_within_hangar():
         assert 0.0 <= cand.x_m <= s.hangar.width_m
         assert 0.0 <= cand.y_m <= s.hangar.length_m
         assert 0.0 <= cand.heading_deg < 360.0
+
+
+def test_perturb_plane_preserves_on_carts():
+    """`_perturb_plane` must keep `on_carts` from the current placement.
+
+    The docstring claims this; without a test, a regression flipping
+    `on_carts` mid-trajectory would silently violate the cart-bucket
+    round-robin's premise.
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import Placement
+    from hangarfit.solver import SearchConfig, _perturb_plane
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    rng = random.Random(42)
+    current_off = Placement(
+        plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False
+    )
+    current_on = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=True)
+    cfg = SearchConfig()
+    for _ in range(20):
+        assert (
+            _perturb_plane(
+                current=current_off, scenario=s, rng=rng, search=cfg, large_jump=False
+            ).on_carts
+            is False
+        )
+        assert (
+            _perturb_plane(
+                current=current_on, scenario=s, rng=rng, search=cfg, large_jump=True
+            ).on_carts
+            is True
+        )
+
+
+def test_perturb_plane_heading_wraps_modulo_360():
+    """Perturbing a heading near 0° (or 360°) should wrap, not clamp.
+
+    A regression that clamped heading to [0, 360) instead of wrapping
+    would cause the search to never visit headings near the wrap-around
+    region from one side, biasing solutions.
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import Placement
+    from hangarfit.solver import SearchConfig, _perturb_plane
+
+    s = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    rng = random.Random(42)
+    current = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=359.0, on_carts=False)
+    cfg = SearchConfig()  # heading_sigma_deg=10.0
+    # Across many perturbations, at least some must land below 180° —
+    # proves wrap (358° + 10° = 368° → 8°), not clamp (would stay at
+    # 359° forever).
+    headings = [
+        _perturb_plane(
+            current=current, scenario=s, rng=rng, search=cfg, large_jump=False
+        ).heading_deg
+        for _ in range(100)
+    ]
+    assert any(h < 180.0 for h in headings), (
+        f"Heading wrap appears broken; all 100 samples stayed in upper half: "
+        f"{sorted(set(int(h) for h in headings))[:10]} (showing first 10 unique)"
+    )
 
 
 def test_solve_finds_layout_for_trivial_single_plane():
@@ -225,3 +316,109 @@ def test_solve_is_deterministic_for_same_seed():
     for la, lb in zip(r1.layouts, r2.layouts, strict=True):
         assert la.placements == lb.placements
         assert la.maintenance_plane == lb.maintenance_plane
+
+
+def test_solve_is_deterministic_for_exhausted_budget_branch():
+    """Multi-plane scenario + tight budget → exercises full descent loop
+    (perturbation, candidate selection, conflict-plane pick) under the
+    same-seed-same-answer canary.
+
+    The found-branch test above only covers initial placement. This test
+    covers the descent loop where determinism is most likely to silently
+    break — specifically the `sorted(conflicting)` at solver.py:700 that
+    cancels set-iteration nondeterminism.
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    r1 = solve(s, budget_s=0.05, alternatives=1, seed=42)
+    r2 = solve(s, budget_s=0.05, alternatives=1, seed=42)
+
+    # Determinism: status, seed, restarts must match.
+    assert r1.status == r2.status
+    assert r1.diagnostics.seed == r2.diagnostics.seed == 42
+    assert r1.diagnostics.restarts_attempted == r2.diagnostics.restarts_attempted
+    # If found: layouts match.
+    assert len(r1.layouts) == len(r2.layouts)
+    for la, lb in zip(r1.layouts, r2.layouts, strict=True):
+        assert la.placements == lb.placements
+    # If exhausted: best_partial_layout placements match.
+    if r1.diagnostics.best_partial_layout is not None:
+        assert r2.diagnostics.best_partial_layout is not None
+        assert (
+            r1.diagnostics.best_partial_layout.placements
+            == r2.diagnostics.best_partial_layout.placements
+        )
+
+
+def test_solve_exhausted_budget_reports_best_partial_pair():
+    """When budget runs out without finding a valid layout, the diagnostics
+    must report `best_partial` and `best_partial_layout` as a paired Some.
+
+    Pins the SolverDiagnostics fused-pair invariant on the
+    exhausted_budget branch (the found branch is covered by the trivial
+    test). Without this, a regression that cleared the layout reference
+    while keeping the score (or vice versa) would only be caught by
+    SolverDiagnostics.__post_init__ — which would crash inside solve(),
+    not surface as a clear test failure.
+    """
+    import pytest
+
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    r = solve(s, budget_s=0.05, alternatives=1, seed=42)
+    if r.status == "found":
+        pytest.skip("seed=42 + 0.05s got lucky; tighten budget if this skips often")
+
+    assert r.status == "exhausted_budget"
+    assert r.layouts == ()
+    assert r.diagnostics.restarts_attempted >= 1, "search must have tried at least once"
+
+    bp = r.diagnostics.best_partial
+    bpl = r.diagnostics.best_partial_layout
+    # Fused-pair contract (Chunk B's SolverDiagnostics.__post_init__).
+    assert (bp is None) == (bpl is None), (
+        f"best_partial/best_partial_layout must be both-None or both-Some; "
+        f"got bp={'None' if bp is None else 'Some'}, "
+        f"bpl={'None' if bpl is None else 'Some'}"
+    )
+    if bp is not None:
+        # If we have a best_partial, it MUST have conflicts (else the layout
+        # would be valid and status would be "found").
+        assert len(bp.conflicts) >= 1
+
+
+def test_descent_step_returns_none_when_all_conflicts_are_pinned():
+    """Unit test for the `_descent_step → None` restart contract.
+
+    When every conflict-causing plane is in `pinned_planes`, the helper
+    must return None (signalling the trajectory to restart). A refactor
+    that swapped `c.planes` → `[c.plane]` or otherwise broke the filter
+    would silently hang within range(10000) instead of restarting.
+
+    Build the smallest scenario that hits this: two planes pinned at
+    overlapping coordinates. The conflict would normally drive descent,
+    but both planes are pinned → conflicting set is empty.
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import SearchConfig, _descent_step
+
+    # solve_infeasible_pins_clash.yaml has two pins at identical coords.
+    # Loading and stepping it manually (bypassing solve()'s pre-search)
+    # to exercise _descent_step directly.
+    s = load_scenario("tests/fixtures/solve_infeasible_pins_clash.yaml")
+    placements = {pid: s.constraints[pid].pin for pid in s.fleet_in}
+    pinned = frozenset(s.fleet_in)  # both planes pinned
+
+    result = _descent_step(
+        placements=placements,
+        scenario=s,
+        rng=random.Random(42),
+        search=SearchConfig(),
+        current_score=(2, 0.0),
+        pinned_planes=pinned,
+    )
+    assert result is None, "all-pinned-conflicts must return None for restart"


### PR DESCRIPTION
## Summary

Implements the RR-MC search engine for the static layout solver:
- Initial placement (§4.2): pinned → pin verbatim; maintenance → bay-biased; free → uniform with bbox-derived margin.
- Cart round-robin (§4.2): C+1 buckets cycled per restart for guaranteed coverage; collapses to `[frozenset()]` when another cart_eligible is pre-committed on carts.
- Scoring (§4.4): `(conflict_count, total_penetration_m2)` — Python-native lexicographic tuple compare.
- Perturbation + descent step (§4.3): min-conflicts — pick a conflicting plane, sample N=8 candidates (6 Gauss + 1 large jump + 1 180° flip), accept best-of-N with score ≤ current; tie-break on smallest displacement.
- Restart trigger (§4.5): `k_stall=50` iterations without improvement OR conflicts-on-pinned-only OR budget exhausted.
- Best-partial tracking for diagnostics across restarts.

Returns `status="found"` with one valid Layout for `alternatives=1` when search succeeds; `status="exhausted_budget"` with `best_partial` populated otherwise. K-diverse alternatives + diversity filter land in the next PR (Chunk E).

## Determinism

One `random.Random(resolved_seed)` instance threads through every sampling decision (initial placement, perturbation, candidate selection, conflict-plane pick). Cart-bucket round-robin uses the non-random restart index. No `set` / `dict` iteration leaks into RNG state (all iteration is over `scenario.fleet_in` tuple ordering, and the conflicting-plane set is `sorted()` before `rng.choice`).

A determinism canary test (`test_solve_is_deterministic_for_same_seed`) was added beyond the plan's listed tests: same seed → identical layout placements across calls. Pins the spec §4.8 contract.

## Fixture note

`tests/fixtures/solve_fresh_six_planes.yaml` was tuned away from the plan's listed roster: `scheibe_falke`'s 18 m wing pushed the fleet bbox sum past the placeholder hangar's 450 m² floor area, tripping the trivially_infeasible Σ-areas check (#2) before search could run. Replaced with `wild_thing` (also non-cart-eligible, much smaller bbox). The six chosen planes sum to ~391 m², leaving the search room to actually search. Fixture header documents this.

## Test plan

- [x] `pytest -q` → 306 passed (295 baseline + 11 new in test_solver_search.py, − 1 deleted placeholder).
- [x] `ruff check src/ tests/` → green.
- [x] `ruff format --check src/ tests/` → green.
- [x] `mypy src/hangarfit/` → green.
- [x] Determinism: `test_solve_is_deterministic_for_same_seed` passes — same seed produces identical placements.

## Out of scope (Chunk E, next PR)

- K-diverse alternatives + diversity filter (spec §4.6)
- Diversity-impossible warning at solve() entry

Closes #88