### PR TITLE
feat(solver): add SearchConfig.max_restarts and best_partial determinism canary (#111)

### DIFF
--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -667,12 +667,21 @@ class SearchConfig:
     """Solver hyperparameters (see spec §4.3, §4.5).
 
     v1 defaults are guesses; tune with real data.
+
+    ``max_restarts`` is the v0.6.0 solver-polish addition (spec §4.2 of
+    ``docs/superpowers/specs/2026-05-22-v0.6.0-solver-polish-release-design.md``).
+    ``None`` preserves the pre-v0.6.0 wall-clock-only termination behavior.
+    When set, it acts as an *upper-bound counter* on the outer restart
+    loop in addition to ``budget_s``: whichever gate trips first wins.
+    Useful for cross-machine-deterministic exhaustion canaries that
+    can't rely on wall-clock budget cutoffs.
     """
 
     candidates_per_iter: int = 8
     k_stall: int = 50
     pos_sigma_m: float = 0.5
     heading_sigma_deg: float = 10.0
+    max_restarts: int | None = None
 
     def __post_init__(self) -> None:
         if self.candidates_per_iter < 1:
@@ -693,4 +702,10 @@ class SearchConfig:
         if self.heading_sigma_deg <= 0.0:
             raise ValueError(
                 f"SearchConfig.heading_sigma_deg must be positive, got {self.heading_sigma_deg}"
+            )
+        if self.max_restarts is not None and self.max_restarts < 1:
+            raise ValueError(
+                f"SearchConfig.max_restarts must be >= 1 when set "
+                f"(zero would skip the search loop entirely; use None to "
+                f"opt out of the restart cap), got {self.max_restarts}"
             )

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -682,6 +682,18 @@ class SearchConfig:
     pos_sigma_m: float = 0.5
     heading_sigma_deg: float = 10.0
     max_restarts: int | None = None
+    """Hard cap on the outer restart loop. ``None`` (default) preserves
+    the pre-v0.6.0 wall-clock-only termination behavior. When set, must
+    be ``>= 1``; serves as an upper-bound counter in addition to
+    ``solve(..., budget_s=...)`` — whichever gate trips first wins.
+    Useful for cross-machine-deterministic exhaustion canaries that
+    can't rely on wall-clock budget cutoffs.
+
+    ``None`` is the only "opt out" sentinel in :class:`SearchConfig` /
+    :class:`DiversityConfig` / :class:`SolverDiagnostics`; all other
+    numeric fields require a concrete positive value. Pass ``None``
+    explicitly to disable the cap; passing ``0`` is rejected (it would
+    skip the search loop entirely)."""
 
     def __post_init__(self) -> None:
         if self.candidates_per_iter < 1:
@@ -706,6 +718,6 @@ class SearchConfig:
         if self.max_restarts is not None and self.max_restarts < 1:
             raise ValueError(
                 f"SearchConfig.max_restarts must be >= 1 when set "
-                f"(zero would skip the search loop entirely; use None to "
-                f"opt out of the restart cap), got {self.max_restarts}"
+                f"(pass ``None`` to disable the restart cap; ``0`` would "
+                f"skip the search loop entirely), got {self.max_restarts}"
             )

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -121,7 +121,18 @@ def solve(
     accepted_layouts: list[Layout] = []
     restart_index = 0
 
-    while time.monotonic() - start < budget_s:
+    # Outer restart loop. Two independent termination gates; first to
+    # trip wins:
+    #   1. Wall-clock budget (`budget_s`) — always present.
+    #   2. Restart count (`search.max_restarts`) — opt-in via v0.6.0's
+    #      SearchConfig field (spec §4.2). `None` preserves the
+    #      pre-v0.6.0 wall-clock-only behavior. Useful for
+    #      cross-machine-deterministic exhaustion canaries.
+    # Inside the loop, the K-diverse termination at the bottom is the
+    # third gate ("found enough alternatives") — independent of these.
+    while time.monotonic() - start < budget_s and (
+        search.max_restarts is None or restart_index < search.max_restarts
+    ):
         cart_bucket = _cart_bucket_for_restart(cart_buckets, restart_index=restart_index)
         try:
             placements = _initial_placements(scenario=scenario, rng=rng, cart_bucket=cart_bucket)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,6 +16,7 @@ from hangarfit.models import (
     MaintenanceBay,
     Part,
     Placement,
+    SearchConfig,
     StrutsSpec,
 )
 
@@ -826,3 +827,27 @@ class TestFrozenBehavior:
         )
         with pytest.raises(dataclasses.FrozenInstanceError):
             layout.maintenance_plane = "foo"  # type: ignore[misc]
+
+
+class TestSearchConfig:
+    """Construction + post_init invariants for ``SearchConfig`` (spec §4.2 of
+    the v0.6.0 solver-polish release adds ``max_restarts``)."""
+
+    def test_max_restarts_default_is_none(self) -> None:
+        """``None`` preserves the pre-v0.6.0 wall-clock-only termination."""
+        sc = SearchConfig()
+        assert sc.max_restarts is None
+
+    def test_max_restarts_positive_accepted(self) -> None:
+        sc = SearchConfig(max_restarts=1)
+        assert sc.max_restarts == 1
+        sc = SearchConfig(max_restarts=42)
+        assert sc.max_restarts == 42
+
+    def test_max_restarts_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match="max_restarts"):
+            SearchConfig(max_restarts=0)
+
+    def test_max_restarts_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match="max_restarts"):
+            SearchConfig(max_restarts=-1)

