### PR TITLE
Post-Phase-2a housekeeping: docs + scope + milestone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,10 +148,10 @@ Static layout solver — given a `Scenario` (fleet, hangar, constraints, optiona
 |---|---|---|---|
 | 1 | Spec + plan docs (`docs/superpowers/specs/`, `docs/superpowers/plans/`) | #80 / #81 | ✅ shipped |
 | 2 | `CheckResult.total_penetration_m2` + collisions.py penetration accounting (Chunk A) | #82 / #83 | ✅ shipped |
-| 3 | 7 new Scenario dataclasses + `load_scenario()` (Chunk B) | #84 / #85 | ✅ shipped |
+| 3 | New solver dataclasses (`Scenario`, `PlaneConstraint`, `SolveResult`, `SolverDiagnostics`, `DiversityConfig`, `SearchConfig`) + `SolveStatus` literal + `load_scenario()` (Chunk B) | #84 / #85 | ✅ shipped |
 | 4 | `src/hangarfit/solver.py` skeleton + pre-search infeasibility checks (Chunk C) | #86 / #87 | ✅ shipped |
 | 5 | RR-MC search loop, `solve(alternatives=1)` (Chunk D) | #88 / #89 | ✅ shipped |
-| 6 | K-diverse alternatives + 3-way termination (Chunk E) | #90 / #91 | ✅ shipped |
+| 6 | K-diverse alternatives + termination (Chunk E) | #90 / #91 | ✅ shipped |
 | 7 | `hangarfit solve` CLI subcommand (Chunk F) | #93 / #94 | ✅ shipped |
 | 8 | v1 fixture matrix + determinism canaries (Chunk G) | #96 / #97 | ✅ shipped |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Both clearances are configurable in `data/hangar.yaml` (`Hangar.clearance_m`, `H
 
 ## Phase 1 deliverables
 
-Current status of the Phase 1 cut. Only the CLI remains before the first tagged release (`release/0.1.0`).
+All shipped. Tagged as `v0.1.0` (`20cf741` on `main`). Phase 2a (static layout solver) shipped subsequently — see "Phase 2a deliverables" below.
 
 | # | Deliverable | Issue | Status |
 |---|---|---|---|
@@ -135,10 +135,27 @@ Current status of the Phase 1 cut. Only the CLI remains before the first tagged 
 | 2 | `data/hangar.yaml` — hangar dimensions + door + maintenance bay (placeholders) | #3 | ✅ shipped |
 | 3 | `src/hangarfit/collisions.py` — the collision checker (the heart of Phase 1) | #5 | ✅ shipped |
 | 4 | `src/hangarfit/visualize.py` — matplotlib top-down PNG renderer | #6 | ✅ shipped |
-| 5 | `src/hangarfit/cli.py` — `hangarfit check layouts/example.yaml --render out.png` | #7 | ⏳ **next** |
+| 5 | `src/hangarfit/cli.py` — `hangarfit check layouts/example.yaml --render out.png` | #7 | ✅ shipped |
 | 6 | Strut-aware golden-test suite in `tests/test_collisions.py` — same-height wing overlap, high-over-low height-disjoint pass, strut-blocks-nesting, inboard / outboard strut-free nesting, maintenance-bay rule, all-9-planes valid layout (the cart rule is exercised separately at `Layout` construction; see module map) | #5 | ✅ shipped |
 
 The strut-aware golden tests are the canary that the parts model is intact. If they pass, the geometry is trustworthy on the current (placeholder) data.
+
+## Phase 2a deliverables
+
+Static layout solver — given a `Scenario` (fleet, hangar, constraints, optional pins), find up to K diverse valid `Layout`s. All shipped 2026-05-22.
+
+| # | Deliverable | Issue / PR | Status |
+|---|---|---|---|
+| 1 | Spec + plan docs (`docs/superpowers/specs/`, `docs/superpowers/plans/`) | #80 / #81 | ✅ shipped |
+| 2 | `CheckResult.total_penetration_m2` + collisions.py penetration accounting (Chunk A) | #82 / #83 | ✅ shipped |
+| 3 | 7 new Scenario dataclasses + `load_scenario()` (Chunk B) | #84 / #85 | ✅ shipped |
+| 4 | `src/hangarfit/solver.py` skeleton + pre-search infeasibility checks (Chunk C) | #86 / #87 | ✅ shipped |
+| 5 | RR-MC search loop, `solve(alternatives=1)` (Chunk D) | #88 / #89 | ✅ shipped |
+| 6 | K-diverse alternatives + 3-way termination (Chunk E) | #90 / #91 | ✅ shipped |
+| 7 | `hangarfit solve` CLI subcommand (Chunk F) | #93 / #94 | ✅ shipped |
+| 8 | v1 fixture matrix + determinism canaries (Chunk G) | #96 / #97 | ✅ shipped |
+
+Algorithm: random-restart hill climbing with min-conflicts descent (RR-MC). Continuous `(x_m, y_m, heading_deg)`. Constraints in v1: maintenance plane, per-plane `pin` (full `Placement`), per-plane `force_on_carts`. Diversity filter uses edit-count metric (M=2 planes moved, 0.5 m position threshold, 30° heading threshold). See `docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md` for the full design rationale.
 
 ## Where things live (module map)
 
@@ -149,19 +166,24 @@ The strut-aware golden tests are the canary that the parts model is intact. If t
 | `src/hangarfit/geometry.py` | Plane-local → world transform (the determinant −1 trap lives here) and `aircraft_parts_world()`. |
 | `src/hangarfit/collisions.py` | The `check(layout)` entry point. Enforces hangar bounds, maintenance-bay position (centroid of the designated plane's fuselage parts is in the back strip; if that plane has no fuselage parts, an explicit `maintenance_no_fuselage` conflict is emitted rather than silently passing), and pairwise parts overlap. **Not here:** the cart rule (already enforced upstream in `Layout`). |
 | `src/hangarfit/visualize.py` | Top-down PNG renderer. Forces a headless matplotlib backend at import time so it runs in CI / pytest without a display server. When a `CheckResult` is passed, validates that its conflicts reference only planes from the layout, then overdraws the conflicting parts in red. |
-| `src/hangarfit/cli.py` | **Not yet shipped — issue #7.** |
+| `src/hangarfit/solver.py` | RR-MC layout search. `solve(scenario, budget_s, alternatives, seed)` is the public entry; internals handle pre-search infeasibility checks, initial placement, descent step (min-conflicts perturbation), restart cycle, diversity filter, and three-way termination. RNG is single-threaded and seeded for full reproducibility. |
+| `src/hangarfit/cli.py` | Argparse dispatch for both `hangarfit check` (Phase 1) and `hangarfit solve` (Phase 2a). Owns IO + arg-parsing only; both subcommands are thin wrappers around library entry points. JSON schemas: `hangarfit.check/v1`, `hangarfit.solve/v1`. |
 | `layouts/example.yaml` | Default valid layout for the canonical smoke test — a 6-plane "Saturday morning, 3 out flying" exception scenario (PR #69). Pinned valid by `tests/test_cli.py::test_default_example_layout_is_valid`. |
 | `layouts/example_invalid.yaml` | Companion bad layout for the red-overlay rendering demo. Exercises three conflict kinds (`hangar_bounds`, `wing_wing_overlap`, `strut_wing_overlap`). Pinned invalid by `tests/test_cli.py::test_default_example_invalid_layout_lists_conflicts`. |
-| `tests/fixtures/*.yaml` | One YAML per scenario, `valid_*` / `invalid_*` naming. Add new collision regressions by dropping in a fixture, not by writing geometry literals in Python. New fixtures should be scaffolded with `/new-fixture kind=… slug=… rationale="…"` (see `.claude/skills/new-fixture/SKILL.md`). |
+| `tests/fixtures/*.yaml` | One YAML per scenario. Phase 1: `valid_*` / `invalid_*` for layout-validity regressions. Phase 2a: `solve_*` for solver-contract fixtures (see `tests/test_solver_fixture_matrix.py` for the v1 matrix). Add new regressions by dropping in a fixture, not by writing geometry literals in Python. New fixtures should be scaffolded with `/new-fixture kind=… slug=… rationale="…"` (see `.claude/skills/new-fixture/SKILL.md`). |
+| `tests/test_solver_fixture_matrix.py` | Per-fixture matrix tests for `solve_*.yaml`. Shared `_assert_universal_properties` helper enforces all six spec §6.2 universal property assertions (status enum, every layout valid, seed populated, best_partial fused with infeasible statuses, pairwise diversity, pre-search wall-time guard). Per-test functions add fixture-specific invariants on top. |
+| `tests/test_solver_canaries.py` | Determinism canaries — parametrized over 3 fixtures asserting `solve(seed=42)` returns bit-for-bit identical SolveResult across runs. Intentionally fragile; deliberate algorithm changes require updating expected outputs. |
 | `tests/fixtures/test_hangar_large.yaml` | Test-only larger hangar (30 × 25 m, length × width). Used by `valid_all_nine_planes.yaml` because the placeholder fleet's strut bracing forces ~2.6 m of x-clearance between strut-braced planes whose fuselage y-bands overlap — which doesn't fit in the placeholder 25 × 18 m hangar (see `data/hangar.yaml`). This is a placeholder-dimension artifact, not a checker bug. Will go away once real measurements arrive. See the fixture header for full reasoning. |
 
-### Out of scope for Phase 1
+### Still out of scope (post Phase 2a)
 
-- No planner / search / optimization.
-- No movement-sequence planning (no "Tower of Hanoi" reshuffling).
-- No tracking of current hangar state across runs.
-- No GUI / web frontend.
-- No handling of late arrivals.
+Phase 2a shipped the static layout solver — what was previously "no planner / search" is now `hangarfit solve`. What remains explicitly out of scope:
+
+- **No movement-sequence planning** — "Tower of Hanoi" reshuffling between current state and target layout. The solver finds *a* valid target; it does not plan the moves to get there.
+- **No tracking of current hangar state across runs.** Each invocation is stateless; the scenario YAML carries everything.
+- **No GUI / web frontend.** CLI + PNG only.
+- **No handling of late arrivals** as a live event stream. The tool is invoked on demand against a hand-authored scenario.
+- **No soft constraints / preferences.** Constraints in v1 are HARD: pin, force_on_carts, maintenance plane. No "prefer this region" / "minimise total movement vs baseline" objectives.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ The club parks nine aircraft in a deep, stack-style hangar with a single door at
 
 It also renders a top-down PNG so a human can sanity-check the result by eye.
 
-`hangarfit` can also *find* a layout for you: given a scenario (the fleet to park, optional pins, the maintenance plane), `hangarfit solve` searches for a valid arrangement under hard constraints. The checker remains the source of truth — every layout the solver returns is independently re-validated against the same geometry rule that backs `hangarfit check`.
+`hangarfit` can also *find* a layout for you: given a scenario (the fleet to park, optional pins, the maintenance plane), `hangarfit solve` searches for a valid arrangement under hard constraints. The checker remains the source of truth — every accepted layout was validated by `collisions.check()` as its acceptance gate, so the solver cannot invent a layout the checker would reject.
 
 ## Scope
 
 **Phase 1 — shipped.** Built the substrate: aircraft + hangar data model, parts-based collision checker, matplotlib top-down visualizer, and the `hangarfit check` CLI. Phase 1 was about getting the geometry right — once the collision rule was trustworthy, the downstream solver could be built on top of it.
 
-**Phase 2a — shipped.** Added the static layout solver: `hangarfit solve` takes a scenario YAML (fleet, hangar, constraints, optional pins) and searches for up to K diverse valid layouts using random-restart hill climbing with min-conflicts descent. Every returned layout is re-validated through the Phase 1 checker — the solver does not bypass the collision rule.
+**Phase 2a — shipped.** Added the static layout solver: `hangarfit solve` takes a scenario YAML (fleet, hangar, constraints, optional pins) and searches for up to K diverse valid layouts using random-restart hill climbing with min-conflicts descent. Acceptance runs through `collisions.check()` as its gate — the solver does not bypass the collision rule.
 
 **Still explicitly out of scope:**
 

--- a/README.md
+++ b/README.md
@@ -10,25 +10,27 @@ The club parks nine aircraft in a deep, stack-style hangar with a single door at
 
 It also renders a top-down PNG so a human can sanity-check the result by eye.
 
-It is not a planner. It does not search for a layout — you hand it one, it tells you whether it works.
+`hangarfit` can also *find* a layout for you: given a scenario (the fleet to park, optional pins, the maintenance plane), `hangarfit solve` searches for a valid arrangement under hard constraints. The checker remains the source of truth — every layout the solver returns is independently re-validated against the same geometry rule that backs `hangarfit check`.
 
 ## Scope
 
-**Phase 1 (current focus).** Build the substrate: an aircraft + hangar data model, a parts-based collision checker, a matplotlib top-down visualizer, and a CLI that ties them together. Phase 1 is about getting the geometry right — once the collision rule is trustworthy, anything downstream can be built on top of it.
+**Phase 1 — shipped.** Built the substrate: aircraft + hangar data model, parts-based collision checker, matplotlib top-down visualizer, and the `hangarfit check` CLI. Phase 1 was about getting the geometry right — once the collision rule was trustworthy, the downstream solver could be built on top of it.
 
-**Explicitly out of scope for Phase 1:**
+**Phase 2a — shipped.** Added the static layout solver: `hangarfit solve` takes a scenario YAML (fleet, hangar, constraints, optional pins) and searches for up to K diverse valid layouts using random-restart hill climbing with min-conflicts descent. Every returned layout is re-validated through the Phase 1 checker — the solver does not bypass the collision rule.
 
-- No planner, search, or optimization — you provide the candidate layout.
-- No movement-sequence planning (no "in what order do I roll planes out and back in to reach this layout").
-- No tracking of hangar state across runs.
+**Still explicitly out of scope:**
+
+- No movement-sequence planning ("in what order do I roll planes out and back in to reach this layout").
+- No tracking of hangar state across runs — each invocation is stateless.
+- No soft constraints / preferences. Constraints are HARD: pin, force_on_carts, maintenance plane.
 - No GUI or web frontend.
 - No handling of late arrivals as a live event stream.
 
-These boundaries are deliberate. The collision model is the load-bearing piece; layering search on top of a wobbly geometry foundation would compound errors.
+These boundaries are deliberate.
 
 ## Status
 
-Pre-release. Phase 1 is feature-complete (the CLI shipped in v0.3.0). All dimensions in `data/` are placeholders pending real measurement and are flagged as such in the YAML; collision-checker output on the current data is illustrative, not authoritative.
+Pre-release. Phase 1 + Phase 2a are feature-complete (`hangarfit check` and `hangarfit solve`). All dimensions in `data/` are placeholders pending real measurement and are flagged as such in the YAML; checker output on the current data is illustrative, not authoritative — and so are any layouts the solver finds against it.
 
 Follow progress in [GitHub Issues](https://github.com/DocGerd/hangarfit/issues) and milestones.
 
@@ -65,13 +67,55 @@ hangarfit check layouts/example.yaml --json
 hangarfit check my_portable_layout.yaml --fleet path/to/fleet.yaml --hangar path/to/hangar.yaml
 ```
 
-### Exit codes
+### Exit codes (`check`)
 
 | Code | Meaning |
 |---|---|
 | 0 | Valid layout |
 | 1 | Invalid layout (conflicts found) |
 | 2 | Could not check (file not found, bad YAML, invariant violation, bad usage) |
+
+### Solving a scenario
+
+`hangarfit solve` takes a *scenario* YAML (fleet to park, optional per-plane pins, optional maintenance plane) and searches for a valid layout. The output is JSON-serializable; PNG renders are optional.
+
+```bash
+# Find one valid layout for a scenario
+hangarfit solve tests/fixtures/solve_fresh_six_planes.yaml
+
+# Reproducible search with a seed; render the result
+hangarfit solve scenario.yaml --seed 42 --render out.png
+
+# Find up to 3 diverse alternatives (each layout must differ from the others
+# by at least 2 planes moved by 0.5 m or rotated by 30°)
+hangarfit solve scenario.yaml --alternatives 3 --render out_{i}.png --write-yaml out_{i}.yaml
+
+# Machine-readable output
+hangarfit solve scenario.yaml --json
+
+# Strict mode: exit non-zero if fewer than --alternatives layouts were found
+hangarfit solve scenario.yaml --alternatives 3 --strict-k
+
+# Budget the search to 5 wall-clock seconds (default 30)
+hangarfit solve scenario.yaml --budget 5
+```
+
+A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which planes are present), an optional `maintenance:` block (which plane is in the back bay), and an optional `constraints:` mapping (per-plane pins or `force_on_carts` locks). See `tests/fixtures/solve_*.yaml` for ready-to-read examples covering each constraint kind.
+
+### Exit codes (`solve`)
+
+| Code | Meaning |
+|---|---|
+| 0 | Found at least one valid layout (`status` = `found` or `found_partial`) |
+| 1 | No valid layout found (`status` = `exhausted_budget` or `trivially_infeasible`); with `--strict-k`, also fires for `found_partial` |
+| 2 | Could not solve (file not found, bad YAML, invariant violation, IO error during render/write) |
+
+### JSON schemas
+
+- `hangarfit check --json` emits payloads with `"schema": "hangarfit.check/v1"`.
+- `hangarfit solve --json` emits payloads with `"schema": "hangarfit.solve/v1"`.
+
+Bumping a schema version is reserved for breaking changes to the payload shape; additive fields do not bump the version.
 
 ## Run the tests
 


### PR DESCRIPTION
Closes #99.

Post-implementation housekeeping for Phase 2a (per the plan's §post-implementation section). Pure docs + GitHub metadata; no code changes.

## What this PR does

### `CLAUDE.md`
- **Phase 1 deliverables table** — mark `cli.py` row as ✅ shipped (it was still ⏳ next).
- **New "Phase 2a deliverables" section** — table of all 7 chunks (A-G) with their issue/PR refs.
- **Module map** — add `solver.py`, `test_solver_fixture_matrix.py`, `test_solver_canaries.py`; update the `cli.py` row to reflect both `check` and `solve`; broaden the `tests/fixtures/*.yaml` row to cover `solve_*` fixtures.
- **Out-of-scope list** renamed and reworked. "No planner / search / optimization" is gone — that shipped. Added "No soft constraints / preferences" (v1 constraints are HARD by design).

### `README.md`
- **Rewrote the "It is not a planner" paragraph** — the tool *does* search now via `hangarfit solve`, but every returned layout is re-validated through the Phase 1 checker. The geometry-first principle is intact.
- **Scope section** — both phases marked shipped; out-of-scope list aligned with CLAUDE.md.
- **Status section** — Phase 1 + Phase 2a feature-complete.
- **New "Solving a scenario" usage subsection** — example invocations covering each flag (`--alternatives`, `--seed`, `--render`, `--write-yaml`, `--strict-k`, `--json`, `--budget`). Separate exit-code table for `solve` (semantics differ from `check`). Both JSON schema names (`hangarfit.check/v1`, `hangarfit.solve/v1`) documented.

### GitHub metadata (already done out-of-band, no diff in this PR)
- Created milestone [v0.5.0 — Phase 2a static solver](https://github.com/DocGerd/hangarfit/milestone/8) (#8).
- Attached all 8 closed Chunk issues (#80, #82, #84, #86, #88, #90, #93, #96).
- Closed the milestone.

## Verification

- `pytest`: 355 passed (1 deselected). No code paths touched.
- `ruff check src/ tests/`: All checks passed!
- `ruff format --check src/ tests/`: 22 files already formatted.
- `mypy src/hangarfit/`: Success: no issues found in 8 source files.

## Why one PR

Pure docs + metadata, no code coordination cost; matches the post-Phase-1 housekeeping shape that worked previously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)