### PR TITLE
chore(gitignore): guard root-level render PNGs from VCS (OSPS-QA-05)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,13 @@ coverage.xml
 .DS_Store
 
 # Project artifacts
+# Root-anchored guard for any PNG dropped at the repo root by
+# `hangarfit check --render <name>.png` (OSPS-QA-05, issue #231).
+# The leading slash restricts the rule to the repo root so that
+# legitimate subdir images (e.g. docs/diagram.png) remain track-able.
+/*.png
+# Keep explicit pattern for visibility — contributors grepping "out.png"
+# immediately see it is intentionally ignored.
 out*.png
 *.local.*
 


### PR DESCRIPTION
## Summary

- Adds a root-anchored `/*.png` rule to `.gitignore` so any PNG written to the repo root by `hangarfit check --render <name>.png` cannot be committed by accident (OSPS-QA-05.01 / OSPS-QA-05.02).
- The leading `/` restricts the rule to the repo root; images in subdirectories (e.g. `docs/diagram.png`) remain track-able.
- The existing `out*.png` line is kept for explicit visibility — contributors grepping "out.png" see it is intentionally ignored.

Closes #231

## Clean-tree audit proof

```
$ git ls-files | grep -iE '\.(png|whl|tar\.gz|tgz|zip|bin|exe|so|dll|jar|pdf)$'
(empty — exit 1)

$ git ls-files '*.tar.gz'
(empty — exit 0)
```

No generated or binary artifacts are tracked in VCS.

## check-ignore proof

Positive (root-level PNG is ignored):
```
$ touch render.png && git check-ignore render.png
render.png          # ← correctly ignored
$ git status --porcelain | grep render.png
(no output — render.png is invisible to git)
```

Negative (subdir PNG is NOT ignored):
```
$ touch docs/diagram.png && git check-ignore docs/diagram.png
(no output — exit 1; docs/diagram.png is NOT ignored)
```

## Test plan

- [x] `git ls-files` audit returns empty for all binary/generated extensions
- [x] `git check-ignore render.png` prints `render.png` (positive match)
- [x] `git status --porcelain` does not list `render.png`
- [x] `git check-ignore docs/diagram.png` prints nothing and exits 1 (negative, subdir unaffected)
- [x] All pre-commit hooks pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)