### PR TITLE
feat(loader): validate plane ids at load boundary with did-you-mean suggestions

### DIFF
--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -91,6 +91,10 @@ Has tests in `tests/test_loader.py` that exercise the `struts:`
 expansion end-to-end so the YAML convenience can never silently
 desync from the canonical parts representation.
 
+Plane ids are case-sensitive; unknown/mis-cased ids are rejected at load
+time with a `did you mean…?` suggestion (see spec
+`docs/superpowers/specs/2026-05-25-loader-plane-id-validation-design.md`).
+
 For the `maintenance.plane` field, the loader raises a YAML-author-
 actionable `LoaderError` when the named occupant also appears in
 `placements`, with the hint "Remove it from placements (or fix the

--- a/docs/superpowers/plans/2026-05-25-loader-plane-id-validation.md
+++ b/docs/superpowers/plans/2026-05-25-loader-plane-id-validation.md
@@ -1,0 +1,597 @@
+# Loader plane-id validation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject unknown/mis-cased plane ids at the loader boundary with a `did you mean 'X'?` suggestion, keeping ids case-sensitive.
+
+**Architecture:** Two private helpers in `loader.py` — `_suggest_plane_id` (casefold-exact match first, then `difflib`) and `_resolve_known_plane_id` (the reject-with-hint gate) — wired into five plane-id reference sites across `load_layout` and `load_scenario`. The `Layout`/`Scenario` model invariants are kept untouched as the programmatic backstop.
+
+**Tech Stack:** Python 3.12, stdlib `difflib`, pytest. Spec: `docs/superpowers/specs/2026-05-25-loader-plane-id-validation-design.md`.
+
+**Worktree note:** This repo's editable install (`.pth`) points at a single worktree, so in any other worktree bare `pytest` imports the wrong source. **Run every test command as `PYTHONPATH=src python3 -m pytest …`** (note: `python3`, not `python`). See `feedback_editable_install_cross_worktree`.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/hangarfit/loader.py` | YAML→model adapter; error-message quality | add 2 helpers + `import difflib`/`collections.abc`; wire 5 call sites; replace the `:315` maintenance check; module-docstring note |
+| `tests/test_loader.py` | loader failure-path tests | new `TestPlaneIdSuggestion` (helper units) + `TestUnknownPlaneId` (layout integration); update `test_unknown_plane_reference_propagates` |
+| `tests/test_loader_scenario.py` | scenario loader tests | new scenario integration cases; update `test_load_scenario_rejects_maintenance_plane_not_in_fleet_in` |
+| `docs/architecture/05-building-block-view.md` | arc42 module map | one-line case-sensitivity note |
+
+---
+
+## Task 1: `_suggest_plane_id` helper
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (imports near `:20`; new function after `_extract_maintenance_plane`, ~`:438`)
+- Test: `tests/test_loader.py` (new class, append at end of file)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_loader.py`. Add `_suggest_plane_id` to the existing `from hangarfit.loader import (…)` block first.
+
+```python
+class TestPlaneIdSuggestion:
+    """Unit tests for the _suggest_plane_id near-match helper."""
+
+    def test_casefold_match_suggests_canonical_with_note(self) -> None:
+        assert _suggest_plane_id("Foo", ["foo"]) == (
+            "; did you mean 'foo'? (plane ids are case-sensitive)"
+        )
+
+    def test_all_caps_case_diff_still_suggests(self) -> None:
+        # difflib alone scores 'FOO' vs 'foo' at 0.0 (SequenceMatcher is
+        # case-sensitive); the casefold pass is what rescues this.
+        assert "did you mean 'foo'?" in _suggest_plane_id("FOO", ["foo"])
+
+    def test_typo_suggests_difflib_match(self) -> None:
+        assert _suggest_plane_id("cesna_150", ["cessna_150", "cessna_140"]) == (
+            "; did you mean 'cessna_150'?"
+        )
+
+    def test_novel_id_no_suggestion(self) -> None:
+        assert _suggest_plane_id("zzz", ["foo", "bar"]) == ""
+
+    def test_ambiguous_casefold_falls_through_to_no_suggestion(self) -> None:
+        # Two valid ids share a casefold → the casefold pass is ambiguous
+        # and is skipped; difflib finds no high-ratio match for 'FOO'.
+        assert _suggest_plane_id("FOO", ["foo", "Foo"]) == ""
+
+    def test_exact_match_returns_empty(self) -> None:
+        assert _suggest_plane_id("foo", ["foo", "bar"]) == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PYTHONPATH=src python3 -m pytest tests/test_loader.py::TestPlaneIdSuggestion -v`
+Expected: FAIL at import (`ImportError: cannot import name '_suggest_plane_id'`).
+
+- [ ] **Step 3: Add imports**
+
+In `src/hangarfit/loader.py`, change the import block near the top (currently `from pathlib import Path` / `from typing import Any`) to add:
+
+```python
+import difflib
+from collections.abc import Collection, Iterable
+from pathlib import Path
+from typing import Any
+```
+
+(Keep `import difflib` with the other stdlib imports, alphabetical; `Collection`/`Iterable` come from `collections.abc`.)
+
+- [ ] **Step 4: Implement `_suggest_plane_id`**
+
+Add immediately after the `_extract_maintenance_plane` function in `src/hangarfit/loader.py`:
+
+```python
+def _suggest_plane_id(candidate: str, valid_ids: Iterable[str]) -> str:
+    """Return a '; did you mean X?' fragment for a near-miss id, or '' if none.
+
+    Two passes, because ``difflib`` alone misses the headline case:
+    ``SequenceMatcher`` is case-sensitive, so ``'FOO'`` vs ``'foo'`` scores
+    0.0 and would yield no suggestion.
+
+    1. Case-insensitive exact match: if exactly one valid id equals the
+       candidate under ``casefold()`` (and isn't the candidate itself),
+       suggest it with the case-sensitivity note. If two valid ids share a
+       casefold (only possible for a fleet that deliberately uses
+       case-distinct ids), the pass is ambiguous and is skipped.
+    2. ``difflib.get_close_matches(n=1, cutoff=0.6)`` for genuine typos.
+    """
+    valid = list(valid_ids)
+    folded = candidate.casefold()
+    ci_matches = [v for v in valid if v.casefold() == folded and v != candidate]
+    if len(ci_matches) == 1:
+        return f"; did you mean {ci_matches[0]!r}? (plane ids are case-sensitive)"
+    close = difflib.get_close_matches(candidate, valid, n=1, cutoff=0.6)
+    if close and close[0] != candidate:
+        return f"; did you mean {close[0]!r}?"
+    return ""
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `PYTHONPATH=src python3 -m pytest tests/test_loader.py::TestPlaneIdSuggestion -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader.py
+git commit -m "feat(loader): add _suggest_plane_id near-match helper (#176)"
+```
+
+---
+
+## Task 2: `_resolve_known_plane_id` gate
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (new function after `_suggest_plane_id`)
+- Test: `tests/test_loader.py` (extend `TestPlaneIdSuggestion` or add `TestResolveKnownPlaneId`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_loader.py`. Add `_resolve_known_plane_id` to the import block.
+
+```python
+class TestResolveKnownPlaneId:
+    """Unit tests for the _resolve_known_plane_id loader gate."""
+
+    def test_known_id_does_not_raise(self) -> None:
+        # Returns None, no exception.
+        assert (
+            _resolve_known_plane_id("foo", ["foo", "bar"], role="placement", path=Path("x.yaml"))
+            is None
+        )
+
+    def test_case_mismatch_raises_with_suggestion(self) -> None:
+        with pytest.raises(LoaderError) as exc:
+            _resolve_known_plane_id("Foo", ["foo"], role="placement", path=Path("x.yaml"))
+        msg = str(exc.value)
+        assert "x.yaml" in msg
+        assert "placement references unknown plane id 'Foo'" in msg
+        assert "did you mean 'foo'?" in msg
+        assert "case-sensitive" in msg
+
+    def test_novel_id_with_fix_hint_shows_hint(self) -> None:
+        with pytest.raises(LoaderError) as exc:
+            _resolve_known_plane_id(
+                "ghost", ["foo"], role="maintenance.plane", path=Path("s.yaml"),
+                fix_hint="either add it to fleet_in ['foo'] or fix the plane id",
+            )
+        msg = str(exc.value)
+        assert "maintenance.plane references unknown plane id 'ghost'" in msg
+        assert "either add it to fleet_in ['foo'] or fix the plane id" in msg
+        assert "did you mean" not in msg
+
+    def test_novel_id_no_hint_is_bare(self) -> None:
+        with pytest.raises(LoaderError) as exc:
+            _resolve_known_plane_id("zzz", ["foo"], role="placement", path=Path("x.yaml"))
+        msg = str(exc.value)
+        assert "unknown plane id 'zzz'" in msg
+        assert "did you mean" not in msg
+        assert msg.rstrip().endswith("'zzz'")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PYTHONPATH=src python3 -m pytest tests/test_loader.py::TestResolveKnownPlaneId -v`
+Expected: FAIL at import (`cannot import name '_resolve_known_plane_id'`).
+
+- [ ] **Step 3: Implement `_resolve_known_plane_id`**
+
+Add immediately after `_suggest_plane_id` in `src/hangarfit/loader.py`:
+
+```python
+def _resolve_known_plane_id(
+    candidate: str,
+    valid_ids: Collection[str],
+    *,
+    role: str,
+    path: Path,
+    fix_hint: str = "",
+) -> None:
+    """Raise :class:`LoaderError` if ``candidate`` is not in ``valid_ids``.
+
+    The message is ``"{path}: {role} references unknown plane id
+    {candidate!r}{tail}"`` where ``tail`` is, in priority order: a
+    ``_suggest_plane_id`` fragment when there is a near match, else
+    ``"; " + fix_hint`` when ``fix_hint`` is set, else empty. A near-match
+    suggestion always wins over ``fix_hint`` — naming the likely-intended
+    id beats generic guidance.
+
+    This is an earlier, friendlier front door to the unknown-id checks in
+    ``Layout``/``Scenario.__post_init__``; those invariants are kept as the
+    backstop for callers that bypass the loader.
+    """
+    if candidate in valid_ids:
+        return
+    tail = _suggest_plane_id(candidate, valid_ids)
+    if not tail and fix_hint:
+        tail = f"; {fix_hint}"
+    raise LoaderError(f"{path}: {role} references unknown plane id {candidate!r}{tail}")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `PYTHONPATH=src python3 -m pytest tests/test_loader.py::TestResolveKnownPlaneId -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader.py
+git commit -m "feat(loader): add _resolve_known_plane_id gate (#176)"
+```
+
+---
+
+## Task 3: Wire into `load_layout` (placements + maintenance)
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (`load_layout`, after maintenance extraction ~`:210`, before the occupant check ~`:212`)
+- Test: `tests/test_loader.py` (new `TestUnknownPlaneIdLayout`; update `test_unknown_plane_reference_propagates`)
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append a class to `tests/test_loader.py`. It reuses the `_minimal_fleet_and_hangar` / `_write` helpers, which live on the test class that already holds `test_unknown_plane_reference_propagates` — copy that class's `_minimal_fleet_and_hangar` pattern, or place these methods in that same class. Standalone version using module helpers:
+
+```python
+class TestUnknownPlaneIdLayout:
+    """Loader-boundary unknown/mis-cased plane id rejection for layouts."""
+
+    def _fleet_and_hangar(self, dir_: Path) -> None:
+        _write(
+            dir_ / "fleet.yaml",
+            _minimal_aircraft_yaml("foo", movement_mode="always_own_gear", turn_radius_m=5.0),
+        )
+        _write(
+            dir_ / "hangar.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 9.0, width_m: 12.0}
+maintenance_bay: {center_x_m: 13.5, width_m: 9, depth_m: 9}
+""",
+        )
+
+    def test_miscased_placement_id_suggests_canonical(self, tmp_path: Path) -> None:
+        self._fleet_and_hangar(tmp_path)
+        layout = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: Foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+""",
+        )
+        with pytest.raises(LoaderError) as exc:
+            load_layout(layout)
+        msg = str(exc.value)
+        assert "placement references unknown plane id 'Foo'" in msg
+        assert "did you mean 'foo'?" in msg
+        assert "case-sensitive" in msg
+
+    def test_miscased_maintenance_id_suggests_canonical(self, tmp_path: Path) -> None:
+        self._fleet_and_hangar(tmp_path)
+        layout = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements: []
+maintenance: {plane: Foo}
+""",
+        )
+        with pytest.raises(LoaderError) as exc:
+            load_layout(layout)
+        msg = str(exc.value)
+        assert "maintenance.plane references unknown plane id 'Foo'" in msg
+        assert "did you mean 'foo'?" in msg
+
+    def test_novel_placement_id_no_false_suggestion(self, tmp_path: Path) -> None:
+        self._fleet_and_hangar(tmp_path)
+        layout = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: zzz, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+""",
+        )
+        with pytest.raises(LoaderError) as exc:
+            load_layout(layout)
+        msg = str(exc.value)
+        assert "unknown plane id 'zzz'" in msg
+        assert "did you mean" not in msg
+```
+
+Confirm `_minimal_aircraft_yaml` is importable at the top of `tests/test_loader.py` (it is used by `_minimal_fleet_and_hangar`). If it is a module-level function in the test file, reuse it directly; if it is defined elsewhere, mirror the existing import.
+
+- [ ] **Step 2: Update the existing message-change test**
+
+In `tests/test_loader.py`, `test_unknown_plane_reference_propagates` (~`:763`): the loader gate now fires before the model. Change:
+
+```python
+        with pytest.raises(LoaderError, match="unknown plane_id 'ghost'"):
+```
+to:
+```python
+        with pytest.raises(LoaderError, match="unknown plane id 'ghost'"):
+```
+
+(`plane_id` → `plane id`: the new loader message uses a space; the underscored form was the model's wording, now shadowed by the earlier loader gate.)
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `PYTHONPATH=src python3 -m pytest tests/test_loader.py::TestUnknownPlaneIdLayout tests/test_loader.py::TestRealDataFiles -v -k "unknown or miscased or novel"`
+Expected: the new `TestUnknownPlaneIdLayout` tests FAIL (no loader gate yet → today's behavior raises the model's `plane_id` message or the wrong role text); `test_unknown_plane_reference_propagates` FAILs on the new `plane id` regex.
+
+- [ ] **Step 4: Wire the gate into `load_layout`**
+
+In `src/hangarfit/loader.py`, after `maintenance_plane = _extract_maintenance_plane(raw, path)` (~`:210`) and **before** the `# Pre-Layout boundary check…` occupant block (~`:212`), insert:
+
+```python
+    for p in placements:
+        _resolve_known_plane_id(p.plane_id, fleet, role="placement", path=path)
+    if maintenance_plane is not None:
+        _resolve_known_plane_id(maintenance_plane, fleet, role="maintenance.plane", path=path)
+```
+
+(`fleet` is the already-loaded `dict[str, Aircraft]`; `candidate in fleet` checks keys.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `PYTHONPATH=src python3 -m pytest tests/test_loader.py -v`
+Expected: PASS (all, including the new class and the updated propagation test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader.py
+git commit -m "feat(loader): reject unknown plane ids in load_layout with suggestion (#176)"
+```
+
+---
+
+## Task 4: Wire into `load_scenario` (fleet_in + maintenance + constraints)
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (`load_scenario`: fleet_in after fleet load; replace `:315` maintenance check; constraints loop ~`:332`)
+- Test: `tests/test_loader_scenario.py` (new cases; update `test_load_scenario_rejects_maintenance_plane_not_in_fleet_in`)
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `tests/test_loader_scenario.py`. These mirror the existing `shutil.copy` data-staging idiom (real fleet ids: `aviat_husky`, `ctsl`).
+
+```python
+def _stage_scenario(tmp_path, body: str):
+    """Write a scenario YAML next to copied real data files; return its path."""
+    import shutil
+
+    (tmp_path / "data").mkdir(exist_ok=True)
+    shutil.copy("data/fleet.yaml", tmp_path / "data" / "fleet.yaml")
+    shutil.copy("data/hangar.yaml", tmp_path / "data" / "hangar.yaml")
+    p = tmp_path / "scenario.yaml"
+    p.write_text("fleet: data/fleet.yaml\nhangar: data/hangar.yaml\n" + body)
+    return p
+
+
+def test_load_scenario_miscased_fleet_in_entry_suggests(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(tmp_path, "fleet_in: [Aviat_husky, ctsl]\n")
+    with pytest.raises(LoaderError) as exc:
+        load_scenario(p)
+    msg = str(exc.value)
+    assert "fleet_in entry references unknown plane id 'Aviat_husky'" in msg
+    assert "did you mean 'aviat_husky'?" in msg
+
+
+def test_load_scenario_miscased_maintenance_suggests(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(tmp_path, "fleet_in: [aviat_husky, ctsl]\nmaintenance:\n  plane: Ctsl\n")
+    with pytest.raises(LoaderError) as exc:
+        load_scenario(p)
+    msg = str(exc.value)
+    assert "maintenance.plane references unknown plane id 'Ctsl'" in msg
+    assert "did you mean 'ctsl'?" in msg
+
+
+def test_load_scenario_miscased_constraint_key_suggests(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(
+        tmp_path,
+        "fleet_in: [aviat_husky, ctsl]\nconstraints:\n  Ctsl:\n    force_on_carts: false\n",
+    )
+    with pytest.raises(LoaderError) as exc:
+        load_scenario(p)
+    msg = str(exc.value)
+    assert "constraints key references unknown plane id 'Ctsl'" in msg
+    assert "did you mean 'ctsl'?" in msg
+```
+
+- [ ] **Step 2: Update the existing message-change test**
+
+In `tests/test_loader_scenario.py`, `test_load_scenario_rejects_maintenance_plane_not_in_fleet_in` (~`:81`) uses `maintenance.plane: ghost` (no near match). The message moves into the helper with the `fix_hint`. Replace the four assertions (lines ~107-116) with:
+
+```python
+    msg = str(exc_info.value)
+    # Names the bad plane id
+    assert "ghost" in msg, f"message should name the bad plane id; got: {msg!r}"
+    # Includes the file path
+    assert str(bad) in msg, f"message should include the file path; got: {msg!r}"
+    # Enumerates the valid fleet_in so the user knows what is valid
+    assert "aviat_husky" in msg, f"message should list valid fleet_in planes; got: {msg!r}"
+    # Actionable guidance (the sorted fleet_in list is inserted, so assert the two halves)
+    assert "either add it to fleet_in" in msg, f"missing add-to-fleet_in guidance; got: {msg!r}"
+    assert "or fix the plane id" in msg, f"missing fix-the-id guidance; got: {msg!r}"
+    # 'ghost' has no near match → no false suggestion
+    assert "did you mean" not in msg, f"'ghost' should not get a suggestion; got: {msg!r}"
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `PYTHONPATH=src python3 -m pytest tests/test_loader_scenario.py -v`
+Expected: the three new tests FAIL (no scenario gate yet → today's behavior raises a `fleet has:`/`not in fleet_in`/`constraints has key` message without the new role text or suggestion); the updated `not_in_fleet_in` test FAILs on the new wording.
+
+- [ ] **Step 4: Wire the gate into `load_scenario`**
+
+Three edits in `src/hangarfit/loader.py`, inside `load_scenario`.
+
+(a) **fleet_in** — after the fleet/hangar load block, immediately before `# maintenance (optional, same shape as load_layout)` (~`:308`), insert:
+
+```python
+    for pid in fleet_in:
+        _resolve_known_plane_id(pid, fleet, role="fleet_in entry", path=path)
+```
+
+(b) **maintenance** — replace the existing block (~`:314-318`):
+
+```python
+    if maintenance_plane is not None and maintenance_plane not in fleet_in:
+        raise LoaderError(
+            f"{path}: maintenance_plane {maintenance_plane!r} is not in fleet_in "
+            f"{list(fleet_in)}; either add it to fleet_in or fix the plane id."
+        )
+```
+with:
+```python
+    if maintenance_plane is not None:
+        _resolve_known_plane_id(
+            maintenance_plane,
+            fleet_in,
+            role="maintenance.plane",
+            path=path,
+            fix_hint=f"either add it to fleet_in {sorted(fleet_in)} or fix the plane id",
+        )
+```
+
+(c) **constraints** — in the constraints loop (~`:332`), validate the key **before** the existing `try`:
+
+```python
+    for plane_id, cdata in constraints_raw.items():
+        _resolve_known_plane_id(
+            plane_id,
+            fleet_in,
+            role="constraints key",
+            path=path,
+            fix_hint=f"either add it to fleet_in {sorted(fleet_in)} or fix the plane id",
+        )
+        try:
+            constraints[plane_id] = _build_plane_constraint(plane_id, cdata)
+        except (ValueError, KeyError, TypeError, LoaderError) as e:
+            raise LoaderError(f"{path}: constraint {plane_id!r}: {e}") from e
+```
+
+(Call it outside the `try` so its message is not re-wrapped with the `constraint {plane_id!r}:` prefix.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `PYTHONPATH=src python3 -m pytest tests/test_loader_scenario.py -v`
+Expected: PASS (all, including the three new tests and the updated `not_in_fleet_in` test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader_scenario.py
+git commit -m "feat(loader): reject unknown plane ids in load_scenario with suggestion (#176)"
+```
+
+---
+
+## Task 5: Docs + full verification + PR
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (module docstring)
+- Modify: `docs/architecture/05-building-block-view.md` (loader note)
+
+- [ ] **Step 1: Add the case-sensitivity contract to the loader module docstring**
+
+In `src/hangarfit/loader.py`, append a paragraph to the module docstring (after the existing struts paragraph, before the closing `"""`):
+
+```
+Plane ids are **case-sensitive** and are not normalised. When a layout or
+scenario names an id that does not match the fleet exactly, the loader
+rejects it at parse time with a ``did you mean 'X'?`` suggestion (a
+case-insensitive match, else a ``difflib`` near match) rather than letting
+a mis-cased id slip through to a late, generic model-invariant error.
+```
+
+- [ ] **Step 2: Add the arc42 note**
+
+In `docs/architecture/05-building-block-view.md`, find the `loader` row/section and add one sentence: *"Plane ids are case-sensitive; unknown/mis-cased ids are rejected at load time with a `did you mean…?` suggestion (see ADR / spec 2026-05-25)."* Then grep for any other stale claim:
+
+Run: `grep -rni "case-sensit\|case sensit\|normali" docs/ src/hangarfit/loader.py`
+Resolve anything that now contradicts the contract. (Per the doc-layer-sweep lesson, PRs #178/#179.)
+
+- [ ] **Step 3: Full verification**
+
+```bash
+PYTHONPATH=src python3 -m pytest -q
+PYTHONPATH=src python3 -m ruff check src/ tests/
+PYTHONPATH=src python3 -m ruff format --check src/ tests/
+PYTHONPATH=src python3 -m mypy src/hangarfit/
+```
+Expected: all pass; mypy clean (verify `Collection`/`Iterable` annotations resolve).
+
+- [ ] **Step 4: Commit docs**
+
+```bash
+git add src/hangarfit/loader.py docs/architecture/05-building-block-view.md
+git commit -m "docs(loader): document case-sensitive plane-id contract (#176)"
+```
+
+- [ ] **Step 5: Push + open PR**
+
+```bash
+git push -u origin feature/176-plane-id-validation
+gh pr create --base develop \
+  --title "feat(loader): validate plane ids at load boundary with did-you-mean suggestions" \
+  --body "Closes #176
+
+Implements Option C from the design spec: strict-validate plane ids at the
+loader boundary with casefold-first + difflib suggestions, across all five
+references (layout placements + maintenance; scenario fleet_in, maintenance,
+constraints). Ids stay case-sensitive; model invariants kept as backstop.
+
+Spec: docs/superpowers/specs/2026-05-25-loader-plane-id-validation-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 6: Set PR metadata** (gh pr edit is broken in this repo; use the REST API)
+
+```bash
+PR=$(gh pr view --json number --jq .number)
+gh api -X PATCH /repos/DocGerd/hangarfit/issues/$PR \
+  -f 'assignees[]=DocGerd' -f 'labels[]=enhancement'
+```
+
+Then run `/pr-review` per the project workflow (this PR touches the loader → include `silent-failure-hunter`; it adds no new types → `type-design-analyzer` not required).
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- §3.1 helpers → Tasks 1, 2. ✓
+- §3.2 message shapes → asserted in Tasks 1-4. ✓
+- §3.3 five call sites → Task 3 (2 layout) + Task 4 (3 scenario). ✓
+- §3.4 ordering (placements/maint before occupant check; constraints key before `try`) → Task 3 Step 4, Task 4 Step 4c. ✓
+- §5 backstops unchanged → no model edits in any task; `test_models.py`/`test_scenario.py` left untouched and run green in Task 5 Step 3. ✓
+- §6 tests (4 shapes × entry points + backstop + 3 message updates) → helper units (T1/T2) + integration (T3/T4) + the two updates (T3 S2, T4 S2). Backstop tests covered by the full-suite run. ✓
+- §7 docs (docstring + arc42 + grep sweep) → Task 5. ✓
+
+**Placeholder scan:** no TBD/TODO; every code step has complete code. ✓
+
+**Type consistency:** `_suggest_plane_id(candidate: str, valid_ids: Iterable[str]) -> str` and `_resolve_known_plane_id(candidate, valid_ids: Collection[str], *, role, path, fix_hint="") -> None` are used with matching argument names/types at every call site (`fleet` is `Collection[str]` via its keys; `fleet_in` is a `tuple[str,...]`). Message substrings asserted in tests match the f-strings in the impl (`"{role} references unknown plane id {candidate!r}"`, `"; did you mean {x!r}? (plane ids are case-sensitive)"`, `"; " + fix_hint`). ✓
+
+**Known follow-on:** `test_load_scenario_rejects_null_maintenance_plane` (added in #219) has a docstring mention of the "maintenance_plane not in fleet_in boundary check"; still accurate after the rename to a helper call — no assertion change, optional light reword only.

--- a/docs/superpowers/specs/2026-05-25-loader-plane-id-validation-design.md
+++ b/docs/superpowers/specs/2026-05-25-loader-plane-id-validation-design.md
@@ -1,0 +1,175 @@
+# Loader plane-id validation — design (issue #176)
+
+**Status:** approved 2026-05-25
+**Tracks:** [#176 Loader: case-sensitivity contract for plane ids](https://github.com/DocGerd/hangarfit/issues/176) — no milestone (loader UX hardening; follow-up from a `silent-failure-hunter` finding on PR #174)
+**Author:** Claude (Opus 4.7), reviewed by @DocGerd
+
+---
+
+## 1. Goals & non-goals
+
+**Goals**
+
+- When a YAML author names a plane id that does not match the fleet exactly, fail at the **loader boundary** with an actionable message: the file path, the offending id, and — when there is a near match — a `did you mean 'X'?` suggestion.
+- Catch the headline case (mis-capitalisation, e.g. `Foo` for `foo`) **and** general typos (`cesna_150` for `cessna_150`) through the same path.
+- Preserve plane ids as **case-sensitive** (no normalisation, no semantic change). This is option **C** from the issue.
+- Document the case-sensitivity contract (the issue's option **A**) — folded in for free.
+
+**Non-goals**
+
+- **No case-folding / normalisation** (issue option B — rejected, see §9). Two ids differing only by case remain distinct.
+- No change to the `Layout` / `Scenario` model invariants — they stay as the programmatic backstop (§6).
+- No new dependency: `difflib` is in the standard library.
+- No fuzzy *resolution* (we never silently accept a near-miss — we only *suggest* and then reject).
+
+---
+
+## 2. The problem (current behaviour)
+
+Plane ids are compared by case-sensitive string equality throughout the loader and the model invariants. A mis-cased or typo'd id is not caught where it is introduced:
+
+- `_build_placement` (`loader.py:568`) builds `Placement(plane_id="Foo")` with **no fleet check**.
+- The unknown id is only caught later, at `Layout.__post_init__` (`models.py:373`): `Placement references unknown plane_id 'Foo'`. The loader's `except ValueError → LoaderError` wrap adds the file path, but the message still (a) names only the typo, (b) offers no correction, and (c) reads as an internal invariant rather than a YAML-author error.
+
+The scenario path has loader-level checks for `maintenance_plane ∉ fleet_in` (`loader.py:315`) and model backstops for `fleet_in ⊄ fleet` and `constraints.keys() ⊄ fleet_in`, but none of them offers a suggestion.
+
+The id `'Foo'` genuinely *is* unknown — so the defect is **diagnostic timing and quality**, not a wrong result. That reframing is why option C (suggest + reject early) dominates option B (case-fold): C fixes the whole class of near-miss ids, surfaced early, while keeping ids exact.
+
+---
+
+## 3. Design
+
+### 3.1 Two new private helpers in `loader.py`
+
+```python
+def _suggest_plane_id(candidate: str, valid_ids: Iterable[str]) -> str:
+    """Return a '; did you mean X?' fragment for a near-miss id, or '' if none.
+
+    Two passes, because difflib alone misses the headline case:
+    SequenceMatcher is case-sensitive, so 'FOO' vs 'foo' scores 0.0 and
+    would yield no suggestion at all.
+
+    1. Case-insensitive exact match: if exactly one valid id equals the
+       candidate under casefold(), suggest it with the case-sensitivity
+       note. (If two valid ids share a casefold — only possible for a
+       fleet that deliberately uses case-distinct ids — skip this pass as
+       ambiguous and fall through to difflib.)
+    2. difflib.get_close_matches(candidate, valid, n=1, cutoff=0.6) for
+       genuine typos.
+    """
+
+def _resolve_known_plane_id(
+    candidate: str,
+    valid_ids: Collection[str],
+    *,
+    role: str,
+    path: Path,
+    fix_hint: str = "",
+) -> None:
+    """Raise LoaderError if candidate is not in valid_ids, otherwise return.
+
+    Message: "{path}: {role} references unknown plane id {candidate!r}{tail}"
+    where tail is, in priority order:
+      - the _suggest_plane_id fragment when there is a near match, else
+      - "; " + fix_hint when fix_hint is non-empty, else
+      - "" (bare).
+    """
+```
+
+A near-match suggestion always wins over `fix_hint`: if we can name the likely intended id, that is more useful than generic guidance.
+
+### 3.2 Message shapes
+
+| Situation | Message (after `{path}: `) |
+|---|---|
+| case mis-match (`Foo`, fleet has `foo`) | `placement references unknown plane id 'Foo'; did you mean 'foo'? (plane ids are case-sensitive)` |
+| typo (`cesna_150`) | `placement references unknown plane id 'cesna_150'; did you mean 'cessna_150'?` |
+| novel id, no near match (`zzz`) | `placement references unknown plane id 'zzz'` |
+| scenario maintenance, novel id (`ghost`) | `maintenance.plane references unknown plane id 'ghost'; either add it to fleet_in ['aviat_husky', 'ctsl'] or fix the plane id` |
+
+### 3.3 Call sites (the comprehensive scope, approved 2026-05-25)
+
+| Path | id reference | `valid_ids` | `role` | `fix_hint` |
+|---|---|---|---|---|
+| `load_layout` | each `placements[].plane` | `fleet` | `"placement"` | — |
+| `load_layout` | `maintenance.plane` | `fleet` | `"maintenance.plane"` | — |
+| `load_scenario` | each `fleet_in[]` | `fleet` | `"fleet_in entry"` | — |
+| `load_scenario` | `maintenance.plane` | `fleet_in` | `"maintenance.plane"` | `"either add it to fleet_in {sorted(fleet_in)} or fix the plane id"` |
+| `load_scenario` | each `constraints` key | `fleet_in` | `"constraints key"` | `"either add it to fleet_in {sorted(fleet_in)} or fix the plane id"` |
+
+**Asymmetry, by design:** references validated against the (large) fleet — placements and `fleet_in` entries — get a `did you mean` suggestion but no inline enumeration (listing all ~9 planes would be noise). References validated against the (small) `fleet_in` — scenario maintenance and constraint keys — additionally enumerate the valid set in `fix_hint`, preserving the helpful behaviour the existing `not_in_fleet_in` check already has.
+
+### 3.4 Ordering of checks
+
+- **`load_layout`:** validate each placement id, then the maintenance id, **before** the existing occupant-in-placements check (`loader.py:222`) and before `Layout(...)` construction. Root-cause (unknown id) surfaces before the more specific occupant rule.
+- **`load_scenario`:** validate `fleet_in` entries (needs `fleet` loaded — placed after the fleet load at `loader.py:~308`); then replace the bare `maintenance_plane not in fleet_in` check (`:315`) with a `_resolve_known_plane_id` call carrying the `fix_hint`; then validate each constraint key inside the existing constraints loop (`:332`), before `_build_plane_constraint`.
+
+---
+
+## 4. Data flow
+
+```
+YAML → _read_yaml → build placements / fleet_in / constraints
+     → _resolve_known_plane_id(id, valid_ids, role, path[, fix_hint])   ← NEW gate
+         └─ on miss: _suggest_plane_id → LoaderError (path + id + hint)
+     → Layout(...) / Scenario(...)   ← model invariants unchanged (backstop)
+```
+
+---
+
+## 5. Backstops unchanged
+
+`Layout.__post_init__` (`models.py:373`, `:405`) and `Scenario.__post_init__` (`models.py:503+`, the `fleet_in ⊆ fleet`, `maintenance ∈ fleet_in`, `constraints ⊆ fleet_in` checks) are **kept verbatim**. They are the only guard for callers that construct models directly (solver internals, tests, REPL) and never touch the loader. The new loader gate is an earlier, friendlier front door — not a replacement.
+
+---
+
+## 6. Tests
+
+**New** (`tests/test_loader.py` for layout, `tests/test_loader_scenario.py` for scenario) — a parametrised class per entry point covering, for each of the five call sites:
+
+- exact match → passes (no raise);
+- case mis-match → `LoaderError` whose message contains `did you mean '<canonical>'` and `case-sensitive`;
+- typo with a near match (e.g. `cesna_150`) → `LoaderError` suggesting the difflib match;
+- novel id with no near match (e.g. `zzz`) → `LoaderError` that names the id and does **not** contain `did you mean` (no false suggestion).
+
+**Backstop preservation** — direct `Layout` / `Scenario` construction with an unknown id still raises `ValueError` (these already exist: `test_models.py:587`, `test_scenario.py:82` — assert they remain green).
+
+**Tests touched (message change):**
+
+- `tests/test_loader.py::test_unknown_plane_reference_propagates` (`:749`) — currently `match="unknown plane_id 'ghost'"`; the loader gate now fires first with `unknown plane id 'ghost'` (space, no underscore). Update the regex.
+- `tests/test_loader_scenario.py::test_load_scenario_rejects_maintenance_plane_not_in_fleet_in` (`:81`) — the message moves into the shared helper. Update its assertions to the new wording: still asserts the bad id `'ghost'`, the path, an `aviat_husky` mention (now inside the `fix_hint` enumeration), and the `add it to fleet_in` guidance — but the exact contiguous substring `either add it to fleet_in or fix the plane id` changes (the sorted list is inserted), so assert on the two halves separately.
+- `tests/test_loader_scenario.py::test_load_scenario_rejects_null_maintenance_plane` (`:119`, added in #219) — its docstring notes the null guard "precedes the maintenance_plane not in fleet_in boundary check"; still true, reword lightly to point at the renamed check if needed. No assertion change.
+
+`tests/test_loader_scenario.py:43` (`match="unknown plane"`) is robust — the substring survives the new wording.
+
+---
+
+## 7. Docs (folds in option A)
+
+- **`src/hangarfit/loader.py` module docstring** — add a short paragraph: plane ids are case-sensitive; the loader does not normalise; near-miss ids are rejected with a suggestion.
+- **arc42** — add a one-line note to the loader entry in [`docs/architecture/05-building-block-view.md`](../../architecture/05-building-block-view.md) and, if a natural home exists, the loader-conventions area of [`08-crosscutting-concepts.md`](../../architecture/08-crosscutting-concepts.md). Per the doc-layer-sweep lesson (PRs #178/#179), enumerate the layers explicitly during implementation and grep for any other "case-sensit" reference before declaring done.
+
+---
+
+## 8. Files touched
+
+- `src/hangarfit/loader.py` — add `_suggest_plane_id` + `_resolve_known_plane_id`; wire the five call sites; replace the bare `:315` maintenance check; module-docstring note. (`import difflib`.)
+- `tests/test_loader.py` — new layout cases; update `test_unknown_plane_reference_propagates`.
+- `tests/test_loader_scenario.py` — new scenario cases; update `test_load_scenario_rejects_maintenance_plane_not_in_fleet_in`; light docstring reword on the null test.
+- `docs/architecture/05-building-block-view.md` (+ possibly `08-crosscutting-concepts.md`) — case-sensitivity contract note.
+
+No production-behaviour change beyond error messages and the *timing* of rejection (loader vs model). Valid layouts/scenarios are unaffected.
+
+---
+
+## 9. Alternatives considered (and why C)
+
+- **A — document only.** Cheapest, zero risk, but leaves the misleading late error exactly as-is. Rejected as insufficient on its own; its documentation half is folded into C (§7).
+- **B — case-fold on read.** Most forgiving, but high blast radius (fleet dict keys, every downstream compare in solver/visualize must normalise consistently), changes the id contract (silently merges case-distinct ids), and *still* needs typo diagnostics for non-case mistakes. Narrow benefit (fleet ids are already `lower_snake`) for broad cost. Rejected.
+- **C — strict-validate + suggest (chosen).** Preserves case-sensitivity, fixes the whole near-miss class (case *and* typo) via one helper, surfaces early at the loader with the path and a suggestion, keeps the model invariants as backstop. ~30 LOC + tests.
+
+## 10. Open questions resolved during design
+
+- **difflib misses big case diffs** (`FOO`→`foo` scores 0.0 because `SequenceMatcher` is case-sensitive) → solved by the casefold-exact first pass in `_suggest_plane_id` (§3.1).
+- **Don't lose the existing `add it to fleet_in` guidance** for scenario maintenance/constraints → carried in `fix_hint`, shown when there is no near match (§3.1, §3.3).
+- **Scope** (layout-only per the issue's literal acceptance vs all five references) → comprehensive, approved 2026-05-25; the shared helper makes scenario coverage near-free and avoids a layout/scenario UX split.

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -480,16 +480,25 @@ def _suggest_plane_id(candidate: str, valid_ids: Iterable[str]) -> str:
        candidate under ``casefold()`` (and isn't the candidate itself),
        suggest it with the case-sensitivity note. If two valid ids share a
        casefold (only possible for a fleet that deliberately uses
-       case-distinct ids), the pass is ambiguous and is skipped.
+       case-distinct ids), the pass is ambiguous and is skipped — in which
+       case difflib may still return a suggestion (without the note) for a
+       near-enough candidate.
     2. ``difflib.get_close_matches(n=1, cutoff=0.6)`` for genuine typos.
+
+    Inputs are coerced to ``str`` defensively: callers pass fleet keys /
+    ``fleet_in`` entries that *should* be str, but a malformed ``fleet.yaml``
+    can carry an unquoted numeric/bool id (e.g. ``id: 1`` → ``int``) that
+    survives loading. This helper only produces a best-effort hint, so a
+    non-str id must degrade to "no suggestion", never an ``AttributeError``.
     """
-    valid = list(valid_ids)
-    folded = candidate.casefold()
-    ci_matches = [v for v in valid if v.casefold() == folded and v != candidate]
+    cand = str(candidate)
+    valid = [str(v) for v in valid_ids]
+    folded = cand.casefold()
+    ci_matches = [v for v in valid if v.casefold() == folded and v != cand]
     if len(ci_matches) == 1:
         return f"; did you mean {ci_matches[0]!r}? (plane ids are case-sensitive)"
-    close = difflib.get_close_matches(candidate, valid, n=1, cutoff=0.6)
-    if close and close[0] != candidate:
+    close = difflib.get_close_matches(cand, valid, n=1, cutoff=0.6)
+    if close and close[0] != cand:
         return f"; did you mean {close[0]!r}?"
     return ""
 

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -312,6 +312,9 @@ def load_scenario(
             f"provided programmatically; remove one to disambiguate"
         )
 
+    for pid in fleet_in:
+        _resolve_known_plane_id(pid, fleet, role="fleet_in entry", path=path)
+
     # maintenance (optional, same shape as load_layout)
     maintenance_plane = _extract_maintenance_plane(raw, path)
 
@@ -319,10 +322,13 @@ def load_scenario(
     # path prefix here instead of relying on Scenario.__post_init__'s
     # bare ValueError bubbling through the except ValueError → LoaderError
     # wrap below (which would drop the actionable fleet_in hint).
-    if maintenance_plane is not None and maintenance_plane not in fleet_in:
-        raise LoaderError(
-            f"{path}: maintenance_plane {maintenance_plane!r} is not in fleet_in "
-            f"{list(fleet_in)}; either add it to fleet_in or fix the plane id."
+    if maintenance_plane is not None:
+        _resolve_known_plane_id(
+            maintenance_plane,
+            fleet_in,
+            role="maintenance.plane",
+            path=path,
+            fix_hint=f"either add it to fleet_in {sorted(fleet_in)} or fix the plane id",
         )
 
     # constraints (optional). `or {}` is wrong here — it collapses every
@@ -337,6 +343,13 @@ def load_scenario(
         raise LoaderError(f"{path}: 'constraints' must be a mapping")
     constraints: dict[str, PlaneConstraint] = {}
     for plane_id, cdata in constraints_raw.items():
+        _resolve_known_plane_id(
+            plane_id,
+            fleet_in,
+            role="constraints key",
+            path=path,
+            fix_hint=f"either add it to fleet_in {sorted(fleet_in)} or fix the plane id",
+        )
         try:
             constraints[plane_id] = _build_plane_constraint(plane_id, cdata)
         except (ValueError, KeyError, TypeError, LoaderError) as e:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -13,6 +13,12 @@ aircraft's high-level ``struts:`` block into two mirrored strut
 :class:`~hangarfit.models.Part` instances. After loading, the
 aircraft's ``parts`` tuple is the single source of truth for geometry
 — there is no separate ``struts`` field on the :class:`Aircraft`.
+
+Plane ids are **case-sensitive** and are not normalised. When a layout or
+scenario names an id that does not match the fleet exactly, the loader
+rejects it at parse time with a ``did you mean 'X'?`` suggestion (a
+case-insensitive match, else a ``difflib`` near match) rather than letting
+a mis-cased id slip through to a late, generic model-invariant error.
 """
 
 from __future__ import annotations

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -18,7 +18,7 @@ aircraft's ``parts`` tuple is the single source of truth for geometry
 from __future__ import annotations
 
 import difflib
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from pathlib import Path
 from typing import Any
 
@@ -463,6 +463,35 @@ def _suggest_plane_id(candidate: str, valid_ids: Iterable[str]) -> str:
     if close and close[0] != candidate:
         return f"; did you mean {close[0]!r}?"
     return ""
+
+
+def _resolve_known_plane_id(
+    candidate: str,
+    valid_ids: Collection[str],
+    *,
+    role: str,
+    path: Path,
+    fix_hint: str = "",
+) -> None:
+    """Raise :class:`LoaderError` if ``candidate`` is not in ``valid_ids``.
+
+    The message is ``"{path}: {role} references unknown plane id
+    {candidate!r}{tail}"`` where ``tail`` is, in priority order: a
+    ``_suggest_plane_id`` fragment when there is a near match, else
+    ``"; " + fix_hint`` when ``fix_hint`` is set, else empty. A near-match
+    suggestion always wins over ``fix_hint`` — naming the likely-intended
+    id beats generic guidance.
+
+    This is an earlier, friendlier front door to the unknown-id checks in
+    ``Layout``/``Scenario.__post_init__``; those invariants are kept as the
+    backstop for callers that bypass the loader.
+    """
+    if candidate in valid_ids:
+        return
+    tail = _suggest_plane_id(candidate, valid_ids)
+    if not tail and fix_hint:
+        tail = f"; {fix_hint}"
+    raise LoaderError(f"{path}: {role} references unknown plane id {candidate!r}{tail}")
 
 
 def _build_aircraft(entry: Any) -> Aircraft:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -318,6 +318,11 @@ def load_scenario(
     # maintenance (optional, same shape as load_layout)
     maintenance_plane = _extract_maintenance_plane(raw, path)
 
+    # Shared "did you mean / else add it to fleet_in" guidance for the two
+    # ids validated against fleet_in (maintenance plane + constraint keys).
+    # Built once so the two call sites can't drift apart during message tuning.
+    fleet_in_fix_hint = f"either add it to fleet_in {sorted(fleet_in)} or fix the plane id"
+
     # Pre-Scenario boundary check: surface the YAML-author error with a
     # path prefix here instead of relying on Scenario.__post_init__'s
     # bare ValueError bubbling through the except ValueError → LoaderError
@@ -328,7 +333,7 @@ def load_scenario(
             fleet_in,
             role="maintenance.plane",
             path=path,
-            fix_hint=f"either add it to fleet_in {sorted(fleet_in)} or fix the plane id",
+            fix_hint=fleet_in_fix_hint,
         )
 
     # constraints (optional). `or {}` is wrong here — it collapses every
@@ -348,7 +353,7 @@ def load_scenario(
             fleet_in,
             role="constraints key",
             path=path,
-            fix_hint=f"either add it to fleet_in {sorted(fleet_in)} or fix the plane id",
+            fix_hint=fleet_in_fix_hint,
         )
         try:
             constraints[plane_id] = _build_plane_constraint(plane_id, cdata)

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -211,6 +211,11 @@ def load_layout(
 
     maintenance_plane = _extract_maintenance_plane(raw, path)
 
+    for p in placements:
+        _resolve_known_plane_id(p.plane_id, fleet, role="placement", path=path)
+    if maintenance_plane is not None:
+        _resolve_known_plane_id(maintenance_plane, fleet, role="maintenance.plane", path=path)
+
     # Pre-Layout boundary check for the most common YAML-author mistake:
     # naming the bay occupant in ``placements``. ``Layout.__post_init__``
     # catches this too, but with a generic invariant message; raise here

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -17,6 +17,8 @@ aircraft's ``parts`` tuple is the single source of truth for geometry
 
 from __future__ import annotations
 
+import difflib
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -436,6 +438,31 @@ def _extract_maintenance_plane(raw: dict, path: Path) -> str | None:
             f"either remove the 'maintenance' block entirely or supply a valid aircraft id"
         )
     return plane
+
+
+def _suggest_plane_id(candidate: str, valid_ids: Iterable[str]) -> str:
+    """Return a '; did you mean X?' fragment for a near-miss id, or '' if none.
+
+    Two passes, because ``difflib`` alone misses the headline case:
+    ``SequenceMatcher`` is case-sensitive, so ``'FOO'`` vs ``'foo'`` scores
+    0.0 and would yield no suggestion.
+
+    1. Case-insensitive exact match: if exactly one valid id equals the
+       candidate under ``casefold()`` (and isn't the candidate itself),
+       suggest it with the case-sensitivity note. If two valid ids share a
+       casefold (only possible for a fleet that deliberately uses
+       case-distinct ids), the pass is ambiguous and is skipped.
+    2. ``difflib.get_close_matches(n=1, cutoff=0.6)`` for genuine typos.
+    """
+    valid = list(valid_ids)
+    folded = candidate.casefold()
+    ci_matches = [v for v in valid if v.casefold() == folded and v != candidate]
+    if len(ci_matches) == 1:
+        return f"; did you mean {ci_matches[0]!r}? (plane ids are case-sensitive)"
+    close = difflib.get_close_matches(candidate, valid, n=1, cutoff=0.6)
+    if close and close[0] != candidate:
+        return f"; did you mean {close[0]!r}?"
+    return ""
 
 
 def _build_aircraft(entry: Any) -> Aircraft:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1209,13 +1209,30 @@ class TestPlaneIdSuggestion:
         assert _suggest_plane_id("zzz", ["foo", "bar"]) == ""
 
     def test_ambiguous_casefold_falls_through_to_no_suggestion(self) -> None:
-        # Two reasons combine to yield "": (1) 'foo' and 'Foo' share a
-        # casefold so the casefold pass is ambiguous and skipped; (2) difflib
-        # then also misses, because a case-only diff ('FOO' vs either) scores
-        # below the 0.6 cutoff. (These two reasons co-occur for any pure
-        # case-variant candidate, which is why the "ambiguous casefold yet
-        # difflib hits" branch is effectively unreachable.)
+        # Two reasons combine to yield "" for THIS input: (1) 'foo' and 'Foo'
+        # share a casefold so the casefold pass is ambiguous and skipped;
+        # (2) difflib then also misses, because 'FOO' differs from both only
+        # by case across all three chars, scoring 0.0 — below the 0.6 cutoff.
+        # A *smaller* case diff can still get a difflib hit after an ambiguous
+        # casefold — see test_ambiguous_casefold_can_still_difflib_suggest.
         assert _suggest_plane_id("FOO", ["foo", "Foo"]) == ""
+
+    def test_ambiguous_casefold_can_still_difflib_suggest(self) -> None:
+        # 'bar' and 'BAR' both fold to 'bar' → casefold pass ambiguous, skipped.
+        # But 'Bar' vs 'bar' differs in only one of three chars (ratio 0.667 >
+        # 0.6), so difflib still suggests — without the case-sensitivity note.
+        result = _suggest_plane_id("Bar", ["bar", "BAR"])
+        assert "did you mean 'bar'?" in result
+        assert "case-sensitive" not in result
+
+    def test_non_str_valid_members_do_not_crash(self) -> None:
+        # A malformed fleet.yaml can carry unquoted numeric/bool ids (int/bool
+        # fleet keys). The helper must degrade to "" — never AttributeError on
+        # .casefold(). (#176 silent-failure regression guard.)
+        assert _suggest_plane_id("ghost", [1, 2.5, True]) == ""
+
+    def test_non_str_candidate_does_not_crash(self) -> None:
+        assert _suggest_plane_id(1, ["foo", "bar"]) == ""  # type: ignore[arg-type]
 
     def test_exact_match_returns_empty(self) -> None:
         assert _suggest_plane_id("foo", ["foo", "bar"]) == ""
@@ -1356,3 +1373,33 @@ placements:
         msg = str(exc.value)
         assert "unknown plane id 'zzz'" in msg
         assert "did you mean" not in msg
+
+    def test_non_str_fleet_id_unknown_ref_is_clean_loadererror(self, tmp_path: Path) -> None:
+        # Regression (#176): an unquoted numeric fleet id (`id: 1` → int fleet
+        # key) plus an unknown *string* placement id must raise a clean
+        # LoaderError, not an AttributeError from .casefold() in the suggester.
+        # (The "1" passed here round-trips through YAML to an int key.)
+        _write(
+            tmp_path / "fleet.yaml",
+            _minimal_aircraft_yaml("1", movement_mode="always_own_gear", turn_radius_m=5.0),
+        )
+        _write(
+            tmp_path / "hangar.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 9.0, width_m: 12.0}
+maintenance_bay: {center_x_m: 13.5, width_m: 9, depth_m: 9}
+""",
+        )
+        layout = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: ghost, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+""",
+        )
+        with pytest.raises(LoaderError, match="unknown plane id 'ghost'"):
+            load_layout(layout)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -13,6 +13,7 @@ import pytest
 
 from hangarfit.loader import (
     LoaderError,
+    _suggest_plane_id,
     load_fleet,
     load_hangar,
     load_layout,
@@ -1178,3 +1179,38 @@ def _minimal_aircraft_yaml(
     return _fleet_yaml(
         _aircraft_entry(plane_id, movement_mode=movement_mode, turn_radius_m=turn_radius_m)
     )
+
+
+# ----------------------------------------------------------------------------
+# _suggest_plane_id helper.
+# ----------------------------------------------------------------------------
+
+
+class TestPlaneIdSuggestion:
+    """Unit tests for the _suggest_plane_id near-match helper."""
+
+    def test_casefold_match_suggests_canonical_with_note(self) -> None:
+        assert _suggest_plane_id("Foo", ["foo"]) == (
+            "; did you mean 'foo'? (plane ids are case-sensitive)"
+        )
+
+    def test_all_caps_case_diff_still_suggests(self) -> None:
+        # difflib alone scores 'FOO' vs 'foo' at 0.0 (SequenceMatcher is
+        # case-sensitive); the casefold pass is what rescues this.
+        assert "did you mean 'foo'?" in _suggest_plane_id("FOO", ["foo"])
+
+    def test_typo_suggests_difflib_match(self) -> None:
+        assert _suggest_plane_id("cesna_150", ["cessna_150", "cessna_140"]) == (
+            "; did you mean 'cessna_150'?"
+        )
+
+    def test_novel_id_no_suggestion(self) -> None:
+        assert _suggest_plane_id("zzz", ["foo", "bar"]) == ""
+
+    def test_ambiguous_casefold_falls_through_to_no_suggestion(self) -> None:
+        # Two valid ids share a casefold → the casefold pass is ambiguous
+        # and is skipped; difflib finds no high-ratio match for 'FOO'.
+        assert _suggest_plane_id("FOO", ["foo", "Foo"]) == ""
+
+    def test_exact_match_returns_empty(self) -> None:
+        assert _suggest_plane_id("foo", ["foo", "bar"]) == ""

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -13,6 +13,7 @@ import pytest
 
 from hangarfit.loader import (
     LoaderError,
+    _resolve_known_plane_id,
     _suggest_plane_id,
     load_fleet,
     load_hangar,
@@ -1214,3 +1215,49 @@ class TestPlaneIdSuggestion:
 
     def test_exact_match_returns_empty(self) -> None:
         assert _suggest_plane_id("foo", ["foo", "bar"]) == ""
+
+
+# ----------------------------------------------------------------------------
+# _resolve_known_plane_id gate.
+# ----------------------------------------------------------------------------
+
+
+class TestResolveKnownPlaneId:
+    """Unit tests for the _resolve_known_plane_id loader gate."""
+
+    def test_known_id_does_not_raise(self) -> None:
+        assert (
+            _resolve_known_plane_id("foo", ["foo", "bar"], role="placement", path=Path("x.yaml"))
+            is None
+        )
+
+    def test_case_mismatch_raises_with_suggestion(self) -> None:
+        with pytest.raises(LoaderError) as exc:
+            _resolve_known_plane_id("Foo", ["foo"], role="placement", path=Path("x.yaml"))
+        msg = str(exc.value)
+        assert "x.yaml" in msg
+        assert "placement references unknown plane id 'Foo'" in msg
+        assert "did you mean 'foo'?" in msg
+        assert "case-sensitive" in msg
+
+    def test_novel_id_with_fix_hint_shows_hint(self) -> None:
+        with pytest.raises(LoaderError) as exc:
+            _resolve_known_plane_id(
+                "ghost",
+                ["foo"],
+                role="maintenance.plane",
+                path=Path("s.yaml"),
+                fix_hint="either add it to fleet_in ['foo'] or fix the plane id",
+            )
+        msg = str(exc.value)
+        assert "maintenance.plane references unknown plane id 'ghost'" in msg
+        assert "either add it to fleet_in ['foo'] or fix the plane id" in msg
+        assert "did you mean" not in msg
+
+    def test_novel_id_no_hint_is_bare(self) -> None:
+        with pytest.raises(LoaderError) as exc:
+            _resolve_known_plane_id("zzz", ["foo"], role="placement", path=Path("x.yaml"))
+        msg = str(exc.value)
+        assert "unknown plane id 'zzz'" in msg
+        assert "did you mean" not in msg
+        assert msg.rstrip().endswith("'zzz'")

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -762,7 +762,7 @@ placements:
     heading_deg: 0
 """,
         )
-        with pytest.raises(LoaderError, match="unknown plane_id 'ghost'"):
+        with pytest.raises(LoaderError, match="unknown plane id 'ghost'"):
             load_layout(layout_path)
 
     def test_cart_rule_violation_propagates(self, tmp_path: Path) -> None:
@@ -1280,3 +1280,79 @@ class TestResolveKnownPlaneId:
         msg = str(exc.value)
         assert "did you mean 'foo'?" in msg
         assert "either add it to fleet_in" not in msg
+
+
+# ----------------------------------------------------------------------------
+# load_layout unknown/mis-cased plane id integration tests.
+# ----------------------------------------------------------------------------
+
+
+class TestUnknownPlaneIdLayout:
+    """Loader-boundary unknown/mis-cased plane id rejection for layouts."""
+
+    def _fleet_and_hangar(self, dir_: Path) -> None:
+        _write(
+            dir_ / "fleet.yaml",
+            _minimal_aircraft_yaml("foo", movement_mode="always_own_gear", turn_radius_m=5.0),
+        )
+        _write(
+            dir_ / "hangar.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 9.0, width_m: 12.0}
+maintenance_bay: {center_x_m: 13.5, width_m: 9, depth_m: 9}
+""",
+        )
+
+    def test_miscased_placement_id_suggests_canonical(self, tmp_path: Path) -> None:
+        self._fleet_and_hangar(tmp_path)
+        layout = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: Foo, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+""",
+        )
+        with pytest.raises(LoaderError) as exc:
+            load_layout(layout)
+        msg = str(exc.value)
+        assert "placement references unknown plane id 'Foo'" in msg
+        assert "did you mean 'foo'?" in msg
+        assert "case-sensitive" in msg
+
+    def test_miscased_maintenance_id_suggests_canonical(self, tmp_path: Path) -> None:
+        self._fleet_and_hangar(tmp_path)
+        layout = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements: []
+maintenance: {plane: Foo}
+""",
+        )
+        with pytest.raises(LoaderError) as exc:
+            load_layout(layout)
+        msg = str(exc.value)
+        assert "maintenance.plane references unknown plane id 'Foo'" in msg
+        assert "did you mean 'foo'?" in msg
+
+    def test_novel_placement_id_no_false_suggestion(self, tmp_path: Path) -> None:
+        self._fleet_and_hangar(tmp_path)
+        layout = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - {plane: zzz, x_m: 5, y_m: 5, heading_deg: 0, on_carts: false}
+""",
+        )
+        with pytest.raises(LoaderError) as exc:
+            load_layout(layout)
+        msg = str(exc.value)
+        assert "unknown plane id 'zzz'" in msg
+        assert "did you mean" not in msg

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1209,8 +1209,12 @@ class TestPlaneIdSuggestion:
         assert _suggest_plane_id("zzz", ["foo", "bar"]) == ""
 
     def test_ambiguous_casefold_falls_through_to_no_suggestion(self) -> None:
-        # Two valid ids share a casefold → the casefold pass is ambiguous
-        # and is skipped; difflib finds no high-ratio match for 'FOO'.
+        # Two reasons combine to yield "": (1) 'foo' and 'Foo' share a
+        # casefold so the casefold pass is ambiguous and skipped; (2) difflib
+        # then also misses, because a case-only diff ('FOO' vs either) scores
+        # below the 0.6 cutoff. (These two reasons co-occur for any pure
+        # case-variant candidate, which is why the "ambiguous casefold yet
+        # difflib hits" branch is effectively unreachable.)
         assert _suggest_plane_id("FOO", ["foo", "Foo"]) == ""
 
     def test_exact_match_returns_empty(self) -> None:
@@ -1261,3 +1265,18 @@ class TestResolveKnownPlaneId:
         assert "unknown plane id 'zzz'" in msg
         assert "did you mean" not in msg
         assert msg.rstrip().endswith("'zzz'")
+
+    def test_near_match_suggestion_beats_fix_hint(self) -> None:
+        # Docstring invariant: when there IS a near match, the suggestion
+        # wins and the (generic) fix_hint is suppressed.
+        with pytest.raises(LoaderError) as exc:
+            _resolve_known_plane_id(
+                "Foo",
+                ["foo"],
+                role="maintenance.plane",
+                path=Path("s.yaml"),
+                fix_hint="either add it to fleet_in ['foo'] or fix the plane id",
+            )
+        msg = str(exc.value)
+        assert "did you mean 'foo'?" in msg
+        assert "either add it to fleet_in" not in msg

--- a/tests/test_loader_scenario.py
+++ b/tests/test_loader_scenario.py
@@ -104,16 +104,17 @@ def test_load_scenario_rejects_maintenance_plane_not_in_fleet_in(tmp_path):
     with pytest.raises(LoaderError) as exc_info:
         load_scenario(bad)
     msg = str(exc_info.value)
-    # Must name the bad plane id
+    # Names the bad plane id
     assert "ghost" in msg, f"message should name the bad plane id; got: {msg!r}"
-    # Must include the file path
+    # Includes the file path
     assert str(bad) in msg, f"message should include the file path; got: {msg!r}"
-    # Must show the actual fleet_in list so the user knows what is valid
+    # Enumerates the valid fleet_in so the user knows what is valid
     assert "aviat_husky" in msg, f"message should list valid fleet_in planes; got: {msg!r}"
-    # Must include a fix hint (actionable suffix)
-    assert "either add it to fleet_in or fix the plane id" in msg, (
-        f"message should include actionable fix hint; got: {msg!r}"
-    )
+    # Actionable guidance (the sorted fleet_in list is inserted, so assert the two halves)
+    assert "either add it to fleet_in" in msg, f"missing add-to-fleet_in guidance; got: {msg!r}"
+    assert "or fix the plane id" in msg, f"missing fix-the-id guidance; got: {msg!r}"
+    # 'ghost' has no near match → no false suggestion
+    assert "did you mean" not in msg, f"'ghost' should not get a suggestion; got: {msg!r}"
 
 
 def test_load_scenario_rejects_null_maintenance_plane(tmp_path):
@@ -158,6 +159,54 @@ def test_load_scenario_rejects_null_maintenance_plane(tmp_path):
     )
     with pytest.raises(LoaderError, match="'maintenance.plane' is null"):
         load_scenario(bad)
+
+
+def _stage_scenario(tmp_path, body: str):
+    """Write a scenario YAML next to copied real data files; return its path."""
+    import shutil
+
+    (tmp_path / "data").mkdir(exist_ok=True)
+    shutil.copy("data/fleet.yaml", tmp_path / "data" / "fleet.yaml")
+    shutil.copy("data/hangar.yaml", tmp_path / "data" / "hangar.yaml")
+    p = tmp_path / "scenario.yaml"
+    p.write_text("fleet: data/fleet.yaml\nhangar: data/hangar.yaml\n" + body)
+    return p
+
+
+def test_load_scenario_miscased_fleet_in_entry_suggests(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(tmp_path, "fleet_in: [Aviat_husky, ctsl]\n")
+    with pytest.raises(LoaderError) as exc:
+        load_scenario(p)
+    msg = str(exc.value)
+    assert "fleet_in entry references unknown plane id 'Aviat_husky'" in msg
+    assert "did you mean 'aviat_husky'?" in msg
+
+
+def test_load_scenario_miscased_maintenance_suggests(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(tmp_path, "fleet_in: [aviat_husky, ctsl]\nmaintenance:\n  plane: Ctsl\n")
+    with pytest.raises(LoaderError) as exc:
+        load_scenario(p)
+    msg = str(exc.value)
+    assert "maintenance.plane references unknown plane id 'Ctsl'" in msg
+    assert "did you mean 'ctsl'?" in msg
+
+
+def test_load_scenario_miscased_constraint_key_suggests(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(
+        tmp_path,
+        "fleet_in: [aviat_husky, ctsl]\nconstraints:\n  Ctsl:\n    force_on_carts: false\n",
+    )
+    with pytest.raises(LoaderError) as exc:
+        load_scenario(p)
+    msg = str(exc.value)
+    assert "constraints key references unknown plane id 'Ctsl'" in msg
+    assert "did you mean 'ctsl'?" in msg
 
 
 def test_scenario_post_init_backstop_still_fires_on_direct_construction():

--- a/tests/test_loader_scenario.py
+++ b/tests/test_loader_scenario.py
@@ -209,6 +209,19 @@ def test_load_scenario_miscased_constraint_key_suggests(tmp_path):
     assert "did you mean 'ctsl'?" in msg
 
 
+def test_load_scenario_typo_fleet_in_entry_suggests_via_difflib(tmp_path):
+    """A genuine (non-case) typo in a fleet_in entry is caught with a difflib
+    near-match suggestion — the other new tests cover only the casefold path."""
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(tmp_path, "fleet_in: [aviat_huksy, ctsl]\n")
+    with pytest.raises(LoaderError) as exc:
+        load_scenario(p)
+    msg = str(exc.value)
+    assert "fleet_in entry references unknown plane id 'aviat_huksy'" in msg
+    assert "did you mean 'aviat_husky'?" in msg
+
+
 def test_scenario_post_init_backstop_still_fires_on_direct_construction():
     """Direct-construction path: Scenario.__post_init__ still raises ValueError
     when maintenance_plane is not in fleet_in, bypassing the loader guard.


### PR DESCRIPTION
Closes #176

## What

Implements **Option C** from the design spec: reject unknown / mis-cased plane ids at the **loader boundary** with a `did you mean 'X'?` suggestion, keeping ids case-sensitive. Two new private helpers in `loader.py` wired into all five plane-id reference sites.

## Why

Previously a mis-cased id (`Foo` for `foo`) or typo passed `_build_placement` unchecked and only surfaced at `Layout.__post_init__` as a late, generic *"unknown plane_id 'Foo'"* — naming the typo, no path framing, no correction. This is a diagnostics-quality fix, not a behavior change for valid input.

## How

- **`_suggest_plane_id`** — casefold-exact match *first* (because `difflib.SequenceMatcher` is case-sensitive and scores `FOO` vs `foo` at 0.0), then `difflib.get_close_matches` for genuine typos.
- **`_resolve_known_plane_id`** — the reject-with-hint gate; a near-match suggestion wins over the generic `fix_hint`.
- **Wired into** `load_layout` (placements + maintenance, validated against `fleet`) and `load_scenario` (`fleet_in` against `fleet`; maintenance + constraint keys against `fleet_in`, with a `fix_hint` enumerating `sorted(fleet_in)`).
- **`Layout` / `Scenario.__post_init__` invariants kept verbatim** as the programmatic backstop for non-loader callers.
- Documents the case-sensitivity contract (folds in the issue's Option A) in the loader module docstring + arc42 §5.

## Tests / verification

- New helper unit tests + end-to-end integration tests per entry point (case-mismatch, difflib typo, novel-id-no-false-suggestion, suggestion-beats-fix_hint). Two existing message-assertion tests updated for the earlier/friendlier wording.
- Full suite: **563 passed, 2 deselected**; `ruff check` + `ruff format --check` clean; `mypy src/hangarfit/` clean.

## Design docs

- Spec: `docs/superpowers/specs/2026-05-25-loader-plane-id-validation-design.md`
- Plan: `docs/superpowers/plans/2026-05-25-loader-plane-id-validation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)