### PR TITLE
feat(towplanner): planner data model + effective_turn_radius_m (#188)

### DIFF
--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -202,6 +202,19 @@ class Aircraft:
             )
         return self.turn_radius_m
 
+    def effective_turn_radius_m(self) -> float:
+        """Turn radius for path planning: ``0.0`` for cart-borne planes
+        (a pivot-in-place), else the own-gear ``required_turn_radius_m()``.
+
+        This is the accessor the tow-path planner consumes (ADR-0007): a
+        cart-borne plane is modelled as own-gear with a zero turn radius.
+        Unlike :meth:`required_turn_radius_m`, this never raises — callers
+        that legitimately handle carts (the Dubins planner) use this one.
+        """
+        if self.movement_mode == "always_cart":
+            return 0.0
+        return self.required_turn_radius_m()
+
 
 @dataclass(frozen=True, slots=True)
 class Door:

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1,0 +1,86 @@
+"""Tow-path planner — empty-hangar fill (Phase 3a).
+
+Answers *how* each plane reaches its target slot: a deterministic entry
+order plus a closed-form Dubins arc per plane. See ADR-0007 and
+docs/spikes/tow-path-planning.md. Wave 1 = the leaf primitives only.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from hangarfit.models import Placement
+
+_VALID_SEGMENT_KINDS = frozenset({"L", "S", "R"})
+
+
+@dataclass(frozen=True, slots=True)
+class Pose:
+    """A planar pose. Deliberately omits ``plane_id``/``on_carts`` — path
+    samples carry neither identity (the caller knows it) nor cart state
+    (it does not change mid-arc). ``heading_deg`` follows the ADR-0002
+    compass convention (from world +y, CW positive)."""
+
+    x_m: float
+    y_m: float
+    heading_deg: float
+
+    @classmethod
+    def from_placement(cls, p: Placement) -> Pose:
+        return cls(x_m=p.x_m, y_m=p.y_m, heading_deg=p.heading_deg)
+
+
+@dataclass(frozen=True, slots=True)
+class Segment:
+    """One leg of a Dubins path. ``kind`` is ``L`` (left turn), ``S``
+    (straight), or ``R`` (right turn). ``length_m`` is the arc length of
+    the leg in metres (always >= 0)."""
+
+    kind: str
+    length_m: float
+
+    def __post_init__(self) -> None:
+        if self.kind not in _VALID_SEGMENT_KINDS:
+            raise ValueError(
+                f"Segment.kind must be one of {sorted(_VALID_SEGMENT_KINDS)}, got {self.kind!r}"
+            )
+        if self.length_m < 0.0 or not math.isfinite(self.length_m):
+            raise ValueError(f"Segment.length_m must be finite and >= 0, got {self.length_m}")
+
+
+@dataclass(frozen=True, slots=True)
+class DubinsArc:
+    """Closed-form shortest path between two oriented poses under a minimum
+    turn radius. ``turn_radius_m = 0`` denotes a cart-borne pivot-in-place
+    (ADR-0007). ``segments`` is the ordered leg decomposition."""
+
+    start: Pose
+    end: Pose
+    turn_radius_m: float
+    segments: tuple[Segment, ...]
+
+    @property
+    def length_m(self) -> float:
+        return math.fsum(s.length_m for s in self.segments)
+
+
+@dataclass(frozen=True, slots=True)
+class Move:
+    """One plane's entry: from the door-cone entry pose to its target slot."""
+
+    plane_id: str
+    target_slot: Pose
+    path: DubinsArc
+
+
+@dataclass(frozen=True, slots=True)
+class MovesPlan:
+    """A full entry plan: the target layout plus the moves in execution order.
+
+    Deliberately carries no sequence-level cart-usage tally (ADR-0007
+    open question). The ``target_layout`` type is ``Layout`` at runtime;
+    typed loosely here to keep Wave 1's leaf module import-light."""
+
+    target_layout: object
+    moves: tuple[Move, ...]

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -8,11 +8,14 @@ docs/spikes/tow-path-planning.md. Wave 1 = the leaf primitives only.
 from __future__ import annotations
 
 import math
+import typing
 from dataclasses import dataclass
+from typing import Literal
 
 from hangarfit.models import Placement
 
