### PR TITLE
feat(towplanner): Reeds–Shepp motion model — reverse arcs eliminate reorientation loops (#261)

### DIFF
--- a/docs/adr/0007-tow-path-planner-v1-scope.md
+++ b/docs/adr/0007-tow-path-planner-v1-scope.md
@@ -1,9 +1,21 @@
 # ADR-0007: Tow-path planner v1 — empty-hangar fill, Dubins-only, cart-as-own-gear
 
-- **Status:** Accepted
+- **Status:** Accepted (fork 2 "Dubins-only" **superseded by [ADR-0010](0010-reeds-shepp-motion-model.md)**)
 
 - **Date:** 2026-05-25
 - **Deciders:** Patrick Kuhn (DocGerd)
+
+> **Update (2026-05-27, ADR-0010):** Fork 2 below ("Motion model: Dubins-only")
+> is **superseded by [ADR-0010 — Reeds–Shepp motion model](0010-reeds-shepp-motion-model.md)**.
+> The towplanner now uses a closed-form **Reeds–Shepp** vocabulary (Dubins +
+> reverse arcs/straights) so a plane can back up to reorient instead of driving
+> a full turning-circle loop; the move stays closed-form and deterministic, so
+> this ADR's determinism driver is unaffected. Everything else in this ADR
+> (empty-hangar-fill scope, cart = own-gear with `turn_radius_m = 0`, the
+> `effective_turn_radius_m()` accessor, the door-as-motion-gate, the bounded
+> greedy-order retry) **still stands**. The "Why not RRT-Connect" reasoning in
+> fork 2 also stands — RRT-Connect remains deferred; ADR-0010 chose reverse arcs,
+> not sampling.
 
 ## Context & Problem Statement
 

--- a/docs/adr/0010-reeds-shepp-motion-model.md
+++ b/docs/adr/0010-reeds-shepp-motion-model.md
@@ -1,0 +1,231 @@
+# ADR-0010: Reeds–Shepp motion model — towplanner v2
+
+- **Status:** Accepted
+
+- **Date:** 2026-05-27
+- **Deciders:** Patrick Kuhn (DocGerd)
+
+## Context & Problem Statement
+
+[ADR-0007](0007-tow-path-planner-v1-scope.md) locked the tow-path planner's
+motion model (its fork 2) to **forward-only Dubins** arcs. A forward-only car
+cannot reverse: to reorient — e.g. to nose a plane *out* of a slot, or to
+achieve a final heading that points back toward the door — it must drive a full
+turning-circle loop. A UAT exposed exactly this waste: a plane parked nose-in
+that needed to leave nose-out drove a ~32 m forward loop where an ~18 m
+back-up-and-pull-forward would do. The question this ADR answers: *do we extend
+the motion vocabulary to include reverse, and if so, with what model — keeping
+the [ADR-0003](0003-rr-mc-solver-algorithm.md) byte-identical-plan determinism
+contract intact?*
+
+The label "v2" is the towplanner subsystem's scope tier (matching ADR-0007's
+"v1" usage), not a `hangarfit` semver version.
+
+## Decision Drivers
+
+- **Eliminate the loop-to-reorient waste** the UAT exposed without giving up
+  closed-form planning.
+- **Preserve the ADR-0003 determinism contract end-to-end.** Same seed → same
+  target layout → same plan, byte-identical. Any probabilistic planner
+  (RRT-Connect) would break this; the motion model must stay closed-form.
+- **Reuse the existing integrator and collision substrate.** The
+  `DubinsArc.pose_at` walker, the `path_first_conflict` oracle, and the
+  Hybrid-A\* search (#222) should carry over with the smallest possible delta.
+- **Prefer forward motion.** Reverse is a tool for the cases that need it, not
+  a free substitute — a plan that gratuitously backs up is harder for a human
+  to execute and easier to get wrong.
+- **Keep cart (`turn_radius_m = 0`) handling uniform.** A carted plane should
+  gain "back straight out of a slot" for free, under the same model.
+
+## Considered Options
+
+1. **Full closed-form Reeds–Shepp** (Dubins + reverse arcs/straights),
+   weighted-length word selection that prefers forward *(chosen)*.
+2. **Keep forward-only Dubins** (the ADR-0007 status quo) and live with the
+   loop-to-reorient waste.
+3. **RRT-Connect** (sampling-based, bidirectional) — the general escape hatch
+   for hard packings, ADR-0007's named v2 candidate.
+4. **Ad-hoc "back up then re-plan forward" heuristic** bolted onto the Dubins
+   planner.
+
+## Decision Outcome
+
+**Chosen option: full closed-form Reeds–Shepp**, because it removes the
+loop-to-reorient waste while remaining closed-form and deterministic — so the
+ADR-0003 contract holds unchanged — and it slots into the existing integrator
+and search with a minimal, well-tested delta.
+
+Concretely:
+
+- **Data model.** `Segment` gains a `gear: Literal[1, -1] = 1` field
+  (`+1` forward, `-1` reverse). `kind` (L/S/R) is *steering*; `gear` is *travel
+  direction* — independent. The default `+1` keeps every pre-existing
+  forward-only `Segment(kind, length)` call (and all Dubins-era tests) valid.
+  `DubinsArc` is retained as the path container (renaming it would be churn for
+  no behavioural gain); its `pose_at` integrator now applies `gear` to the
+  translation step — a reverse straight drives −cos/−sin, a reverse arc retreats
+  around the steering-determined turning centre.
+- **Closed form.** `plan_reeds_shepp(start, end, *, turn_radius_m)` sits beside
+  `plan_dubins`. It is built by the textbook **base-formula + symmetry-generation**
+  method: a handful of base word-solvers (CSC, CCC, CCCC, CCSC, CCSCC) in the
+  normalised math frame, enumerated under the **timeflip / reflect** goal
+  symmetries to generate the classical Reeds–Shepp word family mechanically (no
+  hand-transcription of all 48 ad-hoc formulae).
+- **Cost model — prefer forward.** Word selection minimises
+  Σ(`|leg_length|` × factor), where a **reverse** leg carries
+  `_REVERSE_COST_FACTOR = 1.5`.
+- **Search integration.** `_primitives` returns **six** primitives in fixed
+  order `Lf, Sf, Rf, Lr, Sr, Rr`; `_seg_cost` multiplies a reverse leg by the
+  factor; the Hybrid-A\* analytic-expansion shot is `plan_reeds_shepp` instead
+  of `plan_dubins`.
+- **Cart.** `plan_reeds_shepp` delegates the `turn_radius_m == 0` case to the
+  shared `_plan_cart` helper with reverse enabled, so a carted plane may back
+  straight out of a slot when that is cheaper.
+
+This **supersedes [ADR-0007](0007-tow-path-planner-v1-scope.md) fork 2
+("Dubins-only")**. The rest of ADR-0007 (empty-hangar-fill scope, cart =
+own-gear with `turn_radius_m = 0`, the `effective_turn_radius_m()` accessor,
+the door-as-motion-gate, the bounded greedy-order retry) stands.
+
+### Why `_REVERSE_COST_FACTOR = 1.5`?
+
+A measured nose-out case is **18 m reverse vs 32 m forward**. At **1.5×** the
+reverse weighs 27 m, still beating the 32 m forward loop, so the reverse win is
+kept — while a gratuitous short reverse is discouraged relative to an equal
+forward leg. At **2.0×** the same reverse would weigh 36 m and be *suppressed*
+in favour of the longer forward path, defeating the point of adopting
+Reeds–Shepp at all. 1.5 is the value that keeps the genuine win and still biases
+toward forward; it is pinned by a unit test so a casual retune trips a guard and
+forces an update to this ADR.
+
+### Why not keep forward-only Dubins (option 2)?
+
+That is the waste this ADR exists to remove. Forward-only is simpler, but the
+UAT showed it produces plans a human would reject as obviously circuitous (a
+full loop where a short back-up suffices). The simplicity is not worth shipping
+plans the operator will not trust.
+
+### Why not RRT-Connect (option 3)?
+
+RRT-Connect remains the escape hatch for genuinely tight packings that *no*
+closed-form vocabulary can route (it is still named as future work). But it is
+sampling-based: its determinism story would have to be reconciled with
+ADR-0003's seeded contract (per-tree RNG, deterministic merge order), it adds
+300–500 lines, and — crucially — **it does not address the problem this ADR
+targets.** The UAT waste is not an unsolvable-packing problem; it is a
+*missing-reverse-vocabulary* problem, which Reeds–Shepp solves in closed form
+with the determinism contract intact. RRT-Connect would be a much larger,
+probabilistic answer to a question reverse arcs already answer cleanly.
+
+### Why not an ad-hoc "back up then re-plan" heuristic (option 4)?
+
+Bolting a special-case "if stuck, reverse a bit and try again" onto the Dubins
+planner reintroduces exactly the two-mode complexity ADR-0007 worked to avoid,
+and its behaviour at the seams (when does it trigger? how far does it back up?)
+is hard to make deterministic and hard to test. Reeds–Shepp is the principled,
+closed-form generalisation that makes reverse a first-class leg in the *same*
+word algebra, not a bolt-on. One vocabulary, one cost model, one integrator.
+
+## Consequences
+
+### Positive
+
+- The loop-to-reorient waste is gone: a plane can back up to reorient, and the
+  cost model picks the shorter geared maneuver.
+- The determinism contract (ADR-0003) holds: closed-form, RNG-free, fixed word
+  iteration order + strict-`<` tie-break.
+- Cart planes gain "back straight out of a slot" under the same model.
+- Cases that were genuinely infeasible for forward-only Dubins (a turned goal a
+  forward car could not reach in-bounds) are now routable — the search finds
+  them via the reverse primitives, exact-oracle-clean.
+- Minimal data-model delta: one defaulted `Segment.gear` field; all existing
+  forward-only call sites and tests are untouched.
+
+### Negative
+
+- The search primitive fan **doubled** from 3 (forward L/S/R) to 6 (+ reverse
+  L/S/R), so each Hybrid-A\* expansion screens roughly twice the edges. On an
+  un-towable layout the worst-case budget-exhaustion bail time roughly doubled
+  (the six-plane fresh-fill perf gate went ~26 s → ~50 s; its `slow` ceiling was
+  raised 30 s → 75 s with a documented rationale). A future pass can prune the
+  fan (the reverse cart pivots are redundant with the forward ones) or gate
+  reverse edges behind a heuristic.
+- Two coexisting closed-form planners (`plan_dubins`, `plan_reeds_shepp`). The
+  Hybrid-A\* analytic shot now uses Reeds–Shepp; `plan_dubins` remains for the
+  forward-only Dubins tests and as the historical reference. A future cleanup
+  could retire `plan_dubins` once nothing depends on forward-only behaviour.
+
+### Neutral
+
+- **`DubinsArc` keeps its name** despite now carrying geared, possibly-reverse
+  segments. Renaming it to `MotionArc`/`Path` would touch the public-ish type
+  reference in `cli.py`/`visualize.py`/`models.py` (annotation-only, under
+  `TYPE_CHECKING`) and every test, for no behavioural gain. The class docstring
+  and the module docstring carry the "now Reeds–Shepp, segments carry gear"
+  framing so a reader is not misled by the legacy name.
+- The reverse **front-gap exemption (#222)** is free: `_mover_motion_bounds_conflict`
+  is pose-only and gear-agnostic, so a plane backing out through the door at
+  `y < 0` is exempt on the front wall but still bounded on the side/back walls,
+  exactly as a forward mover is.
+
+## Compliance
+
+- **Integrator round-trip is the primary correctness oracle.**
+  `tests/test_towplanner_reeds_shepp.py::test_reeds_shepp_roundtrip_grid` walks
+  the geared segments `plan_reeds_shepp` emits via `DubinsArc.pose_at` across a
+  grid of start/end poses and several radii, asserting the integrated endpoint
+  reaches the goal. Mirrors the Dubins `test_dubins_roundtrip_grid`. A
+  transcription error in any generated word surfaces here as a missed endpoint.
+  In the solver itself, every generated word is gated by a closed-form-independent
+  re-integration (`_rs_word_reaches`) before it can be chosen, so a base-formula
+  sign error becomes a *missing* candidate, never a *wrong path that ships*.
+- **The 45° heading canary** (the ADR-0007-mandated convention guard) gains a
+  **reverse** case:
+  `tests/test_towplanner_dubins.py::test_heading_45_reverse_path_advances_into_minus_x_minus_y`
+  asserts a reverse leg at heading 45° lands in the (−x, −y) quadrant (the exact
+  negation of the forward case). The symmetric word matrix would pass a CW/CCW
+  sign flip ([ADR-0002](0002-determinant-minus-one-transform.md)) silently; this
+  geometric assert is the real guard for the reverse direction.
+- **Cost-prefers-forward** is pinned by
+  `test_collinear_forward_goal_stays_pure_forward_straight` and
+  `test_reverse_beats_forward_loop_for_short_backup`; the factor value itself by
+  `test_reverse_cost_factor_value` (= 1.5), so a retune trips a guard and forces
+  this ADR to be updated.
+- **Determinism** (ADR-0003) by `test_reeds_shepp_is_deterministic`
+  (byte-identical segments on repeat) plus the fixed primitive order pinned in
+  `test_towplanner_search.py::test_primitives_own_gear_are_six_in_lf_sf_rf_lr_sr_rr_order`.
+- **Reverse front-gap exemption** by
+  `test_towplanner_motion.py::test_reverse_through_door_is_front_gap_exempt`
+  (exempt on the front wall) and `test_reverse_into_side_wall_still_bounded`
+  (still bounded on the side wall).
+- **Cart reverse-straight** by `test_cart_reverse_straight_backs_out`.
+- **Geometry-invariant-guard review.** Any PR touching this motion math (the
+  integrator, the heading adapter, the collision-during-motion check) must be
+  reviewed by the `geometry-invariant-guard` subagent per the standing CLAUDE.md
+  rule — the determinant-(−1) / compass-vs-math sign-flip trap
+  ([ADR-0002](0002-determinant-minus-one-transform.md)) is the hazard the reverse
+  legs add a fresh sign to.
+
+## More Information
+
+- Supersedes: [ADR-0007](0007-tow-path-planner-v1-scope.md) fork 2 ("Dubins-only").
+  The rest of ADR-0007 stands.
+- Related ADRs:
+  [ADR-0002](0002-determinant-minus-one-transform.md) (the heading-convention
+  sign-flip trap the reverse legs must respect),
+  [ADR-0003](0003-rr-mc-solver-algorithm.md) (the determinism contract this
+  closed-form motion model preserves),
+  [ADR-0007](0007-tow-path-planner-v1-scope.md) (towplanner v1 scope).
+- Implementation: [`src/hangarfit/towplanner.py`](../../src/hangarfit/towplanner.py)
+  (`plan_reeds_shepp`, `_plan_cart`, the `_rs_*` base solvers + symmetry
+  generation, `_primitives`, `_seg_cost`).
+- Tests: [`tests/test_towplanner_reeds_shepp.py`](../../tests/test_towplanner_reeds_shepp.py),
+  the reverse canary in [`tests/test_towplanner_dubins.py`](../../tests/test_towplanner_dubins.py),
+  the reverse-motion cases in [`tests/test_towplanner_motion.py`](../../tests/test_towplanner_motion.py),
+  and the six-primitive / canary updates in
+  [`tests/test_towplanner_search.py`](../../tests/test_towplanner_search.py).
+- Related issue: [#261](https://github.com/DocGerd/hangarfit/issues/261).
+- External references: Reeds, J. A. & Shepp, L. A. (1990), *Optimal paths for a
+  car that goes both forwards and backwards*, Pacific J. Math. 145(2); the
+  base-formula + symmetry-generation presentation follows the widely-used
+  PythonRobotics / OMPL implementations.

--- a/docs/adr/0010-reeds-shepp-motion-model.md
+++ b/docs/adr/0010-reeds-shepp-motion-model.md
@@ -74,10 +74,13 @@ Concretely:
 - **Cost model — prefer forward.** Word selection minimises
   Σ(`|leg_length|` × factor), where a **reverse** leg carries
   `_REVERSE_COST_FACTOR = 1.5`.
-- **Search integration.** `_primitives` returns **six** primitives in fixed
-  order `Lf, Sf, Rf, Lr, Sr, Rr`; `_seg_cost` multiplies a reverse leg by the
-  factor; the Hybrid-A\* analytic-expansion shot is `plan_reeds_shepp` instead
-  of `plan_dubins`.
+- **Search integration.** Own-gear (`r > 0`): `_primitives` returns **six**
+  primitives in fixed order `Lf, Sf, Rf, Lr, Sr, Rr`. Cart (`r == 0`): **four**
+  — `Lf, Sf, Rf, Sr` — the reverse pivots are omitted because a reverse pivot
+  rotates heading the same way as the opposite forward pivot (an exact duplicate
+  that always loses the `best_g` race), so only the reverse *straight* is a new
+  cart move. `_seg_cost` multiplies a reverse leg by the factor; the Hybrid-A\*
+  analytic-expansion shot is `plan_reeds_shepp` instead of `plan_dubins`.
 - **Cart.** `plan_reeds_shepp` delegates the `turn_radius_m == 0` case to the
   shared `_plan_cart` helper with reverse enabled, so a carted plane may back
   straight out of a slot when that is cheaper.
@@ -143,12 +146,13 @@ word algebra, not a bolt-on. One vocabulary, one cost model, one integrator.
 
 ### Negative
 
-- The search primitive fan **doubled** from 3 (forward L/S/R) to 6 (+ reverse
-  L/S/R), so each Hybrid-A\* expansion screens roughly twice the edges. On an
-  un-towable layout the worst-case budget-exhaustion bail time roughly doubled
-  (the six-plane fresh-fill perf gate went ~26 s → ~50 s; its `slow` ceiling was
-  raised 30 s → 75 s with a documented rationale). A future pass can prune the
-  fan (the reverse cart pivots are redundant with the forward ones) or gate
+- The own-gear search primitive fan **doubled** from 3 (forward L/S/R) to 6 (+
+  reverse L/S/R), so each Hybrid-A\* expansion screens roughly twice the edges.
+  On an un-towable layout the worst-case budget-exhaustion bail time roughly
+  doubled (the six-plane fresh-fill perf gate went ~26 s → ~50 s; its `slow`
+  ceiling was raised 30 s → 75 s with a documented rationale). The redundant
+  reverse *cart* pivots were already pruned (the cart fan is four, not six — see
+  Decision above); a future pass can further trim the own-gear fan or gate
   reverse edges behind a heuristic.
 - Two coexisting closed-form planners (`plan_dubins`, `plan_reeds_shepp`). The
   Hybrid-A\* analytic shot now uses Reeds–Shepp; `plan_dubins` remains for the

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -84,6 +84,7 @@ manual workflow above is canonical.
 | 0004 | [Diversity metric for K alternatives (edit count with per-plane thresholds)](0004-diversity-metric.md) | Accepted |
 | 0005 | [Maintenance bay rule — fuselage centroid in back strip](0005-maintenance-bay-rule.md)                 | Superseded by [ADR-0006](0006-bay-intrusion-maintenance-rule.md) |
 | 0006 | [Maintenance bay rule — `bay_intrusion` on any non-occupant vertex strictly inside the bay rectangle](0006-bay-intrusion-maintenance-rule.md) | Accepted |
-| 0007 | [Tow-path planner v1 — empty-hangar fill, Dubins-only, cart-as-own-gear](0007-tow-path-planner-v1-scope.md) | Accepted |
+| 0007 | [Tow-path planner v1 — empty-hangar fill, Dubins-only, cart-as-own-gear](0007-tow-path-planner-v1-scope.md) | Accepted (fork-2 "Dubins-only" superseded by [ADR-0010](0010-reeds-shepp-motion-model.md)) |
 | 0008 | [Inter-plane spread soft preference (repulsion-energy surrogate for maximin)](0008-inter-plane-spread-soft-preference.md) | Accepted |
-| 0009 | [Single supported Python — 3.12, anchored to the distro LTS](0009-single-supported-python-version.md) | Proposed |
+| 0009 | [Single supported Python — 3.12, anchored to the distro LTS](0009-single-supported-python-version.md) | Accepted |
+| 0010 | [Reeds–Shepp motion model — towplanner v2](0010-reeds-shepp-motion-model.md) | Accepted |

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -14,7 +14,7 @@ flowchart TD
     geometry["geometry.py<br/>plane-local → world transform<br/>(determinant −1)"]
     collisions["collisions.py<br/>check(layout) entry<br/>hangar bounds + maintenance + part overlaps"]
     solver["solver.py<br/>RR-MC search<br/>deterministic RNG"]
-    towplanner["towplanner.py<br/>tow-path planning<br/>Dubins + bound-aware Hybrid-A*"]
+    towplanner["towplanner.py<br/>tow-path planning<br/>Reeds–Shepp + bound-aware Hybrid-A*"]
     visualize["visualize.py<br/>top-down PNG renderer<br/>headless matplotlib"]
 
     cli --> loader
@@ -204,19 +204,26 @@ Answers *how* the planes get to a layout, where `solver.py` answers
 *where* they go. Given a target `Layout`, `plan_fill` computes a
 collision-free entry **order** (deepest slot first) and a per-plane
 **path** from the door-cone entry pose to the target slot, returning a
-`MovesPlan` (a tuple of `Move`s, each carrying a `DubinsArc`). Scope is
+`MovesPlan` (a tuple of `Move`s, each carrying a `DubinsArc` — the
+historical container name; its segments now carry a `gear`). Scope is
 the **empty-hangar fill** case — every plane enters once (ADR-0007).
 
-- **Single motion primitive** — every plane is routed as a Dubins path;
-  a cart-borne plane is own-gear with `turn_radius_m = 0` (pivot-in-place),
-  via `Aircraft.effective_turn_radius_m()`. No two-mode (holonomic/Dubins)
-  branch — see §8 *Movement modes*.
+- **Single motion model — Reeds–Shepp** ([ADR-0010](../adr/0010-reeds-shepp-motion-model.md),
+  [#261](https://github.com/DocGerd/hangarfit/issues/261)): every plane is
+  routed as a closed-form Reeds–Shepp path (Dubins + reverse arcs/straights),
+  so it can back up to reorient instead of looping; reverse legs cost 1.5×
+  their length so forward is preferred. A cart-borne plane is own-gear with
+  `turn_radius_m = 0` (pivot-in-place, plus back-straight-out), via
+  `Aircraft.effective_turn_radius_m()`. No two-mode (holonomic/Dubins) branch
+  — see §8 *Movement modes*. Supersedes the Dubins-only fork of ADR-0007;
+  still closed-form and deterministic.
 - **Bound-aware Hybrid-A\*** (`plan_path`, [#222](https://github.com/DocGerd/hangarfit/issues/222))
-  — a deterministic search over Dubins motion primitives finds an
-  in-bounds, obstacle-free multi-segment path when a single shortest-arc
-  would clip a wall or an already-placed plane. Bounded by a
-  node-expansion budget; the full returned path is re-validated by the
-  exact `collisions.check`-based oracle (`path_first_conflict`).
+  — a deterministic search over the six Reeds–Shepp motion primitives
+  (forward L/S/R then reverse L/S/R) finds an in-bounds, obstacle-free
+  multi-segment path when a single shortest-arc would clip a wall or an
+  already-placed plane. Bounded by a node-expansion budget; the full returned
+  path is re-validated by the exact `collisions.check`-based oracle
+  (`path_first_conflict`).
 - **Collision-during-motion** reuses the static checker: each sampled
   pose along an arc is checked against the already-placed subset, so
   parts / hangar-bounds / bay rules are honoured *during* the tow, not

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -77,16 +77,24 @@ and collision checker remain deliberately **motion-agnostic** — they
 describe where a plane *is*, never how it got there.
 
 Motion behaviour now lives in the `towplanner` module (Phase 3a), which
-uses a **single Dubins motion primitive** for every plane: a cart-borne
-plane is treated as own-gear with `turn_radius_m = 0` (a pivot-in-place),
-supplied through `Aircraft.effective_turn_radius_m()`. This **retires the
-earlier "holonomic on carts; Dubins-path-style on own gear" two-mode
-framing** — there is one primitive, not two (ADR-0007, forks 2–3). A
-consequence: `turn_radius_m` is now **load-bearing**. It was an unused
-placeholder through Phase 1/2a and is consumed by the planner's Dubins
-arithmetic and its bound-aware Hybrid-A\* path search ([#222](https://github.com/DocGerd/hangarfit/issues/222)).
-Cart planes keep `turn_radius_m: null` in `fleet.yaml`; the zero radius
-is supplied by the accessor, not baked into the data (ADR-0007, fork 4).
+uses a **single closed-form motion model** for every plane —
+**Reeds–Shepp** (Dubins forward arc-line-arc *plus reverse* arcs and
+straights, [ADR-0010](../adr/0010-reeds-shepp-motion-model.md)): a plane
+can back up to reorient instead of driving a full turning-circle loop,
+and reverse legs cost 1.5× their length so forward motion is preferred. A
+cart-borne plane is treated as own-gear with `turn_radius_m = 0` (a
+pivot-in-place, and now a back-straight-out option too), supplied through
+`Aircraft.effective_turn_radius_m()`. This **retires the earlier
+"holonomic on carts; Dubins-path-style on own gear" two-mode framing** —
+there is one motion model, not two (ADR-0007, forks 2–3; ADR-0010
+supersedes fork 2's *Dubins-only* choice with Reeds–Shepp, still
+closed-form and deterministic). A consequence: `turn_radius_m` is now
+**load-bearing**. It was an unused placeholder through Phase 1/2a and is
+consumed by the planner's Reeds–Shepp arithmetic and its bound-aware
+Hybrid-A\* path search ([#222](https://github.com/DocGerd/hangarfit/issues/222),
+[#261](https://github.com/DocGerd/hangarfit/issues/261)). Cart planes keep
+`turn_radius_m: null` in `fleet.yaml`; the zero radius is supplied by the
+accessor, not baked into the data (ADR-0007, fork 4).
 
 ### The door is a visual marker only
 
@@ -103,10 +111,11 @@ the static checker cares solely about the hangar-bounds rectangle. The
 `towplanner` (Phase 3a) is the first consumer to treat the door as a
 **motion gate**: a plane enters from a door-cone entry pose (constrained
 to the door interval, heading into the hangar) and is towed to its slot
-along a Dubins path, with the front gap exempted during motion (a mover
-may straddle `y < 0` in front of the door mid-tow). That door semantics
-lives entirely in the planner and changes no `collisions.check` verdict
-(ADR-0007).
+along a Reeds–Shepp path, with the front gap exempted during motion (a
+mover may straddle `y < 0` in front of the door mid-tow — and may *back
+out* through it, the front-gap exemption being pose-only and
+gear-agnostic). That door semantics lives entirely in the planner and
+changes no `collisions.check` verdict (ADR-0007).
 
 ## The coordinate convention
 

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -67,7 +67,7 @@ class Segment:
     independent (a reverse-L backs up while the wheels steer left). ``length_m``
     is the leg's arc length in metres (always ``>= 0``); the integrator applies
     ``gear`` to the translation step. Defaulting ``gear`` to ``+1`` keeps every
-    forward-only (Dubins-era) ``Segment(kind, length)`` call valid (ADR-0010
+    forward-only (Dubins-era) ``Segment(kind, length_m)`` call valid (ADR-0010
     supersedes ADR-0007 fork-2 "Dubins-only")."""
 
     kind: SegmentKind
@@ -87,9 +87,12 @@ class Segment:
 
 @dataclass(frozen=True, slots=True)
 class DubinsArc:
-    """Closed-form shortest path between two oriented poses under a minimum
+    """Closed-form path container between two oriented poses under a minimum
     turn radius. ``turn_radius_m = 0`` denotes a cart-borne pivot-in-place
-    (ADR-0007). ``segments`` is the ordered leg decomposition."""
+    (ADR-0007). ``segments`` is the ordered leg decomposition; a segment may
+    carry ``gear = -1`` for a **reverse** leg (the Reeds–Shepp extension,
+    ADR-0010), so this now holds Reeds–Shepp paths too — the ``Dubins`` in the
+    name is historical (forward-only Dubins was the v1 motion model)."""
 
     start: Pose
     end: Pose
@@ -116,7 +119,8 @@ class DubinsArc:
         angle from ``+x``) and returns a compass-convention :class:`Pose`.
         For a turn segment, ``s_m`` consumed is metres of arc length when
         ``turn_radius_m > 0`` and **radians of pivot** when it is ``0``
-        (the cart pivot-in-place encoding — see :func:`plan_dubins`).
+        (the cart pivot-in-place encoding — see :func:`_plan_cart`, shared by
+        :func:`plan_dubins` and :func:`plan_reeds_shepp`).
         """
         x = self.start.x_m
         y = self.start.y_m
@@ -487,10 +491,11 @@ def _cart_seg_weight(seg: Segment) -> float:
 #
 # Built by the textbook **base-formula + symmetry-generation** method: a small
 # set of base word-solvers (CSC, CCC, CCCC, CCSC, CCSCC) in the NORMALISED math
-# frame, then the three Reeds–Shepp symmetry transforms — TIMEFLIP (reverse all
-# gears + reflect the goal through time), REFLECT (swap L↔R steering + reflect
-# the goal across the x-axis), and BACKWARDS (traverse the word end-to-start) —
-# applied mechanically to enumerate the full word family. This is the standard
+# frame, then two Reeds–Shepp goal symmetries — TIMEFLIP (reverse all gears;
+# the word for the time-reversed goal (-x, y, -phi)) and REFLECT (swap L↔R
+# steering; the word for the x-axis-mirrored goal (x, -y, -phi)) — each base
+# solver evaluated under the four combinations (identity, timeflip, reflect,
+# timeflip+reflect) to enumerate the full word family. This is the standard
 # `reeds_shepp` construction; the base formulas follow Reeds & Shepp (1990) /
 # the OMPL/PythonRobotics presentation.
 #
@@ -1094,20 +1099,23 @@ _SEARCH_STEP_DEG = 5.0
 def _primitives(turn_radius_m: float) -> tuple[Segment, ...]:
     """The fixed motion-primitive fan, in deterministic order (ADR-0010 v2).
 
-    **Six primitives** in fixed order ``Lf, Sf, Rf, Lr, Sr, Rr`` — the three
-    forward steerings (left arc, straight, right arc) then the same three in
-    reverse (gear ``-1``). The reverse primitives are the Reeds–Shepp extension:
-    the search can now back up to reorient instead of driving a full
-    turning-circle loop. Fixed order ⇒ deterministic expansion (ADR-0003).
+    Own-gear (``r > 0``): **six primitives** in fixed order ``Lf, Sf, Rf, Lr,
+    Sr, Rr`` — the three forward steerings (left arc, straight, right arc) then
+    the same three in reverse (gear ``-1``). The reverse primitives are the
+    Reeds–Shepp extension: the search can now back up to reorient instead of
+    driving a full turning-circle loop. Fixed order ⇒ deterministic expansion
+    (ADR-0003).
 
     Own-gear (``r > 0``): each arc/straight is ``step`` metres, chosen so a turn
-    changes heading by ~one heading cell. Cart (``r == 0``): the L/R primitives
-    are pivots of ``math.radians(_GRID_DEG)`` radians and the straight is
-    ``_GRID_XY_M`` metres. A reverse PIVOT is geometrically identical to the
-    forward pivot of the opposite steering, so only the **reverse straight**
-    adds a genuinely new cart move; the reverse pivots are kept for a uniform
-    six-primitive fan (they are redundant, never harmful — the grid de-dups
-    coincident child cells).
+    changes heading by ~one heading cell. Cart (``r == 0``): a reverse PIVOT
+    rotates heading the same way as the forward pivot of the *opposite* steering
+    (``pose_at`` holds position fixed and flips the heading delta for a reverse
+    leg), so ``Lr``/``Rr`` are exact duplicates of ``Rf``/``Lf`` and would only
+    ever lose the ``best_g`` race to their cheaper forward twin — pure dead work
+    (an extra ``_motion_clear`` sweep per expansion that can never win). They are
+    therefore omitted: the cart fan is the four useful moves ``Lf, Sf, Rf, Sr``
+    (forward pivots + straight, plus the genuinely-new **reverse straight** that
+    backs the cart up). Fixed order ⇒ deterministic expansion (ADR-0003).
     """
     if turn_radius_m == 0.0:
         dtheta = math.radians(_GRID_DEG)
@@ -1115,9 +1123,7 @@ def _primitives(turn_radius_m: float) -> tuple[Segment, ...]:
             Segment("L", dtheta),
             Segment("S", _GRID_XY_M),
             Segment("R", dtheta),
-            Segment("L", dtheta, gear=-1),
             Segment("S", _GRID_XY_M, gear=-1),
-            Segment("R", dtheta, gear=-1),
         )
     step = max(_GRID_XY_M, turn_radius_m * math.radians(_GRID_DEG))
     return (
@@ -1150,7 +1156,9 @@ def _seg_cost(seg: Segment, turn_radius_m: float) -> float:
     :data:`_REVERSE_COST_FACTOR` (ADR-0010), so the search prefers forward
     motion and only backs up when it is genuinely cheaper (the nose-out win).
     The factor scales the whole leg cost — translation and turn penalty alike —
-    so a reverse arc is penalised consistently with a reverse straight.
+    so a reverse arc is penalised consistently with a reverse straight. (The
+    cart fan no longer emits reverse pivots — see :func:`_primitives` — so for
+    ``r == 0`` the factor only ever applies to the reverse straight.)
     """
     factor = _REVERSE_COST_FACTOR if seg.gear == -1 else 1.0
     if seg.kind == "S":

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1,12 +1,19 @@
-"""Tow-path planner — empty-hangar fill (Phase 3a).
+"""Tow-path planner — empty-hangar fill (Phase 3a; Reeds–Shepp motion, v2).
 
 Answers *how* each plane reaches its target slot: a deterministic entry order
 (:func:`back_first_order`) plus an in-bounds, obstacle-free tow path per plane
-found by a deterministic Hybrid-A* search (:func:`plan_path`, #222) over Dubins
-motion primitives — emitted as a single :class:`DubinsArc`. An unobstructed
-plane still finishes in one closed-form Dubins shot (the search's analytic
-expansion). See ADR-0002 (heading convention), ADR-0007 (cart = own-gear, r=0),
-and docs/spikes/tow-path-planning.md.
+found by a deterministic Hybrid-A* search (:func:`plan_path`, #222) over
+**Reeds–Shepp** motion primitives — emitted as a single :class:`DubinsArc`
+(the historical container name; its segments now carry a ``gear``). An
+unobstructed plane finishes in one closed-form Reeds–Shepp shot (the search's
+analytic expansion). Reeds–Shepp = Dubins (forward arc-line-arc) **plus reverse
+arcs/straights** (:func:`plan_reeds_shepp`, #261), so a plane can back up to
+reorient instead of driving a full turning-circle loop; reverse legs cost
+:data:`_REVERSE_COST_FACTOR`× their length so forward motion is preferred. The
+closed form is still deterministic, preserving the ADR-0003 byte-identical-plan
+contract. See ADR-0002 (heading convention), ADR-0010 (Reeds–Shepp motion model,
+supersedes ADR-0007 fork-2 "Dubins-only"), ADR-0007 (cart = own-gear, r=0), and
+docs/spikes/tow-path-planning.md.
 """
 
 from __future__ import annotations
@@ -54,12 +61,18 @@ class Pose:
 
 @dataclass(frozen=True, slots=True)
 class Segment:
-    """One leg of a Dubins path. ``kind`` is ``L`` (left turn), ``S``
-    (straight), or ``R`` (right turn). ``length_m`` is the arc length of
-    the leg in metres (always >= 0)."""
+    """One leg of a Reeds–Shepp path. ``kind`` is the *steering*: ``L`` (left),
+    ``S`` (straight), or ``R`` (right). ``gear`` is the *travel direction*:
+    ``+1`` forward (default), ``-1`` reverse — steering and gear are
+    independent (a reverse-L backs up while the wheels steer left). ``length_m``
+    is the leg's arc length in metres (always ``>= 0``); the integrator applies
+    ``gear`` to the translation step. Defaulting ``gear`` to ``+1`` keeps every
+    forward-only (Dubins-era) ``Segment(kind, length)`` call valid (ADR-0010
+    supersedes ADR-0007 fork-2 "Dubins-only")."""
 
     kind: SegmentKind
     length_m: float
+    gear: Literal[1, -1] = 1
 
     def __post_init__(self) -> None:
         if self.kind not in _VALID_SEGMENT_KINDS:
@@ -68,6 +81,8 @@ class Segment:
             )
         if self.length_m < 0.0 or not math.isfinite(self.length_m):
             raise ValueError(f"Segment.length_m must be finite and >= 0, got {self.length_m}")
+        if self.gear not in (1, -1):
+            raise ValueError(f"Segment.gear must be 1 (forward) or -1 (reverse), got {self.gear!r}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,18 +125,30 @@ class DubinsArc:
         remaining = s_m
         for seg in self.segments:
             step = min(seg.length_m, remaining)
+            gear = float(seg.gear)  # +1 forward, -1 reverse (ADR-0010)
             if seg.kind == "S":
-                x += step * math.cos(theta)
-                y += step * math.sin(theta)
+                # Reverse negates the translation step (drive −cos/−sin).
+                x += gear * step * math.cos(theta)
+                y += gear * step * math.sin(theta)
             else:  # "L"/"R": arc of radius r; r == 0 => cart pivot in place
                 sign = 1.0 if seg.kind == "L" else -1.0
                 if r == 0.0:
-                    # pivot: position fixed; `step` is radians of turn.
+                    # Pivot: position fixed; `step` is radians of turn. A
+                    # pivot-in-place has no travel direction, so gear is left
+                    # at the +1 default for the L/R-encoded cart pivot and the
+                    # `sign` alone sets the rotation direction.
                     theta += sign * step
                 else:
+                    # The turning CENTRE is set by STEERING alone (left/right of
+                    # the car), independent of gear. Forward advances around it,
+                    # reverse retreats: scale the heading sweep AND the position
+                    # update by `gear`. (Equivalently, signed arc-length
+                    # ds = gear·step, dtheta = sign·ds/r.) The roundtrip grid is
+                    # the proof; the sign here is pinned by the reverse 45°
+                    # canary so a CW/CCW flip fails loudly (ADR-0002 trap).
                     cx = x - sign * r * math.sin(theta)
                     cy = y + sign * r * math.cos(theta)
-                    theta += sign * step / r
+                    theta += sign * gear * step / r
                     x = cx + sign * r * math.sin(theta)
                     y = cy - sign * r * math.cos(theta)
             remaining -= step
@@ -137,6 +164,11 @@ class DubinsArc:
         still get angular resolution. The final pose is ``pose_at(length)`` —
         the INTEGRATED endpoint, NOT the stored ``self.end`` — so a wrong
         closed form surfaces as a mismatch instead of being masked.
+
+        Density is **gear-agnostic** (ADR-0010): the accounting below uses
+        ``length_m``, which is the un-signed leg distance (``>= 0`` by the
+        :class:`Segment` invariant, i.e. ``abs(length)``), so a reverse leg
+        gets exactly the density of the equivalent forward leg.
         """
         total = self.length_m  # the "progress" parameter pose_at walks
         trans_len = 0.0  # true translation distance (excludes pivots)
@@ -351,36 +383,7 @@ def plan_dubins(start: Pose, end: Pose, *, turn_radius_m: float) -> DubinsArc:
         raise ValueError(f"turn_radius_m must be finite and >= 0, got {turn_radius_m}")
 
     if turn_radius_m == 0.0:
-        dx = end.x_m - start.x_m
-        dy = end.y_m - start.y_m
-        dist = math.hypot(dx, dy)
-        if dist <= 1e-9:
-            # Pure pivot-in-place (positions coincide): a single turn segment
-            # whose length_m encodes the short-arc heading change in radians.
-            # Compass is CW-positive, so a positive delta is a right turn ("R")
-            # in the math frame the integrator walks; the sign is pinned by
-            # test_zero_radius_is_pivot_in_place.
-            dtheta_deg = (end.heading_deg - start.heading_deg + 180.0) % 360.0 - 180.0
-            pivot_kind: SegmentKind = "R" if dtheta_deg >= 0.0 else "L"
-            return DubinsArc(start, end, 0.0, (Segment(pivot_kind, abs(math.radians(dtheta_deg))),))
-        # Cart translation (ADR-0007 r->0 limit): a cart is own-gear with a zero
-        # turn radius, so the shortest path is pivot to the goal bearing, drive
-        # straight, then pivot to the final heading. All three legs live in one
-        # turn_radius_m=0 DubinsArc; pose_at already integrates an r=0 turn as a
-        # pivot-in-place (position held) and an "S" leg as translation. The goal
-        # bearing as a compass heading: math angle atan2(dy, dx) -> compass.
-        bearing_deg = math_rad_to_compass(math.atan2(dy, dx))
-        cart_segs: list[Segment] = []
-        seg1_deg = (bearing_deg - start.heading_deg + 180.0) % 360.0 - 180.0
-        if abs(seg1_deg) > 1e-9:
-            k1: SegmentKind = "R" if seg1_deg >= 0.0 else "L"
-            cart_segs.append(Segment(k1, abs(math.radians(seg1_deg))))
-        cart_segs.append(Segment("S", dist))
-        seg3_deg = (end.heading_deg - bearing_deg + 180.0) % 360.0 - 180.0
-        if abs(seg3_deg) > 1e-9:
-            k3: SegmentKind = "R" if seg3_deg >= 0.0 else "L"
-            cart_segs.append(Segment(k3, abs(math.radians(seg3_deg))))
-        return DubinsArc(start, end, 0.0, tuple(cart_segs))
+        return _plan_cart(start, end, allow_reverse=False)
 
     word, (t, p, q) = _dubins_shortest(start, end, turn_radius_m)
     r = turn_radius_m
@@ -393,6 +396,440 @@ def plan_dubins(start: Pose, end: Pose, *, turn_radius_m: float) -> DubinsArc:
     # (turn 0, "S", turn 0); drop the zeros so it is ("S",) and the ["S"]
     # segment-kind assertions hold. Keep at least one segment.
     segs = tuple(s for s in raw if s.length_m > 1e-9) or (Segment("S", 0.0),)
+    return DubinsArc(start, end, r, segs)
+
+
+# ---------------------------------------------------------------------------
+# Cart (r == 0) planner — shared by Dubins (forward-only) and Reeds–Shepp.
+#
+# A carted plane pivots in place and translates with a zero turn radius
+# (ADR-0007). The pivot-in-place case is identical for both motion models. The
+# translation case differs only in whether the straight leg may be driven in
+# REVERSE: Reeds–Shepp lets a cart back straight out of a slot (gear −1) when
+# that is cheaper under the reverse cost weighting, which a forward-only Dubins
+# cart cannot. ``length_m`` of a pivot segment encodes RADIANS (ADR-0007); the
+# "S" leg is metres of translation.
+# ---------------------------------------------------------------------------
+
+
+def _plan_cart(start: Pose, end: Pose, *, allow_reverse: bool) -> DubinsArc:
+    """Cart path (``turn_radius_m == 0``): pivot-in-place, or pivot-straight-pivot.
+
+    With ``allow_reverse`` (Reeds–Shepp), the straight leg may be driven in
+    reverse — pivot to the *reverse* bearing, back straight, pivot to the final
+    heading — and the cheaper of the forward/reverse option is returned under
+    the reverse cost weighting (:data:`_REVERSE_COST_FACTOR`). Without it
+    (Dubins) only the forward option is considered, preserving the exact
+    forward-only behaviour ``plan_dubins`` shipped.
+    """
+    dx = end.x_m - start.x_m
+    dy = end.y_m - start.y_m
+    dist = math.hypot(dx, dy)
+    if dist <= 1e-9:
+        # Pure pivot-in-place (positions coincide): a single turn segment whose
+        # length_m encodes the short-arc heading change in radians. Compass is
+        # CW-positive, so a positive delta is a right turn ("R") in the math
+        # frame the integrator walks; the sign is pinned by
+        # test_zero_radius_is_pivot_in_place. Gear is irrelevant for a pivot
+        # (no translation), so it stays at the +1 default.
+        dtheta_deg = (end.heading_deg - start.heading_deg + 180.0) % 360.0 - 180.0
+        pivot_kind: SegmentKind = "R" if dtheta_deg >= 0.0 else "L"
+        return DubinsArc(start, end, 0.0, (Segment(pivot_kind, abs(math.radians(dtheta_deg))),))
+
+    def _pivot_straight_pivot(*, reverse: bool) -> tuple[Segment, ...]:
+        # Bearing the NOSE points along while translating: the goal bearing for
+        # a forward leg, its opposite for a reverse leg (the nose faces away
+        # from the direction of travel when backing up).
+        travel_bearing_deg = math_rad_to_compass(math.atan2(dy, dx))
+        nose_bearing_deg = (travel_bearing_deg + 180.0) % 360.0 if reverse else travel_bearing_deg
+        gear: Literal[1, -1] = -1 if reverse else 1
+        segs: list[Segment] = []
+        seg1_deg = (nose_bearing_deg - start.heading_deg + 180.0) % 360.0 - 180.0
+        if abs(seg1_deg) > 1e-9:
+            k1: SegmentKind = "R" if seg1_deg >= 0.0 else "L"
+            segs.append(Segment(k1, abs(math.radians(seg1_deg))))
+        segs.append(Segment("S", dist, gear=gear))
+        seg3_deg = (end.heading_deg - nose_bearing_deg + 180.0) % 360.0 - 180.0
+        if abs(seg3_deg) > 1e-9:
+            k3: SegmentKind = "R" if seg3_deg >= 0.0 else "L"
+            segs.append(Segment(k3, abs(math.radians(seg3_deg))))
+        return tuple(segs)
+
+    forward = _pivot_straight_pivot(reverse=False)
+    if not allow_reverse:
+        return DubinsArc(start, end, 0.0, forward)
+    reverse = _pivot_straight_pivot(reverse=True)
+    # Weighted cost: pivots are cheap angular moves; the straight leg's metres
+    # carry the reverse factor when backing. Strict < keeps forward on an exact
+    # tie (determinism, ADR-0003) — and forward is the earlier-listed option.
+    best = min(
+        (forward, reverse),
+        key=lambda segs: math.fsum(_cart_seg_weight(s) for s in segs),
+    )
+    # Tie-break must prefer forward on EXACT equality; min() returns the first
+    # argument on a tie, and `forward` is first, so this is already correct.
+    return DubinsArc(start, end, 0.0, best)
+
+
+def _cart_seg_weight(seg: Segment) -> float:
+    """Weighted cost of one cart segment for the forward-vs-reverse choice: a
+    pivot's radians (cheap, gear-agnostic) or a straight's metres scaled by the
+    reverse factor when backing."""
+    if seg.kind != "S":
+        return seg.length_m  # pivot: length_m is radians
+    return seg.length_m * (_REVERSE_COST_FACTOR if seg.gear == -1 else 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Closed-form Reeds–Shepp set (ADR-0010, towplanner v2; supersedes ADR-0007
+# fork-2 "Dubins-only"). Reeds–Shepp = Dubins + reverse arcs/straights, so a
+# car can back up to reorient instead of driving a full turning-circle loop.
+#
+# Built by the textbook **base-formula + symmetry-generation** method: a small
+# set of base word-solvers (CSC, CCC, CCCC, CCSC, CCSCC) in the NORMALISED math
+# frame, then the three Reeds–Shepp symmetry transforms — TIMEFLIP (reverse all
+# gears + reflect the goal through time), REFLECT (swap L↔R steering + reflect
+# the goal across the x-axis), and BACKWARDS (traverse the word end-to-start) —
+# applied mechanically to enumerate the full word family. This is the standard
+# `reeds_shepp` construction; the base formulas follow Reeds & Shepp (1990) /
+# the OMPL/PythonRobotics presentation.
+#
+# Each base solver works on a normalised relative goal ``(x, y, phi)``: the goal
+# expressed in the start frame and scaled by ``1/r`` (so the turn radius is 1).
+# It returns a list of ``_RSElement(steering, gear, t)`` legs with t a normalised
+# length (radians for a turn, units of r for a straight), or ``None`` if
+# infeasible. The integrator ``DubinsArc.pose_at`` walks the scaled-back
+# ``Segment``s, so a correct word reproduces the goal pose — enforced
+# exhaustively by ``test_reeds_shepp_roundtrip_grid``.
+# ---------------------------------------------------------------------------
+
+
+# Reverse legs cost 1.5× their length. Justification (a measured nose-out case):
+# 18 m reverse vs 32 m forward. At 1.5× the reverse weighs 27 m, still beating
+# the 32 m forward loop, so the reverse win is kept — while a gratuitous short
+# reverse is discouraged. At 2.0× the reverse would weigh 36 m and be SUPPRESSED
+# in favour of the longer forward path, defeating the whole point of Reeds–Shepp.
+# Pinned by test_reverse_cost_factor_value; changing it requires an ADR-0010 update.
+_REVERSE_COST_FACTOR = 1.5
+
+
+@dataclass(frozen=True, slots=True)
+class _RSElement:
+    """One normalised Reeds–Shepp leg: steering ``L``/``S``/``R``, ``gear``
+    ``+1``/``-1``, and ``t`` the normalised length (radians for a turn, units
+    of the turn radius for a straight). Always ``t >= 0``."""
+
+    steering: SegmentKind
+    gear: Literal[1, -1]
+    t: float
+
+
+_RSWord = list[_RSElement]
+
+
+def _rs_polar(x: float, y: float) -> tuple[float, float]:
+    """``(r, theta)`` of the vector ``(x, y)`` — magnitude and math-angle."""
+    return math.hypot(x, y), math.atan2(y, x)
+
+
+def _rs_mod2pi(theta: float) -> float:
+    """Normalise to ``(-pi, pi]`` — the branch the RS base formulas assume."""
+    v = _mod2pi(theta)
+    if v > math.pi:
+        v -= 2.0 * math.pi
+    return v
+
+
+# ── Base word solvers (normalised frame, turn radius 1) ─────────────────────
+# Each returns the leg lengths for ONE canonical word shape, or None. The
+# symmetry transforms below generate the remaining words from these bases. The
+# formulas are the OMPL/PythonRobotics presentation of Reeds & Shepp (1990).
+
+
+# A "signed-length leg": steering, the word's nominal gear, and a SIGNED length.
+# Reeds–Shepp word formulas naturally yield signed leg lengths; a negative length
+# means "traverse |length| in the OPPOSITE gear" (the standard sign-flips-gear
+# trick). :func:`_rs_signed_to_word` converts a list of signed legs into an
+# ``_RSWord`` with non-negative ``t`` and the gear resolved from the sign, then
+# the universal :func:`_rs_word_reaches` gate verifies the result actually lands
+# on the goal — so a per-formula feasibility guard is unnecessary (and would be a
+# transcription-error hiding place); the re-integration is the single oracle.
+_SignedLeg = tuple[SegmentKind, "Literal[1, -1]", float]
+
+
+def _rs_signed_to_word(legs: list[_SignedLeg]) -> _RSWord:
+    out: _RSWord = []
+    for steering, gear, length in legs:
+        g: Literal[1, -1] = gear if length >= 0.0 else (-gear)
+        out.append(_RSElement(steering, g, abs(length)))
+    return out
+
+
+def _rs_lsl(x: float, y: float, phi: float) -> _RSWord | None:
+    """Base CSC word L S L (Reeds & Shepp 8.1 / PythonRobotics)."""
+    u, t = _rs_polar(x - math.sin(phi), y - 1.0 + math.cos(phi))
+    v = _rs_mod2pi(phi - t)
+    return _rs_signed_to_word([("L", 1, t), ("S", 1, u), ("L", 1, v)])
+
+
+def _rs_lsr(x: float, y: float, phi: float) -> _RSWord | None:
+    """Base CSC word L S R (Reeds & Shepp 8.2 / PythonRobotics)."""
+    u1, t1 = _rs_polar(x + math.sin(phi), y - 1.0 - math.cos(phi))
+    u1 = u1 * u1
+    if u1 < 4.0:
+        return None
+    u = math.sqrt(u1 - 4.0)
+    theta = math.atan2(2.0, u)
+    t = _rs_mod2pi(t1 + theta)
+    v = _rs_mod2pi(t - phi)
+    return _rs_signed_to_word([("L", 1, t), ("S", 1, u), ("R", 1, v)])
+
+
+def _rs_lrl(x: float, y: float, phi: float) -> _RSWord | None:
+    """Base CCC word L R L (Reeds & Shepp 8.3 / PythonRobotics)."""
+    u1, t1 = _rs_polar(x - math.sin(phi), y - 1.0 + math.cos(phi))
+    if u1 > 4.0:
+        return None
+    u = -2.0 * math.asin(0.25 * u1)
+    t = _rs_mod2pi(t1 + 0.5 * u + math.pi)
+    v = _rs_mod2pi(phi - t + u)
+    return _rs_signed_to_word([("L", 1, t), ("R", 1, u), ("L", 1, v)])
+
+
+def _rs_lrlrn(x: float, y: float, phi: float) -> _RSWord | None:
+    """Base CCCC word L R L R (Reeds & Shepp 8.7 / PythonRobotics ``CCCC`` n)."""
+    xi = x + math.sin(phi)
+    eta = y - 1.0 - math.cos(phi)
+    rho = 0.25 * (2.0 + math.hypot(xi, eta))
+    if rho > 1.0 or rho < 0.0:
+        return None
+    u = math.acos(rho)
+    t, v = _rs_tau_omega(u, -u, xi, eta, phi)
+    return _rs_signed_to_word([("L", 1, t), ("R", 1, u), ("L", 1, -u), ("R", 1, v)])
+
+
+def _rs_lrlrp(x: float, y: float, phi: float) -> _RSWord | None:
+    """Base CCCC word L R L R (Reeds & Shepp 8.8 / PythonRobotics ``CCCC`` p)."""
+    xi = x + math.sin(phi)
+    eta = y - 1.0 - math.cos(phi)
+    rho = (20.0 - xi * xi - eta * eta) / 16.0
+    if rho > 1.0 or rho < 0.0:
+        return None
+    u = -math.acos(rho)
+    if u < -0.5 * math.pi:
+        return None
+    t, v = _rs_tau_omega(u, u, xi, eta, phi)
+    return _rs_signed_to_word([("L", 1, t), ("R", 1, u), ("L", 1, u), ("R", 1, v)])
+
+
+def _rs_tau_omega(u: float, v: float, xi: float, eta: float, phi: float) -> tuple[float, float]:
+    """The (tau, omega) leg pair shared by the CCCC words (PythonRobotics)."""
+    delta = _rs_mod2pi(u - v)
+    a = math.sin(u) - math.sin(delta)
+    b = math.cos(u) - math.cos(delta) - 1.0
+    t1 = math.atan2(eta * a - xi * b, xi * a + eta * b)
+    t2 = 2.0 * (math.cos(delta) - math.cos(v) - math.cos(u)) + 3.0
+    tau = _rs_mod2pi(t1 + math.pi) if t2 < 0.0 else _rs_mod2pi(t1)
+    omega = _rs_mod2pi(tau - u + v - phi)
+    return tau, omega
+
+
+def _rs_lrsr(x: float, y: float, phi: float) -> _RSWord | None:
+    """Base CCSC word L R(−π/2) S R (Reeds & Shepp 8.9 / PythonRobotics)."""
+    xi = x + math.sin(phi)
+    eta = y - 1.0 - math.cos(phi)
+    rho, theta = _rs_polar(-eta, xi)
+    if rho < 2.0:
+        return None
+    t = theta
+    u = 2.0 - rho
+    v = _rs_mod2pi(t + 0.5 * math.pi - phi)
+    return _rs_signed_to_word([("L", 1, t), ("R", 1, -0.5 * math.pi), ("S", 1, u), ("R", 1, v)])
+
+
+def _rs_lrsl(x: float, y: float, phi: float) -> _RSWord | None:
+    """Base CCSC word L R(−π/2) S L (Reeds & Shepp 8.10 / PythonRobotics)."""
+    xi = x - math.sin(phi)
+    eta = y - 1.0 + math.cos(phi)
+    rho, theta = _rs_polar(xi, eta)
+    if rho < 2.0:
+        return None
+    r = math.sqrt(rho * rho - 4.0)
+    u = 2.0 - r
+    t = _rs_mod2pi(theta + math.atan2(r, -2.0))
+    v = _rs_mod2pi(phi - 0.5 * math.pi - t)
+    return _rs_signed_to_word([("L", 1, t), ("R", 1, -0.5 * math.pi), ("S", 1, u), ("L", 1, v)])
+
+
+def _rs_lrslr(x: float, y: float, phi: float) -> _RSWord | None:
+    """Base CCSCC word L R(−π/2) S L(−π/2) R (Reeds & Shepp 8.11 / PythonRobotics)."""
+    xi = x + math.sin(phi)
+    eta = y - 1.0 - math.cos(phi)
+    rho, _theta = _rs_polar(xi, eta)
+    if rho < 2.0:
+        return None
+    u = 4.0 - math.sqrt(rho * rho - 4.0)
+    if u > 0.0:
+        return None
+    t = _rs_mod2pi(math.atan2((4.0 - u) * xi - 2.0 * eta, -2.0 * xi + (u - 4.0) * eta))
+    v = _rs_mod2pi(t - phi)
+    return _rs_signed_to_word(
+        [
+            ("L", 1, t),
+            ("R", 1, -0.5 * math.pi),
+            ("S", 1, u),
+            ("L", 1, -0.5 * math.pi),
+            ("R", 1, v),
+        ]
+    )
+
+
+# ── Symmetry transforms (operate on a base solver) ──────────────────────────
+
+
+def _rs_timeflip(word: _RSWord | None) -> _RSWord | None:
+    """TIMEFLIP: negate every gear (a base solved for the time-reversed goal
+    ``(-x, y, -phi)`` becomes the reverse-gear word for the original goal)."""
+    if word is None:
+        return None
+    return [_RSElement(e.steering, -e.gear, e.t) for e in word]
+
+
+def _rs_reflect(word: _RSWord | None) -> _RSWord | None:
+    """REFLECT: swap L↔R steering (a base solved for the x-axis-reflected goal
+    ``(x, -y, -phi)`` becomes the word for the original goal)."""
+    if word is None:
+        return None
+    swap: dict[SegmentKind, SegmentKind] = {"L": "R", "R": "L", "S": "S"}
+    return [_RSElement(swap[e.steering], e.gear, e.t) for e in word]
+
+
+# The base word solvers. Each canonical word shape is enumerated under the four
+# (timeflip × reflect) goal symmetries below, which together generate the
+# classical Reeds–Shepp 48-word family from this handful of base formulas
+# (Reeds & Shepp 1990; the formulas follow the widely-used PythonRobotics
+# presentation). The roundtrip grid proves the family is complete — every
+# (x, y, phi) is reached by at least one generated word.
+_RS_BASE_SOLVERS: tuple[Callable[[float, float, float], _RSWord | None], ...] = (
+    _rs_lsl,
+    _rs_lsr,
+    _rs_lrl,
+    _rs_lrlrn,
+    _rs_lrlrp,
+    _rs_lrsr,
+    _rs_lrsl,
+    _rs_lrslr,
+)
+
+
+def _rs_solve_normalised(x: float, y: float, phi: float) -> _RSWord:
+    """Shortest feasible Reeds–Shepp word for a normalised goal ``(x, y, phi)``.
+
+    Enumerates :data:`_RS_BASE_SOLVERS` under the timeflip / reflect goal
+    symmetries (the standard mechanical generation of the classical word
+    family), scoring each feasible word by weighted normalised length (reverse
+    legs ×:data:`_REVERSE_COST_FACTOR`) and returning the minimum with a
+    strict-``<`` tie-break so an exact tie deterministically keeps the
+    earliest-enumerated word (determinism, ADR-0003). A Reeds–Shepp path always
+    exists between any two poses, so some word is always feasible — proven
+    exhaustively by ``test_reeds_shepp_roundtrip_grid``.
+
+    Every generated word is gated by :func:`_rs_word_reaches` (an independent
+    re-integration) before it can be chosen: a base-formula sign error then
+    surfaces as a *missing* candidate, never as a *wrong path that ships*. The
+    deterministic enumeration order (base list × the fixed four symmetries) is
+    the iteration order the tie-break relies on.
+    """
+
+    def _candidates_for(base: Callable[[float, float, float], _RSWord | None]) -> list[_RSWord]:
+        out: list[_RSWord | None] = [
+            base(x, y, phi),  # identity
+            _rs_timeflip(base(-x, y, -phi)),  # timeflip
+            _rs_reflect(base(x, -y, -phi)),  # reflect
+            _rs_reflect(_rs_timeflip(base(-x, -y, phi))),  # timeflip + reflect
+        ]
+        return [w for w in out if w is not None]
+
+    best: tuple[float, _RSWord] | None = None
+    for base in _RS_BASE_SOLVERS:
+        for word in _candidates_for(base):
+            if not _rs_word_reaches(word, x, y, phi):
+                continue
+            cost = math.fsum(e.t * (_REVERSE_COST_FACTOR if e.gear == -1 else 1.0) for e in word)
+            if best is None or cost < best[0]:
+                best = (cost, word)
+    if best is None:  # pragma: no cover - a Reeds–Shepp path always exists
+        raise ValueError(f"no feasible Reeds–Shepp path for normalised goal ({x}, {y}, {phi})")
+    return best[1]
+
+
+def _rs_word_reaches(word: _RSWord, x: float, y: float, phi: float) -> bool:
+    """``True`` iff integrating ``word`` in the normalised frame (unit radius,
+    start at the origin heading ``+x``) lands on ``(x, y, phi)``.
+
+    A closed-form-independent check using the SAME unicycle integration the
+    production :meth:`DubinsArc.pose_at` performs, so a base-formula sign error
+    is caught here rather than shipping a wrong path."""
+    px, py, pth = 0.0, 0.0, 0.0
+    for e in word:
+        g = float(e.gear)
+        if e.steering == "S":
+            px += g * e.t * math.cos(pth)
+            py += g * e.t * math.sin(pth)
+        else:
+            sign = 1.0 if e.steering == "L" else -1.0
+            cx = px - sign * math.sin(pth)
+            cy = py + sign * math.cos(pth)
+            pth += sign * g * e.t
+            px = cx + sign * math.sin(pth)
+            py = cy - sign * math.cos(pth)
+    return (
+        abs(px - x) < 1e-6
+        and abs(py - y) < 1e-6
+        and abs((pth - phi + math.pi) % (2.0 * math.pi) - math.pi) < 1e-6
+    )
+
+
+def plan_reeds_shepp(start: Pose, end: Pose, *, turn_radius_m: float) -> DubinsArc:
+    """Closed-form shortest Reeds–Shepp path from ``start`` to ``end`` (ADR-0010).
+
+    Reeds–Shepp extends Dubins with reverse arcs and straights, so a plane can
+    back up to reorient rather than driving a full turning-circle loop. Word
+    selection minimises Σ(``|leg|`` × factor) with reverse legs weighted by
+    :data:`_REVERSE_COST_FACTOR` (prefer forward). Still closed-form and RNG-free,
+    so the ADR-0003 byte-identical-plan contract holds. ``turn_radius_m == 0`` is
+    the cart case and delegates to :func:`_plan_cart` with reverse enabled (a
+    carted plane may back straight out of a slot).
+
+    Works in the standard math frame: positions pass through unchanged; headings
+    convert via :func:`compass_to_math_rad`. The integrated endpoint
+    (:meth:`DubinsArc.pose_at`) reaches the goal — the property
+    ``test_reeds_shepp_roundtrip_grid`` enforces across a pose/radius grid.
+    """
+    if turn_radius_m < 0.0 or not math.isfinite(turn_radius_m):
+        raise ValueError(f"turn_radius_m must be finite and >= 0, got {turn_radius_m}")
+
+    if turn_radius_m == 0.0:
+        return _plan_cart(start, end, allow_reverse=True)
+
+    r = turn_radius_m
+    # Express the goal in the start frame, scaled to unit turn radius. The math
+    # frame: theta0 = compass_to_math_rad(start heading); rotate the world
+    # displacement into the start-aligned frame and normalise by r.
+    theta0 = compass_to_math_rad(start.heading_deg)
+    theta1 = compass_to_math_rad(end.heading_deg)
+    dx = (end.x_m - start.x_m) / r
+    dy = (end.y_m - start.y_m) / r
+    c, s = math.cos(theta0), math.sin(theta0)
+    x = c * dx + s * dy
+    y = -s * dx + c * dy
+    phi = _rs_mod2pi(theta1 - theta0)
+
+    word = _rs_solve_normalised(x, y, phi)
+    raw = tuple(Segment(e.steering, e.t * r, gear=e.gear) for e in word)
+    # Collapse zero-length legs (a collinear same-heading path degenerates to a
+    # single straight); keep at least one segment.
+    segs = tuple(seg for seg in raw if seg.length_m > 1e-9) or (Segment("S", 0.0),)
     return DubinsArc(start, end, r, segs)
 
 
@@ -629,8 +1066,8 @@ def plan_fill(target: Layout) -> MovesPlan:
 
 
 # ── Hybrid-A* tow-path search (spike Q3 v2, #222) ───────────────────────────
-# Deterministic search over Dubins motion primitives. Tuning constants; see the
-# design spec. All RNG-free (ADR-0003).
+# Deterministic search over Reeds–Shepp motion primitives (ADR-0010). Tuning
+# constants; see the design spec. All RNG-free (ADR-0003).
 _GRID_XY_M = 0.5  # (x, y) cell size for state binning
 _GRID_DEG = 15.0  # heading cell size; 360 / 15 = 24 heading bins
 _HEADING_BINS = round(360.0 / _GRID_DEG)
@@ -655,20 +1092,42 @@ _SEARCH_STEP_DEG = 5.0
 
 
 def _primitives(turn_radius_m: float) -> tuple[Segment, ...]:
-    """The fixed motion-primitive fan, in deterministic order (L, S, R).
+    """The fixed motion-primitive fan, in deterministic order (ADR-0010 v2).
 
-    Own-gear (``r > 0``): a left arc, a straight, and a right arc, each of
-    length ``step`` (metres) chosen so a turn changes heading by ~one heading
-    cell. Cart (``r == 0``): a left pivot, a straight of ``_GRID_XY_M`` metres,
-    and a right pivot — the same (L, S, R) order; each pivot is
-    ``math.radians(_GRID_DEG)`` radians (one heading cell; ``length_m`` encodes
-    radians for the pivot segments, ADR-0007).
+    **Six primitives** in fixed order ``Lf, Sf, Rf, Lr, Sr, Rr`` — the three
+    forward steerings (left arc, straight, right arc) then the same three in
+    reverse (gear ``-1``). The reverse primitives are the Reeds–Shepp extension:
+    the search can now back up to reorient instead of driving a full
+    turning-circle loop. Fixed order ⇒ deterministic expansion (ADR-0003).
+
+    Own-gear (``r > 0``): each arc/straight is ``step`` metres, chosen so a turn
+    changes heading by ~one heading cell. Cart (``r == 0``): the L/R primitives
+    are pivots of ``math.radians(_GRID_DEG)`` radians and the straight is
+    ``_GRID_XY_M`` metres. A reverse PIVOT is geometrically identical to the
+    forward pivot of the opposite steering, so only the **reverse straight**
+    adds a genuinely new cart move; the reverse pivots are kept for a uniform
+    six-primitive fan (they are redundant, never harmful — the grid de-dups
+    coincident child cells).
     """
     if turn_radius_m == 0.0:
         dtheta = math.radians(_GRID_DEG)
-        return (Segment("L", dtheta), Segment("S", _GRID_XY_M), Segment("R", dtheta))
+        return (
+            Segment("L", dtheta),
+            Segment("S", _GRID_XY_M),
+            Segment("R", dtheta),
+            Segment("L", dtheta, gear=-1),
+            Segment("S", _GRID_XY_M, gear=-1),
+            Segment("R", dtheta, gear=-1),
+        )
     step = max(_GRID_XY_M, turn_radius_m * math.radians(_GRID_DEG))
-    return (Segment("L", step), Segment("S", step), Segment("R", step))
+    return (
+        Segment("L", step),
+        Segment("S", step),
+        Segment("R", step),
+        Segment("L", step, gear=-1),
+        Segment("S", step, gear=-1),
+        Segment("R", step, gear=-1),
+    )
 
 
 def _step_pose(pose: Pose, seg: Segment, turn_radius_m: float) -> Pose:
@@ -686,12 +1145,19 @@ def _seg_cost(seg: Segment, turn_radius_m: float) -> float:
     Straight: ``length_m`` metres, no turn. Turn ``r > 0``: arc length
     ``length_m`` metres plus penalty over ``length_m / r`` radians. Pivot
     ``r == 0``: no translation, penalty over ``length_m`` radians.
+
+    A **reverse** leg (``gear == -1``) multiplies the cost by
+    :data:`_REVERSE_COST_FACTOR` (ADR-0010), so the search prefers forward
+    motion and only backs up when it is genuinely cheaper (the nose-out win).
+    The factor scales the whole leg cost — translation and turn penalty alike —
+    so a reverse arc is penalised consistently with a reverse straight.
     """
+    factor = _REVERSE_COST_FACTOR if seg.gear == -1 else 1.0
     if seg.kind == "S":
-        return seg.length_m
+        return factor * seg.length_m
     if turn_radius_m > 0.0:
-        return seg.length_m + _TURN_PENALTY * (seg.length_m / turn_radius_m)
-    return _TURN_PENALTY * seg.length_m  # cart pivot: length_m is radians
+        return factor * (seg.length_m + _TURN_PENALTY * (seg.length_m / turn_radius_m))
+    return factor * _TURN_PENALTY * seg.length_m  # cart pivot: length_m is radians
 
 
 def _cell(pose: Pose) -> tuple[int, int, int]:
@@ -908,11 +1374,12 @@ def plan_path(
 ) -> DubinsArc:
     """Deterministic Hybrid-A* tow path from ``entry`` to ``goal`` (#222).
 
-    Searches continuous ``(x, y, heading)`` with the fixed primitive fan
-    (:func:`_primitives`), grid-binned via :func:`_cell`, an admissible Euclidean
-    heuristic, and an analytic-expansion shortcut: at every popped node a direct
-    ``plan_dubins`` shot to ``goal`` is tried first, so an unobstructed plane
-    finishes in one arc. Per-edge and analytic-shot validity during search use
+    Searches continuous ``(x, y, heading)`` with the fixed six-primitive fan
+    (:func:`_primitives` — forward L/S/R then reverse L/S/R, ADR-0010),
+    grid-binned via :func:`_cell`, an admissible Euclidean heuristic, and an
+    analytic-expansion shortcut: at every popped node a direct
+    :func:`plan_reeds_shepp` shot to ``goal`` is tried first, so an unobstructed
+    plane finishes in one arc. Per-edge and analytic-shot validity during search use
     the FAST per-pose checker :func:`_motion_clear` (against an obstacle set
     precomputed once via :func:`_build_obstacles`) — an edge/shot is valid iff
     every sampled pose is clear. Before the analytic shot is RETURNED it is
@@ -960,14 +1427,14 @@ def plan_path(
         # path is exact-oracle-clean no matter what the fast checker accepted
         # during search. The `and` short-circuits left-to-right, so the cheap
         # `_motion_clear` screen always runs before the costly oracle.
-        final_arc = plan_dubins(node.pose, goal, turn_radius_m=r)
+        final_arc = plan_reeds_shepp(node.pose, goal, turn_radius_m=r)
         if all(
             _motion_clear(mover, p, obstacles, hangar)
             for p in final_arc.sample(step_m=_SEARCH_STEP_M, step_deg=_SEARCH_STEP_DEG)
         ):
             segs = tuple(_reconstruct_segments(node)) + final_arc.segments
-            # ``final_arc.segments`` is always non-empty (plan_dubins guarantees
-            # it), so ``segs`` is non-empty by construction. Assert it loudly
+            # ``final_arc.segments`` is always non-empty (plan_reeds_shepp
+            # guarantees it), so ``segs`` is non-empty by construction. Assert it
             # rather than silently substituting a zero-length straight: a future
             # regression that produced empty segs would otherwise return a
             # do-nothing arc that the safety net (sampling only the start pose of

--- a/tests/test_towplanner_dubins.py
+++ b/tests/test_towplanner_dubins.py
@@ -104,6 +104,22 @@ def test_heading_45_path_advances_into_plus_x_plus_y() -> None:
     assert mid.x_m > 0.0 and mid.y_m > 0.0
 
 
+def test_heading_45_reverse_path_advances_into_minus_x_minus_y() -> None:
+    """🔬 Reverse 45° canary (ADR-0010, towplanner v2 Reeds–Shepp).
+
+    Forward heading-45 drives into (+x, +y) (the test above). A reverse leg is
+    the exact negation: backing while heading 45° must move into (−x, −y). A
+    CW/CCW sign flip in :func:`compass_to_math_rad` would send the reverse leg
+    into the wrong quadrant — the symmetric word matrix would pass it silently,
+    so this geometric assert is the real guard for the reverse direction."""
+    from hangarfit.towplanner import DubinsArc, Segment
+
+    start = Pose(0.0, 0.0, 45.0)
+    arc = DubinsArc(start, start, 5.0, (Segment("S", 2.0, gear=-1),))
+    mid = list(arc.sample(step_m=0.25, step_deg=5.0))[1]
+    assert mid.x_m < 0.0 and mid.y_m < 0.0
+
+
 def test_pose_heading_45_right_wingtip_lands_in_plus_x_minus_y() -> None:
     """🔬 The definitive det−1 guard, driven through a planner Pose.
 

--- a/tests/test_towplanner_motion.py
+++ b/tests/test_towplanner_motion.py
@@ -223,6 +223,39 @@ def test_front_door_protrusion_is_exempt_for_mover(simple_hangar: Hangar) -> Non
     assert path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed) is None
 
 
+def test_reverse_through_door_is_front_gap_exempt(simple_hangar: Hangar) -> None:
+    """A plane backing OUT through the door (gear −1) straddles y < 0 just like
+    one being towed in. The front-gap exemption (#222) is pose-only and
+    gear-agnostic, so the reverse maneuver is exempt on the front wall too. A
+    spanning plane reverses from y = 4 to y = 0 (rear vertex reaches y = −2) up
+    the middle: no hangar_bounds conflict (ADR-0010 reverse motion)."""
+    from hangarfit.towplanner import DubinsArc, Segment
+
+    fleet = {"B": _spanning_plane("B")}
+    placed = Layout(fleet=fleet, hangar=simple_hangar, placements=())
+    # Back straight from (10, 4) to (10, 0) heading 0: a single reverse "S".
+    arc = DubinsArc(Pose(10.0, 4.0, 0.0), Pose(10.0, 0.0, 0.0), 4.0, (Segment("S", 4.0, gear=-1),))
+    assert path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed) is None
+
+
+def test_reverse_into_side_wall_still_bounded(simple_hangar: Hangar) -> None:
+    """The reverse front-gap exemption removes ONLY the y < 0 front wall. A
+    plane backing into a SIDE wall (x < 0) while inside (y ≥ 0) still conflicts
+    — bounds are pose-only, so reverse motion is bounded on side/back walls
+    exactly as forward motion is."""
+    from hangarfit.towplanner import DubinsArc, Segment
+
+    fleet = {"B": _spanning_plane("B")}
+    placed = Layout(fleet=fleet, hangar=simple_hangar, placements=())
+    # Heading 90 (nose +x); reverse drives toward −x. From (2, 5) backing to
+    # (0, 5): the 4 m fuselage rear vertex reaches x = −2 < 0 at y ≈ 5 ≥ 0.
+    arc = DubinsArc(Pose(2.0, 5.0, 90.0), Pose(0.0, 5.0, 90.0), 4.0, (Segment("S", 2.0, gear=-1),))
+    conflict = path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed)
+    assert conflict is not None
+    assert conflict.kind == "hangar_bounds"
+    assert "B" in conflict.planes
+
+
 def test_side_wall_still_enforced_for_mover_during_motion(simple_hangar: Hangar) -> None:
     # Front-gap exemption removes ONLY the front (y < 0) boundary. A mover whose
     # part pokes past a side wall (x < 0) while inside (y >= 0) still conflicts:

--- a/tests/test_towplanner_perf.py
+++ b/tests/test_towplanner_perf.py
@@ -2,8 +2,8 @@
 
 ``slow``-marked (excluded from the default ``pytest`` run; see pyproject
 ``addopts``). ``plan_fill`` now runs a Hybrid-A* search (``plan_path``) per
-plane instead of a single closed-form Dubins shot, so this guards against the
-search running away on realistic, solver-produced layouts.
+plane instead of a single closed-form Reeds–Shepp analytic shot, so this guards
+against the search running away on realistic, solver-produced layouts.
 
 NOTE on scope: on this branch the solver does NOT yet call the planner — that
 bundling is #197 (blocked-by #222). So this gate drives ``plan_fill`` DIRECTLY

--- a/tests/test_towplanner_perf.py
+++ b/tests/test_towplanner_perf.py
@@ -26,13 +26,21 @@ from hangarfit.towplanner import NoFeasiblePlanError, path_first_conflict, plan_
 
 # Wall-clock ceiling for one layout's fill. The search budget is per-plane
 # (_MAX_EXPANSIONS expansions), so an un-towable plane costs ~budget-exhaustion
-# time to prove infeasible (~10s for the wide-wing husky on the placeholder
-# hangar at the tuned budget). This `slow`-marked gate is a runaway guard, not a
+# time to prove infeasible. This `slow`-marked gate is a runaway guard, not a
 # tight regression bound — it catches the order-of-magnitude (pre-tuning the
-# same layout took ~177s); the 30s ceiling leaves ~3x margin over the observed
-# worst case for slower machines. Tighten once #197 exercises the planner
-# through solve() on real (measured) hangar geometry.
-_PLAN_FILL_CEILING_S = 30.0
+# same layout took ~177s).
+#
+# Bumped 30s → 75s for the Reeds–Shepp motion model (ADR-0010): the primitive
+# fan grew from 3 (forward L/S/R) to 6 (+ reverse L/S/R), so each expansion now
+# screens roughly twice the edges and the worst-case budget-exhaustion bail on
+# an un-towable layout (the six-plane fresh fill, where several planes are
+# un-routable at 700 expansions each) doubled to ~50s observed. 75s keeps the
+# runaway guard meaningful — it is still less than half the 177s pre-tuning
+# baseline — with margin over the observed worst case for slower machines.
+# Tighten once #197/v2 exercise the planner through solve() on real (measured)
+# hangar geometry, or once the primitive fan is pruned (e.g. dropping the
+# redundant reverse cart pivots, or gating reverse edges behind a heuristic).
+_PLAN_FILL_CEILING_S = 75.0
 
 
 @pytest.mark.slow

--- a/tests/test_towplanner_reeds_shepp.py
+++ b/tests/test_towplanner_reeds_shepp.py
@@ -206,6 +206,25 @@ def test_cart_reverse_straight_backs_out() -> None:
     assert _heading_close(last.heading_deg, 0.0)
 
 
+def test_cart_prefers_forward_when_not_cheaper_to_reverse() -> None:
+    """Mirror of :func:`test_cart_reverse_straight_backs_out`: a goal directly
+    AHEAD (same heading) is a single FORWARD "S" leg. Backing in would cost a
+    180° pivot + a reverse straight (×_REVERSE_COST_FACTOR) + a 180° pivot, so
+    the forward option is strictly cheaper and `_plan_cart`'s `min((forward,
+    reverse), …)` must keep it — pinning the prefer-forward tie-break (ADR-0003
+    determinism: no gratuitous reverse)."""
+    start = Pose(5.0, 3.0, 0.0)
+    end = Pose(5.0, 8.0, 0.0)  # 5 m straight ahead (heading 0 ⇒ +y)
+    arc = plan_reeds_shepp(start, end, turn_radius_m=0.0)
+    assert arc.turn_radius_m == 0.0
+    assert [s.kind for s in arc.segments] == ["S"]
+    assert arc.segments[0].gear == 1  # forward, not a contrived reverse
+    last = arc.pose_at(arc.length_m)
+    assert last.x_m == pytest.approx(5.0, abs=1e-9)
+    assert last.y_m == pytest.approx(8.0, abs=1e-9)
+    assert _heading_close(last.heading_deg, 0.0)
+
+
 def test_cart_pivot_in_place_still_works_via_reeds_shepp() -> None:
     """RS must degrade to the same pivot-in-place as Dubins for r = 0 when the
     positions coincide (delegation to the cart branch)."""

--- a/tests/test_towplanner_reeds_shepp.py
+++ b/tests/test_towplanner_reeds_shepp.py
@@ -1,0 +1,234 @@
+"""Closed-form Reeds–Shepp motion model (#261) — towplanner v2.
+
+Reeds–Shepp extends Dubins (forward arc-line-arc) with **reverse** arcs and
+straights, so a car can back up to reorient instead of driving a full
+turning-circle loop. The primitive is still closed-form and deterministic, so
+the ADR-0003 byte-identical-plan contract holds (ADR-0010 supersedes ADR-0007
+fork-2 "Dubins-only").
+
+The crux of correctness is the **integrator round-trip**: walking the signed,
+geared segments :func:`plan_reeds_shepp` emits must reproduce the goal pose.
+:func:`test_reeds_shepp_roundtrip_grid` is the primary oracle — it mirrors the
+Dubins ``test_dubins_roundtrip_grid`` across a grid of poses and radii. The
+heading-convention guard (ADR-0002: compass CW-positive vs. math CCW-positive)
+is pinned by the reverse 45° canary in ``test_towplanner_dubins.py`` and by the
+reverse-quadrant asserts here.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from hangarfit.towplanner import (
+    _REVERSE_COST_FACTOR,
+    Pose,
+    Segment,
+    plan_reeds_shepp,
+)
+
+
+def _heading_close(a: float, b: float, tol: float = 0.5) -> bool:
+    d = (a - b + 180.0) % 360.0 - 180.0
+    return abs(d) <= tol
+
+
+# --- Segment gear field -----------------------------------------------------
+
+
+def test_segment_defaults_to_forward_gear() -> None:
+    # Every existing Segment(...) call omits gear, so the default must be +1.
+    seg = Segment("S", 3.0)
+    assert seg.gear == 1
+
+
+def test_segment_accepts_reverse_gear() -> None:
+    seg = Segment("S", 3.0, gear=-1)
+    assert seg.gear == -1
+
+
+@pytest.mark.parametrize("bad_gear", [0, 2, -2, 100])
+def test_segment_rejects_invalid_gear(bad_gear: int) -> None:
+    with pytest.raises(ValueError):
+        Segment("S", 3.0, gear=bad_gear)
+
+
+# --- reverse-leg integration in pose_at -------------------------------------
+
+
+def test_reverse_straight_drives_backwards() -> None:
+    """A reverse straight from a pose heading +y must move toward −y.
+
+    Built directly via DubinsArc so the integrator is exercised in isolation
+    of word selection. heading 0 (compass) → forward +y; gear −1 ⇒ −y.
+    """
+    from hangarfit.towplanner import DubinsArc
+
+    start = Pose(0.0, 5.0, 0.0)
+    end = Pose(0.0, 2.0, 0.0)  # 3 m behind, same heading
+    arc = DubinsArc(start, end, 4.0, (Segment("S", 3.0, gear=-1),))
+    last = arc.pose_at(arc.length_m)
+    assert last.x_m == pytest.approx(0.0, abs=1e-9)
+    assert last.y_m == pytest.approx(2.0, abs=1e-9)
+    assert _heading_close(last.heading_deg, 0.0)
+
+
+def test_reverse_arc_curves_opposite_to_forward_arc() -> None:
+    """For a fixed steering kind ("L"), reversing flips the position update.
+
+    A forward "L" leg and a reverse "L" leg of equal length sweep the heading
+    the SAME way (steering is independent of gear) but translate to opposite
+    sides — the round-trip grid is the exhaustive proof; this pins the sign in
+    isolation.
+    """
+    from hangarfit.towplanner import DubinsArc
+
+    start = Pose(0.0, 0.0, 0.0)
+    fwd = DubinsArc(start, start, 2.0, (Segment("L", 1.0, gear=1),)).pose_at(1.0)
+    rev = DubinsArc(start, start, 2.0, (Segment("L", 1.0, gear=-1),)).pose_at(1.0)
+    # The turning CENTRE is set by steering alone (to the −x side for an
+    # L-steered car heading +y), so it is the same for both gears. Forward
+    # advances +y around it; reverse retreats −y around the same centre, so
+    # the two endpoints are mirror images across the y = 0 line through the
+    # start: same x, negated y. Heading sweeps the opposite way for reverse.
+    assert not _heading_close(fwd.heading_deg, rev.heading_deg)
+    assert fwd.x_m == pytest.approx(rev.x_m, abs=1e-9)
+    assert fwd.y_m == pytest.approx(-rev.y_m, abs=1e-9)
+
+
+def test_sample_density_unchanged_for_reverse_legs() -> None:
+    """``sample()`` must use ``abs(length)`` so a reverse leg gets the same
+    sample density as the equivalent forward leg (the #191 motion check relies
+    on dense sampling regardless of travel direction)."""
+    from hangarfit.towplanner import DubinsArc
+
+    fwd = DubinsArc(Pose(0.0, 0.0, 0.0), Pose(0.0, 5.0, 0.0), 4.0, (Segment("S", 5.0, gear=1),))
+    rev = DubinsArc(Pose(0.0, 5.0, 0.0), Pose(0.0, 0.0, 0.0), 4.0, (Segment("S", 5.0, gear=-1),))
+    assert len(list(fwd.sample(step_m=0.5, step_deg=5.0))) == len(
+        list(rev.sample(step_m=0.5, step_deg=5.0))
+    )
+
+
+# --- round-trip oracle (primary correctness check) --------------------------
+
+
+@pytest.mark.parametrize("start_heading", [0.0, 90.0, 210.0])
+@pytest.mark.parametrize(
+    "goal",
+    [(0.0, 6.0), (5.0, 5.0), (-5.0, 3.0), (6.0, 0.0), (-3.0, -4.0), (1.0, 0.5), (0.0, 0.0)],
+)
+@pytest.mark.parametrize("end_heading", [0.0, 45.0, 135.0, 270.0])
+@pytest.mark.parametrize("radius", [1.0, 2.0, 5.0])
+def test_reeds_shepp_roundtrip_grid(start_heading, goal, end_heading, radius) -> None:
+    """The integrated endpoint of the RS path must reach the goal pose.
+
+    This is the RS analog of ``test_dubins_roundtrip_grid`` and the primary
+    correctness oracle: a transcription error in any generated word surfaces
+    here as a missed endpoint. Spans forward + reverse words across a grid of
+    start/end poses and three radii."""
+    start = Pose(0.0, 0.0, start_heading)
+    end = Pose(goal[0], goal[1], end_heading)
+    arc = plan_reeds_shepp(start, end, turn_radius_m=radius)
+    last = arc.pose_at(arc.length_m)
+    assert last.x_m == pytest.approx(end.x_m, abs=1e-3)
+    assert last.y_m == pytest.approx(end.y_m, abs=1e-3)
+    assert _heading_close(last.heading_deg, end.heading_deg)
+
+
+# --- cost model: prefer forward --------------------------------------------
+
+
+def test_reverse_cost_factor_value() -> None:
+    # Pinned so a casual retune to 2.0 (which would suppress the measured
+    # nose-out reverse win) trips this and forces an ADR update.
+    assert _REVERSE_COST_FACTOR == 1.5
+
+
+def test_collinear_forward_goal_stays_pure_forward_straight() -> None:
+    """When the goal is straight ahead on the same heading, RS must NOT pick a
+    reverse maneuver — a forward "S" is both shortest and cheapest. Guards that
+    the reverse-cost weighting actually biases toward forward."""
+    arc = plan_reeds_shepp(Pose(0.0, 0.0, 0.0), Pose(0.0, 8.0, 0.0), turn_radius_m=4.0)
+    assert all(s.gear == 1 for s in arc.segments)
+    assert [s.kind for s in arc.segments] == ["S"]
+
+
+def test_reverse_beats_forward_loop_for_short_backup() -> None:
+    """The nose-out case: goal directly behind, same heading. A forward-only
+    Dubins car must drive a full loop to get there; RS backs straight up. The
+    chosen path must therefore contain a reverse leg and be far shorter than
+    the forward-only loop."""
+    from hangarfit.towplanner import plan_dubins
+
+    start = Pose(0.0, 10.0, 0.0)
+    end = Pose(0.0, 4.0, 0.0)  # 6 m directly behind, same heading
+    rs = plan_reeds_shepp(start, end, turn_radius_m=2.0)
+    dubins = plan_dubins(start, end, turn_radius_m=2.0)
+    assert any(s.gear == -1 for s in rs.segments)
+    # Weighted RS length (6 m reverse × 1.5 = 9 m) still crushes the forward
+    # loop (≳ 4πr ≈ 25 m for a same-heading reversal at r = 2).
+    assert rs.length_m < dubins.length_m
+
+
+# --- reverse 45° canary (heading-convention sign guard) ---------------------
+
+
+def test_reverse_straight_45_advances_into_minus_x_minus_y() -> None:
+    """Backing straight while heading 45° (compass) must move into −x,−y.
+
+    Forward heading-45 drives into (+x, +y) (see the Dubins canary); reverse is
+    the exact negation. A CW/CCW sign flip in the adapter would send it into
+    (−x, +y) or (+x, −y) — this asserts the correct reverse quadrant."""
+    from hangarfit.towplanner import DubinsArc
+
+    start = Pose(0.0, 0.0, 45.0)
+    arc = DubinsArc(start, start, 4.0, (Segment("S", 2.0, gear=-1),))
+    mid = list(arc.sample(step_m=0.25, step_deg=5.0))[1]
+    assert mid.x_m < 0.0 and mid.y_m < 0.0
+
+
+# --- cart r = 0 reverse straight --------------------------------------------
+
+
+def test_cart_reverse_straight_backs_out() -> None:
+    """A carted plane (r = 0) must be able to back straight out: goal directly
+    behind, same heading ⇒ a single reverse "S" leg, no pivots."""
+    start = Pose(5.0, 8.0, 0.0)
+    end = Pose(5.0, 3.0, 0.0)  # 5 m straight behind
+    arc = plan_reeds_shepp(start, end, turn_radius_m=0.0)
+    assert arc.turn_radius_m == 0.0
+    assert [s.kind for s in arc.segments] == ["S"]
+    assert arc.segments[0].gear == -1
+    last = arc.pose_at(arc.length_m)
+    assert last.x_m == pytest.approx(5.0, abs=1e-9)
+    assert last.y_m == pytest.approx(3.0, abs=1e-9)
+    assert _heading_close(last.heading_deg, 0.0)
+
+
+def test_cart_pivot_in_place_still_works_via_reeds_shepp() -> None:
+    """RS must degrade to the same pivot-in-place as Dubins for r = 0 when the
+    positions coincide (delegation to the cart branch)."""
+    arc = plan_reeds_shepp(Pose(1.0, 1.0, 0.0), Pose(1.0, 1.0, 90.0), turn_radius_m=0.0)
+    for pose in arc.sample(step_m=0.05, step_deg=1.0):
+        assert pose.x_m == pytest.approx(1.0)
+        assert pose.y_m == pytest.approx(1.0)
+    assert _heading_close(arc.pose_at(arc.length_m).heading_deg, 90.0)
+
+
+@pytest.mark.parametrize("bad_radius", [-1.0, math.inf, math.nan])
+def test_reeds_shepp_invalid_turn_radius_rejected(bad_radius: float) -> None:
+    with pytest.raises(ValueError):
+        plan_reeds_shepp(Pose(0.0, 0.0, 0.0), Pose(0.0, 5.0, 0.0), turn_radius_m=bad_radius)
+
+
+# --- determinism (ADR-0003) -------------------------------------------------
+
+
+def test_reeds_shepp_is_deterministic() -> None:
+    """Same input → byte-identical segment decomposition (no RNG, fixed word
+    order + strict-< tie-break)."""
+    args = (Pose(0.0, 0.0, 30.0), Pose(4.0, -3.0, 200.0))
+    a = plan_reeds_shepp(*args, turn_radius_m=3.0)
+    b = plan_reeds_shepp(*args, turn_radius_m=3.0)
+    assert a.segments == b.segments

--- a/tests/test_towplanner_search.py
+++ b/tests/test_towplanner_search.py
@@ -17,21 +17,27 @@ from hangarfit.towplanner import (
 )
 
 
-def test_primitives_own_gear_are_left_straight_right_in_order() -> None:
+def test_primitives_own_gear_are_six_in_lf_sf_rf_lr_sr_rr_order() -> None:
+    # ADR-0010: six primitives — forward L/S/R then reverse L/S/R, in that
+    # fixed deterministic order (the order the tie-break depends on).
     segs = _primitives(turn_radius_m=4.0)
-    assert [s.kind for s in segs] == ["L", "S", "R"]
+    assert [s.kind for s in segs] == ["L", "S", "R", "L", "S", "R"]
+    assert [s.gear for s in segs] == [1, 1, 1, -1, -1, -1]
     # Each is a positive-length short step.
     assert all(s.length_m > 0.0 for s in segs)
 
 
-def test_primitives_cart_are_pivot_straight_pivot_in_order() -> None:
+def test_primitives_cart_are_six_pivot_straight_in_order() -> None:
+    # Cart (r == 0): the same six-primitive fan. Pivots encode one heading cell
+    # in radians; the straights encode metres. Reverse straight is the new cart
+    # move (ADR-0010); reverse pivots are redundant but kept for a uniform fan.
     segs = _primitives(turn_radius_m=0.0)
-    assert [s.kind for s in segs] == ["L", "S", "R"]
-    # Pivots encode one heading cell in radians; the straight encodes metres.
-    # Pin both so a length/unit swap between the two is caught.
+    assert [s.kind for s in segs] == ["L", "S", "R", "L", "S", "R"]
+    assert [s.gear for s in segs] == [1, 1, 1, -1, -1, -1]
     assert segs[0].length_m == pytest.approx(math.radians(15.0))
     assert segs[1].length_m == pytest.approx(0.5)
     assert segs[2].length_m == pytest.approx(math.radians(15.0))
+    assert segs[4].length_m == pytest.approx(0.5)  # reverse straight, metres
 
 
 def test_step_pose_straight_advances_along_heading() -> None:
@@ -167,18 +173,36 @@ def test_plan_path_is_deterministic() -> None:
 
 
 def test_plan_path_bails_when_boxed_in() -> None:
-    # A goal whose slot is itself jammed against a wall such that no in-bounds
-    # approach exists within the budget -> NoFeasiblePlanError naming the mover.
-    # span=11.8 fills nearly the full 12m hangar width; ANY heading-change path
-    # is blocked (wing always clips a wall). Adapted from span=11.0 — span bumped
-    # to 11.8 to ensure genuine infeasibility within _MAX_EXPANSIONS.
+    # The mover must reach a heading-90 goal, but two parked planes flank the
+    # turn region so closely that NO maneuver — forward OR reverse (ADR-0010) —
+    # can reorient the wide wing without clipping a neighbour. The goal slot
+    # itself IS a valid static placement; only the *approach* is impossible, so
+    # the planner bails with NoFeasiblePlanError naming the mover.
+    #
+    # Note (Reeds–Shepp v2): the earlier span-11.8 "fills the hangar" framing no
+    # longer guarantees infeasibility — reverse legs let a wide plane shuffle to
+    # reorient even in a tight box. Genuine infeasibility now requires obstacles
+    # that block every gear, not just a tight wall fit. A modest expansion
+    # budget keeps the test fast while still proving the bail.
     h = _hangar(width_m=12.0, length_m=12.0)
-    plane = _winged_plane("A", span_m=11.8, turn_radius_m=5.0)
-    placed = Layout(fleet={"A": plane}, hangar=h, placements=())
+    mover = _winged_plane("A", span_m=8.0, turn_radius_m=5.0)
+    obs_left = _winged_plane("L", span_m=2.0)
+    obs_right = _winged_plane("R", span_m=2.0)
+    fleet = {"A": mover, "L": obs_left, "R": obs_right}
+    placed = Layout(
+        fleet=fleet,
+        hangar=h,
+        placements=(
+            Placement("L", 1.5, 6.0, 0.0, on_carts=False),
+            Placement("R", 10.5, 6.0, 0.0, on_carts=False),
+        ),
+    )
     entry = Pose(6.0, 0.0, 0.0)
-    goal = Pose(6.0, 6.0, 90.0)  # wing along x spans nearly the whole width while turning
+    goal = Pose(6.0, 6.0, 90.0)
     with pytest.raises(NoFeasiblePlanError) as ei:
-        plan_path(plane, entry, goal, hangar=h, placed=placed, mover_on_carts=False)
+        plan_path(
+            mover, entry, goal, hangar=h, placed=placed, mover_on_carts=False, max_expansions=100
+        )
     assert ei.value.plane_id == "A"
 
 
@@ -200,9 +224,17 @@ def test_plan_path_canary_pins_a_known_maneuver() -> None:
         mover_on_carts=False,
     )
     kinds = "".join(s.kind for s in arc.segments)
-    # Values pinned from first green run (2026-05-26).
-    assert kinds == "SSSRSL"
-    assert arc.length_m == pytest.approx(16.81759168818229, abs=1e-6)
+    gears = [s.gear for s in arc.segments]
+    # Values pinned from first green run on the Reeds–Shepp motion model
+    # (ADR-0010, 2026-05-26). The path now closes in a single LRL Reeds–Shepp
+    # analytic shot whose final arc is driven in REVERSE (gear −1) — the
+    # back-up-to-reorient maneuver Reeds–Shepp unlocks, far shorter than the
+    # forward-only Dubins SSSRSL it replaced (16.82 m → 6.60 m). If this
+    # changes, a tie-break or primitive-order regression is the likely cause —
+    # investigate before updating the expected values.
+    assert kinds == "LRL"
+    assert gears == [1, 1, -1]
+    assert arc.length_m == pytest.approx(6.601662791609364, abs=1e-6)
 
 
 # ---------------------------------------------------------------------------
@@ -512,20 +544,36 @@ def test_motion_clear_zero_wing_layer_clearance_skips_non_overlapping_z() -> Non
 
 
 def test_plan_path_budget_exhaustion_breaks_and_raises_no_feasible_path() -> None:
-    # A small expansion budget on a proven-infeasible wide-wing/turned-goal case
-    # forces the budget `break` and the `no_feasible_path` raise, and the
-    # multi-node exploration of the constrained space exercises the
-    # stale-heap-entry skip — all without the cost of a full-budget search.
-    # (span 9 in an 14 m hangar with r=5 needs r+half_span=9.5 m of clearance
-    # each side: the valid turn interval is empty, so the goal is unreachable.)
-    h = _hangar(width_m=14.0, length_m=18.0)
-    plane = _winged_plane("A", span_m=9.0, turn_radius_m=5.0)
-    placed = Layout(fleet={"A": plane}, hangar=h, placements=())
+    # A small expansion budget on a boxed-in, turned-goal case forces the budget
+    # `break` and the `no_feasible_path` raise, and the multi-node exploration of
+    # the constrained space exercises the stale-heap-entry skip — all without the
+    # cost of a full-budget search. Two parked planes flank the heading-90 goal
+    # so neither forward nor reverse (ADR-0010) can reorient the wide wing; the
+    # goal slot itself is a valid placement, so the failure is "no reachable
+    # approach within budget", surfaced as `no_feasible_path`.
+    #
+    # (Reeds–Shepp v2 note: the earlier open-hangar "empty turn interval"
+    # framing no longer holds — reverse arcs reach turned goals a forward-only
+    # Dubins car could not. Genuine infeasibility now needs gear-blocking
+    # obstacles, not just a wall fit.)
+    h = _hangar(width_m=12.0, length_m=12.0)
+    mover = _winged_plane("A", span_m=8.0, turn_radius_m=5.0)
+    obs_left = _winged_plane("L", span_m=2.0)
+    obs_right = _winged_plane("R", span_m=2.0)
+    fleet = {"A": mover, "L": obs_left, "R": obs_right}
+    placed = Layout(
+        fleet=fleet,
+        hangar=h,
+        placements=(
+            Placement("L", 1.5, 6.0, 0.0, on_carts=False),
+            Placement("R", 10.5, 6.0, 0.0, on_carts=False),
+        ),
+    )
     with pytest.raises(NoFeasiblePlanError) as ei:
         plan_path(
-            plane,
+            mover,
             Pose(6.0, 0.0, 0.0),
-            Pose(6.0, 8.0, 234.0),
+            Pose(6.0, 6.0, 90.0),
             hangar=h,
             placed=placed,
             mover_on_carts=False,

--- a/tests/test_towplanner_search.py
+++ b/tests/test_towplanner_search.py
@@ -27,17 +27,19 @@ def test_primitives_own_gear_are_six_in_lf_sf_rf_lr_sr_rr_order() -> None:
     assert all(s.length_m > 0.0 for s in segs)
 
 
-def test_primitives_cart_are_six_pivot_straight_in_order() -> None:
-    # Cart (r == 0): the same six-primitive fan. Pivots encode one heading cell
-    # in radians; the straights encode metres. Reverse straight is the new cart
-    # move (ADR-0010); reverse pivots are redundant but kept for a uniform fan.
+def test_primitives_cart_are_four_pivot_straight_in_order() -> None:
+    # Cart (r == 0): four primitives Lf, Sf, Rf, Sr. Pivots encode one heading
+    # cell in radians; the straights encode metres. The reverse STRAIGHT is the
+    # genuinely-new cart move (ADR-0010); reverse pivots are omitted because a
+    # reverse pivot rotates heading the same way as the opposite forward pivot
+    # (an exact duplicate that always loses the best_g race — pure dead work).
     segs = _primitives(turn_radius_m=0.0)
-    assert [s.kind for s in segs] == ["L", "S", "R", "L", "S", "R"]
-    assert [s.gear for s in segs] == [1, 1, 1, -1, -1, -1]
+    assert [s.kind for s in segs] == ["L", "S", "R", "S"]
+    assert [s.gear for s in segs] == [1, 1, 1, -1]
     assert segs[0].length_m == pytest.approx(math.radians(15.0))
     assert segs[1].length_m == pytest.approx(0.5)
     assert segs[2].length_m == pytest.approx(math.radians(15.0))
-    assert segs[4].length_m == pytest.approx(0.5)  # reverse straight, metres
+    assert segs[3].length_m == pytest.approx(0.5)  # reverse straight, metres
 
 
 def test_step_pose_straight_advances_along_heading() -> None:
@@ -127,8 +129,8 @@ def _winged_plane(pid: str, *, span_m: float = 10.0, turn_radius_m: float = 5.0)
 
 
 def test_plan_path_clear_straight_is_a_single_analytic_shot() -> None:
-    # Slot straight ahead, same heading: the start node's analytic Dubins shot
-    # is clear, so the search returns immediately with that arc's endpoint.
+    # Slot straight ahead, same heading: the start node's analytic Reeds–Shepp
+    # shot is clear, so the search returns immediately with that arc's endpoint.
     h = _hangar()
     plane = _winged_plane("A", span_m=6.0)
     placed = Layout(fleet={"A": plane}, hangar=h, placements=())
@@ -142,8 +144,8 @@ def test_plan_path_clear_straight_is_a_single_analytic_shot() -> None:
 
 
 def test_plan_path_finds_inbounds_path_when_direct_shot_sweeps_a_wing_out() -> None:
-    # Moderately wide wing + a 90-degree final heading: the direct shortest Dubins
-    # shot picks a long R-S-L arc that sweeps the left wing tip outside x=0, so the
+    # Moderately wide wing + a 90-degree final heading: the direct shortest
+    # Reeds–Shepp shot sweeps the left wing tip outside x=0, so the
     # search must maneuver. Geometry chosen so plan_path resolves within budget
     # (span=6 in a 14m hangar; the 10m-span/18m-hangar original is physically
     # infeasible for any heading-change path — see Task 3 report).
@@ -226,7 +228,7 @@ def test_plan_path_canary_pins_a_known_maneuver() -> None:
     kinds = "".join(s.kind for s in arc.segments)
     gears = [s.gear for s in arc.segments]
     # Values pinned from first green run on the Reeds–Shepp motion model
-    # (ADR-0010, 2026-05-26). The path now closes in a single LRL Reeds–Shepp
+    # (ADR-0010, 2026-05-27). The path now closes in a single LRL Reeds–Shepp
     # analytic shot whose final arc is driven in REVERSE (gear −1) — the
     # back-up-to-reorient maneuver Reeds–Shepp unlocks, far shorter than the
     # forward-only Dubins SSSRSL it replaced (16.82 m → 6.60 m). If this


### PR DESCRIPTION
Closes #261

## What
Replaces the tow-path planner's **forward-only Dubins** motion vocabulary with a full **closed-form Reeds–Shepp** model (Dubins + reverse arcs). A forward-only car must drive a full turning-circle loop to reorient before parking — the waste the 2026-05-26 UAT exposed (seed-13). Reeds–Shepp replaces that loop with a short back-up-and-pull-forward. Still **closed-form and deterministic**, so the ADR-0003 determinism contract holds (unlike RRT-Connect).

## Diagnostic that motivated this
Obstacle-free closed-form comparison (placeholder 18×25 hangar, `fk9_mkii`, r=4 m):

| goal | v1 fwd straight-in | reverse-in |
|---|---|---|
| nose-OUT deep (hdg 180°) | 32.4 m | **18.0 m (−14.4)** |
| seed-13 fk9 (hdg 246°) | 21.0 m | **16.5 m (−4.5)** |
| nose-IN deep (hdg 0°) | 18.0 m | 32.4 m (reverse correctly *worse* → not chosen) |

Reverse is the dominant lever in the nose-out direction; a cost-minimising planner correctly declines it where forward is shorter.

## How
- `Segment` gains `gear: Literal[1,-1] = 1` (forward default — every existing `Segment` and test stays valid); `DubinsArc.pose_at` integrates reverse legs; `sample()` density uses `abs(length)`.
- New `plan_reeds_shepp()` — base CSC/CCC/CCCC/CCSC/CCSCC solvers + timeflip/reflect/backwards **symmetry generation** of the full word family; every generated word is gated by an independent re-integration (`_rs_word_reaches`) so a formula sign-error becomes a *missing* candidate, never a shipped wrong path. The roundtrip-grid test proves family completeness.
- Cost model prefers forward: reverse legs ×`_REVERSE_COST_FACTOR = 1.5` (justified by the diagnostic — 1.5× keeps the 14 m nose-out win while discouraging gratuitous short reverses; 2.0× would suppress it).
- Hybrid-A* `_primitives` → 6 (Lf,Sf,Rf,Lr,Sr,Rr); `_seg_cost` reverse-weighted; analytic shot `plan_dubins` → `plan_reeds_shepp`. Cart r=0 degrades to pivot + fwd/rev straight.
- Determinism: fixed word order + strict `<` tie-break. Reverse front-gap exemption (#222) is free (`_mover_motion_bounds_conflict` is gear-agnostic).

## Governance
- **New ADR-0010** "Reeds–Shepp motion model", **Supersedes ADR-0007 fork-2 "Dubins-only"** (ADR-0009 was already taken by the single-Python ADR in #265, so this is 0010). ADR-0007 + ADR README + arc42 §5/§8 updated.
- ADR-0002 sign-flip guard: **reverse 45° heading canary** added.

## Tests
`PYTHONPATH=src pytest -m ""` → **921 passed**. `ruff check` / `ruff format --check` / `mypy` all clean. New `tests/test_towplanner_reeds_shepp.py` (roundtrip-grid oracle, cost-prefers-forward, reverse-cart, determinism, gear validation) + reverse front-gap + canary cases.

## Notes
- `_MAX_EXPANSIONS` unchanged; the 6-primitive fan roughly doubles per-expansion work, so the `slow` perf ceiling was raised 30 s → 75 s (documented; still <½ the pre-tuning baseline).
- `plan_path` edits confined to the analytic-shot line (+`_primitives`/`_seg_cost`); the start-seeding region is untouched (owned by #262) to keep the merge conflict minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)