### PR TITLE
build(packaging): guarantee LICENSE ships in sdist and wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 authors = [{ name = "Patrick Kuhn" }]
 license = "Apache-2.0"
+license-files = ["LICENSE"]
 classifiers = []
 dependencies = [
   "pyyaml>=6.0",


### PR DESCRIPTION
## Summary

Closes #230

OSPS-LE-03.02 requires the license to be included with released assets (sdist and wheel).

**Finding:** LICENSE was already included by setuptools auto-discovery — no file was missing. However, the inclusion was implicit, relying on setuptools' heuristic `LICEN[SC]E*` glob. A future setuptools version bump or default-flip could silently drop it with no build error.

**Change:** Added the explicit PEP 639 declaration to `[project]` in `pyproject.toml`:
```toml
license-files = ["LICENSE"]
```
This makes the guarantee structural and regression-proof. Setuptools 82.0.1 supports this natively. No `MANIFEST.in` or `[tool.setuptools]` fallback was needed.

## Build proof (before and after the change)

**sdist:**
```
$ tar tzf dist/hangarfit-0.6.1.tar.gz | grep -i licen
hangarfit-0.6.1/LICENSE
```

**wheel:**
```
$ unzip -l dist/hangarfit-0.6.1-py3-none-any.whl | grep -i licen
    11358  2026-05-26 15:01   hangarfit-0.6.1.dist-info/licenses/LICENSE
```

Both identical before and after the change. Build emitted zero warnings. 603 tests pass.

## Test plan

- [x] `python3 -m build` completes cleanly (no warnings)
- [x] `tar tzf dist/*.tar.gz | grep -i licen` → `hangarfit-0.6.1/LICENSE`
- [x] `unzip -l dist/*.whl | grep -i licen` → `hangarfit-0.6.1.dist-info/licenses/LICENSE`
- [x] All 603 tests pass (`PYTHONPATH=src python3 -m pytest -q`)
- [x] `git status --porcelain` shows only `pyproject.toml` changed (no lockfile regeneration needed — no dependency changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)