### PR TITLE
test(fixtures): bay_intrusion goldens (#107)

### DIFF
--- a/tests/fixtures/invalid_bay_intrusion_wingtip.yaml
+++ b/tests/fixtures/invalid_bay_intrusion_wingtip.yaml
@@ -1,0 +1,23 @@
+# Negative golden for the bay_intrusion rule: a wingtip strictly inside
+# the closed bay rectangle.
+#
+# Bay (data/hangar.yaml placeholder): x ∈ (9, 18), y > 16.
+#
+# aviat_husky at (6, 16.5, 0) — wing world x = [0.59, 11.41], y =
+# [15.28, 16.68]. The wing's right-rear vertex (11.41, 16.68) sits
+# at x ∈ (9, 18) AND y > 16 → strictly inside the bay. Exactly one
+# `bay_intrusion` conflict fires (the other three wing vertices and
+# all fuselage/strut vertices stay outside).
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+
+maintenance:
+  plane: scheibe_falke
+
+placements:
+  - plane: aviat_husky
+    x_m: 6.0
+    y_m: 16.5
+    heading_deg: 0.0
+    on_carts: false

--- a/tests/fixtures/invalid_bay_intrusion_wingtip.yaml
+++ b/tests/fixtures/invalid_bay_intrusion_wingtip.yaml
@@ -4,8 +4,10 @@
 # Bay (data/hangar.yaml placeholder): x ∈ (9, 18), y > 16.
 #
 # aviat_husky at (6, 16.5, 0) — wing world x = [0.59, 11.41], y =
-# [15.28, 16.68]. The wing's right-rear vertex (11.41, 16.68) sits
-# at x ∈ (9, 18) AND y > 16 → strictly inside the bay. Exactly one
+# [15.28, 16.68]. The wing's right-front vertex (11.41, 16.68) sits
+# at x ∈ (9, 18) AND y > 16 → strictly inside the bay. (Plane-local
+# +x is forward toward the nose, so the wing's +x edge maps to the
+# deeper-into-hangar side of the part at heading 0.) Exactly one
 # `bay_intrusion` conflict fires (the other three wing vertices and
 # all fuselage/strut vertices stay outside).
 

--- a/tests/fixtures/solve_infeasible_bay_closes_floor.yaml
+++ b/tests/fixtures/solve_infeasible_bay_closes_floor.yaml
@@ -11,10 +11,12 @@
 # burning the budget.
 #
 # Bay (data/hangar.yaml placeholder): x ∈ (9, 18), y > 16.
-# aviat_husky pinned at (6, 16.5, 0) — wing right-rear vertex at
-# (11.41, 16.68) is strictly inside the bay. scheibe_falke is the
-# maintenance occupant (in fleet_in, but absent from placements
-# by Layout invariant).
+# aviat_husky pinned at (6, 16.5, 0) — wing right-front vertex at
+# (11.41, 16.68) is strictly inside the bay. (Plane-local +x is
+# forward toward the nose, so the wing's +x edge maps to the
+# deeper-into-hangar side of the part at heading 0.) scheibe_falke
+# is the maintenance occupant (in fleet_in, but absent from
+# placements by Layout invariant).
 #
 # Future-of-#108 note: once the solver gains bay-area awareness
 # (drops the occupant from the placeable set, narrows the floor by

--- a/tests/fixtures/solve_infeasible_bay_closes_floor.yaml
+++ b/tests/fixtures/solve_infeasible_bay_closes_floor.yaml
@@ -1,0 +1,33 @@
+# Bay closure forces infeasibility — pinning a plane such that its
+# geometry intrudes into the closed bay leaves the solver no feasible
+# trajectory, and `_check_trivially_infeasible` catches it pre-search.
+#
+# Mechanism (current solver, post-#150): pre-search check #3 builds
+# a pin-only Layout from `scenario.constraints[*].pin` placements
+# (with the maintenance occupant filtered out per the invariant) and
+# runs `collisions.check()` on it. If that Layout already has
+# conflicts — here, a pinned wingtip strictly inside the closed bay
+# — the solver short-circuits to status=trivially_infeasible without
+# burning the budget.
+#
+# Bay (data/hangar.yaml placeholder): x ∈ (9, 18), y > 16.
+# aviat_husky pinned at (6, 16.5, 0) — wing right-rear vertex at
+# (11.41, 16.68) is strictly inside the bay. scheibe_falke is the
+# maintenance occupant (in fleet_in, but absent from placements
+# by Layout invariant).
+#
+# Future-of-#108 note: once the solver gains bay-area awareness
+# (drops the occupant from the placeable set, narrows the floor by
+# the bay rect), this fixture may additionally trip the Σ-areas
+# check #2. Either path is the spec's intended behavior.
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [aviat_husky, ctsl, scheibe_falke]
+
+maintenance:
+  plane: scheibe_falke
+
+constraints:
+  aviat_husky:
+    pin: { x_m: 6.0, y_m: 16.5, heading_deg: 0.0, on_carts: false }

--- a/tests/fixtures/valid_bay_closed_no_intruder.yaml
+++ b/tests/fixtures/valid_bay_closed_no_intruder.yaml
@@ -6,8 +6,10 @@
 # (absent from placements by Layout invariant).
 #
 # ctsl at (5, 5, 0): wing world x = [0.705, 9.295], y = [4.97, 6.37].
-# Wing's right-rear vertex (9.295, 6.37) has x > 9 (just inside bay x
+# Wing's right-front vertex (9.295, 6.37) has x > 9 (just inside bay x
 # range), but y = 6.37 < 16 (well outside bay y range) → no intrusion.
+# (Plane-local +x is forward toward the nose, so the wing's +x edge maps
+# to the deeper-into-hangar side of the part at heading 0.)
 # Pins down the "well clear" happy path for the bay rule.
 
 fleet: ../../data/fleet.yaml

--- a/tests/fixtures/valid_bay_closed_no_intruder.yaml
+++ b/tests/fixtures/valid_bay_closed_no_intruder.yaml
@@ -1,0 +1,24 @@
+# Bay-intrusion happy path — closed bay, all placed planes well clear
+# of the bay rectangle.
+#
+# Bay (data/hangar.yaml placeholder): center_x=13.5, width=9, depth=9
+# → x ∈ (9, 18), y > 16. scheibe_falke is the maintenance occupant
+# (absent from placements by Layout invariant).
+#
+# ctsl at (5, 5, 0): wing world x = [0.705, 9.295], y = [4.97, 6.37].
+# Wing's right-rear vertex (9.295, 6.37) has x > 9 (just inside bay x
+# range), but y = 6.37 < 16 (well outside bay y range) → no intrusion.
+# Pins down the "well clear" happy path for the bay rule.
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+
+maintenance:
+  plane: scheibe_falke
+
+placements:
+  - plane: ctsl
+    x_m: 5.0
+    y_m: 5.0
+    heading_deg: 0.0
+    on_carts: false

--- a/tests/fixtures/valid_bay_open_planes_in_back_strip.yaml
+++ b/tests/fixtures/valid_bay_open_planes_in_back_strip.yaml
@@ -1,0 +1,26 @@
+# Open-bay semantics — bay rectangle is just floor when no plane is
+# in maintenance.
+#
+# Bay area would be (9, 18) × (16, 25] for the placeholder hangar,
+# but with `maintenance_plane: null` the bay is open and the
+# `bay_intrusion` rule never fires.
+#
+# aviat_husky at (8, 19, 0) parks squarely inside what WOULD be the
+# bay if it were closed: wing world x = [2.59, 13.41], y = [17.78,
+# 19.18] — the right wing reaches into x > 9 AND y > 16, which would
+# be a bay_intrusion under a closed bay. With the bay open, the rule
+# is a no-op and the layout is valid.
+#
+# Pins down the open-bay = normal floor contract.
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+
+# No `maintenance:` block — bay is open.
+
+placements:
+  - plane: aviat_husky
+    x_m: 8.0
+    y_m: 19.0
+    heading_deg: 0.0
+    on_carts: false

--- a/tests/fixtures/valid_part_vertex_on_bay_edge.yaml
+++ b/tests/fixtures/valid_part_vertex_on_bay_edge.yaml
@@ -1,0 +1,27 @@
+# Strict-inequality boundary: a part vertex landing exactly on a bay
+# edge counts as outside.
+#
+# Bay (data/hangar.yaml placeholder): x ∈ (9, 18), y > 16. The
+# `_bay_intrusion_conflicts` test predicate is
+# `x_min < x < x_max and y > y_min` — strict on all three interior
+# edges. A vertex with `x == x_min` (= 9) falls in the closed-open
+# gap and must NOT trip the rule.
+#
+# ctsl at (4.705, 20, 0) — wing world x = [0.41, 9.0], y = [19.97,
+# 21.37]. The wing's right-rear and right-front vertices both land
+# at x = 9.0 exactly (the left edge of the bay). x_min < 9.0 is
+# False, so neither vertex is "strictly inside". → no intrusion,
+# valid layout. Guards against a future tightening of `<` to `<=`.
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+
+maintenance:
+  plane: scheibe_falke
+
+placements:
+  - plane: ctsl
+    x_m: 4.705
+    y_m: 20.0
+    heading_deg: 0.0
+    on_carts: false

--- a/tests/fixtures/valid_partial_width_bay_plane_in_side_aisle.yaml
+++ b/tests/fixtures/valid_partial_width_bay_plane_in_side_aisle.yaml
@@ -1,0 +1,28 @@
+# Partial-width bay semantics — a plane parked in the back strip but
+# beside the bay (in the unused x-aisle of the back strip) is valid.
+#
+# Bay (data/hangar.yaml placeholder): x ∈ (9, 18), y > 16. The
+# back strip is x ∈ [0, 18], y ∈ [16, 25]. The "side aisle" is the
+# part of the back strip the bay does NOT cover: x ∈ [0, 9].
+#
+# ctsl at (4.5, 20, 0) parks in the side aisle. Wing world x =
+# [0.205, 8.795]: max x = 8.795 < 9, so the wing is fully outside
+# the bay x range even though its y range [19.97, 21.37] is squarely
+# in the bay y range. Fuselage x range [4.0, 5.0] also outside bay x
+# range. → no intrusion, valid layout.
+#
+# Pins down the partial-width contract: the side aisle remains usable
+# even when the bay is closed.
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+
+maintenance:
+  plane: scheibe_falke
+
+placements:
+  - plane: ctsl
+    x_m: 4.5
+    y_m: 20.0
+    heading_deg: 0.0
+    on_carts: false

--- a/tests/test_collisions.py
+++ b/tests/test_collisions.py
@@ -385,6 +385,53 @@ class TestBayIntrusion:
         assert "maintenance_position" not in kinds
         assert "maintenance_no_fuselage" not in kinds
 
+    # ── End-to-end fixture goldens (loader → checker contract) ──────────
+
+    def test_fixture_bay_closed_no_intruder_valid(self) -> None:
+        """Closed bay, all placed planes well clear of the bay rectangle."""
+        result = check(_load("valid_bay_closed_no_intruder"))
+        assert result.valid, f"clear layout must pass with closed bay, got {result.conflicts!r}"
+
+    def test_fixture_bay_open_planes_in_back_strip_valid(self) -> None:
+        """Open bay (maintenance_plane=None) — a plane parked inside the
+        area that WOULD be the bay must still pass; the rule is a no-op."""
+        layout = _load("valid_bay_open_planes_in_back_strip")
+        assert layout.maintenance_plane is None
+        result = check(layout)
+        assert result.valid, (
+            f"open bay must not fire bay_intrusion against a plane in "
+            f"the back strip, got {result.conflicts!r}"
+        )
+
+    def test_fixture_partial_width_bay_plane_in_side_aisle_valid(self) -> None:
+        """Closed bay, plane parked in the side aisle (back strip, but
+        outside the bay x range). Asserts partial-width semantics — the
+        side aisle remains usable even when the bay is closed."""
+        result = check(_load("valid_partial_width_bay_plane_in_side_aisle"))
+        assert result.valid, (
+            f"side-aisle layout must pass with closed partial-width bay, got {result.conflicts!r}"
+        )
+
+    def test_fixture_bay_intrusion_wingtip_invalid(self) -> None:
+        """A wingtip vertex strictly inside the closed bay must trip
+        exactly one ``bay_intrusion`` conflict."""
+        result = check(_load("invalid_bay_intrusion_wingtip"))
+        assert not result.valid
+        assert _conflict_kinds(result) == {"bay_intrusion"}, (
+            f"expected exactly bay_intrusion, got {result.conflicts!r}"
+        )
+        assert len(result.conflicts) == 1, (
+            f"expected exactly one offending part, got {result.conflicts!r}"
+        )
+
+    def test_fixture_part_vertex_on_bay_edge_valid(self) -> None:
+        """A vertex landing exactly on a bay edge (``x == x_min``) must
+        NOT trip the rule. Guards the strict-inequality semantics at
+        the fixture level (the synthetic unit tests do the same at the
+        function level)."""
+        result = check(_load("valid_part_vertex_on_bay_edge"))
+        assert result.valid, f"vertex on bay edge must count as outside; got {result.conflicts!r}"
+
     def test_defensive_skip_protects_against_occupant_leak(self) -> None:
         """If the maintenance occupant ever leaks into ``world_parts``
         (would require a Layout-invariant bypass), the rule must skip

--- a/tests/test_collisions.py
+++ b/tests/test_collisions.py
@@ -406,10 +406,35 @@ class TestBayIntrusion:
     def test_fixture_partial_width_bay_plane_in_side_aisle_valid(self) -> None:
         """Closed bay, plane parked in the side aisle (back strip, but
         outside the bay x range). Asserts partial-width semantics — the
-        side aisle remains usable even when the bay is closed."""
-        result = check(_load("valid_partial_width_bay_plane_in_side_aisle"))
+        side aisle remains usable even when the bay is closed.
+
+        Beyond ``result.valid``, this also pins the geometric intent:
+        at least one part must have a vertex with ``y > y_min`` (i.e.
+        in the back strip) AND ``x < x_min`` (in the side aisle). A
+        future fixture drift that pushed the plane forward of the
+        back strip would still pass ``result.valid`` but would no
+        longer exercise the partial-width path.
+        """
+        from hangarfit.geometry import aircraft_parts_world
+
+        layout = _load("valid_partial_width_bay_plane_in_side_aisle")
+        result = check(layout)
         assert result.valid, (
             f"side-aisle layout must pass with closed partial-width bay, got {result.conflicts!r}"
+        )
+        bay = layout.hangar.maintenance_bay
+        x_min = bay.center_x_m - bay.width_m / 2
+        y_min = layout.hangar.length_m - bay.depth_m
+        in_side_aisle = any(
+            vx < x_min and vy > y_min
+            for placement in layout.placements
+            for wp in aircraft_parts_world(layout.fleet[placement.plane_id], placement)
+            for vx, vy in list(wp.polygon.exterior.coords)[:-1]
+        )
+        assert in_side_aisle, (
+            "fixture must place at least one vertex in the side aisle "
+            "(x < x_min and y > y_min); otherwise it no longer exercises "
+            "the partial-width semantics it documents"
         )
 
     def test_fixture_bay_intrusion_wingtip_invalid(self) -> None:
@@ -428,9 +453,35 @@ class TestBayIntrusion:
         """A vertex landing exactly on a bay edge (``x == x_min``) must
         NOT trip the rule. Guards the strict-inequality semantics at
         the fixture level (the synthetic unit tests do the same at the
-        function level)."""
-        result = check(_load("valid_part_vertex_on_bay_edge"))
+        function level).
+
+        Beyond ``result.valid``, this also pins the on-edge property:
+        at least one part must have a vertex with ``abs(x - x_min)``
+        below floating-point tolerance. If a future fixture drift
+        moved the plane off the edge by a few cm, ``result.valid``
+        would still hold but the fixture would no longer guard the
+        strict-vs-non-strict boundary case.
+        """
+        import math
+
+        from hangarfit.geometry import aircraft_parts_world
+
+        layout = _load("valid_part_vertex_on_bay_edge")
+        result = check(layout)
         assert result.valid, f"vertex on bay edge must count as outside; got {result.conflicts!r}"
+        bay = layout.hangar.maintenance_bay
+        x_min = bay.center_x_m - bay.width_m / 2
+        on_edge = any(
+            math.isclose(vx, x_min, abs_tol=1e-9)
+            for placement in layout.placements
+            for wp in aircraft_parts_world(layout.fleet[placement.plane_id], placement)
+            for vx, _vy in list(wp.polygon.exterior.coords)[:-1]
+        )
+        assert on_edge, (
+            "fixture must place at least one part vertex at x = x_min "
+            "exactly; otherwise it no longer exercises the strict-< edge "
+            "case it documents"
+        )
 
     def test_defensive_skip_protects_against_occupant_leak(self) -> None:
         """If the maintenance occupant ever leaks into ``world_parts``

