### PR TITLE
Fix: solver determinism test was wall-clock-flaky

### DIFF
--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -319,39 +319,43 @@ def test_solve_is_deterministic_for_same_seed():
 
 
 def test_solve_is_deterministic_through_descent_loop():
-    """Multi-plane scenario — seeded RNG must produce identical layouts
-    across two calls of ``solve()``, even through the descent loop.
+    """Seeded RNG must produce identical layouts across two ``solve()``
+    calls, even through the multi-restart descent loop.
 
-    Exercises the full descent path (perturbation, candidate selection,
-    conflict-plane pick) where determinism is most likely to silently
-    break — specifically the ``sorted(conflicting)`` in ``_descent_step``
-    that cancels set-iteration nondeterminism.
+    Names the specific concern that the parametrized canary suite in
+    ``test_solver_canaries.py`` does NOT explicitly cover: descent-step
+    set-iteration order (``sorted(conflicting)`` in ``_descent_step``).
+    The canary suite parametrizes determinism over fixtures; this test
+    parametrizes determinism over a *codepath*, asserting that
+    ``restarts_attempted`` matches across runs — a check the canary
+    suite deliberately omits because it is wall-clock-dependent for
+    ``status=exhausted_budget`` but is in fact deterministic-by-seed
+    for ``status=found`` (the run terminates at the restart that
+    succeeds, regardless of wall-clock).
 
-    Budget choice: 5 s (against ~1.4 s typical search time for this
-    fixture at seed=42, leaving ~3× headroom for slow CI runners). An
-    earlier version used 0.05 s to also exercise the ``exhausted_budget``
-    branch, but that made the test wall-clock-flaky — machine-load
-    variance between the two consecutive ``solve()`` calls could leave
-    each call at a different restart count when the budget expired,
-    producing different ``best_partial_layout``s. The exhausted-budget
-    determinism branch is genuinely wall-clock-dependent and cannot be
-    asserted via a same-seed-same-answer canary; see issue #101.
+    Budget is set high enough that the search reliably ends in
+    ``found``; if a slow CI runner cannot reach ``found`` within
+    ``budget_s`` the test will fail with a status mismatch — bump the
+    budget or skip rather than weakening the assertion.
     """
     from hangarfit.loader import load_scenario
     from hangarfit.solver import solve
 
     s = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
-    r1 = solve(s, budget_s=5.0, alternatives=1, seed=42)
-    r2 = solve(s, budget_s=5.0, alternatives=1, seed=42)
+    r1 = solve(s, budget_s=10.0, alternatives=1, seed=42)
+    r2 = solve(s, budget_s=10.0, alternatives=1, seed=42)
 
-    # Adequate budget: both calls must reach `found` deterministically.
-    assert r1.status == r2.status == "found"
+    # Status mismatch here almost certainly means the CI runner is too
+    # slow to reach `found` within budget_s, not a determinism break —
+    # the canary suite catches actual non-determinism with a smaller
+    # surface. Bump budget if this trips.
+    assert r1.status == r2.status == "found", (
+        f"expected both runs to find within 10 s; got {r1.status!r} / {r2.status!r}. "
+        f"Likely cause: CI runner is slow; bump budget_s."
+    )
     assert r1.diagnostics.seed == r2.diagnostics.seed == 42
-    # When status=found, restart count is determined by the seed (not
-    # wall-clock); the run terminates at the restart that succeeds.
     assert r1.diagnostics.restarts_attempted == r2.diagnostics.restarts_attempted
 
-    # Layouts must match element-wise.
     assert len(r1.layouts) == len(r2.layouts) == 1
     for la, lb in zip(r1.layouts, r2.layouts, strict=True):
         assert la.placements == lb.placements

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -318,38 +318,43 @@ def test_solve_is_deterministic_for_same_seed():
         assert la.maintenance_plane == lb.maintenance_plane
 
 
-def test_solve_is_deterministic_for_exhausted_budget_branch():
-    """Multi-plane scenario + tight budget → exercises full descent loop
-    (perturbation, candidate selection, conflict-plane pick) under the
-    same-seed-same-answer canary.
+def test_solve_is_deterministic_through_descent_loop():
+    """Multi-plane scenario — seeded RNG must produce identical layouts
+    across two calls of ``solve()``, even through the descent loop.
 
-    The found-branch test above only covers initial placement. This test
-    covers the descent loop where determinism is most likely to silently
-    break — specifically the `sorted(conflicting)` at solver.py:700 that
-    cancels set-iteration nondeterminism.
+    Exercises the full descent path (perturbation, candidate selection,
+    conflict-plane pick) where determinism is most likely to silently
+    break — specifically the ``sorted(conflicting)`` in ``_descent_step``
+    that cancels set-iteration nondeterminism.
+
+    Budget choice: 5 s (against ~1.4 s typical search time for this
+    fixture at seed=42, leaving ~3× headroom for slow CI runners). An
+    earlier version used 0.05 s to also exercise the ``exhausted_budget``
+    branch, but that made the test wall-clock-flaky — machine-load
+    variance between the two consecutive ``solve()`` calls could leave
+    each call at a different restart count when the budget expired,
+    producing different ``best_partial_layout``s. The exhausted-budget
+    determinism branch is genuinely wall-clock-dependent and cannot be
+    asserted via a same-seed-same-answer canary; see issue #101.
     """
     from hangarfit.loader import load_scenario
     from hangarfit.solver import solve
 
     s = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
