### PR TITLE
docs(towplanner): arc42 §5/§6/§8 + fleet.yaml towplanner sweep (#194)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ This file is the durable **operational** context for the project: how we work, w
 |---|---|
 | What `hangarfit` is and the quality goals it optimizes for | [§1 Introduction & Goals](docs/architecture/01-introduction-and-goals.md) |
 | What is in / out of scope, the external actors, exit-code semantics pointer | [§3 Context & Scope](docs/architecture/03-context-and-scope.md) |
-| Module map (`cli`, `loader`, `models`, `geometry`, `collisions`, `solver`, `visualize`) and per-module responsibilities | [§5 Building Block View](docs/architecture/05-building-block-view.md) |
+| Module map (`cli`, `loader`, `models`, `geometry`, `collisions`, `solver`, `towplanner`, `visualize`) and per-module responsibilities | [§5 Building Block View](docs/architecture/05-building-block-view.md) |
 | Runtime flow of `check` and `solve` invocations | [§6 Runtime View](docs/architecture/06-runtime-view.md) |
 | **The parts model** (collision rule, why parts not bbox, `struts:` block) | [§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md#the-parts-model) + [ADR-0001](docs/adr/0001-aircraft-parts-model.md) |
 | **The coordinate convention + the determinant-−1 transform trap** | [§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md#the-coordinate-convention) + [ADR-0002](docs/adr/0002-determinant-minus-one-transform.md) |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The test suite includes a strut-aware golden set for the collision checker cover
 ## Project layout
 
 ```
-src/hangarfit/      # models, loader, geometry, collisions, visualize, cli
+src/hangarfit/      # models, loader, geometry, collisions, solver, towplanner, visualize, cli
 data/               # fleet.yaml, hangar.yaml — placeholder measurements
 layouts/            # hand-authored candidate layouts, one YAML per scenario
 tests/              # pytest suite, including strut-aware collision golden tests

--- a/data/fleet.yaml
+++ b/data/fleet.yaml
@@ -14,6 +14,13 @@
 # - Heights z_bottom_m / z_top_m are above-ground in world coords
 # - struts block (optional) is expanded by the loader into two mirrored
 #   strut Parts; cantilever aircraft omit the block entirely
+# - turn_radius_m: own-gear minimum taxi turn radius (m). LOAD-BEARING since
+#   Phase 3a — consumed by the `towplanner` module's Dubins / Hybrid-A*
+#   path planning (it was an unused placeholder through Phase 1/2a). `null`
+#   on always_cart planes: they have no own-gear taxi radius, so the
+#   towplanner substitutes 0 (pivot-in-place on the cart) via
+#   `Aircraft.effective_turn_radius_m()` rather than baking 0 into the data
+#   (ADR-0007, fork 4).
 
 aircraft:
   # ----------------------------------------------------------------------------
@@ -24,7 +31,7 @@ aircraft:
     wing_position: high
     gear: monowheel
     movement_mode: always_cart
-    turn_radius_m: null
+    turn_radius_m: null  # always_cart → towplanner uses 0 (pivot); see header + ADR-0007
     measured: false
     notes: "Cantilever wing; outriggers folded into wing footprint at the tips"
     parts:
@@ -110,7 +117,7 @@ aircraft:
     wing_position: high
     gear: nosewheel
     movement_mode: always_cart
-    turn_radius_m: null
+    turn_radius_m: null  # always_cart → towplanner uses 0 (pivot); see header + ADR-0007
     measured: false
     parts:
       - kind: fuselage
@@ -142,7 +149,7 @@ aircraft:
     wing_position: high
     gear: tailwheel
     movement_mode: always_cart
-    turn_radius_m: null
+    turn_radius_m: null  # always_cart → towplanner uses 0 (pivot); see header + ADR-0007
     measured: false
     parts:
       - kind: fuselage

--- a/docs/architecture/01-introduction-and-goals.md
+++ b/docs/architecture/01-introduction-and-goals.md
@@ -21,8 +21,8 @@ In rough order of priority — earlier goals trump later ones when they
 conflict.
 
 1. **Correctness of the collision rule.** Every downstream feature
-   (`check`, `solve`, future planners) sits on top of the parts-based
-   collision check. A subtle bug here produces output that *looks*
+   (`check`, `solve`, the `towplanner`, future planners) sits on top of
+   the parts-based collision check. A subtle bug here produces output that *looks*
    plausible but is wrong, which is the worst possible failure mode in
    this domain. The strut-aware golden-test suite in `tests/test_collisions.py`
    is the canary.

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -14,6 +14,7 @@ flowchart TD
     geometry["geometry.py<br/>plane-local → world transform<br/>(determinant −1)"]
     collisions["collisions.py<br/>check(layout) entry<br/>hangar bounds + maintenance + part overlaps"]
     solver["solver.py<br/>RR-MC search<br/>deterministic RNG"]
+    towplanner["towplanner.py<br/>tow-path planning<br/>Dubins + bound-aware Hybrid-A*"]
     visualize["visualize.py<br/>top-down PNG renderer<br/>headless matplotlib"]
 
     cli --> loader
@@ -26,6 +27,11 @@ flowchart TD
 
     solver --> collisions
     solver --> models
+    solver --> towplanner
+
+    towplanner --> collisions
+    towplanner --> geometry
+    towplanner --> models
 
     collisions --> geometry
     collisions --> models
@@ -184,10 +190,50 @@ Internally:
   pre-search literal `trivially_infeasible` returned before the
   search loop runs at all.
 - **Spread post-pass** (`_spread`, `_inter_plane_energy`) — after a layout reaches `(0, 0.0)`, maximizes inter-plane separation by minimizing the repulsion energy `Σ exp(−gap/scale)` while preserving validity. On by default; `--no-spread` / `SearchConfig.spread=False` disables it. See [ADR-0008](../adr/0008-inter-plane-spread-soft-preference.md).
+- **Tow-plan bundling** (`plan_paths=True`, default) — each returned layout is tow-planned via `towplanner.plan_fill`, and the result is index-aligned into `SolveResult.plans`. This is **best-effort**: a layout the v1 planner cannot route gets `plans[i] = None` (and is named in `diagnostics.unroutable_planes`) rather than being discarded — the static layout is the answer, the tow plan is advisory. `status` stays search-driven. See the `towplanner.py` entry below and [ADR-0007](../adr/0007-tow-path-planner-v1-scope.md).
 
 The RNG is single-threaded and seeded for bit-identical reproducibility
 across runs (compliance check:
-`tests/test_solver_canaries.py`).
+`tests/test_solver_canaries.py`). Tow-planning is RNG-free, so the
+bundled `(Layout, MovesPlan)` output preserves the same determinism
+contract.
+
+### `towplanner.py` — tow-path planning
+
+Answers *how* the planes get to a layout, where `solver.py` answers
+*where* they go. Given a target `Layout`, `plan_fill` computes a
+collision-free entry **order** (deepest slot first) and a per-plane
+**path** from the door-cone entry pose to the target slot, returning a
+`MovesPlan` (a tuple of `Move`s, each carrying a `DubinsArc`). Scope is
+the **empty-hangar fill** case — every plane enters once (ADR-0007).
+
+- **Single motion primitive** — every plane is routed as a Dubins path;
+  a cart-borne plane is own-gear with `turn_radius_m = 0` (pivot-in-place),
+  via `Aircraft.effective_turn_radius_m()`. No two-mode (holonomic/Dubins)
+  branch — see §8 *Movement modes*.
+- **Bound-aware Hybrid-A\*** (`plan_path`, [#222](https://github.com/DocGerd/hangarfit/issues/222))
+  — a deterministic search over Dubins motion primitives finds an
+  in-bounds, obstacle-free multi-segment path when a single shortest-arc
+  would clip a wall or an already-placed plane. Bounded by a
+  node-expansion budget; the full returned path is re-validated by the
+  exact `collisions.check`-based oracle (`path_first_conflict`).
+- **Collision-during-motion** reuses the static checker: each sampled
+  pose along an arc is checked against the already-placed subset, so
+  parts / hangar-bounds / bay rules are honoured *during* the tow, not
+  just at the destination. The front gap at the door is exempt during
+  motion (§8 *The door*).
+- **Failure is honest** — a layout it cannot route raises
+  `NoFeasiblePlanError` naming the offending plane; `solve` records it
+  best-effort (see the bundling bullet above), and the CLI's
+  `--render-paths` surfaces it (warning + exit code 3, [§6](06-runtime-view.md)).
+- **Deterministic** (no RNG): a given `Layout` always yields the same
+  `MovesPlan`, preserving [ADR-0003](../adr/0003-rr-mc-solver-algorithm.md)'s
+  contract through the bundle.
+
+The module is pure-data + closed-form geometry plus the Hybrid-A\* search;
+it imports `models`, `geometry`, and `collisions`, and is imported only
+by `solver.py` (the `MovesPlan` type reference in `cli.py` / `visualize.py`
+is annotation-only, under `TYPE_CHECKING`).
 
 ### `visualize.py` — top-down PNG renderer
 

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -232,8 +232,8 @@ the **empty-hangar fill** case — every plane enters once (ADR-0007).
 
 The module is pure-data + closed-form geometry plus the Hybrid-A\* search;
 it imports `models`, `geometry`, and `collisions`, and is imported only
-by `solver.py` (the `MovesPlan` type reference in `cli.py` / `visualize.py`
-is annotation-only, under `TYPE_CHECKING`).
+by `solver.py` at runtime (the `MovesPlan` type reference in `cli.py`,
+`visualize.py`, and `models.py` is annotation-only, under `TYPE_CHECKING`).
 
 ### `visualize.py` — top-down PNG renderer
 

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -64,6 +64,7 @@ sequenceDiagram
     participant CLI as cli.py
     participant Loader as loader.py
     participant Solver as solver.py
+    participant Tow as towplanner.py
     participant Coll as collisions.py
     participant Viz as visualize.py
     participant FS as Filesystem
@@ -98,22 +99,26 @@ sequenceDiagram
             end
         end
         alt K accepted before budget
-            Solver-->>CLI: SolveResult(status=found, layouts, diagnostics, seed)
+            Solver->>Tow: plan_fill(layout) per accepted layout (if plan_paths)
+            Tow-->>Solver: MovesPlan or None (best-effort)
+            Solver-->>CLI: SolveResult(status=found, layouts, plans, diagnostics, seed)
         else some-but-fewer-than-K accepted, budget exhausted
-            Solver-->>CLI: SolveResult(status=found_partial, layouts, diagnostics, seed)
+            Solver-->>CLI: SolveResult(status=found_partial, layouts, plans, diagnostics, seed)
         else zero accepted, budget exhausted
-            Solver-->>CLI: SolveResult(status=exhausted_budget, layouts=[], diagnostics, seed)
+            Solver-->>CLI: SolveResult(status=exhausted_budget, layouts=[], plans=[], diagnostics, seed)
         end
     end
 
     loop per accepted layout
-        CLI->>Viz: render(layout)
+        CLI->>Viz: render(layout, moves_plan if --render-paths)
         Viz->>FS: write out_i.png
     end
     CLI->>Op: stdout JSON / stderr status + exit code
 ```
 
 **Spread (if `SearchConfig.spread`, default on):** the valid placements are refined by `_spread` to maximize inter-plane separation (minimize `Σ exp(−gap/scale)`), accepting only moves that stay valid. The spread layout is what proceeds to the diversity filter. See [ADR-0008](../adr/0008-inter-plane-spread-soft-preference.md).
+
+**Tow-plan bundle (if `plan_paths`, default on):** before returning, `solve` tow-plans each accepted layout via `towplanner.plan_fill`, producing `SolveResult.plans` index-aligned with `layouts` — the bundled `(Layout, MovesPlan)` output. This is **best-effort**: a layout the v1 planner cannot route gets `plans[i] = None` (the blocking plane recorded in `diagnostics.unroutable_planes`) rather than being dropped, so `status` stays search-driven (ADR-0007 / [§8 *Movement modes*](08-crosscutting-concepts.md)). The CLI computes the bundle only under `--render-paths` (it overlays each path on the PNG, and exits 3 if no candidate is routable — see the exit-code note below); a plain `solve` invocation passes `plan_paths=False` and pays no planning cost. Tow-planning is RNG-free, so the bundle is bit-identical across runs for a seed.
 
 **Determinism.** Given the same scenario, the same `--seed`, and the
 same project version (same `hangarfit.solve/v1` schema), the returned

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -98,9 +98,11 @@ sequenceDiagram
                 Note over Solver: increment<br/>diversity_rejected_count
             end
         end
-        alt K accepted before budget
-            Solver->>Tow: plan_fill(layout) per accepted layout (if plan_paths)
+        opt plan_paths (default on) — applies to found & found_partial
+            Solver->>Tow: plan_fill(layout) per accepted layout
             Tow-->>Solver: MovesPlan or None (best-effort)
+        end
+        alt K accepted before budget
             Solver-->>CLI: SolveResult(status=found, layouts, plans, diagnostics, seed)
         else some-but-fewer-than-K accepted, budget exhausted
             Solver-->>CLI: SolveResult(status=found_partial, layouts, plans, diagnostics, seed)

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -67,15 +67,26 @@ PRs. The current rule's decision is recorded in
 by ADR-0006**). The implementation lives in
 `src/hangarfit/collisions.py::_bay_intrusion_conflicts`.
 
-### Movement modes (relevant for the future planner, not Phase 1)
+### Movement modes
 
 Each aircraft has a `movement_mode` in `{"always_cart",
 "always_own_gear", "cart_eligible"}`. The cart rule — at most one
 `cart_eligible` plane on carts in any layout — is enforced in
-`Layout.__post_init__`, not in the collision checker. Motion behaviour
-itself (holonomic on carts; Dubins-path-style on own gear) is a
-property of the planner that does not yet exist; the parts model and
-collision checker are deliberately motion-agnostic.
+`Layout.__post_init__`, not in the collision checker. The parts model
+and collision checker remain deliberately **motion-agnostic** — they
+describe where a plane *is*, never how it got there.
+
+Motion behaviour now lives in the `towplanner` module (Phase 3a), which
+uses a **single Dubins motion primitive** for every plane: a cart-borne
+plane is treated as own-gear with `turn_radius_m = 0` (a pivot-in-place),
+supplied through `Aircraft.effective_turn_radius_m()`. This **retires the
+earlier "holonomic on carts; Dubins-path-style on own gear" two-mode
+framing** — there is one primitive, not two (ADR-0007, forks 2–3). A
+consequence: `turn_radius_m` is now **load-bearing**. It was an unused
+placeholder through Phase 1/2a and is consumed by the planner's Dubins
+arithmetic and its bound-aware Hybrid-A\* path search ([#222](https://github.com/DocGerd/hangarfit/issues/222)).
+Cart planes keep `turn_radius_m: null` in `fleet.yaml`; the zero radius
+is supplied by the accessor, not baked into the data (ADR-0007, fork 4).
 
 ### The door is a visual marker only
 
@@ -85,9 +96,17 @@ treat the door as a separate opening: every part of every placed plane
 must fit fully inside the hangar rectangle for the layout to be
 considered valid. There is no "door clearance" rule beyond the
 hangar-bounds check itself (`_hangar_bounds_conflicts` in
-`src/hangarfit/collisions.py`). Whether a plane can be *moved* out
-through the door is a future-planner concern, deliberately out of
-scope here.
+`src/hangarfit/collisions.py`).
+
+At the `collisions.check` level the door stays a **visual marker only** —
+the static checker cares solely about the hangar-bounds rectangle. The
+`towplanner` (Phase 3a) is the first consumer to treat the door as a
+**motion gate**: a plane enters from a door-cone entry pose (constrained
+to the door interval, heading into the hangar) and is towed to its slot
+along a Dubins path, with the front gap exempted during motion (a mover
+may straddle `y < 0` in front of the door mid-tow). That door semantics
+lives entirely in the planner and changes no `collisions.check` verdict
+(ADR-0007).
 
 ## The coordinate convention
 


### PR DESCRIPTION
Closes #194.

Final Phase 3a issue (9/10; spike item 9 + Q5 supersession). Sweeps **every doc layer** in one PR so no anchor goes stale ([[feedback_enumerate_doc_layers]] discipline) now that the `towplanner` module + `solve()` bundle have shipped (#188–#197, #222).

## Layers swept

- **arc42 §5** — `towplanner` registered in the module-map mermaid (`solver → towplanner`; `towplanner → collisions/geometry/models`) + a per-module subsection (single Dubins primitive, bound-aware Hybrid-A* #222, collision-during-motion, best-effort failure, determinism). Added a tow-plan-bundling bullet to the `solver` subsection.
- **arc42 §6** — bundled `(Layout, MovesPlan)` runtime flow in the solve sequence (`Tow` participant, `plan_fill` per layout, `plans` in `SolveResult`) + a best-effort / `--render-paths` note.
- **arc42 §8** — **retired the "holonomic on carts; Dubins-path-style on own gear" two-mode framing** (ADR-0007: one Dubins primitive, cart = `turn_radius_m=0` via `effective_turn_radius_m()`); noted `turn_radius_m` is now load-bearing; noted the door is a towplanner-level **motion gate** but still a **visual marker only** at the `collisions.check` level.
- **data/fleet.yaml** — documented `turn_radius_m` in the header conventions + an inline pointer on each of the three `always_cart` `null` placeholders.
- **CLAUDE.md + README** — added `towplanner` (and the pre-existing-missing `solver`) to the module-list enumerations.

## Notes / decisions

- **`docs/adr/README.md` already carries the ADR-0007 row** (added by #195/#209) — no change needed there; the issue bullet is already satisfied.
- **ADR-0007 left immutable.** Its motion fork reads "Dubins-only + order-retry," but the shipped planner is the bound-aware Hybrid-A* from #222. Rather than rewrite an accepted ADR, I reconcile the wording **at point-of-use** — §5/§8 describe the shipped Hybrid-A* and cite #222 alongside ADR-0007. (If you'd prefer a formal supersession/amendment ADR for the #222 planner, that's a separate ticket.)
- Pure docs + `fleet.yaml` comments — no code. `check-yaml` passes; full suite **641 passed** (fleet still loads; the three cart planes still resolve `effective_turn_radius_m() == 0.0`).

This is the **last open issue in milestone #16** — merging it closes Phase 3a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)