### PR TITLE
chore: back-merge v0.6.1 into develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hangarfit"
-version = "0.6.0"
+version = "0.6.1"
 description = "Helper tool for arranging the flying club fleet in a stack-style hangar — collision checker + visualizer (Phase 1)."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Back-merge v0.6.1 into develop

Merges the `release/0.6.1` branch back into `develop` to keep the
branches in sync after the release.

This PR should be merged AFTER the main release PR (#146) is merged.