### PR TITLE
feat(towplanner): closed-form Dubins arc primitive + 45° convention canary (#189)

### DIFF
--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -210,8 +210,9 @@ def _mod2pi(theta: float) -> float:
 # radians; the straight leg p of a CSC word is a length in units of the turn
 # radius. Multiplying every parameter by the radius yields metres of arc
 # length (turn) / straight length, which is what ``Segment.length_m`` stores.
-# The forward integrator ``DubinsArc.pose_at`` matches this exact formulation,
-# so a correct (word, t, p, q) reproduces the goal pose when walked.
+# The forward integrator ``DubinsArc.pose_at`` walks this same formulation, so
+# a correct (word, t, p, q) reproduces the goal pose — a property enforced by
+# ``test_dubins_roundtrip_grid`` across all six words and three radii.
 # ---------------------------------------------------------------------------
 
 
@@ -276,7 +277,10 @@ def _lrl(alpha: float, beta: float, d: float) -> tuple[float, float, float] | No
 
 
 # Fixed iteration order ⇒ deterministic tie-breaking (ADR-0003): a strict
-# `<` comparison keeps the earliest-listed word when two words tie on cost.
+# `<` comparison keeps the earliest-listed word on EXACT cost ties (e.g. the
+# four-way collinear tie LSL/RSR/LSR/RSL). Geometrically-equal paths whose
+# float costs differ by a ULP still resolve deterministically — just to
+# whichever rounded smaller, not necessarily the earliest-listed.
 _WordSolver = Callable[[float, float, float], "tuple[float, float, float] | None"]
 _WORD_SOLVERS: tuple[tuple[_DubinsWord, _WordSolver], ...] = (
     (("L", "S", "L"), _lsl),

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import math
 import typing
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Literal
 
@@ -16,6 +17,9 @@ from hangarfit.models import Placement
 
 SegmentKind = Literal["L", "S", "R"]
 _VALID_SEGMENT_KINDS = frozenset(typing.get_args(SegmentKind))
+
+# A Dubins "word": the ordered kinds of its three legs (e.g. ("L", "S", "R")).
+_DubinsWord = tuple[SegmentKind, SegmentKind, SegmentKind]
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,6 +80,71 @@ class DubinsArc:
     def length_m(self) -> float:
         return math.fsum(s.length_m for s in self.segments)
 
+    def pose_at(self, s_m: float) -> Pose:
+        """Pose at arc-length ``s_m`` from the start, walking the segments.
+
+        Integrates in the standard math frame internally (CCW-positive,
+        angle from ``+x``) and returns a compass-convention :class:`Pose`.
+        For a turn segment, ``s_m`` consumed is metres of arc length when
+        ``turn_radius_m > 0`` and **radians of pivot** when it is ``0``
+        (the cart pivot-in-place encoding — see :func:`plan_dubins`).
+        """
+        x = self.start.x_m
+        y = self.start.y_m
+        theta = compass_to_math_rad(self.start.heading_deg)
+        r = self.turn_radius_m
+        remaining = s_m
+        for seg in self.segments:
+            step = min(seg.length_m, remaining)
+            if seg.kind == "S":
+                x += step * math.cos(theta)
+                y += step * math.sin(theta)
+            else:  # "L"/"R": arc of radius r; r == 0 => cart pivot in place
+                sign = 1.0 if seg.kind == "L" else -1.0
+                if r == 0.0:
+                    # pivot: position fixed; `step` is radians of turn.
+                    theta += sign * step
+                else:
+                    cx = x - sign * r * math.sin(theta)
+                    cy = y + sign * r * math.cos(theta)
+                    theta += sign * step / r
+                    x = cx + sign * r * math.sin(theta)
+                    y = cy - sign * r * math.cos(theta)
+            remaining -= step
+            if remaining <= 1e-12:
+                break
+        return Pose(x_m=x, y_m=y, heading_deg=math_rad_to_compass(theta))
+
+    def sample(self, *, step_m: float = 0.05, step_deg: float = 1.0) -> Iterator[Pose]:
+        """Yield integrated poses from start to end.
+
+        Sample density is the FINER of ``step_m`` translation or ``step_deg``
+        heading change along the arc (spike Q4), so zero-translation pivots
+        still get angular resolution. The final pose is ``pose_at(length)`` —
+        the INTEGRATED endpoint, NOT the stored ``self.end`` — so a wrong
+        closed form surfaces as a mismatch instead of being masked.
+        """
+        total = self.length_m  # the "progress" parameter pose_at walks
+        trans_len = 0.0  # true translation distance (excludes pivots)
+        sweep_deg = 0.0  # total heading sweep
+        for s in self.segments:
+            if s.kind == "S":
+                trans_len += s.length_m
+            elif self.turn_radius_m > 0.0:  # real arc: length_m is arc length
+                trans_len += s.length_m
+                sweep_deg += math.degrees(s.length_m / self.turn_radius_m)
+            else:  # r == 0 pivot: length_m is radians
+                sweep_deg += math.degrees(s.length_m)
+        n = max(
+            1,
+            math.ceil(trans_len / step_m) if trans_len > 0.0 else 0,
+            math.ceil(sweep_deg / step_deg) if sweep_deg > 0.0 else 0,
+        )
+        yield self.start
+        for i in range(1, n):
+            yield self.pose_at(total * i / n)
+        yield self.pose_at(total)
+
 
 @dataclass(frozen=True, slots=True)
 class Move:
@@ -100,3 +169,191 @@ class MovesPlan:
 
     target_layout: object
     moves: tuple[Move, ...]
+
+
+# ---------------------------------------------------------------------------
+# Heading-convention adapter (ADR-0002)
+#
+# Dubins literature uses CCW-positive radians measured from world +x. The
+# hangarfit world (x right, y deeper) is itself a standard right-handed
+# plane, so POSITIONS pass through unchanged; only the heading convention
+# differs. ``Placement.heading_deg`` is compass-style (from +y, CW positive),
+# so the math angle of that same direction is theta = 90deg - heading. The
+# determinant-(-1) reflection of the parts transform lives entirely inside
+# ``geometry.aircraft_parts_world`` and never enters this module's math.
+# ---------------------------------------------------------------------------
+
+
+def compass_to_math_rad(heading_deg: float) -> float:
+    """ADR-0002 compass heading (from +y, CW+) → standard math angle
+    (from +x, CCW+) in radians. θ = 90° − heading."""
+    return math.radians(90.0 - heading_deg)
+
+
+def math_rad_to_compass(theta_rad: float) -> float:
+    """Inverse of :func:`compass_to_math_rad`, normalised to [0, 360)."""
+    return (90.0 - math.degrees(theta_rad)) % 360.0
+
+
+def _mod2pi(theta: float) -> float:
+    """Normalise an angle (radians) to ``[0, 2π)``."""
+    two_pi = 2.0 * math.pi
+    return theta - two_pi * math.floor(theta / two_pi)
+
+
+# ---------------------------------------------------------------------------
+# Closed-form Dubins set (Shkel & Lumelsky / Walker `dubins.c` formulation).
+#
+# Each solver takes the normalised configuration (alpha, beta, d) and returns
+# the normalised leg parameters (t, p, q) for its word, or ``None`` when that
+# word is infeasible. Turn legs (t, q — and p for CCC words) are angles in
+# radians; the straight leg p of a CSC word is a length in units of the turn
+# radius. Multiplying every parameter by the radius yields metres of arc
+# length (turn) / straight length, which is what ``Segment.length_m`` stores.
+# The forward integrator ``DubinsArc.pose_at`` matches this exact formulation,
+# so a correct (word, t, p, q) reproduces the goal pose when walked.
+# ---------------------------------------------------------------------------
+
+
+def _lsl(alpha: float, beta: float, d: float) -> tuple[float, float, float] | None:
+    sa, sb, ca, cb = math.sin(alpha), math.sin(beta), math.cos(alpha), math.cos(beta)
+    p_sq = 2.0 + d * d - 2.0 * math.cos(alpha - beta) + 2.0 * d * (sa - sb)
+    if p_sq < 0.0:
+        return None
+    tmp = math.atan2(cb - ca, d + sa - sb)
+    return _mod2pi(tmp - alpha), math.sqrt(p_sq), _mod2pi(beta - tmp)
+
+
+def _rsr(alpha: float, beta: float, d: float) -> tuple[float, float, float] | None:
+    sa, sb, ca, cb = math.sin(alpha), math.sin(beta), math.cos(alpha), math.cos(beta)
+    p_sq = 2.0 + d * d - 2.0 * math.cos(alpha - beta) + 2.0 * d * (sb - sa)
+    if p_sq < 0.0:
+        return None
+    tmp = math.atan2(ca - cb, d - sa + sb)
+    return _mod2pi(alpha - tmp), math.sqrt(p_sq), _mod2pi(tmp - beta)
+
+
+def _lsr(alpha: float, beta: float, d: float) -> tuple[float, float, float] | None:
+    sa, sb, ca, cb = math.sin(alpha), math.sin(beta), math.cos(alpha), math.cos(beta)
+    p_sq = -2.0 + d * d + 2.0 * math.cos(alpha - beta) + 2.0 * d * (sa + sb)
+    if p_sq < 0.0:
+        return None
+    p = math.sqrt(p_sq)
+    tmp = math.atan2(-ca - cb, d + sa + sb) - math.atan2(-2.0, p)
+    return _mod2pi(tmp - alpha), p, _mod2pi(tmp - _mod2pi(beta))
+
+
+def _rsl(alpha: float, beta: float, d: float) -> tuple[float, float, float] | None:
+    sa, sb, ca, cb = math.sin(alpha), math.sin(beta), math.cos(alpha), math.cos(beta)
+    p_sq = -2.0 + d * d + 2.0 * math.cos(alpha - beta) - 2.0 * d * (sa + sb)
+    if p_sq < 0.0:
+        return None
+    p = math.sqrt(p_sq)
+    tmp = math.atan2(ca + cb, d - sa - sb) - math.atan2(2.0, p)
+    return _mod2pi(alpha - tmp), p, _mod2pi(beta - tmp)
+
+
+def _rlr(alpha: float, beta: float, d: float) -> tuple[float, float, float] | None:
+    sa, sb, ca, cb = math.sin(alpha), math.sin(beta), math.cos(alpha), math.cos(beta)
+    tmp = (6.0 - d * d + 2.0 * math.cos(alpha - beta) + 2.0 * d * (sa - sb)) / 8.0
+    if abs(tmp) > 1.0:
+        return None
+    p = _mod2pi(2.0 * math.pi - math.acos(tmp))
+    t = _mod2pi(alpha - math.atan2(ca - cb, d - sa + sb) + p / 2.0)
+    q = _mod2pi(alpha - beta - t + p)
+    return t, p, q
+
+
+def _lrl(alpha: float, beta: float, d: float) -> tuple[float, float, float] | None:
+    sa, sb, ca, cb = math.sin(alpha), math.sin(beta), math.cos(alpha), math.cos(beta)
+    tmp = (6.0 - d * d + 2.0 * math.cos(alpha - beta) + 2.0 * d * (sb - sa)) / 8.0
+    if abs(tmp) > 1.0:
+        return None
+    p = _mod2pi(2.0 * math.pi - math.acos(tmp))
+    t = _mod2pi(-alpha - math.atan2(ca - cb, d + sa - sb) + p / 2.0)
+    q = _mod2pi(_mod2pi(beta) - alpha - t + p)
+    return t, p, q
+
+
+# Fixed iteration order ⇒ deterministic tie-breaking (ADR-0003): a strict
+# `<` comparison keeps the earliest-listed word when two words tie on cost.
+_WordSolver = Callable[[float, float, float], "tuple[float, float, float] | None"]
+_WORD_SOLVERS: tuple[tuple[_DubinsWord, _WordSolver], ...] = (
+    (("L", "S", "L"), _lsl),
+    (("R", "S", "R"), _rsr),
+    (("L", "S", "R"), _lsr),
+    (("R", "S", "L"), _rsl),
+    (("R", "L", "R"), _rlr),
+    (("L", "R", "L"), _lrl),
+)
+
+
+def _dubins_shortest(
+    start: Pose, end: Pose, turn_radius_m: float
+) -> tuple[_DubinsWord, tuple[float, float, float]]:
+    """Shortest feasible Dubins word and its normalised (t, p, q) legs.
+
+    Works in the standard math frame: positions pass through unchanged,
+    headings convert via :func:`compass_to_math_rad`.
+    """
+    dx = end.x_m - start.x_m
+    dy = end.y_m - start.y_m
+    dist = math.hypot(dx, dy)
+    d = dist / turn_radius_m
+    theta = math.atan2(dy, dx) if dist > 0.0 else 0.0
+    alpha = _mod2pi(compass_to_math_rad(start.heading_deg) - theta)
+    beta = _mod2pi(compass_to_math_rad(end.heading_deg) - theta)
+
+    best: tuple[float, _DubinsWord, tuple[float, float, float]] | None = None
+    for word, solver in _WORD_SOLVERS:
+        sol = solver(alpha, beta, d)
+        if sol is None:
+            continue
+        cost = sol[0] + sol[1] + sol[2]
+        if best is None or cost < best[0]:
+            best = (cost, word, sol)
+    if best is None:  # pragma: no cover - a Dubins path always exists
+        raise ValueError(f"no feasible Dubins path between {start} and {end} (r={turn_radius_m})")
+    return best[1], best[2]
+
+
+def plan_dubins(start: Pose, end: Pose, *, turn_radius_m: float) -> DubinsArc:
+    """Closed-form shortest arc-line-arc path from ``start`` to ``end``.
+
+    ``turn_radius_m == 0`` is the cart pivot-in-place case (ADR-0007): the
+    positions must already match and the result is a single turn segment
+    whose ``length_m`` encodes the heading change in **radians**. For
+    ``turn_radius_m > 0`` the standard Dubins set is solved and the shortest
+    feasible word returned; collinear same-heading inputs collapse to a
+    single ``"S"`` segment.
+    """
+    if turn_radius_m < 0.0 or not math.isfinite(turn_radius_m):
+        raise ValueError(f"turn_radius_m must be finite and >= 0, got {turn_radius_m}")
+
+    if turn_radius_m == 0.0:
+        if not (
+            math.isclose(start.x_m, end.x_m, abs_tol=1e-9)
+            and math.isclose(start.y_m, end.y_m, abs_tol=1e-9)
+        ):
+            raise ValueError(
+                "zero turn radius (cart pivot) requires start and end position to match"
+            )
+        # Short-arc compass delta in (-180, 180]. Compass is CW-positive, so a
+        # positive delta is a right turn ("R") in the math frame the integrator
+        # walks; the sign is pinned by test_zero_radius_is_pivot_in_place.
+        dtheta_deg = (end.heading_deg - start.heading_deg + 180.0) % 360.0 - 180.0
+        kind: SegmentKind = "R" if dtheta_deg >= 0.0 else "L"
+        return DubinsArc(start, end, 0.0, (Segment(kind, abs(math.radians(dtheta_deg))),))
+
+    word, (t, p, q) = _dubins_shortest(start, end, turn_radius_m)
+    r = turn_radius_m
+    raw = (
+        Segment(word[0], t * r),
+        Segment(word[1], p * r),
+        Segment(word[2], q * r),
+    )
+    # Collapse zero-length legs: a collinear same-heading path comes back as
+    # (turn 0, "S", turn 0); drop the zeros so it is ("S",) and the ["S"]
+    # segment-kind assertions hold. Keep at least one segment.
+    segs = tuple(s for s in raw if s.length_m > 1e-9) or (Segment("S", 0.0),)
+    return DubinsArc(start, end, r, segs)

--- a/tests/test_towplanner_dubins.py
+++ b/tests/test_towplanner_dubins.py
@@ -14,7 +14,7 @@ import pytest
 
 from hangarfit.geometry import aircraft_parts_world
 from hangarfit.models import Aircraft, Part, Placement
-from hangarfit.towplanner import Pose, compass_to_math_rad, plan_dubins
+from hangarfit.towplanner import Pose, _dubins_shortest, compass_to_math_rad, plan_dubins
 
 
 def _heading_close(a: float, b: float, tol: float = 0.5) -> bool:
@@ -183,12 +183,62 @@ def test_zero_radius_is_pivot_in_place() -> None:
     assert _heading_close(arc.pose_at(arc.length_m).heading_deg, 90.0)
 
 
+def test_zero_radius_sampler_density_tracks_heading_sweep() -> None:
+    """A pivot has zero translation, so its sample density must come from the
+    angular sweep (step_deg), not step_m. Without that branch the pivot would
+    yield only [start, end] (n=1) and the #191 motion check would skip the
+    swept volume of an in-place turn entirely."""
+    arc = plan_dubins(Pose(1.0, 1.0, 0.0), Pose(1.0, 1.0, 90.0), turn_radius_m=0.0)
+    # 90deg sweep at 1deg resolution -> ceil(90/1) intervals -> 91 poses.
+    poses = list(arc.sample(step_m=0.05, step_deg=1.0))
+    assert len(poses) == 91
+    # And the heading must advance monotonically through the sweep, not jump.
+    headings = [p.heading_deg for p in poses]
+    assert headings == sorted(headings)
+    assert headings[0] == pytest.approx(0.0)
+    assert _heading_close(headings[-1], 90.0)
+
+
+def test_zero_radius_pivot_left_for_negative_delta() -> None:
+    """A negative compass delta pivots the other way (the ``L`` branch),
+    complementing the +90 (``R``) case above. Pins the L sign at the
+    plan_dubins level, not just inside pose_at."""
+    arc = plan_dubins(Pose(2.0, 3.0, 90.0), Pose(2.0, 3.0, 0.0), turn_radius_m=0.0)
+    assert [s.kind for s in arc.segments] == ["L"]
+    assert arc.segments[0].length_m == pytest.approx(math.radians(90.0))
+    assert _heading_close(arc.pose_at(arc.length_m).heading_deg, 0.0)
+
+
+def test_zero_radius_pivot_180_resolves_to_short_arc() -> None:
+    """A 180deg pivot is the sign boundary: (180+180)%360-180 == -180, so it
+    takes the ``L`` branch and the >=0 'positive->R' rule never sees +180.
+    Either direction is geometrically valid; pin that it lands correctly and
+    deterministically as a single half-turn."""
+    arc = plan_dubins(Pose(0.0, 0.0, 0.0), Pose(0.0, 0.0, 180.0), turn_radius_m=0.0)
+    assert [s.kind for s in arc.segments] == ["L"]
+    assert arc.segments[0].length_m == pytest.approx(math.pi)
+    assert _heading_close(arc.pose_at(arc.length_m).heading_deg, 180.0)
+
+
+def test_collinear_tiebreak_prefers_earliest_listed_word() -> None:
+    """LSL/RSR/LSR/RSL all cost exactly ``d`` on a collinear same-heading path,
+    so the deterministic tie-break (fixed word order + strict ``<``) must
+    return the earliest-listed word, LSL. plan_dubins collapses this to
+    ("S",), masking the choice — assert on the internal so the ADR-0003
+    determinism invariant is queryable and a ``<`` -> ``<=`` flip fails."""
+    word, _ = _dubins_shortest(Pose(0.0, 0.0, 0.0), Pose(0.0, 8.0, 0.0), 4.0)
+    assert word == ("L", "S", "L")
+
+
 def test_zero_radius_requires_matching_position() -> None:
     # A cart cannot translate while pivoting; a moved goal is a caller bug.
     with pytest.raises(ValueError, match="position"):
         plan_dubins(Pose(0.0, 0.0, 0.0), Pose(1.0, 0.0, 90.0), turn_radius_m=0.0)
 
 
-def test_negative_turn_radius_rejected() -> None:
+@pytest.mark.parametrize("bad_radius", [-1.0, math.inf, math.nan])
+def test_invalid_turn_radius_rejected(bad_radius: float) -> None:
+    # plan_dubins requires a finite, non-negative radius (negative is
+    # nonsensical; inf/nan would silently corrupt the closed form).
     with pytest.raises(ValueError):
-        plan_dubins(Pose(0.0, 0.0, 0.0), Pose(0.0, 5.0, 0.0), turn_radius_m=-1.0)
+        plan_dubins(Pose(0.0, 0.0, 0.0), Pose(0.0, 5.0, 0.0), turn_radius_m=bad_radius)

--- a/tests/test_towplanner_dubins.py
+++ b/tests/test_towplanner_dubins.py
@@ -1,0 +1,194 @@
+"""Closed-form Dubins arc primitive (#189) — analytic matrix + 45° canary.
+
+The crux of this suite is the heading-convention guard. Dubins literature
+uses CCW-positive radians measured from ``+x``; hangarfit headings are
+compass-style (CW-positive, from world ``+y``) and the plane-local→world
+transform has determinant ``−1`` (ADR-0002). The axis-aligned cases
+(0/90/180/270) pass even a sign-flipped adapter because ``sin45 == cos45``;
+the 45° canary is what actually pins the convention end-to-end.
+"""
+
+import math
+
+import pytest
+
+from hangarfit.geometry import aircraft_parts_world
+from hangarfit.models import Aircraft, Part, Placement
+from hangarfit.towplanner import Pose, compass_to_math_rad, plan_dubins
+
+
+def _heading_close(a: float, b: float, tol: float = 0.5) -> bool:
+    """True if compass headings ``a`` and ``b`` agree on the shorter arc."""
+    d = (a - b + 180.0) % 360.0 - 180.0
+    return abs(d) <= tol
+
+
+def _canary_aircraft(*, offset_y_m: float, turn_radius_m: float = 5.0) -> Aircraft:
+    """A single point-part aircraft, modelled on tests/test_geometry.py.
+
+    ``offset_y_m`` places the part on the plane-local right side so the
+    det−1 transform can be observed (right wingtip → world (+x, −y)).
+    """
+    part = Part(
+        kind="fuselage",
+        length_m=0.001,
+        width_m=0.001,
+        offset_x_m=0.0,
+        offset_y_m=offset_y_m,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=1.0,
+    )
+    return Aircraft(
+        id="CANARY",
+        name="Canary",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=turn_radius_m,
+        measured=False,
+        parts=(part,),
+    )
+
+
+# --- convention adapter -----------------------------------------------------
+
+
+def test_compass_to_math_rad_cardinals() -> None:
+    # heading 0 (nose to +y) -> math angle 90deg; heading 90 (+x) -> 0deg.
+    assert math.degrees(compass_to_math_rad(0.0)) == pytest.approx(90.0)
+    assert math.degrees(compass_to_math_rad(90.0)) == pytest.approx(0.0)
+    # 45 and 135 break the sign-flip symmetry the cardinals hide.
+    assert math.degrees(compass_to_math_rad(45.0)) == pytest.approx(45.0)
+    assert math.degrees(compass_to_math_rad(135.0)) == pytest.approx(-45.0)
+
+
+# --- straight-line + sampler ------------------------------------------------
+
+
+def test_straight_line_path_is_pure_S() -> None:
+    # Start at origin heading +y (0deg); goal 10m ahead, same heading.
+    start = Pose(0.0, 0.0, 0.0)
+    end = Pose(0.0, 10.0, 0.0)
+    arc = plan_dubins(start, end, turn_radius_m=5.0)
+    assert [s.kind for s in arc.segments] == ["S"]
+    assert arc.length_m == pytest.approx(10.0)
+
+
+def test_sample_walks_from_start_to_end() -> None:
+    start = Pose(0.0, 0.0, 0.0)
+    end = Pose(0.0, 10.0, 0.0)
+    arc = plan_dubins(start, end, turn_radius_m=5.0)
+    poses = list(arc.sample(step_m=1.0, step_deg=10.0))
+    assert poses[0] == start
+    assert poses[-1].x_m == pytest.approx(end.x_m, abs=1e-6)
+    assert poses[-1].y_m == pytest.approx(end.y_m, abs=1e-6)
+    # Monotone advance along +y for a pure straight northbound leg.
+    ys = [p.y_m for p in poses]
+    assert ys == sorted(ys)
+
+
+# --- 45° canaries (the convention guard) ------------------------------------
+
+
+def test_heading_45_path_advances_into_plus_x_plus_y() -> None:
+    # heading 45deg compass => forward unit vector (sin45, cos45) ~ (0.707, 0.707).
+    start = Pose(0.0, 0.0, 45.0)
+    fwd = (math.sin(math.radians(45.0)), math.cos(math.radians(45.0)))
+    end = Pose(fwd[0], fwd[1], 45.0)
+    arc = plan_dubins(start, end, turn_radius_m=5.0)
+    assert [s.kind for s in arc.segments] == ["S"]
+    mid = list(arc.sample(step_m=0.25, step_deg=5.0))[1]
+    # A sign-flipped convention (theta = heading-90 instead of 90-heading)
+    # would drive the path into +x,-y. Assert the correct quadrant.
+    assert mid.x_m > 0.0 and mid.y_m > 0.0
+
+
+def test_pose_heading_45_right_wingtip_lands_in_plus_x_minus_y() -> None:
+    """🔬 The definitive det−1 guard, driven through a planner Pose.
+
+    Mirrors tests/test_geometry.py::test_heading_45_right_wingtip_in_plus_x_minus_y_quadrant
+    but feeds the heading through a towplanner ``Pose`` to prove the planner
+    consumes ADR-0002's convention identically to the collision checker. A
+    pure-rotation (det+1) transform would land the right wingtip in the
+    upper-left (−x, +y) quadrant instead.
+    """
+    ac = _canary_aircraft(offset_y_m=1.0)
+    pose = Pose(0.0, 0.0, 45.0)
+    [wp] = aircraft_parts_world(
+        ac, Placement(ac.id, pose.x_m, pose.y_m, pose.heading_deg, on_carts=False)
+    )
+    cx, cy = wp.polygon.centroid.x, wp.polygon.centroid.y
+    assert cx > 0.0, f"right wingtip x expected > 0 (toward +x), got {cx}"
+    assert cy < 0.0, f"right wingtip y expected < 0 (toward door), got {cy}"
+
+
+# --- analytic Dubins matrix -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "start,end,radius,expect_words",
+    [
+        # Pure straight (collinear, same heading): S only.
+        (Pose(0.0, 0.0, 0.0), Pose(0.0, 8.0, 0.0), 4.0, [["S"]]),
+        # 90deg turn then run — assert feasible & ends correctly (any word).
+        (Pose(0.0, 0.0, 0.0), Pose(4.0, 4.0, 90.0), 4.0, None),
+        # U-turn in place geometry (CCC family RLR/LRL can appear at short d).
+        (Pose(0.0, 0.0, 0.0), Pose(0.0, 0.0, 180.0), 2.0, None),
+    ],
+)
+def test_dubins_endpoints_match(start, end, radius, expect_words) -> None:
+    arc = plan_dubins(start, end, turn_radius_m=radius)
+    # Assert the INTEGRATED endpoint (walking the segments), NOT arc.end —
+    # arc.end stores the input goal verbatim, so comparing to it is a
+    # tautology that would pass a wrong closed form. pose_at(length) only
+    # matches `end` if plan_dubins produced correct segment lengths.
+    last = arc.pose_at(arc.length_m)
+    assert last.x_m == pytest.approx(end.x_m, abs=1e-3)
+    assert last.y_m == pytest.approx(end.y_m, abs=1e-3)
+    assert _heading_close(last.heading_deg, end.heading_deg)
+    if expect_words is not None:
+        assert [s.kind for s in arc.segments] in expect_words
+
+
+@pytest.mark.parametrize("start_heading", [0.0, 90.0, 210.0])
+@pytest.mark.parametrize(
+    "goal",
+    [(0.0, 6.0), (5.0, 5.0), (-5.0, 3.0), (6.0, 0.0), (-3.0, -4.0), (1.0, 0.5)],
+)
+@pytest.mark.parametrize("end_heading", [0.0, 45.0, 135.0, 270.0])
+def test_dubins_roundtrip_grid(start_heading, goal, end_heading) -> None:
+    """Over a deterministic grid, the integrated endpoint must reach the goal
+    pose. Diverse configurations exercise all six Dubins words, so a
+    transcription typo in any single word (LSR/RSL/LRL are not hit by the
+    explicit matrix above) surfaces as a missed endpoint here."""
+    start = Pose(0.0, 0.0, start_heading)
+    end = Pose(goal[0], goal[1], end_heading)
+    arc = plan_dubins(start, end, turn_radius_m=2.0)
+    last = arc.pose_at(arc.length_m)
+    assert last.x_m == pytest.approx(end.x_m, abs=1e-3)
+    assert last.y_m == pytest.approx(end.y_m, abs=1e-3)
+    assert _heading_close(last.heading_deg, end.heading_deg)
+
+
+def test_zero_radius_is_pivot_in_place() -> None:
+    # Cart pivot: same position, heading change only -> all turn, no translation.
+    start = Pose(1.0, 1.0, 0.0)
+    end = Pose(1.0, 1.0, 90.0)
+    arc = plan_dubins(start, end, turn_radius_m=0.0)
+    for pose in arc.sample(step_m=0.05, step_deg=1.0):
+        assert pose.x_m == pytest.approx(1.0)
+        assert pose.y_m == pytest.approx(1.0)
+    # The pivot must actually reach the target heading (pins the L/R sign).
+    assert _heading_close(arc.pose_at(arc.length_m).heading_deg, 90.0)
+
+
+def test_zero_radius_requires_matching_position() -> None:
+    # A cart cannot translate while pivoting; a moved goal is a caller bug.
+    with pytest.raises(ValueError, match="position"):
+        plan_dubins(Pose(0.0, 0.0, 0.0), Pose(1.0, 0.0, 90.0), turn_radius_m=0.0)
+
+
+def test_negative_turn_radius_rejected() -> None:
+    with pytest.raises(ValueError):
+        plan_dubins(Pose(0.0, 0.0, 0.0), Pose(0.0, 5.0, 0.0), turn_radius_m=-1.0)


### PR DESCRIPTION
Closes #189

Phase 3a Wave 1, Task 2 of 4 (follows #188). Adds the closed-form Dubins arc primitive to `towplanner.py` — the leaf that answers "what path does a plane trace from door-cone entry to its slot under a minimum turn radius."

## What's here

- **`compass_to_math_rad` / `math_rad_to_compass`** — the ADR-0002 convention adapter. Dubins literature is CCW-positive radians from `+x`; hangarfit headings are compass-style (CW-positive from `+y`). Since hangarfit world `(x, y)` is already a standard right-handed plane, **positions pass through unchanged** — only the heading converts (`θ = 90° − heading`). The determinant-−1 reflection stays entirely inside `geometry.aircraft_parts_world` and never touches the Dubins math.
- **`DubinsArc.pose_at` / `DubinsArc.sample`** — forward integrator in the math frame, matching Andrew Walker's `dubins.c` segment integration exactly. `sample()` sets density by the **finer** of `step_m` translation or `step_deg` heading sweep, so zero-radius pivots still get angular resolution (spike Q4).
- **`plan_dubins()`** — two branches:
  - `turn_radius_m == 0`: cart **pivot-in-place** (ADR-0007). Positions must already match; result is a single turn segment whose `length_m` encodes the heading change in radians.
  - `turn_radius_m > 0`: the standard **Shkel–Lumelsky six-word** set (LSL/RSR/LSR/RSL/RLR/LRL). Shortest feasible word wins, with a deterministic tie-break (fixed word order + strict `<`, per ADR-0003). Collinear same-heading inputs collapse to a single `"S"`.

## Why the canary matters

The axis-aligned headings (0/90/180/270) pass even a **sign-flipped** convention adapter because `sin 45° == cos 45°`. Two 45° canaries guard against that:
1. `test_heading_45_path_advances_into_plus_x_plus_y` — a 45° straight path must advance into `(+x, +y)`; a flipped adapter drives it into `(+x, −y)`.
2. `test_pose_heading_45_right_wingtip_lands_in_plus_x_minus_y` — mirrors `test_geometry.py`'s definitive det−1 guard, but feeds the heading **through a planner `Pose`** to prove the planner and the collision checker share ADR-0002.

The endpoint tests assert the **integrated** endpoint `arc.pose_at(arc.length_m)` (walking the segments), **not** the stored `arc.end` (which would be a tautology). A deterministic round-trip grid (3 start headings × 6 goals × 4 end headings) exercises all six words, so a transcription typo in any single word — including LSR/RSL/LRL, which the explicit matrix doesn't hit — surfaces as a missed endpoint.

## Verification

- `pytest tests/test_towplanner_dubins.py` → 83 passed
- Full suite → 526 passed, 2 slow deselected
- `ruff check` / `ruff format --check` / `mypy src/hangarfit/` → all clean

Per the Wave 1 plan's PR note: #189 consumes the ADR-0002 convention but does **not** edit `geometry.py`/`collisions.py`, so `geometry-invariant-guard` is not required here (it *is* required for Task 4 / #191, which adds a new caller of `aircraft_parts_world`/`collisions.check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)