### PR TITLE
docs(security-posture): self-attest MFA control OSPS-AC-01.01

### DIFF
--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -183,6 +183,40 @@ A -1 here is the correct answer for a deliberately unpublished tool.
 
 ---
 
+## Two-factor authentication (OSPS-AC-01.01)
+
+**What the control requires.** OSPS Baseline L1 control OSPS-AC-01.01 requires
+that multi-factor authentication (MFA) is enabled for all accounts that can
+perform sensitive repository actions — including pushing commits, merging pull
+requests, and changing branch-protection settings.
+
+**Status: enabled.** The sole maintainer account (@DocGerd) has two-factor
+authentication enabled at the GitHub account level. Every sensitive repository
+action — commit pushes, PR merges, branch-protection changes — is gated behind
+this factor.
+
+**Why this is a self-attestation.** Account-level 2FA on a *personal* GitHub
+account is not externally verifiable via the GitHub REST API. The
+`GET /users/{username}` endpoint returns `"two_factor_authentication": null`
+for all callers, including the authenticated account holder. There is no
+API surface that exposes this field to outside observers.
+
+A GitHub *organisation* can enforce "require 2FA for all members" as a policy
+and expose that enforcement status via `GET /orgs/{org}`; but `hangarfit` is
+hosted under a personal account, not an organisation, so no equivalent
+enforcement object exists.
+
+This attestation therefore mirrors the posture already used for the structural
+Scorecard zeros above: an honest written statement in-tree, with the
+verifiability limit stated explicitly, rather than a claimed machine-checkable
+signal that does not exist.
+
+**Will it change?** Only if the repository moves under a GitHub organisation,
+at which point organisation-level 2FA enforcement can be turned on and would
+become externally verifiable.
+
+---
+
 ## Alternatives considered
 
 For completeness — these were considered for the Code-Review zero and

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -195,11 +195,16 @@ authentication enabled at the GitHub account level. Every sensitive repository
 action — commit pushes, PR merges, branch-protection changes — is gated behind
 this factor.
 
-**Why this is a self-attestation.** Account-level 2FA on a *personal* GitHub
-account is not externally verifiable via the GitHub REST API. The
-`GET /users/{username}` endpoint returns `"two_factor_authentication": null`
-for all callers, including the authenticated account holder. There is no
-API surface that exposes this field to outside observers.
+**Why this is a self-attestation.** A *personal* GitHub account's 2FA status is
+not verifiable by an *outside* observer via the GitHub REST API. The public
+`GET /users/{username}` endpoint never exposes a user's
+`two_factor_authentication` status to third parties. The *authenticated*
+`GET /user` endpoint can surface the field to the account holder, but whether
+it returns a boolean or `null` depends on the token type and scope (a classic
+PAT with `read:user` can return it; the OAuth token used by the `gh` CLI here
+returns `null`) — and that is the holder inspecting their *own* account, not a
+third party verifying it. No endpoint lets an external reviewer confirm a
+personal account's 2FA state.
 
 A GitHub *organisation* can enforce "require 2FA for all members" as a policy
 and expose that enforcement status via `GET /orgs/{org}`; but `hangarfit` is


### PR DESCRIPTION
## Summary

- Adds a new `## Two-factor authentication (OSPS-AC-01.01)` section to `docs/security-posture.md`.
- Attests (in present tense) that 2FA is enabled on the maintainer account (@DocGerd).
- Explains the verifiability limit: `GET /users/{username}` returns `two_factor_authentication: null` for all callers on personal accounts, so this is a self-attestation — the same honest posture as the existing structural-zero rebuttals in the same document.
- No code or test changes; docs-only.

Closes #229