### PR TITLE
feat(towplanner): deterministic greedy back-first ordering (#190)

### DIFF
--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -361,3 +361,16 @@ def plan_dubins(start: Pose, end: Pose, *, turn_radius_m: float) -> DubinsArc:
     # segment-kind assertions hold. Keep at least one segment.
     segs = tuple(s for s in raw if s.length_m > 1e-9) or (Segment("S", 0.0),)
     return DubinsArc(start, end, r, segs)
+
+
+# ---------------------------------------------------------------------------
+# Entry ordering (spike Q2)
+# ---------------------------------------------------------------------------
+
+
+def back_first_order(placements: tuple[Placement, ...]) -> tuple[Placement, ...]:
+    """Deepest target slot first. Deterministic total order: ``y`` descending,
+    then ``x`` ascending, then ``plane_id`` ascending (ADR-0003 determinism;
+    spike Q2). Shallower slots become obstacles for deeper ones, so deeper
+    planes enter first."""
+    return tuple(sorted(placements, key=lambda p: (-p.y_m, p.x_m, p.plane_id)))

--- a/tests/test_towplanner.py
+++ b/tests/test_towplanner.py
@@ -4,7 +4,14 @@ import math
 import pytest
 
 from hangarfit.models import Placement
-from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+from hangarfit.towplanner import (
+    DubinsArc,
+    Move,
+    MovesPlan,
+    Pose,
+    Segment,
+    back_first_order,
+)
 
 
 def test_pose_from_placement_drops_identity_and_cart_state():
@@ -98,3 +105,29 @@ def test_movesplan_construction_roundtrip():
     plan = MovesPlan(target_layout=layout, moves=(move,))
     assert plan.moves[0].plane_id == "DG-ABC"
     assert plan.moves[0].path.end == plan.moves[0].target_slot
+
+
+def _pl(pid: str, x: float, y: float) -> Placement:
+    return Placement(plane_id=pid, x_m=x, y_m=y, heading_deg=0.0, on_carts=False)
+
+
+def test_back_first_orders_deepest_y_first():
+    placements = (_pl("A", 0.0, 1.0), _pl("B", 0.0, 9.0), _pl("C", 0.0, 5.0))
+    assert [p.plane_id for p in back_first_order(placements)] == ["B", "C", "A"]
+
+
+def test_back_first_tiebreak_is_x_asc_then_plane_id():
+    placements = (
+        _pl("Z", 3.0, 5.0),
+        _pl("A", 3.0, 5.0),  # same y, same x as Z -> plane_id breaks tie
+        _pl("M", 1.0, 5.0),  # same y, smaller x -> first among the y=5 group
+    )
+    assert [p.plane_id for p in back_first_order(placements)] == ["M", "A", "Z"]
+
+
+def test_back_first_is_pure_and_deterministic():
+    placements = (_pl("A", 0.0, 1.0), _pl("B", 0.0, 9.0))
+    once = back_first_order(placements)
+    twice = back_first_order(placements)
+    assert once == twice
+    assert placements == (_pl("A", 0.0, 1.0), _pl("B", 0.0, 9.0))  # input untouched

--- a/tests/test_towplanner.py
+++ b/tests/test_towplanner.py
@@ -131,3 +131,13 @@ def test_back_first_is_pure_and_deterministic():
     twice = back_first_order(placements)
     assert once == twice
     assert placements == (_pl("A", 0.0, 1.0), _pl("B", 0.0, 9.0))  # input untouched
+    # Return type is a tuple, not the list sorted() produces — the tuple(...)
+    # wrapper is load-bearing (immutable return, matches the field type) and no
+    # other assertion would catch its removal (all project to lists).
+    assert isinstance(once, tuple)
+
+
+def test_back_first_empty_input_returns_empty_tuple():
+    # An all-away / maintenance-occupant-only layout has zero placements; the
+    # planner must hand that through cleanly (Layout permits zero placements).
+    assert back_first_order(()) == ()


### PR DESCRIPTION
## What

Adds `back_first_order()` to `towplanner.py` — the third Wave 1 primitive of the Phase 3a tow-path planner.

```python
def back_first_order(placements: tuple[Placement, ...]) -> tuple[Placement, ...]:
    return tuple(sorted(placements, key=lambda p: (-p.y_m, p.x_m, p.plane_id)))
```

## Why

The planner enters planes one at a time; each placed plane becomes an obstacle for the ones still to come. So the **deepest** target slot (largest `y`, deeper into the hangar) must be filled **first**, before shallower slots can block the corridor to it (spike Q2).

The sort key is a **total order**, which matters for the ADR-0003 determinism contract:
- `-y_m` — the domain rule: deepest first.
- `x_m` (asc), then `plane_id` (asc) — pure tie-breaks. They carry no domain meaning; they exist solely so two planes at equal depth can never compare equal, eliminating any insertion-order / RNG dependence.

Pure function — input tuple is never mutated (`sorted` returns a new list; we re-tuple it).

## Tests (TDD)

`tests/test_towplanner.py`, 3 new tests:
- `test_back_first_orders_deepest_y_first` — y-descending is the primary key.
- `test_back_first_tiebreak_is_x_asc_then_plane_id` — both tie-break levels.
- `test_back_first_is_pure_and_deterministic` — idempotent + input untouched.

Full suite: **535 passed** (was 532). `ruff`, `ruff format --check`, `mypy` all clean.

## Scope notes

- No `geometry.py` / `collisions.py` edits → `geometry-invariant-guard` not required (that guard is needed for the next task, #191).
- Wave 1 leaf primitive only: no `solve` wiring, no CLI, no rendering.

Closes #190