### PR TITLE
feat(cli): --render-paths flag + exit-3 tow-routability (#193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which
 |---|---|
 | 0 | Found at least one valid layout (`status` = `found` or `found_partial`) |
 | 1 | No valid layout found (`status` = `exhausted_budget` or `trivially_infeasible`); with `--strict-k`, also fires for `found_partial` |
-| 2 | Could not solve (file not found, bad YAML, invariant violation, IO error during render/write) |
+| 2 | Could not solve (file not found, bad YAML, invariant violation, IO error during render/write, or `--render-paths` without `--render`) |
+| 3 | `--render-paths` only: valid layout(s) found but the v1 tow planner could not route **any** of them. The layouts still render (without path overlays); each blocked layout gets a stderr warning naming the plane. Distinct from code 1 (no layout at all). |
+
+`--render-paths` overlays each plane's tow path on the `--render` PNG(s) (one colour per plane). It tow-plans every returned layout; a layout the v1 planner cannot route is rendered without paths. If **at least one** candidate is routable the exit code is 0 (un-routable ones still warn); code 3 fires only when none are routable.
 
 ### JSON schemas
 

--- a/docs/architecture/03-context-and-scope.md
+++ b/docs/architecture/03-context-and-scope.md
@@ -28,7 +28,7 @@ flowchart LR
 
     json["JSON result<br/>(stdout)"]
     png["PNG render<br/>(optional)"]
-    exitcode["exit code<br/>(0 / 1 / 2)"]
+    exitcode["exit code<br/>(0 / 1 / 2 / 3)"]
 
     yaml_fleet --> cli
     yaml_hangar --> cli

--- a/docs/architecture/03-context-and-scope.md
+++ b/docs/architecture/03-context-and-scope.md
@@ -53,7 +53,8 @@ The tool runs entirely on the user's local machine:
   `--render`. Exit-code semantics differ between `hangarfit check` and
   `hangarfit solve` (e.g., `solve` reports `1` for both
   "no layout found" and, under `--strict-k`, "fewer than K alternatives
-  found"); the canonical tables live in the root
+  found", and `3` under `--render-paths` when no candidate is
+  tow-routable); the canonical tables live in the root
   [`README.md`](../../README.md#exit-codes-check).
 - **No external systems.** The CLI does not call any network service,
   read any database, write to any shared state, or read environment

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -136,6 +136,20 @@ With `--strict-k`, `found_partial` also returns exit code 1 — useful
 for scripted invocation where "fewer than K alternatives" should be
 treated as failure.
 
+**Exit code 3 — `--render-paths` tow-routability (#193).** Exit code is
+not solely a function of `SolveStatus`. When `--render-paths` is set the
+CLI tow-plans every returned layout (the bundled `(Layout, MovesPlan)`
+of `solve()`, ADR-0007) and renders the path overlay. Because the v1
+planner has documented false-negatives, an un-routable layout is *kept*
+(best-effort, #197) and rendered without paths. If **no** returned
+candidate is tow-routable, the CLI exits **3** — distinct from exit 1
+(no layout at all), since a valid static layout was still found and
+rendered. If at least one candidate is routable the exit code stays 0
+(each un-routable one emits a stderr warning naming the blocked plane).
+Exit 3 is checked before the `--strict-k` exit-1 rule. Without
+`--render-paths` the CLI does not tow-plan, so tow-routability never
+affects the exit code.
+
 **No retries inside solve().** The solver does not retry on a single
 candidate's failure — it just restarts. There is no exception path
 from `check()` into the solver other than structural failure (which

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -425,18 +425,24 @@ def _warn_unroutable(result: SolveResult) -> None:
     valid and rendered, just without a path overlay — ADR-0007 / #197).
 
     ``diagnostics.unroutable_planes`` is a *compacted* list (one entry per
-    ``None`` plan, in returned-layout order), so the k-th ``None`` aligns with
-    the k-th blocking plane — consumed here as an in-order iterator.
+    ``None`` plan, in returned-layout order), so the j-th ``None`` plan pairs
+    with the j-th blocking plane. The solver builds both in one pass (one
+    plane appended per ``None``), so the lengths must match; we assert that
+    rather than papering over a desync with a misleading placeholder name (a
+    mismatch is a producer bug, not a user condition).
     """
-    blocked = iter(result.diagnostics.unroutable_planes)
-    for i, plan in enumerate(result.plans, start=1):
-        if plan is None:
-            plane = next(blocked, "<unknown>")
-            print(
-                f"warning: layout {i}: no feasible tow path "
-                f"(plane {plane!r} could not be routed); rendered without paths",
-                file=sys.stderr,
-            )
+    unrouted_layouts = [i for i, plan in enumerate(result.plans, start=1) if plan is None]
+    planes = result.diagnostics.unroutable_planes
+    assert len(planes) == len(unrouted_layouts), (
+        f"unroutable_planes ({len(planes)}) out of sync with None plans "
+        f"({len(unrouted_layouts)}) — solver bug"
+    )
+    for layout_index, plane in zip(unrouted_layouts, planes, strict=True):
+        print(
+            f"warning: layout {layout_index}: no feasible tow path "
+            f"(plane {plane!r} could not be routed); rendered without paths",
+            file=sys.stderr,
+        )
 
 
 def _resolve_fleet_hangar_refs(args: argparse.Namespace) -> tuple[str, str]:

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -16,10 +16,17 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from typing import TYPE_CHECKING
 
 from hangarfit import collisions, visualize
 from hangarfit.loader import LoaderError, load_fleet, load_hangar, load_layout
 from hangarfit.models import CheckResult, Conflict, DiversityConfig, Layout, SolveResult
+
+if TYPE_CHECKING:
+    # Annotation-only: avoids importing the solver/towplanner stack at module
+    # load for `hangarfit check` callers (the solver import is already deferred
+    # into cmd_solve for the same reason).
+    from hangarfit.towplanner import MovesPlan
 
 _JSON_SCHEMA = "hangarfit.check/v1"
 _SOLVE_JSON_SCHEMA = "hangarfit.solve/v1"
@@ -87,6 +94,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="PATTERN",
         help="Write top-down PNG(s). Must contain '{i}' if --alternatives > 1.",
+    )
+    solve.add_argument(
+        "--render-paths",
+        action="store_true",
+        dest="render_paths",
+        help=(
+            "Overlay each plane's tow path on the --render PNG(s), one colour per "
+            "plane (requires --render). Tow-plans every returned layout; a layout "
+            "the v1 planner cannot route is rendered without paths and a warning "
+            "names the blocking plane. Exit 3 if NO candidate is tow-routable."
+        ),
     )
     solve.add_argument(
         "--write-yaml",
@@ -300,6 +318,13 @@ def cmd_solve(args: argparse.Namespace) -> int:
                 )
                 return 2
 
+    # --render-paths overlays the tow paths onto the --render PNG(s); without a
+    # --render target there is nothing to draw on. Fail fast (usage error)
+    # rather than tow-plan and silently produce no visible output.
+    if args.render_paths and args.render is None:
+        print("error: --render-paths requires --render PATTERN", file=sys.stderr)
+        return 2
+
     try:
         fleet_override = load_fleet(args.fleet) if args.fleet is not None else None
         hangar_override = load_hangar(args.hangar) if args.hangar is not None else None
@@ -308,17 +333,17 @@ def cmd_solve(args: argparse.Namespace) -> int:
         print(f"error: {e}", file=sys.stderr)
         return 2
 
-    # plan_paths=False: the library-level bundle (SolveResult.plans) exists as
-    # of #197, but surfacing tow paths in the CLI (rendering + exit-code
-    # semantics) is #193. Until then, computing plans the CLI never displays
-    # would only add the per-plane Hybrid-A* search cost for no visible output.
+    # Tow-plan only when the user asked to render paths (#193). Otherwise
+    # plan_paths=False: the library bundle (SolveResult.plans) is available to
+    # callers, but the CLI would just pay the per-plane Hybrid-A* search cost
+    # for output it never draws.
     result = solve(
         scenario,
         budget_s=args.budget,
         alternatives=args.alternatives,
         seed=args.seed,
         search=SearchConfig(spread=args.spread),
-        plan_paths=False,
+        plan_paths=args.render_paths,
     )
 
     if args.json:
@@ -326,12 +351,22 @@ def cmd_solve(args: argparse.Namespace) -> int:
     else:
         _emit_solve_human(result, alternatives=args.alternatives)
 
+    # Structured tow-path warnings: name the plane that blocked each layout the
+    # v1 planner could not route (best-effort — the layout is still valid and is
+    # rendered, just without a path overlay; ADR-0007 / #197).
+    if args.render_paths:
+        _warn_unroutable(result)
+
     # Renders / YAML writes. Only run if we have layouts to write —
     # exhausted_budget / trivially_infeasible carry empty `layouts`.
     if result.layouts:
         try:
             if args.render is not None:
-                _write_renders(result.layouts, args.render)
+                _write_renders(
+                    result.layouts,
+                    args.render,
+                    plans=result.plans if args.render_paths else None,
+                )
             if args.write_yaml is not None:
                 fleet_ref, hangar_ref = _resolve_fleet_hangar_refs(args)
                 _write_yamls(result.layouts, args.write_yaml, fleet_ref, hangar_ref)
@@ -339,9 +374,15 @@ def cmd_solve(args: argparse.Namespace) -> int:
             print(f"error: write failed: {e}", file=sys.stderr)
             return 2
 
-    # Exit code (spec §5.2). --strict-k flips 0 -> 1 only for found_partial.
+    # Exit code (spec §5.2). Precedence: no layouts > no-tow-order > strict-k.
     if not result.layouts:
         return 1
+    # --render-paths only: exit 3 when the v1 planner could route NO candidate
+    # (spike Q8/Q2 "no feasible order for any candidate"). A valid layout still
+    # rendered, so this is distinct from exit 1 (no layout at all). Checked
+    # before --strict-k: "can't tow anything" is the more actionable failure.
+    if args.render_paths and all(plan is None for plan in result.plans):
+        return 3
     if result.status == "found_partial" and args.strict_k:
         return 1
     return 0
@@ -356,15 +397,46 @@ def _expand_pattern(pattern: str, i: int) -> str:
     return pattern.replace("{i}", str(i))
 
 
-def _write_renders(layouts: tuple[Layout, ...], pattern: str) -> None:
+def _write_renders(
+    layouts: tuple[Layout, ...],
+    pattern: str,
+    *,
+    plans: tuple[MovesPlan | None, ...] | None = None,
+) -> None:
     """Render each layout to PATTERN with ``{i}`` substituted.
+
+    When ``plans`` is supplied (``--render-paths``), it is index-aligned with
+    ``layouts``: ``plans[i]`` is overlaid as a tow-path polyline, or ``None``
+    (un-routable layout) renders the plain layout. ``plans=None`` renders no
+    overlays at all.
 
     Single-pass loop — any OSError bubbles to the caller; we don't
     swallow partial-write state because a half-written render set is
     worse than a clean failure that the user can re-run.
     """
     for i, layout in enumerate(layouts, start=1):
-        visualize.render_layout(layout, _expand_pattern(pattern, i))
+        moves_plan = plans[i - 1] if plans is not None else None
+        visualize.render_layout(layout, _expand_pattern(pattern, i), moves_plan=moves_plan)
+
+
+def _warn_unroutable(result: SolveResult) -> None:
+    """Emit one stderr warning per returned layout the v1 planner could not
+    tow-route, naming the blocking plane (best-effort; the layout is still
+    valid and rendered, just without a path overlay — ADR-0007 / #197).
+
+    ``diagnostics.unroutable_planes`` is a *compacted* list (one entry per
+    ``None`` plan, in returned-layout order), so the k-th ``None`` aligns with
+    the k-th blocking plane — consumed here as an in-order iterator.
+    """
+    blocked = iter(result.diagnostics.unroutable_planes)
+    for i, plan in enumerate(result.plans, start=1):
+        if plan is None:
+            plane = next(blocked, "<unknown>")
+            print(
+                f"warning: layout {i}: no feasible tow path "
+                f"(plane {plane!r} could not be routed); rendered without paths",
+                file=sys.stderr,
+            )
 
 
 def _resolve_fleet_hangar_refs(args: argparse.Namespace) -> tuple[str, str]:
@@ -503,6 +575,10 @@ def _emit_solve_json(scenario_path: str, result: SolveResult) -> None:
                 if d.best_partial_layout is not None
                 else None
             ),
+            # Additive field (#193): the planes the v1 tow planner could not
+            # route, in returned-layout order. Empty unless --render-paths ran
+            # the planner. Backward-compatible — no schema bump.
+            "unroutable_planes": list(d.unroutable_planes),
         },
     }
     print(json.dumps(payload, indent=2))

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -130,9 +130,9 @@ def render_layout(
     ``moves_plan`` are independent: a layout can be rendered with neither,
     either, or both.
 
-    This is renderer-only: no CLI flag exposes ``moves_plan`` to end users
-    yet — wiring ``--render-paths`` (and the bundle plumbing) is deferred to
-    #193.
+    The ``hangarfit solve --render-paths`` flag is the CLI entry point that
+    plumbs each layout's bundled ``MovesPlan`` (from ``solve()``) through to
+    this parameter (#193).
     """
     # Defense in depth: even with ``matplotlib.use("Agg", force=True)``
     # at module import, a misconfigured environment (interactive backend

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from hangarfit.cli import build_parser, main
 
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
@@ -752,3 +754,100 @@ class TestSolveRenderPaths:
         assert rc == 3
         payload = json.loads(capsys.readouterr().out)
         assert payload["diagnostics"]["unroutable_planes"] == ["husky"]
+
+    def test_multi_none_warnings_name_planes_in_order(self, tmp_path, monkeypatch, capsys):
+        # Three layouts, the 1st and 3rd un-routable: the compacted
+        # unroutable_planes (["alpha","gamma"]) must pair with the 1st and 3rd
+        # None positions in order — guards the zip/correspondence in
+        # _warn_unroutable that a single-None test cannot.
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve(
+            monkeypatch,
+            self._result(
+                "found",
+                (layout, layout, layout),
+                (None, plan, None),
+                unroutable=("alpha", "gamma"),
+            ),
+        )
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--alternatives",
+                "3",
+                "--render",
+                str(tmp_path / "p_{i}.png"),
+                "--render-paths",
+                "--seed",
+                "42",
+            ]
+        )
+        assert rc == 0  # layout 2 routable
+        err = capsys.readouterr().err
+        assert "layout 1" in err and "alpha" in err
+        assert "layout 3" in err and "gamma" in err
+        assert "layout 2" not in err
+        # Order: layout 1's warning (alpha) precedes layout 3's (gamma).
+        assert err.index("alpha") < err.index("gamma")
+
+    def test_unroutable_planes_desync_is_loud(self, tmp_path, monkeypatch):
+        # A None plan with an empty unroutable_planes is a producer-side
+        # invariant violation (solver appends one plane per None). _warn_unroutable
+        # must surface it loudly, not paper over it with a placeholder name.
+        layout = self._layout()
+        self._patch_solve(monkeypatch, self._result("found", (layout,), (None,), unroutable=()))
+        with pytest.raises(AssertionError, match="out of sync"):
+            main(
+                [
+                    "solve",
+                    SMOKE_FIXTURE,
+                    "--render",
+                    str(tmp_path / "p.png"),
+                    "--render-paths",
+                    "--seed",
+                    "42",
+                ]
+            )
+
+    def test_empty_layouts_exits_1_not_3(self, tmp_path, monkeypatch):
+        # No layouts (exhausted_budget): exit 1 wins over the exit-3 check even
+        # under --render-paths (the all-None test would otherwise be vacuously
+        # true on empty plans). Pins the "no layouts > no-tow-order" precedence.
+        self._patch_solve(monkeypatch, self._result("exhausted_budget", (), ()))
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--render",
+                str(tmp_path / "p.png"),
+                "--render-paths",
+                "--seed",
+                "42",
+            ]
+        )
+        assert rc == 1
+
+    @pytest.mark.slow
+    def test_real_solve_render_paths_end_to_end(self, tmp_path):
+        # Real solve -> plan_fill -> render_layout(moves_plan=...), no monkeypatch:
+        # guards the live integration the monkeypatched tests can't (the single
+        # smoke-fixture plane is towable). rc 0 (routable) or 3 (if not); either
+        # way the pipeline must run and write a PNG.
+        out = tmp_path / "real.png"
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--budget",
+                "5.0",
+                "--seed",
+                "42",
+                "--render",
+                str(out),
+                "--render-paths",
+            ]
+        )
+        assert rc in (0, 3)
+        assert out.exists() and out.stat().st_size > 0

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -581,3 +581,174 @@ def test_solve_no_spread_flag_accepted_and_runs(tmp_path):
     )
     assert rc == 0
     assert out.exists()
