### PR TITLE
Loader: pre-Scenario check for maintenance_plane in fleet_in (closes #177)

### DIFF
--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -308,12 +308,10 @@ def load_scenario(
     # maintenance (optional, same shape as load_layout)
     maintenance_plane = _extract_maintenance_plane(raw, path)
 
-    # Pre-Scenario boundary check: maintenance_plane must be in fleet_in.
-    # Mirrors the pre-Layout check added in PR #105 for load_layout.
-    # Catching this here (before Scenario construction) lets us produce a
-    # path-prefixed actionable message with the actual fleet_in list instead
-    # of the bare ValueError that would otherwise bubble up from
-    # Scenario.__post_init__.
+    # Pre-Scenario boundary check: surface the YAML-author error with a
+    # path prefix here instead of relying on Scenario.__post_init__'s
+    # bare ValueError bubbling through the except ValueError → LoaderError
+    # wrap below (which would drop the actionable fleet_in hint).
     if maintenance_plane is not None and maintenance_plane not in fleet_in:
         raise LoaderError(
             f"{path}: maintenance_plane {maintenance_plane!r} is not in fleet_in "

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -308,6 +308,18 @@ def load_scenario(
     # maintenance (optional, same shape as load_layout)
     maintenance_plane = _extract_maintenance_plane(raw, path)
 
+    # Pre-Scenario boundary check: maintenance_plane must be in fleet_in.
+    # Mirrors the pre-Layout check added in PR #105 for load_layout.
+    # Catching this here (before Scenario construction) lets us produce a
+    # path-prefixed actionable message with the actual fleet_in list instead
+    # of the bare ValueError that would otherwise bubble up from
+    # Scenario.__post_init__.
+    if maintenance_plane is not None and maintenance_plane not in fleet_in:
+        raise LoaderError(
+            f"{path}: maintenance_plane {maintenance_plane!r} is not in fleet_in "
+            f"{list(fleet_in)}; either add it to fleet_in or fix the plane id."
+        )
+
     # constraints (optional). `or {}` is wrong here — it collapses every
     # falsy YAML value (including `constraints: []` or `constraints: 0`)
     # to `{}` before the isinstance check, silently treating shape bugs

--- a/tests/test_loader_scenario.py
+++ b/tests/test_loader_scenario.py
@@ -84,13 +84,13 @@ def test_load_scenario_rejects_maintenance_plane_not_in_fleet_in(tmp_path):
     actual fleet_in list, and a fix hint.  This mirrors the boundary-check
     added for load_layout in PR #105 (closes #177).
     """
+    import shutil
+
     from hangarfit.loader import load_scenario
 
     # Write the bad scenario adjacent to root data files so relative refs
     # resolve correctly from tmp_path.
     (tmp_path / "data").mkdir()
-    import shutil
-
     shutil.copy("data/fleet.yaml", tmp_path / "data" / "fleet.yaml")
     shutil.copy("data/hangar.yaml", tmp_path / "data" / "hangar.yaml")
     bad = tmp_path / "bad_maintenance.yaml"

--- a/tests/test_loader_scenario.py
+++ b/tests/test_loader_scenario.py
@@ -76,3 +76,60 @@ def test_load_scenario_missing_fleet_in(tmp_path):
     missing.write_text("fleet: ../../data/fleet.yaml\nhangar: ../../data/hangar.yaml\n")
     with pytest.raises(LoaderError, match="fleet_in"):
         load_scenario(missing)
+
+
+def test_load_scenario_rejects_maintenance_plane_not_in_fleet_in(tmp_path):
+    """Loader-path: maintenance.plane not in fleet_in raises LoaderError with
+    an actionable message that includes the path, the bad plane id, the
+    actual fleet_in list, and a fix hint.  This mirrors the boundary-check
+    added for load_layout in PR #105 (closes #177).
+    """
+    from hangarfit.loader import load_scenario
+
+    # Write the bad scenario adjacent to root data files so relative refs
+    # resolve correctly from tmp_path.
+    (tmp_path / "data").mkdir()
+    import shutil
+
+    shutil.copy("data/fleet.yaml", tmp_path / "data" / "fleet.yaml")
+    shutil.copy("data/hangar.yaml", tmp_path / "data" / "hangar.yaml")
+    bad = tmp_path / "bad_maintenance.yaml"
+    bad.write_text(
+        "fleet: data/fleet.yaml\n"
+        "hangar: data/hangar.yaml\n"
+        "fleet_in: [aviat_husky, ctsl]\n"
+        "maintenance:\n"
+        "  plane: ghost\n"
+    )
+    with pytest.raises(LoaderError) as exc_info:
+        load_scenario(bad)
+    msg = str(exc_info.value)
+    # Must name the bad plane id
+    assert "ghost" in msg, f"message should name the bad plane id; got: {msg!r}"
+    # Must include the file path
+    assert str(bad) in msg, f"message should include the file path; got: {msg!r}"
+    # Must show the actual fleet_in list so the user knows what is valid
+    assert "aviat_husky" in msg, f"message should list valid fleet_in planes; got: {msg!r}"
+    # Must include a fix hint (actionable suffix)
+    assert "either add it to fleet_in or fix the plane id" in msg, (
+        f"message should include actionable fix hint; got: {msg!r}"
+    )
+
+
+def test_scenario_post_init_backstop_still_fires_on_direct_construction():
+    """Direct-construction path: Scenario.__post_init__ still raises ValueError
+    when maintenance_plane is not in fleet_in, bypassing the loader guard.
+    This ensures the programmatic backstop is not removed.
+    """
+    from hangarfit.loader import load_fleet, load_hangar
+    from hangarfit.models import Scenario
+
+    fleet = load_fleet("data/fleet.yaml")
+    hangar = load_hangar("data/hangar.yaml")
+    with pytest.raises(ValueError, match="maintenance_plane"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("aviat_husky", "ctsl"),
+            maintenance_plane="ghost",  # not in fleet_in and not in fleet
+        )


### PR DESCRIPTION
Closes #177.

## Summary
- Add pre-Scenario actionable LoaderError when `maintenance.plane` is not in `fleet_in`.
- Mirrors the boundary-check pattern PR #105 established for `load_layout`.
- `Scenario.__post_init__` invariant retained as programmatic backstop.

## Test plan
- [x] `pytest` all green
- [x] `ruff check` clean
- [x] `mypy src/hangarfit/` clean