### PR TITLE
ci(scorecard): fix push trigger to default branch + add workflow_dispatch (#126)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,10 +1,11 @@
 name: Scorecard supply-chain security
 on:
+  workflow_dispatch:
   branch_protection_rule:
   schedule:
     - cron: '0 6 * * 1'
   push:
-    branches: [main]
+    branches: [develop]
 
 permissions: read-all
 


### PR DESCRIPTION
## Root cause

The `ossf/scorecard-action` enforces that it only runs on the repository's default branch, and rejects all others with:

> Only the default branch develop is supported

This repo follows GitFlow — `develop` is the default branch on GitHub. The previous `on.push.branches: [main]` trigger fired on every release-merge into `main`, causing an immediate failure (confirmed: failing run **26328664451**). The scheduled Monday run would also fail once `develop` diverged from `main`.

## Change

Three lines in `.github/workflows/scorecard.yml`:

- Add `workflow_dispatch:` event trigger (enables ad-hoc reruns via `gh workflow run scorecard.yml --ref develop`).
- Change `push: branches: [main]` → `push: branches: [develop]` so the push trigger targets the actual default branch.

No other changes: action SHA pins, permissions block, and all steps are untouched.

## Post-merge verification

```bash
# Trigger a manual run on develop and watch it succeed
gh workflow run scorecard.yml --ref develop -R DocGerd/hangarfit
gh run list --workflow=scorecard.yml -R DocGerd/hangarfit --limit 3

# Once the run completes, check the published scorecard (may take ~30 min to propagate)
curl -s https://api.securityscorecards.dev/projects/github.com/DocGerd/hangarfit | jq '{score, date}'
```

Closes #126