### PR TITLE
test(solver): make fixture-matrix fail loudly on regression (#98)

### DIFF
--- a/tests/test_solver_fixture_matrix.py
+++ b/tests/test_solver_fixture_matrix.py
@@ -121,19 +121,28 @@ def test_solve_repair_minimal_edit_honors_all_pins():
     spec §6.5 "only the unpinned plane differs from baseline" property
     requires a baseline-layout reference that the v1 fixture format does
     not yet carry, so it is NOT asserted here — tracked as follow-up.
+
+    Calibration (spec §4.3, ``K = max(observed × 2, 5)`` under ``seed=42``):
+    observed restarts_attempted = 1 (deterministic across 3 trials); K = 5.
+    A regression that pushes this beyond 5 restarts trips the assert below
+    instead of silently skipping.
     """
     s = load_scenario(f"{FIXTURES}/solve_repair_minimal_edit.yaml")
-    r = solve(s, budget_s=5.0, alternatives=1, seed=42)
+    r = solve(
+        s,
+        budget_s=5.0,
+        alternatives=1,
+        seed=42,
+        search=SearchConfig(max_restarts=5),
+    )
 
-    if r.status == "exhausted_budget":
-        pytest.skip(
-            f"Solver didn't find a layout in 5s for solve_repair_minimal_edit "
-            f"(restarts={r.diagnostics.restarts_attempted}). Acceptable on slow CI; "
-            f"placeholder hangar with 5 pins is a constrained search."
-        )
+    assert r.status == "found", (
+        f"Fixture 'solve_repair_minimal_edit.yaml' exhausted within max_restarts=5 "
+        f"(restarts_attempted={r.diagnostics.restarts_attempted}); a regression "
+        f"is likely (was previously found within 1 restart under seed=42)."
+    )
 
     _assert_universal_properties(r)
-    assert r.status == "found"
     assert len(r.layouts) == 1
 
     placements_by_id = {p.plane_id: p for p in r.layouts[0].placements}

--- a/tests/test_solver_fixture_matrix.py
+++ b/tests/test_solver_fixture_matrix.py
@@ -14,7 +14,7 @@ import pytest
 
 from hangarfit.collisions import check
 from hangarfit.loader import LoaderError, load_scenario
-from hangarfit.models import DiversityConfig, SolveResult
+from hangarfit.models import DiversityConfig, SearchConfig, SolveResult
 from hangarfit.solver import _heading_delta_short_arc, solve
 
 FIXTURES = "tests/fixtures"
@@ -77,19 +77,28 @@ def _count_planes_moved(la, lb, cfg: DiversityConfig) -> int:
 def test_solve_pinned_one_plane_honors_pin():
     """Pinned plane's placement must match the pin exactly in the
     returned layout. Spec §6.5: `found`, pinned unchanged.
+
+    Calibration (spec §4.3, ``K = max(observed × 2, 5)`` under ``seed=42``):
+    observed restarts_attempted = 1 (deterministic across 3 trials); K = 5.
+    A regression that pushes this beyond 5 restarts trips the assert below
+    instead of silently skipping.
     """
     s = load_scenario(f"{FIXTURES}/solve_pinned_one_plane.yaml")
-    r = solve(s, budget_s=5.0, alternatives=1, seed=42)
+    r = solve(
+        s,
+        budget_s=5.0,
+        alternatives=1,
+        seed=42,
+        search=SearchConfig(max_restarts=5),
+    )
 
-    if r.status == "exhausted_budget":
-        pytest.skip(
-            f"Solver didn't find a layout in 5s for solve_pinned_one_plane "
-            f"(restarts={r.diagnostics.restarts_attempted}). Acceptable on "
-            f"slow CI; the test_hangar_large geometry should usually succeed."
-        )
+    assert r.status == "found", (
+        f"Fixture 'solve_pinned_one_plane.yaml' exhausted within max_restarts=5 "
+        f"(restarts_attempted={r.diagnostics.restarts_attempted}); a regression "
+        f"is likely (was previously found within 1 restart under seed=42)."
+    )
 
     _assert_universal_properties(r)
-    assert r.status == "found"
     assert len(r.layouts) == 1
 
     pinned = s.constraints["aviat_husky"].pin

--- a/tests/test_solver_fixture_matrix.py
+++ b/tests/test_solver_fixture_matrix.py
@@ -244,16 +244,25 @@ def test_solve_maintenance_bay_required_places_maintenance_in_bay():
     from hangarfit.geometry import aircraft_parts_world
 
     s = load_scenario(f"{FIXTURES}/solve_maintenance_bay_required.yaml")
-    r = solve(s, budget_s=5.0, alternatives=1, seed=42)
+    # Calibration (spec §4.3, ``K = max(observed × 2, 5)`` under ``seed=42``):
+    # observed restarts_attempted = 1 (deterministic across 3 trials); K = 5.
+    # A regression that pushes this beyond 5 restarts trips the assert below
+    # instead of silently skipping.
+    r = solve(
+        s,
+        budget_s=5.0,
+        alternatives=1,
+        seed=42,
+        search=SearchConfig(max_restarts=5),
+    )
 
-    if r.status == "exhausted_budget":
-        pytest.skip(
-            f"Solver didn't find a layout in 5s for solve_maintenance_bay_required "
-            f"(restarts={r.diagnostics.restarts_attempted})."
-        )
+    assert r.status == "found", (
+        f"Fixture 'solve_maintenance_bay_required.yaml' exhausted within max_restarts=5 "
+        f"(restarts_attempted={r.diagnostics.restarts_attempted}); a regression "
+        f"is likely (was previously found within 1 restart under seed=42)."
+    )
 
     _assert_universal_properties(r)
-    assert r.status == "found"
     layout = r.layouts[0]
     assert layout.maintenance_plane == "wild_thing"
 

--- a/tests/test_solver_fixture_matrix.py
+++ b/tests/test_solver_fixture_matrix.py
@@ -167,18 +167,28 @@ def test_solve_force_carts_lock_respects_lock():
     """force_on_carts=True must be reflected in every returned layout's
     placement for that plane. Spec §6.5: `found`, returned layout
     respects the lock.
+
+    Calibration (spec §4.3, ``K = max(observed × 2, 5)`` under ``seed=42``):
+    observed restarts_attempted = 1 (deterministic across 3 trials); K = 5.
+    A regression that pushes this beyond 5 restarts trips the assert below
+    instead of silently skipping.
     """
     s = load_scenario(f"{FIXTURES}/solve_force_carts_lock.yaml")
-    r = solve(s, budget_s=5.0, alternatives=1, seed=42)
+    r = solve(
+        s,
+        budget_s=5.0,
+        alternatives=1,
+        seed=42,
+        search=SearchConfig(max_restarts=5),
+    )
 
-    if r.status == "exhausted_budget":
-        pytest.skip(
-            f"Solver didn't find a layout in 5s for solve_force_carts_lock "
-            f"(restarts={r.diagnostics.restarts_attempted})."
-        )
+    assert r.status == "found", (
+        f"Fixture 'solve_force_carts_lock.yaml' exhausted within max_restarts=5 "
+        f"(restarts_attempted={r.diagnostics.restarts_attempted}); a regression "
+        f"is likely (was previously found within 1 restart under seed=42)."
+    )
 
     _assert_universal_properties(r)
-    assert r.status == "found"
     placed = next(p for p in r.layouts[0].placements if p.plane_id == "cessna_140")
     assert placed.on_carts is True
 

--- a/tests/test_solver_fixture_matrix.py
+++ b/tests/test_solver_fixture_matrix.py
@@ -296,22 +296,28 @@ def test_solve_all_nine_large_hangar_finds_layout():
 
     Spec §6.5: expected `found`. Universal properties cover validity;
     nothing additional to assert beyond status + layout count.
+
+    Calibration (spec §4.3, ``K = max(observed × 2, 5)`` under ``seed=42``):
+    observed restarts_attempted = 2 (deterministic across 3 trials at ~3.2s
+    wall time per run); K = max(2 × 2, 5) = 5. A regression that pushes this
+    beyond 5 restarts trips the assert below instead of silently skipping.
     """
     s = load_scenario(f"{FIXTURES}/solve_all_nine_large_hangar.yaml")
-    r = solve(s, budget_s=30.0, alternatives=1, seed=42)
+    r = solve(
+        s,
+        budget_s=30.0,
+        alternatives=1,
+        seed=42,
+        search=SearchConfig(max_restarts=5),
+    )
 
-    if r.status == "exhausted_budget":
-        pytest.skip(
-            f"Solver didn't find a 9-plane layout in 30s "
-            f"(restarts={r.diagnostics.restarts_attempted}). The Phase 1 "
-            f"hand-authored valid_all_nine_planes layout demonstrates a "
-            f"solution exists; the solver just didn't stumble onto it. "
-            f"Re-tune SearchConfig or extend the budget if this becomes "
-            f"a pattern."
-        )
+    assert r.status == "found", (
+        f"Fixture 'solve_all_nine_large_hangar.yaml' exhausted within max_restarts=5 "
+        f"(restarts_attempted={r.diagnostics.restarts_attempted}); a regression "
+        f"is likely (was previously found within 2 restarts under seed=42)."
+    )
 
     _assert_universal_properties(r)
-    assert r.status == "found"
     assert len(r.layouts) == 1
     assert len(r.layouts[0].placements) == 9
     # Maintenance plane survival: a regression where the solver dropped


### PR DESCRIPTION
Closes #98

Implements spec §4.3 of `docs/superpowers/specs/2026-05-22-v0.6.0-solver-polish-release-design.md`.

## Changes

- Five matrix tests in `tests/test_solver_fixture_matrix.py` (previously calling `pytest.skip` on `exhausted_budget`) now use `SearchConfig(max_restarts=K)` from Wave 1's #111 to force deterministic outcomes.
- On `exhausted_budget`, tests now `assert r.status == "found"` with a diagnostic message identifying the fixture and the previously observed restart count under `seed=42` — regressions fail loudly instead of silently skipping.
- Per-fixture K values recorded in comments above each test (`K = max(observed × 2, 5)` derived from `seed=42` calibration, 3 trials each).
- The now-redundant `assert r.status == "found"` lines that previously sat just below `_assert_universal_properties(r)` are dropped: the diagnostic assert above already guarantees that status.

## Per-fixture calibration table

All five fixtures were calibrated under `seed=42`, three trials each. Observed restart counts were identical across all trials (zero variance), so the headroom rule `K = max(observed × 2, 5)` applies to the single observed value.

| Fixture | observed restarts (seed=42, 3 trials) | K (max(obs × 2, 5)) |
|---|---|---|
| `solve_pinned_one_plane.yaml` | 1 | 5 |
| `solve_repair_minimal_edit.yaml` | 1 | 5 |
| `solve_force_carts_lock.yaml` | 1 | 5 |
| `solve_maintenance_bay_required.yaml` | 1 | 5 |
| `solve_all_nine_large_hangar.yaml` | 2 | 5 |

The floor `K=5` dominated everywhere — none of the five fixtures stretch the doubling rule above the spec's minimum.

## Verification

- `grep -n 'pytest.skip' tests/test_solver_fixture_matrix.py` returns zero matches.
- `pytest tests/test_solver_fixture_matrix.py -v -m ""` shows all 7 matrix tests PASS (5 solve fixtures + 2 LoaderError contradictions), no SKIP, no XFAIL.
- Full suite (`pytest -m ""`) green: 367 passed.
- `ruff check src/ tests/` clean.
- `ruff format --check src/ tests/` clean.
- `mypy src/hangarfit/` clean.

## Out of scope

The "dead `found_partial` branch" item from earlier drafts was a phantom — no such branch exists in `_assert_universal_properties` (only set membership in `r.status in {...}` at L29). Spec §4.3 explicitly notes this; the helper is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)