### PR TITLE
docs(security): Scorecard structural-zero rationale doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,12 @@ Allowed but not the default. Use only when two feature branches need parallel wo
 
 ---
 
+## Security policy & Scorecard rationale
+
+Vulnerability reporting lives in [SECURITY.md](SECURITY.md). The rationale for the structural-zero OpenSSF Scorecard checks (Code-Review, Maintained, Contributors, Packaging) — why they score 0 by design and what we do instead — is documented in [docs/security-posture.md](docs/security-posture.md). Read it before reacting to the aggregate Scorecard number.
+
+---
+
 ## Open questions / TBD before trusting output
 
 - **Real measurements** for every aircraft (`measured: false` in `fleet.yaml`). All current dimensions are eyeballed placeholders.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Allowed but not the default. Use only when two feature branches need parallel wo
 
 ## Security policy & Scorecard rationale
 
-Vulnerability reporting lives in [SECURITY.md](SECURITY.md). The rationale for the structural-zero OpenSSF Scorecard checks (Code-Review, Maintained, Contributors, Packaging) — why they score 0 by design and what we do instead — is documented in [docs/security-posture.md](docs/security-posture.md). Read it before reacting to the aggregate Scorecard number.
+Vulnerability reporting lives in [SECURITY.md](SECURITY.md). The rationale for the structural-zero OpenSSF Scorecard checks (Code-Review, Maintained, Contributors, Packaging) — why they score 0 by design and what we do instead — is documented in [docs/security-posture.md](docs/security-posture.md). If you're asked about the Scorecard number, point at that doc rather than the raw aggregate.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,3 +27,9 @@ The following areas have non-zero attack surface and merit scrutiny:
 - **Visualizer** (`src/hangarfit/visualize.py`): renders user-supplied aircraft placements and conflict data
 
 We welcome reports of resource exhaustion, parsing edge cases, or rendering defects that could affect the tool's reliability or the user's system.
