### PR TITLE
ci(deps): bump github/codeql-action v3.35.5 → v4.36.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,11 +24,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f411752efdf656cb71aa17b755b22c890960da1d  # v3.35.5
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f411752efdf656cb71aa17b755b22c890960da1d  # v3.35.5
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
           category: "/language:python"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,6 +40,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@458d36d7d4f47d0dd16ca424c1d3cda0060f1360  # v3.35.5
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Bumps `github/codeql-action` from v3.35.5 to **v4.36.0** (hash-pinned), clearing the two GitHub Actions deprecation warnings tracked in #207. The codeql-action was the only Node-20-based action left in the repo.

### What this fixes

| Warning | Resolved by |
|---|---|
| Node.js 20 runner deprecation (forced Node 24 default **2026-06-02**, Node 20 removed **2026-09-16**) | v4.36.0 sub-actions run on `node24` |
| CodeQL Action v3 deprecation (v3 EOL **2026-12**) | v4 is the current major |

### Changes

Three `uses:` pins, all to commit `7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0`:

- `.github/workflows/codeql.yml` — `codeql-action/init`, `codeql-action/analyze`
- `.github/workflows/scorecard.yml` — `codeql-action/upload-sarif`

### Verification

- Confirmed `init`, `analyze`, and `upload-sarif` `action.yml` all declare `using: node24` at the pinned ref (queried `github/codeql-action` contents API).
- Incidentally reconciles a pre-existing inconsistency: `codeql.yml` and `scorecard.yml` previously pinned **different** SHAs (`f411…` vs `458d…`) under the same `# v3.35.5` comment; both now point to the same verified v4.36.0 SHA.
- Post-merge check: re-run CodeQL + Scorecard and confirm the deprecation annotations are gone (the verification command is in #207).

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)