### PR TITLE
Loader: validate maintenance.plane type (closes #175)

### DIFF
--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -421,7 +421,10 @@ def _extract_maintenance_plane(raw: dict, path: Path) -> str | None:
             f"got {plane!r} ({type(plane).__name__})"
         )
     if not plane:
-        raise LoaderError(f"{path}: 'maintenance.plane' must be non-empty")
+        raise LoaderError(
+            f"{path}: 'maintenance.plane' must be non-empty; "
+            f"either remove the 'maintenance' block entirely or supply a valid aircraft id"
+        )
     return plane
 
 

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -409,7 +409,20 @@ def _extract_maintenance_plane(raw: dict, path: Path) -> str | None:
         )
     if "plane" not in m:
         raise LoaderError(f"{path}: 'maintenance' block present but lacks required 'plane' key")
-    return m["plane"]
+    plane = m["plane"]
+    if plane is None:
+        raise LoaderError(
+            f"{path}: 'maintenance.plane' is null; either remove the 'maintenance' "
+            f"block entirely or name an aircraft id"
+        )
+    if not isinstance(plane, str):
+        raise LoaderError(
+            f"{path}: 'maintenance.plane' must be a string aircraft id, "
+            f"got {plane!r} ({type(plane).__name__})"
+        )
+    if not plane:
+        raise LoaderError(f"{path}: 'maintenance.plane' must be non-empty")
+    return plane
 
 
 def _build_aircraft(entry: Any) -> Aircraft:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1052,8 +1052,12 @@ maintenance:
   plane: 42
 """,
         )
-        with pytest.raises(LoaderError, match="'maintenance.plane' must be a string"):
+        with pytest.raises(LoaderError) as exc_info:
             load_layout(layout_path)
+        msg = str(exc_info.value)
+        assert "must be a string aircraft id" in msg
+        assert "42" in msg
+        assert "int" in msg
 
     def test_maintenance_plane_empty_string_rejected(self, tmp_path: Path) -> None:
         """`maintenance: {plane: ""}` used to slip through silently."""
@@ -1069,8 +1073,12 @@ maintenance:
   plane: ""
 """,
         )
-        with pytest.raises(LoaderError, match="'maintenance.plane' must be non-empty"):
+        with pytest.raises(LoaderError) as exc_info:
             load_layout(layout_path)
+        msg = str(exc_info.value)
+        assert "must be non-empty" in msg
+        assert "either remove the 'maintenance' block entirely" in msg
+        assert "supply a valid aircraft id" in msg
 
     def test_override_and_yaml_ref_conflict_for_fleet(self, tmp_path: Path) -> None:
         """If the layout YAML has `fleet:` AND the caller passes a fleet

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1019,6 +1019,59 @@ placements:
         with pytest.raises(LoaderError, match="maintenance_plane 'bar' is named in placements"):
             load_layout(layout_path)
 
+    def test_maintenance_plane_null_rejected(self, tmp_path: Path) -> None:
+        """`maintenance: {plane: ~}` used to silently return None, disabling
+        the maintenance feature.  It should raise with an actionable message."""
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+maintenance:
+  plane: ~
+""",
+        )
+        with pytest.raises(LoaderError, match="'maintenance.plane' is null"):
+            load_layout(layout_path)
+
+    def test_maintenance_plane_non_string_rejected(self, tmp_path: Path) -> None:
+        """`maintenance: {plane: 42}` (int) used to pass through silently,
+        then fail with a confusing 'not in fleet' message at Layout construction."""
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+maintenance:
+  plane: 42
+""",
+        )
+        with pytest.raises(LoaderError, match="'maintenance.plane' must be a string"):
+            load_layout(layout_path)
+
+    def test_maintenance_plane_empty_string_rejected(self, tmp_path: Path) -> None:
+        """`maintenance: {plane: ""}` used to slip through silently."""
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+maintenance:
+  plane: ""
+""",
+        )
+        with pytest.raises(LoaderError, match="'maintenance.plane' must be non-empty"):
+            load_layout(layout_path)
+
     def test_override_and_yaml_ref_conflict_for_fleet(self, tmp_path: Path) -> None:
         """If the layout YAML has `fleet:` AND the caller passes a fleet
         override, the loader refuses to silently shadow one with the other."""


### PR DESCRIPTION
Closes #175.

## Summary
- Replace silent return of bad `maintenance.plane` values with actionable `LoaderError`s.
- Covers four shapes: null, non-string, empty string, missing key.

## Test plan
- [x] `pytest` all green
- [x] `ruff check` clean
- [x] `mypy src/hangarfit/` clean