### PR TITLE
docs(spec): broaden diversity_impossible precondition wording (#119)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-v0.6.0-solver-polish-release-design.md
+++ b/docs/superpowers/specs/2026-05-22-v0.6.0-solver-polish-release-design.md
@@ -53,7 +53,7 @@ Each row below is the **complete, committed contents** of one PR. Anything not l
 Add two structured signal fields so the diversity warning at `solver.py` becomes machine-readable rather than logger-only.
 
 **Adds (`src/hangarfit/models.py`):**
-- `SolverDiagnostics.diversity_impossible: bool = False` — `True` iff the static `K > 1 ∧ free_planes < min_planes_moved` precondition fires (where `min_planes_moved` defaults to 2 via `DiversityConfig`).
+- `SolverDiagnostics.diversity_impossible: bool = False` — `True` iff the static `K > 1 ∧ free_planes < min_planes_moved` precondition fires.
 - `SolverDiagnostics.diversity_rejected_count: int = 0` — increments whenever the diversity filter rejects a candidate that would otherwise have been accepted.
 - `__post_init__` guard: `diversity_rejected_count >= 0`.
 

--- a/docs/superpowers/specs/2026-05-22-v0.6.0-solver-polish-release-design.md
+++ b/docs/superpowers/specs/2026-05-22-v0.6.0-solver-polish-release-design.md
@@ -53,7 +53,7 @@ Each row below is the **complete, committed contents** of one PR. Anything not l
 Add two structured signal fields so the diversity warning at `solver.py` becomes machine-readable rather than logger-only.
 
 **Adds (`src/hangarfit/models.py`):**
-- `SolverDiagnostics.diversity_impossible: bool = False` — `True` iff the static `K > 1 ∧ planes_count == 0 ∧ everything-pinned` precondition fires.
+- `SolverDiagnostics.diversity_impossible: bool = False` — `True` iff the static `K > 1 ∧ free_planes < min_planes_moved` precondition fires (where `min_planes_moved` defaults to 2 via `DiversityConfig`).
 - `SolverDiagnostics.diversity_rejected_count: int = 0` — increments whenever the diversity filter rejects a candidate that would otherwise have been accepted.
 - `__post_init__` guard: `diversity_rejected_count >= 0`.
 


### PR DESCRIPTION
## What

Amends `docs/superpowers/specs/2026-05-22-v0.6.0-solver-polish-release-design.md` §4.1 wording for the `diversity_impossible` precondition.

The spec described it as `K > 1 ∧ planes_count == 0 ∧ everything-pinned`. The actual implementation in `solver.py` (merged via PR #118) uses the broader `K > 1 ∧ free_planes < min_planes_moved` condition (defaults to `min_planes_moved=2` via `DiversityConfig`).

Docs-only — the field name, semantics, defaults, and `__post_init__` guard remain as-is per #118.

## Why

Surfaced by code-reviewer on PR #118. The spec wording was narrower than the implementation; cases like "2 free planes, M=3" do trigger `diversity_impossible` in code but weren't covered by the spec text.

## Verification

No code change; no tests required. The field docstring in `src/hangarfit/models.py` already uses the broader wording.

Closes #119