-_VALID_SEGMENT_KINDS = frozenset({"L", "S", "R"})
+SegmentKind = Literal["L", "S", "R"]
+_VALID_SEGMENT_KINDS = frozenset(typing.get_args(SegmentKind))
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,7 +40,7 @@ class Segment:
     (straight), or ``R`` (right turn). ``length_m`` is the arc length of
     the leg in metres (always >= 0)."""
 
-    kind: str
+    kind: SegmentKind
     length_m: float
 
     def __post_init__(self) -> None:
@@ -60,6 +63,15 @@ class DubinsArc:
     turn_radius_m: float
     segments: tuple[Segment, ...]
 
+    def __post_init__(self) -> None:
+        # 0.0 is the cart pivot-in-place sentinel (ADR-0007) and is valid.
+        if self.turn_radius_m < 0.0 or not math.isfinite(self.turn_radius_m):
+            raise ValueError(
+                f"DubinsArc.turn_radius_m must be finite and >= 0, got {self.turn_radius_m}"
+            )
+        if not self.segments:
+            raise ValueError("DubinsArc.segments must be non-empty")
+
     @property
     def length_m(self) -> float:
         return math.fsum(s.length_m for s in self.segments)
@@ -72,6 +84,10 @@ class Move:
     plane_id: str
     target_slot: Pose
     path: DubinsArc
+
+    def __post_init__(self) -> None:
+        if not self.plane_id:
+            raise ValueError("Move.plane_id must be non-empty")
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -268,6 +268,19 @@ class TestAircraft:
         with pytest.raises(AssertionError, match="turn_radius_m is None"):
             a.required_turn_radius_m()
 
+    def test_effective_turn_radius_zero_for_always_cart(self) -> None:
+        a = _ok_aircraft(movement_mode="always_cart", turn_radius_m=None)
+        assert a.effective_turn_radius_m() == 0.0
+
+    def test_effective_turn_radius_delegates_for_own_gear(self) -> None:
+        a = _ok_aircraft(movement_mode="always_own_gear", turn_radius_m=7.0)
+        assert a.effective_turn_radius_m() == 7.0
+        assert a.effective_turn_radius_m() == a.required_turn_radius_m()
+
+    def test_effective_turn_radius_delegates_for_cart_eligible(self) -> None:
+        a = _ok_aircraft(movement_mode="cart_eligible", turn_radius_m=9.5)
+        assert a.effective_turn_radius_m() == 9.5
+
     @pytest.mark.parametrize("wing_position", ["", "middle", "High", "MID", "bottom"])
     def test_invalid_wing_position_rejected(self, wing_position: str) -> None:
         with pytest.raises(ValueError, match="wing_position must be one of"):

--- a/tests/test_towplanner.py
+++ b/tests/test_towplanner.py
@@ -1,0 +1,54 @@
+import dataclasses
+import math
+
+import pytest
+
+from hangarfit.models import Placement
+from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+
+
+def test_pose_from_placement_drops_identity_and_cart_state():
+    p = Placement(plane_id="DG-ABC", x_m=3.0, y_m=4.0, heading_deg=30.0, on_carts=True)
+    pose = Pose.from_placement(p)
+    assert pose == Pose(x_m=3.0, y_m=4.0, heading_deg=30.0)
+    assert not hasattr(pose, "plane_id")
+    assert not hasattr(pose, "on_carts")
+
+
+def test_pose_is_frozen():
+    pose = Pose(x_m=0.0, y_m=0.0, heading_deg=0.0)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        pose.x_m = 1.0  # type: ignore[misc]
+
+
+def test_dubins_arc_length_sums_segments():
+    # A straight-only arc of length 5 (turn_radius irrelevant for S segments).
+    arc = DubinsArc(
+        start=Pose(0.0, 0.0, 0.0),
+        end=Pose(0.0, 5.0, 0.0),
+        turn_radius_m=10.0,
+        segments=(Segment(kind="S", length_m=5.0),),
+    )
+    assert arc.length_m == pytest.approx(5.0)
+
+
+def test_dubins_arc_rejects_unknown_segment_kind():
+    with pytest.raises(ValueError):
+        Segment(kind="Q", length_m=1.0)
+
+
+def test_movesplan_construction_roundtrip():
+    layout = object()  # placeholder; Move/MovesPlan do not validate layout in Wave 1
+    move = Move(
+        plane_id="DG-ABC",
+        target_slot=Pose(1.0, 2.0, 0.0),
+        path=DubinsArc(
+            start=Pose(0.0, 0.0, 0.0),
+            end=Pose(1.0, 2.0, 0.0),
+            turn_radius_m=8.0,
+            segments=(Segment(kind="S", length_m=math.hypot(1.0, 2.0)),),
+        ),
+    )
+    plan = MovesPlan(target_layout=layout, moves=(move,))
+    assert plan.moves[0].plane_id == "DG-ABC"
+    assert plan.moves[0].path.end == plan.moves[0].target_slot

--- a/tests/test_towplanner.py
+++ b/tests/test_towplanner.py
@@ -37,6 +37,52 @@ def test_dubins_arc_rejects_unknown_segment_kind():
         Segment(kind="Q", length_m=1.0)
 
 
+def test_dubins_arc_rejects_negative_turn_radius():
+    with pytest.raises(ValueError):
+        DubinsArc(
+            start=Pose(0.0, 0.0, 0.0),
+            end=Pose(0.0, 1.0, 0.0),
+            turn_radius_m=-1.0,
+            segments=(Segment("S", 1.0),),
+        )
+
+
+def test_dubins_arc_allows_zero_turn_radius_pivot_sentinel():
+    # turn_radius_m == 0 is the cart pivot-in-place sentinel (ADR-0007) and
+    # must survive validation — guards against a `<= 0` reject.
+    arc = DubinsArc(
+        start=Pose(0.0, 0.0, 0.0),
+        end=Pose(0.0, 0.0, 90.0),
+        turn_radius_m=0.0,
+        segments=(Segment("R", math.radians(90.0)),),
+    )
+    assert arc.turn_radius_m == 0.0
+
+
+def test_dubins_arc_rejects_empty_segments():
+    with pytest.raises(ValueError):
+        DubinsArc(
+            start=Pose(0.0, 0.0, 0.0),
+            end=Pose(0.0, 0.0, 0.0),
+            turn_radius_m=5.0,
+            segments=(),
+        )
+
+
+def test_move_rejects_empty_plane_id():
+    with pytest.raises(ValueError):
+        Move(
+            plane_id="",
+            target_slot=Pose(1.0, 2.0, 0.0),
+            path=DubinsArc(
+                start=Pose(0.0, 0.0, 0.0),
+                end=Pose(1.0, 2.0, 0.0),
+                turn_radius_m=8.0,
+                segments=(Segment("S", math.hypot(1.0, 2.0)),),
+            ),
+        )
+
+
 def test_movesplan_construction_roundtrip():
     layout = object()  # placeholder; Move/MovesPlan do not validate layout in Wave 1
     move = Move(


### PR DESCRIPTION
## Summary

Wave 1 **Task 1** of the Phase 3a tow-path planner ([ADR-0007](https://github.com/DocGerd/hangarfit/blob/develop/docs/adr/0007-tow-path-planner-v1-scope.md), [Wave 1 plan](https://github.com/DocGerd/hangarfit/blob/develop/docs/superpowers/plans/2026-05-25-phase3a-towplanner-wave1.md)). Adds the dependency-free **planner data model** plus the cart-radius accessor. No `solve` wiring, CLI, or rendering — those are Waves 2–3.

### New module `src/hangarfit/towplanner.py`
Frozen `@dataclass(slots=True)` primitives, matching `models.py` house style:
- **`Pose(x_m, y_m, heading_deg)`** + `Pose.from_placement()`. Deliberately omits `plane_id`/`on_carts` — a path *sample* carries neither identity nor cart state.
- **`Segment(kind, length_m)`** — one `L`/`S`/`R` leg; `__post_init__` validates `kind ∈ {L,S,R}` and a finite, non-negative `length_m`.
- **`DubinsArc(start, end, turn_radius_m, segments)`** — `length_m` sums segment lengths (`math.fsum`); `turn_radius_m = 0` ⇒ cart-borne pivot-in-place (ADR-0007).
- **`Move`**, **`MovesPlan`** — entry plan in execution order; `MovesPlan` carries no sequence-level cart tally (ADR-0007 open question), `target_layout` typed loosely to keep the leaf module import-light.

### `models.py`
- **`Aircraft.effective_turn_radius_m()`** — `0.0` for `always_cart`, else delegates to `required_turn_radius_m()`. The accessor the Dubins planner consumes; never raises (cf. `required_turn_radius_m`, which does).

## Test plan
- `tests/test_models.py` — 3 accessor tests (cart → 0.0; own-gear & cart-eligible → delegate).
- `tests/test_towplanner.py` — 5 dataclass tests (`from_placement` drop, frozen via `FrozenInstanceError`, `length_m` sum, bad-`kind` rejection, `MovesPlan` round-trip).
- Full suite: **439 passed**; `ruff check` + `ruff format --check` clean; `mypy` clean.

Built test-first (RED→GREEN per the plan's TDD steps).

Closes #188
