### PR TITLE
test(coverage): measure branch coverage via pyproject (#243)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,16 @@ markers = [
     "slow: tests that may exceed the default 5 s per-fixture solve budget (excluded by default via addopts; run on demand via `pytest -m slow`)",
 ]
 
+[tool.coverage.run]
+# Measure branch coverage, not just statement coverage, so a conditional
+# whose body is exercised but whose alternate edge is never taken (e.g. an
+# `if` with no covered `else`) shows up as a partial rather than reading as
+# fully covered. Set here rather than as a `--cov-branch` CLI flag so local
+# `pytest --cov` and CI pick it up identically — same local==CI parity goal
+# as the `addopts` marker filter above. coverage.py reads this section
+# automatically under pytest-cov.
+branch = true
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"


### PR DESCRIPTION
Enables `branch = true` under `[tool.coverage.run]` in `pyproject.toml` so coverage.py reports **partial branches** (a conditional whose body runs but whose alternate edge is never taken) instead of counting them as fully covered.

## Why pyproject, not a `--cov-branch` CLI flag in ci.yml
Setting it in pyproject means **local `pytest --cov` and CI measure branch coverage identically** — the same local==CI parity goal as the existing `addopts` slow-marker filter. coverage.py reads `[tool.coverage.run]` automatically under pytest-cov, so no `ci.yml` change is needed.

## Scope
- Branch coverage is already **~93%** (736 branches, 46 partial) / **96% combined**, well above any threshold — this only **turns on measurement**, no new tests required.
- **Decoupled from the parked Best Practices Gold milestone** (per maintainer request): measuring branch coverage is useful hygiene regardless of badge pursuit. Moved to `v0.7.1 — Security follow-ups`. The blocked-by edge to the parked Gold capstone (#246) is retained, so Gold still tracks this as satisfied.

There is no Codecov status gate, so the slightly different reported % (combined branch+statement) cannot break CI.

Closes #243