### PR TITLE
chore(cli): Chunk F cleanup bundle (#95)

### DIFF
--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -19,7 +19,7 @@ import sys
 
 from hangarfit import collisions, visualize
 from hangarfit.loader import LoaderError, load_fleet, load_hangar, load_layout
-from hangarfit.models import CheckResult, Conflict, Layout, SolveResult
+from hangarfit.models import CheckResult, Conflict, DiversityConfig, Layout, SolveResult
 
 _JSON_SCHEMA = "hangarfit.check/v1"
 _SOLVE_JSON_SCHEMA = "hangarfit.solve/v1"
@@ -233,26 +233,26 @@ def _emit_solve_human(result: SolveResult, *, alternatives: int) -> None:
         print(line)
 
 
-# Position threshold (m) used purely for the human-output "shifted vs"
-# count. Mirrors DiversityConfig.position_threshold_m's default so the
-# narration agrees with the filter that gated acceptance — not imported
-# from DiversityConfig because the CLI doesn't (yet) expose the threshold
-# as a flag; if it ever does, swap the constant for the configured value.
-_HUMAN_SHIFT_THRESHOLD_M = 0.5
-
-
 def _placement_delta(a: Layout, b: Layout) -> tuple[int, float]:
     """Return (planes_moved, mean_xy_shift_m) between two layouts.
 
     Planes-moved counts placements whose Euclidean (x, y) shift exceeds
-    ``_HUMAN_SHIFT_THRESHOLD_M`` — same metric the solver's diversity
-    filter uses. Heading-only shifts are intentionally ignored for the
-    narration: the audience is reading "how different does this layout
-    LOOK"; a pure rotation reads as the same layout to the eye even
-    though the solver considers it diverse.
+    ``DiversityConfig().position_threshold_m`` — same metric the
+    solver's diversity filter uses. Pulling the threshold directly from
+    ``DiversityConfig`` (rather than mirroring it as a local constant)
+    keeps the human-output narration in lockstep with the filter that
+    gated acceptance: if the default ever changes, both sides shift
+    together. ``DiversityConfig`` is a frozen dataclass with no side
+    effects, so instantiating it here is free.
+
+    Heading-only shifts are intentionally ignored for the narration:
+    the audience is reading "how different does this layout LOOK"; a
+    pure rotation reads as the same layout to the eye even though the
+    solver considers it diverse.
     """
     import math
 
+    threshold = DiversityConfig().position_threshold_m
     by_id_a = {p.plane_id: p for p in a.placements}
     by_id_b = {p.plane_id: p for p in b.placements}
     shared = sorted(set(by_id_a) & set(by_id_b))
@@ -264,7 +264,7 @@ def _placement_delta(a: Layout, b: Layout) -> tuple[int, float]:
         dy = pa.y_m - pb.y_m
         shift = math.hypot(dx, dy)
         total_shift += shift
-        if shift > _HUMAN_SHIFT_THRESHOLD_M:
+        if shift > threshold:
             moved += 1
     mean = total_shift / len(shared) if shared else 0.0
     return moved, mean

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -182,7 +182,7 @@ def cmd_check(args: argparse.Namespace) -> int:
 
 
 def _emit_solve_human(result: SolveResult, *, alternatives: int) -> None:
-    """Write the human-readable summary to stdout. See spec §5.3."""
+    """Write the human-readable summary to stdout."""
     d = result.diagnostics
     if result.status == "trivially_infeasible":
         # `best_partial` is fused with the explanatory conflict by the
@@ -271,7 +271,7 @@ def _placement_delta(a: Layout, b: Layout) -> tuple[int, float]:
 
 
 def cmd_solve(args: argparse.Namespace) -> int:
-    """Run the ``solve`` subcommand. See spec §5 for the data flow."""
+    """Run the ``solve`` subcommand."""
     # Defer the solver import only: ``hangarfit check`` invocations should
     # not pay the solver's import cost. Matplotlib is NOT deferred here —
     # ``from hangarfit import visualize`` at module top (cli.py:20) already
@@ -470,7 +470,7 @@ def _check_result_to_dict(result: CheckResult) -> dict:
 
 
 def _emit_solve_json(scenario_path: str, result: SolveResult) -> None:
-    """Write the hangarfit.solve/v1 payload to stdout. See spec §5.4."""
+    """Write the hangarfit.solve/v1 payload to stdout."""
     d = result.diagnostics
     payload = {
         "schema": _SOLVE_JSON_SCHEMA,

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -272,9 +272,11 @@ def _placement_delta(a: Layout, b: Layout) -> tuple[int, float]:
 
 def cmd_solve(args: argparse.Namespace) -> int:
     """Run the ``solve`` subcommand. See spec §5 for the data flow."""
-    # Imports are local so that `hangarfit check` users don't pay the
-    # solver / matplotlib import cost — matplotlib is the slow one and
-    # only `--render` needs it.
+    # Defer the solver import only: ``hangarfit check`` invocations should
+    # not pay the solver's import cost. Matplotlib is NOT deferred here —
+    # ``from hangarfit import visualize`` at module top (cli.py:20) already
+    # eagerly imports matplotlib and pins the Agg backend, so both `check`
+    # and `solve` callers pay that cost regardless.
     from hangarfit.loader import load_scenario
     from hangarfit.solver import solve
 

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -344,6 +344,41 @@ class TestSolveRender:
         assert rc == 0
         assert out.exists()
 
+    def test_write_yaml_roundtrip_preserves_maintenance_plane(self, tmp_path, capsys):
+        """Maintenance round-trip: the `payload["maintenance"] = ...`
+        branch at the bottom of ``_write_yamls`` had no coverage because
+        the smoke fixture is single-Husky with no maintenance block.
+
+        Pre-condition fence: this test uses an existing maintenance
+        fixture as-is — Milestone #9 (maintenance bay walling) is
+        deferred per spec §8 and this test does NOT assume walled-bay
+        semantics. The current soft-hint bay model is what's under test.
+        """
+        from hangarfit import loader
+
+        fixture = str(FIXTURES_DIR / "solve_maintenance_bay_required.yaml")
+        out = tmp_path / "roundtrip.yaml"
+        rc = main(
+            [
+                "solve",
+                fixture,
+                "--budget",
+                "5.0",
+                "--seed",
+                "42",
+                "--write-yaml",
+                str(out),
+            ]
+        )
+        assert rc == 0, f"solve failed (rc={rc}); stderr={capsys.readouterr().err}"
+        assert out.exists()
+        capsys.readouterr()  # drain solve stdout
+
+        # Round-trip: load the written layout and verify the
+        # maintenance plane key survived the dump → parse cycle.
+        layout = loader.load_layout(out)
+        assert layout.maintenance_plane == "wild_thing"
+
     def test_write_yaml_roundtrips_via_check(self, tmp_path, capsys):
         out = tmp_path / "out.yaml"
         rc = main(

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -156,6 +156,85 @@ class TestSolveHumanOutput:
         assert "Hint: increase --budget" in out
 
 
+class TestSolveFleetHangarOverrides:
+    """`--fleet` / `--hangar` override flags exercise both branches of
+    :func:`hangarfit.cli._resolve_fleet_hangar_refs` (override + embedded)
+    plus the LoaderError collision when both are set.
+    """
+
+    # Resolve repo-relative defaults to absolute paths once: scenarios
+    # written into tmp_path can't use the original "../../data/..." refs.
+    REPO_ROOT = Path(__file__).resolve().parents[1]
+    DEFAULT_FLEET = str(REPO_ROOT / "data" / "fleet.yaml")
+    DEFAULT_HANGAR = str(REPO_ROOT / "data" / "hangar.yaml")
+
+    def test_fleet_and_hangar_overrides_positive_path(self, tmp_path, capsys):
+        """Scenario without embedded refs + both CLI overrides → solves.
+
+        Exercises the `args.fleet is not None` and `args.hangar is not
+        None` branches of `_resolve_fleet_hangar_refs` (plus the
+        load_scenario override paths).
+        """
+        scenario = tmp_path / "scenario_no_refs.yaml"
+        scenario.write_text("fleet_in: [aviat_husky]\n")
+        rc = main(
+            [
+                "solve",
+                str(scenario),
+                "--budget",
+                "2.0",
+                "--seed",
+                "42",
+                "--fleet",
+                self.DEFAULT_FLEET,
+                "--hangar",
+                self.DEFAULT_HANGAR,
+            ]
+        )
+        assert rc == 0, f"override solve failed; stderr={capsys.readouterr().err}"
+        out = capsys.readouterr().out
+        assert "Found" in out
+
+    def test_fleet_override_collides_with_embedded_ref(self, tmp_path, capsys):
+        """`--fleet` + scenario with `fleet:` → LoaderError → rc=2."""
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--budget",
+                "0.1",
+                "--seed",
+                "42",
+                "--fleet",
+                self.DEFAULT_FLEET,
+            ]
+        )
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "error:" in captured.err
+        # LoaderError text identifies the ambiguous field.
+        assert "fleet" in captured.err
+
+    def test_hangar_override_collides_with_embedded_ref(self, tmp_path, capsys):
+        """`--hangar` + scenario with `hangar:` → LoaderError → rc=2."""
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--budget",
+                "0.1",
+                "--seed",
+                "42",
+                "--hangar",
+                self.DEFAULT_HANGAR,
+            ]
+        )
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "error:" in captured.err
+        assert "hangar" in captured.err
+
+
 class TestSolveJsonOutput:
     """Spec §5.4 — hangarfit.solve/v1 schema."""
 

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -461,6 +461,31 @@ class TestSolveRender:
         assert "--render" in captured.err
         assert not out.exists()
 
