### PR TITLE
ci: assert critical pins survive lockfile regeneration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,18 @@ jobs:
             echo "::error::extract() produced an empty package set — the regex in .github/workflows/ci.yml no longer matches the lockfile format. Update the guard."
             exit 1
           fi
+          # Defense-in-depth (issue #199): the non-empty check above
+          # catches a *fully* empty extract, but not a pip-compile run that
+          # exits 0 while emitting a *partial* lockfile. Assert the
+          # load-bearing runtime deps + core dev tools survived the
+          # regeneration, so a silently-dropped pin can't diff equal
+          # against an identically-degraded committed file.
+          for pkg in pyyaml shapely matplotlib pytest ruff mypy; do
+            grep -qE "^${pkg}==" /tmp/regenerated.set || {
+              echo "::error::dev lockfile regeneration is missing a required pin: ${pkg} — pip-compile may have produced partial output."
+              exit 1
+            }
+          done
           if ! diff -u /tmp/committed.set /tmp/regenerated.set; then
             echo "::error::requirements-dev.txt is out of sync with pyproject.toml. Regenerate on Python 3.11 with pip-tools==7.5.3: pip-compile --generate-hashes --no-strip-extras --extra dev -o requirements-dev.txt pyproject.toml"
             exit 1
@@ -223,6 +235,16 @@ jobs:
             echo "::error::extract() produced an empty package set — the regex in .github/workflows/ci.yml no longer matches the lockfile format. Update the guard."
             exit 1
           fi
+          # Defense-in-depth (issue #199): same partial-output guard as the
+          # dev-lockfile job. Assert the build toolchain's required pins
+          # survived the regeneration so a silently-dropped pin can't diff
+          # equal against an identically-degraded committed file.
+          for pkg in build setuptools wheel packaging; do
+            grep -qE "^${pkg}==" /tmp/regenerated-build.set || {
+              echo "::error::build lockfile regeneration is missing a required pin: ${pkg} — pip-compile may have produced partial output."
+              exit 1
+            }
+          done
           if ! diff -u /tmp/committed-build.set /tmp/regenerated-build.set; then
             echo "::error::requirements-build.txt is out of sync. Regenerate on Python 3.11 with pip-tools==7.5.3: pip-compile --generate-hashes --no-strip-extras --allow-unsafe -o requirements-build.txt requirements-build.in"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,13 +157,20 @@ jobs:
           fi
           # Defense-in-depth (issue #199): the non-empty check above
           # catches a *fully* empty extract, but not a pip-compile run that
-          # exits 0 while emitting a *partial* lockfile. Assert the
-          # load-bearing runtime deps + core dev tools survived the
-          # regeneration, so a silently-dropped pin can't diff equal
-          # against an identically-degraded committed file.
-          for pkg in pyyaml shapely matplotlib pytest ruff mypy; do
+          # exits 0 while emitting a *partial* lockfile — if the committed
+          # and regenerated files are degraded identically, the diff below
+          # passes and a dropped pin goes unnoticed. Assert that every
+          # *directly-declared* dependency (pyproject [project.dependencies]
+          # + [project.optional-dependencies] dev) survived regeneration.
+          # The declaration boundary is the principled line: transitives are
+          # pip-compile's concern, and a dropped transitive surfaces via the
+          # diff (asymmetric drop) or as an ImportError at test collection.
+          # A count-floor would add nothing — a regen-vs-committed shortfall
+          # is already an asymmetric diff failure; only this absolute check
+          # covers the symmetric-degradation case.
+          for pkg in pyyaml shapely matplotlib pytest pytest-cov ruff mypy types-pyyaml types-shapely; do
             grep -qE "^${pkg}==" /tmp/regenerated.set || {
-              echo "::error::dev lockfile regeneration is missing a required pin: ${pkg} — pip-compile may have produced partial output."
+              echo "::error::dev lockfile regeneration dropped a declared dependency: ${pkg} — pip-compile may have produced partial output."
               exit 1
             }
           done
@@ -236,12 +243,16 @@ jobs:
             exit 1
           fi
           # Defense-in-depth (issue #199): same partial-output guard as the
-          # dev-lockfile job. Assert the build toolchain's required pins
-          # survived the regeneration so a silently-dropped pin can't diff
-          # equal against an identically-degraded committed file.
+          # dev-lockfile job, inlined here so it survives independent edits.
+          # Asserts the directly-declared build deps (requirements-build.in:
+          # build, setuptools, wheel) plus `packaging` — the cross-lockfile
+          # skew anchor constrained via `-c requirements-dev.txt`.
+          # Transitives (e.g. pyproject-hooks) are out of scope for the same
+          # reason as the dev job: their loss surfaces via the diff or a
+          # build failure.
           for pkg in build setuptools wheel packaging; do
             grep -qE "^${pkg}==" /tmp/regenerated-build.set || {
-              echo "::error::build lockfile regeneration is missing a required pin: ${pkg} — pip-compile may have produced partial output."
+              echo "::error::build lockfile regeneration dropped a declared dependency: ${pkg} — pip-compile may have produced partial output."
               exit 1
             }
           done


### PR DESCRIPTION
## Summary

Closes #199.

Hardens **both** lockfile-drift guards against the partial-`pip-compile` silent path identified by `silent-failure-hunter` during the PR #198 review (finding M1).

## The gap

Both `lockfile-drift` and `build-lockfile-drift` already assert the extracted `package==version` set is **non-empty** (`[ -s ]`). That catches a *fully* empty extract (regex stops matching the format). It does **not** catch a `pip-compile` run that exits 0 while emitting a *partial* lockfile (resolver edge case, future pip-tools behavior change, a momentarily-unreadable `-c` constraint). If the committed and regenerated files are degraded identically, the two sets diff equal and the guard reports green with a pin silently dropped.

The guard's true invariant is *"non-empty **AND** contains the known-critical pins,"* not merely *"non-empty."*

## Change

A critical-name assertion in each compare step, run against the freshly **regenerated** set (the resolution most likely to be partial in this failure mode):

| Job | Asserted pins | Rationale |
|---|---|---|
| `lockfile-drift` | `pyyaml`, `shapely`, `matplotlib` + `pytest`, `ruff`, `mypy` | the load-bearing runtime deps (the whole reason this guard exists) + core dev tools |
| `build-lockfile-drift` | `build`, `setuptools`, `wheel`, `packaging` | the entire build toolchain |

## Test plan

- [x] Assertion logic verified locally against the committed lockfiles: **passes** with all pins present, and **fails** when any asserted pin is removed from the regenerated set (proving it is not a no-op and the grep patterns match the normalized names).
- [x] `ci.yml` validated as well-formed YAML.
- [ ] CI green on this PR (both drift jobs still pass with the new assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)