### PR TITLE
Loader: reject occupant-in-placements with actionable error + bay-out-of-hangar test (closes #105)

### DIFF
--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -213,15 +213,18 @@ def load_layout(
     # naming the bay occupant in ``placements``. ``Layout.__post_init__``
     # catches this too, but with a generic invariant message; raise here
     # with an actionable suffix so the YAML author knows exactly what to
-    # edit. The Layout invariant remains the programmatic backstop for
-    # callers that build Layouts in code rather than via load_layout.
+    # edit. DO NOT remove the Layout invariant — it's the only line of
+    # defense for callers that construct Layouts directly in code
+    # (tests, solver internals, REPL exploration). This loader check is
+    # a UX improvement for the YAML path, not a replacement.
     if maintenance_plane is not None:
         for p in placements:
             if p.plane_id == maintenance_plane:
                 raise LoaderError(
                     f"{path}: maintenance_plane {maintenance_plane!r} is named in "
                     f"placements; an aircraft in maintenance is treated as away and "
-                    f"must NOT be placed. Remove it from placements."
+                    f"must NOT be placed. Remove it from placements (or fix the plane "
+                    f"id if it doesn't match an aircraft in the fleet)."
                 )
 
     try:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -209,6 +209,21 @@ def load_layout(
 
     maintenance_plane = _extract_maintenance_plane(raw, path)
 
+    # Pre-Layout boundary check for the most common YAML-author mistake:
+    # naming the bay occupant in ``placements``. ``Layout.__post_init__``
+    # catches this too, but with a generic invariant message; raise here
+    # with an actionable suffix so the YAML author knows exactly what to
+    # edit. The Layout invariant remains the programmatic backstop for
+    # callers that build Layouts in code rather than via load_layout.
+    if maintenance_plane is not None:
+        for p in placements:
+            if p.plane_id == maintenance_plane:
+                raise LoaderError(
+                    f"{path}: maintenance_plane {maintenance_plane!r} is named in "
+                    f"placements; an aircraft in maintenance is treated as away and "
+                    f"must NOT be placed. Remove it from placements."
+                )
+
     try:
         return Layout(
             fleet=fleet,

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -610,24 +610,48 @@ maintenance_bay: {center_x_m: 13.5, width_m: 9, depth_m: 9}
         with pytest.raises(LoaderError, match="doesn't fit in hangar width"):
             load_hangar(path)
 
-    def test_maintenance_bay_does_not_fit_propagates_from_model(self, tmp_path: Path) -> None:
-        """Mirror of ``test_door_does_not_fit_propagates_from_model`` for
-        the bay rectangle. ``center_x_m + width_m/2 > hangar.width_m``
-        violates :attr:`Hangar.maintenance_bay` bounds (fires from
-        :meth:`Hangar.__post_init__`); the loader must wrap the
-        ``ValueError`` as ``LoaderError`` like every other Hangar invariant.
+    @pytest.mark.parametrize(
+        ("bay_yaml", "expected_match"),
+        [
+            # Right-wall overflow: center_x_m + width_m/2 = 15.0 + 4.5 = 19.5 > width_m=18.0.
+            (
+                "{center_x_m: 15.0, width_m: 9, depth_m: 9}",
+                r"MaintenanceBay.*doesn't fit in hangar width",
+            ),
+            # Left-wall overflow: center_x_m - width_m/2 = 2.0 - 4.5 = -2.5 < 0.
+            (
+                "{center_x_m: 2.0, width_m: 9, depth_m: 9}",
+                r"MaintenanceBay.*doesn't fit in hangar width",
+            ),
+            # Depth equals length: leaves no non-bay parking. Hangar.__post_init__
+            # raises a *different* ValueError than the width-overflow branch.
+            (
+                "{center_x_m: 13.5, width_m: 9, depth_m: 25}",
+                r"MaintenanceBay\.depth_m.*must be strictly less than Hangar\.length_m",
+            ),
+        ],
+        ids=["right_wall_overflow", "left_wall_overflow", "depth_equals_length"],
+    )
+    def test_maintenance_bay_invariant_propagates_from_model(
+        self, tmp_path: Path, bay_yaml: str, expected_match: str
+    ) -> None:
+        """Each ``Hangar.__post_init__`` invariant on the maintenance bay
+        must wrap as ``LoaderError`` at the loader boundary (mirror of
+        ``test_door_does_not_fit_propagates_from_model`` but parametrized
+        over the two ``bay_left < 0 or bay_right > width_m`` cases plus
+        the ``depth_m >= length_m`` branch — three failure modes from
+        three distinct model-level ``raise ValueError`` sites).
         """
         path = _write(
             tmp_path / "h.yaml",
-            """
+            f"""
 length_m: 25.0
 width_m: 18.0
-door: {center_x_m: 9.0, width_m: 12.0}
-maintenance_bay: {center_x_m: 15.0, width_m: 9, depth_m: 9}
+door: {{center_x_m: 9.0, width_m: 12.0}}
+maintenance_bay: {bay_yaml}
 """,
         )
-        # center_x_m=15.0 + width_m/2=4.5 = 19.5 > width_m=18.0 → bay overflows the right wall.
-        with pytest.raises(LoaderError, match="MaintenanceBay.*doesn't fit in hangar width"):
+        with pytest.raises(LoaderError, match=expected_match):
             load_hangar(path)
 
     def test_top_level_not_a_mapping(self, tmp_path: Path) -> None:
@@ -925,6 +949,12 @@ maintenance:
         ("Remove it from placements") rather than the bubbled Layout
         invariant text. Layout's invariant remains the programmatic
         backstop for non-loader callers.
+
+        The parenthetical "(or fix the plane id if it doesn't match an
+        aircraft in the fleet)" steers users toward the right root cause
+        in the typo'd-id case, where naive "remove the row" advice would
+        be a two-step debug (remove row → hit "not in fleet" → realise
+        the id was wrong all along).
         """
         self._minimal_fleet_and_hangar(tmp_path)
         layout_path = _write(
@@ -945,6 +975,49 @@ placements:
         assert "Remove it from placements" in msg, (
             f"error must include actionable suffix; got: {msg}"
         )
+        assert "fix the plane id" in msg, f"error must include the typo'd-id hint; got: {msg}"
+
+    def test_maintenance_occupant_appearing_among_other_placements_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        """The loop-not-just-first-row form of the check: when the
+        occupant appears alongside *other* valid placements, the loader
+        still catches it. Guards against a buggy short-circuit like
+        ``placements[0].plane_id == maintenance_plane`` that would happen
+        to pass the single-plane fixture above.
+        """
+        _write(
+            tmp_path / "fleet.yaml",
+            _fleet_yaml(
+                _aircraft_entry("foo", movement_mode="always_own_gear", turn_radius_m=5.0),
+                _aircraft_entry("bar", movement_mode="always_own_gear", turn_radius_m=5.0),
+            ),
+        )
+        _write(
+            tmp_path / "hangar.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 9.0, width_m: 12.0}
+maintenance_bay: {center_x_m: 13.5, width_m: 9, depth_m: 9}
+""",
+        )
+        # `bar` is the maintenance occupant. The realistic real-world bug
+        # shape: user has a valid layout for `foo` and accidentally adds a
+        # row for the maintenance plane as the second placement.
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+maintenance: {plane: bar}
+placements:
+  - {plane: foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+  - {plane: bar, x_m: 10, y_m: 10, heading_deg: 0, on_carts: false}
+""",
+        )
+        with pytest.raises(LoaderError, match="maintenance_plane 'bar' is named in placements"):
+            load_layout(layout_path)
 
     def test_override_and_yaml_ref_conflict_for_fleet(self, tmp_path: Path) -> None:
         """If the layout YAML has `fleet:` AND the caller passes a fleet

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -610,6 +610,26 @@ maintenance_bay: {center_x_m: 13.5, width_m: 9, depth_m: 9}
         with pytest.raises(LoaderError, match="doesn't fit in hangar width"):
             load_hangar(path)
 
+    def test_maintenance_bay_does_not_fit_propagates_from_model(self, tmp_path: Path) -> None:
+        """Mirror of ``test_door_does_not_fit_propagates_from_model`` for
+        the bay rectangle. ``center_x_m + width_m/2 > hangar.width_m``
+        violates :attr:`Hangar.maintenance_bay` bounds (fires from
+        :meth:`Hangar.__post_init__`); the loader must wrap the
+        ``ValueError`` as ``LoaderError`` like every other Hangar invariant.
+        """
+        path = _write(
+            tmp_path / "h.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 9.0, width_m: 12.0}
+maintenance_bay: {center_x_m: 15.0, width_m: 9, depth_m: 9}
+""",
+        )
+        # center_x_m=15.0 + width_m/2=4.5 = 19.5 > width_m=18.0 → bay overflows the right wall.
+        with pytest.raises(LoaderError, match="MaintenanceBay.*doesn't fit in hangar width"):
+            load_hangar(path)
+
     def test_top_level_not_a_mapping(self, tmp_path: Path) -> None:
         path = _write(tmp_path / "h.yaml", "- a\n- b\n")
         with pytest.raises(LoaderError, match="top-level must be a mapping"):
@@ -891,6 +911,40 @@ maintenance:
             LoaderError, match="'maintenance' block present but lacks required 'plane'"
         ):
             load_layout(layout_path)
+
+    def test_maintenance_occupant_also_in_placements_rejected_with_actionable_error(
+        self, tmp_path: Path
+    ) -> None:
+        """A layout YAML that names a ``maintenance.plane`` and also lists
+        that plane under ``placements`` is rejected at load time with an
+        actionable error.
+
+        The bay occupant is treated as away — absent from ``placements`` by
+        Layout invariant (#103). The loader catches this combination
+        explicitly so YAML authors get a directly-actionable message
+        ("Remove it from placements") rather than the bubbled Layout
+        invariant text. Layout's invariant remains the programmatic
+        backstop for non-loader callers.
+        """
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+maintenance: {plane: foo}
+placements:
+  - {plane: foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+""",
+        )
+        with pytest.raises(LoaderError) as exc_info:
+            load_layout(layout_path)
+        msg = str(exc_info.value)
+        assert "'foo'" in msg, f"error must name the offending plane: {msg}"
+        assert "placements" in msg, f"error must point at placements: {msg}"
+        assert "Remove it from placements" in msg, (
+            f"error must include actionable suffix; got: {msg}"
+        )
 
     def test_override_and_yaml_ref_conflict_for_fleet(self, tmp_path: Path) -> None:
         """If the layout YAML has `fleet:` AND the caller passes a fleet


### PR DESCRIPTION
## Summary

#103 flipped the Layout invariant so the maintenance occupant must be absent from `Layout.placements`. The loader was already rejecting the combination via `Layout.__post_init__` (bubbled `ValueError` → `LoaderError`), but with a generic invariant message that didn't tell a YAML author what to fix.

Two changes:

1. **`load_layout`** now performs a pre-Layout boundary check. When `maintenance_plane` is set AND the occupant also appears in `placements`, raise `LoaderError` with the actionable suffix "Remove it from placements." per spec §5.7 and the issue body's proposed wording. `Layout.__post_init__` remains the programmatic backstop for callers that build Layouts in code.
2. **New test** `test_maintenance_bay_does_not_fit_propagates_from_model` mirrors the existing `test_door_does_not_fit_propagates_from_model`. The bay-out-of-hangar invariant (`center_x_m + width_m/2 > hangar.width_m`) was pinned in `Hangar.__post_init__` but had no loader-layer regression guard; asymmetric coverage now closed.

Closes #105.

## Design call: layered checks (loader + invariant), not single source

The loader check and the Layout invariant are **not redundant** — they have different audiences:

- **Layout invariant** catches programmatic misuse (e.g., solver internals building Layouts directly). Stays as the structural backstop.
- **Loader check** catches YAML-author mistakes with an actionable suffix. Per CLAUDE.md "validate at system boundaries," the loader IS the boundary between user-authored YAML and internal models.

Considered alternative: change the Layout invariant's error wording instead. Rejected because the Layout invariant fires for any caller, not just YAML loaders — its message should stay general; the loader is where YAML-specific guidance belongs.

## Out of scope

- Adding similar pre-Layout checks for other Layout invariants (cart rule, pin/movement_mode consistency). Those don't have YAML-only entry points in the same way and aren't part of the #105 scope.
- Whether to also add a Scenario-level check (for a user pinning the maintenance plane via `constraints`) — that's covered by the deferred follow-up issue #171 (filed during /pr-review on PR #170).

## Test plan
- [x] `pytest -m ""` (incl. @slow): 405 passed
- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [x] `mypy src/hangarfit/` clean
- [x] New test `test_maintenance_occupant_also_in_placements_rejected_with_actionable_error` asserts plane name + "placements" + "Remove it from placements" in the error
- [x] New test `test_maintenance_bay_does_not_fit_propagates_from_model` asserts the LoaderError chain on a bay overflowing the right wall

🤖 Generated with [Claude Code](https://claude.com/claude-code)