+    def test_render_to_nonexistent_dir_returns_2(self, tmp_path, capsys):
+        """OSError during write → rc=2 with `error:` in stderr.
+
+        Covers the ``except OSError`` arm at cli.py wrapping
+        ``_write_renders`` / ``_write_yamls`` — currently unexercised
+        because every other render/write test routes to a tmp_path
+        directory that already exists.
+        """
+        target = tmp_path / "no_such_dir" / "out.png"
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--budget",
+                "2.0",
+                "--seed",
+                "42",
+                "--render",
+                str(target),
+            ]
+        )
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "error:" in captured.err
+
     def test_k_gt_1_substitutes_i_for_each_alternative(self, tmp_path, capsys):
         """K>1 happy path: ``{i}`` substitutes at every i in 1..K.
 

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -139,7 +139,8 @@ class TestSolveHumanOutput:
         already used by ``test_solver_search`` for the same purpose)
         with a tiny budget so the solver almost certainly exhausts.
         Skip-on-lucky guard follows the
-        ``tests/test_solver_search.py:355-391`` pattern: if a fast
+        ``test_solve_exhausted_budget_reports_best_partial_pair``
+        pattern (in ``tests/test_solver_search.py``): if a fast
         machine accidentally finds a layout we skip rather than fail.
         """
         import pytest

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -120,8 +120,10 @@ class TestSolveHumanOutput:
         out = capsys.readouterr().out
         assert "Trivially infeasible" in out
 