+
+
+class TestSolveRenderPaths:
+    """`--render-paths` flag: tow-path overlay rendering + exit-3 semantics (#193).
+
+    Uses a monkeypatched ``solve`` so exit-code / overlay behaviour is tested
+    deterministically and fast, without paying for a real Hybrid-A* search.
+    ``load_scenario`` still runs on the real fixture (validation), then the
+    fake ``solve`` returns a controlled bundle.
+    """
+
+    @staticmethod
+    def _layout():
+        from hangarfit.loader import load_layout
+
+        return load_layout(FIXTURES_DIR / "valid_two_separated.yaml")
+
+    @staticmethod
+    def _plan(layout):
+        from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+
+        start = Pose(x_m=2.0, y_m=0.0, heading_deg=0.0)
+        end = Pose(x_m=2.0, y_m=5.0, heading_deg=0.0)
+        arc = DubinsArc(start=start, end=end, turn_radius_m=1.0, segments=(Segment("S", 5.0),))
+        return MovesPlan(
+            target_layout=layout, moves=(Move(plane_id="a", target_slot=end, path=arc),)
+        )
+
+    @staticmethod
+    def _result(status, layouts, plans, unroutable=()):
+        from hangarfit.models import SolverDiagnostics, SolveResult
+
+        diag = SolverDiagnostics(
+            restarts_attempted=1,
+            wall_time_s=0.1,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=42,
+            unroutable_planes=unroutable,
+        )
+        return SolveResult(status=status, layouts=layouts, plans=plans, diagnostics=diag)
+
+    @staticmethod
+    def _patch_solve(monkeypatch, result):
+        import hangarfit.solver as solver_mod
+
+        captured = {}
+
+        def fake_solve(scenario, **kwargs):
+            captured.update(kwargs)
+            return result
+
+        monkeypatch.setattr(solver_mod, "solve", fake_solve)
+        return captured
+
+    def test_flag_defaults_false_and_parses(self):
+        parser = build_parser()
+        assert parser.parse_args(["solve", SMOKE_FIXTURE]).render_paths is False
+        parsed = parser.parse_args(["solve", SMOKE_FIXTURE, "--render", "x.png", "--render-paths"])
+        assert parsed.render_paths is True
+
+    def test_render_paths_requires_render(self, capsys):
+        rc = main(["solve", SMOKE_FIXTURE, "--render-paths"])
+        assert rc == 2
+        assert "requires --render" in capsys.readouterr().err
+
+    def test_without_flag_solve_is_not_asked_to_plan(self, tmp_path, monkeypatch):
+        captured = self._patch_solve(monkeypatch, self._result("found", (self._layout(),), (None,)))
+        rc = main(["solve", SMOKE_FIXTURE, "--render", str(tmp_path / "p.png"), "--seed", "42"])
+        assert rc == 0
+        assert captured["plan_paths"] is False
+
+    def test_routable_exit_0_and_overlay_passed_to_renderer(self, tmp_path, monkeypatch):
+        from hangarfit import visualize
+
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve(monkeypatch, self._result("found", (layout,), (plan,)))
+        seen = []
+        real = visualize.render_layout
+
+        def spy(lay, path, **kw):
+            seen.append(kw.get("moves_plan"))
+            return real(lay, path, **kw)
+
+        monkeypatch.setattr(visualize, "render_layout", spy)
+        out = tmp_path / "p.png"
+        rc = main(["solve", SMOKE_FIXTURE, "--render", str(out), "--render-paths", "--seed", "42"])
+        assert rc == 0
+        assert seen == [plan]  # the per-layout MovesPlan was threaded through
+        assert out.exists() and out.stat().st_size > 0
+
+    def test_all_unroutable_exits_3_warns_and_renders_plain(self, tmp_path, monkeypatch, capsys):
+        layout = self._layout()
+        self._patch_solve(
+            monkeypatch, self._result("found", (layout,), (None,), unroutable=("husky",))
+        )
+        out = tmp_path / "p.png"
+        rc = main(["solve", SMOKE_FIXTURE, "--render", str(out), "--render-paths", "--seed", "42"])
+        assert rc == 3
+        err = capsys.readouterr().err
+        assert "no feasible tow path" in err and "husky" in err
+        assert out.exists()  # the valid layout is still rendered, just plain
+
+    def test_partial_mix_exit_0_warns_only_the_unroutable(self, tmp_path, monkeypatch, capsys):
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve(
+            monkeypatch,
+            self._result("found", (layout, layout), (plan, None), unroutable=("b",)),
+        )
+        pattern = str(tmp_path / "p_{i}.png")
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--alternatives",
+                "2",
+                "--render",
+                pattern,
+                "--render-paths",
+                "--seed",
+                "42",
+            ]
+        )
+        assert rc == 0  # >=1 routable candidate
+        err = capsys.readouterr().err
+        assert "layout 2" in err and "b" in err
+        assert "layout 1" not in err
+        assert (tmp_path / "p_1.png").exists() and (tmp_path / "p_2.png").exists()
+
+    def test_exit_3_precedes_strict_k(self, tmp_path, monkeypatch):
+        layout = self._layout()
+        self._patch_solve(
+            monkeypatch,
+            self._result("found_partial", (layout,), (None,), unroutable=("z",)),
+        )
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--render",
+                str(tmp_path / "p.png"),
+                "--render-paths",
+                "--strict-k",
+                "--seed",
+                "42",
+            ]
+        )
+        assert rc == 3  # all-un-routable wins over found_partial+strict-k
+
+    def test_json_surfaces_unroutable_planes(self, tmp_path, monkeypatch, capsys):
+        layout = self._layout()
+        self._patch_solve(
+            monkeypatch, self._result("found", (layout,), (None,), unroutable=("husky",))
+        )
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--render",
+                str(tmp_path / "p.png"),
+                "--render-paths",
+                "--json",
+                "--seed",
+                "42",
+            ]
+        )
+        assert rc == 3
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["diagnostics"]["unroutable_planes"] == ["husky"]


