### PR TITLE
feat(solver): bundle best-effort tow-plans into solve() (#197)

### DIFF
--- a/docs/superpowers/plans/2026-05-25-bound-aware-towpath-planner.md
+++ b/docs/superpowers/plans/2026-05-25-bound-aware-towpath-planner.md
@@ -1,5 +1,18 @@
 # Bound-Aware Tow-Path Planner (Hybrid-A*) Implementation Plan
 
+> **⚠️ Acceptance criterion revised by #197 (2026-05-26).** This plan assumed
+> that with `plan_path` in place the solver fixture matrix would return to
+> `found` **with bundled, exact-validated plans** (see the "Definition of done"
+> / final acceptance steps). That proved too optimistic: even bound-aware
+> Hybrid-A* cannot route dense multi-plane fills in v1 (the 6-plane fixtures and
+> `layouts/example.yaml` are un-towable; spike Risk #1). #197 therefore reversed
+> the "fail-whole-solve / `no_feasible_plan`" decision to **best-effort
+> enrichment** — the matrix returns `found` with `plans[i] = None` where the
+> planner can't route a layout, and the `no_feasible_plan` status was dropped.
+> Hybrid-A* is still a real win (it routes turned/wide-wing single cases that
+> single-Dubins could not); dense-fill routing remains v2 (RRT-Connect). Treat
+> any `no_feasible_plan` reference below as historical.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Replace the single-shot `plan_dubins` call in `plan_fill` with a deterministic Hybrid-A* search (`plan_path`) that finds an in-bounds, obstacle-free multi-segment tow path from the door-cone entry pose to the target slot, so `solve` returns genuinely tow-able layouts (#222, unblocks #197).

--- a/docs/superpowers/plans/2026-05-25-phase3a-towplanner-wave2.md
+++ b/docs/superpowers/plans/2026-05-25-phase3a-towplanner-wave2.md
@@ -1,5 +1,21 @@
 # Phase 3a Tow-Path Planner — Wave 2 (Module + solve integration) Implementation Plan
 
+> **⚠️ Partially superseded during #197 implementation (2026-05-26).** The
+> "Layout valid but un-towable → **fail whole solve**" decision below was
+> **reversed to best-effort enrichment** when implementation revealed that the
+> v1 planner cannot route *any* dense multi-plane fill — even the project's own
+> `layouts/example.yaml` and a 6-plane fill in the roomy 30×25 m test hangar are
+> un-towable (spike Risk #1 / ADR-0007: Dubins-only + bounded Hybrid-A* with
+> documented false-negatives). Fail-whole would have made `hangarfit solve`
+> return `no_feasible_plan` for essentially every realistic scenario, discarding
+> valid static layouts on a heuristic's false negative. The shipped behaviour:
+> `solve()` keeps every valid layout and sets `plans[i] = None` where the planner
+> could not route it; the `no_feasible_plan` status was dropped; status stays
+> search-driven; the blocking planes are recorded in
+> `SolverDiagnostics.unroutable_planes`. A new `plan_paths: bool = True` param
+> lets callers skip the (expensive) tow-planning. The CLI passes `plan_paths=False`
+> (surfacing tow paths is #193). See the updated row 3 below and the #197 PR.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Wire the Wave 1 primitives into a working empty-hangar-fill planner — `plan_fill(target: Layout) -> MovesPlan` with a bounded deterministic order-retry loop (#196) — then have `hangarfit solve` return a bundled `(Layout, MovesPlan)` result (#197).
@@ -18,7 +34,7 @@ These three forks were genuinely open after ADR-0007; the user chose, alternativ
 |---|---|---|
 | **Cart door→slot traversal** | **Extend `plan_dubins` r=0** to emit pivot→straight→pivot when start/end positions differ (still one `DubinsArc`, `turn_radius_m=0`). `plan_fill` stays cart-agnostic, honoring ADR-0007's "one motion primitive, no cart special-case in the planner body". | (b) *Separate `_plan_cart_arc` helper* — keeps the Wave 1 primitive test untouched but pushes a `movement_mode` branch into the planner body, against the ADR driver. (c) *Defer carts* — the fleet has 3 `always_cart` planes (Falke, Wild Thing, Zlin Savage); realistic scenarios would hard-fail. |
 | **`solve` result shape** | **Parallel `plans: tuple[MovesPlan, ...]` field** on `SolveResult`, index-aligned with `layouts`. Minimal glue (matches the issue's "~20 lines"); CLI keeps reading `.layouts`; backward-compatible (defaults to `()`). | *Bundle/`Candidate` type* (`layouts`→`candidates`) — higher cohesion but churns `SolveResult`, both CLI emit paths, the render/write helpers, and every existing solver test that builds or reads a `SolveResult`. |
-| **Layout valid but un-towable** | **Fail whole solve** — if *any* returned layout's `plan_fill` raises `NoFeasiblePlanError`, `solve` returns `status="no_feasible_plan"` with empty `layouts`/`plans` and the offending plane named in diagnostics. | *Keep layout, plan=None* — preserves valid static layouts but weakens the "every returned layout is tow-able" guarantee. *Drop the layout* — silently discards work. The user chose strict; see the **regression-guard** note in Task 6. |
+| **Layout valid but un-towable** | ~~**Fail whole solve**~~ → **REVERSED to "keep layout, plan=None" during #197 (see banner at top).** Originally: if *any* returned layout's `plan_fill` raises `NoFeasiblePlanError`, `solve` returns `status="no_feasible_plan"` with empty `layouts`/`plans`. Implementation showed the v1 planner cannot route any dense fill, so fail-whole made `solve` near-useless; the rejected "keep layout, plan=None" alternative became the chosen one. | *Drop the layout* — silently discards work (still rejected). The "every returned layout is tow-able" guarantee is intentionally not offered in v1: an un-routable layout is still a valid static arrangement, and the planner's failure is advisory (spike Risk #8). |
 
 **Consequence to carry into Wave 3 (#193 CLI):** because un-towable ⇒ whole-solve failure, the Wave 3 exit-code rule should read "exit non-zero when `status == no_feasible_plan`" — which already falls out of the existing `if not result.layouts: return 1` path (Task 6 keeps that intact). The spike's #193 wording ("non-zero exit when no feasible order exists for any candidate") is *tightened* by this decision; note it on #193 when Wave 3 is planned.
 

--- a/docs/superpowers/plans/2026-05-25-phase3a-towplanner-wave2.md
+++ b/docs/superpowers/plans/2026-05-25-phase3a-towplanner-wave2.md
@@ -4,8 +4,9 @@
 > "Layout valid but un-towable → **fail whole solve**" decision below was
 > **reversed to best-effort enrichment** when implementation revealed that the
 > v1 planner cannot route *any* dense multi-plane fill — even the project's own
-> `layouts/example.yaml` and a 6-plane fill in the roomy 30×25 m test hangar are
-> un-towable (spike Risk #1 / ADR-0007: Dubins-only + bounded Hybrid-A* with
+> `layouts/example.yaml`, the tight-hangar `solve_fresh_six_planes.yaml`, and a
+> 6-plane fill in the *roomy* 30×25 m test hangar (`solve_pinned_one_plane.yaml`)
+> are all un-towable (spike Risk #1 / ADR-0007: Dubins-only + bounded Hybrid-A* with
 > documented false-negatives). Fail-whole would have made `hangarfit solve`
 > return `no_feasible_plan` for essentially every realistic scenario, discarding
 > valid static layouts on a heuristic's false negative. The shipped behaviour:

--- a/docs/superpowers/specs/2026-05-25-bound-aware-towpath-planner-design.md
+++ b/docs/superpowers/specs/2026-05-25-bound-aware-towpath-planner-design.md
@@ -133,8 +133,8 @@ This planner is a **prerequisite** for #197 (solve integration) to go green/merg
 work already done on the `feature/197-solve-bundled-movesplan` branch is consistent with
 this design and is **kept**:
 
-- **Task 4** (`SolveResult.plans`, `no_feasible_plan` status, `unplannable_plane`) — correct as-is.
-- **Task 5** (solver wires `plan_fill`, fail-whole-solve) — correct; exactly what "keep strict" wants.
+- **Task 4** (`SolveResult.plans`, ~~`no_feasible_plan` status, `unplannable_plane`~~) — `SolveResult.plans` kept; **the `no_feasible_plan` status and `unplannable_plane` field were dropped during #197** (see top banner) — status stays search-driven and diagnostics carries `unroutable_planes: tuple[str, ...]`.
+- **Task 5** (solver wires `plan_fill`, ~~fail-whole-solve~~) — `plan_fill` is wired in, but **fail-whole was reversed to best-effort** (#197, top banner): un-routable layout → `plans[i] = None`, layout kept.
 - **Front-gap exemption** (`_mover_motion_bounds_conflict` + `path_first_conflict` change) — correct; any planner needs it.
 
 The Hybrid-A\* planner is new tracked work (its own issue/PR off `develop`, in milestone

--- a/docs/superpowers/specs/2026-05-25-bound-aware-towpath-planner-design.md
+++ b/docs/superpowers/specs/2026-05-25-bound-aware-towpath-planner-design.md
@@ -4,6 +4,19 @@
 > spike's v2 obstacle/bound-aware path planning ([docs/spikes/tow-path-planning.md](../../spikes/tow-path-planning.md) Q3)
 > because the shipped v1 single-Dubins planner cannot tow the real fleet.
 > Next step: `superpowers:writing-plans` → implementation plan.
+>
+> **⚠️ Updated by #197 implementation (2026-05-26).** Two assumptions in this
+> spec proved false and were revised: (1) **"Decision-3 / fail-whole-solve"**
+> (referenced in §1, §4 failure semantics, §6 Tasks 4–5) was **reversed to
+> best-effort enrichment** — `solve()` keeps every valid layout and sets
+> `plans[i] = None` where the planner can't route it; the `no_feasible_plan`
+> status was dropped. (2) The §5 acceptance expectation that the bound-aware
+> planner would return the fixture matrix to `found` **with populated plans** was
+> too optimistic: even Hybrid-A* cannot route dense multi-plane fills in v1
+> (the 6-plane fixtures and `layouts/example.yaml` are un-towable), so the matrix
+> returns `found` with best-effort **`None`** plans. The planner is a real
+> improvement (it routes cases single-Dubins could not), but dense-fill routing
+> remains v2 (RRT-Connect). See the #197 PR for the shipped behaviour.
 
 ## 1. Problem & motivation
 

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -308,12 +308,17 @@ def cmd_solve(args: argparse.Namespace) -> int:
         print(f"error: {e}", file=sys.stderr)
         return 2
 
+    # plan_paths=False: the library-level bundle (SolveResult.plans) exists as
+    # of #197, but surfacing tow paths in the CLI (rendering + exit-code
+    # semantics) is #193. Until then, computing plans the CLI never displays
+    # would only add the per-plane Hybrid-A* search cost for no visible output.
     result = solve(
         scenario,
         budget_s=args.budget,
         alternatives=args.alternatives,
         seed=args.seed,
         search=SearchConfig(spread=args.spread),
+        plan_paths=False,
     )
 
     if args.json:

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -17,7 +17,10 @@ import typing
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from hangarfit.towplanner import MovesPlan
 
 WingPosition = Literal["high", "mid", "low"]
 Gear = Literal["tailwheel", "nosewheel", "monowheel"]
@@ -679,6 +682,16 @@ class SolverDiagnostics:
     decisions; that's ``status``'s job. They exist so dashboards and
     tests can read the same signals as the logger without scraping log
     records.
+
+    ``unroutable_planes`` records, in returned-layout order, the plane
+    the v1 tow-path planner could not route for each layout it failed to
+    plan (one entry per ``None`` in :attr:`SolveResult.plans`). Empty
+    when every returned layout was tow-planned, or when tow-planning was
+    not attempted (``solve(..., plan_paths=False)``). It is **advisory**:
+    the v1 planner (Dubins-only + bounded Hybrid-A*, ADR-0007) has
+    documented false-negatives, so an un-routable layout is still a valid
+    static arrangement — the entry flags a planning gap, not an invalid
+    layout.
     """
 
     restarts_attempted: int
@@ -688,6 +701,7 @@ class SolverDiagnostics:
     seed: int
     diversity_impossible: bool = False
     diversity_rejected_count: int = 0
+    unroutable_planes: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if (self.best_partial is None) != (self.best_partial_layout is None):
@@ -720,19 +734,41 @@ class SolveResult:
 
     - ``"found"`` / ``"found_partial"`` → at least one layout
     - ``"exhausted_budget"`` / ``"trivially_infeasible"`` → zero layouts
+
+    ``plans`` is index-aligned with ``layouts``: ``plans[i]`` is the
+    :class:`~hangarfit.towplanner.MovesPlan` for ``layouts[i]``, or
+    ``None`` when the v1 tow-path planner could not route that layout
+    (best-effort enrichment — see ADR-0007). It is also all-``None`` when
+    tow-planning was skipped (``solve(..., plan_paths=False)``). A ``None``
+    entry does **not** invalidate the corresponding layout: the static
+    arrangement remains valid; only its tow plan is unavailable. For
+    statuses with empty ``layouts`` the field is always ``()``.
     """
 
     status: SolveStatus
     layouts: tuple[Layout, ...]
     diagnostics: SolverDiagnostics
+    plans: tuple[MovesPlan | None, ...] = ()
 
     def __post_init__(self) -> None:
         if self.status in ("found", "found_partial") and not self.layouts:
             raise ValueError(f"SolveResult.status={self.status!r} requires at least one layout")
-        if self.status in ("exhausted_budget", "trivially_infeasible") and self.layouts:
+        _empty_statuses = ("exhausted_budget", "trivially_infeasible")
+        if self.status in _empty_statuses and self.layouts:
             raise ValueError(
                 f"SolveResult.status={self.status!r} must have empty layouts, "
                 f"got {len(self.layouts)}"
+            )
+        # plans is index-aligned with layouts for EVERY status: empty-layout
+        # statuses therefore require empty plans too, and this subsumes the
+        # found/found_partial cardinality check (layouts is already forced
+        # non-empty for those by the first guard). Entries may be None
+        # (best-effort: the v1 planner couldn't route that layout), but the
+        # length must still match.
+        if len(self.plans) != len(self.layouts):
+            raise ValueError(
+                f"SolveResult.plans length ({len(self.plans)}) must equal "
+                f"layouts length ({len(self.layouts)}) (status={self.status!r})"
             )
 
 

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -683,15 +683,18 @@ class SolverDiagnostics:
     tests can read the same signals as the logger without scraping log
     records.
 
-    ``unroutable_planes`` records, in returned-layout order, the plane
-    the v1 tow-path planner could not route for each layout it failed to
-    plan (one entry per ``None`` in :attr:`SolveResult.plans`). Empty
-    when every returned layout was tow-planned, or when tow-planning was
-    not attempted (``solve(..., plan_paths=False)``). It is **advisory**:
-    the v1 planner (Dubins-only + bounded Hybrid-A*, ADR-0007) has
-    documented false-negatives, so an un-routable layout is still a valid
-    static arrangement — the entry flags a planning gap, not an invalid
-    layout.
+    ``unroutable_planes`` is a flat, advisory list of the blocking plane
+    ids for the layouts the v1 tow-path planner could not route, in
+    returned-layout order. There is one entry per ``None`` in
+    :attr:`SolveResult.plans`, but the tuple is **compacted** (only the
+    failing layouts contribute) — it is *not* positionally indexable to
+    ``plans``/``layouts``; to attribute a failure to a specific layout,
+    read the ``None`` positions in ``plans``. Empty when every returned
+    layout was tow-planned, or when tow-planning was not attempted
+    (``solve(..., plan_paths=False)``). Advisory: the v1 planner
+    (Dubins-only + bounded Hybrid-A* — #222 under ADR-0007) has documented
+    false-negatives, so an un-routable layout is still a valid static
+    arrangement — the entry flags a planning gap, not an invalid layout.
     """
 
     restarts_attempted: int

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -35,6 +35,7 @@ from hangarfit.models import (
     SolveResult,
     SolveStatus,
 )
+from hangarfit.towplanner import MovesPlan, NoFeasiblePlanError, plan_fill
 
 _logger = logging.getLogger(__name__)
 
@@ -47,10 +48,24 @@ def solve(
     seed: int | None = None,
     diversity: DiversityConfig | None = None,
     search: SearchConfig | None = None,
+    plan_paths: bool = True,
 ) -> SolveResult:
     """Solve a Scenario into up to ``alternatives`` diverse valid Layouts.
 
     See spec §3.3 for the contract.
+
+    When ``plan_paths`` is ``True`` (the default), each returned layout is
+    also tow-planned (#197): ``result.plans[i]`` is the
+    :class:`~hangarfit.towplanner.MovesPlan` for ``result.layouts[i]``, or
+    ``None`` where the v1 planner could not route it (best-effort
+    enrichment — a ``None`` plan never discards an otherwise-valid layout;
+    see ADR-0007 and :class:`~hangarfit.models.SolveResult`). Pass
+    ``plan_paths=False`` to skip tow-planning entirely — useful when only
+    the static layout is needed, since tow-planning runs a bounded
+    Hybrid-A* search per plane and is the dominant cost on multi-plane
+    fills. With it off, ``plans`` is all-``None`` (still index-aligned).
+    Tow-planning is RNG-free, so it preserves the seeded determinism
+    contract (ADR-0003) end-to-end through the bundle.
     """
     if diversity is None:
         diversity = DiversityConfig()
@@ -259,9 +274,35 @@ def solve(
         # is one driver, but any K>1 run that runs out of budget mid-fill
         # also lands here).
         status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
+        # Tow-plan every returned layout (best-effort enrichment, #197). The
+        # v1 planner (Dubins-only + bounded Hybrid-A*, ADR-0007) cannot route
+        # dense multi-plane fills and has documented false-negatives, so an
+        # un-routable layout is recorded as plans[i]=None rather than discarding
+        # the otherwise-valid static arrangement — the layout is the headline
+        # answer; the tow plan is advisory (spike Risk #8). The `status` stays
+        # search-driven: tow-planning never changes found/found_partial.
+        plans: tuple[MovesPlan | None, ...]
+        unroutable: list[str] = []
+        if plan_paths:
+            built: list[MovesPlan | None] = []
+            for layout in accepted_layouts:
+                try:
+                    built.append(plan_fill(layout))
+                except NoFeasiblePlanError as e:
+                    built.append(None)
+                    unroutable.append(e.plane_id)
+                    _logger.warning(
+                        "layout not tow-routable by the v1 planner: plane %r blocked; "
+                        "returning the valid static layout without a tow plan",
+                        e.plane_id,
+                    )
+            plans = tuple(built)
+        else:
+            plans = (None,) * len(accepted_layouts)
         return SolveResult(
             status=status,
             layouts=tuple(accepted_layouts),
+            plans=plans,
             diagnostics=SolverDiagnostics(
                 restarts_attempted=restart_index,
                 wall_time_s=elapsed,
@@ -270,6 +311,7 @@ def solve(
                 seed=resolved_seed,
                 diversity_impossible=diversity_impossible,
                 diversity_rejected_count=diversity_rejected_count,
+                unroutable_planes=tuple(unroutable),
             ),
         )
     bp = check_layout(best_partial_layout) if best_partial_layout is not None else None

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -275,12 +275,13 @@ def solve(
         # also lands here).
         status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
         # Tow-plan every returned layout (best-effort enrichment, #197). The
-        # v1 planner (Dubins-only + bounded Hybrid-A*, ADR-0007) cannot route
-        # dense multi-plane fills and has documented false-negatives, so an
-        # un-routable layout is recorded as plans[i]=None rather than discarding
-        # the otherwise-valid static arrangement — the layout is the headline
-        # answer; the tow plan is advisory (spike Risk #8). The `status` stays
-        # search-driven: tow-planning never changes found/found_partial.
+        # v1 planner (Dubins-only + bounded Hybrid-A* — #222 under ADR-0007)
+        # cannot route dense multi-plane fills and has documented
+        # false-negatives, so an un-routable layout is recorded as plans[i]=None
+        # rather than discarding the otherwise-valid static arrangement — the
+        # layout is the headline answer; the tow plan is advisory (spike
+        # Risk #8). The `status` stays search-driven: tow-planning never changes
+        # found/found_partial.
         plans: tuple[MovesPlan | None, ...]
         unroutable: list[str] = []
         if plan_paths:
@@ -291,10 +292,16 @@ def solve(
                 except NoFeasiblePlanError as e:
                     built.append(None)
                     unroutable.append(e.plane_id)
+                    # Log the conflict kind/detail too, not just the plane: it
+                    # distinguishes a genuinely-boxed-in plane from a Hybrid-A*
+                    # budget exhaustion (a known false-negative class), which
+                    # call for different operator responses.
                     _logger.warning(
-                        "layout not tow-routable by the v1 planner: plane %r blocked; "
-                        "returning the valid static layout without a tow plan",
+                        "layout not tow-routable by the v1 planner: plane %r blocked "
+                        "(%s: %s); returning the valid static layout without a tow plan",
                         e.plane_id,
+                        e.conflict.kind,
+                        e.conflict.detail,
                     )
             plans = tuple(built)
         else:

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -178,11 +178,9 @@ class MovesPlan:
     """A full entry plan: the target layout plus the moves in execution order.
 
     Deliberately carries no sequence-level cart-usage tally (ADR-0007
-    open question). The ``target_layout`` type is ``Layout`` at runtime; kept as
-    ``object`` to avoid tightening the bundled-output public API until #197
-    locks its shape."""
+    open question)."""
 
-    target_layout: object
+    target_layout: Layout
     moves: tuple[Move, ...]
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,6 +17,8 @@ from hangarfit.models import (
     Part,
     Placement,
     SearchConfig,
+    SolverDiagnostics,
+    SolveResult,
     StrutsSpec,
 )
 
@@ -987,3 +989,71 @@ class TestSearchConfig:
         # None (adaptive) and positive are accepted
         assert SearchConfig(spread_scale_m=None).spread_scale_m is None
         assert SearchConfig(spread_scale_m=3.5).spread_scale_m == 3.5
+
+
+# ---------------------------------------------------------------------------
+# SolveResult.plans — best-effort tow-plan bundle (#197)
+# ---------------------------------------------------------------------------
+
+
+def _make_diag() -> SolverDiagnostics:
+    """Minimal valid SolverDiagnostics with all required fields set."""
+    return SolverDiagnostics(
+        restarts_attempted=0,
+        wall_time_s=0.1,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=42,
+    )
+
+
+def _make_valid_layout() -> Layout:
+    """A minimal valid Layout (one plane, empty placements)."""
+    a = _ok_aircraft("p1", movement_mode="always_own_gear", turn_radius_m=5.0)
+    return Layout(
+        fleet={a.id: a},
+        hangar=_ok_hangar(),
+        placements=(Placement(plane_id="p1", x_m=5.0, y_m=10.0, heading_deg=0.0, on_carts=False),),
+    )
+
+
+class TestSolveResultPlans:
+    """Invariant tests for the SolveResult.plans best-effort tow-plan bundle."""
+
+    def test_solveresult_plans_must_align_with_layouts(self) -> None:
+        # found/found_partial: len(plans) must equal len(layouts).
+        diag = _make_diag()
+        layout = _make_valid_layout()
+        with pytest.raises(ValueError, match="plans"):
+            SolveResult(status="found", layouts=(layout,), plans=(), diagnostics=diag)
+
+    def test_solveresult_plans_allows_none_entries(self) -> None:
+        # Best-effort: a returned layout whose tow plan the v1 planner could
+        # not compute is recorded as plans[i]=None — still aligned, still valid.
+        from hangarfit.towplanner import MovesPlan
+
+        diag = _make_diag()
+        layout = _make_valid_layout()
+        plan = MovesPlan(target_layout=layout, moves=())
+        sr = SolveResult(
+            status="found", layouts=(layout, layout), plans=(plan, None), diagnostics=diag
+        )
+        assert sr.plans == (plan, None)
+
+    def test_solveresult_plans_defaults_empty_for_backward_compat(self) -> None:
+        # Existing callers that build exhausted_budget/trivially_infeasible
+        # results without plans keep working.
+        diag = _make_diag()
+        sr = SolveResult(status="exhausted_budget", layouts=(), diagnostics=diag)
+        assert sr.plans == ()
+
+    def test_solveresult_empty_layout_status_rejects_stray_plans(self) -> None:
+        # plans is index-aligned with layouts for EVERY status, so an
+        # empty-layout status with a non-empty plans tuple is rejected too
+        # (not just the found/found_partial cardinality mismatch).
+        from hangarfit.towplanner import MovesPlan
+
+        diag = _make_diag()
+        stray = MovesPlan(target_layout=_make_valid_layout(), moves=())
+        with pytest.raises(ValueError, match="plans"):
+            SolveResult(status="exhausted_budget", layouts=(), plans=(stray,), diagnostics=diag)

--- a/tests/test_solver_canaries.py
+++ b/tests/test_solver_canaries.py
@@ -28,6 +28,27 @@ from hangarfit.loader import load_scenario
 from hangarfit.models import SearchConfig
 from hangarfit.solver import solve
 
+
+@pytest.fixture(autouse=True)
+def _stub_towplanning(monkeypatch):
+    """Keep these determinism canaries fast by stubbing tow-planning.
+
+    solve() tow-plans every returned layout by default (``plan_paths=True``,
+    #197), and tow-planning runs a bounded Hybrid-A* search per plane —
+    seconds on a multi-plane fill. These canaries assert IDENTICAL solver
+    output across runs (layouts/seed/best_partial), never on ``plans``, so a
+    trivial ``plan_fill`` stub preserves the default code path while removing
+    the cost. The real planner↔solver integration lives in
+    ``tests/test_solver_towplanner.py``.
+    """
+    import hangarfit.solver as solver_mod
+    from hangarfit.towplanner import MovesPlan
+
+    monkeypatch.setattr(
+        solver_mod, "plan_fill", lambda target: MovesPlan(target_layout=target, moves=())
+    )
+
+
 # Three canary fixtures chosen for coverage breadth:
 #  - trivial_single_plane: simplest possible search; sensitive to the
 #    initial-placement RNG.

--- a/tests/test_solver_fixture_matrix.py
+++ b/tests/test_solver_fixture_matrix.py
@@ -20,6 +20,26 @@ from hangarfit.solver import _heading_delta_short_arc, solve
 FIXTURES = "tests/fixtures"
 
 
+@pytest.fixture(autouse=True)
+def _stub_towplanning(monkeypatch):
+    """Keep these fixture-matrix tests fast by stubbing tow-planning.
+
+    solve() tow-plans every returned layout by default (``plan_paths=True``,
+    #197), and tow-planning runs a bounded Hybrid-A* search per plane —
+    seconds on a multi-plane fill. These tests assert the user-facing
+    *layout* contract (status, validity, pins, cart locks), never on
+    ``plans``, so a trivial ``plan_fill`` stub preserves the default code
+    path while removing the cost. The real planner↔solver integration lives
+    in ``tests/test_solver_towplanner.py``.
+    """
+    import hangarfit.solver as solver_mod
+    from hangarfit.towplanner import MovesPlan
+
+    monkeypatch.setattr(
+        solver_mod, "plan_fill", lambda target: MovesPlan(target_layout=target, moves=())
+    )
+
+
 def _assert_universal_properties(r: SolveResult, max_wall_time_s: float | None = None) -> None:
     """Apply spec §6.2 property assertions that every fixture test
     shares: status enum, every layout independently valid, seed populated,

--- a/tests/test_solver_infeasibility.py
+++ b/tests/test_solver_infeasibility.py
@@ -2,6 +2,28 @@
 
 from __future__ import annotations
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_towplanning(monkeypatch):
+    """Keep these infeasibility/smoke tests fast by stubbing tow-planning.
+
+    solve() tow-plans every returned layout by default (``plan_paths=True``,
+    #197), and tow-planning runs a bounded Hybrid-A* search per plane —
+    seconds on a multi-plane fill. These tests assert on status/seed/diagnostics,
+    never on ``plans``, so a trivial ``plan_fill`` stub preserves the default
+    code path while removing the cost (the trivially-infeasible cases never
+    reach tow-planning anyway). The real planner↔solver integration lives in
+    ``tests/test_solver_towplanner.py``.
+    """
+    import hangarfit.solver as solver_mod
+    from hangarfit.towplanner import MovesPlan
+
+    monkeypatch.setattr(
+        solver_mod, "plan_fill", lambda target: MovesPlan(target_layout=target, moves=())
+    )
+
 
 def test_solve_resolves_none_seed_to_entropy():
     """seed=None resolves to a random int and is recorded in diagnostics."""

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -7,6 +7,26 @@ import random
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _stub_towplanning(monkeypatch):
+    """Keep these search tests fast by stubbing tow-planning.
+
+    solve() tow-plans every returned layout by default (``plan_paths=True``,
+    #197), and tow-planning runs a bounded Hybrid-A* search per plane —
+    seconds on a multi-plane fill. These tests assert on search behaviour
+    (layouts, diversity, determinism), never on ``plans``, so a trivial
+    ``plan_fill`` stub preserves the default code path while removing the
+    cost. The real planner↔solver integration lives in
+    ``tests/test_solver_towplanner.py``.
+    """
+    import hangarfit.solver as solver_mod
+    from hangarfit.towplanner import MovesPlan
+
+    monkeypatch.setattr(
+        solver_mod, "plan_fill", lambda target: MovesPlan(target_layout=target, moves=())
+    )
+
+
 def test_initial_placement_for_pinned_plane_returns_the_pin():
     """If a plane is pinned, its initial placement IS the pin (no sampling)."""
     from hangarfit.loader import load_scenario

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -5,6 +5,26 @@ from __future__ import annotations
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _stub_towplanning(monkeypatch):
+    """Keep these search/spread tests fast by stubbing tow-planning.
+
+    solve() tow-plans every returned layout by default (``plan_paths=True``,
+    #197), and tow-planning runs a bounded Hybrid-A* search per plane —
+    seconds on a multi-plane fill. These tests assert on the *layouts*
+    (placements, gaps, determinism), never on ``plans``, so a trivial
+    ``plan_fill`` stub preserves the default code path while removing the
+    cost. The real planner↔solver integration lives in
+    ``tests/test_solver_towplanner.py``.
+    """
+    import hangarfit.solver as solver_mod
+    from hangarfit.towplanner import MovesPlan
+
+    monkeypatch.setattr(
+        solver_mod, "plan_fill", lambda target: MovesPlan(target_layout=target, moves=())
+    )
+
+
 def _min_pairwise_gap(layout, scenario) -> float:
     """Smallest plan-view edge-to-edge gap between any two planes in a layout."""
     from hangarfit.geometry import aircraft_parts_world

--- a/tests/test_solver_towplanner.py
+++ b/tests/test_solver_towplanner.py
@@ -1,0 +1,123 @@
+"""Tests for solver.solve() — tow-plan bundling (Wave 2, Task 5 / #197).
+
+Verifies that ``solve()`` returns a ``MovesPlan`` (or ``None``) per accepted
+layout (index-aligned in ``SolveResult.plans``) and that the **best-effort**
+behaviour is correct: a layout the v1 planner cannot route is recorded as
+``plans[i] is None`` (with the blocking plane in
+``diagnostics.unroutable_planes``) and the valid static layout is still
+returned — the tow plan is advisory enrichment, never a gate (ADR-0007).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def solvable_scenario():
+    """Minimal solvable scenario: one plane in a large hangar.
+
+    Uses ``solve_trivial_single_plane.yaml`` — one Husky in the 30×25 m
+    test hangar. This is the most reliable fixture for getting
+    ``status='found'`` with a *towable* layout (a single plane always has
+    a clear door-to-slot path) without depending on a tight budget or
+    multi-plane ordering luck.
+    """
+    from hangarfit.loader import load_scenario
+
+    return load_scenario("tests/fixtures/solve_trivial_single_plane.yaml")
+
+
+def test_solve_bundles_a_plan_per_layout(solvable_scenario):
+    from hangarfit.solver import solve
+    from hangarfit.towplanner import MovesPlan
+
+    result = solve(solvable_scenario, budget_s=10.0, alternatives=1, seed=7)
+    assert result.status in ("found", "found_partial")
+    # Index-aligned, one entry per layout.
+    assert len(result.plans) == len(result.layouts)
+    # The single-plane fixture is towable, so every entry is a real MovesPlan.
+    assert all(isinstance(p, MovesPlan) for p in result.plans)
+    for layout, plan in zip(result.layouts, result.plans, strict=True):
+        assert plan is not None
+        assert plan.target_layout is layout
+        assert {m.plane_id for m in plan.moves} == {p.plane_id for p in layout.placements}
+    # No layout was un-routable, so the advisory list is empty.
+    assert result.diagnostics.unroutable_planes == ()
+
+
+def test_solve_bundle_is_deterministic_for_a_seed(solvable_scenario):
+    from hangarfit.solver import solve
+
+    a = solve(solvable_scenario, budget_s=10.0, alternatives=1, seed=42)
+    b = solve(solvable_scenario, budget_s=10.0, alternatives=1, seed=42)
+    assert a.status == b.status
+    assert a.layouts == b.layouts
+    assert a.plans == b.plans
+    assert a.diagnostics.unroutable_planes == b.diagnostics.unroutable_planes
+
+
+def test_solve_best_effort_none_when_a_layout_is_untowable(solvable_scenario, monkeypatch):
+    """A layout the planner cannot route → plans[i] is None, layout kept."""
+    import hangarfit.solver as solver_mod
+    from hangarfit.models import Conflict
+    from hangarfit.solver import solve
+    from hangarfit.towplanner import NoFeasiblePlanError
+
+    def boom(target):
+        raise NoFeasiblePlanError("A", Conflict.single(kind="parts_overlap", plane="A", detail="x"))
+
+    monkeypatch.setattr(solver_mod, "plan_fill", boom)
+    result = solve(solvable_scenario, budget_s=10.0, alternatives=1, seed=7)
+    # The valid static layout is NOT discarded — status stays search-driven.
+    assert result.status in ("found", "found_partial")
+    assert len(result.layouts) >= 1
+    # ...but its tow plan is absent, and the blocking plane is recorded.
+    assert len(result.plans) == len(result.layouts)
+    assert all(p is None for p in result.plans)
+    assert result.diagnostics.unroutable_planes == ("A",) * len(result.layouts)
+
+
+def test_solve_plan_paths_false_skips_planning(solvable_scenario, monkeypatch):
+    """plan_paths=False must not invoke the planner at all (the perf opt-out)."""
+    import hangarfit.solver as solver_mod
+    from hangarfit.solver import solve
+
+    def fail_if_called(target):
+        raise AssertionError("plan_fill must not be called when plan_paths=False")
+
+    monkeypatch.setattr(solver_mod, "plan_fill", fail_if_called)
+    result = solve(solvable_scenario, budget_s=10.0, alternatives=1, seed=7, plan_paths=False)
+    assert result.status in ("found", "found_partial")
+    assert len(result.layouts) >= 1
+    # Still index-aligned, but unpopulated, and nothing was flagged un-routable.
+    assert len(result.plans) == len(result.layouts)
+    assert all(p is None for p in result.plans)
+    assert result.diagnostics.unroutable_planes == ()
+
+
+@pytest.mark.slow
+def test_solve_best_effort_real_planner_on_untowable_fill():
+    """End-to-end: the real v1 planner on a dense fill it cannot route.
+
+    ``solve_fresh_six_planes`` packs six planes into the tight placeholder
+    hangar — a valid static layout the Dubins-only + bounded Hybrid-A*
+    planner cannot fully route in v1 (spike Risk #1). Best-effort must
+    still return the layout(s) with a ``None`` plan and name the blocking
+    plane, rather than failing the whole solve. Slow (real per-plane
+    search), so excluded from the default suite.
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    scenario = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    result = solve(scenario, budget_s=10.0, alternatives=1, seed=7)
+    # Search succeeds: a valid static layout exists.
+    assert result.status in ("found", "found_partial")
+    assert len(result.layouts) >= 1
+    assert len(result.plans) == len(result.layouts)
+    # The dense fill is un-routable in v1, so the plan is None and the
+    # blocking plane is recorded — but the valid layout is preserved.
+    assert any(p is None for p in result.plans)
+    assert len(result.diagnostics.unroutable_planes) == sum(1 for p in result.plans if p is None)
+    assert result.diagnostics.unroutable_planes  # non-empty

--- a/tests/test_solver_towplanner.py
+++ b/tests/test_solver_towplanner.py
@@ -121,3 +121,48 @@ def test_solve_best_effort_real_planner_on_untowable_fill():
     assert any(p is None for p in result.plans)
     assert len(result.diagnostics.unroutable_planes) == sum(1 for p in result.plans if p is None)
     assert result.diagnostics.unroutable_planes  # non-empty
+
+
+def test_solve_k_gt_1_bundle_alignment_with_mixed_routability(monkeypatch):
+    """K>1: the per-layout loop builds an aligned plans tuple with a mix of
+    real plans and None, and unroutable_planes records exactly the failed
+    layouts in order.
+
+    Uses the real RR-MC search to produce multiple diverse layouts, but a
+    selective ``plan_fill`` stub that fails only the *second* layout planned —
+    so we can pin the positional alignment (plans[1] is None, the others are
+    real) deterministically, which no single-alternative test can.
+    """
+    import hangarfit.solver as solver_mod
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import Conflict
+    from hangarfit.solver import solve
+    from hangarfit.towplanner import MovesPlan, NoFeasiblePlanError
+
+    calls = {"n": 0}
+
+    def fail_second_only(target):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            pid = target.placements[0].plane_id
+            raise NoFeasiblePlanError(
+                pid, Conflict.single(kind="no_feasible_path", plane=pid, detail="stub")
+            )
+        return MovesPlan(target_layout=target, moves=())
+
+    monkeypatch.setattr(solver_mod, "plan_fill", fail_second_only)
+
+    scenario = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    result = solve(scenario, budget_s=10.0, alternatives=3, seed=0)
+
+    # This fixture+seed must yield at least 2 diverse layouts for the test to
+    # be meaningful; fail loudly (not vacuously) if the search regresses.
+    assert len(result.layouts) >= 2, f"need >=2 layouts to test K>1 alignment, got {result.layouts}"
+    assert len(result.plans) == len(result.layouts)
+    # The 2nd layout planned is the only failure: positionally aligned None.
+    assert result.plans[0] is not None
+    assert result.plans[1] is None
+    assert all(p is not None for i, p in enumerate(result.plans) if i != 1)
+    # unroutable_planes is the compacted list of exactly that one failure.
+    assert result.diagnostics.unroutable_planes == (result.layouts[1].placements[0].plane_id,)
+    assert len(result.diagnostics.unroutable_planes) == sum(1 for p in result.plans if p is None)


### PR DESCRIPTION
Closes #197.

Threads the tow-path planner into `solve()` so it returns bundled
`(Layout, MovesPlan)` candidates — the Phase 3a "solve integration" (spike
issue 6/10; spike Q8 + Summary).

## The design decision this PR makes (please review)

The parked draft on this branch implemented **fail-whole-solve**: if *any*
returned layout was un-towable, `solve()` returned `no_feasible_plan` with
zero layouts. Resuming the work surfaced a decisive fact:

| Fixture | Hangar | Planes | tow-planning result |
|---|---|---|---|
| single plane | large 30×25 | 1 | **towable** ✓ |
| `solve_fresh_six_planes` | placeholder 25×18 | 6 | un-routable (`cessna_140`) |
| `solve_pinned_one_plane` | **large 30×25** | 6 | un-routable (`ctsl`) |
| `layouts/example.yaml` | placeholder | 5 | un-routable (`fuji`) |

The v1 planner (Dubins-only + bounded Hybrid-A*, ADR-0007) **cannot route
dense multi-plane fills even in a roomy hangar** — this is the documented v1
limit (spike Risk #1; RRT-Connect is the deferred v2 escape hatch), not a bug.
Under fail-whole, `hangarfit solve` would have returned no result for nearly
every realistic scenario, including the project's own example.

**Resolution (agreed with maintainer): best-effort enrichment.** `solve()`
keeps every valid layout and attaches a `MovesPlan` where the planner can
route, `None` where it can't. A heuristic with documented false-negatives must
not veto an otherwise-valid layout — the static arrangement is the headline
answer; the tow plan is advisory (spike Risk #8: v1 paths are "illustrative,
not authoritative"). The `no_feasible_plan` status is dropped; status stays
search-driven.

## Changes

- **`models.py`** — `SolveResult.plans: tuple[MovesPlan | None, ...]`
  (index-aligned with `layouts`); dropped `no_feasible_plan` `SolveStatus`;
  replaced `SolverDiagnostics.unplannable_plane` with advisory
  `unroutable_planes: tuple[str, ...]`.
- **`solver.py`** — new `plan_paths: bool = True` param; best-effort bundling
  loop; un-routable → `plans[i]=None` + plane recorded; RNG-free (ADR-0003
  preserved through the bundle).
- **`cli.py`** — `solve(..., plan_paths=False)`. Surfacing tow paths (render +
  exit-code semantics) is **#193**; computing plans nothing displays yet would
  only add the per-plane search cost.
- **tests** — rewrote `test_solver_towplanner.py` for best-effort (+ a `@slow`
  real-planner test on an un-towable fill); fixed `test_models.py`; pure-search
  test files stub `plan_fill` (autouse) so `solve()`'s default path stays fast
  without re-testing the planner.
- **docs** — supersession banners on the three Phase 3a planning artifacts that
  recorded the reversed decision.

## Scope boundaries

In scope: the **library-level** bundle (`SolveResult.plans`). Out of scope and
tracked separately: **#192** (polyline overlay in `visualize.py`), **#193** (CLI
`--render-paths` + exit codes), **#194** (arc42 §5/§6/§8 + ADR README + fleet.yaml
docs sweep). ADR-0007 is unaffected — it never mandated fail-whole.

## Verification

- `pytest` (default markers): **611 passed, 5 deselected** (~2:50).
- `pytest -m slow tests/test_solver_towplanner.py`: real-planner best-effort
  test passes (6.6s).
- `ruff check`, `ruff format --check`, `mypy src/hangarfit/`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)