### PR TITLE
feat(visualize): tow-path polyline overlay (#192)

### DIFF
--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -129,6 +129,10 @@ def render_layout(
     overlay — see :func:`_draw_tow_paths` (#192). ``check_result`` and
     ``moves_plan`` are independent: a layout can be rendered with neither,
     either, or both.
+
+    This is renderer-only: no CLI flag exposes ``moves_plan`` to end users
+    yet — wiring ``--render-paths`` (and the bundle plumbing) is deferred to
+    #193.
     """
     # Defense in depth: even with ``matplotlib.use("Agg", force=True)``
     # at module import, a misconfigured environment (interactive backend
@@ -399,6 +403,11 @@ def _draw_tow_paths(ax: Any, moves_plan: MovesPlan) -> None:
     colour regardless of move order (the ADR-0003 determinism spirit). The
     in-memory ``MovesPlan`` shape is rich enough that a per-move PNG sequence
     or animation can be added later without changing it (spike Q7).
+
+    Each polyline carries its ``plane_id`` as a matplotlib ``label``. No
+    legend is rendered today (``_finalize_axes`` draws none), so the label is
+    currently inert — it is a deliberate forward hook for a future legend, and
+    a path is already disambiguated by terminating at its annotated slot.
     """
     plane_ids = sorted({move.plane_id for move in moves_plan.moves})
     colour_for = {

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import matplotlib
 
@@ -37,6 +37,13 @@ from matplotlib.patches import Polygon as MplPolygon  # noqa: E402
 
 from .geometry import WorldPart, aircraft_parts_world  # noqa: E402
 from .models import CheckResult, Layout, Placement, WingPosition  # noqa: E402
+
+if TYPE_CHECKING:
+    # Annotation-only import: the runtime code in _draw_tow_paths is duck-typed
+    # (moves_plan.moves / move.path.sample()), so importing MovesPlan eagerly
+    # would add a needless module dependency. towplanner does not import
+    # visualize, so this is safe under TYPE_CHECKING either way.
+    from .towplanner import MovesPlan
 
 _WING_COLORS: dict[WingPosition, str] = {
     "high": "#3498db",  # blue
@@ -50,6 +57,23 @@ _WING_COLORS: dict[WingPosition, str] = {
 _FALLBACK_COLOR = "#95a5a6"  # gray
 
 _CONFLICT_COLOR = "#e74c3c"  # red
+
+# Tow-path overlay palette (#192). One colour per plane, cycled by sorted
+# plane_id. Deliberately excludes the conflict red (#e74c3c) and the gray
+# fallback so a path never blurs into a conflict highlight or a placeholder
+# part. Eight entries cover the fleet (<=9 planes); a 9th plane reuses the
+# first colour — acceptable since each path terminates at its annotated slot.
+_TOW_PATH_COLORS = (
+    "#1f77b4",  # blue
+    "#ff7f0e",  # orange
+    "#2ca02c",  # green
+    "#9467bd",  # purple
+    "#8c564b",  # brown
+    "#17becf",  # cyan
+    "#bcbd22",  # olive
+    "#e377c2",  # pink
+)
+_TOW_PATH_LINEWIDTH = 1.6
 
 _FUSELAGE_ALPHA = 0.9  # near-opaque: two fuselages overlapping is always
 # a conflict, no value in seeing through.
@@ -86,6 +110,7 @@ def render_layout(
     output_path: Path | str,
     *,
     check_result: CheckResult | None = None,
+    moves_plan: MovesPlan | None = None,
     title: str | None = None,
     dpi: int = 100,
 ) -> None:
@@ -98,6 +123,12 @@ def render_layout(
     part of every plane named in any conflict rather than guess which
     part-pair is the actual culprit. A future refinement could plumb
     part indices through ``Conflict.detail``.
+
+    If ``moves_plan`` is supplied, each plane's tow path is overlaid as a
+    polyline (one colour per plane) at the same z-tier as the conflict
+    overlay — see :func:`_draw_tow_paths` (#192). ``check_result`` and
+    ``moves_plan`` are independent: a layout can be rendered with neither,
+    either, or both.
     """
     # Defense in depth: even with ``matplotlib.use("Agg", force=True)``
     # at module import, a misconfigured environment (interactive backend
@@ -120,6 +151,8 @@ def render_layout(
         _draw_aircraft(ax, layout)
         if not (check_result is None or check_result.valid):
             _draw_conflict_overlay(ax, layout, check_result)
+        if moves_plan is not None:
+            _draw_tow_paths(ax, moves_plan)
         _finalize_axes(ax, layout, title)
         fig.savefig(str(output_path), dpi=dpi, bbox_inches="tight")
     finally:
@@ -353,6 +386,36 @@ def _draw_conflict_overlay(ax: Any, layout: Layout, check_result: CheckResult) -
                 zorder=5,
             )
             ax.add_patch(patch)
+
+
+def _draw_tow_paths(ax: Any, moves_plan: MovesPlan) -> None:
+    """Overlay each plane's tow path as a polyline, one colour per plane (#192).
+
+    Companion to :func:`_draw_conflict_overlay` at the same z-tier (5), so the
+    paths read on top of the aircraft parts (zorder 1-4) — spike Q7. Each path
+    is the sampled :class:`~hangarfit.towplanner.DubinsArc` polyline from the
+    door-cone entry pose to the target slot. Colours are assigned by *sorted*
+    ``plane_id`` so a given plan always renders the same plane in the same
+    colour regardless of move order (the ADR-0003 determinism spirit). The
+    in-memory ``MovesPlan`` shape is rich enough that a per-move PNG sequence
+    or animation can be added later without changing it (spike Q7).
+    """
+    plane_ids = sorted({move.plane_id for move in moves_plan.moves})
+    colour_for = {
+        pid: _TOW_PATH_COLORS[i % len(_TOW_PATH_COLORS)] for i, pid in enumerate(plane_ids)
+    }
+    for move in moves_plan.moves:
+        poses = list(move.path.sample())
+        xs = [p.x_m for p in poses]
+        ys = [p.y_m for p in poses]
+        ax.plot(
+            xs,
+            ys,
+            color=colour_for[move.plane_id],
+            lw=_TOW_PATH_LINEWIDTH,
+            zorder=5,
+            label=move.plane_id,
+        )
 
 
 def _finalize_axes(ax: Any, layout: Layout, title: str | None) -> None:

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -524,3 +524,59 @@ class TestDrawTowPaths:
         out = tmp_path / "with_paths.png"
         render_layout(layout, out, moves_plan=plan)
         _assert_valid_png(out)
+
+    @staticmethod
+    def _curved_move(plane_id: str):
+        """A genuinely curved (multi-segment CSC) move built via the real
+        ``plan_dubins``, so ``sample()`` yields interior poses — exercises the
+        non-straight branch the vertical S-leg helper cannot reach."""
+        from hangarfit.towplanner import Move, Pose, plan_dubins
+
+        start = Pose(x_m=0.0, y_m=0.0, heading_deg=0.0)
+        goal = Pose(x_m=5.0, y_m=0.0, heading_deg=180.0)
+        arc = plan_dubins(start, goal, turn_radius_m=1.5)
+        return Move(plane_id=plane_id, target_slot=goal, path=arc)
+
+    def test_curved_path_samples_interior_points(self) -> None:
+        # A turning path must be drawn as the full sampled polyline, not just
+        # its two endpoints — guards a regression that collapses sample() to
+        # [start, end] (which would silently flatten every curve).
+        from hangarfit.visualize import _draw_tow_paths
+
+        ax = MagicMock()
+        _draw_tow_paths(ax, self._plan(self._curved_move("a")))
+        xs = ax.plot.call_args.args[0]
+        assert len(xs) > 2, f"curved path should sample interior points, got {len(xs)}"
+
+    def test_label_is_the_plane_id(self) -> None:
+        # The matplotlib label carries the plane id (a future-legend hook);
+        # pin it directly rather than only relying on it as a test proxy.
+        from hangarfit.visualize import _draw_tow_paths
+
+        ax = MagicMock()
+        _draw_tow_paths(ax, self._plan(self._vertical_move("husky", 0.0, 0.0, 5.0)))
+        assert ax.plot.call_args.kwargs["label"] == "husky"
+
+    def test_colour_cycle_wraps_beyond_palette(self) -> None:
+        # 9 planes > 8-colour palette: must not raise (the i % len cycle), and
+        # exactly one colour repeats (the 9th reuses the first). Guards against
+        # a regression to direct indexing (IndexError on a 9-plane fleet).
+        from hangarfit.visualize import _TOW_PATH_COLORS, _draw_tow_paths
+
+        moves = [self._vertical_move(f"p{i}", float(i), 0.0, 3.0) for i in range(9)]
+        ax = MagicMock()
+        _draw_tow_paths(ax, self._plan(*moves))
+        assert ax.plot.call_count == 9
+        colours = [c.kwargs["color"] for c in ax.plot.call_args_list]
+        assert len(set(colours)) == len(_TOW_PATH_COLORS)  # 8 distinct, one reused
+
+    def test_render_layout_with_both_check_result_and_moves_plan(self, tmp_path: Path) -> None:
+        # The docstring promises check_result and moves_plan are independent —
+        # render an invalid layout with BOTH overlays and confirm a valid PNG.
+        layout = _load("invalid_wing_wing_same_height")
+        result = check(layout)
+        assert not result.valid  # fixture precondition
+        plan = self._plan(self._vertical_move("a", 3.0, 1.0, 6.0))
+        out = tmp_path / "both_overlays.png"
+        render_layout(layout, out, check_result=result, moves_plan=plan)
+        _assert_valid_png(out)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -405,3 +405,122 @@ class TestDrawPartHandlesTailKind:
         ax = MagicMock()
         _draw_part(ax, tail_part, "#3498db")
         ax.add_patch.assert_called_once()
+
+
+class TestDrawTowPaths:
+    """`_draw_tow_paths` overlays each plane's tow path as a polyline, one
+    colour per plane, at the conflict-overlay z-tier (#192). Companion to
+    ``_draw_conflict_overlay``.
+    """
+
+    @staticmethod
+    def _vertical_move(plane_id: str, x0: float, y0: float, length: float):
+        """A trivial straight (S-leg) move from (x0,y0) heading +y, so the
+        sampled polyline is the vertical segment (x0, y0)→(x0, y0+length)."""
+        from hangarfit.towplanner import DubinsArc, Move, Pose, Segment
+
+        start = Pose(x_m=x0, y_m=y0, heading_deg=0.0)
+        end = Pose(x_m=x0, y_m=y0 + length, heading_deg=0.0)
+        arc = DubinsArc(start=start, end=end, turn_radius_m=1.0, segments=(Segment("S", length),))
+        return Move(plane_id=plane_id, target_slot=end, path=arc)
+
+    def _plan(self, *moves):
+        from hangarfit.towplanner import MovesPlan
+
+        return MovesPlan(target_layout=MagicMock(), moves=tuple(moves))
+
+    def test_draws_one_polyline_per_move(self) -> None:
+        from hangarfit.visualize import _draw_tow_paths
+
+        plan = self._plan(
+            self._vertical_move("a", 0.0, 0.0, 5.0),
+            self._vertical_move("b", 2.0, 0.0, 4.0),
+        )
+        ax = MagicMock()
+        _draw_tow_paths(ax, plan)
+        assert ax.plot.call_count == 2
+
+    def test_one_colour_per_distinct_plane(self) -> None:
+        from hangarfit.visualize import _draw_tow_paths
+
+        plan = self._plan(
+            self._vertical_move("a", 0.0, 0.0, 5.0),
+            self._vertical_move("b", 2.0, 0.0, 4.0),
+        )
+        ax = MagicMock()
+        _draw_tow_paths(ax, plan)
+        colours = [c.kwargs["color"] for c in ax.plot.call_args_list]
+        assert len(set(colours)) == 2, f"distinct planes must get distinct colours, got {colours}"
+
+    def test_same_plane_keeps_one_colour(self) -> None:
+        # "one colour per plane": two moves for the same plane id share a colour.
+        from hangarfit.visualize import _draw_tow_paths
+
+        plan = self._plan(
+            self._vertical_move("a", 0.0, 0.0, 5.0),
+            self._vertical_move("a", 1.0, 0.0, 3.0),
+        )
+        ax = MagicMock()
+        _draw_tow_paths(ax, plan)
+        colours = [c.kwargs["color"] for c in ax.plot.call_args_list]
+        assert colours[0] == colours[1]
+
+    def test_colour_assignment_is_order_independent(self) -> None:
+        # Sorting plane ids before assigning colours makes the mapping
+        # deterministic regardless of move order (ADR-0003 spirit).
+        from hangarfit.visualize import _draw_tow_paths
+
+        ax1, ax2 = MagicMock(), MagicMock()
+        _draw_tow_paths(
+            ax1,
+            self._plan(
+                self._vertical_move("a", 0.0, 0.0, 5.0),
+                self._vertical_move("b", 2.0, 0.0, 4.0),
+            ),
+        )
+        _draw_tow_paths(
+            ax2,
+            self._plan(
+                self._vertical_move("b", 2.0, 0.0, 4.0),
+                self._vertical_move("a", 0.0, 0.0, 5.0),
+            ),
+        )
+        # Map plane->colour via the per-call label, then compare the mappings.
+        m1 = {c.kwargs["label"]: c.kwargs["color"] for c in ax1.plot.call_args_list}
+        m2 = {c.kwargs["label"]: c.kwargs["color"] for c in ax2.plot.call_args_list}
+        assert m1 == m2
+
+    def test_empty_plan_is_noop(self) -> None:
+        from hangarfit.visualize import _draw_tow_paths
+
+        ax = MagicMock()
+        _draw_tow_paths(ax, self._plan())
+        ax.plot.assert_not_called()
+
+    def test_polyline_traces_sampled_path_endpoints(self) -> None:
+        from hangarfit.visualize import _draw_tow_paths
+
+        ax = MagicMock()
+        _draw_tow_paths(ax, self._plan(self._vertical_move("a", 0.0, 0.0, 5.0)))
+        xs, ys = ax.plot.call_args.args[0], ax.plot.call_args.args[1]
+        assert (xs[0], ys[0]) == pytest.approx((0.0, 0.0))
+        assert (xs[-1], ys[-1]) == pytest.approx((0.0, 5.0))
+
+    def test_paths_sit_at_overlay_z_tier(self) -> None:
+        # Same z-tier as the conflict overlay (zorder 5) so paths read on top
+        # of aircraft (zorder 1-4) per spike Q7.
+        from hangarfit.visualize import _draw_tow_paths
+
+        ax = MagicMock()
+        _draw_tow_paths(ax, self._plan(self._vertical_move("a", 0.0, 0.0, 5.0)))
+        assert ax.plot.call_args.kwargs["zorder"] >= 5
+
+    def test_render_layout_with_moves_plan_produces_valid_png(self, tmp_path: Path) -> None:
+        layout = _load("valid_two_separated")
+        plan = self._plan(
+            self._vertical_move("a", 3.0, 1.0, 6.0),
+            self._vertical_move("b", 8.0, 1.0, 5.0),
+        )
+        out = tmp_path / "with_paths.png"
+        render_layout(layout, out, moves_plan=plan)
+        _assert_valid_png(out)


### PR DESCRIPTION
Closes #192.

Phase 3a logical issue 7/10 (spike Q7). Adds the v1 tow-path visualization: a polyline overlay on the existing PNG, one colour per plane.

## What it does

- New `_draw_tow_paths(ax, moves_plan)` — companion to `_draw_conflict_overlay` at the same z-tier (5), so paths read on top of the aircraft parts (zorder 1-4).
- New optional `render_layout(..., moves_plan: MovesPlan | None = None)`. When supplied, each plane's tow path is sampled from its `DubinsArc` and drawn as a polyline; colour is assigned by **sorted `plane_id`** so the plane→colour mapping is deterministic regardless of move order.
- `check_result` and `moves_plan` are independent — a layout renders with neither, either, or both.

## Scope

Renderer only. Wiring a `--render-paths` CLI flag to actually pass the solver's `MovesPlan` bundle through is **#193**; this PR ships the drawing capability #193 will call. The in-memory `MovesPlan` shape is untouched, so a per-move PNG sequence / animation remains an additive future extension (spike Q7).

`MovesPlan` is imported under `TYPE_CHECKING` (annotation-only; `_draw_tow_paths` is duck-typed on `.moves` / `.path.sample()`), so there is no import cycle with `towplanner`.

## Tests

A focused `TestDrawTowPaths` unit class (MagicMock axes, mirroring the existing `_draw_maintenance_bay` direct-axes pattern): one-polyline-per-move, one-colour-per-distinct-plane, same-plane-same-colour, order-independent colour assignment, empty-plan no-op, sampled-endpoint tracing, overlay z-tier; plus a `render_layout(..., moves_plan=...)` end-to-end valid-PNG check.

## Verification

- `pytest` (default): **626 passed, 5 deselected** (~41s).
- `ruff check`, `ruff format --check`, `mypy src/hangarfit/`: clean.

Visual quality of the overlay is for your eye — the tests deliberately assert structure/validity, not pixels (matching this module's existing convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)