### PR TITLE
ci(codecov): wire CODECOV_TOKEN for non-main coverage uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,4 @@ jobs:
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `token: ${{ secrets.CODECOV_TOKEN }}` to the `codecov/codecov-action` `with:` block in `.github/workflows/ci.yml`.
- One line added; nothing else changed.

Closes #127

## Root cause

Codecov's tokenless upload path is restricted to the repository's default branch on github.com. Every run against `develop` or a `feature/*` branch currently fails with:

```
Token required - not valid tokenless upload
```

This was first observed in CI run **26328334051** on the `develop` branch. The fix is to supply a repository secret token so that Codecov accepts uploads from all branches.

## Merge order — safe to land before or after the secret is set

`${{ secrets.CODECOV_TOKEN }}` interpolates to an **empty string** when the secret does not exist in repo Settings → Secrets and variables → Actions. An empty token is functionally identical to the current tokenless state: the upload step exits `0` (because `fail_ci_if_error: false`) and coverage is not recorded on Codecov.

**Merging before the secret is added does NOT break CI.** Once the user adds `CODECOV_TOKEN` in repo Settings, the very next CI run picks it up automatically — no further code change needed.

## Post-merge verification

After adding `CODECOV_TOKEN` as a repository secret:

1. Trigger any CI run on `develop` (push a trivial commit or re-run the last workflow).
2. In the "Upload coverage to Codecov" step output, look for `Token length: <non-zero>` and `Uploading to https://codecov.io`.
3. Confirm the badge at `https://codecov.io/gh/DocGerd/hangarfit/branch/develop/graph/badge.svg` resolves to a real percentage rather than "unknown".

## Deferred follow-ups (not in scope here)

- `fail_ci_if_error: false` → `true` (once uploads are confirmed reliable on all branches — tracked in a separate issue per #127 description).
- OIDC keyless auth (more complex setup; deliberately deferred).