### PR TITLE
docs(governance): Best Practices Silver governance, roles, CoC, and code-review docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,17 @@ review.
 
 ---
 
+## Code of Conduct
+
+This project adopts the [Contributor Covenant](CODE_OF_CONDUCT.md). By taking
+part — issues, pull requests, discussions — you agree to uphold it. Report
+unacceptable behaviour via a
+[private security advisory](https://github.com/DocGerd/hangarfit/security/advisories/new)
+or a direct message to [@DocGerd](https://github.com/DocGerd), as described in
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+---
+
 ## First-time setup
 
 1. Install dev dependencies:
@@ -107,6 +118,12 @@ Before the PR can merge:
 ---
 
 ## Code review
+
+**Every change is reviewed before it is released.** No commit reaches `develop`
+or `main` except through a pull request that has been reviewed and had its
+findings resolved — the maintainer does not merge unreviewed changes. This is
+enforced socially by the process below and structurally by branch protection
+(direct pushes to `develop`/`main` are blocked).
 
 The project uses the `pr-review-toolkit` — invoke it with `/pr-review` in
 the Claude Code CLI. Reviewers file findings as **review threads on the diff**,

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,71 @@
+# Governance
+
+This document describes how decisions are made in `hangarfit` and who is
+responsible for what. It is deliberately honest about the project's size:
+`hangarfit` is a small, single-maintainer hobby tool for a flying club, not a
+multi-stakeholder foundation project. The model below reflects that reality
+rather than borrowing ceremony the project does not need.
+
+## Model
+
+`hangarfit` follows a **single-maintainer (BDFL-style)** model. The maintainer
+is the final decision-maker on scope, design, and what ships. This is not a
+committee or a voting body; it is one person maintaining a focused tool, with a
+transparent, written process so that decisions and their rationale are visible
+to anyone reading the repository.
+
+The maintainer commits to keeping that process transparent: every change is
+tracked by a public issue, lands through a reviewed pull request, and — for
+anything that shapes the system — is recorded in an
+[Architecture Decision Record](docs/adr/).
+
+## How decisions are made
+
+- **Proposing a change.** Anyone may open an issue (bug report, feature
+  request, or design question) using the templates in
+  [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/). Discussion happens on
+  the issue and in [GitHub Discussions](https://github.com/DocGerd/hangarfit/discussions).
+- **Accepting a change.** Work is done on a `feature/<slug>` branch off
+  `develop`, opened as a pull request that links its issue with `Closes #N`.
+  Every PR is reviewed before it merges (see
+  [Code review in `CONTRIBUTING.md`](CONTRIBUTING.md#code-review)); the
+  maintainer is the only approver and merger. The full branching model is
+  GitFlow, documented in [`CONTRIBUTING.md`](CONTRIBUTING.md#workflow-gitflow).
+- **Architectural decisions.** Choices that shape the substrate are written up
+  as ADRs in [`docs/adr/`](docs/adr/) and the arc42 docs in
+  [`docs/architecture/`](docs/architecture/), so the *why* behind a decision
+  outlives the conversation that produced it.
+- **Disagreements.** Raise them on the relevant issue or PR thread. The
+  maintainer makes the final call and records the reasoning in the thread or an
+  ADR.
+
+## Key roles and current holders
+
+For a single-maintainer project these roles are all currently held by the same
+person; they are listed separately so the *responsibilities* are explicit and
+so the list stays meaningful if the project ever grows.
+
+| Role | Responsibility | Current holder |
+|---|---|---|
+| **Maintainer / project lead** | Final say on scope, design, and releases; reviews and merges all PRs. | [@DocGerd](https://github.com/DocGerd) |
+| **Security contact** | Receives and triages vulnerability reports; see [`SECURITY.md`](SECURITY.md). Reports go through GitHub [private security advisories](https://github.com/DocGerd/hangarfit/security/advisories/new). | [@DocGerd](https://github.com/DocGerd) |
+| **Release manager** | Cuts releases from `develop` via the GitFlow `release/*` process, tags them, and publishes the GitHub release. | [@DocGerd](https://github.com/DocGerd) |
+| **Code-of-Conduct enforcement** | Handles conduct reports per [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). | [@DocGerd](https://github.com/DocGerd) |
+
+## Becoming a maintainer
+
+There is no formal maintainer-promotion process today because the project does
+not yet need one. If `hangarfit` attracts sustained contribution, the
+maintainer will revisit this document to add additional maintainers and a
+shared decision process at that point. Until then, the fastest way to influence
+direction is a well-argued issue or a clean pull request.
+
+## Related documents
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — how to contribute, the GitFlow
+  workflow, PR requirements, and the code-review process.
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — expected behaviour and how to
+  report conduct issues.
+- [`SECURITY.md`](SECURITY.md) — how to report a vulnerability.
+- [`CLAUDE.md`](CLAUDE.md) — the operational guide (workflow, tooling,
+  project-local configuration).

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ tests/              # pytest suite, including strut-aware collision golden tests
 
 - [`docs/architecture/`](docs/architecture/) — the project's architecture documentation, in a slim subset of the [Arc42](https://arc42.org/) template. Read [§1 Introduction & Goals](docs/architecture/01-introduction-and-goals.md) and [§3 Context & Scope](docs/architecture/03-context-and-scope.md) first.
 - [`docs/adr/`](docs/adr/) — Architecture Decision Records (the *why* behind the architecture). Start with [ADR-0000](docs/adr/0000-record-architecture-decisions.md), then read individual records as their topics come up.
+- **Community & governance** — [`CONTRIBUTING.md`](CONTRIBUTING.md) (how to contribute), [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) (Contributor Covenant), and [`GOVERNANCE.md`](GOVERNANCE.md) (decision-making model and key roles).
 - **Security & standards** — [`docs/security-posture.md`](docs/security-posture.md) (OpenSSF Scorecard structural zeros, explained), [`docs/openssf-best-practices-badge.md`](docs/openssf-best-practices-badge.md) (Best Practices Badge answer script), and [`docs/osps-baseline-L1.md`](docs/osps-baseline-L1.md) (OpenSSF Baseline Level-1 self-attestation).
 
 ## More depth


### PR DESCRIPTION
## Summary

Bundled gap-closers for the **Best Practices Silver** milestone. These four issues are tightly coupled doc changes on shared files (`GOVERNANCE.md`, `README.md`, `CONTRIBUTING.md`), so they ship as one cohesive PR rather than four conflicting ones.

- **`GOVERNANCE.md`** (new) — an honest single-maintainer (BDFL-style) decision-making model: who decides, how changes are proposed/accepted (issue → `feature/*` → PR → `/pr-review` → maintainer merge; GitFlow), how architectural decisions are recorded (ADRs), and a **key-roles table** (maintainer / security contact / release manager / CoC enforcement — all currently @DocGerd, listed separately so responsibilities are explicit). Closes #237 (`governance`), Closes #238 (`roles_responsibilities`).
- **Code of Conduct linkage** — the existing Contributor Covenant `CODE_OF_CONDUCT.md` (which already has a real enforcement contact: private advisory + DM @DocGerd) is now linked from `README.md` and from a new `## Code of Conduct` section in `CONTRIBUTING.md`. Closes #239 (`code_of_conduct`).
- **Code-review statement** — added the explicit "**Every change is reviewed before it is released**" statement to `CONTRIBUTING.md` §Code review (the Silver questionnaire asks for it), noting it's enforced both socially and structurally (branch protection blocks direct pushes). Closes #240.
- **README discoverability** — new *Community & governance* doc bullet (CONTRIBUTING / CoC / GOVERNANCE were previously unlinked from the README).

Closes #237
Closes #238
Closes #239
Closes #240

## Notes

- The **two-distinct-humans** review requirement is a *Gold* criterion (parked #242), not Silver — `GOVERNANCE.md` and the §Code review wording deliberately describe single-maintainer review, not a two-person process.
- These docs become the governance/CoC/review evidence for the Silver questionnaire capstone (#241), which is blocked-by all four issues here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)