### PR TITLE
Scenario: reject pin on maintenance_plane (closes #171)

### DIFF
--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -503,6 +503,9 @@ class Scenario:
         force_on_carts=False → plane must NOT be always_cart
     - pin.on_carts is consistent with movement_mode (same rules)
     - if both a pin and force_on_carts are set, their on_carts must agree
+    - maintenance_plane (if set) must not also carry a pin or force_on_carts in
+      constraints (the occupant is treated as away — those constraints would be
+      incoherent and would be silently ignored by the solver)
     - fleet and constraints are wrapped in MappingProxyType (same pattern as Layout)
 
     See spec §3.2 for the rationale.

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -547,6 +547,25 @@ class Scenario:
             if key not in fleet_in_set:
                 raise ValueError(f"Scenario.constraints has key {key!r} not in fleet_in")
 
+        # maintenance_plane cannot carry a pin or force_on_carts constraint.
+        # The maintenance occupant is treated as away (absent from placements),
+        # so any pin or force_on_carts on it would be silently ignored by the
+        # solver.  Reject early so the user gets a clear error rather than a
+        # layout that ignored their constraint.
+        if (
+            self.maintenance_plane is not None
+            and self.maintenance_plane in self.constraints
+            and (
+                self.constraints[self.maintenance_plane].pin is not None
+                or self.constraints[self.maintenance_plane].force_on_carts is not None
+            )
+        ):
+            raise ValueError(
+                f"Scenario.maintenance_plane {self.maintenance_plane!r} cannot also "
+                f"carry a pin or force_on_carts constraint — the maintenance occupant "
+                f"is treated as away (absent from placements)."
+            )
+
         # per-constraint validation
         for plane_id, constraint in self.constraints.items():
             plane = self.fleet[plane_id]

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -375,11 +375,15 @@ def _check_trivially_infeasible(
 
         # Build a Layout containing ONLY the pinned planes.
         #
-        # The maintenance plane (if any) is excluded from placements by
-        # Layout invariant — it is treated as "away". Pinning the
-        # maintenance plane is incoherent under that semantics and is
-        # filtered here defensively (Scenario validation could also
-        # reject it; for now we just ignore the pin).
+        # ``maintenance_plane`` is forwarded to the pin-only Layout so that
+        # ``collisions.check()`` can fire the maintenance_position rule if the
+        # pins collectively leave the maintenance area occupied by another plane
+        # or violated (detected early, before burning the full solve() budget
+        # on a restart loop that can never escape a pinned conflict).
+        #
+        # Scenario.__post_init__ guarantees that the maintenance_plane cannot
+        # carry a pin (raises ValueError if it does), so ``pinned_placements``
+        # is provably free of the maintenance occupant — no filter is needed.
         #
         # No try/except: every remaining Layout invariant that could fire
         # here is either structurally impossible given pin-only construction
@@ -390,9 +394,7 @@ def _check_trivially_infeasible(
         pin_only_layout = Layout(
             fleet=scenario.fleet,
             hangar=scenario.hangar,
-            placements=tuple(
-                p for p in pinned_placements if p.plane_id != scenario.maintenance_plane
-            ),
+            placements=tuple(pinned_placements),
             maintenance_plane=scenario.maintenance_plane,
         )
 

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -290,6 +290,61 @@ def test_scenario_rejects_pin_and_force_on_carts_disagreement(fleet, hangar):
         )
 
 
+# ── Scenario: maintenance_plane + constraint guard ──────────────────────
+
+
+def test_scenario_rejects_pin_on_maintenance_plane(fleet, hangar):
+    """Pinning the maintenance plane is incoherent — it is treated as absent
+    from placements, so a pin on it would be silently ignored by the solver.
+    Scenario.__post_init__ must reject this with a clear ValueError."""
+    # cessna_140 is cart_eligible so on_carts=True is valid per movement_mode.
+    # The rejection must fire because it is ALSO the maintenance_plane, not
+    # because of any cart-rule or movement_mode violation.
+    with pytest.raises(ValueError, match="cessna_140"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("cessna_140", "aviat_husky"),
+            maintenance_plane="cessna_140",
+            constraints={
+                "cessna_140": PlaneConstraint(
+                    pin=Placement(
+                        plane_id="cessna_140",
+                        x_m=2.0,
+                        y_m=14.0,
+                        heading_deg=0.0,
+                        on_carts=True,
+                    )
+                )
+            },
+        )
+
+
+def test_scenario_rejects_force_on_carts_on_maintenance_plane(fleet, hangar):
+    """force_on_carts on the maintenance plane is equally incoherent.
+
+    The maintenance occupant is absent from placements so the solver cannot
+    honour a force_on_carts constraint on it — reject at construction rather
+    than silently ignoring it.
+
+    Pinned as a separate test to ensure both branches of the disjunct
+    (pin is not None | force_on_carts is not None) are covered independently
+    — a refactor that checked only one branch would silently miss the other.
+    """
+    # aviat_husky is always_own_gear; force_on_carts=False would ordinarily
+    # be an independent movement_mode violation — use cessna_150 (cart_eligible)
+    # so force_on_carts=True is otherwise legal and the rejection is solely
+    # due to the maintenance_plane conflict.
+    with pytest.raises(ValueError, match="cessna_150"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("cessna_150", "aviat_husky"),
+            maintenance_plane="cessna_150",
+            constraints={"cessna_150": PlaneConstraint(force_on_carts=True)},
+        )
+
+
 # ── SolveStatus / SolverDiagnostics / SolveResult ───────────────────────
 
 

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -300,7 +300,10 @@ def test_scenario_rejects_pin_on_maintenance_plane(fleet, hangar):
     # cessna_140 is cart_eligible so on_carts=True is valid per movement_mode.
     # The rejection must fire because it is ALSO the maintenance_plane, not
     # because of any cart-rule or movement_mode violation.
-    with pytest.raises(ValueError, match="cessna_140"):
+    with pytest.raises(
+        ValueError,
+        match=r"cessna_140.*cannot also carry|cannot also carry.*cessna_140",
+    ):
         Scenario(
             fleet=fleet,
             hangar=hangar,
@@ -335,13 +338,39 @@ def test_scenario_rejects_force_on_carts_on_maintenance_plane(fleet, hangar):
     # be an independent movement_mode violation — use cessna_150 (cart_eligible)
     # so force_on_carts=True is otherwise legal and the rejection is solely
     # due to the maintenance_plane conflict.
-    with pytest.raises(ValueError, match="cessna_150"):
+    with pytest.raises(
+        ValueError,
+        match=r"cessna_150.*cannot also carry|cannot also carry.*cessna_150",
+    ):
         Scenario(
             fleet=fleet,
             hangar=hangar,
             fleet_in=("cessna_150", "aviat_husky"),
             maintenance_plane="cessna_150",
             constraints={"cessna_150": PlaneConstraint(force_on_carts=True)},
+        )
+
+
+def test_scenario_rejects_force_on_carts_false_on_maintenance_plane(fleet, hangar):
+    """force_on_carts=False on the maintenance plane is rejected by the
+    maintenance-plane guard, not by the movement_mode guard.
+
+    ``cessna_140`` is cart_eligible, so ``force_on_carts=False`` (use own gear)
+    is a valid movement_mode choice in isolation.  The maintenance-plane guard
+    must fire first — confirming the ``is not None`` check covers both True and
+    False, and that the error message names the maintenance-plane conflict rather
+    than a movement_mode violation.
+    """
+    with pytest.raises(
+        ValueError,
+        match=r"cessna_140.*cannot also carry|cannot also carry.*cessna_140",
+    ):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("cessna_140", "cessna_150"),
+            maintenance_plane="cessna_140",
+            constraints={"cessna_140": PlaneConstraint(force_on_carts=False)},
         )
 
 


### PR DESCRIPTION
Closes #171.

## Summary
- Move the maintenance-plane pin guard from solver to `Scenario.__post_init__` so every caller benefits.
- Delete the unreachable silent-strip filter in `_check_trivially_infeasible`.
- Tests cover both `pin` and `force_on_carts` paths.

## Test plan
- [x] `pytest` all green (409 passed)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `mypy src/hangarfit/` clean