--- a/tests/test_solver_canaries.py
+++ b/tests/test_solver_canaries.py
@@ -107,6 +107,21 @@ def test_solve_deterministic_best_partial_under_max_restarts() -> None:
         restart 0), this canary needs re-calibration on
         ``solve_diversity_impossible_warn.yaml`` per the plan's
         fallback procedure.
+
+    Fallback fixture calibration (recorded 2026-05-23):
+        Ran ``solve(scenario, budget_s=10.0, seed=42)`` on
+        ``solve_diversity_impossible_warn.yaml`` to pre-pin the
+        fallback. Observed ``status=found, restarts_attempted=1,
+        wall_time≈0.009 s``. With observed=1, the standard
+        ``max_restarts = observed // 2`` recipe would yield 0, which
+        :class:`SearchConfig.__post_init__` rejects. If a future
+        switch to this fallback fixture is needed, pick a different
+        seed whose natural restart count is ≥ 2 (so ``observed // 2
+        >= 1``) or use a different fixture — do NOT clamp to
+        ``max_restarts=1``, which would NOT trip before natural
+        success on this fixture (the cap would equal the natural
+        success count and the predicate is strictly ``<``, not
+        ``<=``).
     """
     fixture = "tests/fixtures/solve_fresh_six_planes.yaml"
     max_restarts = 1
@@ -152,3 +167,40 @@ def test_solve_deterministic_best_partial_under_max_restarts() -> None:
     # reproducible, not just the accepted layouts.
     assert bpl1.placements == bpl2.placements
     assert bpl1.maintenance_plane == bpl2.maintenance_plane
+
+
+def test_solve_budget_trips_before_max_restarts() -> None:
+    """When ``budget_s`` would cut the loop short of ``max_restarts``,
+    the budget gate wins — exercises the compound termination
+    condition's other branch.
+
+    Pair with ``test_solve_deterministic_best_partial_under_max_restarts``
+    above which pins the inverse case (max_restarts trips first). The two
+    canaries together pin both branches of the
+    ``time.monotonic() - start < budget_s and (… or restart_index <
+    search.max_restarts)`` compound predicate in ``solver.solve``'s outer
+    loop. If a future refactor flips the short-circuit order, drops a
+    clause, or accidentally turns ``and`` into ``or``, one or the other
+    canary will go red.
+    """
+    fixture = "tests/fixtures/solve_fresh_six_planes.yaml"
+
+    s = load_scenario(fixture)
+    r = solve(
+        s,
+        budget_s=0.001,  # tiny budget — trips first
+        alternatives=1,
+        seed=42,
+        search=SearchConfig(max_restarts=1000),  # cap that won't be reached
+    )
+
+    # The budget — not the restart cap — must be the gate that trips.
+    # ``restarts_attempted`` may be 0 or a small handful depending on
+    # machine speed and per-restart cost, but it is bounded by what the
+    # tiny 1 ms budget allows, well below the 1000-restart cap. If this
+    # tripped at the cap, ``restarts_attempted`` would equal 1000 and
+    # the assertion would fire loud.
+    assert r.diagnostics.restarts_attempted < 100, (
+        f"expected budget-first termination (a few restarts at most), "
+        f"got restarts_attempted={r.diagnostics.restarts_attempted}"
+    )

--- a/tests/test_solver_canaries.py
+++ b/tests/test_solver_canaries.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import pytest
 
 from hangarfit.loader import load_scenario
+from hangarfit.models import SearchConfig
 from hangarfit.solver import solve
 
 # Three canary fixtures chosen for coverage breadth:
@@ -79,3 +80,75 @@ def test_solve_deterministic_given_seed(fixture):
     # The deterministic-layout assertion above is enough to catch any
     # accidental non-determinism (unseeded random, set/dict ordering, etc.):
     # different RNG state -> different layouts.
+
+
+def test_solve_deterministic_best_partial_under_max_restarts() -> None:
+    """``solve(..., search=SearchConfig(max_restarts=K))`` exhausts
+    deterministically across machines.
+
+    The existing wall-clock canaries above don't assert on
+    ``best_partial_layout`` when ``status == "exhausted_budget"`` because
+    a fast machine may flip to ``found`` within the 5 s budget. With
+    ``max_restarts=K`` capping the outer loop, exhaustion is the
+    inevitable outcome regardless of machine speed, and the
+    ``best_partial_layout`` becomes machine-independent.
+
+    Calibration (recorded 2026-05-22 for traceability):
+        Ran ``solve(scenario, budget_s=10.0, seed=42)`` once on
+        ``solve_fresh_six_planes.yaml`` to record the natural restart
+        count to first success. Observed ``restarts_attempted=2``
+        (status=found, wall_time≈1.3 s on the calibration machine).
+        Per the v0.6.0 plan Task 2 brief, the canary's ``max_restarts``
+        is set deliberately small (``observed // 2 = 1``) so the cap
+        trips before the natural success, forcing exhaustion. The
+        ``budget_s=30.0`` here is generous; ``max_restarts`` is the
+        gate that trips first. If a future algorithm change pushes
+        natural success below 2 restarts at seed=42 (i.e., succeeds on
+        restart 0), this canary needs re-calibration on
+        ``solve_diversity_impossible_warn.yaml`` per the plan's
+        fallback procedure.
+    """
+    fixture = "tests/fixtures/solve_fresh_six_planes.yaml"
+    max_restarts = 1
+
+    s1 = load_scenario(fixture)
+    r1 = solve(
+        s1,
+        budget_s=30.0,
+        alternatives=1,
+        seed=42,
+        search=SearchConfig(max_restarts=max_restarts),
+    )
+
+    s2 = load_scenario(fixture)
+    r2 = solve(
+        s2,
+        budget_s=30.0,
+        alternatives=1,
+        seed=42,
+        search=SearchConfig(max_restarts=max_restarts),
+    )
+
+    # The max_restarts cap (not wall-clock) must be the gate that trips —
+    # otherwise the canary's purpose (cross-machine determinism of the
+    # exhausted-budget branch) is lost.
+    assert r1.status == "exhausted_budget", (
+        f"expected exhausted_budget under max_restarts={max_restarts}; "
+        f"got {r1.status} (calibration drift — see test docstring)"
+    )
+    assert r2.status == r1.status
+    assert r1.diagnostics.restarts_attempted == max_restarts
+    assert r2.diagnostics.restarts_attempted == max_restarts
+
+    # The fused-pair contract — both Some when exhausted_budget.
+    bpl1 = r1.diagnostics.best_partial_layout
+    bpl2 = r2.diagnostics.best_partial_layout
+    assert bpl1 is not None, "exhausted_budget must populate best_partial_layout"
+    assert bpl2 is not None
+
+    # The headline assertion: bit-for-bit identical best_partial_layout
+    # across the two runs. This is what the canary buys over the existing
+    # wall-clock canaries — under max_restarts the outcome is fully
+    # reproducible, not just the accepted layouts.
+    assert bpl1.placements == bpl2.placements
+    assert bpl1.maintenance_plane == bpl2.maintenance_plane


### PR DESCRIPTION
Closes #111

Implements spec §4.2 of `docs/superpowers/specs/2026-05-22-v0.6.0-solver-polish-release-design.md`.

## Changes

- `SearchConfig.max_restarts: int | None = None` — `None` preserves current wall-clock-only behavior.
- `solver.py` outer restart loop honors `max_restarts` in addition to `budget_s`; first gate to trip wins.
- New determinism canary in `tests/test_solver_canaries.py` pinning a deterministic `best_partial_layout` via `max_restarts` — exhausts deterministically across machines.
- `tests/test_models.py` cases for the default + the post_init guard.

Calibration of canary's `max_restarts` value: observed `restarts_attempted=2` under `seed=42` on `solve_fresh_six_planes.yaml` (status=found, wall_time≈1.3 s on calibration machine). Per the plan Task 2 brief, chose `max_restarts = observed // 2 = 1` so the cap trips before natural success, forcing exhaustion. Recorded in the test docstring for future re-calibration if the algorithm changes.

## Out of scope

Anything beyond spec §4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)