### PR TITLE
chore(automations): lockfile-edit guard + ruff-on-edit hooks, bump pre-commit ruff

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -16,7 +16,7 @@ This directory holds **team-shared** [Claude Code](https://docs.claude.com/en/do
 
 ### PreToolUse — lockfile guard (blocking)
 
-Before an edit lands, this hook inspects the target path. If its basename matches `requirements-*.txt` it **blocks the edit** (exit code `2`) and tells Claude to regenerate the lockfile with the matching `pip-compile` command in [`CLAUDE.md`](../CLAUDE.md) instead. Those files (`requirements-dev.txt`, `requirements-build.txt`, `requirements-fuzz.txt`, `requirements-pip-tools.txt`) are hash-pinned and machine-generated; hand-editing them passes locally but fails the `*-lockfile-drift` CI jobs confusingly. The guard keys on the `.txt` extension, so the editable `requirements-*.in` sources are never blocked, and `pip-compile` (which runs via Bash, not Edit/Write) is unaffected. This is the one **blocking** hook — a safety rail, not advisory.
+Before an edit lands, this hook inspects the target path. If its basename matches `requirements-*.txt` it **blocks the edit** (exit code `2`) and tells Claude to regenerate the lockfile with the matching `pip-compile` command in [`CLAUDE.md`](../CLAUDE.md) instead. Those files (`requirements-dev.txt`, `requirements-build.txt`, `requirements-fuzz.txt`, `requirements-pip-tools.txt`) are hash-pinned and machine-generated; hand-editing them passes locally but fails the `*-lockfile-drift` CI jobs confusingly. The guard keys on the `requirements-*.txt` glob, so the editable `requirements-*.in` sources are never blocked, and `pip-compile` (which runs via Bash, not Edit/Write) is unaffected. This is the one **blocking** hook — a safety rail, not advisory.
 
 ### PostToolUse — ruff + pytest (non-blocking)
 

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -6,24 +6,32 @@ This directory holds **team-shared** [Claude Code](https://docs.claude.com/en/do
 
 | File | Status | Purpose |
 |---|---|---|
-| `settings.json` | committed | Team defaults — auto-run `pytest` after edits under `src/hangarfit/` or `tests/`. |
+| `settings.json` | committed | Team defaults — a `PreToolUse` guard that blocks hand-edits to the hash-pinned `requirements-*.txt` lockfiles, plus a `PostToolUse` hook that runs `ruff` + `pytest` after edits under `src/hangarfit/` or `tests/`. |
 | `settings.local.json` | **gitignored** | Optional per-contributor override (see below). |
 | `README.md` | committed | This file. |
 
-## The PostToolUse pytest hook
+## The on-edit hooks
 
-`settings.json` registers a `PostToolUse` hook on the `Edit` and `Write` tools. After Claude Code edits a file, the hook inspects the edited path and:
+`settings.json` registers two hooks on the `Edit` and `Write` tools, both shared with every contributor on clone.
 
-- If the path matches `src/hangarfit/**` or `tests/**` → runs `pytest -q --no-header 2>&1 | tail -30` and shows the last 30 lines in the transcript.
+### PreToolUse — lockfile guard (blocking)
+
+Before an edit lands, this hook inspects the target path. If its basename matches `requirements-*.txt` it **blocks the edit** (exit code `2`) and tells Claude to regenerate the lockfile with the matching `pip-compile` command in [`CLAUDE.md`](../CLAUDE.md) instead. Those files (`requirements-dev.txt`, `requirements-build.txt`, `requirements-fuzz.txt`, `requirements-pip-tools.txt`) are hash-pinned and machine-generated; hand-editing them passes locally but fails the `*-lockfile-drift` CI jobs confusingly. The guard keys on the `.txt` extension, so the editable `requirements-*.in` sources are never blocked, and `pip-compile` (which runs via Bash, not Edit/Write) is unaffected. This is the one **blocking** hook — a safety rail, not advisory.
+
+### PostToolUse — ruff + pytest (non-blocking)
+
+After Claude Code edits a file, this hook inspects the edited path and:
+
+- If the path matches `src/hangarfit/**` or `tests/**` → runs `ruff check` and `ruff format --check` on the edited file, then `pytest -q --no-header`, showing the tail of each in the transcript.
 - Otherwise → no-op.
 
-The hook is **non-blocking**: it always exits `0`, even if `pytest` fails. The failing output is shown to Claude as feedback, but the edit itself is never aborted. Treat it as a fast smoke signal, not a gate.
+This mirrors three of the gates CI enforces (`ruff check`, `ruff format --check`, `pytest`) so problems surface on edit instead of in CI. `mypy` is deliberately omitted — too slow to run on every edit. The hook is **non-blocking**: it always exits `0`, even if a check fails. Failing output is shown to Claude as feedback, but the edit itself is never aborted. Treat it as a fast smoke signal, not a gate.
 
 Path matching is glob-based (`*/src/hangarfit/*` / `*/tests/*`), anchored with a leading `/` so that sibling directories like `vendor-src/hangarfit/` or `contests/` do not accidentally trigger the hook.
 
 ## Opting out (per contributor)
 
-Set the env var `HANGARFIT_SKIP_PYTEST_HOOK=1` in your shell init (`~/.bashrc`, `~/.zshrc`, etc.). The hook detects this and exits immediately without running pytest. Unset (or restart your shell) to re-enable.
+Set the env var `HANGARFIT_SKIP_PYTEST_HOOK=1` in your shell init (`~/.bashrc`, `~/.zshrc`, etc.). The **PostToolUse** ruff + pytest hook detects this and exits immediately. Unset (or restart your shell) to re-enable. The PreToolUse lockfile guard is intentionally **not** opt-out-able — it is a cheap safety rail and the legitimate regeneration path (`pip-compile` via Bash) is never blocked anyway.
 
 ```bash
 # ~/.bashrc or ~/.zshrc

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,24 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "path=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"tool_input\",{}).get(\"file_path\",\"\"))'); case \"$(basename \"$path\")\" in requirements-*.txt) echo \"[hangarfit guard] $path is a hash-pinned lockfile — do not hand-edit. Regenerate it with the matching pip-compile command in CLAUDE.md (Useful commands); the *-lockfile-drift CI jobs enforce this.\" >&2; exit 2 ;; *) exit 0 ;; esac",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -n \"$HANGARFIT_SKIP_PYTEST_HOOK\" ]; then cat > /dev/null; exit 0; fi; path=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"tool_input\",{}).get(\"file_path\",\"\"))'); case \"$path\" in */src/hangarfit/*|*/tests/*) echo \"[hangarfit hook] running pytest after edit of $path\"; pytest -q --no-header 2>&1 | tail -30 ;; *) : ;; esac; exit 0",
+            "command": "if [ -n \"$HANGARFIT_SKIP_PYTEST_HOOK\" ]; then cat > /dev/null; exit 0; fi; path=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"tool_input\",{}).get(\"file_path\",\"\"))'); case \"$path\" in */src/hangarfit/*|*/tests/*) echo \"[hangarfit hook] ruff + pytest after edit of $path\"; ruff check \"$path\" 2>&1 | tail -15; ruff format --check \"$path\" 2>&1 | tail -5; pytest -q --no-header 2>&1 | tail -30 ;; *) : ;; esac; exit 0",
             "timeout": 120
           }
         ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.9
+    rev: v0.15.14
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format


### PR DESCRIPTION
## Summary

Three local-tooling hardening changes for **local == CI parity**, surfaced in an automation audit. Successor to the closed *Contributor automations* milestone (#4), now filed under **Contributor automations II**.

| # | Change | Why |
|---|--------|-----|
| 1 | **PreToolUse guard hook** — blocks `Edit`/`Write` to `requirements-*.txt` (exit 2), pointing at the matching `pip-compile` command | The hash-pinned lockfiles have four `*-lockfile-drift` CI jobs enforcing "regenerate, never hand-edit" but **no local guard** — a hand-edit passes locally and fails CI confusingly. Spares the editable `*.in` sources and the Bash-run `pip-compile` itself. |
| 2 | **PostToolUse hook** now runs `ruff check` + `ruff format --check` on the edited file before `pytest` (src/tests edits) | The on-edit hook only ran `pytest`; this closes 2 of the 3 remaining CI lint/type gates locally. Non-blocking; honors `HANGARFIT_SKIP_PYTEST_HOOK`. `mypy` omitted (too slow per-edit). |
| 3 | `.pre-commit-config.yaml` ruff `v0.9.9` → `v0.15.14` | Pre-commit pinned a stale ruff while installed/CI ruff is `0.15.14` — pre-commit could auto-format one way and CI's newer `ruff format --check` then disagree. Bump also renames the legacy `ruff` lint-hook id to `ruff-check`. |

`.claude/README.md` updated to document both hooks (the blocking guard vs the non-blocking ruff+pytest, and the opt-out scope).

## Verification

- `settings.json` is valid JSON.
- Guard exercised across path classes: **blocks** `requirements-dev.txt` / `requirements-pip-tools.txt` (exit 2 + message); **allows** `requirements-build.in`, `src/hangarfit/*.py`, `data/*.yaml` (exit 0).
- PostToolUse: opt-out env var short-circuits (exit 0, no output); non-matching path is a no-op; `ruff check` + `ruff format --check` run clean on real `src/` files with ruff 0.15.14.
- `pre-commit validate-config` passes; the bumped `ruff-check`/`ruff-format` v0.15.14 hooks resolved and ran green on commit.

## Out of scope (handled separately)

A dead permission entry in the **gitignored** `.claude/settings.local.json` (pointing at the long-gone `feature/103-maintenance-bay-model` worktree) — local-only, not part of this PR; flagged to the maintainer for manual removal.

Closes #266