-    def test_human_output_exhausted_budget(self, capsys):
-        # Plane bigger than hangar -> trivially infeasible via check #1.
+    def test_human_output_trivially_infeasible_plane_too_big(self, capsys):
+        # Plane bigger than hangar -> trivially infeasible via check #1
+        # (per-plane bbox > max hangar dim). Pairs with the pins-clash
+        # variant above to cover both pre-search infeasibility kinds.
         fixture = str(FIXTURES_DIR / "solve_infeasible_plane_too_big.yaml")
         rc = main(["solve", fixture, "--budget", "1.0", "--seed", "42"])
         assert rc == 1
@@ -129,6 +131,29 @@ class TestSolveHumanOutput:
         # plane_too_big hits the per-plane infeasibility check (#1), so
         # it surfaces as trivially_infeasible too.
         assert "Trivially infeasible" in out
+
+    def test_human_output_exhausted_budget(self, capsys):
+        """Real `exhausted_budget` branch of `_emit_solve_human`.
+
+        Uses ``solve_fresh_six_planes.yaml`` (the six-plane fixture
+        already used by ``test_solver_search`` for the same purpose)
+        with a tiny budget so the solver almost certainly exhausts.
+        Skip-on-lucky guard follows the
+        ``tests/test_solver_search.py:355-391`` pattern: if a fast
+        machine accidentally finds a layout we skip rather than fail.
+        """
+        import pytest
+
+        fixture = str(FIXTURES_DIR / "solve_fresh_six_planes.yaml")
+        rc = main(["solve", fixture, "--budget", "0.05", "--seed", "42"])
+        out = capsys.readouterr().out
+        if rc == 0 and "Found" in out:
+            pytest.skip("seed=42 + 0.05s got lucky; tighten budget if this skips often")
+        assert rc == 1
+        # Three diagnostic lines printed by the exhausted_budget branch:
+        assert "No valid layout found in" in out
+        assert "Best partial had" in out and "conflict" in out
+        assert "Hint: increase --budget" in out
 
 
 class TestSolveJsonOutput:

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -381,3 +381,38 @@ class TestSolveRender:
         assert "{i}" in captured.err
         assert "--render" in captured.err
         assert not out.exists()