### PR DESCRIPTION
Closes #193.

Phase 3a logical issue 8/10 (spike Q8 + Q2). Wires the solver's tow-plan bundle (#197) and the visualize overlay (#192) through the CLI.

## What it does

- **`--render-paths`** on `hangarfit solve`: tow-plans every returned layout (`solve(plan_paths=True)`) and overlays each plane's path on the `--render` PNG(s) via `render_layout(moves_plan=...)`. **Requires `--render`** (usage error / exit 2 otherwise). Without the flag, the CLI does not tow-plan — behaviour and exit codes are unchanged.
- **Best-effort surfacing** (ADR-0007 / #197): a layout the v1 planner can't route is still rendered (without paths) and gets a stderr warning naming the blocking plane.

## Exit codes — reconciled with the best-effort reversal

The spike's "non-zero exit when no feasible order exists for any candidate" predates #197 (which dropped whole-solve failure). New semantics (per your call to add a distinct code):

| Situation (`--render-paths`) | Exit |
|---|---|
| ≥1 candidate routable | **0** (un-routable ones warn) |
| valid layout(s) but **none** routable | **3** (NEW — distinct from "no layout at all") |
| no layouts at all | 1 (unchanged) |
| `--render-paths` without `--render` | 2 |

Exit 3 is checked **before** `--strict-k`'s exit-1 ("can't tow anything" is the more actionable failure). Without `--render-paths`, tow-routability never affects the exit code.

`unroutable_planes` added to the `solve --json` diagnostics (additive — no schema bump).

## Scope / docs

Exit-3 expands the documented 0/1/2 scheme, so this PR updates where that contract lives: **README** exit-codes table, **arc42 §3** diagram, **arc42 §6** runtime view. The broader towplanner docs sweep (module map, runtime bundle flow, `fleet.yaml`, retiring holonomic-on-carts) remains **#194**.

The spike's "name the Dubins-arc segment" is intentionally **not** done: the bundle carries only plane ids post-solve (`unroutable_planes`), not per-segment conflict detail — surfacing the plane is the achievable, useful part.

## Tests

`TestSolveRenderPaths` (monkeypatched `solve` for fast, deterministic exit-code coverage): flag parse/default, requires-`--render` (exit 2), `plan_paths` toggle, overlay threaded to the renderer, all-un-routable → exit 3 + warning + plain render, partial mix → exit 0 + targeted warning, exit-3-precedes-`--strict-k`, JSON `unroutable_planes`.

## Verification

- `pytest` (default): **638 passed, 5 deselected** (~44s).
- `ruff check`, `ruff format --check`, `mypy src/hangarfit/`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)