--- a/tests/test_solver_infeasibility.py
+++ b/tests/test_solver_infeasibility.py
@@ -176,6 +176,38 @@ def test_solve_trivially_infeasible_alternatives_1_clears_diversity_impossible()
 # along with the ``maintenance_position`` collision rule. Pinning the
 # maintenance plane is incoherent under the new "occupant is away"
 # semantics — the bay-closure rule operates on the perimeter, not on the
-# occupant's geometry, so there is nothing to pin against. The bay
-# perimeter rule itself (``bay_intrusion``) gets its own goldens once it
-# ships.
+# occupant's geometry, so there is nothing to pin against.
+
+
+def test_solve_trivially_infeasible_when_pinned_plane_intrudes_into_closed_bay():
+    """Pinning a non-maintenance plane such that its geometry intrudes
+    into the closed bay must be caught pre-search.
+
+    Pre-search check #3 builds a pin-only Layout from the pinned
+    placements (with the maintenance occupant filtered out per the
+    invariant) and runs ``collisions.check()`` on it. A pinned wingtip
+    strictly inside the closed bay triggers ``bay_intrusion`` on that
+    Layout — and the solver short-circuits to trivially_infeasible
+    instead of burning the budget on restarts where every iteration
+    hits the same conflict on a pinned plane.
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    s = load_scenario("tests/fixtures/solve_infeasible_bay_closes_floor.yaml")
+    r = solve(s, budget_s=5.0, seed=42)
+
+    # Must fire trivially_infeasible (pre-search), NOT exhausted_budget.
+    assert r.status == "trivially_infeasible", (
+        f"expected pre-search rejection; got {r.status} after "
+        f"{r.diagnostics.restarts_attempted} restarts (silent-failure regression?)"
+    )
+    # Wall time should be ~zero — no real search ran.
+    assert r.diagnostics.wall_time_s < 0.5
+    assert r.diagnostics.restarts_attempted == 0
+    bp = r.diagnostics.best_partial
+    assert bp is not None
+    assert any(c.kind == "bay_intrusion" for c in bp.conflicts), (
+        f"expected a bay_intrusion conflict on the pin-only Layout, "
+        f"got {[c.kind for c in bp.conflicts]}"
+    )


### PR DESCRIPTION
Closes #107.

Spec: `docs/superpowers/specs/2026-05-22-maintenance-bay-walling-design.md` §6 (fixture migration).

## Summary

Author the spec's six new fixtures exercising the `bay_intrusion` perimeter rule (introduced in #104) through the loader+checker contract, plus the matching solver pre-search infeasibility test. The complementary deletes (`invalid_maintenance_position.yaml`, `valid_maintenance_at_bay_boundary.yaml`, `solve_infeasible_maint_pin_outside_bay.yaml`) already shipped in #150.

### New fixtures (6)

| Fixture | Asserts |
|---|---|
| `valid_bay_closed_no_intruder.yaml` | Happy path: closed bay, plane well clear |
| `valid_bay_open_planes_in_back_strip.yaml` | Open-bay = normal floor (rule is no-op when `maintenance_plane is None`) |
| `valid_partial_width_bay_plane_in_side_aisle.yaml` | Side aisle (x < 9) remains usable with closed bay |
| `invalid_bay_intrusion_wingtip.yaml` | One wingtip strictly inside bay → exactly one `bay_intrusion` conflict |
| `valid_part_vertex_on_bay_edge.yaml` | Vertex at `x == x_min` counts as outside (strict-inequality boundary) |
| `solve_infeasible_bay_closes_floor.yaml` | Pinned wingtip in closed bay → pre-search check #3 returns `trivially_infeasible` |

Every fixture's headers include the bay geometry (`x ∈ (9, 18), y > 16`) and the precise world-coordinate reasoning so a reader can verify the assertion without running the checker.

### New tests

- `tests/test_collisions.py::TestBayIntrusion` — 5 fixture-based goldens alongside the existing synthetic unit tests. The two suites cover the same semantic surface from different angles: end-to-end YAML → loader → checker vs. direct private-function input shapes.
- `tests/test_solver_infeasibility.py::test_solve_trivially_infeasible_when_pinned_plane_intrudes_into_closed_bay` — asserts status, wall_time, restarts, and best_partial conflict kind. Replaces the legacy maint-pin-outside-bay regression deleted in #150.

## Verification

- `pytest`: **395 passed**, 1 skipped (carry-over canary from #150), 1 deselected
- `mypy src/hangarfit/`: clean
- `ruff check` + `ruff format`: clean

## Test plan

- [x] All 6 fixtures load cleanly through `load_layout` / `load_scenario`
- [x] Each fixture's expected validity / conflict kind verified empirically before adding test code
- [x] Goldens added in the right test files (collisions vs solver_infeasibility)
- [x] Full local gate green