### PR TITLE
docs(adr): flip ADR-0007 status Proposed → Accepted

### DIFF
--- a/docs/adr/0007-tow-path-planner-v1-scope.md
+++ b/docs/adr/0007-tow-path-planner-v1-scope.md
@@ -1,6 +1,6 @@
 # ADR-0007: Tow-path planner v1 — empty-hangar fill, Dubins-only, cart-as-own-gear
 
-- **Status:** Proposed
+- **Status:** Accepted
 
 - **Date:** 2026-05-25
 - **Deciders:** Patrick Kuhn (DocGerd)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -84,5 +84,5 @@ manual workflow above is canonical.
 | 0004 | [Diversity metric for K alternatives (edit count with per-plane thresholds)](0004-diversity-metric.md) | Accepted |
 | 0005 | [Maintenance bay rule — fuselage centroid in back strip](0005-maintenance-bay-rule.md)                 | Superseded by [ADR-0006](0006-bay-intrusion-maintenance-rule.md) |
 | 0006 | [Maintenance bay rule — `bay_intrusion` on any non-occupant vertex strictly inside the bay rectangle](0006-bay-intrusion-maintenance-rule.md) | Accepted |
-| 0007 | [Tow-path planner v1 — empty-hangar fill, Dubins-only, cart-as-own-gear](0007-tow-path-planner-v1-scope.md) | Proposed |
+| 0007 | [Tow-path planner v1 — empty-hangar fill, Dubins-only, cart-as-own-gear](0007-tow-path-planner-v1-scope.md) | Accepted |
 | 0008 | [Inter-plane spread soft preference (repulsion-energy surrogate for maximin)](0008-inter-plane-spread-soft-preference.md) | Accepted |


### PR DESCRIPTION
Mechanical post-merge follow-up. ADR-0007 merged via #206 with **Status: Proposed**; per `docs/adr/README.md` the status flips to **Accepted** on merge. Updates the Status line in the ADR and its row in the index. Two-line change, no content change.

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)