+
+## Project security posture
+
+`hangarfit` runs an [OpenSSF Scorecard](https://securityscorecards.dev/) workflow on every push to `develop` (see [`.github/workflows/scorecard.yml`](.github/workflows/scorecard.yml)). Several of the checks score 0 for structural reasons specific to this project — single maintainer, single deployment site, deliberately unpublished — rather than because the underlying concern is unaddressed.
+
+The rationale for each structural zero, plus what we *do* in lieu of the standard remediation (e.g. the in-repo `/pr-review` toolkit substituting for formal `APPROVED` reviews), is documented in [`docs/security-posture.md`](docs/security-posture.md). Read that before drawing conclusions from the aggregate Scorecard number.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,6 @@ We welcome reports of resource exhaustion, parsing edge cases, or rendering defe
 
 ## Project security posture
 
-`hangarfit` runs an [OpenSSF Scorecard](https://securityscorecards.dev/) workflow on every push to `develop` (see [`.github/workflows/scorecard.yml`](.github/workflows/scorecard.yml)). Several of the checks score 0 for structural reasons specific to this project — single maintainer, single deployment site, deliberately unpublished — rather than because the underlying concern is unaddressed.
+`hangarfit` runs an [OpenSSF Scorecard](https://securityscorecards.dev/) workflow on every push to `develop` and on a weekly schedule (see [`.github/workflows/scorecard.yml`](.github/workflows/scorecard.yml)). Several of the checks score 0 for structural reasons specific to this project — single maintainer, single deployment site, deliberately unpublished — rather than because the underlying concern is unaddressed.
 
-The rationale for each structural zero, plus what we *do* in lieu of the standard remediation (e.g. the in-repo `/pr-review` toolkit substituting for formal `APPROVED` reviews), is documented in [`docs/security-posture.md`](docs/security-posture.md). Read that before drawing conclusions from the aggregate Scorecard number.
+The rationale for each structural zero, plus what we *do* in lieu of the standard remediation (e.g. the `/pr-review` workflow substituting for formal `APPROVED` reviews), is documented in [`docs/security-posture.md`](docs/security-posture.md). Read that before drawing conclusions from the aggregate Scorecard number.

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -1,18 +1,20 @@
 # Security posture — Scorecard structural zeros, explained
 
 [OpenSSF Scorecard](https://securityscorecards.dev/) gives `hangarfit` an
-aggregate of around **6.5 / 10** at the time of writing. Four of the
-checks contributing to that number score **0** (or **-1**), and they
-score that way because of structural properties of the project that we
-do not intend to change. This document explains, per check, why the
-zero is *structural* rather than a defect — so an outside reviewer
-arriving from a Scorecard report can see the rationale in-tree rather
-than guessing.
+aggregate of around **6.5 / 10** at the time this document was written
+(PR #166, 2026-05-23). Four of the checks contributing to that number
+score **0** (or **-1**), and they score that way because of structural
+properties of the project that we do not intend to change. This
+document explains, per check, why the zero is *structural* rather than
+a defect — so an outside reviewer arriving from a Scorecard report can
+see the rationale in-tree rather than guessing.
 
 Three of the four also cap the realistic ceiling of our aggregate score
-at roughly **8.0–8.5**, even after the rest of the supply-chain
-hardening in milestone
-[v0.7.0](https://github.com/DocGerd/hangarfit/milestone/13) lands.
+at roughly **8.0–8.5** — the per-check breakdown that produces that
+ceiling lives in the
+[v0.7.0 milestone description](https://github.com/DocGerd/hangarfit/milestone/13).
+Even after the rest of the supply-chain hardening in that milestone
+lands, three structural zeros remain in the average.
 
 If you want to verify any of this against the live data, see
 [Where the score lives](#where-the-score-lives) at the bottom.
@@ -21,26 +23,29 @@ If you want to verify any of this against the live data, see
 
 ## Code-Review (score 0)
 
-**What the check measures.** Scorecard inspects the most recent (up to
-30) commits on the default branch and counts how many landed via a
-pull request with at least one `APPROVED` review. A score of 0 means
-**none** of them did.
+**What the check measures.** Scorecard inspects the most recent
+changesets (up to 30) on the default branch and scores on the **share**
+of those that show evidence of review — on GitHub, that means a PR with
+at least one `APPROVED` review. A score of 0 means none of the
+inspected changesets carry that evidence.
 
-**Why we score 0.** `hangarfit` has a single maintainer. GitHub does
-not permit a maintainer to formally `APPROVE` their own pull request
-(the "Approve" radio is disabled when reviewing your own PR), so every
-PR merges with **zero** formal approvals on file — regardless of how
-much review actually happened.
+**Why we score 0.** `hangarfit` has a single maintainer.
+[GitHub does not allow a PR's author to approve their own pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews):
+submitting an `APPROVE` review event as the PR author is refused
+(HTTP 422 from the REST API). Every PR therefore merges with **zero**
+formal approvals on file, regardless of how much review actually
+happened.
 
 What did happen on every one of those PRs is a substantive review pass
-performed by Claude Code via the in-repo
-[`/pr-review` toolkit](../.claude/README.md). That toolkit dispatches
-specialised review subagents (the `pr-review-toolkit` family plus
-repo-specific ones like `geometry-invariant-guard`), and every finding
-is converted into a review thread **on the diff**, then either fixed
-in code or replied to with rationale before the thread is resolved.
-The PR-review process is documented in
-[CLAUDE.md › Per-PR process](../CLAUDE.md#per-pr-process).
+performed by Claude Code via the
+[`/pr-review` workflow documented in CLAUDE.md](../CLAUDE.md#per-pr-process).
+That workflow dispatches a mix of subagents from the external
+`pr-review-toolkit` plugin (`code-reviewer`, `comment-analyzer`,
+`silent-failure-hunter`, …) and the repo-local
+[`geometry-invariant-guard`](../.claude/agents/geometry-invariant-guard.md).
+Every finding is converted into a review thread **on the diff**, then
+either fixed in code or replied to with rationale before the thread is
+resolved.
 
 So the Scorecard 0 is accurate as a count of `APPROVED` reviews; it is
 **not** accurate as a count of *reviews that happened*. We have not
@@ -87,8 +92,7 @@ scope statement. The expected contributor population is one
 maintainer plus, perhaps, a small number of club members. There are no
 upstream consumers and no realistic path to multi-organisation
 commits, because the tool is not interesting to anyone outside this
-specific deployment. The check is, in effect, asking the wrong
-question of this codebase.
+specific deployment.
 
 **Will it move?** Almost certainly not, and we are not trying to move
 it. A 0 here means "this project does not look like a typical

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -1,0 +1,150 @@
+# Security posture — Scorecard structural zeros, explained
+
+[OpenSSF Scorecard](https://securityscorecards.dev/) gives `hangarfit` an
+aggregate of around **6.5 / 10** at the time of writing. Four of the
+checks contributing to that number score **0** (or **-1**), and they
+score that way because of structural properties of the project that we
+do not intend to change. This document explains, per check, why the
+zero is *structural* rather than a defect — so an outside reviewer
+arriving from a Scorecard report can see the rationale in-tree rather
+than guessing.
+
+Three of the four also cap the realistic ceiling of our aggregate score
+at roughly **8.0–8.5**, even after the rest of the supply-chain
+hardening in milestone
+[v0.7.0](https://github.com/DocGerd/hangarfit/milestone/13) lands.
+
+If you want to verify any of this against the live data, see
+[Where the score lives](#where-the-score-lives) at the bottom.
+
+---
+
+## Code-Review (score 0)
+
+**What the check measures.** Scorecard inspects the most recent (up to
+30) commits on the default branch and counts how many landed via a
+pull request with at least one `APPROVED` review. A score of 0 means
+**none** of them did.
+
+**Why we score 0.** `hangarfit` has a single maintainer. GitHub does
+not permit a maintainer to formally `APPROVE` their own pull request
+(the "Approve" radio is disabled when reviewing your own PR), so every
+PR merges with **zero** formal approvals on file — regardless of how
+much review actually happened.
+
+What did happen on every one of those PRs is a substantive review pass
+performed by Claude Code via the in-repo
+[`/pr-review` toolkit](../.claude/README.md). That toolkit dispatches
+specialised review subagents (the `pr-review-toolkit` family plus
+repo-specific ones like `geometry-invariant-guard`), and every finding
+is converted into a review thread **on the diff**, then either fixed
+in code or replied to with rationale before the thread is resolved.
+The PR-review process is documented in
+[CLAUDE.md › Per-PR process](../CLAUDE.md#per-pr-process).
+
+So the Scorecard 0 is accurate as a count of `APPROVED` reviews; it is
+**not** accurate as a count of *reviews that happened*. We have not
+found a way to register the second signal with Scorecard without
+inventing a second-account-approves-its-own-bot fiction (see
+[Alternatives considered](#alternatives-considered)).
+
+**Will it move?** Not without an external co-maintainer joining the
+project. That would be welcome but is not on the roadmap.
+
+---
+
+## Maintained (score 0)
+
+**What the check measures.** Scorecard considers a project "maintained"
+if it has had at least one commit (or release) in the last 90 days
+**and** it has existed for at least 90 days.
+
+**Why we score 0.** The repository was created on **2026-05-21**. The
+90-day age threshold is therefore crossed around **2026-08-19**. Until
+then, the check returns 0 for everyone — there is no remediation
+available to a project that is simply too new.
+
+**Will it move?** Yes, automatically, around **2026-08-19**. No action
+needed; the check will resample on its next scheduled run after that
+date. If the score has not moved by early September 2026, it's worth
+re-investigating, but no manual intervention is appropriate before
+then.
+
+---
+
+## Contributors (score 0)
+
+**What the check measures.** Scorecard counts the number of distinct
+**companies or organisations** (inferred from contributors' GitHub
+profile affiliation) whose members have committed to the project.
+Scoring expects at least three; zero scores 0.
+
+**Why we score 0.** `hangarfit` is an exception-handling CLI for a
+**single flying club's** hangar — see
+[§1 Introduction & Goals](architecture/01-introduction-and-goals.md)
+and [§3 Context & Scope](architecture/03-context-and-scope.md) for the
+scope statement. The expected contributor population is one
+maintainer plus, perhaps, a small number of club members. There are no
+upstream consumers and no realistic path to multi-organisation
+commits, because the tool is not interesting to anyone outside this
+specific deployment. The check is, in effect, asking the wrong
+question of this codebase.
+
+**Will it move?** Almost certainly not, and we are not trying to move
+it. A 0 here means "this project does not look like a typical
+multi-organisation open-source project"; the project genuinely is not
+one.
+
+---
+
+## Packaging (score -1)
+
+**What the check measures.** Scorecard looks for evidence that the
+project publishes a versioned artifact to a package registry (PyPI,
+npm, etc.) via a recognised workflow. A score of **-1** ("inconclusive")
+means it cannot find one.
+
+**Why we score -1.** We deliberately do not publish `hangarfit` to
+PyPI. The tool is consumed via `pip install -e .` from a local clone,
+exactly as documented in
+[CLAUDE.md › Useful commands](../CLAUDE.md#useful-commands). Publishing
+would imply a contract with downstream users that does not exist:
+there are no downstream users, the dependency model is "clone and run
+out of the checkout", and the per-deployment config (the placeholder
+fleet and hangar YAML) is meaningful only to the one club that owns
+the data.
+
+**Will it move?** No, not unless we change our minds about publishing.
+A -1 here is the correct answer for a deliberately unpublished tool.
+
+---
+
+## Alternatives considered
+
+For completeness — these were considered for the Code-Review zero and
+explicitly rejected:
+
+**A. A `claude[bot]`-style second account that auto-`APPROVE`s a PR
+once `/pr-review` reports no outstanding findings.** This would move
+the Scorecard number but defeat the spirit of the check, which is
+specifically about *human* peer review. Bot-as-second-reviewer is
+security theatre; we prefer the 0 with a written rebuttal to a green
+checkmark with a fictional reviewer.
+
+**B. Solicit a real external co-maintainer.** This would be the only
+honest way to move the Code-Review zero. It is welcome in principle
+but cannot be engineered for a Scorecard pass — a co-maintainer joins
+because they want to work on the tool, not so the score goes up.
+
+---
+
+## Where the score lives
+
+- **Live Scorecard JSON for this repository:**
+  <https://api.securityscorecards.dev/projects/github.com/DocGerd/hangarfit>
+- **Workflow that publishes the score on every push to `develop` and
+  weekly:** [`.github/workflows/scorecard.yml`](../.github/workflows/scorecard.yml)
+- **Findings are also uploaded to the GitHub Security tab via SARIF.**
+
+If the numbers in this document drift from the live JSON, the live
+JSON is authoritative — open an issue and we'll refresh this page.


### PR DESCRIPTION
## Summary

Closes #142.

Adds **`docs/security-posture.md`** explaining why four OpenSSF Scorecard checks score 0 (or -1) for *structural* reasons specific to this project — solo maintainer, single-deployment scope, intentionally unpublished — rather than because the underlying concern is unaddressed.

Per-check rationale:

| Check | Score | Why it's structural |
|---|:---:|---|
| Code-Review | 0 | Solo maintainer; GitHub forbids self-APPROVE. In-repo `/pr-review` toolkit substitutes for formal approvals. |
| Maintained | 0 | Repo <90 days old; auto-resolves ~2026-08-19. |
| Contributors | 0 | Single-club tool; multi-org commit signal doesn't apply. |
| Packaging | -1 | Deliberately not published to PyPI. |

The doc also records the two alternatives we considered and rejected for the Code-Review zero (a bot-as-second-reviewer, and soliciting an external co-maintainer), and links to the live Scorecard JSON + `.github/workflows/scorecard.yml`.

Cross-references:
- `SECURITY.md` — new "Project security posture" section pointing to the doc.
- `CLAUDE.md` — new "Security policy & Scorecard rationale" pointer section between *Worktrees* and *Open questions / TBD*.

This is an analytical / documentation change. **The Scorecard number itself will not move** — that is intentional (per the issue's acceptance criteria).

## Test plan

- [ ] Render `docs/security-posture.md` on GitHub; confirm all relative links resolve (`../.claude/README.md`, `../.github/workflows/scorecard.yml`, `../CLAUDE.md#per-pr-process`, `../CLAUDE.md#useful-commands`, `architecture/01-introduction-and-goals.md`, `architecture/03-context-and-scope.md`).
- [ ] Confirm in-page anchors work (`#alternatives-considered`, `#where-the-score-lives`).
- [ ] Confirm SECURITY.md anchor link to `docs/security-posture.md` works.
- [ ] Confirm CLAUDE.md anchor link works.
- [ ] Open live Scorecard JSON URL; confirm it still resolves: <https://api.securityscorecards.dev/projects/github.com/DocGerd/hangarfit>.