### PR TITLE
docs: refresh CLAUDE.md for shipped Phase 3a + flip ADR-0009 to Accepted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,8 +229,9 @@ pip-compile --generate-hashes --no-strip-extras --allow-unsafe -o requirements-p
 # Phase 1 acceptance smoke test
 hangarfit check layouts/example.yaml --render out.png
 
-# Phase 3a: solve + tow-path overlay. Best-effort: un-routable planes are
-# dropped from the overlay; exit 3 only if NO candidate layout is tow-routable.
+# Phase 3a: solve + tow-path overlay. Best-effort: a layout the v1 planner
+# can't fully route renders without paths (blocking plane named on stderr);
+# exit 3 only if NO candidate layout is tow-routable.
 hangarfit solve tests/fixtures/scenario_minimal.yaml --render out.png --render-paths
 
 # GitFlow loops

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file is the durable **operational** context for the project: how we work, w
 
 `hangarfit` is an **on-demand exception tool** for a flying club: when the standard hangar parking layout breaks (delayed return, surprise maintenance, etc.), it helps find *a* valid alternative arrangement. The tool checks whether a hand-authored candidate layout is physically valid and renders a top-down PNG so a human can eyeball it; the solver searches for one when no candidate is in hand.
 
-**Status:** Phase 1 (substrate) and Phase 2a (static layout solver, `hangarfit solve`) have both shipped. Live milestone status lives in auto-memory and GitHub milestones, not here.
+**Status:** Phase 1 (substrate), Phase 2a (static layout solver, `hangarfit solve`), and Phase 3a (tow-path planning, `hangarfit solve --render-paths`) have all shipped. Live milestone status lives in auto-memory and GitHub milestones, not here.
 
 ---
 
@@ -29,6 +29,8 @@ This file is the durable **operational** context for the project: how we work, w
 | RR-MC solver algorithm and the determinism contract | [ADR-0003](docs/adr/0003-rr-mc-solver-algorithm.md) |
 | Diversity metric (edit-count, thresholds) | [ADR-0004](docs/adr/0004-diversity-metric.md) |
 | **The spread post-pass** (maximize inter-plane gap once valid) | [ADR-0008](docs/adr/0008-inter-plane-spread-soft-preference.md) |
+| **The tow-path planner** (empty-hangar fill, Dubins arcs, `solve --render-paths`, exit-3 tow-routability) | [§5 Building Block View](docs/architecture/05-building-block-view.md) (`towplanner`) + [ADR-0007](docs/adr/0007-tow-path-planner-v1-scope.md) |
+| Why the project targets a single Python (3.12), not a range | [ADR-0009](docs/adr/0009-single-supported-python-version.md) |
 | All architecture decisions, including superseded ones | [`docs/adr/`](docs/adr/) |
 
 If you find yourself about to write a domain assertion in this file, **don't** — extend the relevant arc42 section or ADR instead. CLAUDE.md is for *how we work together*; arc42/ADR is for *what the system is and why*.
@@ -226,6 +228,10 @@ pip-compile --generate-hashes --no-strip-extras --allow-unsafe -o requirements-p
 
 # Phase 1 acceptance smoke test
 hangarfit check layouts/example.yaml --render out.png
+
+# Phase 3a: solve + tow-path overlay. Best-effort: un-routable planes are
+# dropped from the overlay; exit 3 only if NO candidate layout is tow-routable.
+hangarfit solve tests/fixtures/scenario_minimal.yaml --render out.png --render-paths
 
 # GitFlow loops
 git switch develop && git pull

--- a/docs/adr/0009-single-supported-python-version.md
+++ b/docs/adr/0009-single-supported-python-version.md
@@ -1,7 +1,6 @@
 # ADR-0009: Single supported Python — 3.12, anchored to the distro LTS
 
-- **Status:** Proposed
-  <!-- Flips to Accepted when the implementing PR (#213) merges. -->
+- **Status:** Accepted
 
 - **Date:** 2026-05-25
 - **Deciders:** Patrick Kuhn (DocGerd)


### PR DESCRIPTION
Closes #264

CLAUDE.md's delegation table and Status line had fallen behind `develop` since Phase 3a (tow-path planning) shipped. Pointer/status fixes only — no domain assertions added to CLAUDE.md (keeps its "extend arc42/ADR, not this file" rule).

## Changes
| File | Edit |
|---|---|
| CLAUDE.md | **Status line** — add Phase 3a (`solve --render-paths`) to the shipped list |
| CLAUDE.md | **Quick Reference** — new **ADR-0007** row (tow-path planner v1: Dubins fill, `--render-paths`, exit-3 tow-routability) |
| CLAUDE.md | **Quick Reference** — new **ADR-0009** row (single supported Python 3.12) |
| CLAUDE.md | **Useful commands** — runnable `solve --render-paths` smoke test |
| docs/adr/0009 | **Status** Proposed → Accepted (implementing PR #214 merged; conditional note removed) |

## Verification
- `hangarfit solve tests/fixtures/scenario_minimal.yaml --render … --render-paths` runs (exit 0; ctsl un-routable → dropped from overlay, best-effort). The doc comment matches the real exit-3 rule (`all(plan is None …)`).
- Confirmed: `solve` takes a **scenario**, not a layout — example uses a real scenario fixture, not `layouts/example.yaml`.
- ADR-0009 line-120 "Related issues / PRs: #213" left intact (that's the issue; #214 was the PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)