-    r1 = solve(s, budget_s=0.05, alternatives=1, seed=42)
-    r2 = solve(s, budget_s=0.05, alternatives=1, seed=42)
+    r1 = solve(s, budget_s=5.0, alternatives=1, seed=42)
+    r2 = solve(s, budget_s=5.0, alternatives=1, seed=42)
 
-    # Determinism: status, seed, restarts must match.
-    assert r1.status == r2.status
+    # Adequate budget: both calls must reach `found` deterministically.
+    assert r1.status == r2.status == "found"
     assert r1.diagnostics.seed == r2.diagnostics.seed == 42
+    # When status=found, restart count is determined by the seed (not
+    # wall-clock); the run terminates at the restart that succeeds.
     assert r1.diagnostics.restarts_attempted == r2.diagnostics.restarts_attempted
-    # If found: layouts match.
-    assert len(r1.layouts) == len(r2.layouts)
+
+    # Layouts must match element-wise.
+    assert len(r1.layouts) == len(r2.layouts) == 1
     for la, lb in zip(r1.layouts, r2.layouts, strict=True):
         assert la.placements == lb.placements
-    # If exhausted: best_partial_layout placements match.
-    if r1.diagnostics.best_partial_layout is not None:
-        assert r2.diagnostics.best_partial_layout is not None
-        assert (
-            r1.diagnostics.best_partial_layout.placements
-            == r2.diagnostics.best_partial_layout.placements
-        )
 
 
 def test_solve_exhausted_budget_reports_best_partial_pair():


### PR DESCRIPTION
Closes #101.

## Symptom

`test_solve_is_deterministic_for_exhausted_budget_branch` failed on PR #100's Python 3.12 CI job; surfaced as a flake locally (3/5 fail) the moment I tried to reproduce.

```
AssertionError: assert (Placement(...)) == (Placement(...))
  At index 0 diff: x_m=10.017, y_m=5.470, heading=91.876 vs x_m=8.134, y_m=19.441, heading=230.399
```

## Root cause

The test ran `solve(..., budget_s=0.05)` twice and asserted:
- `r1.diagnostics.restarts_attempted == r2.diagnostics.restarts_attempted`
- `r1.diagnostics.best_partial_layout.placements == r2.diagnostics.best_partial_layout.placements`

Both are wall-clock-dependent. With a 50 ms budget, machine-load variance between the two consecutive calls means each call may complete a different number of restarts before the budget expires. Since the solver consumes one RNG draw stream, different restart counts → different RNG state at cutoff → different `best_partial_layout`.

This was a latent flake from the Chunk D arc; it just happened to hit reliably enough on Python 3.12 CI to surface now.

## Fix

- Expand budget to **5 s** (against ~1.4 s typical search time for this fixture at seed=42, giving ~3× headroom for slow CI runners).
- Assert determinism on the **`found` path only** — when status is `found`, restart count is determined by the seed (the run terminates at the restart that succeeds), so it's deterministic. The exhausted-budget branch is genuinely wall-clock-dependent and cannot be asserted via a same-seed-same-answer canary; explicitly noted in the docstring.
- Rename to `test_solve_is_deterministic_through_descent_loop` to reflect what the test actually verifies. The original name (`_for_exhausted_budget_branch`) no longer matches the budget regime.

The descent-loop coverage that was the test's actual unique value is preserved — at seed=42 the fixture takes 2 restarts to find, so descent runs on at least the failed restart(s) before the successful one.

## Verification

- 5/5 local repeats of the formerly flaky test pass.
- `pytest -q`: 355 passed (1 deselected).
- `ruff check`, `ruff format --check`, `mypy src/hangarfit/`: all clean.

## Unblocks

PR #100's CI was the visible symptom that surfaced this. Once this merges, rerun #100's CI and it should pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)