### PR TITLE
Solver: drop maintenance occupant from placeable set (closes #108)

### DIFF
--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -531,10 +531,10 @@ def _initial_placements(
     4. Membership in ``cart_bucket`` for cart_eligible planes.
 
     The maintenance plane (if any) is skipped entirely — under the
-    ``bay_intrusion`` semantics from milestone #9 the occupant is treated
-    as away (absent from the Layout's placements). The bay rectangle is
-    a hard obstacle via the collision rule, so no surrogate sample is
-    needed.
+    ``bay_intrusion`` semantics (see ``docs/architecture/08-crosscutting-concepts.md``
+    "The maintenance bay rule") the occupant is treated as away (absent
+    from the Layout's placements). The bay rectangle is a hard obstacle
+    via the collision rule, so no surrogate sample is needed.
     """
     placements: dict[str, Placement] = {}
     for pid in scenario.fleet_in:
@@ -595,6 +595,11 @@ def _enumerate_cart_buckets(scenario: Scenario) -> list[frozenset[str]]:
     free_cart_eligibles: list[str] = []
     has_committed_cart_eligible_on_carts = False
     for pid in scenario.fleet_in:
+        if pid == scenario.maintenance_plane:
+            # Occupant is treated as away — it never enters the layout, so
+            # round-robining a singleton cart bucket for it would be a no-op
+            # restart that wastes one slot of the C+1 rotation.
+            continue
         plane = scenario.fleet[pid]
         if not plane.is_cart_eligible:
             continue
@@ -725,10 +730,6 @@ def _descent_step(
     ``Layout.__post_init__`` and are skipped.
     """
     # Build current Layout from placements (uses Layout invariants — free check).
-    # ``placements`` is the dict produced by ``_initial_placements`` and threaded
-    # through descent — the maintenance plane is absent from its keys by
-    # construction, so a straight ``placements.values()`` upholds the
-    # bay-occupant Layout invariant without an inline filter.
     current_layout = Layout(
         fleet=scenario.fleet,
         hangar=scenario.hangar,

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -149,17 +149,16 @@ def solve(
         # ValueError is reachable here. `_enumerate_cart_buckets` already
         # filters bucket assignments that would violate the cart rule;
         # Scenario invariants enforce pin/on_carts/movement_mode consistency;
-        # the placements generator skips the maintenance plane so the
+        # `_initial_placements` skips the maintenance plane so the
         # bay-occupant invariant holds; remaining placements are over
-        # `scenario.fleet_in` (no duplicates, all in fleet). Any
-        # ValueError here would mean a real bug — let it propagate as
-        # one rather than burn the budget on silent restart absorption.
+        # ``scenario.fleet_in − {maintenance_plane}`` (no duplicates, all in
+        # fleet). Any ValueError here would mean a real bug — let it
+        # propagate as one rather than burn the budget on silent restart
+        # absorption.
         initial_layout = Layout(
             fleet=scenario.fleet,
             hangar=scenario.hangar,
-            placements=tuple(
-                placements[pid] for pid in scenario.fleet_in if pid != scenario.maintenance_plane
-            ),
+            placements=tuple(placements.values()),
             maintenance_plane=scenario.maintenance_plane,
         )
         current_score = _score(initial_layout)
@@ -183,11 +182,7 @@ def solve(
                 candidate_layout = Layout(
                     fleet=scenario.fleet,
                     hangar=scenario.hangar,
-                    placements=tuple(
-                        placements[pid]
-                        for pid in scenario.fleet_in
-                        if pid != scenario.maintenance_plane
-                    ),
+                    placements=tuple(placements.values()),
                     maintenance_plane=scenario.maintenance_plane,
                 )
                 if _is_diverse_enough(candidate_layout, accepted_layouts, diversity):
@@ -225,11 +220,7 @@ def solve(
                 best_partial_layout = Layout(
                     fleet=scenario.fleet,
                     hangar=scenario.hangar,
-                    placements=tuple(
-                        placements[pid]
-                        for pid in scenario.fleet_in
-                        if pid != scenario.maintenance_plane
-                    ),
+                    placements=tuple(placements.values()),
                     maintenance_plane=scenario.maintenance_plane,
                 )
 
@@ -457,12 +448,10 @@ def _initial_placement_for_plane(
     scenario: Scenario,
     rng: _random_module.Random,
     on_carts: bool,
-    bias_to_maintenance_bay: bool = False,
 ) -> Placement:
     """Sample an initial :class:`Placement` for one plane (spec §4.2).
 
     - If pinned → return the pin verbatim.
-    - If ``bias_to_maintenance_bay`` → ``(x, y)`` uniform in the back bay strip.
     - Otherwise → ``(x, y)`` uniform inside hangar (with bbox-derived margin),
       ``heading_deg`` uniform on ``[0, 360°)``.
 
@@ -483,13 +472,8 @@ def _initial_placement_for_plane(
     margin_x = max(max_length, max_width) / 2
     margin_y = margin_x
 
-    if bias_to_maintenance_bay:
-        bay_depth = hangar.maintenance_bay.depth_m
-        y_lo = max(margin_y, hangar.length_m - bay_depth)
-        y_hi = hangar.length_m - margin_y
-    else:
-        y_lo = margin_y
-        y_hi = hangar.length_m - margin_y
+    y_lo = margin_y
+    y_hi = hangar.length_m - margin_y
 
     x_lo = margin_x
     x_hi = hangar.width_m - margin_x
@@ -546,12 +530,17 @@ def _initial_placements(
     3. Plane's ``movement_mode`` for always_cart / always_own_gear.
     4. Membership in ``cart_bucket`` for cart_eligible planes.
 
-    The maintenance plane gets the bay-bias unless it's pinned (a pin
-    already fixes its position; biasing would be a no-op since the pin
-    is returned verbatim).
+    The maintenance plane (if any) is skipped entirely — under the
+    ``bay_intrusion`` semantics from milestone #9 the occupant is treated
+    as away (absent from the Layout's placements). The bay rectangle is
+    a hard obstacle via the collision rule, so no surrogate sample is
+    needed.
     """
     placements: dict[str, Placement] = {}
     for pid in scenario.fleet_in:
+        if pid == scenario.maintenance_plane:
+            continue
+
         plane = scenario.fleet[pid]
         constraint = scenario.constraints.get(pid)
 
@@ -567,14 +556,11 @@ def _initial_placements(
         else:  # cart_eligible
             on_carts = pid in cart_bucket
 
-        bias = scenario.maintenance_plane == pid and (constraint is None or constraint.pin is None)
-
         placements[pid] = _initial_placement_for_plane(
             plane_id=pid,
             scenario=scenario,
             rng=rng,
             on_carts=on_carts,
-            bias_to_maintenance_bay=bias,
         )
 
     return placements
@@ -738,13 +724,15 @@ def _descent_step(
     (e.g. cart rule) raise ``ValueError`` from
     ``Layout.__post_init__`` and are skipped.
     """
-    # Build current Layout from placements (uses Layout invariants — free check)
+    # Build current Layout from placements (uses Layout invariants — free check).
+    # ``placements`` is the dict produced by ``_initial_placements`` and threaded
+    # through descent — the maintenance plane is absent from its keys by
+    # construction, so a straight ``placements.values()`` upholds the
+    # bay-occupant Layout invariant without an inline filter.
     current_layout = Layout(
         fleet=scenario.fleet,
         hangar=scenario.hangar,
-        placements=tuple(
-            placements[pid] for pid in scenario.fleet_in if pid != scenario.maintenance_plane
-        ),
+        placements=tuple(placements.values()),
         maintenance_plane=scenario.maintenance_plane,
     )
 
@@ -815,9 +803,7 @@ def _descent_step(
             trial_layout = Layout(
                 fleet=scenario.fleet,
                 hangar=scenario.hangar,
-                placements=tuple(
-                    trial[pid] for pid in scenario.fleet_in if pid != scenario.maintenance_plane
-                ),
+                placements=tuple(trial.values()),
                 maintenance_plane=scenario.maintenance_plane,
             )
         except ValueError:

--- a/tests/test_solver_canaries.py
+++ b/tests/test_solver_canaries.py
@@ -94,11 +94,12 @@ def test_solve_deterministic_best_partial_under_max_restarts() -> None:
     ``best_partial_layout`` becomes machine-independent.
 
     Calibration (recorded 2026-05-23 for #108):
-        After milestone #9 dropped the maintenance plane from the
-        solver's placeable set, the RNG state shifted (one fewer
-        ``random()``/``uniform()`` call per restart) and every
+        After the solver stopped sampling an initial placement for
+        the maintenance occupant (#108 closes the milestone-#9 cleanup
+        that began at #103), the RNG state shifted — one fewer
+        ``random()``/``uniform()`` call per restart — and every
         previously-tried (fixture, seed=42) combination collapsed to
-        natural-success on restart 0 — leaving no ``max_restarts``
+        natural-success on restart 0, leaving no ``max_restarts``
         value that could trip before success.
 
         Re-probed with ``solve(scenario, budget_s=10.0)`` across the
@@ -106,16 +107,23 @@ def test_solve_deterministic_best_partial_under_max_restarts() -> None:
         ``solve_fresh_six_planes.yaml`` at ``seed=256`` records
         ``status=found, restarts_attempted=3`` — the most headroom in
         the probe. Per the v0.6.0 plan Task 2 recipe, the cap is set
-        deliberately small (``observed // 2 = 1``) so it trips well
-        before the natural success at restart 3, forcing exhaustion.
-        Two-restart headroom protects against future RNG-shift
-        regressions tightening natural success to 2.
+        deliberately small (``max_restarts = observed // 2 = 1``) so
+        it trips well before the natural success at restart 3,
+        forcing exhaustion. Two-restart headroom protects against
+        future RNG-shift regressions tightening natural success to 2.
 
         Re-calibration trigger: if a future algorithm change pushes
-        natural success below 2 restarts at seed=256 (i.e., succeeds
-        on restart 0 or 1), re-probe seeds for the same fixture and
-        pick one whose ``restarts_attempted >= 2``; update ``seed``
-        below.
+        natural success to ``restarts_attempted <= 1`` at seed=256,
+        re-probe seeds for the same fixture and pick one whose
+        ``restarts_attempted >= 2``; update ``seed`` below.
+
+        Floor: ``observed >= 2`` is required because
+        ``max_restarts = observed // 2`` must be ``>= 1`` and
+        :class:`SearchConfig.__post_init__` rejects
+        ``max_restarts=0``. With ``observed=2``, the cap is still
+        ``1 < 2`` (the predicate is strictly ``<``, not ``<=``), so
+        the canary keeps working — but headroom drops to one restart
+        and is one regression away from breaking.
     """
     fixture = "tests/fixtures/solve_fresh_six_planes.yaml"
     max_restarts = 1
@@ -147,7 +155,19 @@ def test_solve_deterministic_best_partial_under_max_restarts() -> None:
         f"got {r1.status} (calibration drift — see test docstring)"
     )
     assert r2.status == r1.status
-    assert r1.diagnostics.restarts_attempted == max_restarts
+    # restarts_attempted == max_restarts confirms the cap was the gate that
+    # tripped, not the wall-clock budget. If wall_time_s drifts close to
+    # budget_s=30.0 (e.g., per-restart slowdown on a slow CI VM), the budget
+    # would trip first and restarts_attempted would be < max_restarts —
+    # exhausted_budget status would still hold but for the wrong reason.
+    assert r1.diagnostics.restarts_attempted == max_restarts, (
+        f"max_restarts cap must trip before wall-clock budget. "
+        f"Got restarts_attempted={r1.diagnostics.restarts_attempted}, "
+        f"max_restarts={max_restarts}, wall_time_s={r1.diagnostics.wall_time_s:.2f}, "
+        f"budget_s=30.0. If wall_time is near budget, the canary's "
+        f"cross-machine determinism guarantee is broken — raise budget_s "
+        f"or investigate per-restart slowdown."
+    )
     assert r2.diagnostics.restarts_attempted == max_restarts
 
     # The fused-pair contract — both Some when exhausted_budget.

--- a/tests/test_solver_canaries.py
+++ b/tests/test_solver_canaries.py
@@ -82,19 +82,6 @@ def test_solve_deterministic_given_seed(fixture):
     # different RNG state -> different layouts.
 
 
-@pytest.mark.skip(
-    reason=(
-        "Calibration drift: filtering the maintenance plane out of solver "
-        "output shortened the search by one plane, so every available "
-        "fixture/seed combination now finds a layout on restart 0 — there is "
-        "no max_restarts value below the natural success count that would "
-        "trip the exhausted_budget branch this canary is meant to exercise. "
-        "Recalibrate against a freshly-constructed tighter fixture once the "
-        "solver-internals work (drop maintenance plane from placeable set, "
-        "remove bay-bias machinery) lands. Tracked alongside the broader "
-        "solver migration for the maintenance-bay walling milestone."
-    )
-)
 def test_solve_deterministic_best_partial_under_max_restarts() -> None:
     """``solve(..., search=SearchConfig(max_restarts=K))`` exhausts
     deterministically across machines.
@@ -106,45 +93,40 @@ def test_solve_deterministic_best_partial_under_max_restarts() -> None:
     inevitable outcome regardless of machine speed, and the
     ``best_partial_layout`` becomes machine-independent.
 
-    Calibration (recorded 2026-05-22 for traceability):
-        Ran ``solve(scenario, budget_s=10.0, seed=42)`` once on
-        ``solve_fresh_six_planes.yaml`` to record the natural restart
-        count to first success. Observed ``restarts_attempted=2``
-        (status=found, wall_time≈1.3 s on the calibration machine).
-        Per the v0.6.0 plan Task 2 brief, the canary's ``max_restarts``
-        is set deliberately small (``observed // 2 = 1``) so the cap
-        trips before the natural success, forcing exhaustion. The
-        ``budget_s=30.0`` here is generous; ``max_restarts`` is the
-        gate that trips first. If a future algorithm change pushes
-        natural success below 2 restarts at seed=42 (i.e., succeeds on
-        restart 0), this canary needs re-calibration on
-        ``solve_diversity_impossible_warn.yaml`` per the plan's
-        fallback procedure.
+    Calibration (recorded 2026-05-23 for #108):
+        After milestone #9 dropped the maintenance plane from the
+        solver's placeable set, the RNG state shifted (one fewer
+        ``random()``/``uniform()`` call per restart) and every
+        previously-tried (fixture, seed=42) combination collapsed to
+        natural-success on restart 0 — leaving no ``max_restarts``
+        value that could trip before success.
 
-    Fallback fixture calibration (recorded 2026-05-23):
-        Ran ``solve(scenario, budget_s=10.0, seed=42)`` on
-        ``solve_diversity_impossible_warn.yaml`` to pre-pin the
-        fallback. Observed ``status=found, restarts_attempted=1,
-        wall_time≈0.009 s``. With observed=1, the standard
-        ``max_restarts = observed // 2`` recipe would yield 0, which
-        :class:`SearchConfig.__post_init__` rejects. If a future
-        switch to this fallback fixture is needed, pick a different
-        seed whose natural restart count is ≥ 2 (so ``observed // 2
-        >= 1``) or use a different fixture — do NOT clamp to
-        ``max_restarts=1``, which would NOT trip before natural
-        success on this fixture (the cap would equal the natural
-        success count and the predicate is strictly ``<``, not
-        ``<=``).
+        Re-probed with ``solve(scenario, budget_s=10.0)`` across the
+        existing fixture set at seeds {7, 13, 42, 99, 123, 256}.
+        ``solve_fresh_six_planes.yaml`` at ``seed=256`` records
+        ``status=found, restarts_attempted=3`` — the most headroom in
+        the probe. Per the v0.6.0 plan Task 2 recipe, the cap is set
+        deliberately small (``observed // 2 = 1``) so it trips well
+        before the natural success at restart 3, forcing exhaustion.
+        Two-restart headroom protects against future RNG-shift
+        regressions tightening natural success to 2.
+
+        Re-calibration trigger: if a future algorithm change pushes
+        natural success below 2 restarts at seed=256 (i.e., succeeds
+        on restart 0 or 1), re-probe seeds for the same fixture and
+        pick one whose ``restarts_attempted >= 2``; update ``seed``
+        below.
     """
     fixture = "tests/fixtures/solve_fresh_six_planes.yaml"
     max_restarts = 1
+    seed = 256
 
     s1 = load_scenario(fixture)
     r1 = solve(
         s1,
         budget_s=30.0,
         alternatives=1,
-        seed=42,
+        seed=seed,
         search=SearchConfig(max_restarts=max_restarts),
     )
 
@@ -153,7 +135,7 @@ def test_solve_deterministic_best_partial_under_max_restarts() -> None:
         s2,
         budget_s=30.0,
         alternatives=1,
-        seed=42,
+        seed=seed,
         search=SearchConfig(max_restarts=max_restarts),
     )
 

--- a/tests/test_solver_fixture_matrix.py
+++ b/tests/test_solver_fixture_matrix.py
@@ -336,8 +336,11 @@ def test_solve_all_nine_large_hangar_finds_layout():
 
     _assert_universal_properties(r, max_wall_time_s=15.0)
     assert len(r.layouts) == 1
-    assert len(r.layouts[0].placements) == 9
+    # 9-plane fleet with one in maintenance → 8 placed planes. The Layout
+    # invariant (#103) forbids the occupant from appearing in placements.
+    assert len(r.layouts[0].placements) == 8
     # Maintenance plane survival: a regression where the solver dropped
-    # `maintenance_plane=None` would still produce a valid 9-plane layout
-    # because the bay rule no-ops when no maintenance plane is set.
+    # ``maintenance_plane=None`` would still produce a valid 8-plane layout
+    # (the bay rule no-ops when no maintenance plane is set), so we pin the
+    # field explicitly to catch that case.
     assert r.layouts[0].maintenance_plane == "scheibe_falke"

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -50,12 +50,12 @@ def test_initial_placements_skips_maintenance_plane():
     returned dict — the bay is closed and the occupant is treated as away
     (Layout invariant: maintenance_plane MUST NOT appear in placements).
 
-    Before milestone #9, the solver sampled an initial placement for the
-    maintenance plane (biased into the back strip) and then filtered it
-    out at Layout-build time. With the new ``bay_intrusion`` semantics,
-    there is no plane-shaped occupant to sample for — the bay rectangle
-    becomes a hard obstacle via the collision rule, and the solver simply
-    iterates over the N−1 non-maintenance planes.
+    Previously the solver sampled an initial placement for the maintenance
+    plane (biased into the back strip) and then filtered it out at
+    Layout-build time. With the ``bay_intrusion`` semantics, there is no
+    plane-shaped occupant to sample for — the bay rectangle becomes a
+    hard obstacle via the collision rule, and the solver simply iterates
+    over the N−1 non-maintenance planes.
     """
     from hangarfit.loader import load_scenario
     from hangarfit.solver import _initial_placements

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -45,23 +45,32 @@ def test_initial_placement_for_free_plane_is_within_hangar():
     assert 0.0 <= p.heading_deg < 360.0
 
 
-def test_initial_placement_for_maintenance_biases_to_back_strip():
-    """The maintenance plane's initial y is inside the maintenance bay."""
+def test_initial_placements_skips_maintenance_plane():
+    """``_initial_placements`` must omit the maintenance occupant from the
+    returned dict — the bay is closed and the occupant is treated as away
+    (Layout invariant: maintenance_plane MUST NOT appear in placements).
+
+    Before milestone #9, the solver sampled an initial placement for the
+    maintenance plane (biased into the back strip) and then filtered it
+    out at Layout-build time. With the new ``bay_intrusion`` semantics,
+    there is no plane-shaped occupant to sample for — the bay rectangle
+    becomes a hard obstacle via the collision rule, and the solver simply
+    iterates over the N−1 non-maintenance planes.
+    """
     from hangarfit.loader import load_scenario
-    from hangarfit.solver import _initial_placement_for_plane
+    from hangarfit.solver import _initial_placements
 
     s = load_scenario("tests/fixtures/scenario_with_pin.yaml")
-    # In scenario_with_pin, maintenance_plane is fuji (not pinned).
+    assert s.maintenance_plane == "fuji", "fixture sanity"
+
     rng = random.Random(42)
-    p = _initial_placement_for_plane(
-        plane_id="fuji",
-        scenario=s,
-        rng=rng,
-        on_carts=False,
-        bias_to_maintenance_bay=True,
+    placements = _initial_placements(scenario=s, rng=rng, cart_bucket=frozenset())
+
+    assert "fuji" not in placements, (
+        f"maintenance occupant must not be sampled, got keys={set(placements)}"
     )
-    bay_y_start = s.hangar.length_m - s.hangar.maintenance_bay.depth_m
-    assert bay_y_start <= p.y_m <= s.hangar.length_m
+    expected = set(s.fleet_in) - {"fuji"}
+    assert set(placements) == expected
 
 
 def test_cart_buckets_collapses_when_another_cart_eligible_is_force_locked_on():


### PR DESCRIPTION
## Summary

Finishes the maintenance-bay walling cleanup in `solver.py`. The occupant has been excluded from solver output since #103 flipped the Layout invariant, but the solver was still sampling for it (with a back-strip bias) and filtering it out at Layout-build time. With #104's `bay_intrusion` rule turning the bay into a hard obstacle via the collision checker, no surrogate sample is needed — the solver now iterates over `fleet_in − {maintenance_plane}` directly.

Closes #108.

## What changed

**Solver:**

- `_initial_placements` skips `pid == scenario.maintenance_plane` at the top of its loop — the returned dict has N−1 keys when a maintenance plane is set.
- `_initial_placement_for_plane` drops the `bias_to_maintenance_bay` parameter and the bay-strip-anchored y-range branch. No callers remain.
- All `Layout(...)` constructions in `solver.py` build `placements` from `placements.values()` / `trial.values()`. The upstream skip guarantees the dict provably excludes the occupant, so the inline `if pid != scenario.maintenance_plane` filter (previously at five call sites) is removed; the Layout invariant remains the safety net.
- The `pin_only_layout` filter on `pinned_placements` (line 394) is **left in place** — it covers a different concern (user pins on the maintenance plane via constraints), not the now-deleted bay-bias path.

**Tests:**

- **New**: `test_initial_placements_skips_maintenance_plane` proves the returned dict excludes the occupant.
- **Removed**: `test_initial_placement_for_maintenance_biases_to_back_strip` — the behavior it locked in no longer exists.
- **Recalibrated**: `test_solve_deterministic_best_partial_under_max_restarts` was skipped pending #108 (no available seed produced enough restarts at the time to trip the cap before natural success). Re-probed seeds {7, 13, 42, 99, 123, 256} across the existing fixture set; selected `solve_fresh_six_planes.yaml` at **seed=256** which records `restarts_attempted=3` naturally. The cap stays at `max_restarts = observed // 2 = 1` per the v0.6.0 plan recipe (2-restart headroom for future regressions). Confirmed deterministic across three trials.

## Pre-existing test bug surfaced (not regression)

While running `pytest -m ""` (which includes `@slow`), `test_solve_all_nine_large_hangar_finds_layout` was already failing on `develop` HEAD with `assert 8 == 9`. The assertion was a leftover from before the Layout invariant flip in #103: it expected a 9-plane fleet to produce 9 placements, but with one plane in maintenance the invariant guarantees 8. Verified pre-existing via `git stash && pytest` on the test before applying any of this PR's changes.

Latent because `@slow` is excluded from default CI. Updated the assertion to `== 8` in-place (1-char fix) with the invariant cited inline; this keeps the `@slow` suite green for #108. The broader cleanup category — stale assertions left behind by #103's invariant flip — could be a follow-up sweep if any other `@slow` checks turn out similar; none surfaced in this run.

## Acceptance per #108

- [x] No reference to `bias_to_maintenance_bay` or `maint_for_check` remains in `src/` or `tests/` (verified via grep).
- [x] `solve(scenario_with_maintenance_plane, ...)` returns a Layout where the maintenance plane is in `fleet` and `maintenance_plane` but NOT in `placements` — covered by `test_solve_maintenance_bay_required_excludes_occupant_from_placements` (already on develop, still green).
- [x] The `solve_infeasible_bay_closes_floor.yaml` fixture produces an infeasible result with at least one `bay_intrusion` conflict — covered by `test_solve_trivially_infeasible_when_pinned_plane_intrudes_into_closed_bay` (added in #157, still green).
- [x] All `tests/test_solver_*.py` pass after #103, #104, and #157 — 397 tests green, 0 skipped, 0 failed.

## Test plan
- [x] `pytest` (default profile): 396 passed
- [x] `pytest -m ""` (incl. @slow): 397 passed
- [x] `ruff check src/ tests/`: clean
- [x] `ruff format --check src/ tests/`: clean
- [x] `mypy src/hangarfit/`: clean
- [x] Recalibrated canary deterministic across 3 trials (same `best_partial_layout.placements[0].x_m == 5.410000`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)