### PR TITLE
Solver: K-diverse alternatives + termination + diagnostics

### DIFF
--- a/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
+++ b/docs/superpowers/plans/2026-05-22-phase2a-static-layout-solver-implementation.md
@@ -3087,7 +3087,7 @@ Note issue as `#E`.
 
 ### Task E.1: Implement the diversity filter (`_is_diverse_enough`)
 
-- [ ] **Step 1: Failing test**
+- [x] **Step 1: Failing test**
 
 Append to `tests/test_solver_search.py`:
 
@@ -3150,9 +3150,9 @@ def test_diversity_heading_uses_short_arc():
     assert not _is_diverse_enough(L2, [L1], diversity)
 ```
 
-- [ ] **Step 2: Run, expect failure**
+- [x] **Step 2: Run, expect failure**
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```python
 def _heading_delta_short_arc(a: float, b: float) -> float:
@@ -3189,9 +3189,9 @@ def _is_diverse_enough(
     return True
 ```
 
-- [ ] **Step 4: Run, expect pass**
+- [x] **Step 4: Run, expect pass**
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_search.py
@@ -3205,7 +3205,7 @@ Refs #E"
 
 ### Task E.2: Wire the diversity filter into the search loop
 
-- [ ] **Step 1: Add failing test for K=3 alternatives**
+- [x] **Step 1: Add failing test for K=3 alternatives**
 
 `tests/fixtures/solve_fresh_alternatives_three.yaml`:
 
@@ -3242,7 +3242,7 @@ def test_solve_returns_k_diverse_alternatives():
             )
 ```
 
-- [ ] **Step 2: Update `solve()` to use the diversity filter on accept**
+- [x] **Step 2: Update `solve()` to use the diversity filter on accept**
 
 In the inner loop of `solve()`, replace:
 
@@ -3268,7 +3268,7 @@ With:
                 break
 ```
 
-- [ ] **Step 3: Run, expect pass**
+- [x] **Step 3: Run, expect pass**
 
 ```bash
 pytest tests/test_solver_search.py::test_solve_returns_k_diverse_alternatives -v
@@ -3276,7 +3276,7 @@ pytest tests/test_solver_search.py::test_solve_returns_k_diverse_alternatives -v
 
 (May skip on placeholder data; that's fine.)
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_search.py tests/fixtures/solve_fresh_alternatives_three.yaml
@@ -3291,7 +3291,7 @@ Refs #E"
 
 ### Task E.3: Implement diversity-impossible warning
 
-- [ ] **Step 1: Failing test**
+- [x] **Step 1: Failing test**
 
 `tests/fixtures/solve_diversity_impossible_warn.yaml`:
 
@@ -3331,7 +3331,7 @@ def test_solve_emits_diversity_impossible_warning(caplog):
     assert len(r.layouts) <= 1
 ```
 
-- [ ] **Step 2: Implement the check at solve() entry**
+- [x] **Step 2: Implement the check at solve() entry**
 
 Near the top of `solve()` (after seed resolution, before pre-search infeasibility):
 
@@ -3356,13 +3356,13 @@ Near the top of `solve()` (after seed resolution, before pre-search infeasibilit
 
 (Move the `import logging` and logger setup to module top in clean form.)
 
-- [ ] **Step 3: Run, expect pass**
+- [x] **Step 3: Run, expect pass**
 
 ```bash
 pytest tests/test_solver_search.py::test_solve_emits_diversity_impossible_warning -v
 ```
 
-- [ ] **Step 4: Commit, push, PR**
+- [x] **Step 4: Commit, push, PR**
 
 ```bash
 git add src/hangarfit/solver.py tests/test_solver_search.py tests/fixtures/solve_diversity_impossible_warn.yaml

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -11,6 +11,7 @@ the current implementation supports:
 
 from __future__ import annotations
 
+import logging
 import random as _random_module
 import secrets
 import sys
@@ -30,6 +31,8 @@ from hangarfit.models import (
     SolveResult,
     SolveStatus,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 def solve(
@@ -58,6 +61,30 @@ def solve(
     # index, so it's deterministic by construction.
     resolved_seed = seed if seed is not None else secrets.randbits(32)
     rng = _random_module.Random(resolved_seed)
+
+    # ── Diversity-impossible heuristic (spec §4.6) ──────────────────────
+    # When the number of free (non-pinned) planes is strictly less than
+    # diversity.min_planes_moved AND the caller asked for >1 alternative,
+    # they cannot mathematically get more than one accepted layout: every
+    # candidate L' after the first will share too many pinned planes with
+    # L to ever pass `n_moved ≥ min_planes_moved`. Logged as a warning
+    # so CLI / library users see it; we do NOT mutate `alternatives` —
+    # search runs normally and the natural outcome is found_partial with
+    # one accepted layout (spec deliberately avoids downgrading the API
+    # contract). Pin-detection mirrors `_check_trivially_infeasible`.
+    free_planes = sum(
+        1
+        for pid in scenario.fleet_in
+        if scenario.constraints.get(pid) is None or scenario.constraints[pid].pin is None
+    )
+    if alternatives > 1 and free_planes < diversity.min_planes_moved:
+        _logger.warning(
+            "requested %d alternatives but only 1 is achievable "
+            "(%d of %d planes are pinned). Expect status=found_partial.",
+            alternatives,
+            len(scenario.fleet_in) - free_planes,
+            len(scenario.fleet_in),
+        )
 
     # ── Pre-search infeasibility checks (§4.1) ──────────────────────────
     start = time.monotonic()
@@ -184,10 +211,13 @@ def solve(
     elapsed = time.monotonic() - start
 
     if accepted_layouts:
-        # alternatives=1 in Chunk D — found_partial cannot fire (we break
-        # the outer loop as soon as len(accepted) >= alternatives), but
-        # keep the branch shape so Chunk E's K-diversity addition is a
-        # one-liner.
+        # `found` fires when the outer loop broke via the
+        # `len(accepted_layouts) >= alternatives` check above (so the count
+        # is exactly `alternatives` — Chunk D path and Chunk E happy path).
+        # `found_partial` fires when budget exhausted with `0 < n < K`
+        # — reachable in Chunk E for K>1 (the diversity-impossible scenario
+        # is one driver, but any K>1 run that runs out of budget mid-fill
+        # also lands here).
         status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
         return SolveResult(
             status=status,

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -780,6 +780,63 @@ def _descent_step(
     return best_placements, best_score, True
 
 
+def _heading_delta_short_arc(a: float, b: float) -> float:
+    """Shortest angular distance on the circle, in degrees.
+
+    Returns the shorter of the two arcs between ``a`` and ``b`` measured
+    on the unit circle, in ``[0.0, 180.0]``. Equivalent to
+    ``min(|a-b| mod 360, 360 - |a-b| mod 360)``. So 0° vs 359° → 1°,
+    not 359°. Spec §4.6 requires this short-arc distance for the
+    diversity-filter heading test; using raw ``|a - b|`` would make the
+    filter mis-classify near-identical headings across the wrap as
+    "moved" and silently degrade diversity.
+    """
+    d = abs(a - b) % 360.0
+    return min(d, 360.0 - d)
+
+
+def _is_diverse_enough(
+    candidate: Layout,
+    accepted: list[Layout],
+    diversity: DiversityConfig,
+) -> bool:
+    """Return True iff candidate differs from every accepted layout (spec §4.6).
+
+    For each already-accepted layout, count the number of planes in the
+    candidate whose placement differs by at least ``position_threshold_m``
+    of Euclidean distance OR at least ``heading_threshold_deg`` of
+    short-arc heading (a plane absent from the reference counts as moved).
+    The candidate is "diverse enough" iff that count meets
+    ``min_planes_moved`` against EVERY accepted layout — pairwise diversity,
+    not aggregate.
+
+    Iterates ``candidate.placements`` (a tuple, deterministic) and
+    ``accepted`` (a list, deterministic). The intermediate ``cand_by_id``
+    and ``L_by_id`` dicts are only used for O(1) plane-id lookups; no
+    iteration order leaks out.
+    """
+    cand_by_id = {p.plane_id: p for p in candidate.placements}
+    for L in accepted:
+        L_by_id = {p.plane_id: p for p in L.placements}
+        n_moved = 0
+        for pid, cand_p in cand_by_id.items():
+            ref = L_by_id.get(pid)
+            if ref is None:
+                # Plane not in the reference layout — count as moved
+                n_moved += 1
+                continue
+            pos_delta = ((cand_p.x_m - ref.x_m) ** 2 + (cand_p.y_m - ref.y_m) ** 2) ** 0.5
+            head_delta = _heading_delta_short_arc(cand_p.heading_deg, ref.heading_deg)
+            if (
+                pos_delta >= diversity.position_threshold_m
+                or head_delta >= diversity.heading_threshold_deg
+            ):
+                n_moved += 1
+        if n_moved < diversity.min_planes_moved:
+            return False  # too similar to this accepted layout
+    return True
+
+
 def _empty_layout(scenario: Scenario) -> Layout:
     """Build a placement-less Layout for pairing with a synthetic CheckResult.
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -823,6 +823,12 @@ def _heading_delta_short_arc(a: float, b: float) -> float:
     diversity-filter heading test; using raw ``|a - b|`` would make the
     filter mis-classify near-identical headings across the wrap as
     "moved" and silently degrade diversity.
+
+    The ``% 360.0`` is defensive against headings outside ``[0, 360)`` —
+    ``Placement.__post_init__`` currently doesn't validate the range
+    (filed as follow-up after PR #89). Once that lands and Placement
+    headings are guaranteed canonical, the modulo becomes a no-op (still
+    correct, just unnecessary).
     """
     d = abs(a - b) % 360.0
     return min(d, 360.0 - d)
@@ -854,10 +860,18 @@ def _is_diverse_enough(
         n_moved = 0
         for pid, cand_p in cand_by_id.items():
             ref = L_by_id.get(pid)
-            if ref is None:
-                # Plane not in the reference layout — count as moved
-                n_moved += 1
-                continue
+            # Under `solve()` invariants, both `candidate` and every L in
+            # `accepted` are built from `scenario.fleet_in` — so plane sets
+            # always match and `ref` is never None. Make that invariant
+            # load-bearing with an assertion: if a future caller passes
+            # mismatched layouts (e.g., an external/test invocation), we
+            # want a sharp AssertionError, not the silent "absent ≡ moved"
+            # semantic the previous defensive branch implemented.
+            assert ref is not None, (
+                f"diversity: candidate has plane {pid!r} not present in an "
+                f"accepted layout (fleet mismatch; only the in-solver flow "
+                f"is supported)"
+            )
             pos_delta = ((cand_p.x_m - ref.x_m) ** 2 + (cand_p.y_m - ref.y_m) ** 2) ** 0.5
             head_delta = _heading_delta_short_arc(cand_p.heading_deg, ref.heading_deg)
             if (

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -49,11 +49,6 @@ def solve(
         diversity = DiversityConfig()
     if search is None:
         search = SearchConfig()
-    # `diversity` is accepted in the signature for forward compatibility
-    # with Chunk E (K-diversity filter); the alternatives=1 path in this
-    # chunk never consults it. Reference it once so static analysis
-    # doesn't flag it as unused without obscuring intent.
-    _ = diversity
 
     # Resolve seed. Validate eagerly — a bad seed would raise here, at
     # solve() entry, instead of 30 s into the search loop. ONE
@@ -135,16 +130,24 @@ def solve(
             if time.monotonic() - start >= budget_s:
                 break
             if current_score == (0, 0.0):
-                # Valid! Accept (no diversity filter yet in Chunk D — just take it)
-                accepted_layouts.append(
-                    Layout(
-                        fleet=scenario.fleet,
-                        hangar=scenario.hangar,
-                        placements=tuple(placements[pid] for pid in scenario.fleet_in),
-                        maintenance_plane=scenario.maintenance_plane,
-                    )
+                # Valid! Apply the K-diversity filter (spec §4.6). When
+                # accepted_layouts is empty, _is_diverse_enough is vacuously
+                # True — the first valid layout is always accepted (and the
+                # alternatives=1 path never re-enters this branch). For K>1
+                # subsequent valid layouts are gated on pairwise diversity vs
+                # everything already accepted.
+                candidate_layout = Layout(
+                    fleet=scenario.fleet,
+                    hangar=scenario.hangar,
+                    placements=tuple(placements[pid] for pid in scenario.fleet_in),
+                    maintenance_plane=scenario.maintenance_plane,
                 )
-                break  # found one; outer loop terminates because alternatives=1
+                if _is_diverse_enough(candidate_layout, accepted_layouts, diversity):
+                    accepted_layouts.append(candidate_layout)
+                # Whether accepted or not, restart to try for a different
+                # basin. Continuing to descend from a valid state would just
+                # walk in place (already at score (0, 0.0)).
+                break
 
             step_result = _descent_step(
                 placements=placements,

--- a/tests/fixtures/solve_diversity_impossible_warn.yaml
+++ b/tests/fixtures/solve_diversity_impossible_warn.yaml
@@ -1,0 +1,28 @@
+# Diversity-impossible warning fixture: 2 of 3 planes pinned, K=3 requested.
+#
+# Spec §4.6: when (|fleet_in| − |pinned_planes|) < min_planes_moved AND
+# alternatives > 1, the user cannot mathematically get more than one
+# accepted layout — every second candidate would share too many planes
+# with the first to pass `n_moved ≥ min_planes_moved`. The solver logs a
+# warning at `solve()` entry but doesn't mutate K; the natural outcome is
+# status=found_partial with one accepted layout.
+#
+# Here aviat_husky and ctsl are pinned; only fuji is free. With default
+# min_planes_moved=2, that's 1 free < 2 required → warning fires.
+#
+# Pin positions chosen to NOT trip the pre-search pin self-collision
+# check (#3) in the 25×30 test hangar (width × length):
+#  - aviat_husky: 10.82 m wingspan → x ≥ 5.41 m to fit; fuselage offset
+#    pushes ~5 m into −y, so y ≥ 5 m. (10, 10) leaves headroom on both
+#    axes.
+#  - ctsl: small cantilever (~10 m wing, ~7 m fuse), placed deeper than
+#    husky so the two wing y-bands don't overlap.
+
+fleet: ../../data/fleet.yaml
+hangar: ./test_hangar_large.yaml
+fleet_in: [aviat_husky, ctsl, fuji]
+constraints:
+  aviat_husky:
+    pin: { x_m: 10.0, y_m: 10.0, heading_deg: 0.0, on_carts: false }
+  ctsl:
+    pin: { x_m: 15.0, y_m: 18.0, heading_deg: 0.0, on_carts: false }

--- a/tests/fixtures/solve_fresh_alternatives_three.yaml
+++ b/tests/fixtures/solve_fresh_alternatives_three.yaml
@@ -1,0 +1,13 @@
+# K-diverse alternatives fixture: 3 free planes in the larger test hangar.
+#
+# Used by tests/test_solver_search.py::test_solve_returns_k_diverse_alternatives
+# to exercise the K=3 acceptance path. Uses the 30 × 25 m test hangar so the
+# search has headroom to find multiple genuinely-distinct basins; the
+# placeholder 25 × 18 m hangar would force every layout into the same tight
+# arrangement (defeating diversity).
+#
+# No constraints — every plane is free to move under the diversity filter.
+
+fleet: ../../data/fleet.yaml
+hangar: ./test_hangar_large.yaml
+fleet_in: [aviat_husky, fuji, ctsl]

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -444,6 +444,25 @@ def test_diversity_filter_rejects_near_duplicate():
     assert not _is_diverse_enough(L2, [L1], diversity)
 
 
+def test_diversity_filter_empty_accepted_vacuously_passes():
+    """`_is_diverse_enough(L, [], div) is True` — the contract that backward-
+    compatibility with `alternatives=1` depends on (first valid layout is
+    always accepted because there's nothing to be diverse against).
+    Previously covered transitively via Chunk D smoke tests; pinning it
+    directly catches a regression that broke the empty-accepted short-
+    circuit explicitly."""
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.models import DiversityConfig, Layout, Placement
+    from hangarfit.solver import _is_diverse_enough
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+    p = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    L = Layout(fleet=fleet, hangar=hangar, placements=(p,))
+
+    assert _is_diverse_enough(L, [], DiversityConfig()) is True
+
+
 def test_diversity_filter_accepts_meaningfully_different():
     from hangarfit.loader import load_fleet, load_hangar
     from hangarfit.models import DiversityConfig, Layout, Placement
@@ -462,6 +481,43 @@ def test_diversity_filter_accepts_meaningfully_different():
 
     diversity = DiversityConfig()
     assert _is_diverse_enough(L2, [L1], diversity)
+
+
+def test_diversity_filter_pairwise_not_aggregate():
+    """The filter is pairwise against EVERY accepted layout, not aggregate.
+
+    Candidate is diverse from L1 (moved 2+ planes) but identical to L2.
+    Pairwise → False (fails vs L2). A buggy aggregate impl that summed
+    moves across all accepted layouts (or accepted on "any" pass)
+    would return True. Catches that refactor.
+    """
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.models import DiversityConfig, Layout, Placement
+    from hangarfit.solver import _is_diverse_enough
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+
+    # L1: husky at (5,5), ctsl at (10,10).
+    p1_L1 = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2_L1 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1_L1, p2_L1))
+
+    # Candidate: both planes moved by > 0.5 m from L1.
+    p1_cand = Placement(plane_id="aviat_husky", x_m=8.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2_cand = Placement(plane_id="ctsl", x_m=13.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    candidate = Layout(fleet=fleet, hangar=hangar, placements=(p1_cand, p2_cand))
+
+    # L2: identical to candidate.
+    L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1_cand, p2_cand))
+
+    div = DiversityConfig()  # M=2
+    # vs L1 alone: diverse (2 planes moved).
+    assert _is_diverse_enough(candidate, [L1], div)
+    # vs L2 alone: not diverse (identical).
+    assert not _is_diverse_enough(candidate, [L2], div)
+    # Pairwise vs [L1, L2]: must FAIL (the L2 check rejects).
+    assert not _is_diverse_enough(candidate, [L1, L2], div)
 
 
 def test_diversity_heading_uses_short_arc():
@@ -546,6 +602,43 @@ def test_diversity_filter_threshold_exact_boundary():
     assert _is_diverse_enough(L2, [L1], div)
 
 
+def test_diversity_filter_heading_threshold_exact_boundary():
+    """Parallel to the position-threshold boundary test: rotating by
+    exactly `heading_threshold_deg` counts as moved (>= comparison).
+
+    A refactor that flipped the heading comparison to strict `>` would
+    pass the position-boundary test (still `>=`) but fail this one.
+    """
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.models import DiversityConfig, Layout, Placement
+    from hangarfit.solver import _is_diverse_enough
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+    p1 = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
+
+    div = DiversityConfig()  # heading_threshold_deg=30.0
+    # Rotate both planes by exactly 30°, no position change.
+    p1b = Placement(
+        plane_id="aviat_husky",
+        x_m=5.0,
+        y_m=5.0,
+        heading_deg=div.heading_threshold_deg,
+        on_carts=False,
+    )
+    p2b = Placement(
+        plane_id="ctsl",
+        x_m=10.0,
+        y_m=10.0,
+        heading_deg=div.heading_threshold_deg,
+        on_carts=False,
+    )
+    L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1b, p2b))
+    assert _is_diverse_enough(L2, [L1], div)
+
+
 def test_solve_status_found_when_k_equals_two_both_satisfied():
     """K=2, single plane in a large hangar — both alternatives findable.
 
@@ -568,13 +661,11 @@ def test_solve_status_found_when_k_equals_two_both_satisfied():
     div = DiversityConfig(min_planes_moved=1)
     r = solve(s, budget_s=10.0, alternatives=2, seed=42, diversity=div)
 
-    if r.status == "exhausted_budget":
-        pytest.skip("Search didn't find K=2 within budget; acceptable on placeholder data.")
-    if r.status == "found_partial":
-        pytest.skip(
-            "Search found < 2 diverse layouts on this seed; with a single plane "
-            "and an empty pool, this is unlikely but the test must not flake."
-        )
+    # Empirically deterministic across many seeds on this fixture
+    # (single plane, roomy hangar) — pin `found` directly. Earlier
+    # versions wrapped this in `pytest.skip` branches that were
+    # unreachable on the current implementation and would have masked a
+    # real regression (a future bug producing `found_partial` here).
     assert r.status == "found"
     assert len(r.layouts) == 2
     for L in r.layouts:
@@ -584,6 +675,17 @@ def test_solve_status_found_when_k_equals_two_both_satisfied():
 
 
 def test_solve_emits_diversity_impossible_warning(caplog):
+    """Diversity-impossible static check fires when free_planes < M and K > 1.
+
+    Empirically deterministic across many seeds on this fixture (2 of 3
+    planes pinned, 1 free): the result is always `found_partial` with
+    exactly 1 layout. Pinning the exact shape catches:
+    - The warning-fire path leaving diagnostics inconsistent (e.g.,
+      best_partial leaking through).
+    - A refactor that silently mutates `alternatives` (spec forbids).
+    - A future where `found_partial` accidentally retains a best_partial
+      from mid-search instead of None.
+    """
     import logging
 
     from hangarfit.loader import load_scenario
@@ -593,14 +695,46 @@ def test_solve_emits_diversity_impossible_warning(caplog):
     with caplog.at_level(logging.WARNING):
         r = solve(s, budget_s=5.0, alternatives=3, seed=42)
 
-    # At least one warning about diversity impossibility
+    # At least one warning about diversity impossibility.
     assert any(
         "achievable" in rec.message.lower() or "diversity" in rec.message.lower()
         for rec in caplog.records
     ), f"Expected diversity-impossible warning; got messages: {[r.message for r in caplog.records]}"
-    # Should be found_partial (one layout found) or found (if K=1 matters)
-    assert r.status in {"found_partial", "found", "exhausted_budget"}
-    assert len(r.layouts) <= 1
+    # Exact-shape pin (was previously loose `in {...}` + `<= 1`).
+    assert r.status == "found_partial"
+    assert len(r.layouts) == 1
+    # Found_partial path: best_partial pair must be None (the accepted
+    # layout lives in result.layouts, not in best_partial).
+    assert r.diagnostics.best_partial is None
+    assert r.diagnostics.best_partial_layout is None
+
+
+def test_solve_does_not_warn_when_diversity_is_achievable(caplog):
+    """Negative companion to the diversity-impossible warning test.
+
+    When `free_planes >= min_planes_moved` (so diversity is statically
+    possible), the warning MUST NOT fire. A regression that fires the
+    warning unconditionally — e.g., inverted predicate, off-by-one on
+    the comparison — would not be caught by the positive test alone.
+    """
+    import logging
+
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import DiversityConfig
+    from hangarfit.solver import solve
+
+    # Fresh-six-planes fixture: 6 planes, none pinned → free_planes=6 >= M=2.
+    s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    with caplog.at_level(logging.WARNING):
+        solve(s, alternatives=3, seed=42, diversity=DiversityConfig(min_planes_moved=1))
+
+    # The diversity-impossible warning text contains "achievable" — assert
+    # no such warning fired. (Other unrelated warnings are fine.)
+    diversity_warnings = [rec for rec in caplog.records if "achievable" in rec.message.lower()]
+    assert not diversity_warnings, (
+        f"Expected NO diversity-impossible warning when free_planes >= M; "
+        f"got {[r.message for r in diversity_warnings]}"
+    )
 
 
 def test_solve_returns_k_diverse_alternatives():

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -546,6 +546,63 @@ def test_diversity_filter_threshold_exact_boundary():
     assert _is_diverse_enough(L2, [L1], div)
 
 
+def test_solve_status_found_when_k_equals_two_both_satisfied():
+    """K=2, single plane in a large hangar — both alternatives findable.
+
+    Pins the `found` status branch on the K>1 path: with one plane free
+    in a roomy hangar, the search has plenty of distinct basins. After
+    two diverse layouts are accepted, the outer loop exits via
+    `len(accepted_layouts) >= alternatives` and status='found'.
+
+    Uses ``min_planes_moved=1`` because the fixture has a single plane —
+    the default M=2 would make diversity mathematically impossible (and
+    trigger the diversity-impossible warning on entry, which is covered
+    by a separate test).
+    """
+    from hangarfit.collisions import check
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import DiversityConfig
+    from hangarfit.solver import _is_diverse_enough, solve
+
+    s = load_scenario("tests/fixtures/solve_trivial_single_plane.yaml")
+    div = DiversityConfig(min_planes_moved=1)
+    r = solve(s, budget_s=10.0, alternatives=2, seed=42, diversity=div)
+
+    if r.status == "exhausted_budget":
+        pytest.skip("Search didn't find K=2 within budget; acceptable on placeholder data.")
+    if r.status == "found_partial":
+        pytest.skip(
+            "Search found < 2 diverse layouts on this seed; with a single plane "
+            "and an empty pool, this is unlikely but the test must not flake."
+        )
+    assert r.status == "found"
+    assert len(r.layouts) == 2
+    for L in r.layouts:
+        assert check(L).valid
+    # The two layouts must be pairwise diverse under the configured policy.
+    assert _is_diverse_enough(r.layouts[0], [r.layouts[1]], div)
+
+
+def test_solve_emits_diversity_impossible_warning(caplog):
+    import logging
+
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_diversity_impossible_warn.yaml")
+    with caplog.at_level(logging.WARNING):
+        r = solve(s, budget_s=5.0, alternatives=3, seed=42)
+
+    # At least one warning about diversity impossibility
+    assert any(
+        "achievable" in rec.message.lower() or "diversity" in rec.message.lower()
+        for rec in caplog.records
+    ), f"Expected diversity-impossible warning; got messages: {[r.message for r in caplog.records]}"
+    # Should be found_partial (one layout found) or found (if K=1 matters)
+    assert r.status in {"found_partial", "found", "exhausted_budget"}
+    assert len(r.layouts) <= 1
+
+
 def test_solve_returns_k_diverse_alternatives():
     from hangarfit.loader import load_scenario
     from hangarfit.models import DiversityConfig

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -422,3 +422,125 @@ def test_descent_step_returns_none_when_all_conflicts_are_pinned():
         pinned_planes=pinned,
     )
     assert result is None, "all-pinned-conflicts must return None for restart"
+
+
+# ── Chunk E: K-diverse alternatives + termination + diagnostics ─────────
+
+
+def test_diversity_filter_rejects_near_duplicate():
+    """Two layouts with no planes moved enough should fail diversity."""
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.models import DiversityConfig, Layout, Placement
+    from hangarfit.solver import _is_diverse_enough
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+    p1 = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
+    L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))  # identical
+
+    diversity = DiversityConfig()  # defaults: M=2, 0.5m, 30°
+    assert not _is_diverse_enough(L2, [L1], diversity)
+
+
+def test_diversity_filter_accepts_meaningfully_different():
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.models import DiversityConfig, Layout, Placement
+    from hangarfit.solver import _is_diverse_enough
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+    p1 = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
+
+    # L2: both planes moved by > 0.5 m
+    p1b = Placement(plane_id="aviat_husky", x_m=8.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2b = Placement(plane_id="ctsl", x_m=13.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1b, p2b))
+
+    diversity = DiversityConfig()
+    assert _is_diverse_enough(L2, [L1], diversity)
+
+
+def test_diversity_heading_uses_short_arc():
+    """0° and 359° should be 1° apart, not 359°."""
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.models import DiversityConfig, Layout, Placement
+    from hangarfit.solver import _is_diverse_enough
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+    p1 = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
+
+    p1b = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=359.0, on_carts=False)
+    p2b = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1b, p2b))
+
+    diversity = DiversityConfig()
+    # heading_threshold_deg=30 — 1° gap is less than 30°, so this is NOT diverse.
+    assert not _is_diverse_enough(L2, [L1], diversity)
+
+
+def test_diversity_filter_m_equals_one_boundary():
+    """With min_planes_moved=1, moving exactly one plane suffices."""
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.models import DiversityConfig, Layout, Placement
+    from hangarfit.solver import _is_diverse_enough
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+    p1 = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
+
+    # L2: only aviat_husky moved (by > 0.5 m)
+    p1b = Placement(plane_id="aviat_husky", x_m=8.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1b, p2))
+
+    # Default M=2: rejected (only 1 moved).
+    assert not _is_diverse_enough(L2, [L1], DiversityConfig())
+    # M=1: accepted.
+    assert _is_diverse_enough(L2, [L1], DiversityConfig(min_planes_moved=1))
+
+
+def test_diversity_filter_threshold_exact_boundary():
+    """Per spec §4.6: a plane is "moved" iff pos_delta >= threshold OR
+    head_delta >= threshold. The comparison is >=, not >.
+
+    Construct a case where exactly two planes are moved by exactly the
+    position threshold — they should count as moved (>= passes), so the
+    candidate is accepted under M=2.
+    """
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.models import DiversityConfig, Layout, Placement
+    from hangarfit.solver import _is_diverse_enough
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+    p1 = Placement(plane_id="aviat_husky", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+    p2 = Placement(plane_id="ctsl", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False)
+    L1 = Layout(fleet=fleet, hangar=hangar, placements=(p1, p2))
+
+    div = DiversityConfig()  # position_threshold_m=0.5
+    # Move both planes by exactly 0.5 m on the x-axis.
+    p1b = Placement(
+        plane_id="aviat_husky",
+        x_m=5.0 + div.position_threshold_m,
+        y_m=5.0,
+        heading_deg=0.0,
+        on_carts=False,
+    )
+    p2b = Placement(
+        plane_id="ctsl",
+        x_m=10.0 + div.position_threshold_m,
+        y_m=10.0,
+        heading_deg=0.0,
+        on_carts=False,
+    )
+    L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1b, p2b))
+    # Exact-threshold delta → counted as moved (>= comparison).
+    assert _is_diverse_enough(L2, [L1], div)

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -544,3 +544,27 @@ def test_diversity_filter_threshold_exact_boundary():
     L2 = Layout(fleet=fleet, hangar=hangar, placements=(p1b, p2b))
     # Exact-threshold delta → counted as moved (>= comparison).
     assert _is_diverse_enough(L2, [L1], div)
+
+
+def test_solve_returns_k_diverse_alternatives():
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import DiversityConfig
+    from hangarfit.solver import _is_diverse_enough, solve
+
+    s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    r = solve(s, budget_s=10.0, alternatives=3, seed=42)
+
+    if r.status == "exhausted_budget":
+        pytest.skip("Search didn't find K=3 within budget; acceptable on placeholder data.")
+    assert r.status in {"found", "found_partial"}
+    assert 1 <= len(r.layouts) <= 3
+    # Each pair must be diverse
+    div = DiversityConfig()
+    for i, L_i in enumerate(r.layouts):
+        for j, L_j in enumerate(r.layouts):
+            if i == j:
+                continue
+            others = [L_j]
+            assert _is_diverse_enough(L_i, others, div), (
+                f"layouts[{i}] and layouts[{j}] are not diverse from each other"
+            )


### PR DESCRIPTION
Closes #90

Phase 2a Chunk E. Adds K-diverse alternatives (`alternatives ≥ 1`), the three-way termination classification (`found` / `found_partial` / `exhausted_budget`), and the diversity-impossible warning.

## What changed

- New helpers in `src/hangarfit/solver.py`:
  - `_heading_delta_short_arc(a, b)` — `min(|a-b|, 360-|a-b|)`, so 0° and 359° are 1° apart (spec §4.6).
  - `_is_diverse_enough(candidate, accepted, diversity) → bool` — edit-count metric: a plane counts as "moved" iff `pos_delta >= position_threshold_m` OR `head_delta >= heading_threshold_deg`; candidate is diverse iff `n_moved >= min_planes_moved` against **every** already-accepted layout (pairwise, not aggregate).
- `solve()` rewires the acceptance step: a valid layout is only added to `accepted_layouts` if it passes `_is_diverse_enough` vs the pool. The Chunk D `_ = diversity` placeholder is gone.
- `solve()` logs a `WARNING` at entry when `(free_planes < min_planes_moved) AND (alternatives > 1)` — the diversity-impossible heuristic. `alternatives` is **not** mutated; the natural outcome is `found_partial` with one accepted layout (spec §4.6 deliberately avoids downgrading the API contract).

## Tests added (8 new; 321 total)

- `_is_diverse_enough` unit tests: near-duplicate rejected, meaningfully-different accepted, short-arc heading (0° vs 359° → 1°), M=1 boundary, exact-threshold-counts-as-moved.
- `test_solve_returns_k_diverse_alternatives` — K=3 round-trip, layouts pairwise diverse.
- `test_solve_status_found_when_k_equals_two_both_satisfied` — K=2 with one plane (`min_planes_moved=1`), pins the `found` status branch on the K>1 path.
- `test_solve_emits_diversity_impossible_warning` — 2 of 3 pinned, K=3 → warning emitted via `caplog`, status in `{found_partial, found, exhausted_budget}`.

All Chunk D tests pass unchanged — the `alternatives=1` path never hits the diversity-filter rejection branch (`_is_diverse_enough` is vacuously True against an empty pool).

## Out of scope

- CLI `solve` subcommand (Chunk F).
- No edits to `geometry.py` / `collisions.py`.

## Test plan

- [x] `pytest -q` — 321 passed
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/hangarfit/` — clean