### PR TITLE
feat(towplanner): sampled collision-during-motion check (#191)

### DIFF
--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -13,7 +13,8 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Literal
 
-from hangarfit.models import Placement
+from hangarfit.collisions import check as _check
+from hangarfit.models import Aircraft, Conflict, Layout, Placement
 
 SegmentKind = Literal["L", "S", "R"]
 _VALID_SEGMENT_KINDS = frozenset(typing.get_args(SegmentKind))
@@ -374,3 +375,47 @@ def back_first_order(placements: tuple[Placement, ...]) -> tuple[Placement, ...]
     spike Q2). Shallower slots become obstacles for deeper ones, so deeper
     planes enter first."""
     return tuple(sorted(placements, key=lambda p: (-p.y_m, p.x_m, p.plane_id)))
+
+
+# ---------------------------------------------------------------------------
+# Sampled collision-during-motion (spike Q4)
+# ---------------------------------------------------------------------------
+
+
+def path_first_conflict(
+    arc: DubinsArc,
+    mover: Aircraft,
+    *,
+    mover_on_carts: bool,
+    placed: Layout,
+    step_m: float = 0.05,
+    step_deg: float = 1.0,
+) -> Conflict | None:
+    """First conflict naming ``mover`` while it tows along ``arc``, else ``None``.
+
+    Samples the arc; at each pose the mover is placed at that pose and checked
+    against the already-placed ``placed`` layout via :func:`collisions.check`.
+    This reuses the static oracle wholesale, so parts-overlap, hangar-bounds,
+    and bay-intrusion are all honoured *during motion* (spike Q4) — the path
+    planner does not re-derive any geometry. ``mover_on_carts`` is constant
+    along the arc (cart state does not change mid-tow), and conflicts that do
+    not involve ``mover`` (e.g. a pre-existing clash among placed planes) are
+    skipped so the mover is never blamed for them.
+    """
+    for pose in arc.sample(step_m=step_m, step_deg=step_deg):
+        moving = Placement(mover.id, pose.x_m, pose.y_m, pose.heading_deg, on_carts=mover_on_carts)
+        # Rebuilding the Layout per sample re-runs Layout.__post_init__ (cart
+        # cap, cart↔mode consistency, unique ids). Because placed.placements ∪
+        # {mover} is a subset of a valid target layout those invariants hold;
+        # a future caller that violates them gets a real ValueError, not a
+        # suppressed one.
+        sample_layout = Layout(
+            fleet=placed.fleet,
+            hangar=placed.hangar,
+            placements=(*placed.placements, moving),
+            maintenance_plane=placed.maintenance_plane,
+        )
+        for conflict in _check(sample_layout).conflicts:
+            if mover.id in conflict.planes:
+                return conflict
+    return None

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -401,6 +401,12 @@ def path_first_conflict(
     along the arc (cart state does not change mid-tow), and conflicts that do
     not involve ``mover`` (e.g. a pre-existing clash among placed planes) are
     skipped so the mover is never blamed for them.
+
+    Precondition: ``mover.id`` must exist in ``placed.fleet`` — each per-sample
+    :class:`Layout` references it, so an unknown id raises ``ValueError`` from
+    ``Layout`` construction rather than being silently skipped. The Wave 2
+    caller (#196) builds ``placed`` from the full target fleet, which satisfies
+    this.
     """
     for pose in arc.sample(step_m=step_m, step_deg=step_deg):
         moving = Placement(mover.id, pose.x_m, pose.y_m, pose.heading_deg, on_carts=mover_on_carts)

