### PR TITLE
Docs: refresh arc42 §5 + CLAUDE.md + hangar.yaml for milestone #9 (closes #109)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Vulnerability reporting lives in [SECURITY.md](SECURITY.md). The rationale for t
 ## Open questions / TBD before trusting output
 
 - **Real measurements** for every aircraft (`measured: false` in `fleet.yaml`). All current dimensions are eyeballed placeholders.
-- **Real hangar measurements** (`data/hangar.yaml`) — length, width, door position and width, maintenance bay depth.
+- **Real hangar measurements** (`data/hangar.yaml`) — length, width, door position and width, maintenance bay rectangle (`center_x_m`, `width_m`, `depth_m` — back-anchored, partial-width).
 - **Placeholder hangar can't fit the full fleet.** The placeholder hangar in [`data/hangar.yaml`](data/hangar.yaml) is too tight to fit every aircraft at once under the placeholder clearance budget. The default [`layouts/example.yaml`](layouts/example.yaml) is a deliberate 6-plane subset; test fixtures that need the full fleet use [`tests/fixtures/test_hangar_large.yaml`](tests/fixtures/test_hangar_large.yaml). Real hangar measurements will reset this.
 
 The collision checker will run on placeholder data, but until the measurements are real, the output is illustrative only.

--- a/data/fleet.yaml
+++ b/data/fleet.yaml
@@ -5,7 +5,8 @@
 # entry has `measured: false` as a grep handle so you can audit what
 # still needs real numbers.
 #
-# Conventions (see CLAUDE.md for the full version):
+# Conventions (see `docs/architecture/08-crosscutting-concepts.md`
+# "The coordinate convention" and "The parts model" for the full version):
 # - Plane-local coords: +x = forward (toward nose), +y = right (toward right wingtip)
 # - Origin of plane-local frame = main-gear / cart centroid
 # - Each Part is an oriented rectangle: length_m runs along plane +x,

--- a/data/hangar.yaml
+++ b/data/hangar.yaml
@@ -5,7 +5,8 @@
 #
 # Coordinates: (0, 0) at the front-left corner of the hangar floor,
 # looking down. +x runs right along the door wall, +y runs deeper
-# into the hangar. See CLAUDE.md for the full convention.
+# into the hangar. See `docs/architecture/08-crosscutting-concepts.md`
+# "The coordinate convention" for the full convention.
 
 length_m: 25.0          # depth from front wall (door side) to back wall
 width_m: 18.0           # left-to-right span

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,4 +82,4 @@ manual workflow above is canonical.
 | 0002 | [Plane-local → world transform has determinant −1](0002-determinant-minus-one-transform.md)            | Accepted |
 | 0003 | [Random-restart min-conflicts (RR-MC) for the static layout solver](0003-rr-mc-solver-algorithm.md)    | Accepted |
 | 0004 | [Diversity metric for K alternatives (edit count with per-plane thresholds)](0004-diversity-metric.md) | Accepted |
