### PR TITLE
chore(gitignore): ignore .claude/worktrees/ (#148)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ out*.png
 # Explicit even though *.local.* already matches — keeps the intent
 # visible to contributors grepping for ".claude" (issue #35).
 .claude/settings.local.json
+
+# Per-agent isolation worktrees created by Claude Code's Agent tool when
+# invoked with `isolation: "worktree"`. The tool writes to
+# `.claude/worktrees/agent-<hash>/`; nothing in there is ever meant to be
+# committed (issue #148).
+.claude/worktrees/


### PR DESCRIPTION
## What

Adds `.claude/worktrees/` to `.gitignore`. 6-line diff: comment block + the path entry, placed adjacent to the existing `.claude/settings.local.json` exclusion to keep the `.claude/`-related entries grouped (same pattern as #35).

## Why

Claude Code's Agent tool, when invoked with `isolation: "worktree"`, creates per-agent worktrees under `.claude/worktrees/agent-<hash>/`. That directory is never meant to be committed but was previously visible in `git status --porcelain` as untracked noise.

This surfaced concretely during the v0.6.1 release cut on 2026-05-23: the `/release-cut` skill's strict clean-tree check (`git status --porcelain` must be empty) refused to proceed until the deviation was acknowledged in the plan. The release went ahead, but the `??` line should not have appeared in the first place.

## Scope

- Ignores `.claude/worktrees/` only.
- **Does NOT** broaden to `.claude/` — the project's team-shared Claude Code settings (`settings.json`, hooks, etc.) are intentionally tracked.

## Acceptance criteria

- [x] `git status --porcelain` no longer reports `?? .claude/worktrees/` after the Agent tool has created an isolation worktree there (verified locally — the modified `.gitignore` already produces the desired behaviour).
- [x] `.claude/settings.json` and other tracked files remain tracked (`git status -uall` shows no newly-ignored tracked content).
- [x] The new entry sits next to the existing `.claude/settings.local.json` block with an explanatory comment.

Closes #148