--- a/tests/test_towplanner_motion.py
+++ b/tests/test_towplanner_motion.py
@@ -1,0 +1,120 @@
+"""Sampled collision-during-motion check (#191) — ``path_first_conflict``.
+
+``path_first_conflict`` walks a :class:`~hangarfit.towplanner.DubinsArc`,
+rebuilds the mover's :class:`~hangarfit.models.Placement` at each sampled
+pose, and runs the *same* :func:`hangarfit.collisions.check` oracle the
+static solver uses. It therefore inherits parts-overlap, hangar-bounds, and
+bay-intrusion detection for free (spike Q4); these tests pin the three
+behaviours that matter: a clear corridor returns ``None``, a path driven
+through a parked plane returns a conflict naming the mover, and a conflict
+that does not involve the mover is never attributed to it.
+
+Fixtures are module-local (mirroring the inline ``_canary_aircraft`` helper
+in ``test_towplanner_dubins.py``) rather than a shared ``conftest.py``:
+they are planner-motion-specific and have a single consumer today. The
+geometry is deliberate — each plane is one small fuselage box mounted
+*forward* of the plane origin (``offset_x_m = +length/2``) so that a
+placement at the front wall (``y = 0``, where every entry path starts)
+keeps every world vertex at ``y >= 0`` and does not trip a spurious
+``hangar_bounds`` conflict on the first sample.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.models import Aircraft, Door, Hangar, Layout, MaintenanceBay, Part, Placement
+from hangarfit.towplanner import Pose, path_first_conflict, plan_dubins
+
+
+def _box_plane(plane_id: str, *, turn_radius_m: float = 4.0) -> Aircraft:
+    """A minimal own-gear plane: one 1.0 m × 0.6 m fuselage box.
+
+    ``offset_x_m = 0.5`` puts the box's rear edge at the plane-local origin.
+    Under the heading-0 transform (``world_y = py + forward``), that keeps a
+    placement at ``y = 0`` entirely inside the hangar (``world_y ∈ [0, 1]``).
+    """
+    return Aircraft(
+        id=plane_id,
+        name=f"Plane {plane_id}",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=turn_radius_m,
+        measured=False,
+        parts=(
+            Part(
+                kind="fuselage",
+                length_m=1.0,
+                width_m=0.6,
+                offset_x_m=0.5,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.0,
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def simple_hangar() -> Hangar:
+    """A 20 m × 20 m hangar — large enough for an unobstructed x = 8 corridor."""
+    return Hangar(
+        length_m=20.0,
+        width_m=20.0,
+        door=Door(center_x_m=10.0, width_m=6.0),
+        maintenance_bay=MaintenanceBay(center_x_m=10.0, width_m=4.0, depth_m=2.0),
+        clearance_m=0.5,
+        wing_layer_clearance_m=0.5,
+    )
+
+
+@pytest.fixture
+def two_planes_fleet() -> dict[str, Aircraft]:
+    return {"A": _box_plane("A"), "B": _box_plane("B")}
+
+
+def test_clear_path_returns_none(
+    simple_hangar: Hangar, two_planes_fleet: dict[str, Aircraft]
+) -> None:
+    fleet = two_planes_fleet
+    placed = Layout(
+        fleet=fleet,
+        hangar=simple_hangar,
+        placements=(Placement("A", 2.0, 8.0, 0.0, on_carts=False),),
+    )
+    # B drives straight up the x = 8 corridor; A sits well clear at x = 2.
+    arc = plan_dubins(Pose(8.0, 0.0, 0.0), Pose(8.0, 8.0, 0.0), turn_radius_m=4.0)
+    assert path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed) is None
+
+
+def test_path_through_placed_plane_returns_conflict(
+    simple_hangar: Hangar, two_planes_fleet: dict[str, Aircraft]
+) -> None:
+    fleet = two_planes_fleet
+    # Place A squarely in B's straight-line corridor.
+    placed = Layout(
+        fleet=fleet,
+        hangar=simple_hangar,
+        placements=(Placement("A", 8.0, 4.0, 0.0, on_carts=False),),
+    )
+    arc = plan_dubins(Pose(8.0, 0.0, 0.0), Pose(8.0, 8.0, 0.0), turn_radius_m=4.0)
+    conflict = path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed)
+    assert conflict is not None
+    assert "B" in conflict.planes
+
+
+def test_conflict_only_reports_mover_involvement(
+    simple_hangar: Hangar, two_planes_fleet: dict[str, Aircraft]
+) -> None:
+    # A short hop far from A: the mover must not be blamed for anything.
+    fleet = two_planes_fleet
+    placed = Layout(
+        fleet=fleet,
+        hangar=simple_hangar,
+        placements=(Placement("A", 2.0, 8.0, 0.0, on_carts=False),),
+    )
+    arc = plan_dubins(Pose(8.0, 0.0, 0.0), Pose(8.0, 1.0, 0.0), turn_radius_m=4.0)
+    res = path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed)
+    assert res is None or "B" in res.planes

--- a/tests/test_towplanner_motion.py
+++ b/tests/test_towplanner_motion.py
@@ -4,10 +4,23 @@
 rebuilds the mover's :class:`~hangarfit.models.Placement` at each sampled
 pose, and runs the *same* :func:`hangarfit.collisions.check` oracle the
 static solver uses. It therefore inherits parts-overlap, hangar-bounds, and
-bay-intrusion detection for free (spike Q4); these tests pin the three
-behaviours that matter: a clear corridor returns ``None``, a path driven
-through a parked plane returns a conflict naming the mover, and a conflict
-that does not involve the mover is never attributed to it.
+bay-intrusion detection for free (spike Q4).
+
+These tests pin the behaviours that are unique to *motion* (the static
+oracle is already exhaustively tested in ``test_collisions.py``):
+
+- the happy path: a clear corridor → ``None``; a path through a parked
+  plane → a conflict naming the mover;
+- the mover-only filter: a pre-existing conflict among *other* placed
+  planes is never attributed to the mover;
+- each of the three oracle checks fires *during motion* —
+  ``fuselage_fuselage_overlap`` (parts), ``hangar_bounds``, and
+  ``bay_intrusion`` — each gated on motion-specific wiring (the per-sample
+  ``Placement`` heading/cart-state and the ``maintenance_plane`` thread-through);
+- a *turning* (non-axis-aligned) arc, so the sampled poses' rotated headings
+  actually reach the collision check (not only heading-0 straights);
+- the cart pivot-in-place branch (``mover_on_carts=True``, ``turn_radius=0``),
+  whose zero-translation angular sweep is sampled by ``step_deg``.
 
 Fixtures are module-local (mirroring the inline ``_canary_aircraft`` helper
 in ``test_towplanner_dubins.py``) rather than a shared ``conftest.py``:
@@ -27,13 +40,26 @@ from hangarfit.models import Aircraft, Door, Hangar, Layout, MaintenanceBay, Par
 from hangarfit.towplanner import Pose, path_first_conflict, plan_dubins
 
 
-def _box_plane(plane_id: str, *, turn_radius_m: float = 4.0) -> Aircraft:
-    """A minimal own-gear plane: one 1.0 m × 0.6 m fuselage box.
+def _fuselage_box() -> Part:
+    """A 1.0 m × 0.6 m fuselage box with its rear edge at the plane origin.
 
-    ``offset_x_m = 0.5`` puts the box's rear edge at the plane-local origin.
-    Under the heading-0 transform (``world_y = py + forward``), that keeps a
-    placement at ``y = 0`` entirely inside the hangar (``world_y ∈ [0, 1]``).
-    """
+    Mounting it forward (``offset_x_m = 0.5``) means the heading-0 transform
+    (``world_y = py + forward``) keeps a placement at ``y = 0`` inside the
+    hangar (``world_y ∈ [0, 1]``)."""
+    return Part(
+        kind="fuselage",
+        length_m=1.0,
+        width_m=0.6,
+        offset_x_m=0.5,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=1.0,
+    )
+
+
+def _box_plane(plane_id: str, *, turn_radius_m: float = 4.0) -> Aircraft:
+    """A minimal own-gear plane (one fuselage box)."""
     return Aircraft(
         id=plane_id,
         name=f"Plane {plane_id}",
@@ -42,24 +68,31 @@ def _box_plane(plane_id: str, *, turn_radius_m: float = 4.0) -> Aircraft:
         movement_mode="always_own_gear",
         turn_radius_m=turn_radius_m,
         measured=False,
-        parts=(
-            Part(
-                kind="fuselage",
-                length_m=1.0,
-                width_m=0.6,
-                offset_x_m=0.5,
-                offset_y_m=0.0,
-                angle_deg=0.0,
-                z_bottom_m=0.0,
-                z_top_m=1.0,
-            ),
-        ),
+        parts=(_fuselage_box(),),
+    )
+
+
+def _cart_plane(plane_id: str, *, turn_radius_m: float = 4.0) -> Aircraft:
+    """A cart-eligible plane — may ride on carts (``on_carts=True``) and so
+    can pivot in place (``effective_turn_radius_m() == 0``)."""
+    return Aircraft(
+        id=plane_id,
+        name=f"Cart plane {plane_id}",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="cart_eligible",
+        turn_radius_m=turn_radius_m,
+        measured=False,
+        parts=(_fuselage_box(),),
     )
 
 
 @pytest.fixture
 def simple_hangar() -> Hangar:
-    """A 20 m × 20 m hangar — large enough for an unobstructed x = 8 corridor."""
+    """A 20 m × 20 m hangar — large enough for an unobstructed x = 8 corridor.
+
+    The maintenance bay is the back-anchored rectangle ``x ∈ (8, 12)``,
+    ``y ∈ (18, 20]`` (centre 10, width 4, depth 2)."""
     return Hangar(
         length_m=20.0,
         width_m=20.0,
@@ -105,16 +138,106 @@ def test_path_through_placed_plane_returns_conflict(
     assert "B" in conflict.planes
 
 
-def test_conflict_only_reports_mover_involvement(
-    simple_hangar: Hangar, two_planes_fleet: dict[str, Aircraft]
-) -> None:
-    # A short hop far from A: the mover must not be blamed for anything.
-    fleet = two_planes_fleet
+def test_pre_existing_non_mover_conflict_not_attributed_to_mover(simple_hangar: Hangar) -> None:
+    # A and C already overlap EACH OTHER at x ≈ 2; the mover B tows up the
+    # far x = 8 corridor, clear of both. collisions.check reports the A–C
+    # conflict at every sample — path_first_conflict must skip it (B is not
+    # named) and return None. A regression that dropped the
+    # ``mover.id in conflict.planes`` filter would return the A–C conflict
+    # here, so this is the test that actually guards that branch.
+    fleet = {"A": _box_plane("A"), "B": _box_plane("B"), "C": _box_plane("C")}
     placed = Layout(
         fleet=fleet,
         hangar=simple_hangar,
-        placements=(Placement("A", 2.0, 8.0, 0.0, on_carts=False),),
+        placements=(
+            Placement("A", 2.0, 8.0, 0.0, on_carts=False),
+            Placement("C", 2.3, 8.0, 0.0, on_carts=False),  # overlaps A
+        ),
     )
-    arc = plan_dubins(Pose(8.0, 0.0, 0.0), Pose(8.0, 1.0, 0.0), turn_radius_m=4.0)
-    res = path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed)
-    assert res is None or "B" in res.planes
+    # Sanity: the placed layout really does contain a non-mover conflict.
+    from hangarfit.collisions import check
+
+    pre = check(placed)
+    assert not pre.valid and all("B" not in c.planes for c in pre.conflicts)
+
+    arc = plan_dubins(Pose(8.0, 0.0, 0.0), Pose(8.0, 8.0, 0.0), turn_radius_m=4.0)
+    assert path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed) is None
+
+
+def test_hangar_bounds_during_motion_names_mover(
+    simple_hangar: Hangar, two_planes_fleet: dict[str, Aircraft]
+) -> None:
+    # B is towed straight at the back wall and past it: once its nose box
+    # crosses y = 20 the bounds check fires, naming the mover.
+    fleet = two_planes_fleet
+    placed = Layout(fleet=fleet, hangar=simple_hangar, placements=())
+    arc = plan_dubins(Pose(5.0, 18.0, 0.0), Pose(5.0, 20.5, 0.0), turn_radius_m=4.0)
+    conflict = path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed)
+    assert conflict is not None
+    assert conflict.kind == "hangar_bounds"
+    assert "B" in conflict.planes
+
+
+def test_bay_intrusion_during_motion_names_mover(
+    simple_hangar: Hangar, two_planes_fleet: dict[str, Aircraft]
+) -> None:
+    # With A in maintenance (away), the back bay (y ∈ (18, 20]) is a keep-out.
+    # B is towed up x = 10 into the bay; the intrusion must name the mover.
+    # This is gated on `maintenance_plane` being threaded into the per-sample
+    # Layout — a regression dropping it would silently disable bay detection.
+    fleet = two_planes_fleet
+    placed = Layout(fleet=fleet, hangar=simple_hangar, placements=(), maintenance_plane="A")
+    arc = plan_dubins(Pose(10.0, 16.0, 0.0), Pose(10.0, 18.6, 0.0), turn_radius_m=4.0)
+    conflict = path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed)
+    assert conflict is not None
+    assert conflict.kind == "bay_intrusion"
+    assert "B" in conflict.planes
+
+
+def test_turning_arc_to_blocked_slot_names_mover(simple_hangar: Hangar) -> None:
+    # A genuinely turning arc (heading 0 → 90 with an x/y offset) ends on a
+    # parked plane. The sampled poses carry rotated headings into the per-pose
+    # Placement, so this exercises the heading→placement wiring on a non-
+    # axis-aligned path — not just the heading-0 straights above.
+    fleet = {"A": _box_plane("A"), "B": _box_plane("B")}
+    arc = plan_dubins(Pose(4.0, 2.0, 0.0), Pose(10.0, 8.0, 90.0), turn_radius_m=4.0)
+    assert [s.kind for s in arc.segments] != ["S"]  # really a turn, not a straight
+    placed = Layout(
+        fleet=fleet,
+        hangar=simple_hangar,
+        placements=(Placement("A", 10.0, 8.0, 90.0, on_carts=False),),  # B's end slot
+    )
+    conflict = path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed)
+    assert conflict is not None
+    assert conflict.kind == "fuselage_fuselage_overlap"
+    assert "B" in conflict.planes
+
+
+def test_cart_pivot_clear_returns_none(simple_hangar: Hangar) -> None:
+    # A cart-borne mover pivots in place (turn_radius 0) with no obstacle.
+    # Because nothing conflicts, sample() runs the FULL angular sweep, placing
+    # the on-carts mover at every swept heading — exercising the pivot sampler
+    # and the on_carts=True placement / cart-rule path end to end.
+    fleet = {"A": _box_plane("A"), "B": _cart_plane("B")}
+    placed = Layout(
+        fleet=fleet,
+        hangar=simple_hangar,
+        placements=(Placement("A", 2.0, 2.0, 0.0, on_carts=False),),
+    )
+    pivot = plan_dubins(Pose(10.0, 10.0, 0.0), Pose(10.0, 10.0, 90.0), turn_radius_m=0.0)
+    assert path_first_conflict(pivot, fleet["B"], mover_on_carts=True, placed=placed) is None
+
+
+def test_cart_pivot_into_neighbour_names_mover(simple_hangar: Hangar) -> None:
+    # Same cart pivot, but a neighbour sits on the pivot footprint: the
+    # on-carts mover must be named in the resulting conflict.
+    fleet = {"A": _box_plane("A"), "B": _cart_plane("B")}
+    placed = Layout(
+        fleet=fleet,
+        hangar=simple_hangar,
+        placements=(Placement("A", 10.0, 10.3, 0.0, on_carts=False),),
+    )
+    pivot = plan_dubins(Pose(10.0, 10.0, 0.0), Pose(10.0, 10.0, 90.0), turn_radius_m=0.0)
+    conflict = path_first_conflict(pivot, fleet["B"], mover_on_carts=True, placed=placed)
+    assert conflict is not None
+    assert "B" in conflict.planes


### PR DESCRIPTION
## What

Adds `path_first_conflict(arc, mover, *, mover_on_carts, placed, step_m, step_deg)` to `towplanner.py` — the **fourth and final Wave 1 primitive** of the Phase 3a tow-path planner (milestone #16).

It walks a `DubinsArc` via `DubinsArc.sample`, and at each sampled pose rebuilds the mover's `Placement` and checks it against the already-placed `Layout` using **the existing `collisions.check` oracle**. It returns the first `Conflict` that names the mover, else `None`.

Closes #191.

## Why this shape

Reusing `collisions.check` rather than re-deriving geometry means parts-overlap, hangar-bounds, **and** bay-intrusion are all honoured *during motion* for free (spike Q4). Conflicts that don't involve the mover (e.g. a pre-existing clash among placed planes) are skipped, so the mover is never blamed for them. `mover_on_carts` is constant along the arc (cart state doesn't change mid-tow).

This is a **new caller of `aircraft_parts_world` / `collisions.check`**, so per ADR-0002 / CLAUDE.md it gets the `geometry-invariant-guard` review.

## Tests

`tests/test_towplanner_motion.py` (3 tests): clear corridor → `None`; path driven through a parked plane → conflict naming the mover; a conflict not involving the mover → never attributed to it. Full suite: **539 passed**, ruff + format + mypy clean.

## Deviation from the plan (flagged for review)

The plan's Task 4 sketched the hangar/fleet fixtures in `tests/conftest.py`. I put them **module-local in `test_towplanner_motion.py`** instead, mirroring the inline `_canary_aircraft` precedent #189 set in this same test family. Rationale: they're planner-motion-specific with a single consumer today (YAGNI on a shared conftest); Wave 2 (#196/#197) can promote them if it needs the same geometry. The fixture box is mounted forward of the plane origin (`offset_x_m = +length/2`) so a placement at the front wall (`y=0`, where every entry path starts) stays in-bounds and doesn't trip a spurious `hangar_bounds` on sample 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)