-| 0005 | [Maintenance bay rule — fuselage centroid in back strip](0005-maintenance-bay-rule.md)                 | Accepted |
+| 0005 | [Maintenance bay rule — fuselage centroid in back strip](0005-maintenance-bay-rule.md)                 | Deprecated (superseded in code; successor ADR tracked in [#158](https://github.com/DocGerd/hangarfit/issues/158)) |

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -50,6 +50,12 @@ Frozen dataclasses for every domain concept: `Part`, `Aircraft`,
 `PlaneConstraint`, `SolveResult`, `SolverDiagnostics`,
 `DiversityConfig`, `SearchConfig` and the `SolveStatus` literal.
 
+`MaintenanceBay` is a back-anchored partial-width rectangle
+(`center_x_m`, `width_m`, `depth_m`) — `Hangar.__post_init__`
+enforces that the bay sub-rectangle fits inside the hangar
+(`center_x_m ± width_m/2 ∈ [0, hangar.width_m]` and
+`depth_m < hangar.length_m`).
+
 `__post_init__` enforces all invariants that cannot be expressed via
 the type system — the cart rule (`movement_mode` ↔ `on_carts`
 consistency, at most one cart-eligible plane actually on carts), the
@@ -78,6 +84,14 @@ of truth, eliminating any risk of strut volume being double-counted.
 Has tests in `tests/test_loader.py` that exercise the `struts:`
 expansion end-to-end so the YAML convenience can never silently
 desync from the canonical parts representation.
+
+For the `maintenance.plane` field, the loader raises a YAML-author-
+actionable `LoaderError` when the named occupant also appears in
+`placements`, with the hint "Remove it from placements (or fix the
+plane id if it doesn't match an aircraft in the fleet)". The
+`Layout.__post_init__` invariant catches the same combination as a
+programmatic backstop for callers that construct `Layout` instances
+directly.
 
 ### `geometry.py` — the determinant −1 transform
 
@@ -129,8 +143,14 @@ integer `len(conflicts)` metric).
 Internally:
 
 - **Pre-search infeasibility checks** — fail fast on obviously broken
-  scenarios (e.g., maintenance plane pinned outside the back strip,
-  pins outside hangar bounds).
+  scenarios (e.g., a non-maintenance plane pinned such that its geometry
+  intrudes into the closed bay rectangle, fleet bbox sum exceeds hangar
+  floor area, pin self-collision on the pin-only Layout).
+- **Maintenance plane handling** — when `scenario.maintenance_plane` is
+  set, the solver drops that plane from the placeable set entirely (no
+  initial placement, no perturbation, no cart-bucket slot). The bay
+  rectangle is enforced as a hard obstacle by the `bay_intrusion`
+  collision rule, so no surrogate sample is needed.
 - **Initial placement** — random valid placements respecting pins.
 - **Descent step** — min-conflicts perturbation: identify the plane
   with the largest conflict contribution (by `total_penetration_m2`),
@@ -158,6 +178,15 @@ across runs (compliance check:
 Renders a layout (with or without a `CheckResult` overlay) to PNG using
 matplotlib. Forces a headless backend at import time so the module runs
 in CI / pytest without a display server.
+
+The maintenance bay renders conditionally on `layout.maintenance_plane`:
+when `None`, the bay area is just normal floor (no overlay); when a
+plane is named, the partial-width bay rectangle
+(`MaintenanceBay.center_x_m` / `width_m` / `depth_m`) is filled with a
+hatched red "wall" style and the label `IN MAINTENANCE: <plane_id>` is
+centered inside. The occupant aircraft itself is not drawn — by Layout
+invariant it's absent from `placements` and the existing draw loop
+skips it without special-casing.
 
 When a `CheckResult` is passed, the renderer validates that every
 conflict's referenced planes are in the layout, then overdraws the

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -56,6 +56,12 @@ enforces that the bay sub-rectangle fits inside the hangar
 (`center_x_m ± width_m/2 ∈ [0, hangar.width_m]` and
 `depth_m < hangar.length_m`).
 
+`Layout.__post_init__` inverts the Phase 1 maintenance invariant
+(updated in [#103](https://github.com/DocGerd/hangarfit/issues/103)):
+the bay occupant must **not** appear in `placements` (it is treated as
+away). The collision checker and visualizer rely on this invariant —
+neither needs to special-case the occupant.
+
 `__post_init__` enforces all invariants that cannot be expressed via
 the type system — the cart rule (`movement_mode` ↔ `on_carts`
 consistency, at most one cart-eligible plane actually on carts), the
@@ -142,10 +148,14 @@ integer `len(conflicts)` metric).
 `solve(scenario, budget_s, alternatives, seed)` is the public entry.
 Internally:
 
-- **Pre-search infeasibility checks** — fail fast on obviously broken
-  scenarios (e.g., a non-maintenance plane pinned such that its geometry
-  intrudes into the closed bay rectangle, fleet bbox sum exceeds hangar
-  floor area, pin self-collision on the pin-only Layout).
+- **Pre-search infeasibility checks** — three literal-impossibility
+  gates fail fast before the search loop runs: (1) a per-plane bbox
+  exceeds the hangar's max dimension, (2) the fleet's Σ bbox areas
+  exceed the hangar floor, (3) the pin-only Layout (every constrained
+  pin, occupant excluded) fails ``check_layout`` — including the case
+  where a non-maintenance plane is pinned such that its geometry
+  intrudes into the closed bay rectangle (covered by
+  ``test_solve_trivially_infeasible_when_pinned_plane_intrudes_into_closed_bay``).
 - **Maintenance plane handling** — when `scenario.maintenance_plane` is
   set, the solver drops that plane from the placeable set entirely (no
   initial placement, no perturbation, no cart-bucket slot). The bay

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -74,7 +74,7 @@ sequenceDiagram
     Loader-->>CLI: Scenario (structurally valid)
 
     CLI->>Solver: solve(scenario, budget_s=30, alternatives=3, seed=42)
-    Note over Solver: Pre-search infeasibility checks<br/>(pins inside hangar?<br/>maint plane in back strip?)
+    Note over Solver: Pre-search infeasibility checks<br/>(per-plane bbox fits?<br/>Σ areas fit?<br/>pin-only Layout passes check?)
     alt trivially infeasible
         Solver-->>CLI: SolveResult(status=trivially_infeasible)
     else feasible

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -6,7 +6,8 @@ instead of lists where collections appear (so the whole graph is
 effectively immutable after construction).
 
 The full coordinate convention and parts-model collision rule live in
-``CLAUDE.md`` at the repo root — this module just encodes the types.
+``docs/architecture/08-crosscutting-concepts.md`` — this module just
+encodes the types.
 """
 
 from __future__ import annotations
@@ -34,8 +35,9 @@ class Part:
     """One oriented rectangle in plane-local coordinates with a height range.
 
     The universal collision unit. Fuselage, wing, and each strut are all
-    represented as ``Part`` instances. See ``CLAUDE.md`` for the
-    plane-local coordinate convention (``+x`` forward, ``+y`` right).
+    represented as ``Part`` instances. See
+    ``docs/architecture/08-crosscutting-concepts.md`` "The coordinate
+    convention" for plane-local coordinates (``+x`` forward, ``+y`` right).
 
     ``kind`` is closed: ``"fuselage" | "wing" | "strut" | "tail"``. New
     kinds must be added to ``PartKind`` and the matching ``_VALID_PART_KINDS``
@@ -251,7 +253,9 @@ class Hangar:
     """The hangar floor plan.
 
     Coordinates: ``(0, 0)`` at the front-left corner, ``+x`` along the
-    door wall, ``+y`` deeper into the hangar. See ``CLAUDE.md``.
+    door wall, ``+y`` deeper into the hangar. See
+    ``docs/architecture/08-crosscutting-concepts.md`` "The coordinate
+    convention".
     """
 
     length_m: float


### PR DESCRIPTION
## Summary

Closing PR for **milestone #9** (Maintenance bay walling). All other issues (#103, #104, #105, #106, #107, #108) have shipped; this is the docs sweep that lands last.

The original #109 issue body assumed the pre-slim CLAUDE.md structure ("The hangar" section at line 41, "Module map" embedded in CLAUDE.md). After milestone #12 slimmed CLAUDE.md (#137 via #159), the architectural content moved to `docs/architecture/` and ADRs. So the actual targets shifted from CLAUDE.md to arc42 §5 + a CLAUDE.md operational pointer + the hangar.yaml comment block. Arc42 §8 ("The maintenance bay rule") was already updated by milestone #12 and needs no further work here.

Closes #109. Closes #110 — last open dependency of the epic.

## What changed (initial commit `e52c9cb`)

**`CLAUDE.md`** — Open Questions list: "maintenance bay depth" → "maintenance bay rectangle (`center_x_m`, `width_m`, `depth_m` — back-anchored, partial-width)". The bay went from one number to three back in #103; the open-questions list still spoke as if it were one.

**`docs/architecture/05-building-block-view.md`** — Per-module refresh of every file milestone #9 touched:

| Module | Refresh |
|---|---|
| `models.py` | Added a paragraph naming `MaintenanceBay` as a back-anchored partial-width rectangle with `Hangar.__post_init__` bounds invariants + the headline `Layout.__post_init__` invariant flip from #103. |
| `loader.py` | Added a paragraph documenting the YAML-author-actionable `LoaderError` for the occupant-in-placements case (#105) alongside its `Layout.__post_init__` programmatic backstop. |
| `solver.py` | Replaced the **stale** pre-search example "maintenance plane pinned outside the back strip" (Phase 1 centroid rule, ADR-0005 Deprecated). After #108 the maintenance plane isn't even in the placeable set, so the actual modern pre-search check is `bay_intrusion` firing on a non-maintenance plane's pin. Added a dedicated "Maintenance plane handling" bullet describing the occupant-skip mechanism from #108. |
| `visualize.py` | Added the conditional bay rendering paragraph (open → no overlay, closed → hatched red partial-width rect + label) from #106. |
| `collisions.py` | Already accurate post-#12 (mentions `bay_intrusion`, partial-width, occupant-absent-from-placements). No change. |

**`data/hangar.yaml`** — Replaced the stale `CLAUDE.md` pointer in the coordinate-convention comment with the durable `docs/architecture/08-crosscutting-concepts.md` anchor.

## /pr-review fixes (commit `ea7efcf`)

Both `comment-analyzer` and `code-reviewer` flagged **6 in-scope findings** I missed — all the same milestone-#12-slim-down rot pattern:

- **`docs/architecture/06-runtime-view.md:77`**: Mermaid pre-search note still said "maint plane in back strip" (Phase-1 wording). Rewrote to enumerate the three actual pre-search gates.
- **`docs/adr/README.md:85`**: ADR-0005 status column said `Accepted` but the ADR file itself says `Deprecated`. Aligned + linked #158.
- **`data/fleet.yaml:8`**: stale `CLAUDE.md` pointer, identical pattern to the `hangar.yaml` fix. Redirected to arc42 §8.
- **`src/hangarfit/models.py`** (three docstrings): module-level + `Part` + `Hangar` all referenced `CLAUDE.md`. All redirected to arc42 §8.
- **arc42 §5 solver bullet**: structurally confused (the bay-intrusion case IS the pin-only-Layout check, not a sibling). Rewrote as three numbered gates with the test name as the anchor.
- **arc42 §5 models.py paragraph**: silent on the headline #103 `Layout.__post_init__` invariant flip. Added one clause.

## Deferred (filed for follow-up, out of scope for #109)

- **ADR-0003** lines 88 + 210 assert the maintenance plane "gets a back-bay biased initial" — no longer true post-#108. ADR-0003 is not Deprecated (it's the current RR-MC ADR), so an in-place amendment is intertwined with the ADR-0006 successor work. **Folded into [#158](https://github.com/DocGerd/hangarfit/issues/158)** as a comment.

## Scope discipline

What I deliberately did **not** touch:
- Arc42 §8 ("The maintenance bay rule") — already accurate post-#12.
- ADR-0005 file — already marked `Deprecated`; the successor ADR-0006 is tracked separately in #158.
- README — issue body explicitly listed as out of scope ("not currently maintained as project-canonical").
- No code changes — strict docs-only.

## Milestone closure

Closing this PR closes **#109** (the docs issue) and **#110** (the epic — the only remaining open dependency was #109). Milestone #9 "Maintenance bay walling" will hit 100% completion alongside.

Other follow-ups already filed during the milestone work (not in scope here):
- **#158**: Backfill ADR-0006 for the `bay_intrusion` rule (will Supersede the Deprecated ADR-0005). Now also includes the ADR-0003 amendment.
- **#171**: Solver — reject pin on maintenance_plane instead of silently stripping (from /pr-review on #170).
- **#175**: Loader — validate types and reject null/non-string `maintenance.plane` value (from /pr-review on #174).
- **#176**: Loader case-sensitivity policy + "did you mean…?" hints (from /pr-review on #174).
- **#177**: Pre-Scenario actionable check when `maintenance_plane not in fleet_in` (from /pr-review on #174).

## Test plan
- [x] `pytest -m ""` (incl. @slow): 408 passed
- [x] Docs-only diff (8 files after /pr-review fixes, +60/-15 lines)
- [x] No source-code behavior changed; no fixtures changed; only docstrings + markdown
- [x] All cross-references checked (every #NNN, every ADR link, every file path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)