### PR TITLE
docs(adr): backfill 5 retroactive ADRs for Phase 1 + 2a decisions

### DIFF
--- a/docs/adr/0001-aircraft-parts-model.md
+++ b/docs/adr/0001-aircraft-parts-model.md
@@ -1,0 +1,226 @@
+# ADR-0001: Aircraft geometry as a list of parts (not a single bounding box)
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+`hangarfit` has to decide, for any candidate parking layout, whether two
+aircraft physically collide. The mixed fleet makes the simple answer
+("compare bounding boxes") wrong: a high-wing's wingtip is legally
+allowed to hang over a low-wing's fuselage area in plan view because
+the two are at different heights, and a strut-braced plane's wing
+volume is *not* free for another plane's wing to nest through — the
+strut itself occupies a thin column between fuselage and wing
+underside. Phase 1 had to commit, before any solver, visualizer, or
+test fixture was written, to a geometric representation that could
+distinguish "they overlap in plan view but at disjoint heights" from
+"they collide." Every later subsystem keys off this choice; getting it
+wrong would have made every downstream layout wrong.
+
+## Decision Drivers
+
+- **Height-disjoint pass-through must be expressible.** The only
+  low-wing in the fleet (`fuji`) sits well below every high-wing's
+  wing layer; a representation that cannot reason about height-disjoint
+  parts cannot model this case at all.
+- **Strut volume must be representable as occupied.** Five of the nine
+  aircraft (`aviat_husky`, `wild_thing`, `zlin_savage`, `cessna_140`,
+  `cessna_150`, `fk9_mkii`) are strut-braced. The strut is what
+  prevents another plane's wing from nesting through the gap between
+  fuselage and wing — and nothing in the wing's own footprint expresses
+  that constraint.
+- **Same-aircraft "self-collision" must not register.** A Husky's wing
+  and its own strut occupy the same column by design; the
+  representation has to give a natural way to skip pairs that share an
+  aircraft ID, not require special-case suppression rules.
+- **The collision predicate should stay small.** A clean two-part rule
+  ("close in plan view AND close in height") is easier to test, easier
+  to render the failure of (the visualizer overdraws conflicting parts
+  in red), and easier to extend with a penetration metric later (which
+  the Phase 2a solver depends on as a smooth secondary score).
+- **YAML authoring stays human-scale.** Whichever representation wins
+  internally, the file an operator edits (`data/fleet.yaml`) cannot
+  require them to type out every strut twice with mirrored offsets.
+
+## Considered Options
+
+1. **A list of oriented-rectangle `Part`s per aircraft, each with a
+   `[z_bottom_m, z_top_m]` height range** — the chosen option. The
+   closed set of `PartKind` values (`fuselage`, `wing`, `strut`,
+   `tail`) lives in [`src/hangarfit/models.py`](../../src/hangarfit/models.py).
+2. **A single 2D axis-aligned (or oriented) bounding rectangle per
+   aircraft** — one footprint, no height.
+3. **A single 3D axis-aligned bounding box per aircraft** — adds a
+   height range to option 2 but keeps the "one box per plane"
+   simplification.
+4. **A general 3D convex polygon mesh per aircraft** — the most
+   expressive of the alternatives; full 3D overlap test.
+
+## Decision Outcome
+
+**Chosen option: a list of oriented-rectangle `Part`s with height
+ranges.** It is the smallest representation that can express both
+height-disjoint pass-through (heights live on the part) and strut
+nesting (the strut is its own part, separately checkable), while
+keeping the collision predicate to a two-line rule and skipping
+same-aircraft pairs structurally rather than by special case.
+
+The shape of the chosen representation: each `Aircraft` carries a
+`tuple[Part, ...]`; each `Part` is an oriented rectangle in
+plane-local coordinates plus `[z_bottom_m, z_top_m]`. The collision
+checker [`src/hangarfit/collisions.py`](../../src/hangarfit/collisions.py)
+iterates over part-pairs across distinct aircraft and applies:
+
+> Two parts from different aircraft conflict iff (a) their plan-view
+> polygons are closer than `hangar.clearance_m` AND (b) the gap
+> between their `[z_bottom_m, z_top_m]` ranges is less than
+> `hangar.wing_layer_clearance_m` (overlap counted as zero gap).
+
+For YAML readability, the loader ([`src/hangarfit/loader.py`](../../src/hangarfit/loader.py))
+accepts a high-level `struts:` block on each strut-braced aircraft
+and expands it into two mirrored strut `Part`s before constructing
+the `Aircraft`. The constructed `Aircraft` has no `struts:` field —
+the parts tuple is the single source of truth, eliminating any risk
+of strut volume being double-counted from both a struts block and a
+strut Part.
+
+### Why not a single 2D bounding rectangle?
+
+It cannot model the only low-wing in the fleet at all. With a flat
+footprint, the Fuji and any high-wing whose wingtip plan-projects
+over the Fuji's fuselage area would have to be reported as
+colliding — but they are physically fine; their wings live in
+different height layers. The whole point of the exception tool is to
+fit more planes in by overlapping in plan view where heights allow,
+which a 2D-only model forbids by construction. It also cannot
+distinguish a strut-braced plane from a cantilever plane: both
+project to identical wing-plus-fuselage footprints in plan view, even
+though only one of them blocks wing-nesting.
+
+### Why not a single 3D axis-aligned bounding box?
+
+A 3D bbox per plane captures height, which solves the high-wing /
+low-wing case. But it cannot capture struts: the entire column from
+ground to wing-top is part of *one* per-plane box, so even the
+strut-free outboard region (where another plane's wing could legally
+nest) is marked occupied. The fleet has both strut-braced and
+cantilever high-wings; a representation that treats them identically
+loses the most operationally-relevant distinction in the data. The 3D
+bbox also forces a 3D overlap test, which is more arithmetic than the
+chosen 2D-distance + height-gap predicate without buying back the
+fidelity it cost.
+
+### Why not a general 3D convex polygon mesh per aircraft?
+
+Expressively, this is a superset of the chosen option — every Part
+can be lifted to a 3D prism, and convex meshes can represent
+fuselage curvature, wing dihedral, and tail empennage faithfully.
+Rejected on cost-benefit grounds. The collision question that
+actually matters for a flying club's tight hangar is "do these two
+structures touch?" which the part-pair predicate already answers
+correctly at the resolution real measurements will support
+(centimeters via tape measure, not millimeters via 3D scan). Mesh
+overlap is also substantially more code to write, test, and visualize
+than the current `shapely`-polygon-pairs implementation, with no
+operational decision riding on the extra fidelity. If a future use
+case demands true 3D — for example, modeling a tug clearance under a
+wing — a later ADR can supersede this one without invalidating any
+of the Phase 1 or Phase 2a code that depends on the part-pair
+predicate; the upgrade path is additive.
+
+## Consequences
+
+### Positive
+
+- **Both fleet edge cases are expressible.** High-wing over low-wing
+  fuselage passes (height-disjoint), and strut-blocks-nesting fails
+  (strut is its own part).
+- **Same-aircraft pairs are skipped structurally.** The collision
+  loop iterates over pairs of aircraft, then pairs of parts within
+  each aircraft pair; no special-case rule needed for a plane's wing
+  vs. its own strut.
+- **The collision predicate is small.** Two clauses (plan-view distance
+  + height gap) — easy to test, easy to render the failure of, and
+  easy to extend with a penetration metric (added in Phase 2a Chunk A
+  as `CheckResult.total_penetration_m2`, used by the solver as a
+  smooth secondary score that breaks plateaus in the integer
+  `len(conflicts)` metric).
+- **Visualization composes naturally.** Each Part is already a
+  renderable polygon; the top-down PNG renderer
+  [`src/hangarfit/visualize.py`](../../src/hangarfit/visualize.py)
+  draws each Part once and overdraws conflicting parts in red without
+  a separate geometry pipeline.
+
+### Negative
+
+- **More arithmetic per check.** For each aircraft pair, the loop
+  considers O(parts_a × parts_b) part-pairs instead of one
+  bbox-pair test. In the placeholder fleet (≤ 5 parts per plane —
+  fuselage + wing + ≤ 2 struts + optional tail) the constant is
+  small, but it scales linearly in part count if a future aircraft
+  model needs more articulation.
+- **YAML authors have to think in parts.** A bbox model would have
+  one length × width per plane; the parts model has multiple offsets,
+  orientations, and height ranges. The `struts:` convenience block
+  mitigates this for the common strut-braced case but does not
+  eliminate it; adding a new aircraft is more involved than filling
+  in two numbers.
+
+### Neutral
+
+- **`PartKind` is a closed set.** Adding a new structural element
+  (engine nacelle, ventral fin, wing-tip fuel tank) is a code change
+  in `models.py` and the matching `_VALID_PART_KINDS` set, not just a
+  YAML edit. This is a deliberate trade-off: a closed kind set keeps
+  the visualizer's color scheme and the conflict-kind taxonomy
+  stable, at the cost of YAML-only extension. The four kinds in use
+  today cover the placeholder fleet.
+- **The parts model says nothing about motion.** Holonomic-vs-Dubins
+  motion (relevant for the future planner) is a property of the
+  `Aircraft`, not its `Part`s; the geometry layer and the planner
+  layer remain decoupled. This is intentional, not an oversight of
+  the parts model.
+
+## Compliance
+
+- **The strut-aware golden tests in
+  [`tests/test_collisions.py`](../../tests/test_collisions.py)** are
+  the canary that the parts model is intact. They cover:
+  same-height wing overlap (must fail), high-over-low height-disjoint
+  pass-through (must pass), strut-blocks-nesting (must fail),
+  inboard- and outboard-strut-free nesting (must pass), the
+  maintenance-bay position rule, and a known-good layout for all
+  nine aircraft on the larger test hangar. If those tests pass, the
+  geometry is trustworthy on the current (placeholder) measurements.
+- **Loader expansion is covered by the loader's tests** — the
+  `struts:` YAML block is exercised end-to-end into the matching
+  pair of mirrored strut `Part`s, so the YAML convenience can never
+  silently desync from the canonical parts representation.
+- **`PartKind` is a `Literal` validated in `Part.__post_init__`** —
+  any code path constructing a `Part` with an unknown kind raises at
+  construction time, not at the collision step. This is the type-level
+  enforcement that keeps the closed set actually closed.
+
+## More Information
+
+- [ADR-0002: Coordinate transform with determinant −1](0002-determinant-minus-one-transform.md)
+  — the plane-local → world transform that makes Parts addressable in
+  the hangar frame. The parts model and the transform are
+  co-dependent: parts authored in plane-local coordinates only become
+  collidable once placed.
+- [`CLAUDE.md` — "The parts model (the most important rule)"](../../CLAUDE.md)
+  is the operational statement of this decision (the rule itself,
+  with the two-clause collision predicate); this ADR records *why*
+  the rule has the shape it does.
+- [`src/hangarfit/models.py`](../../src/hangarfit/models.py) —
+  `PartKind` literal, `Part` / `StrutsSpec` / `Aircraft` dataclasses,
+  invariant checks.
+- [`src/hangarfit/collisions.py`](../../src/hangarfit/collisions.py) —
+  the part-pair loop and the two-clause predicate implementation
+  (`_parts_conflict`).
+- [`src/hangarfit/loader.py`](../../src/hangarfit/loader.py) —
+  the `struts:` block expansion into mirrored strut `Part`s.
+- Related issue: [#136](https://github.com/DocGerd/hangarfit/issues/136)
+  (the retroactive-ADR backfill that produced this record).

--- a/docs/adr/0001-aircraft-parts-model.md
+++ b/docs/adr/0001-aircraft-parts-model.md
@@ -25,7 +25,7 @@ wrong would have made every downstream layout wrong.
   low-wing in the fleet (`fuji`) sits well below every high-wing's
   wing layer; a representation that cannot reason about height-disjoint
   parts cannot model this case at all.
-- **Strut volume must be representable as occupied.** Five of the nine
+- **Strut volume must be representable as occupied.** Six of the nine
   aircraft (`aviat_husky`, `wild_thing`, `zlin_savage`, `cessna_140`,
   `cessna_150`, `fk9_mkii`) are strut-braced. The strut is what
   prevents another plane's wing from nesting through the gap between

--- a/docs/adr/0002-determinant-minus-one-transform.md
+++ b/docs/adr/0002-determinant-minus-one-transform.md
@@ -1,0 +1,353 @@
+# ADR-0002: The plane-local-to-world transform has determinant −1 (intentional left-handed mapping)
+
+- **Status:** Accepted
+- **Date:** 2026-05-23
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+`hangarfit` represents every aircraft as a list of plane-local parts (see
+[ADR-0001](0001-aircraft-parts-model.md)) and places each aircraft
+in the hangar via a `Placement(x_m, y_m, heading_deg)`. The collision
+checker, the solver, and the visualizer all consume world-coordinate
+geometry, so a single transform must map every plane-local part to its
+world position.
+
+That transform is implemented in
+[`src/hangarfit/geometry.py`](../../src/hangarfit/geometry.py)
+(`aircraft_parts_world`) as:
+
+```
+world_x = px + u·sin(h) + v·cos(h)
+world_y = py + u·cos(h) − v·sin(h)
+```
+
+where `(u, v)` is plane-local (forward, right), `(px, py, h)` is the
+placement, and the linear part of the map is the 2×2 matrix
+`[[sin h, cos h], [cos h, −sin h]]`. Its determinant is
+`sin h·(−sin h) − cos h·cos h = −sin²h − cos²h = −1`.
+
+A reader trained on standard 2D graphics will look at this matrix, notice
+it is *not* the textbook CCW rotation `[[cos α, −sin α], [sin α, cos α]]`,
+and reach for the rebase button. **They will be wrong.** The form is
+deliberate, the determinant is supposed to be −1, and the implementation
+encodes two simultaneous convention flips (compass-vs-math, world-frame
+handedness). This ADR exists to stop the "correction" that turns a
+working transform into a silently broken one, and to make the *why*
+discoverable from the code rather than reachable only through CLAUDE.md
+or a synchronous conversation with the maintainer.
+
+## Decision Drivers
+
+- **World coordinates must match how a human sees the hangar.** A person
+  standing in front of the open door sees `+x` going right along the
+  door and `+y` going deeper into the building. Layout YAMLs and PNG
+  renders both have to read naturally in that frame.
+- **Plane-local coordinates must match aviation convention.** A pilot
+  thinks of "forward" (toward the nose) and "right" (toward the
+  starboard wingtip). The YAML offsets in `data/fleet.yaml` are easier
+  to author and review when the local axes obey that convention.
+- **Compass headings (CW positive from north) are how the layout
+  authors think about orientations**, not standard math angles
+  (CCW positive from `+x`). Mixing the two conventions silently is
+  the project's headline trap.
+- **Once two convention choices are fixed, the matrix follows.** The
+  linear map's handedness is determined, not chosen — given the
+  desired axis conventions, the resulting transform must compose a
+  rotation with a reflection. We cannot have all three of "natural
+  world frame," "natural plane-local frame," and "pure rotation
+  matrix" simultaneously.
+- **Future contributors will, at some point, want to "fix" this.** The
+  decision drivers above explain why a fix is the wrong move; the
+  decision must be findable from the code, not just from the
+  maintainer's head.
+
+## Considered Options
+
+1. **Keep the det = −1 transform; document loudly + enforce via a 45°
+   canary test in `tests/test_geometry.py`.**
+2. **Replace the matrix with a standard CCW rotation
+   `[[cos h, −sin h], [sin h, cos h]]`** and accept whatever knock-on
+   effects propagate through the rest of the code.
+3. **Redefine world coordinates** so `+y` points *shallower* (toward
+   the door) instead of deeper, making the matrix come out to a pure
+   rotation.
+4. **Redefine plane-local axes** so `+y` is "left" (port) rather than
+   "right" (starboard), again producing a pure rotation.
+
+## Decision Outcome
+
+**Chosen option: keep the det = −1 transform**, because both axis
+conventions are independently defensible (world coords match the human
+view of the hangar; plane-local axes match aviation convention), and
+the cost of a slightly surprising matrix is paid by the maintainer
+*once* — at the documentation level — while the cost of breaking either
+convention is paid by *every* future YAML author and PNG reader.
+
+The transform's handedness is not a bug to be fixed but a derived
+consequence of two upstream choices we want to keep. We make it safe
+by documenting it three ways (CLAUDE.md, this ADR, the module
+docstring) and by pinning it with a regression test that fails the
+instant someone substitutes a pure rotation.
+
+### Why the matrix has determinant −1: the two sign flips
+
+The matrix comes out to `[[sin h, cos h], [cos h, −sin h]]` for two
+independent reasons. **Both flips must happen** — either alone would
+give a different (and also wrong) matrix. The two flips are:
+
+**1. Compass headings rotate clockwise; standard math angles rotate
+counter-clockwise.**
+
+A textbook 2D rotation, rotating a vector CCW by angle α, is:
+
+```
+R_ccw(α) = [[cos α, −sin α],
+            [sin α,  cos α]]
+```
+
+`heading_deg` is defined as "the compass-style angle of the nose,
+measured from world `+y` (deeper into hangar), CW positive." Going from
+CCW to CW negates the angle inside the matrix: substitute `α → −h`,
+remember `cos(−h) = cos h` and `sin(−h) = −sin h`, and the matrix
+becomes:
+
+```
+R_cw(h) = [[ cos h,  sin h],
+           [−sin h,  cos h]]
+```
+
+That is the first sign flip. The matrix is still a pure rotation
+(det = +1), just CW instead of CCW.
+
+**2. Plane-local `(forward, right)` describes a left-handed mapping
+into world `(right-along-door, deeper-into-hangar)`.**
+
+Now the basis-axis correspondence. At heading 0°:
+
+- Plane-local `+u` (forward, toward nose) must map to world `+y`
+  (deeper into hangar).
+- Plane-local `+v` (right, toward starboard wingtip) must map to world
+  `+x` (right along the door).
+
+So the column of the linear map applied to `(1, 0)` (the plane-local
+forward unit vector) at `h = 0` must be `(0, 1)` in world coords, and
+the column applied to `(0, 1)` (plane-local right unit vector) must be
+`(1, 0)`. That immediately forces the matrix at `h = 0` to be
+`[[0, 1], [1, 0]]` — a swap of axes, which is a reflection
+(det = −1), not a rotation (det = +1).
+
+Plugging into the general form: at `h = 0` the world coords reduce to
+
+```
+world_x = u·sin 0 + v·cos 0 = v
+world_y = u·cos 0 − v·sin 0 = u
+```
+
+which is exactly the swap. The matrix is `[[sin h, cos h], [cos h,
+−sin h]]`, and its determinant is `sin h·(−sin h) − cos h·cos h = −1`.
+
+That is the second sign flip. The first flip alone (CW rotation, no
+axis swap) would still be a pure rotation; the second flip alone (axis
+swap, no CW conversion) would be a reflection at the wrong rotation
+direction. Composing them gives the rotation-plus-reflection map we
+actually want: a left-handed (det = −1) mapping that respects both the
+compass convention and the natural axis assignment.
+
+### Worked example at heading 45° (the canonical canary)
+
+`sin 45° = cos 45° = √2/2 ≈ 0.7071`. Placement at origin
+`(px, py) = (0, 0)`. Two probes:
+
+**Probe A — nose-forward: plane-local `(u=1, v=0)`.**
+
+```
+world_x = 0 + 1·sin 45° + 0·cos 45° = +√2/2
+world_y = 0 + 1·cos 45° − 0·sin 45° = +√2/2
+```
+
+The nose lands in the `(+x, +y)` quadrant — right and deeper into the
+hangar. This matches intuition: at heading 45° (halfway between
+"deeper" and "right"), the nose should point into that diagonal.
+
+A textbook CCW rotation matrix would give *the same* answer for this
+probe (because `sin 45° = cos 45°`, the row swap is invisible). So
+**this probe alone does not detect a sign-flip regression**, even at
+45°.
+
+**Probe B — right wingtip: plane-local `(u=0, v=1)`.**
+
+```
+world_x = 0 + 0·sin 45° + 1·cos 45° = +√2/2
+world_y = 0 + 0·cos 45° − 1·sin 45° = −√2/2
+```
+
+The right wingtip lands in the `(+x, −y)` quadrant — right and toward
+the door. This also matches intuition: at heading 45° (nose toward the
+diagonal away from the door), the right wingtip rotates around to
+point toward the door.
+
+A textbook CCW rotation would send `(0, 1)` to
+`(−sin 45°, cos 45°) = (−√2/2, +√2/2)` — the `(−x, +y)` quadrant,
+i.e. *left and deeper*. That is the wrong answer. **Probe B is
+distinguishing** — the correct and the would-be-fixed transforms
+disagree on it.
+
+This is exactly why
+[`tests/test_geometry.py::TestAircraftPartsWorld::test_heading_45_right_wingtip_in_plus_x_minus_y_quadrant`](../../tests/test_geometry.py)
+(line 274) is the load-bearing test for this ADR: it pins probe B at
+heading 45°, and any "fix" to a CCW matrix flips both signs in the
+expected output, failing the assertion loudly.
+
+### Why not Option 2 — replace with a standard CCW rotation matrix?
+
+A pure rotation matrix `[[cos h, −sin h], [sin h, cos h]]` has
+determinant `+1` and is *almost* indistinguishable from the correct
+transform under casual inspection. The catch: it silently flips the
+right-vs-left orientation of every aircraft against the world frame.
+At heading 0° the wrong matrix would send plane-local `(0, 1)` (right
+wingtip) to world `(−1, 0)` (left along the door) instead of world
+`(+1, 0)` (right along the door) — mirroring every aircraft.
+
+This bug is invisible at the symmetric headings (0°, 90°, 180°, 270°)
+because `sin` or `cos` is 0 at each one, masking the swapped term.
+Test cases at *only* axis-aligned headings cannot catch it. The
+failure mode would surface as:
+
+- Strut-braced planes whose struts are modeled on one side of the
+  fuselage would collide differently than intended in some real
+  layouts and not in others (depending on heading).
+- PNG renders would show planes with their wing struts on the wrong
+  side, but only at non-axis-aligned headings — and only if a human
+  noticed.
+- Solver outputs would still be "valid" by the (broken) checker, so
+  the bug would not raise — it would just be wrong.
+
+The cost of "rotation matrix looks normal" is paid by everyone
+downstream, forever. Rejected.
+
+### Why not Option 3 — redefine world coordinates so `+y` points "shallower"?
+
+The world frame was chosen to match how a human standing in front of
+the hangar perceives the layout: looking through the door, `+x` runs
+right along the door wall, `+y` runs *away from the viewer* (deeper).
+This is the "looking down at a map" frame familiar from architectural
+drawings.
+
+Flipping `+y` to point toward the door would invert every layout YAML
+ever authored (`y_m: 5.0` would now mean "5 meters in front of the
+door" instead of "5 meters into the hangar"), every PNG render
+(planes near the door would appear at the bottom of the image
+instead of the top, contrary to the convention), and every collision
+fixture in `tests/fixtures/`. The matrix would simplify, but the
+ecosystem of artifacts that depends on the current convention would
+all have to change — for a cosmetic win on a single matrix that
+already has a regression test pinning it. Rejected.
+
+### Why not Option 4 — redefine plane-local axes so `+y` is "left" (port)?
+
+Aviation convention is firm: starboard = right, port = left. The
+plane-local `+y` axis is "right" specifically because that matches a
+pilot's mental model and the conventional fuselage-station-line
+diagrams used in the wider sport-aviation community. Inverting to
+"left = `+y`" would make `data/fleet.yaml` harder to author from
+manufacturer drawings (the part offsets would have inverted signs
+from what the drawings show) and harder for future contributors with
+aviation background to review.
+
+The trade is: pay a one-time cost to document a surprising matrix, or
+pay an ongoing cost to author every YAML against a flipped axis. The
+ongoing cost is worse. Rejected.
+
+## Consequences
+
+### Positive
+
+- **World coordinates match the human view of the hangar.** Layout
+  YAMLs, PNG renders, and architectural intuition all align.
+- **Plane-local coordinates match aviation convention.** Authoring
+  fleet data from manufacturer drawings is straightforward.
+- **The transform is mathematically valid.** A rotation composed with
+  a reflection is a perfectly well-defined linear map; det = −1 is not
+  a defect, just a property. The map is invertible (its inverse is
+  itself, since reflections are involutions composed with rotations of
+  appropriate sign).
+- **The decision is now discoverable from `docs/adr/` and from the
+  module docstring**, not only from CLAUDE.md or a maintainer
+  conversation.
+
+### Negative
+
+- **Every contributor will, at some point, want to "fix" this.** The
+  matrix does not look like the textbook form most graphics tutorials
+  teach. We accept the recurring overhead of explaining why it stays.
+- **One more concept to learn** before touching `geometry.py`. The
+  module docstring and CLAUDE.md "Coordinate convention" section
+  attempt to front-load that learning, and the
+  `geometry-invariant-guard` subagent catches regressions at PR
+  review, but the cost is real.
+
+### Neutral
+
+- **Tests at the symmetric headings (0°, 90°, 180°, 270°) cannot
+  catch a regression** to a pure rotation — they are consistent with
+  both the correct and the wrong matrix. Test coverage must include
+  at least one non-axis-aligned heading with a *distinguishing*
+  probe (one where the correct and CCW transforms produce different
+  outputs). See
+  [`.claude/agents/geometry-invariant-guard.md`](../../.claude/agents/geometry-invariant-guard.md)
+  for the distinguishing-probe rule.
+- The 45° heading is canonical for *probe B* (right-wingtip) because
+  it is the simplest distinguishing case; 135° works for *probe A*
+  (nose-forward) because at 135° `sin h ≠ cos h` and the row swap
+  becomes visible on the nose vector alone. Both are pinned in the
+  test suite.
+
+## Compliance
+
+- **The canary regression test:**
+  [`tests/test_geometry.py::TestAircraftPartsWorld::test_heading_45_right_wingtip_in_plus_x_minus_y_quadrant`](../../tests/test_geometry.py)
+  (line 274). At heading 45°, plane-local `(u=0, v=1)` must land at
+  world `(+√2/2, −√2/2)`. Any regression to a det = +1 matrix sends
+  the probe to `(−√2/2, +√2/2)` and fails the assertion. This test
+  also has a companion at line 301
+  (`test_heading_135_nose_distinguishes_correct_from_ccw`) that uses
+  the nose vector at 135° as a redundant guard.
+- **The `geometry-invariant-guard` subagent**
+  ([`.claude/agents/geometry-invariant-guard.md`](../../.claude/agents/geometry-invariant-guard.md))
+  is invoked on every PR touching `src/hangarfit/geometry.py` or
+  `src/hangarfit/collisions.py`. It re-derives the matrix form from
+  the diff, checks the determinant, and verifies that any new
+  geometry test exercises at least one non-axis-aligned heading with
+  a distinguishing probe. This is a defense-in-depth layer beyond
+  the pytest assertion.
+- **The CLAUDE.md "Coordinate convention" section** spells out the
+  convention in prose, so contributors encounter the explanation
+  before they encounter the code. The
+  `geometry.py` module docstring repeats the warning at the file
+  level.
+- **The PR review checklist** (per CLAUDE.md "Subagents" section)
+  routes any change to `geometry.py` or `collisions.py` through
+  `geometry-invariant-guard` automatically — the maintainer does not
+  have to remember to invoke it.
+
+Together: docstring at the code site, ADR for the rationale,
+CLAUDE.md for the operational convention, pytest assertion for
+automated regression, and a subagent for PR-time review. A
+"correction" to a pure-rotation matrix would have to defeat all five
+to land.
+
+## More Information
+
+- **Authoritative prose explanation:** `CLAUDE.md` §"Coordinate
+  convention" — the source the rest of this ADR distills.
+- **Implementation:** [`src/hangarfit/geometry.py`](../../src/hangarfit/geometry.py),
+  specifically `aircraft_parts_world` (the world-coordinate list
+  comprehension is the load-bearing line).
+- **Canary test:** [`tests/test_geometry.py`](../../tests/test_geometry.py),
+  line 274 (right-wingtip at 45°) and line 301 (nose at 135°).
+- **Review-time guard:** [`.claude/agents/geometry-invariant-guard.md`](../../.claude/agents/geometry-invariant-guard.md).
+- **Related ADRs:** [ADR-0001 — Parts-based collision model](0001-aircraft-parts-model.md)
+  (defines what is being transformed); [ADR-0000 — Record
+  architecture decisions](0000-record-architecture-decisions.md)
+  (the meta-ADR that motivates this one's existence).

--- a/docs/adr/0002-determinant-minus-one-transform.md
+++ b/docs/adr/0002-determinant-minus-one-transform.md
@@ -194,10 +194,10 @@ distinguishing** — the correct and the would-be-fixed transforms
 disagree on it.
 
 This is exactly why
-[`tests/test_geometry.py::TestAircraftPartsWorld::test_heading_45_right_wingtip_in_plus_x_minus_y_quadrant`](../../tests/test_geometry.py)
-(line 274) is the load-bearing test for this ADR: it pins probe B at
-heading 45°, and any "fix" to a CCW matrix flips both signs in the
-expected output, failing the assertion loudly.
+`tests/test_geometry.py::TestAircraftPartsWorld::test_heading_45_right_wingtip_in_plus_x_minus_y_quadrant`
+is the load-bearing test for this ADR: it pins probe B at heading 45°,
+and any "fix" to a CCW matrix flips both signs in the expected output,
+failing the assertion loudly.
 
 ### Why not Option 2 — replace with a standard CCW rotation matrix?
 
@@ -306,13 +306,12 @@ ongoing cost is worse. Rejected.
 ## Compliance
 
 - **The canary regression test:**
-  [`tests/test_geometry.py::TestAircraftPartsWorld::test_heading_45_right_wingtip_in_plus_x_minus_y_quadrant`](../../tests/test_geometry.py)
-  (line 274). At heading 45°, plane-local `(u=0, v=1)` must land at
-  world `(+√2/2, −√2/2)`. Any regression to a det = +1 matrix sends
-  the probe to `(−√2/2, +√2/2)` and fails the assertion. This test
-  also has a companion at line 301
-  (`test_heading_135_nose_distinguishes_correct_from_ccw`) that uses
-  the nose vector at 135° as a redundant guard.
+  `tests/test_geometry.py::TestAircraftPartsWorld::test_heading_45_right_wingtip_in_plus_x_minus_y_quadrant`.
+  At heading 45°, plane-local `(u=0, v=1)` must land at world
+  `(+√2/2, −√2/2)`. Any regression to a det = +1 matrix sends the probe
+  to `(−√2/2, +√2/2)` and fails the assertion. The companion test
+  `test_heading_135_nose_distinguishes_correct_from_ccw` uses the nose
+  vector at 135° as a redundant guard.
 - **The `geometry-invariant-guard` subagent**
   ([`.claude/agents/geometry-invariant-guard.md`](../../.claude/agents/geometry-invariant-guard.md))
   is invoked on every PR touching `src/hangarfit/geometry.py` or
@@ -344,8 +343,10 @@ to land.
 - **Implementation:** [`src/hangarfit/geometry.py`](../../src/hangarfit/geometry.py),
   specifically `aircraft_parts_world` (the world-coordinate list
   comprehension is the load-bearing line).
-- **Canary test:** [`tests/test_geometry.py`](../../tests/test_geometry.py),
-  line 274 (right-wingtip at 45°) and line 301 (nose at 135°).
+- **Canary tests:** [`tests/test_geometry.py`](../../tests/test_geometry.py)
+  — `test_heading_45_right_wingtip_in_plus_x_minus_y_quadrant`
+  (right-wingtip at 45°) and `test_heading_135_nose_distinguishes_correct_from_ccw`
+  (nose at 135°).
 - **Review-time guard:** [`.claude/agents/geometry-invariant-guard.md`](../../.claude/agents/geometry-invariant-guard.md).
 - **Related ADRs:** [ADR-0001 — Parts-based collision model](0001-aircraft-parts-model.md)
   (defines what is being transformed); [ADR-0000 — Record

--- a/docs/adr/0003-rr-mc-solver-algorithm.md
+++ b/docs/adr/0003-rr-mc-solver-algorithm.md
@@ -133,8 +133,10 @@ The state space is continuous, and constraint solvers want it discrete
 or interval. Quantising to a grid fine enough to preserve the
 operational resolution (centimetres for position, degrees for heading)
 explodes the per-plane variable domain into the tens of millions, and
-the combinatorial product over 6–9 planes makes the problem intractable
-at exactly the scenarios that matter (full fleet, tight clearance).
+the combinatorial product over 6–9 planes was judged intractable for
+the scenarios that matter (full fleet, tight clearance). This is an
+engineering judgement, not a benchmarked claim — no CP-SAT prototype
+was built; a future ADR could revisit this with measured data.
 Reproducibility would be easier (constraint solvers are deterministic
 modulo solver-version pinning), but that gain doesn't buy back the
 fidelity loss. The K-diverse-alternatives contract also fits awkwardly
@@ -244,7 +246,8 @@ silently rejected at scoring time). Rejected.
   `k_stall = 50`, `pos_sigma_m = 0.5`, `heading_sigma_deg = 10.0` are
   guesses calibrated on the placeholder fleet; the spec explicitly
   flags them as "tune with real data." A `SearchConfig` kwarg exposes
-  them programmatically, but the CLI does not (deferred to v1.1).
+  them programmatically, but the CLI does not (deferred to a future
+  release).
 
 ### Neutral
 

--- a/docs/adr/0003-rr-mc-solver-algorithm.md
+++ b/docs/adr/0003-rr-mc-solver-algorithm.md
@@ -1,0 +1,308 @@
+# ADR-0003: Random-restart min-conflicts (RR-MC) for the static layout solver
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+Phase 2a had to commit `hangarfit solve` to a search algorithm before any
+restart loop, scoring function, or diversity filter was written. The
+solver takes a `Scenario` (fleet subset, hangar, hard constraints,
+optional pins) and must return up to K diverse valid `Layout`s within a
+wall-clock budget — or, on failure, an honest diagnostic instead of a
+black-box "didn't work." The search runs on the Phase 1 parts-based
+collision substrate (see [ADR-0001](0001-aircraft-parts-model.md)), so
+the state space is **continuous in `(x_m, y_m, heading_deg)` per plane**
+and the collision predicate has **non-smooth boundaries** at the
+plan-view-distance threshold. Phase 1 also exposes only HARD constraints
+in v1 (maintenance plane, per-plane `pin`, per-plane `force_on_carts`) —
+no soft preferences to optimize against. Whichever algorithm shipped
+would lock in the failure-mode taxonomy, the diagnostic surface, and the
+reproducibility contract for every downstream user; getting it wrong
+would have meant tearing out and re-shaping the public API the day after
+ship.
+
+## Decision Drivers
+
+- **Continuous state.** A plane's placement is a point in
+  `(x_m ∈ [0, width], y_m ∈ [0, length], heading_deg ∈ [0, 360°))`.
+  Quantising for a constraint solver (Z3, MiniZinc, OR-tools CP-SAT)
+  loses geometric fidelity at the same resolution real measurements will
+  support, and the cell count explodes — a 0.05 m grid over a 25 × 18 m
+  hangar with a 1° heading grid is 500 × 360 × 360 ≈ 6.5 × 10⁷ states
+  per plane, before considering 6–9 planes simultaneously.
+- **Non-smooth collision boundary.** The two-clause part-pair predicate
+  (plan-view distance < `clearance_m` AND height gap <
+  `wing_layer_clearance_m`) is discontinuous: penetration is 0 just past
+  threshold and jumps as soon as parts touch. Gradient-based optimisers
+  stall in the zero-gradient infeasible regions where every direction
+  looks equally bad.
+- **Satisficing, not optimising.** The tool's job is to find *a* valid
+  alternative when the standard layout breaks. There is no objective
+  function ranking valid layouts against each other (modulo the
+  diversity filter, which is structural rather than scalar). RR-MC is a
+  satisficer by construction.
+- **Reproducibility is a contract, not a nice-to-have.** Same scenario +
+  same seed → bit-identical `SolveResult`. This is needed for canary
+  tests (`tests/test_solver_canaries.py`), for users who want to share a
+  "this layout came out of seed 42" claim, and for the CLI's
+  diagnostics to be reviewable in a PR.
+- **K diverse alternatives from the same engine.** The public contract
+  is "return up to K diverse layouts" (see
+  [ADR-0004](0004-diversity-metric.md) for the metric). Restart-based
+  algorithms get this for free; single-shot constraint solvers do not.
+- **Honest failure modes.** Three-way termination
+  (`found` / `found_partial` / `exhausted_budget`) plus the literal
+  `trivially_infeasible` pre-search status. Each must be distinguishable
+  to the CLI and the JSON schema.
+
+## Considered Options
+
+1. **Random-restart hill climbing with min-conflicts descent (RR-MC) on
+   continuous state** — the chosen option.
+2. **Constraint solver (Z3 / MiniZinc / CP-SAT) with quantised state.**
+3. **Genetic algorithm / evolutionary search on continuous state.**
+4. **Gradient-based continuous optimisation (e.g. simulated annealing
+   with a smoothed penetration cost).**
+5. **Pure random sampling with reject-if-invalid.**
+6. **Geometric packing heuristic (one-pass placement: largest plane
+   first, fit each subsequent plane into remaining free space).**
+
+## Decision Outcome
+
+**Chosen option: RR-MC on continuous state**, because it is the
+smallest algorithm that natively handles continuous placement, tolerates
+the non-smooth collision boundary, produces bit-identical output under a
+seed, and trivially extends to K alternatives via restart count. The
+implementation lives in
+[`src/hangarfit/solver.py`](../../src/hangarfit/solver.py); the full
+design rationale is in the Phase 2a spec
+[`docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md`](../superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md).
+
+### Algorithm shape (as actually implemented)
+
+- **Random restart loop.** Each restart samples a fresh initial
+  placement for every non-pinned plane (uniform in the hangar interior
+  with a bbox-derived margin; heading uniform on `[0°, 360°)`). The
+  maintenance plane (if not pinned) gets a back-bay biased initial.
+  Cart-eligible planes round-robin over the `C + 1` legal cart buckets
+  across restarts (`{none, plane_1_on_carts, …, plane_C_on_carts}` for
+  the C unlocked cart-eligible planes) to guarantee coverage instead of
+  leaving buckets unsampled.
+- **Min-conflicts perturbation step.** From the current candidate's
+  `CheckResult.conflicts`, build the set of conflicting non-pinned
+  planes. Pick one uniformly at random; generate `N` candidate moves
+  (`N − 2` small Gaussian nudges + 1 large jump + 1 180° heading flip);
+  pick the candidate with the lowest score, tie-broken by smallest
+  displacement.
+- **Scoring is hierarchical.** `_score(layout) → (conflict_count,
+  total_penetration_m2)`. The integer primary key drives descent
+  direction; the smooth secondary key breaks plateaus (which integer
+  packing scores are known to produce). `(0, 0.0)` means valid.
+  `total_penetration_m2` is the Phase 1 extension shipped in Chunk A
+  (see [`src/hangarfit/collisions.py`](../../src/hangarfit/collisions.py)
+  and `CheckResult` in
+  [`src/hangarfit/models.py`](../../src/hangarfit/models.py)).
+- **Acceptance gate.** Every accepted candidate is run through
+  `collisions.check()` — the solver does NOT bypass the checker. The
+  checker is the source of truth, and `Layout.__post_init__` is the
+  invariant trap behind it (cart rule, movement-mode consistency, etc.).
+- **Diversity filter** runs post-acceptance; candidates within the
+  diversity threshold of an already-accepted layout are rejected, with
+  `diversity_rejected_count` surfaced in `SolverDiagnostics`. See
+  [ADR-0004](0004-diversity-metric.md) for the metric.
+- **Three-way termination.** `found` (K layouts accepted),
+  `found_partial` (`0 < n < K`, budget exhausted), `exhausted_budget`
+  (0 accepted). Plus `trivially_infeasible` from the pre-search gate.
+- **Pre-search infeasibility checks** run before the main loop:
+  (1) per-plane bbox vs. hangar, (2) Σ bbox areas vs. floor area,
+  (3) pin self-collision via `check()` on a pin-only Layout. Catches
+  literal impossibilities (a 200 m wingspan typo, two pins on top of
+  each other) in milliseconds instead of after the full budget burns.
+- **Single-threaded, fully seeded RNG.** One `random.Random(seed)` drives
+  every sampling decision (initial placement, perturbation,
+  candidate selection, conflicting-plane pick). `seed=None` resolves to
+  `secrets.randbits(32)` at `solve()` entry and is recorded in
+  `SolverDiagnostics.seed`. Cart-bucket round-robin uses the
+  non-random restart index, so it is deterministic by construction.
+
+### Why not a constraint solver (Z3 / MiniZinc / CP-SAT)?
+
+The state space is continuous, and constraint solvers want it discrete
+or interval. Quantising to a grid fine enough to preserve the
+operational resolution (centimetres for position, degrees for heading)
+explodes the per-plane variable domain into the tens of millions, and
+the combinatorial product over 6–9 planes makes the problem intractable
+at exactly the scenarios that matter (full fleet, tight clearance).
+Reproducibility would be easier (constraint solvers are deterministic
+modulo solver-version pinning), but that gain doesn't buy back the
+fidelity loss. The K-diverse-alternatives contract also fits awkwardly
+onto a single-shot solver: you have to either re-solve K times with
+ad-hoc "diversity" constraints encoding the previous solutions
+("planes A and B must be > 0.5 m from their previous positions"), or
+emit a model that asks the solver to find K disjoint solutions
+simultaneously — both substantially heavier than "restart with a fresh
+seed." A future ADR could supersede this if a CP-SAT-friendly variant of
+the problem emerges (e.g. coarse-grid pre-placement with a continuous
+RR-MC refinement pass), but for v1 the cost-benefit is clearly against
+it.
+
+### Why not a genetic / evolutionary algorithm?
+
+Population-based search needs a population, crossover, and mutation
+operators, all of which are harder to make bit-deterministic across
+runs than a single-threaded greedy descent. Crossover between two
+layouts is also conceptually awkward: there is no obvious "swap the
+front half" operation when each plane is an independent
+`(x_m, y_m, heading_deg)` triple — the closest sensible operator is
+"adopt plane X's placement from parent A and the rest from parent B,"
+which is essentially a coarse min-conflicts move applied across an
+artificial population boundary. The diagnostic story is also worse:
+"why did this layout win" is "it scored highest at generation 47 of
+population size 64," which is harder to trace than RR-MC's "it was the
+4th restart with seed 42, descended in 23 iterations." Rejected on
+operational and reproducibility grounds, not capability grounds.
+
+### Why not gradient-based continuous optimisation?
+
+The collision boundary is non-smooth: penetration area is 0 wherever
+parts are farther apart than `clearance_m`, and jumps to a positive
+value as soon as they're closer. Gradient methods stall in the flat
+zero-gradient regions of infeasible space (where every direction looks
+equally bad to a local sensor), and smoothing the boundary (e.g. with a
+sigmoid penalty around the threshold) introduces an arbitrary bias that
+shifts the location of valid solutions in ways the operator cannot
+inspect. Simulated annealing without gradients would work, but it
+collapses to RR-MC's behaviour at the temperature schedule that matters
+(cold enough to actually accept improvements), with extra hyperparameters
+to tune for no clear gain. Rejected.
+
+### Why not pure random sampling with reject-if-invalid?
+
+On the placeholder fleet, finding *any* valid layout for the all-9-plane
+scenario requires the larger test hangar (see
+`tests/fixtures/test_hangar_large.yaml`); on the default 25 × 18 m
+hangar even a 6-plane subset has a low success rate for fully-random
+placements. The rejection rate is dominated by the tightest pair
+clearance, and the resulting wall-clock-per-valid-sample is so high
+that the budget exhausts before the first valid layout. Min-conflicts
+descent uses information from the `CheckResult` to direct the next
+move toward fewer conflicts, which is exactly what rejection sampling
+discards. Rejected.
+
+### Why not a geometric packing heuristic (largest-first one-pass)?
+
+One-pass heuristics (sort planes by bbox area descending, place each
+into the largest remaining free region) are common in bin-packing
+literature and would be fast. They fail on this problem for two
+reasons. First, the parts model (ADR-0001) means "free region" is not a
+2D shape but a 2.5D structure (per-height-layer occupancy), and the
+height-disjoint pass-through case (a high-wing's wingtip over the
+Fuji's fuselage area) is exactly the leverage an exception tool needs
+— a one-pass heuristic that flattens to 2D throws that away. Second,
+the cart rule and the maintenance-bay rule are global constraints that
+local placement greedy doesn't see; a one-pass heuristic that places
+plane 5 in the back bay because it fit there will be reversed when
+plane 7 turns out to be the maintenance plane. RR-MC handles both by
+construction (the maintenance plane gets a back-bay biased initial; the
+cart rule is enforced by `Layout.__post_init__` and the candidate is
+silently rejected at scoring time). Rejected.
+
+## Consequences
+
+### Positive
+
+- **Continuous state is native.** Every degree of heading and every
+  centimetre of position is reachable; nothing about the algorithm
+  forces quantisation.
+- **The non-smooth collision boundary is the algorithm's friend.**
+  Min-conflicts works on integer conflict counts; the smooth
+  `total_penetration_m2` secondary key handles plateaus without
+  requiring the boundary itself to be differentiable.
+- **Reproducibility is bit-identical** under a seed — see the
+  `tests/test_solver_canaries.py` parametrized fixtures.
+- **K alternatives compose with restarts.** No extra machinery; the
+  diversity filter runs at acceptance time, the search keeps going.
+- **Budget-based termination is honest.** The CLI surfaces `found` /
+  `found_partial` / `exhausted_budget` distinctly; `--strict-k` maps
+  `found_partial` to exit 1 for callers who want it strict.
+
+### Negative
+
+- **No completeness guarantee.** `exhausted_budget` is a legitimate
+  outcome for a feasible scenario if the budget was too short or the
+  basin of attraction was too narrow. The CLI's exit codes and
+  `--strict-k` mode are the interpretive lever; users have to read the
+  documentation to understand that `exhausted_budget ≠ infeasible`.
+- **`found_partial` is a real outcome.** Users asking for K = 3
+  alternatives can receive 1 or 2 within budget, especially when many
+  planes are pinned (the "diversity impossible" heuristic in
+  `solve()` even warns about this case up front, see `solver.py`'s
+  `diversity_impossible` branch).
+- **Hyperparameters are unprincipled.** `candidates_per_iter = 8`,
+  `k_stall = 50`, `pos_sigma_m = 0.5`, `heading_sigma_deg = 10.0` are
+  guesses calibrated on the placeholder fleet; the spec explicitly
+  flags them as "tune with real data." A `SearchConfig` kwarg exposes
+  them programmatically, but the CLI does not (deferred to v1.1).
+
+### Neutral
+
+- **Single-threaded by design.** Parallelism is the price of
+  bit-identical reproducibility; a parallel RR-MC would need
+  per-worker independent RNGs and a deterministic merge order. Could
+  be revisited if performance becomes a real constraint, but for v1's
+  budget defaults (30 s) the cost is acceptable.
+- **The 180° heading-flip candidate** is a domain bet that
+  "nose-wrong-way" cases are common enough to deserve a dedicated
+  candidate type. It costs one extra `check()` call per iteration; if
+  it never fires usefully, the cost is small and the safety is real.
+- **Cart-bucket round-robin** is the deterministic-by-construction
+  alternative to per-restart random cart picks. Guarantees every
+  cart configuration is sampled at least once within `C + 1` restarts.
+
+## Compliance
+
+- [`tests/test_solver_canaries.py`](../../tests/test_solver_canaries.py)
+  — parametrized over three fixtures, asserts `solve(seed=42)` returns
+  bit-for-bit identical `SolveResult` across two consecutive runs.
+  **Intentionally fragile**: any deliberate algorithm change (RNG
+  consumption order, perturbation mix, scoring tweak) requires updating
+  the expected outputs. This is the canary that the reproducibility
+  contract above is actually being honored.
+- [`tests/test_solver_fixture_matrix.py`](../../tests/test_solver_fixture_matrix.py)
+  — per-fixture matrix tests with the shared
+  `_assert_universal_properties` helper enforcing the six spec §6.2
+  universal property assertions on every solver run: `status` is one
+  of the four legal values, every returned `Layout` validates under
+  `collisions.check()`, the seed is populated in diagnostics,
+  `best_partial` is fused with the right status set, pairwise diversity
+  holds for `len(layouts) ≥ 2`, and the pre-search wall-time guard is
+  respected.
+- The Phase 2a spec
+  [`docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md`](../superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md)
+  is the authoritative design document; any future algorithm change
+  should be reflected there (and supersede this ADR if it changes the
+  algorithm family).
+
+## More Information
+
+- [ADR-0001: Aircraft geometry as a list of parts](0001-aircraft-parts-model.md)
+  — the collision substrate the solver descends against. The
+  non-smooth collision boundary discussed in the decision drivers is a
+  direct consequence of the parts-based predicate; without ADR-0001
+  this ADR's "why not gradient" argument would not hold.
+- [ADR-0004: Diversity metric for K alternatives](0004-diversity-metric.md)
+  — the edit-count metric the diversity filter uses; co-designed with
+  this algorithm choice (restart-based search makes K alternatives cheap
+  to generate; the metric defines when two are different enough).
+- Phase 2a design spec:
+  [`docs/superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md`](../superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md).
+- Implementation: [`src/hangarfit/solver.py`](../../src/hangarfit/solver.py).
+- Determinism canaries:
+  [`tests/test_solver_canaries.py`](../../tests/test_solver_canaries.py).
+- Universal property tests:
+  [`tests/test_solver_fixture_matrix.py`](../../tests/test_solver_fixture_matrix.py).
+- Related issue:
+  [#136](https://github.com/DocGerd/hangarfit/issues/136)
+  (the retroactive-ADR backfill that produced this record).

--- a/docs/adr/0004-diversity-metric.md
+++ b/docs/adr/0004-diversity-metric.md
@@ -1,0 +1,266 @@
+# ADR-0004: Diversity metric for K alternatives (edit count with per-plane thresholds)
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+`hangarfit solve --alternatives K` promises "up to K **diverse** valid
+layouts." The RR-MC search loop ([ADR-0003](0003-rr-mc-solver-algorithm.md)) reaches
+valid layouts repeatedly during its random-restart trajectory — but
+without a filter, the layouts it accepts in succession tend to cluster
+near the same easily-reached local minima. An early prototype with
+`K = 3` regularly returned three near-identical layouts that differed
+only by centimeter-scale jitter and degree-scale heading wobble, which is
+operationally useless: the human looking at the PNGs cannot tell them
+apart, let alone choose between them as genuine alternatives. Phase 2a
+Chunk E ([#90](https://github.com/DocGerd/hangarfit/issues/90),
+[PR #91](https://github.com/DocGerd/hangarfit/pull/91)) had to commit to
+a *metric* — a function of two layouts that decides whether the second
+counts as a real alternative to the first — before the K-alternatives
+feature could ship. Diversity-by-what is the question this ADR answers.
+
+## Decision Drivers
+
+- **The metric must be domain-meaningful, not numerical.** Two layouts
+  that differ by 5 cm in a single plane are not meaningfully different
+  to a human eyeballing the top-down PNG; they should be filtered as
+  duplicates. The metric must distinguish "noise" from "design intent."
+- **The metric must be per-plane semantic.** "Every plane jiggled 5 cm"
+  is noise; "one plane rotated 45°" is a real second option. An
+  aggregate-over-the-fleet score conflates these two cases and rewards
+  the wrong one.
+- **Determinism is non-negotiable.** A given `seed` must produce a
+  bit-identical `SolveResult` (enforced by
+  `tests/test_solver_canaries.py`). The filter must therefore be
+  deterministic — no RNG inside the diversity test, no order-dependent
+  clustering state.
+- **The metric is in the inner loop.** For each candidate valid layout
+  the filter runs against every already-accepted layout. With small K
+  (≤ 5) the cost is bounded, but the per-comparison work still has to
+  be cheap; nothing exotic.
+- **Thresholds must be tunable per call.** The placeholder hangar is
+  25 × 18 m, but the operational hangar may differ substantially once
+  measured; a hard-coded threshold that suits one scale will not suit
+  another. The metric's parameters live in a `DiversityConfig`
+  dataclass so a caller can override them without forking the solver.
+
+## Considered Options
+
+1. **Edit count with per-plane thresholds** — count the planes whose
+   `(x_m, y_m)` shifted by ≥ `position_threshold_m` *or* whose heading
+   shifted by ≥ `heading_threshold_deg`; accept the candidate iff that
+   count is ≥ `min_planes_moved`, against *every* already-accepted
+   layout (pairwise, not aggregate). Encoded as
+   [`DiversityConfig`](../../src/hangarfit/models.py) with defaults
+   `min_planes_moved = 2`, `position_threshold_m = 0.5`,
+   `heading_threshold_deg = 30.0`.
+2. **L2 distance over flattened `(x, y, heading)` vectors** across all
+   planes, with a single scalar threshold for "different enough."
+3. **Hamming distance over a per-plane same-or-different binary
+   predicate** — count how many planes "changed" under some equality
+   rule, accept if the count exceeds a threshold.
+4. **K-medoids / clustering in a learned plane-displacement space** —
+   cluster the candidate pool, return one representative per cluster.
+5. **No diversity filter** — return the first K accepted candidates in
+   order of acceptance.
+6. **Footprint-overlap fraction** — compute the area of the symmetric
+   difference between the two layouts' fleet footprints (sum of plane
+   bounding polygons in plan view) as a fraction of total fleet
+   footprint; accept if that fraction exceeds a threshold.
+
+## Decision Outcome
+
+**Chosen option: edit count with per-plane thresholds**, with defaults
+`min_planes_moved = 2`, `position_threshold_m = 0.5 m`, and
+`heading_threshold_deg = 30°`. The filter is applied between RR-MC
+acceptance and the final `SolveResult` return, in
+[`_is_diverse_enough()`](../../src/hangarfit/solver.py); rejected
+candidates increment `SolverDiagnostics.diversity_rejected_count` so
+inefficient runs are observable.
+
+Concretely: a plane is considered "moved" iff its position differs by
+≥ 0.5 m *or* its heading differs by ≥ 30° (short-arc — so 359° and 0°
+register as 1°, not 359°). A candidate layout is accepted iff at least
+two planes are moved relative to *every* already-accepted layout
+(pairwise diversity, not aggregate).
+
+### Why these specific numbers
+
+- **0.5 m** is large enough to be visually obvious in a top-down PNG of
+  a 25 × 18 m hangar (≈ 1/50 of the long axis) and small enough that
+  two layouts that genuinely differ in plane positions register as
+  different. Below this, the difference reads as fitting tolerance.
+- **30°** is the rough boundary at which a plane looks "noticeably
+  re-aimed" in the render. Smaller angle deltas read as the solver
+  settling into the same local minimum from a slightly different start,
+  not as a different design intent.
+- **M = 2** ensures the alternative is not just "one plane moved a bit."
+  One plane different is not a real second option; the operator wants
+  to see the layout *reorganize*. Two planes moved is the minimum
+  useful disturbance.
+
+These are domain-judgement calls, not derived from a formal
+optimisation. They are listed under the spec's
+"[Pre-empirical default](../superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md)"
+risk register and are explicitly tunable via `DiversityConfig` per call.
+
+### Why not L2 distance over flattened `(x, y, heading)` vectors?
+
+It is aggregate over the whole fleet and insensitive to which plane
+moved. "Every plane jiggled 5 cm" sums to the same L2 distance as
+"one plane rotated 45°," but only the second is a real alternative.
+There is no choice of scalar threshold that separates the two cases —
+the metric has thrown the per-plane structure away. A weighted L2
+(weights per plane and per axis) would recover some of that, but at
+the cost of having to pick the weights without operational data; the
+chosen edit-count metric exposes its parameters in domain-meaningful
+units (meters, degrees, plane count) instead of opaque weights.
+
+### Why not Hamming distance over a binary same-or-different predicate?
+
+It still requires a threshold for "same" — the binary predicate
+collapses some `(position_threshold, heading_threshold)` choice into
+itself rather than removing it. So this is not actually a different
+metric; it is the edit-count metric with the thresholds hidden inside
+the predicate. The chosen option keeps those thresholds explicit and
+caller-visible in `DiversityConfig` — exactly the surface a future
+operator-driven retune will need.
+
+### Why not K-medoids / clustering in a learned plane-displacement space?
+
+Overkill for K ≤ 5 alternatives. Clustering algorithms introduce their
+own non-determinism (initial-centroid choice, tie-breaking) which would
+have to be carefully seeded to preserve the solver's reproducibility
+guarantee. The learning step assumes a corpus of layouts to learn from,
+which the on-demand-exception use case does not produce. Adds a heavy
+dependency (sklearn or hand-rolled equivalent) for marginal benefit
+over a five-line filter.
+
+### Why not "no diversity filter, return the first K accepted"?
+
+This is what the prototype did, and it is why the filter exists. With
+RR-MC's randomized restarts, the first K candidates tend to cluster
+near the most-easily-reached local minima; with `K = 3` the run
+regularly returned three near-identical layouts. The filter is the
+*reason* the K-alternatives feature is useful at all.
+
+### Why not footprint-overlap fraction?
+
+Plan-view symmetric difference is geometrically appealing — it directly
+measures "how different do the layouts look in the PNG." Rejected on
+two grounds. First, computing polygon symmetric difference across the
+whole fleet for every candidate-vs-accepted pair is substantially more
+arithmetic than the per-plane numeric comparison, and the filter runs
+inside the inner loop. Second, the metric still has a threshold that
+needs to be picked in opaque units (square meters), and unlike the
+chosen metric's `(0.5 m, 30°, 2 planes)` parameters it does not
+correspond cleanly to a human description of "what makes this a real
+alternative." If a future visualization-driven use case needs it, a
+later ADR can supersede this one without invalidating
+`DiversityConfig` — the edit-count metric and a footprint metric can
+coexist as alternative filter strategies.
+
+## Consequences
+
+### Positive
+
+- **Domain-meaningful.** A user inspecting a rejected candidate via the
+  diagnostics can read "1 plane moved (need 2)" and immediately
+  understand why; the metric speaks the operator's language.
+- **Deterministic.** No RNG, no order-dependent state. The same
+  `(scenario, seed)` always produces the same accept/reject decision
+  sequence; the canaries in `tests/test_solver_canaries.py` depend on
+  this.
+- **Cheap.** Each diversity test is O(planes × accepted_so_far) numeric
+  comparisons — well under a millisecond for typical fleets and
+  K ≤ 5.
+- **Tunable per call.** `DiversityConfig` is a `solve()` kwarg; a
+  caller with a small hangar or a tight tolerance can override the
+  defaults without changing the solver source.
+- **Observable.** `SolverDiagnostics.diversity_rejected_count` surfaces
+  filter activity: a high reject count signals a tight scenario where
+  the solver keeps re-finding the same minimum, suggesting either
+  loosening `DiversityConfig` or raising `budget_s`.
+
+### Negative
+
+- **Thresholds are domain judgement, not derived.** `0.5 m`, `30°`, and
+  `M = 2` were chosen by eye against the placeholder hangar; they may
+  be wrong for the real hangar's scale once measured, or for an
+  unusually small or large fleet. Mitigation: `DiversityConfig` is
+  per-call, and a future operator-feedback round can adjust the
+  defaults without changing the metric's shape.
+- **No interpolation between "diverse" and "not diverse."** The metric
+  is a hard predicate, not a continuous score. A pair of layouts that
+  differs by 1.9 planes (e.g., one plane fully moved and one plane
+  borderline) gets rejected; a pair that differs by exactly 2 planes
+  marginally gets accepted. Mitigation: this matches how a human reads
+  the PNGs — "two things changed" *is* the natural threshold.
+
+### Neutral
+
+- **`diversity_rejected_count` adds one field to `SolverDiagnostics`.**
+  Worth it for the observability; the spec §6.2 universal property
+  test in `tests/test_solver_fixture_matrix.py` exercises the field's
+  monotonic-non-negative invariant alongside the rest of the
+  diagnostics.
+- **Pairwise, not aggregate.** The candidate must be diverse vs *every*
+  already-accepted layout, not just the most recent. This is the only
+  sane choice for K > 2 — aggregate-over-accepted would let a third
+  layout be accepted that is identical to the first as long as it
+  differs from the second. Pairwise costs O(K) per candidate, which is
+  cheap at the K ≤ 5 regime the CLI exposes.
+
+## Compliance
+
+- The pairwise-diversity universal property assertion lives in
+  [`tests/test_solver_fixture_matrix.py::_assert_universal_properties`](../../tests/test_solver_fixture_matrix.py)
+  (the `if len(r.layouts) > 1:` block at lines 67–76). It mirrors the
+  solver's edit-count metric via the local `_count_planes_moved`
+  helper, then asserts `n_moved >= cfg.min_planes_moved` for every pair
+  of accepted layouts. Every fixture in the v1 matrix runs this
+  helper, so any future change to the filter that breaks the
+  invariant fails CI immediately.
+- The
+  [`DiversityConfig`](../../src/hangarfit/models.py) dataclass in
+  `src/hangarfit/models.py` is the single source of truth for the
+  thresholds. It is `@dataclass(frozen=True, slots=True)` with
+  `__post_init__` validation rejecting `min_planes_moved < 1`,
+  non-positive `position_threshold_m`, and `heading_threshold_deg`
+  outside `[0, 180]` (the short-arc range).
+- The filter itself —
+  [`_is_diverse_enough()`](../../src/hangarfit/solver.py) — is module-
+  private but exercised end-to-end by every `solve_*` fixture test;
+  the per-fixture rejection-count assertions in the same file pin its
+  behavior in addition to the universal property.
+
+## More Information
+
+- [ADR-0003: RR-MC solver](0003-rr-mc-solver-algorithm.md) — the search algorithm
+  this filter sits on top of. The diversity filter assumes the search
+  produces multiple valid layouts; without RR-MC's random-restart
+  trajectory there would be nothing to filter.
+- [`src/hangarfit/models.py`](../../src/hangarfit/models.py) —
+  `DiversityConfig` dataclass with default thresholds and invariant
+  validation.
+- [`src/hangarfit/solver.py`](../../src/hangarfit/solver.py) —
+  `_is_diverse_enough()` (the filter), `_heading_delta_short_arc()`
+  (the angle normalization), and the K-acceptance loop in `solve()`
+  that calls them.
+- [Phase 2a design spec — §4.6 Diversity filter](../superpowers/specs/2026-05-22-phase2a-static-layout-solver-design.md) —
+  the full design rationale, including the diversity-impossible warning
+  flow (`(|fleet_in| − |pinned|) < min_planes_moved` ⇒ `found_partial`
+  is honest, no silent K downgrade).
+- [`tests/test_solver_fixture_matrix.py`](../../tests/test_solver_fixture_matrix.py) —
+  the `_assert_universal_properties` helper and the per-fixture
+  diversity-rejection assertions.
+- Related issues / PRs:
+  [#90](https://github.com/DocGerd/hangarfit/issues/90) (Chunk E),
+  [PR #91](https://github.com/DocGerd/hangarfit/pull/91)
+  (K-diverse alternatives implementation),
+  [#95](https://github.com/DocGerd/hangarfit/issues/95) (the
+  pairwise-diversity assertion placement),
+  [#136](https://github.com/DocGerd/hangarfit/issues/136) (the
+  retroactive-ADR backfill that produced this record).

--- a/docs/adr/0004-diversity-metric.md
+++ b/docs/adr/0004-diversity-metric.md
@@ -217,7 +217,7 @@ coexist as alternative filter strategies.
 
 - The pairwise-diversity universal property assertion lives in
   [`tests/test_solver_fixture_matrix.py::_assert_universal_properties`](../../tests/test_solver_fixture_matrix.py)
-  (the `if len(r.layouts) > 1:` block at lines 67–76). It mirrors the
+  — specifically the `if len(r.layouts) > 1:` block, which mirrors the
   solver's edit-count metric via the local `_count_planes_moved`
   helper, then asserts `n_moved >= cfg.min_planes_moved` for every pair
   of accepted layouts. Every fixture in the v1 matrix runs this

--- a/docs/adr/0005-maintenance-bay-rule.md
+++ b/docs/adr/0005-maintenance-bay-rule.md
@@ -1,0 +1,221 @@
+# ADR-0005: Maintenance bay rule — fuselage centroid in back strip, explicit conflict on no fuselage
+
+- **Status:** Accepted
+- **Date:** 2026-05-21
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+The hangar's back-most strip doubles as the **maintenance bay** — the
+curtained-off area where the technician works. A scenario designates one
+aircraft as the maintenance occupant; the checker has to decide whether
+a candidate layout actually parks that aircraft in the bay. "In the bay"
+is a domain rule, not a geometric tautology — it has to be defined
+precisely enough that the solver can pin against it and the visualizer
+can render conflicts against it. Phase 1 had to commit to a definition
+before any test fixture or solver constraint could be written.
+
+This ADR records the rule as it stands today
+(`src/hangarfit/collisions.py`). Milestone #9 ("Maintenance bay
+walling") is in flight and is layering a richer model on top —
+notably the bay as a physical obstacle (`bay_intrusion_rule`, #104) and
+partial-width bays (shipped via #103 / PR #150). If that work extends or
+replaces this rule, a follow-up ADR will record the supersession.
+
+## Decision Drivers
+
+- **The rule must be a single-point check.** "Plane X is in the bay" has
+  to be true or false for any given placement, computable from
+  `layout.placements[X]` and the aircraft's parts alone — no
+  layout-global state, no order dependence, no iteration.
+- **The rule must match the operational intuition.** The maintenance
+  technician looks at the layout and asks "is the body of the plane
+  back where I work on it?" — they don't care about wingtips that
+  protrude forward toward the door, and they don't care about
+  millimeter-precise edge alignment.
+- **The rule must surface unevaluatable cases loudly, not silently.**
+  A scenario where the designated maintenance plane has *no* fuselage
+  parts is structurally undefined; silently passing or silently failing
+  would be the worst-case outcome. The checker has to say so.
+- **The rule must compose with the parts model (ADR-0001) and the
+  transform (ADR-0002).** It is consumed by the collision checker,
+  which already iterates over world-coordinate parts; the rule should
+  reuse that pipeline rather than introduce a parallel geometry path.
+
+## Considered Options
+
+1. **Fuselage-parts centroid in the back strip, with an explicit
+   `maintenance_no_fuselage` conflict when no fuselage parts exist**
+   — the chosen option.
+2. **Any fuselage part touches the back strip.**
+3. **All fuselage parts entirely inside the back strip.**
+4. **The aircraft's plan-view bounding box overlaps the bay rectangle.**
+5. **Centroid of *all* parts (not just fuselage) in the back strip.**
+6. **Silent pass when no fuselage parts exist.** (Listed explicitly so
+   the rejection is on the record — see Decision Outcome.)
+
+## Decision Outcome
+
+**Chosen option: the fuselage centroid rule with an explicit
+`maintenance_no_fuselage` conflict on the structural edge case.**
+
+Concretely, in
+[`src/hangarfit/collisions.py`](../../src/hangarfit/collisions.py)
+(`_maintenance_conflicts`, around line 107): the check filters the
+world-coordinate parts of `layout.maintenance_plane` to those with
+`kind == "fuselage"`, computes the area-weighted centroid, and tests
+whether its `y` coordinate satisfies
+`y ≥ hangar.length_m − hangar.maintenance_bay.depth_m`. If yes, no
+conflict; if no, emit a `maintenance_position` conflict. If the
+designated plane has zero fuselage parts, emit a
+`maintenance_no_fuselage` conflict (line 143) instead of silently
+passing.
+
+### Why not "any fuselage part touches the back strip"?
+
+A plane with its nose 30 cm inside the bay and its tail near the door
+would qualify — but that is not what the operational rule wants. The
+technician needs the *body* of the plane back where they work, not just
+its nose. "Touches" is too lenient; a single conforming centimeter
+should not satisfy the rule.
+
+### Why not "all fuselage parts entirely inside the back strip"?
+
+Too tight. A tailwheel plane parked correctly inside the bay might still
+have its tail-fuselage segment protrude 5 cm past the rear-side
+boundary of the bay rectangle (or, more commonly, project a small slice
+past the *forward* boundary because the bay depth is set by partition
+position, not by aircraft length). The human operator would unambiguously
+call that placement "in the bay." A strict-containment rule fails such
+placements while adding no operational value.
+
+### Why not "plane's bounding box overlaps the bay rectangle"?
+
+This reverts to a bbox model, which the project rejected globally in
+ADR-0001 — for good reasons that still apply here. Worse, it would
+include the *wings* in the qualifying overlap. A high-wing whose
+wingtip happens to project over the bay rectangle would qualify as "in
+the bay" even though the fuselage is nowhere near the back strip. The
+fuselage is the body of the plane; including wings turns the rule into
+"some plane geometry is over the bay area," which is not what
+"maintenance plane is in the bay" means.
+
+### Why not "centroid of all parts (not just fuselage)"?
+
+Wings, struts, and tail surfaces can have substantial plan-view area
+relative to the fuselage. For wing-area-dominated aircraft (most
+notably the `scheibe_falke`, with an 18 m wingspan and a comparatively
+short fuselage), the all-parts centroid lands further forward than the
+fuselage centroid — sometimes meters forward. A "plane is at the back"
+rule that registers `scheibe_falke` as further forward than every
+other aircraft when its body is identically placed is the wrong
+answer. Fuselage-only is the right narrowing: the body of the plane is
+what defines "the plane is at the back."
+
+### Why not silent pass on no-fuselage?
+
+This is exactly the silent-failure shape that the project's general
+guidance rejects: a hard constraint that quietly admits an
+unevaluatable scenario will be discovered only when a downstream
+consumer (the solver, the visualizer, a human reviewer) notices a
+suspicious layout — and may not be discovered at all. The explicit
+`maintenance_no_fuselage` conflict surfaces the case at the checker
+level, with a named conflict kind that fixtures can pin against and
+that the visualizer can render. It is rare on the current fleet (every
+placeholder aircraft has fuselage parts), but the cost of the explicit
+emission is one branch in `_maintenance_conflicts`, and the benefit is
+that a future aircraft definition or a YAML-authoring slip cannot ever
+silently bypass the rule.
+
+## Consequences
+
+### Positive
+
+- **Order-independent and stateless.** The rule depends only on the
+  designated plane's parts and the hangar back-strip threshold; nothing
+  about other planes or about iteration order can change the verdict.
+- **Matches operational intuition.** "Body of the plane at the back" is
+  what the technician asks; the fuselage centroid encodes it cleanly.
+- **The no-fuselage edge case is observable.** Tests can pin the
+  `maintenance_no_fuselage` conflict; the visualizer can show it;
+  scenarios that hit it fail loudly rather than silently.
+- **Composes with the rest of the checker.** The rule sits inside
+  `check()` between hangar-bounds and pairwise-parts overlap, and uses
+  the same world-coordinate parts the rest of the checker uses; no
+  parallel geometry path is needed.
+
+### Negative
+
+- **The rule does not check bay *containment* of wings or tail.** A
+  plane whose body is centered correctly in the bay but whose long
+  tail-cone protrudes back through a (real, physical) bay wall is
+  reported as conforming. Milestone #9's `bay_intrusion_rule` (#104)
+  is the planned defense; until that ships, the current rule trusts
+  the layout author / solver to not park planes whose tails punch
+  through walls.
+- **The centroid is a single point.** A pathologically shaped fuselage
+  (e.g., a hypothetical aircraft whose fuselage has been modeled as two
+  disjoint segments fore and aft) can have a centroid that lands
+  between them in empty plan-view space. The fleet today contains no
+  such aircraft, but the assumption deserves naming.
+
+### Neutral
+
+- **The rule lives in `collisions.py`, not in `models.py`.** The cart
+  rule and other cross-reference invariants are enforced upstream in
+  `Layout.__post_init__`, but the maintenance-bay rule needs the
+  hangar's bay geometry, the aircraft's fuselage parts, AND the
+  plane-local-to-world transform — all of which the checker already
+  composes. Moving the rule into `models.py` would import the geometry
+  layer into the data layer, which the parts model deliberately keeps
+  separate.
+
+## Compliance
+
+- **Positive cases:** `tests/test_collisions.py` covers a layout whose
+  designated maintenance plane is centered in the back strip and
+  asserts no `maintenance_position` conflict is emitted. Fixtures in
+  `tests/fixtures/valid_maintenance_*.yaml` exercise this directly.
+- **Negative cases:** `tests/test_collisions.py` covers a layout whose
+  designated maintenance plane is parked forward of the bay; the
+  expected `maintenance_position` conflict is asserted. Fixtures in
+  `tests/fixtures/invalid_maintenance_*.yaml` exercise this.
+- **No-fuselage case:** a dedicated test constructs an `Aircraft` with
+  no fuselage parts, designates it as the maintenance plane, and
+  asserts the `maintenance_no_fuselage` conflict is emitted. This is
+  the regression-test for the explicit-emission decision and was a
+  conscious add during Phase 1 to lock the behaviour in.
+- **Cross-reference invariants** (the maintenance plane must be in
+  `layout.fleet` and absent from `layout.placements`) are enforced in
+  `Layout.__post_init__`, not here, so the checker can assume a
+  well-formed layout. See `src/hangarfit/models.py`.
+
+## More Information
+
+- [ADR-0001: Aircraft geometry as a list of parts](0001-aircraft-parts-model.md)
+  — makes "fuselage centroid" a coherent concept (fuselage is one
+  closed-set `PartKind`; centroid is over those parts in plan view).
+- [ADR-0002: Coordinate transform with determinant −1](0002-determinant-minus-one-transform.md)
+  — the transform that maps the plane-local fuselage parts into hangar
+  coordinates for the back-strip test.
+- [`src/hangarfit/collisions.py`](../../src/hangarfit/collisions.py)
+  — `_maintenance_conflicts` is the implementation (line 107); the
+  `maintenance_no_fuselage` emission is at line 143; the
+  `maintenance_position` emission is at line 158.
+- [`src/hangarfit/models.py`](../../src/hangarfit/models.py)
+  — `Hangar.maintenance_bay`, `Conflict.kind` taxonomy,
+  `Layout.__post_init__` cross-reference checks.
+- [`CLAUDE.md` — "The hangar" + "Phase 1 deliverables" + Module map](../../CLAUDE.md)
+  — operational statement of the rule.
+- **Open follow-up:** [Milestone #9 — Maintenance bay walling](https://github.com/DocGerd/hangarfit/milestone/9).
+  Issues #103 (partial-width bay, shipped via PR #150), #104
+  (`bay_intrusion_rule`), and the milestone epic
+  [#110](https://github.com/DocGerd/hangarfit/issues/110) are layering
+  a richer bay model on top. If that work redefines "in the bay" or
+  introduces a bay-as-obstacle rule that subsumes this ADR's centroid
+  check, a successor ADR should mark this one **Superseded by
+  ADR-XXXX**. The centroid rule itself may survive as one of several
+  conditions (e.g., centroid in bay AND no wall intrusion), in which
+  case this ADR stays Accepted and the successor ADR layers on top.
+- Related issue: [#136](https://github.com/DocGerd/hangarfit/issues/136)
+  (the retroactive-ADR backfill that produced this record).

--- a/docs/adr/0005-maintenance-bay-rule.md
+++ b/docs/adr/0005-maintenance-bay-rule.md
@@ -19,8 +19,8 @@ This ADR records the rule as it stands today
 (`src/hangarfit/collisions.py`). Milestone #9 ("Maintenance bay
 walling") is in flight and is layering a richer model on top —
 notably the bay as a physical obstacle (`bay_intrusion_rule`, #104) and
-partial-width bays (shipped via #103 / PR #150). If that work extends or
-replaces this rule, a follow-up ADR will record the supersession.
+partial-width bays (#103). If that work extends or replaces this rule,
+a follow-up ADR will record the supersession.
 
 ## Decision Drivers
 
@@ -65,11 +65,12 @@ Concretely, in
 world-coordinate parts of `layout.maintenance_plane` to those with
 `kind == "fuselage"`, computes the area-weighted centroid, and tests
 whether its `y` coordinate satisfies
-`y ≥ hangar.length_m − hangar.maintenance_bay.depth_m`. If yes, no
-conflict; if no, emit a `maintenance_position` conflict. If the
-designated plane has zero fuselage parts, emit a
-`maintenance_no_fuselage` conflict (line 143) instead of silently
-passing.
+`y ≥ hangar.length_m − hangar.maintenance_bay.depth_m` — equivalently,
+the code emits a `maintenance_position` conflict iff
+`centroid_y < bay_start_y` (strict `<`; a fuselage centroid that lands
+*exactly* on the bay boundary counts as parked in the bay, not as
+violating). If the designated plane has zero fuselage parts, emit a
+`maintenance_no_fuselage` conflict instead of silently passing.
 
 ### Why not "any fuselage part touches the back strip"?
 
@@ -199,16 +200,18 @@ silently bypass the rule.
   — the transform that maps the plane-local fuselage parts into hangar
   coordinates for the back-strip test.
 - [`src/hangarfit/collisions.py`](../../src/hangarfit/collisions.py)
-  — `_maintenance_conflicts` is the implementation (line 107); the
-  `maintenance_no_fuselage` emission is at line 143; the
-  `maintenance_position` emission is at line 158.
+  — `_maintenance_conflicts` is the implementation; the
+  `maintenance_no_fuselage` and `maintenance_position` conflict
+  emissions are both inside that function.
 - [`src/hangarfit/models.py`](../../src/hangarfit/models.py)
   — `Hangar.maintenance_bay`, `Conflict.kind` taxonomy,
   `Layout.__post_init__` cross-reference checks.
 - [`CLAUDE.md` — "The hangar" + "Phase 1 deliverables" + Module map](../../CLAUDE.md)
   — operational statement of the rule.
 - **Open follow-up:** [Milestone #9 — Maintenance bay walling](https://github.com/DocGerd/hangarfit/milestone/9).
-  Issues #103 (partial-width bay, shipped via PR #150), #104
+  Issues [#103](https://github.com/DocGerd/hangarfit/issues/103)
+  (partial-width bay),
+  [#104](https://github.com/DocGerd/hangarfit/issues/104)
   (`bay_intrusion_rule`), and the milestone epic
   [#110](https://github.com/DocGerd/hangarfit/issues/110) are layering
   a richer bay model on top. If that work redefines "in the bay" or

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -75,12 +75,11 @@ manual workflow above is canonical.
 
 ## Index
 
-| ADR | Title                                                                        | Status   |
-|-----|------------------------------------------------------------------------------|----------|
-| 0000 | [Record architecture decisions](0000-record-architecture-decisions.md)      | Accepted |
-
-The five initial retroactive ADRs (parts model, det = −1 coordinate
-transform, RR-MC solver algorithm, diversity metric, maintenance bay
-rule) will be added by [#136](https://github.com/DocGerd/hangarfit/issues/136)
-and successive PRs in milestone #12; this Index is the canonical list
-once they land.
+| ADR  | Title                                                                                                  | Status   |
+|------|--------------------------------------------------------------------------------------------------------|----------|
+| 0000 | [Record architecture decisions](0000-record-architecture-decisions.md)                                 | Accepted |
+| 0001 | [Aircraft geometry as a list of parts](0001-aircraft-parts-model.md)                                   | Accepted |
+| 0002 | [Plane-local → world transform has determinant −1](0002-determinant-minus-one-transform.md)            | Accepted |
+| 0003 | [Random-restart min-conflicts (RR-MC) for the static layout solver](0003-rr-mc-solver-algorithm.md)    | Accepted |
+| 0004 | [Diversity metric for K alternatives (edit count with per-plane thresholds)](0004-diversity-metric.md) | Accepted |
+| 0005 | [Maintenance bay rule — fuselage centroid in back strip](0005-maintenance-bay-rule.md)                 | Accepted |


### PR DESCRIPTION
Closes #136 (fifth of six milestone-#12 issues).

## Summary

Backfills the first five real ADRs into `docs/adr/`, capturing the
load-bearing decisions of Phase 1 + Phase 2a that were previously
documented only in CLAUDE.md, in commit messages, and in the
maintainer's head. The meta-ADR-0000 (shipped in #135) explains why
we record these at all; this PR provides the substantive content.

## The five ADRs

| ADR | Title | Why this one |
|---|---|---|
| 0001 | Aircraft geometry as a list of parts | The most load-bearing geometric choice; expresses height-disjoint pass-through and strut-volume blockage that a bbox model cannot. |
| 0002 | Plane-local → world transform has determinant −1 | **The highest-value record in the set** — the "looks like a bug, is intentional" decision. Without this ADR, a future contributor could "fix" the matrix into actual brokenness. |
| 0003 | Random-restart min-conflicts (RR-MC) solver | Considered Z3/MiniZinc with quantised state, GA/SA, gradient-based, and pure random sampling. RR-MC handles continuous state, non-smooth boundaries, and deterministic reproducibility. |
| 0004 | Diversity metric (edit count, M=2, 0.5 m, 30°) | Plane-semantic; rejects aggregate L2 distance and binary Hamming alternatives. Tunable via `DiversityConfig`. |
| 0005 | Maintenance bay rule (fuselage centroid + explicit `maintenance_no_fuselage` conflict) | Matches operational intuition; flagged as possibly Superseded by milestone #9's richer bay-as-obstacle model once that lands. |

## Acceptance criteria (from #136)

- [x] 5 new ADR files at `docs/adr/0001..0005-*.md`, all with **Status: Accepted**.
- [x] Each ADR follows the template from #135 (Status / Context / Decision Drivers / Considered Options [≥ 2] / Decision Outcome / Consequences / Compliance / More Information).
- [x] Every ADR considers ≥ 2 real alternatives with concrete rejection reasoning.
- [x] Cross-references between ADRs use actual on-disk filenames (several agent-introduced filename mismatches were corrected during integration).
- [x] `docs/adr/README.md` Index updated to list all six (0000 + 0001..0005).

## How this was authored

The 5 ADRs were drafted in parallel — 5 subagents, one per ADR — per the
`dispatching-parallel-agents` pattern. The orchestrator (this session)
briefed each agent with the historical decision drivers, the constraint
to write only its own ADR file, and the references it should link.
ADR-0005 was authored in-session after the parallel batch (one of the
five agents hit a session-quota limit before writing its file).
Filename mismatches between sibling cross-references were corrected
during the integration step. The Index was synthesized after all five
files were on disk.

## Out of scope

- ADR-XXXX for milestone #9 / #104 (`bay_intrusion_rule`) — that's a
  future ADR that may supersede #5 (called out in 0005's More
  Information).
- CLAUDE.md content migration — #137 is the cleanup pass that will
  decide which CLAUDE.md content moves where (Arc42 §8, ADRs, or
  stays as operational guidance).

## Test plan

- [ ] Visual: open `docs/adr/README.md` on GitHub — Index renders, all six rows resolve.
- [ ] Visual: open ADR-0002 — confirm the matrix form, the 45° worked example, and the test+agent compliance references render.
- [ ] Spot-check: each ADR has ≥ 2 considered options with concrete rejection reasoning (this is the load-bearing discipline from ADR-0000).
- [ ] Click every internal `(0NNN-…)` link in each ADR — none should 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)