### PR TITLE
docs(claude-md): fix four currency drifts surfaced by audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file is the durable context for the project. Read it first in any new sessi
 
 The tool checks whether a hand-authored candidate layout is physically valid (no fuselage / wing / strut collisions, fits in the hangar, maintenance plane in the right spot) and renders a top-down PNG so a human can eyeball it.
 
-**Phase 1 scope** (the current focus): build the substrate — aircraft data model, hangar model, collision checker, visualizer, CLI. **No planner / search / optimization** in Phase 1.
+**Status:** Phase 1 (substrate: data model, collision checker, visualizer, CLI) and Phase 2a (static layout solver, `hangarfit solve`) have both shipped. Current active work and milestone status live in auto-memory and GitHub milestones, not here.
 
 ---
 
@@ -242,7 +242,7 @@ The `.claude/` directory holds team-shared Claude Code settings (currently: a Po
 
 ## MCP servers
 
-`.mcp.json` at the repo root declares two project-scoped MCP servers so every contributor gets them automatically on a fresh clone — no per-user setup step. See also [.claude/README.md](.claude/README.md) for the broader Claude Code config ecosystem in this repo.
+`.mcp.json` at the repo root declares the project-scoped GitHub MCP server so every contributor gets it automatically on a fresh clone — no per-user setup step. See also [.claude/README.md](.claude/README.md) for the broader Claude Code config ecosystem in this repo.
 
 | Server | Transport | Purpose |
 |---|---|---|
@@ -290,6 +290,11 @@ pip install -e ".[dev]"
 # Run tests
 pytest
 
+# Run only the slow set (excluded by default; see pyproject.toml addopts)
+pytest -m slow
+# Or run everything regardless of marker
+pytest -m ""
+
 # Lint + format check (CI also runs these)
 ruff check src/ tests/
 ruff format --check src/ tests/
@@ -304,7 +309,7 @@ mypy src/hangarfit/
 # CI: GitHub Actions runs `pytest` on Python 3.11 + 3.12 for PRs into
 # develop/main (see .github/workflows/ci.yml). No coverage gate yet.
 
-# Phase 1 acceptance smoke test (once CLI lands)
+# Phase 1 acceptance smoke test
 hangarfit check layouts/example.yaml --render out.png
 
 # GitFlow loops


### PR DESCRIPTION
Closes #113

A `/claude-md-improver` audit of `CLAUDE.md` flagged four small currency bugs. This PR fixes them and adds one useful command. No behavioral / source changes.

## Changes (all in `CLAUDE.md`)

### 1. Top-of-file framing — Phase 1 is no longer "the current focus"

Phase 1 shipped 2026-05-21 (v0.1.0, tag at `20cf741`) and Phase 2a shipped 2026-05-22. Reframed the lead paragraph so new sessions don't start with an outdated mental model.

```diff
-**Phase 1 scope** (the current focus): build the substrate — …
+**Status:** Phase 1 (substrate: …) and Phase 2a (static layout solver, `hangarfit solve`) have both shipped. Current active work and milestone status live in auto-memory and GitHub milestones, not here.
```

### 2. MCP servers — "two" → "one"

`.mcp.json` declares one server (`github`). The prose said "two" but the adjacent table already only listed one, so prose and table disagreed. Prose now matches.

### 3. Drop "(once CLI lands)" fossil

The CLI shipped in PR #7. The parenthetical was a leftover from when the smoke-test recipe was written ahead of the CLI.

### 4. Add `pytest -m slow` / `pytest -m ""` to useful-commands

`pyproject.toml` sets `addopts = "-ra -m 'not slow'"`, so `pytest` excludes the slow set by default. The on-demand opt-in form is non-obvious — documenting it here prevents recurring confusion.

## What I deliberately did **not** touch

- Coordinate convention / determinant-−1 trap section (L69-125) — load-bearing, intact.
- Module map (L160-176) — verified accurate against `src/hangarfit/` and `tests/`.
- Phase 1 / Phase 2a deliverable tables — historical record flagged ✅ shipped, fine to keep.
- Milestone-#9 maintenance-bay status — fast-moving; lives in auto-memory.

## Test plan

- [x] `git diff` matches the four targeted edits exactly (8 insertions, 3 deletions).
- [ ] Pre-commit hooks pass (whitespace / EOF / large-files / merge-conflicts) — confirmed locally.
- [ ] No source changes → no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)