+
+    def test_k_gt_1_substitutes_i_for_each_alternative(self, tmp_path, capsys):
+        """K>1 happy path: ``{i}`` substitutes at every i in 1..K.
+
+        The K=1 substitute test only exercises ``i=1``. This test runs
+        ``--alternatives 2`` against a fixture that reliably yields two
+        diverse layouts and asserts the enumerate-loop body fires for
+        both i=1 AND i=2 (the i>=2 case is the previously-uncovered
+        branch).
+        """
+        fixture = str(FIXTURES_DIR / "solve_fresh_alternatives_three.yaml")
+        render_pattern = str(tmp_path / "out_{i}.png")
+        yaml_pattern = str(tmp_path / "out_{i}.yaml")
+        rc = main(
+            [
+                "solve",
+                fixture,
+                "--alternatives",
+                "2",
+                "--budget",
+                "5.0",
+                "--seed",
+                "42",
+                "--render",
+                render_pattern,
+                "--write-yaml",
+                yaml_pattern,
+            ]
+        )
+        assert rc == 0, f"K>1 solve failed (rc={rc}); stderr={capsys.readouterr().err}"
+        # Both alternatives must be present — i=1 and the new i=2 branch.
+        assert (tmp_path / "out_1.png").exists()
+        assert (tmp_path / "out_2.png").exists()
+        assert (tmp_path / "out_1.yaml").exists()
+        assert (tmp_path / "out_2.yaml").exists()


### PR DESCRIPTION
Closes #95

Implements spec §4.4 of `docs/superpowers/specs/2026-05-22-v0.6.0-solver-polish-release-design.md`. Bundles the Chunk F /pr-review follow-ups merged before threads landed on PR #94.

## Code/comment fixes

1. Matplotlib deferred-import comment in `cmd_solve` rewritten to be honest about what is and isn't deferred (only the solver import is deferred; matplotlib is paid by every CLI caller via `visualize` at module top).
2. `_HUMAN_SHIFT_THRESHOLD_M` replaced with `DiversityConfig().position_threshold_m` reference (one less knob to keep in sync).
3. Per-function `§5.x` docstring references dropped from `cmd_solve`, `_emit_solve_human`, `_emit_solve_json` (rot surface > value).

## Test coverage

4. `exhausted_budget` human-output branch — three new assertions; skip-on-lucky guard follows the `tests/test_solver_search.py:355-391` pattern.
5. Misnamed `test_human_output_exhausted_budget` renamed to `test_human_output_trivially_infeasible_plane_too_big` to reflect actual coverage.
6. K>1 happy path with `{i}` substitution exercises the enumerate loop at i=2 (against `solve_fresh_alternatives_three.yaml`).
7. `--fleet`/`--hangar` override branches now have positive override + two collision-rejection tests.
8. `OSError`-during-write rc=2 path (`--render /nonexistent_dir/out.png`).
9. `maintenance_plane` round-trip via solve → write-yaml → `loader.load_layout`.

## Out of scope

- Maintenance bay walling semantics — Milestone #9 stays deferred per spec §8.
- Anything not in spec §4.4. No adjacent issues filed during implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)