### PR TITLE
feat(solver): best-of-all-basins spread selection (#267)

### DIFF
--- a/docs/adr/0003-rr-mc-solver-algorithm.md
+++ b/docs/adr/0003-rr-mc-solver-algorithm.md
@@ -331,11 +331,17 @@ Therefore:
   selected layout. The `tests/test_solver_canaries.py` determinism canaries
   remain meaningful on any `max_restarts`-bounded solve call.
 - A run bounded by a pure wall-clock `budget_s` allows a *variable* number of
-  restarts depending on machine speed and load. When basins are near-tied on
-  maximin gap the selected layout can differ between machines (or the same
-  machine under different load) — the pool size varies and a near-tie may
-  resolve differently. Same seed on the same machine under the same load
-  remains reproducible.
+  restarts depending on machine speed and load — **but only on the spread-ON
+  best-of-all path.** When basins are near-tied on maximin gap the selected
+  layout can differ between machines (or the same machine under different load)
+  — the pool size varies and a near-tie may resolve differently. Same seed on
+  the same machine under the same load remains reproducible.
+
+- With `spread=False` the wall-clock timing-dependence does **not** apply: the
+  loop keeps the pre-#267 first-valid early exit and terminates at a
+  seed-deterministic restart (once `alternatives` diverse valid layouts are
+  found), independent of `budget_s` / machine speed. That mode is therefore
+  reproducible across runs and machines regardless of the wall-clock bound.
 
 **Guidance.** For guaranteed cross-machine reproducibility, bound the search by
 `max_restarts` rather than (or in addition to) wall-clock `budget_s`. The

--- a/docs/adr/0003-rr-mc-solver-algorithm.md
+++ b/docs/adr/0003-rr-mc-solver-algorithm.md
@@ -312,6 +312,45 @@ silently rejected at scoring time). Rejected.
 
 ## Amendments
 
+### 2026-05-27 — best-of-all-basins selection and determinism scoping (issue #267)
+
+Since [#267](https://github.com/DocGerd/hangarfit/issues/267), `solve()` no
+longer breaks on the first valid layout. The restart loop runs to its
+termination gate, appends every valid spread-polished basin to a pool, and calls
+`_select_spread_diverse` to pick the best-spread layout(s) subject to the
+diversity gate (ADR-0004). See the ADR-0008 amendment (2026-05-27) for the
+spread-selection rationale.
+
+**Consequence for the determinism contract.** The seed still fixes the complete
+RNG sequence, and `_select_spread_diverse` is a fully-ordered pure sort
+(`restart_index` is the final tiebreak, so no two pool entries compare equal).
+Therefore:
+
+- A run bounded by `max_restarts` (a deterministic restart count) is **fully
+  reproducible across runs and machines** — same seed → same pool → same
+  selected layout. The `tests/test_solver_canaries.py` determinism canaries
+  remain meaningful on any `max_restarts`-bounded solve call.
+- A run bounded by a pure wall-clock `budget_s` allows a *variable* number of
+  restarts depending on machine speed and load. When basins are near-tied on
+  maximin gap the selected layout can differ between machines (or the same
+  machine under different load) — the pool size varies and a near-tie may
+  resolve differently. Same seed on the same machine under the same load
+  remains reproducible.
+
+**Guidance.** For guaranteed cross-machine reproducibility, bound the search by
+`max_restarts` rather than (or in addition to) wall-clock `budget_s`. The
+default CLI path uses `budget_s` for responsiveness; this is an accepted,
+deliberate tradeoff — spread robustness was chosen over wall-clock-independent
+determinism for the interactive use case.
+
+The RR-MC algorithm itself (descent step, scoring, diversity filter, status
+taxonomy) is unchanged by this amendment. The amendment block above under
+*Consequences → Positive* ("Reproducibility is bit-identical under a seed")
+remains accurate for the `max_restarts`-bounded path; under a pure `budget_s`
+bound it is timing-scoped as described above.
+
+---
+
 ### 2026-05-23 — maintenance-plane handling, post-milestone-#9
 
 Two passages in the body above describe how RR-MC handles the

--- a/docs/adr/0008-inter-plane-spread-soft-preference.md
+++ b/docs/adr/0008-inter-plane-spread-soft-preference.md
@@ -166,6 +166,12 @@ deterministic final key) subject to the existing diversity gate (ADR-0004).
 basins, not from a smarter climb. Returned alternatives are ordered
 best-spread-first (`layouts[0]` is the roomiest).
 
+Best-of-all engages **only when spread is enabled**: with `spread=False` there
+is nothing to optimize, so `solve()` retains the pre-#267 first-valid fast path
+(`--no-spread` / `SearchConfig.spread=False`) — the restart loop stops as soon
+as `alternatives` diverse valid layouts have been found rather than running to
+budget.
+
 **Observability.** The achieved minimum pairwise plan-view gap per returned
 layout is reported in `SolverDiagnostics.min_pairwise_gap_m` (index-aligned with
 `layouts`; `math.inf` / `null` for <2 planes), in the human CLI summary, and in

--- a/docs/adr/0008-inter-plane-spread-soft-preference.md
+++ b/docs/adr/0008-inter-plane-spread-soft-preference.md
@@ -143,3 +143,43 @@ stream is byte-identical to the pre-spread solver).
 - External references: Kuby, M. J. (1987). "Programming models for facility
   dispersion: the *p*-dispersion and maxisum dispersion problems."
   *Geographical Analysis* 19(4): 315–329.
+
+## Amendments
+
+### 2026-05-27 — best-of-all-basins spread selection (issue #267)
+
+**Background.** ADR-0008's `_spread` post-pass is a greedy single-plane
+hill-climb. It can only polish whichever basin the restart loop handed it — a
+single-plane nudge cannot cross a validity barrier out of a nested pair (e.g. a
+low fuselage legally tucked under a high wing, producing a 0.0 m plan-view gap).
+Because `solve()` originally accepted the **first** valid basin, spread quality
+was seed-luck: a seed sweep on a representative 5-plane fill showed ~1/3 of
+seeds settled with a nested pair (0.0 m gap) while the rest spread to 1.7–2.5 m
+— same scenario, same fleet, same hangar, only the restart seed different.
+
+**Change.** Since [#267](https://github.com/DocGerd/hangarfit/issues/267),
+`solve()` runs all restarts within budget to their termination gate, appends
+every valid spread-polished basin to a pool, and **selects the layout(s) with
+the largest minimum plan-view gap** (energy tiebreak, then restart index as the
+deterministic final key) subject to the existing diversity gate (ADR-0004).
+`_spread` itself is unchanged — the robustness gain comes from choosing among
+basins, not from a smarter climb. Returned alternatives are ordered
+best-spread-first (`layouts[0]` is the roomiest).
+
+**Observability.** The achieved minimum pairwise plan-view gap per returned
+layout is reported in `SolverDiagnostics.min_pairwise_gap_m` (index-aligned with
+`layouts`; `math.inf` / `null` for <2 planes), in the human CLI summary, and in
+`--json`. `SolverDiagnostics.valid_basins_found` records the pool size — how
+many spread-polished basins the selection had to choose from.
+
+**Space-bound limitation (best-effort, not a guarantee).** Best-of-all returns
+the roomiest *available* basin; it cannot eliminate nesting when the fill is
+space-tight and every reachable basin nests. Empirically, on the tight 6-plane
+default fixture some seeds still return a 0.0 m nested pair because no
+non-nested arrangement is reachable within the budget. Spread is a soft
+preference (see ADR-0008's design drivers), not a guarantee of positive
+separation.
+
+**Determinism.** See the ADR-0003 amendment dated 2026-05-27 for the precise
+scoping: reproducible under a `max_restarts` bound; timing-dependent under a
+pure wall-clock `budget_s` bound.

--- a/docs/superpowers/plans/2026-05-27-solver-spread-robustness.md
+++ b/docs/superpowers/plans/2026-05-27-solver-spread-robustness.md
@@ -1,0 +1,854 @@
+# Solver Spread Robustness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `solve()` consistently return a well-spread valid layout regardless of seed, by collecting all valid spread-polished basins within budget and selecting the best by maximin plan-view gap (subject to the diversity gate).
+
+**Architecture:** Replace the first-valid-basin-then-break behavior with a collect-then-select pool: the restart loop runs to budget/`max_restarts`, recording every valid (spread-polished) basin; a new pure `_select_spread_diverse` then picks `alternatives` candidates ordered by `(−min_gap, energy, restart_index)`, greedily enforcing pairwise diversity. Achieved min-gap is surfaced in `SolverDiagnostics`, the human CLI, and `--json`.
+
+**Tech Stack:** Python 3.12, shapely (plan-view part polygons), pytest, ruff, mypy. Single supported Python (ADR-0009).
+
+**Design spec:** `docs/superpowers/specs/2026-05-27-solver-spread-robustness-design.md`. Issue #267.
+
+**Commit convention:** end every commit body with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` (project rule). The PostToolUse hook auto-runs ruff+pytest after each `src/`/`tests/` edit — read its tail for fast feedback.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/hangarfit/solver.py` | search + spread + selection | Add `_resolve_spread_scale`, `_spread_quality`, `_SpreadCandidate`, `_select_spread_diverse`; restructure `solve()` loop; refactor `_spread` to use `_resolve_spread_scale`. |
+| `src/hangarfit/models.py` | dataclasses | Add 2 fields to `SolverDiagnostics` + validation + docstring. |
+| `src/hangarfit/cli.py` | output rendering | Surface min-gap in `_emit_solve_human` + `_emit_solve_json`. |
+| `tests/test_solver_spread.py` | spread-robustness tests | New file: pure-unit (primary regression) + wiring integration + `@slow` sweep. |
+| `tests/test_models.py` | dataclass tests | Add `SolverDiagnostics` new-field test (append if file exists; else create). |
+| `tests/test_cli.py` | CLI output tests | Add assertions for the new human line + JSON keys. |
+| `docs/adr/0008-inter-plane-spread-soft-preference.md` | ADR | Addendum: best-of-all-basins selection. |
+
+---
+
+## Task 1: `_resolve_spread_scale` + `_spread_quality` helpers
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` (add helpers near `_inter_plane_energy`, ~line 569; refactor `_spread` scale block at `solver.py:620-624`)
+- Test: `tests/test_solver_spread.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_solver_spread.py`:
+
+```python
+"""Spread-robustness: best-of-all-basins selection (#267)."""
+
+import math
+
+from hangarfit.loader import load_scenario
+from hangarfit.solver import (
+    _inter_plane_energy,
+    _resolve_spread_scale,
+    _spread_quality,
+)
+from hangarfit.models import Placement, SearchConfig
+
+
+def _placements(scenario, specs):
+    """Build a {plane_id: Placement} from (plane_id, x, y, heading) specs."""
+    return {
+        pid: Placement(plane_id=pid, x_m=x, y_m=y, heading_deg=h, on_carts=False)
+        for (pid, x, y, h) in specs
+    }
+
+
+def test_spread_quality_energy_matches_inter_plane_energy():
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    pids = list(scenario.fleet_in)
+    placements = _placements(scenario, [(pids[0], 2.0, 2.0, 0.0), (pids[1], 12.0, 9.0, 0.0)])
+    scale = _resolve_spread_scale(scenario, SearchConfig())
+    min_gap, energy = _spread_quality(placements, scenario, scale)
+    assert energy == _inter_plane_energy(placements, scenario, scale)
+    assert math.isfinite(min_gap) and min_gap >= 0.0
+
+
+def test_spread_quality_single_plane_is_inf_zero():
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    pid = scenario.fleet_in[0]
+    placements = _placements(scenario, [(pid, 2.0, 2.0, 0.0)])
+    scale = _resolve_spread_scale(scenario, SearchConfig())
+    assert _spread_quality(placements, scenario, scale) == (math.inf, 0.0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_solver_spread.py -q`
+Expected: FAIL with `ImportError: cannot import name '_resolve_spread_scale'` (and `_spread_quality`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/hangarfit/solver.py`, immediately after `_inter_plane_energy` (after `solver.py:596`):
+
+```python
+def _resolve_spread_scale(scenario: Scenario, search: SearchConfig) -> float:
+    """Repulsion length-scale for spread (spec §4): explicit override or
+    20% of the smaller hangar dimension. Single source so ``_spread`` and
+    ``_spread_quality`` always agree."""
+    if search.spread_scale_m is not None:
+        return search.spread_scale_m
+    return 0.2 * min(scenario.hangar.width_m, scenario.hangar.length_m)
+
+
+def _spread_quality(
+    placements: dict[str, Placement],
+    scenario: Scenario,
+    scale: float,
+) -> tuple[float, float]:
+    """Return ``(min_gap, energy)`` for a layout in one pass over plane-pairs.
+
+    ``min_gap`` is the minimum plan-view edge-to-edge distance between any two
+    planes' world parts (``math.inf`` when <2 planes — no pairs). ``energy``
+    is the same ``Σ exp(−gap/scale)`` repulsion :func:`_inter_plane_energy`
+    computes; returning both from one pairwise sweep avoids paying the
+    (expensive) shapely distances twice when scoring a candidate basin. The
+    hot ``_spread`` loop keeps using the energy-only :func:`_inter_plane_energy`
+    — this is called once per accepted basin, not per perturbation.
+    """
+    ids = sorted(placements)
+    if len(ids) < 2:
+        return (math.inf, 0.0)
+    world: dict[str, list[WorldPart]] = {
+        pid: aircraft_parts_world(scenario.fleet[pid], placements[pid]) for pid in ids
+    }
+    min_gap = math.inf
+    energy = 0.0
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            gap = min(
+                pa.polygon.distance(pb.polygon) for pa in world[ids[i]] for pb in world[ids[j]]
+            )
+            min_gap = min(min_gap, gap)
+            energy += math.exp(-gap / scale)
+    return (min_gap, energy)
+```
+
+Then refactor `_spread`'s scale block (`solver.py:620-624`) to:
+
+```python
+    scale = _resolve_spread_scale(scenario, search)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_solver_spread.py -q`
+Expected: PASS (2 passed). Also run `pytest tests/test_solver.py tests/test_solver_spread_postpass.py -q` if those exist, to confirm the `_spread` refactor is behavior-preserving (grep first: `ls tests/ | grep -i spread`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_spread.py
+git commit -m "feat(solver): add _spread_quality + _resolve_spread_scale helpers (#267)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `_select_spread_diverse` pure selection (PRIMARY REGRESSION)
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` (add `_SpreadCandidate` NamedTuple + `_select_spread_diverse` near `_is_diverse_enough`, ~`solver.py:1072`)
+- Test: `tests/test_solver_spread.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_solver_spread.py`:
+
+```python
+from hangarfit.models import DiversityConfig, Layout
+from hangarfit.solver import _SpreadCandidate, _select_spread_diverse
+
+
+def _layout(scenario, specs):
+    """A valid Layout from (plane_id, x, y, heading) specs. Layout.__post_init__
+    enforces only structural invariants (no collision check), so arbitrary
+    positions are fine for selection/diversity tests."""
+    return Layout(
+        fleet=scenario.fleet,
+        hangar=scenario.hangar,
+        placements=tuple(_placements(scenario, specs).values()),
+        maintenance_plane=None,
+    )
+
+
+def test_select_nested_pair_loses_to_spread():
+    """The core regression: a nested basin (min_gap 0.0) must never be chosen
+    over a well-spread one (min_gap 2.0), even with a worse restart_index."""
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    p = list(scenario.fleet_in)
+    nested = _layout(scenario, [(p[0], 2.0, 2.0, 0.0), (p[1], 2.0, 2.0, 0.0)])
+    spread = _layout(scenario, [(p[0], 2.0, 2.0, 0.0), (p[1], 12.0, 9.0, 0.0)])
+    pool = [
+        _SpreadCandidate(layout=nested, min_gap=0.0, energy=5.0, restart_index=0),
+        _SpreadCandidate(layout=spread, min_gap=2.0, energy=1.0, restart_index=1),
+    ]
+    selected, rejected = _select_spread_diverse(pool, alternatives=1, diversity=DiversityConfig())
+    assert [c.min_gap for c in selected] == [2.0]
+    assert rejected == 0
+
+
+def test_select_energy_breaks_min_gap_ties():
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    p = list(scenario.fleet_in)
+    a = _layout(scenario, [(p[0], 2.0, 2.0, 0.0), (p[1], 12.0, 9.0, 0.0)])
+    b = _layout(scenario, [(p[0], 2.0, 2.0, 0.0), (p[1], 12.0, 9.0, 0.0)])
+    pool = [
+        _SpreadCandidate(layout=a, min_gap=2.0, energy=3.0, restart_index=0),
+        _SpreadCandidate(layout=b, min_gap=2.0, energy=1.0, restart_index=1),
+    ]
+    selected, _ = _select_spread_diverse(pool, alternatives=1, diversity=DiversityConfig())
+    assert selected[0].energy == 1.0  # lower energy wins the tie
+
+
+def test_select_enforces_diversity_and_counts_rejects():
+    """K=2: the top-spread basin is picked; a near-identical second basin is
+    rejected by the diversity gate; a genuinely different one is accepted."""
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    p = list(scenario.fleet_in)
+    # base layout
+    base = _layout(scenario, [(p[0], 2.0, 2.0, 0.0), (p[1], 12.0, 9.0, 0.0)])
+    # near-identical: both planes within position_threshold_m (0.5) of base
+    twin = _layout(scenario, [(p[0], 2.1, 2.0, 0.0), (p[1], 12.1, 9.0, 0.0)])
+    # different: both planes moved well beyond threshold
+    diff = _layout(scenario, [(p[0], 6.0, 5.0, 0.0), (p[1], 16.0, 12.0, 0.0)])
+    pool = [
+        _SpreadCandidate(layout=base, min_gap=3.0, energy=1.0, restart_index=0),
+        _SpreadCandidate(layout=twin, min_gap=2.5, energy=1.0, restart_index=1),
+        _SpreadCandidate(layout=diff, min_gap=2.0, energy=1.0, restart_index=2),
+    ]
+    selected, rejected = _select_spread_diverse(pool, alternatives=2, diversity=DiversityConfig())
+    assert [c.min_gap for c in selected] == [3.0, 2.0]  # base, then diff; twin skipped
+    assert rejected == 1
+
+
+def test_select_empty_pool_returns_empty():
+    selected, rejected = _select_spread_diverse([], alternatives=2, diversity=DiversityConfig())
+    assert selected == [] and rejected == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_solver_spread.py -q`
+Expected: FAIL with `ImportError: cannot import name '_SpreadCandidate'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/hangarfit/solver.py`, just before `_is_diverse_enough` (`solver.py:1072`). Ensure `from typing import NamedTuple` is imported at the top (add if absent):
+
+```python
+class _SpreadCandidate(NamedTuple):
+    """A valid, spread-polished basin found during search, with its quality."""
+
+    layout: Layout
+    min_gap: float
+    energy: float
+    restart_index: int
+
+
+def _select_spread_diverse(
+    pool: list[_SpreadCandidate],
+    alternatives: int,
+    diversity: DiversityConfig,
+) -> tuple[list[_SpreadCandidate], int]:
+    """Select up to ``alternatives`` best-spread, pairwise-diverse candidates.
+
+    Order the pool by ``(−min_gap, energy, restart_index)``: largest minimum
+    plan-view gap first, ties broken by lower repulsion energy, then by restart
+    order for a *total* (so deterministic — ADR-0003) ordering. Greedily accept
+    a candidate iff it is diverse enough (ADR-0004) against everything already
+    selected; the first pick is always accepted (diversity is vacuous on the
+    empty selection). Returns ``(selected, diversity_rejected)`` in best-spread
+    order, where ``diversity_rejected`` counts candidates *examined* (before the
+    ``alternatives`` quota was met) that the diversity gate turned away. For
+    ``alternatives == 1`` this is always 0 — selection stops after the first,
+    vacuous pick.
+    """
+    ordered = sorted(pool, key=lambda c: (-c.min_gap, c.energy, c.restart_index))
+    selected: list[_SpreadCandidate] = []
+    diversity_rejected = 0
+    for cand in ordered:
+        if _is_diverse_enough(cand.layout, [c.layout for c in selected], diversity):
+            selected.append(cand)
+            if len(selected) >= alternatives:
+                break
+        else:
+            diversity_rejected += 1
+    return selected, diversity_rejected
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_solver_spread.py -q`
+Expected: PASS (6 passed total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_spread.py
+git commit -m "feat(solver): _select_spread_diverse best-of-all-basins selection (#267)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `SolverDiagnostics` new fields
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (`SolverDiagnostics` `solver.py`→`models.py:653-727`)
+- Test: `tests/test_models.py` (grep `class TestSolverDiagnostics` / `SolverDiagnostics(` to find the section; create file if none)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_models.py` (mirror existing `SolverDiagnostics` construction in that file for required-arg values):
+
+```python
+def test_solver_diagnostics_spread_fields_default_and_validate():
+    from hangarfit.models import SolverDiagnostics
+
+    d = SolverDiagnostics(
+        restarts_attempted=3,
+        wall_time_s=1.0,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=7,
+    )
+    assert d.min_pairwise_gap_m == ()
+    assert d.valid_basins_found == 0
+
+    d2 = SolverDiagnostics(
+        restarts_attempted=3,
+        wall_time_s=1.0,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=7,
+        min_pairwise_gap_m=(2.5,),
+        valid_basins_found=12,
+    )
+    assert d2.min_pairwise_gap_m == (2.5,)
+    assert d2.valid_basins_found == 12
+
+    import pytest
+
+    with pytest.raises(ValueError, match="valid_basins_found"):
+        SolverDiagnostics(
+            restarts_attempted=0,
+            wall_time_s=0.0,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=0,
+            valid_basins_found=-1,
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_models.py -q -k spread_fields`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'min_pairwise_gap_m'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/hangarfit/models.py`, add two fields after `unroutable_planes` (`models.py:707`):
+
+```python
+    min_pairwise_gap_m: tuple[float, ...] = ()
+    valid_basins_found: int = 0
+```
+
+Append to the `SolverDiagnostics` docstring (after the `unroutable_planes` paragraph, before the closing `"""`):
+
+```
+    ``min_pairwise_gap_m`` is index-aligned with :attr:`SolveResult.layouts`:
+    the achieved minimum plan-view gap (m) between any two planes in that
+    returned layout — the quality the best-of-all-basins spread selection
+    maximizes (#267, ADR-0008). ``math.inf`` for a layout with <2 planes
+    (no pairs). ``valid_basins_found`` is the number of valid spread-polished
+    basins the search collected before selection — how much choice best-of-all
+    had. Both are advisory.
+```
+
+Add to `__post_init__` (after the `diversity_rejected_count` check, `models.py:727`):
+
+```python
+        if self.valid_basins_found < 0:
+            raise ValueError(
+                f"SolverDiagnostics.valid_basins_found must be >= 0, "
+                f"got {self.valid_basins_found}"
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_models.py -q -k spread_fields`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_models.py
+git commit -m "feat(models): SolverDiagnostics min_pairwise_gap_m + valid_basins_found (#267)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire `solve()` — build pool, select, populate diagnostics
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` (`solve()` restart loop `solver.py:142-337`)
+- Test: `tests/test_solver_spread.py`
+
+> **Behavior change to flag at review:** best-of-all engages on every solve (the loop now always runs to `budget_s`/`max_restarts` rather than breaking on the first valid layout) — including `--no-spread`, which now also runs full budget but selects the best *raw* basin (no polish). This matches the approved "full budget, best-of-all" decision. The fast first-valid path is gone; if a speed escape hatch is wanted later, that's a follow-up.
+
+- [ ] **Step 1: Write the failing test (wiring + determinism)**
+
+Append to `tests/test_solver_spread.py`:
+
+```python
+from hangarfit.solver import solve
+
+
+def test_solve_populates_spread_diagnostics():
+    scenario = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    r = solve(scenario, seed=7, search=SearchConfig(max_restarts=20), plan_paths=False)
+    assert r.status in ("found", "found_partial")
+    d = r.diagnostics
+    # min_pairwise_gap_m is index-aligned with layouts and populated.
+    assert len(d.min_pairwise_gap_m) == len(r.layouts)
+    assert d.valid_basins_found >= len(r.layouts)
+    # the returned layout cleared the nested-pair pathology
+    assert all(g > 0.0 for g in d.min_pairwise_gap_m)
+
+
+def test_solve_spread_selection_is_deterministic():
+    scenario = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    cfg = SearchConfig(max_restarts=20)
+    a = solve(scenario, seed=7, search=cfg, plan_paths=False)
+    b = solve(scenario, seed=7, search=cfg, plan_paths=False)
+    assert a.diagnostics.min_pairwise_gap_m == b.diagnostics.min_pairwise_gap_m
+    assert [_layout_key(l) for l in a.layouts] == [_layout_key(l) for l in b.layouts]
+
+
+def _layout_key(layout):
+    return tuple(
+        (p.plane_id, round(p.x_m, 6), round(p.y_m, 6), round(p.heading_deg, 6))
+        for p in layout.placements
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_solver_spread.py -q -k "diagnostics or deterministic"`
+Expected: FAIL — `AssertionError` on `len(d.min_pairwise_gap_m) == len(r.layouts)` (currently always `()`).
+
+- [ ] **Step 3: Write the implementation**
+
+Restructure `solve()`'s search section. Replace the accumulator declarations (`solver.py:140-144`) — drop `accepted_layouts` / `diversity_rejected_count` running counters in favor of a pool:
+
+```python
+    best_partial_score: tuple[int, float] = (sys.maxsize, float("inf"))
+    best_partial_layout: Layout | None = None
+    pool: list[_SpreadCandidate] = []
+    restart_index = 0
+    spread_scale = _resolve_spread_scale(scenario, search)
+```
+
+In the inner loop, replace the valid-found block (`solver.py:194-232`) with: on valid, spread (if enabled), score quality, append to pool, and restart (do **not** break the outer loop):
+
+```python
+            if current_score == (0, 0.0):
+                if search.spread:
+                    placements = _spread(
+                        placements,
+                        scenario,
+                        rng,
+                        search,
+                        start=start,
+                        budget_s=budget_s,
+                        pinned_planes=pinned_planes,
+                    )
+                # _spread preserves every Layout invariant; a ValueError here
+                # would be a structural bug, so let it propagate.
+                candidate_layout = Layout(
+                    fleet=scenario.fleet,
+                    hangar=scenario.hangar,
+                    placements=tuple(placements.values()),
+                    maintenance_plane=scenario.maintenance_plane,
+                )
+                min_gap, energy = _spread_quality(placements, scenario, spread_scale)
+                pool.append(
+                    _SpreadCandidate(
+                        layout=candidate_layout,
+                        min_gap=min_gap,
+                        energy=energy,
+                        restart_index=restart_index,
+                    )
+                )
+                break  # restart to seek a different basin
+```
+
+Delete the now-removed early-exit `if len(accepted_layouts) >= alternatives: break` (`solver.py:263`). The loop now exits only on budget / `max_restarts`.
+
+After the loop, replace the result-assembly (`solver.py:266-337`). Select, then build the result:
+
+```python
+    elapsed = time.monotonic() - start
+
+    selected, diversity_rejected_count = _select_spread_diverse(pool, alternatives, diversity)
+
+    if selected:
+        accepted_layouts = [c.layout for c in selected]
+        min_gaps = tuple(c.min_gap for c in selected)
+        status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
+        plans: tuple[MovesPlan | None, ...]
+        unroutable: list[str] = []
+        if plan_paths:
+            built: list[MovesPlan | None] = []
+            for layout in accepted_layouts:
+                try:
+                    built.append(plan_fill(layout))
+                except NoFeasiblePlanError as e:
+                    built.append(None)
+                    unroutable.append(e.plane_id)
+                    _logger.warning(
+                        "layout not tow-routable by the v1 planner: plane %r blocked "
+                        "(%s: %s); returning the valid static layout without a tow plan",
+                        e.plane_id,
+                        e.conflict.kind,
+                        e.conflict.detail,
+                    )
+            plans = tuple(built)
+        else:
+            plans = (None,) * len(accepted_layouts)
+        return SolveResult(
+            status=status,
+            layouts=tuple(accepted_layouts),
+            plans=plans,
+            diagnostics=SolverDiagnostics(
+                restarts_attempted=restart_index,
+                wall_time_s=elapsed,
+                best_partial=None,
+                best_partial_layout=None,
+                seed=resolved_seed,
+                diversity_impossible=diversity_impossible,
+                diversity_rejected_count=diversity_rejected_count,
+                unroutable_planes=tuple(unroutable),
+                min_pairwise_gap_m=min_gaps,
+                valid_basins_found=len(pool),
+            ),
+        )
+    bp = check_layout(best_partial_layout) if best_partial_layout is not None else None
+    return SolveResult(
+        status="exhausted_budget",
+        layouts=(),
+        diagnostics=SolverDiagnostics(
+            restarts_attempted=restart_index,
+            wall_time_s=elapsed,
+            best_partial=bp,
+            best_partial_layout=best_partial_layout,
+            seed=resolved_seed,
+            diversity_impossible=diversity_impossible,
+            diversity_rejected_count=diversity_rejected_count,
+            valid_basins_found=len(pool),
+        ),
+    )
+```
+
+Update `solve()`'s docstring (`solver.py:53-69`) to note: returns the best-spread valid layout(s) found across all restarts within budget (best-of-all-basins, #267), not the first valid one.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_solver_spread.py -q`
+Expected: PASS (all). Then the full default solver suite to catch regressions in diversity/alternatives behavior:
+Run: `pytest tests/ -q -k solver`
+Expected: PASS. **If a K>1 test asserts discovery-order layout sequence, update it** — layouts are now best-spread-first (documented behavior change). Inspect any failure before editing the test; do not weaken a real assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_spread.py
+git commit -m "feat(solver): best-of-all-basins spread selection in solve() (#267)
+
+Replaces first-valid-basin-then-break with a collect-then-select pool: run
+restarts to budget, record every valid spread-polished basin, then select K
+by maximin gap subject to the diversity gate. Surfaces min_pairwise_gap_m and
+valid_basins_found in diagnostics. Returned layouts are now best-spread-first.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Surface min-gap in the human CLI
+
+**Files:**
+- Modify: `src/hangarfit/cli.py` (`_emit_solve_human` `cli.py:247-258`)
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cli.py` (follow the existing CLI invocation pattern in that file — capture stdout from a `solve` run on `tests/fixtures/solve_trivial_single_plane.yaml` and a multi-plane fixture):
+
+```python
+def test_solve_human_output_shows_min_gap(capsys):
+    from hangarfit.cli import main
+
+    rc = main(["solve", "tests/fixtures/solve_fresh_six_planes.yaml",
+               "--seed", "7", "--budget", "5"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "min gap" in out  # per-layout spread quality line
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cli.py -q -k min_gap`
+Expected: FAIL — `assert "min gap" in out`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `_emit_solve_human`, modify the per-layout loop (`cli.py:247-258`) to append a min-gap suffix. Replace the loop body with:
+
+```python
+    for i, layout in enumerate(result.layouts, start=1):
+        gap = d.min_pairwise_gap_m[i - 1] if i - 1 < len(d.min_pairwise_gap_m) else math.inf
+        gap_str = f"{gap:.2f} m" if math.isfinite(gap) else "n/a (single plane)"
+        if i > 1:
+            parts = []
+            for j in range(i - 1):
+                moved, avg_shift = _placement_delta(result.layouts[j], layout)
+                total = len(layout.placements)
+                parts.append(
+                    f"{moved} of {total} planes shifted vs #{j + 1} (avg shift {avg_shift:.1f} m)"
+                )
+            line = f"  #{i}: {'; '.join(parts)}; min gap {gap_str}"
+        else:
+            line = (
+                f"  #{i}: {len(layout.placements)} planes placed; 0 conflicts; "
+                f"score=(0, 0.0); min gap {gap_str}"
+            )
+        print(line)
+```
+
+Ensure `import math` is present at the top of `cli.py` (add if absent).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_cli.py -q -k min_gap`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/cli.py tests/test_cli.py
+git commit -m "feat(cli): show achieved min gap per layout in solve summary (#267)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Surface min-gap + basin count in `--json`
+
+**Files:**
+- Modify: `src/hangarfit/cli.py` (`_emit_solve_json` `cli.py:572-588`)
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cli.py`:
+
+```python
+def test_solve_json_output_has_spread_diagnostics(capsys):
+    import json
+    from hangarfit.cli import main
+
+    rc = main(["solve", "tests/fixtures/solve_fresh_six_planes.yaml",
+               "--seed", "7", "--budget", "5", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    diag = payload["diagnostics"]
+    assert "min_pairwise_gap_m" in diag
+    assert "valid_basins_found" in diag
+    assert len(diag["min_pairwise_gap_m"]) == len(payload["layouts"])
+    # finite floats stay numbers; single-plane inf becomes null
+    assert all(g is None or isinstance(g, (int, float)) for g in diag["min_pairwise_gap_m"])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cli.py -q -k json_output_has_spread`
+Expected: FAIL — `KeyError`/`assert "min_pairwise_gap_m" in diag`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `_emit_solve_json`, add to the `"diagnostics"` dict after `"unroutable_planes"` (`cli.py:587`). `json.dumps` cannot emit `Infinity` as valid JSON, so map non-finite gaps to `null`:
+
+```python
+            # Additive (#267): achieved min plan-view gap per returned layout
+            # (null where <2 planes, i.e. math.inf) + basins the search had to
+            # choose from. Backward-compatible — no schema bump.
+            "min_pairwise_gap_m": [
+                g if math.isfinite(g) else None for g in d.min_pairwise_gap_m
+            ],
+            "valid_basins_found": d.valid_basins_found,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_cli.py -q -k json_output_has_spread`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/cli.py tests/test_cli.py
+git commit -m "feat(cli): add min_pairwise_gap_m + valid_basins_found to solve --json (#267)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `@slow` deep seed sweep
+
+**Files:**
+- Test: `tests/test_solver_spread.py`
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/test_solver_spread.py`:
+
+```python
+import pytest
+
+
+@pytest.mark.slow
+def test_no_seed_emits_nested_pair_over_sweep():
+    """Deep confidence: across seeds 1-30, the best-of-all selection returns a
+    layout with no nested pair (min gap > 0). Excluded from the default run
+    (slow); the pure _select_spread_diverse tests are the fast regression."""
+    scenario = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    cfg = SearchConfig(max_restarts=40)
+    offenders = []
+    for seed in range(1, 31):
+        r = solve(scenario, seed=seed, search=cfg, plan_paths=False)
+        if r.status in ("found", "found_partial"):
+            worst = min(r.diagnostics.min_pairwise_gap_m, default=math.inf)
+            if worst <= 0.0:
+                offenders.append((seed, worst))
+    assert not offenders, f"seeds still emitting a nested pair: {offenders}"
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pytest tests/test_solver_spread.py -q -m slow -k nested_pair`
+Expected: PASS. If it FAILS for some seeds, raise `max_restarts` (the pool needs at least one non-nested basin per seed) before adjusting the threshold; record findings in the PR. If it PASSES even with `max_restarts=1`, note that `solve_fresh_six_planes.yaml` does not reproduce the pathology — the pure-unit test remains the true regression; consider a tighter fixture as a follow-up.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_solver_spread.py
+git commit -m "test(solver): @slow seed-sweep confidence for spread robustness (#267)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Docs — ADR-0008 addendum
+
+**Files:**
+- Modify: `docs/adr/0008-inter-plane-spread-soft-preference.md`
+
+- [ ] **Step 1: Add the addendum**
+
+Append a section to the ADR:
+
+```markdown
+## Addendum (2026-05, #267): best-of-all-basins selection
+
+ADR-0008's `_spread` post-pass is a greedy single-plane hill-climb that polishes
+only the basin handed to it. Because `solve()` originally accepted the *first*
+valid basin, spread quality was seed-luck: ~1/3 of seeds settled with a nested
+pair (0.0 m plan-view gap) the single-plane climb could not escape.
+
+The solver now runs all restarts within budget, records every valid
+spread-polished basin, and **selects** the layout(s) with the largest minimum
+plan-view gap (energy tiebreak), subject to the existing diversity gate
+(ADR-0004). `_spread` itself is unchanged — the robustness comes from choosing
+among basins rather than from a smarter climb. Determinism (ADR-0003) is
+preserved: same single RNG, restart-ordered pool, total selection ordering.
+The achieved min gap is reported in `SolverDiagnostics.min_pairwise_gap_m`, the
+CLI summary, and `--json`. Returned alternatives are now ordered best-spread-first.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/adr/0008-inter-plane-spread-soft-preference.md
+git commit -m "docs(adr): ADR-0008 addendum — best-of-all-basins spread selection (#267)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Full verification + PR
+
+- [ ] **Step 1: Run the whole default suite + lint + types**
+
+```bash
+pytest -q
+ruff check src/ tests/
+ruff format --check src/ tests/
+mypy src/hangarfit
+```
+Expected: all green. Fix any finding at the source (the lockfile guard / hooks are active).
+
+- [ ] **Step 2: Run the slow set once**
+
+```bash
+pytest -q -m slow
+```
+Expected: PASS (includes the seed sweep).
+
+- [ ] **Step 3: Manual smoke (observe the new output)**
+
+```bash
+hangarfit solve tests/fixtures/solve_fresh_six_planes.yaml --seed 7 --budget 5
+hangarfit solve tests/fixtures/solve_fresh_six_planes.yaml --seed 7 --budget 5 --json
+```
+Expected: human summary shows `min gap N.NN m` per layout; JSON `diagnostics` has `min_pairwise_gap_m` + `valid_basins_found`.
+
+- [ ] **Step 4: Push + open PR**
+
+```bash
+git push -u origin feature/267-solver-spread-robustness
+gh pr create --base develop \
+  --title "feat(solver): best-of-all-basins spread selection (#267)" \
+  --body-file <(printf '%s\n' "Closes #267" "" "Best-of-all-basins spread selection — see docs/superpowers/specs/2026-05-27-solver-spread-robustness-design.md.") \
+  --assignee DocGerd --label enhancement --milestone "Phase 2c — Solver polish"
+```
+
+- [ ] **Step 5: Review per CLAUDE.md**
+
+Run `/pr-review` (code-reviewer + type-design-analyzer since `models.py` changed; **geometry-invariant-guard is NOT required** — no `geometry.py`/`collisions.py` change). Convert findings to diff threads, resolve each, confirm CI green, hand off to the user for final review/merge. Do not merge.
+
+---
+
+## Self-review notes (filled by plan author)
+
+- **Spec coverage:** pool model (T4) · maximin+energy+restart_index selection (T2) · `_spread_quality` min-gap/inf (T1) · diagnostics fields + semantics shift (T3) · CLI human (T5) + JSON inf→null (T6) · determinism (T4 test) · pure-unit primary regression (T2) + wiring integration (T4) + `@slow` sweep (T7) · ADR addendum (T8). All spec sections map to a task.
+- **Behavior changes flagged:** full-budget on every solve incl. `--no-spread` (T4 note); best-spread-first ordering for K>1 (T4 Step 4 test-update guard).
+- **Type consistency:** `_SpreadCandidate(layout, min_gap, energy, restart_index)` used identically in T2 and T4; `_select_spread_diverse -> (list, int)` consumed as `selected, diversity_rejected_count` in T4; `_spread_quality -> (min_gap, energy)` consumed in T1 test and T4 wiring; `min_pairwise_gap_m: tuple[float, ...]` set in T4, read in T5/T6.
+- **No placeholders:** every code/test step shows real code; commands have expected output.

--- a/docs/superpowers/specs/2026-05-27-solver-spread-robustness-design.md
+++ b/docs/superpowers/specs/2026-05-27-solver-spread-robustness-design.md
@@ -1,0 +1,150 @@
+# Solver spread robustness — best-of-all-basins selection
+
+**Issue:** #267 — *solver: spread post-pass is seed-fragile — ~1/3 of seeds emit a nested-pair layout*
+**Milestone:** Phase 2c — Solver polish
+**Status:** Design approved (brainstorming), pending implementation plan
+**Date:** 2026-05-27
+
+---
+
+## Problem
+
+`solve()` returns, for `alternatives=1`, the **first** valid basin its restart loop
+lands in (`solver.py:194-232`): it finds a valid layout, runs the `_spread`
+post-pass on it, accepts, and breaks the outer restart loop (`solver.py:263`).
+`_spread` (`solver.py:599-717`) is a greedy single-plane hill-climb on
+`_inter_plane_energy` (`Σ exp(−gap/scale)`, a smooth maximin surrogate). It can
+only polish *whichever* basin the restart handed it — a validity-preserving
+single-plane nudge cannot cross the validity barrier out of a nested pair (a low
+fuselage legally tucked under a high wing, min plan-view gap 0.0 m).
+
+Consequence: spread quality is decided by which basin the loop happened to reach
+first, i.e. by the seed. A seed sweep on a representative 5-plane fill showed
+~1/3 of seeds settle with a nested pair (min gap 0.0 m) while the rest spread to
+1.7–2.5 m — same scenario, same fleet, same hangar, only the restart seed differs.
+The layouts are **genuinely valid** (height-aware collision model permits the
+nesting); this is a **spread-quality / robustness** gap, not a correctness bug.
+
+This is orthogonal to milestone #23 (towplanner v2): #23 lives in `towplanner.py`
+and addresses tow-routability of tight layouts; it does nothing for the solver
+inconsistently emitting the well-spread layout it is already capable of producing.
+
+## Locked decisions
+
+| Axis | Decision |
+|---|---|
+| **Cost model** | Full budget, best-of-all. `alternatives=1` now uses the whole `budget_s` / `max_restarts` to find the best-spread valid layout (accepted wall-clock change for the common case; layout quality > latency for an on-demand exception tool). |
+| **Selection metric** | Maximin gap, energy tiebreak. Primary key = maximize the minimum pairwise plan-view gap (the acceptance metric); near-ties broken by lower `_inter_plane_energy`. |
+| **Scope** | All alternatives (K>1 too) — unified collect-then-select pool. |
+| **Diagnostic** | Surface achieved min-gap in `SolverDiagnostics` + human CLI + `--json`. |
+
+## Approach: collect-then-select pool
+
+Chosen over two alternatives:
+
+- **Sub-seed wrapper** (run `solve()` N times with `seed, seed+1, …`, keep best):
+  re-runs infeasibility checks, needs sub-seed plumbing, N is arbitrary. Rejected.
+- **Incremental best-tracking** (running best across restarts): works for K=1 but
+  tangles with the K>1 diversity gate. Rejected once scope = all alternatives.
+
+The **pool model** unifies both. The restart loop already produces a multi-restart
+trajectory from one rng; we stop discarding it. K=1 is just the K=1 case of the
+same selection.
+
+### Data flow
+
+1. **Restart loop** (`solver.py:155-264`): remove the early break on first
+   valid-accept and on `len(accepted) >= alternatives`. The loop runs to
+   `budget_s` / `max_restarts`. Each time a restart's descent reaches a valid
+   layout (`score == (0, 0.0)`), run `_spread` as today, compute
+   `(min_gap, energy)`, append a pool entry
+   `(layout, min_gap, energy, restart_index)`, and restart — instead of
+   accept-and-stop.
+2. **Selection** (new `_select_spread_diverse`): sort the pool by
+   `(−min_gap, energy, restart_index)` — best maximin gap first, energy tiebreak,
+   `restart_index` as the deterministic final key. Greedily pick entries that pass
+   `_is_diverse_enough` against those already picked, until `alternatives` chosen.
+   K=1 trivially picks the top-spread basin (diversity vacuously true on the empty
+   accepted set). **Behavior change for K>1:** returned `layouts` are now ordered
+   best-spread-first (sorted), not discovery-order — beneficial (`layouts[0]` is the
+   roomiest), but the plan must check existing K>1 tests that may assume
+   discovery-order.
+3. **Status** (meaning unchanged): `found` (K selected) / `found_partial`
+   (0 < n < K) / `exhausted_budget` (empty pool — no valid basin found).
+   `best_partial` tracking for the exhausted case is unchanged. Tow-planning runs
+   on the selected K, unchanged (RNG-free, best-effort `plans[i]=None` per #197).
+
+## Components & touch-points
+
+- **`_spread_quality(placements, scenario, scale) -> tuple[float, float]`** *(new)* —
+  returns `(min_gap, energy)` in one pass over plane-pairs, sharing the shapely
+  world-parts distance logic with `_inter_plane_energy` (`solver.py:569-596`).
+  `min_gap = math.inf` for <2 planes.
+- **`_select_spread_diverse(pool, alternatives, diversity) -> list[...]`** *(new)* —
+  pure, deterministic selection; unit-testable in isolation with no solving.
+- **`solve()`** (`solver.py:43-337`) — restart loop restructured to build the pool
+  and call selection; assemble `layouts` + aligned `min_pairwise_gap_m`.
+- **`SolverDiagnostics`** (`models.py:653-707`) — add:
+  - `min_pairwise_gap_m: tuple[float, ...] = ()` — index-aligned with `layouts`;
+    achieved min plan-view gap per returned layout (`math.inf` for <2 planes,
+    surfaced as `null` in JSON / "n/a" in human text).
+  - `valid_basins_found: int = 0` — pool size; shows how much choice best-of-all
+    had.
+  - `diversity_rejected_count` keeps its field; **semantics shift** to "pool
+    entries examined and rejected by the diversity gate during selection." Stays
+    `0` for K=1 (selection breaks after the first, vacuous pick). Documented on the
+    field.
+- **CLI** — `_emit_solve_human` (`cli.py:209`) adds a per-layout min-gap line;
+  `_emit_solve_json` (`cli.py:564-590`) adds `min_pairwise_gap_m` +
+  `valid_basins_found` to the diagnostics dict.
+
+## Determinism (ADR-0003)
+
+Preserved by construction: the same single `rng`, same restart order, pool built in
+restart order, and a fully-ordered selection sort (`restart_index` is the final
+tiebreak so no two entries compare equal). Tow-planning is RNG-free. Same seed →
+byte-identical output. The bounded-`max_restarts` path stays the cross-machine
+deterministic canary it already is.
+
+## Testing strategy
+
+Correctness is pushed into pure functions so the default suite stays fast and the
+core guarantee is non-flaky.
+
+- **Pure unit (primary regression, instant, non-flaky):**
+  - `_select_spread_diverse` — a hand-built pool with a nested entry
+    (`min_gap=0.0`) and a spread entry (`min_gap=2.0`): assert the spread entry
+    wins. This directly encodes "a nested basin never wins" without depending on
+    the RNG ever producing one. Also: diversity enforcement, K-partial selection,
+    empty pool, deterministic tiebreak (energy then `restart_index`).
+  - `_spread_quality` — min-gap math on hand-placed layouts; `<2 planes → inf`.
+- **Integration (default suite, ~seconds — proves wiring):** a 2–3-plane
+  nested-prone fixture under `tests/fixtures/` (one low-fuselage + one high-wing in
+  a roomy hangar, reproducing the nesting pathology), bounded `max_restarts`
+  (~15–25, deterministic, sub-second/solve), seeds `{3, 7, 8, 9}` (issue-flagged
+  nesters); assert `min_pairwise_gap_m ≥ 0.5` for each. (0.5 m is the issue's
+  `pairs<0.5m` nested-pair indicator.) Confirms the loop builds the pool, selection
+  is invoked, and diagnostics align.
+- **`@slow` (on demand / nightly, excluded by default per `pyproject.toml`):** full
+  seeds 1–30 sweep on the larger fixture asserting the threshold for every seed —
+  deep confidence without taxing the default run.
+
+The issue cited `scenarios/demo_5planes.yaml`, which was an ad-hoc demo file (never
+committed); the plan adds a committed `tests/fixtures/` equivalent instead.
+
+## Out of scope (YAGNI)
+
+- No new `SearchConfig` knob (full-budget best-of-all reuses `budget_s` /
+  `max_restarts`).
+- No change to `_spread`'s internals, `_inter_plane_energy`, the `_score` tuple, or
+  the diversity thresholds.
+
+## Docs
+
+- **ADR-0008** (inter-plane spread soft preference) gets an addendum: the post-pass
+  is now applied across *all* valid basins found within budget, with best-maximin-gap
+  selection (subject to the diversity gate), rather than to the single first-found
+  basin. The greedy single-basin `_spread` itself is unchanged; the robustness comes
+  from selecting among basins.
+- The solver spec section referenced by `_spread` / the restart loop is updated to
+  describe the pool + selection.

--- a/docs/superpowers/specs/2026-05-27-solver-spread-robustness-design.md
+++ b/docs/superpowers/specs/2026-05-27-solver-spread-robustness-design.md
@@ -100,11 +100,25 @@ same selection.
 
 ## Determinism (ADR-0003)
 
-Preserved by construction: the same single `rng`, same restart order, pool built in
-restart order, and a fully-ordered selection sort (`restart_index` is the final
-tiebreak so no two entries compare equal). Tow-planning is RNG-free. Same seed →
-byte-identical output. The bounded-`max_restarts` path stays the cross-machine
-deterministic canary it already is.
+Partially preserved — the scope depends on the termination gate:
+
+- **`max_restarts`-bounded:** fully reproducible across runs and machines. The
+  same single `rng`, same restart order, pool built in restart order, and a
+  fully-ordered selection sort (`restart_index` is the final tiebreak so no two
+  entries compare equal). Tow-planning is RNG-free. Same seed + same
+  `max_restarts` → byte-identical output. The canary tests in
+  `tests/test_solver_canaries.py` use this path and remain the
+  cross-machine determinism canaries.
+- **Pure wall-clock `budget_s`-bounded:** the number of restarts that complete
+  before the timer fires depends on machine speed and load. Pool size therefore
+  varies between machines (or runs under different load). When two basins are
+  near-tied on maximin gap the selected layout can differ — same seed does NOT
+  guarantee byte-identical output across machines in this mode.
+
+The default CLI path uses `budget_s` for responsiveness. This timing-dependence
+is an accepted tradeoff; see the ADR-0003 amendment dated 2026-05-27 for the
+full rationale. For guaranteed cross-machine reproducibility, bound by
+`max_restarts`.
 
 ## Testing strategy
 

--- a/docs/superpowers/specs/2026-05-27-solver-spread-robustness-design.md
+++ b/docs/superpowers/specs/2026-05-27-solver-spread-robustness-design.md
@@ -33,7 +33,7 @@ inconsistently emitting the well-spread layout it is already capable of producin
 
 | Axis | Decision |
 |---|---|
-| **Cost model** | Full budget, best-of-all. `alternatives=1` now uses the whole `budget_s` / `max_restarts` to find the best-spread valid layout (accepted wall-clock change for the common case; layout quality > latency for an on-demand exception tool). |
+| **Cost model** | Full budget, best-of-all — **when spread is enabled.** `alternatives=1` now uses the whole `budget_s` / `max_restarts` to find the best-spread valid layout (accepted wall-clock change for the common case; layout quality > latency for an on-demand exception tool). With `spread=False` there is nothing to optimize, so the loop keeps the pre-#267 first-valid early exit (the `--no-spread` fast path). |
 | **Selection metric** | Maximin gap, energy tiebreak. Primary key = maximize the minimum pairwise plan-view gap (the acceptance metric); near-ties broken by lower `_inter_plane_energy`. |
 | **Scope** | All alternatives (K>1 too) — unified collect-then-select pool. |
 | **Diagnostic** | Surface achieved min-gap in `SolverDiagnostics` + human CLI + `--json`. |
@@ -54,10 +54,13 @@ same selection.
 ### Data flow
 
 1. **Restart loop** (`solver.py:155-264`): remove the early break on first
-   valid-accept and on `len(accepted) >= alternatives`. The loop runs to
-   `budget_s` / `max_restarts`. Each time a restart's descent reaches a valid
-   layout (`score == (0, 0.0)`), run `_spread` as today, compute
-   `(min_gap, energy)`, append a pool entry
+   valid-accept and on `len(accepted) >= alternatives` **when spread is
+   enabled**; with spread disabled the loop keeps the first-valid early exit
+   (stops once `alternatives` diverse valid layouts are found — best-of-all is a
+   spread-quality feature and adds nothing when there is no separation to
+   optimize). On the spread-ON path the loop runs to `budget_s` / `max_restarts`.
+   Each time a restart's descent reaches a valid layout (`score == (0, 0.0)`),
+   run `_spread` as today, compute `(min_gap, energy)`, append a pool entry
    `(layout, min_gap, energy, restart_index)`, and restart — instead of
    accept-and-stop.
 2. **Selection** (new `_select_spread_diverse`): sort the pool by
@@ -109,11 +112,14 @@ Partially preserved — the scope depends on the termination gate:
   `max_restarts` → byte-identical output. The canary tests in
   `tests/test_solver_canaries.py` use this path and remain the
   cross-machine determinism canaries.
-- **Pure wall-clock `budget_s`-bounded:** the number of restarts that complete
-  before the timer fires depends on machine speed and load. Pool size therefore
-  varies between machines (or runs under different load). When two basins are
-  near-tied on maximin gap the selected layout can differ — same seed does NOT
-  guarantee byte-identical output across machines in this mode.
+- **Pure wall-clock `budget_s`-bounded (spread ON):** the number of restarts that
+  complete before the timer fires depends on machine speed and load. Pool size
+  therefore varies between machines (or runs under different load). When two
+  basins are near-tied on maximin gap the selected layout can differ — same seed
+  does NOT guarantee byte-identical output across machines in this mode. This
+  timing-dependence applies **only with spread enabled**: with `spread=False`
+  the loop keeps the first-valid early exit and terminates at a seed-deterministic
+  restart regardless of wall-clock, so it stays reproducible across machines.
 
 The default CLI path uses `budget_s` for responsiveness. This timing-dependence
 is an accepted tradeoff; see the ADR-0003 amendment dated 2026-05-27 for the

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from typing import TYPE_CHECKING
 
@@ -245,7 +246,8 @@ def _emit_solve_human(result: SolveResult, *, alternatives: int) -> None:
             f"{d.wall_time_s:.1f}s (seed={d.seed}, {d.restarts_attempted} restarts)."
         )
     for i, layout in enumerate(result.layouts, start=1):
-        line = f"  #{i}: {len(layout.placements)} planes placed; 0 conflicts; score=(0, 0.0)"
+        gap = d.min_pairwise_gap_m[i - 1] if i - 1 < len(d.min_pairwise_gap_m) else math.inf
+        gap_str = f"{gap:.2f} m" if math.isfinite(gap) else "n/a (single plane)"
         if i > 1:
             parts = []
             for j in range(i - 1):
@@ -254,7 +256,12 @@ def _emit_solve_human(result: SolveResult, *, alternatives: int) -> None:
                 parts.append(
                     f"{moved} of {total} planes shifted vs #{j + 1} (avg shift {avg_shift:.1f} m)"
                 )
-            line = f"  #{i}: {'; '.join(parts)}"
+            line = f"  #{i}: {'; '.join(parts)}; min gap {gap_str}"
+        else:
+            line = (
+                f"  #{i}: {len(layout.placements)} planes placed; 0 conflicts; "
+                f"score=(0, 0.0); min gap {gap_str}"
+            )
         print(line)
 
 

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -592,6 +592,11 @@ def _emit_solve_json(scenario_path: str, result: SolveResult) -> None:
             # route, in returned-layout order. Empty unless --render-paths ran
             # the planner. Backward-compatible — no schema bump.
             "unroutable_planes": list(d.unroutable_planes),
+            # Additive (#267): achieved min plan-view gap per returned layout
+            # (null where <2 planes, i.e. math.inf) + basins the search had to
+            # choose from. Backward-compatible — no schema bump.
+            "min_pairwise_gap_m": [g if math.isfinite(g) else None for g in d.min_pairwise_gap_m],
+            "valid_basins_found": d.valid_basins_found,
         },
     }
     print(json.dumps(payload, indent=2))

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -88,7 +88,13 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         metavar="S",
-        help="RNG seed (default: None -> resolved from system entropy).",
+        help=(
+            "RNG seed (default: None -> resolved from system entropy). "
+            "Under a wall-clock --budget, results are reproducible on the same "
+            "machine but not guaranteed identical across machines, because the "
+            "best-of-all basin selection (#267) depends on how many restarts "
+            "fit the budget."
+        ),
     )
     solve.add_argument(
         "--render",

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -670,11 +670,14 @@ class SolverDiagnostics:
     warning as a structured, machine-readable signal so callers don't
     have to scrape log records.
 
-    ``diversity_rejected_count`` is the number of valid layouts the
-    diversity filter rejected during the run. ``0`` is the healthy
-    default; a non-zero value means search produced more valid layouts
-    than the K-diversity gate accepted (informative when K>1 returns
-    ``found_partial``).
+    ``diversity_rejected_count`` is the number of pool candidates the
+    diversity gate turned away during best-of-all selection (#267) —
+    examined in best-spread order until ``alternatives`` were chosen, so
+    candidates beyond the quota are never examined or counted. ``0`` is
+    the healthy default and is always the value for ``alternatives == 1``
+    (selection stops after the first, vacuous pick). When ``K>1`` returns
+    ``found_partial`` a non-zero value shows the diversity gate turned
+    away otherwise-valid basins.
 
     ``diversity_impossible`` and ``diversity_rejected_count`` are
     **advisory**: structured mirrors of log warnings / search
@@ -739,6 +742,11 @@ class SolverDiagnostics:
             raise ValueError(
                 f"SolverDiagnostics.valid_basins_found must be >= 0, got {self.valid_basins_found}"
             )
+        if any(math.isnan(g) or g < 0.0 for g in self.min_pairwise_gap_m):
+            raise ValueError(
+                "SolverDiagnostics.min_pairwise_gap_m entries must be non-negative "
+                f"(math.inf allowed for <2-plane layouts), got {self.min_pairwise_gap_m!r}"
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -786,6 +794,14 @@ class SolveResult:
             raise ValueError(
                 f"SolveResult.plans length ({len(self.plans)}) must equal "
                 f"layouts length ({len(self.layouts)}) (status={self.status!r})"
+            )
+        if self.diagnostics.min_pairwise_gap_m and len(self.diagnostics.min_pairwise_gap_m) != len(
+            self.layouts
+        ):
+            raise ValueError(
+                "SolveResult.diagnostics.min_pairwise_gap_m, when populated, must be "
+                f"index-aligned with layouts: got {len(self.diagnostics.min_pairwise_gap_m)} "
+                f"gaps for {len(self.layouts)} layouts"
             )
 
 

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -695,6 +695,14 @@ class SolverDiagnostics:
     (Dubins-only + bounded Hybrid-A* — #222 under ADR-0007) has documented
     false-negatives, so an un-routable layout is still a valid static
     arrangement — the entry flags a planning gap, not an invalid layout.
+
+    ``min_pairwise_gap_m`` is index-aligned with :attr:`SolveResult.layouts`:
+    the achieved minimum plan-view gap (m) between any two planes in that
+    returned layout — the quality the best-of-all-basins spread selection
+    maximizes (#267, ADR-0008). ``math.inf`` for a layout with <2 planes
+    (no pairs). ``valid_basins_found`` is the number of valid spread-polished
+    basins the search collected before selection — how much choice best-of-all
+    had. Both are advisory.
     """
 
     restarts_attempted: int
@@ -705,6 +713,8 @@ class SolverDiagnostics:
     diversity_impossible: bool = False
     diversity_rejected_count: int = 0
     unroutable_planes: tuple[str, ...] = ()
+    min_pairwise_gap_m: tuple[float, ...] = ()
+    valid_basins_found: int = 0
 
     def __post_init__(self) -> None:
         if (self.best_partial is None) != (self.best_partial_layout is None):
@@ -724,6 +734,10 @@ class SolverDiagnostics:
             raise ValueError(
                 f"SolverDiagnostics.diversity_rejected_count must be >= 0, "
                 f"got {self.diversity_rejected_count}"
+            )
+        if self.valid_basins_found < 0:
+            raise ValueError(
+                f"SolverDiagnostics.valid_basins_found must be >= 0, got {self.valid_basins_found}"
             )
 
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -59,7 +59,8 @@ def solve(
     within budget (best-of-all-basins, #267) — NOT the first valid one. The
     restart loop always runs to ``budget_s`` / ``search.max_restarts`` (no
     break-on-first-valid, including under ``search.spread=False``), recording
-    every valid (spread-polished) basin into a pool; the returned layouts are
+    every valid basin (spread-polished when ``search.spread=True``, measured
+    as-found otherwise) into a pool; the returned layouts are
     then chosen from that pool by maximin plan-view gap subject to the
     diversity gate (ADR-0004). Consequently the returned ``alternatives`` are
     ordered **best-spread-first**, not in discovery order, and
@@ -162,8 +163,8 @@ def solve(
     #      SearchConfig field (spec §4.2). `None` preserves the
     #      pre-v0.6.0 wall-clock-only behavior. Useful for
     #      cross-machine-deterministic exhaustion canaries.
-    # Inside the loop, the K-diverse termination at the bottom is the
-    # third gate ("found enough alternatives") — independent of these.
+    # Selection of the K best basins happens after the loop completes;
+    # the loop itself runs only to budget / max_restarts.
     while time.monotonic() - start < budget_s and (
         search.max_restarts is None or restart_index < search.max_restarts
     ):

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -57,13 +57,16 @@ def solve(
 
     Returns the **best-spread** valid layout(s) found across *all* restarts
     within budget (best-of-all-basins, #267) — NOT the first valid one. The
-    restart loop always runs to ``budget_s`` / ``search.max_restarts`` (no
-    break-on-first-valid, including under ``search.spread=False``), recording
-    every valid basin (spread-polished when ``search.spread=True``, measured
-    as-found otherwise) into a pool; the returned layouts are
-    then chosen from that pool by maximin plan-view gap subject to the
-    diversity gate (ADR-0004). Consequently the returned ``alternatives`` are
-    ordered **best-spread-first**, not in discovery order, and
+    restart loop runs to ``budget_s`` / ``search.max_restarts`` only when
+    ``search.spread`` is enabled (the default); recording every valid basin
+    (spread-polished) into a pool, the returned layouts are then chosen from
+    that pool by maximin plan-view gap subject to the diversity gate
+    (ADR-0004). With ``search.spread=False`` there is nothing to optimize, so
+    the loop keeps the pre-#267 first-valid early exit — it stops as soon as
+    ``alternatives`` diverse valid layouts have been found (a seed-deterministic
+    termination, independent of wall-clock; preserves the ``--no-spread`` fast
+    path). Consequently the returned ``alternatives`` are ordered
+    **best-spread-first**, not in discovery order, and
     ``diagnostics.min_pairwise_gap_m`` / ``diagnostics.valid_basins_found``
     surface the selected gaps and the size of the explored basin pool.
 
@@ -263,6 +266,18 @@ def solve(
                 break  # stall — restart
 
         restart_index += 1
+
+        # Best-of-all-basins selection (#267) only adds value when the spread
+        # post-pass can reorder basins by separation quality. With spread
+        # disabled there is nothing to optimize, so continuing past
+        # `alternatives` diverse valid layouts cannot improve the result —
+        # restore the pre-#267 early exit. This keeps the `--no-spread` fast
+        # path (the speed escape hatch) and gives a seed-deterministic
+        # termination for that mode (independent of wall-clock).
+        if not search.spread:
+            selected_so_far, _ = _select_spread_diverse(pool, alternatives, diversity)
+            if len(selected_so_far) >= alternatives:
+                break
 
     elapsed = time.monotonic() - start
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -596,6 +596,48 @@ def _inter_plane_energy(
     return energy
 
 
+def _resolve_spread_scale(scenario: Scenario, search: SearchConfig) -> float:
+    """Repulsion length-scale for spread (spec §4): explicit override or
+    20% of the smaller hangar dimension. Single source so ``_spread`` and
+    ``_spread_quality`` always agree."""
+    if search.spread_scale_m is not None:
+        return search.spread_scale_m
+    return 0.2 * min(scenario.hangar.width_m, scenario.hangar.length_m)
+
+
+def _spread_quality(
+    placements: dict[str, Placement],
+    scenario: Scenario,
+    scale: float,
+) -> tuple[float, float]:
+    """Return ``(min_gap, energy)`` for a layout in one pass over plane-pairs.
+
+    ``min_gap`` is the minimum plan-view edge-to-edge distance between any two
+    planes' world parts (``math.inf`` when <2 planes — no pairs). ``energy``
+    is the same ``Σ exp(−gap/scale)`` repulsion :func:`_inter_plane_energy`
+    computes; returning both from one pairwise sweep avoids paying the
+    (expensive) shapely distances twice when scoring a candidate basin. The
+    hot ``_spread`` loop keeps using the energy-only :func:`_inter_plane_energy`
+    — this is called once per accepted basin, not per perturbation.
+    """
+    ids = sorted(placements)
+    if len(ids) < 2:
+        return (math.inf, 0.0)
+    world: dict[str, list[WorldPart]] = {
+        pid: aircraft_parts_world(scenario.fleet[pid], placements[pid]) for pid in ids
+    }
+    min_gap = math.inf
+    energy = 0.0
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            gap = min(
+                pa.polygon.distance(pb.polygon) for pa in world[ids[i]] for pb in world[ids[j]]
+            )
+            min_gap = min(min_gap, gap)
+            energy += math.exp(-gap / scale)
+    return (min_gap, energy)
+
+
 def _spread(
     placements: dict[str, Placement],
     scenario: Scenario,
@@ -617,11 +659,7 @@ def _spread(
 
     See ADR-0008 and spec §5.
     """
-    scale = (
-        search.spread_scale_m
-        if search.spread_scale_m is not None
-        else 0.2 * min(scenario.hangar.width_m, scenario.hangar.length_m)
-    )
+    scale = _resolve_spread_scale(scenario, search)
 
     movable = sorted(pid for pid in placements if pid not in pinned_planes)
     if not movable or len(placements) < 2:

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -19,6 +19,7 @@ import random as _random_module
 import secrets
 import sys
 import time
+from typing import NamedTuple
 
 from hangarfit.collisions import check as check_layout
 from hangarfit.geometry import WorldPart, aircraft_parts_world
@@ -1105,6 +1106,46 @@ def _heading_delta_short_arc(a: float, b: float) -> float:
     """
     d = abs(a - b) % 360.0
     return min(d, 360.0 - d)
+
+
+class _SpreadCandidate(NamedTuple):
+    """A valid, spread-polished basin found during search, with its quality."""
+
+    layout: Layout
+    min_gap: float
+    energy: float
+    restart_index: int
+
+
+def _select_spread_diverse(
+    pool: list[_SpreadCandidate],
+    alternatives: int,
+    diversity: DiversityConfig,
+) -> tuple[list[_SpreadCandidate], int]:
+    """Select up to ``alternatives`` best-spread, pairwise-diverse candidates.
+
+    Order the pool by ``(−min_gap, energy, restart_index)``: largest minimum
+    plan-view gap first, ties broken by lower repulsion energy, then by restart
+    order for a *total* (so deterministic — ADR-0003) ordering. Greedily accept
+    a candidate iff it is diverse enough (ADR-0004) against everything already
+    selected; the first pick is always accepted (diversity is vacuous on the
+    empty selection). Returns ``(selected, diversity_rejected)`` in best-spread
+    order, where ``diversity_rejected`` counts candidates *examined* (before the
+    ``alternatives`` quota was met) that the diversity gate turned away. For
+    ``alternatives == 1`` this is always 0 — selection stops after the first,
+    vacuous pick.
+    """
+    ordered = sorted(pool, key=lambda c: (-c.min_gap, c.energy, c.restart_index))
+    selected: list[_SpreadCandidate] = []
+    diversity_rejected = 0
+    for cand in ordered:
+        if _is_diverse_enough(cand.layout, [c.layout for c in selected], diversity):
+            selected.append(cand)
+            if len(selected) >= alternatives:
+                break
+        else:
+            diversity_rejected += 1
+    return selected, diversity_rejected
 
 
 def _is_diverse_enough(

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -55,6 +55,17 @@ def solve(
 
     See spec §3.3 for the contract.
 
+    Returns the **best-spread** valid layout(s) found across *all* restarts
+    within budget (best-of-all-basins, #267) — NOT the first valid one. The
+    restart loop always runs to ``budget_s`` / ``search.max_restarts`` (no
+    break-on-first-valid, including under ``search.spread=False``), recording
+    every valid (spread-polished) basin into a pool; the returned layouts are
+    then chosen from that pool by maximin plan-view gap subject to the
+    diversity gate (ADR-0004). Consequently the returned ``alternatives`` are
+    ordered **best-spread-first**, not in discovery order, and
+    ``diagnostics.min_pairwise_gap_m`` / ``diagnostics.valid_basins_found``
+    surface the selected gaps and the size of the explored basin pool.
+
     When ``plan_paths`` is ``True`` (the default), each returned layout is
     also tow-planned (#197): ``result.plans[i]`` is the
     :class:`~hangarfit.towplanner.MovesPlan` for ``result.layouts[i]``, or
@@ -140,9 +151,9 @@ def solve(
     # natural tuple lex-compare unambiguous.
     best_partial_score: tuple[int, float] = (sys.maxsize, float("inf"))
     best_partial_layout: Layout | None = None
-    accepted_layouts: list[Layout] = []
-    diversity_rejected_count = 0
+    pool: list[_SpreadCandidate] = []
     restart_index = 0
+    spread_scale = _resolve_spread_scale(scenario, search)
 
     # Outer restart loop. Two independent termination gates; first to
     # trip wins:
@@ -193,12 +204,6 @@ def solve(
             if time.monotonic() - start >= budget_s:
                 break
             if current_score == (0, 0.0):
-                # Valid! Apply the K-diversity filter (spec §4.6). When
-                # accepted_layouts is empty, _is_diverse_enough is vacuously
-                # True — the first valid layout is always accepted (and the
-                # alternatives=1 path never re-enters this branch). For K>1
-                # subsequent valid layouts are gated on pairwise diversity vs
-                # everything already accepted.
                 if search.spread:
                     placements = _spread(
                         placements,
@@ -209,28 +214,24 @@ def solve(
                         budget_s=budget_s,
                         pinned_planes=pinned_planes,
                     )
-                # No try/except: _spread returns placements preserving every Layout invariant
-                # (on_carts unchanged, no dup/fleet drift), so any ValueError here is a
-                # structural bug and should propagate.
+                # _spread preserves every Layout invariant; a ValueError here
+                # would be a structural bug, so let it propagate.
                 candidate_layout = Layout(
                     fleet=scenario.fleet,
                     hangar=scenario.hangar,
                     placements=tuple(placements.values()),
                     maintenance_plane=scenario.maintenance_plane,
                 )
-                if _is_diverse_enough(candidate_layout, accepted_layouts, diversity):
-                    accepted_layouts.append(candidate_layout)
-                else:
-                    # The candidate is valid (score (0, 0.0)) but too
-                    # similar to an already-accepted layout. Count it
-                    # so callers can see how much search work was lost
-                    # to the diversity gate (spec §4.1 of the v0.6.0
-                    # solver-polish release design).
-                    diversity_rejected_count += 1
-                # Whether accepted or not, restart to try for a different
-                # basin. Continuing to descend from a valid state would just
-                # walk in place (already at score (0, 0.0)).
-                break
+                min_gap, energy = _spread_quality(placements, scenario, spread_scale)
+                pool.append(
+                    _SpreadCandidate(
+                        layout=candidate_layout,
+                        min_gap=min_gap,
+                        energy=energy,
+                        restart_index=restart_index,
+                    )
+                )
+                break  # restart to seek a different basin
 
             step_result = _descent_step(
                 placements=placements,
@@ -261,19 +262,14 @@ def solve(
                 break  # stall — restart
 
         restart_index += 1
-        if len(accepted_layouts) >= alternatives:
-            break
 
     elapsed = time.monotonic() - start
 
-    if accepted_layouts:
-        # `found` fires when the outer loop broke via the
-        # `len(accepted_layouts) >= alternatives` check above (so the count
-        # is exactly `alternatives` — Chunk D path and Chunk E happy path).
-        # `found_partial` fires when budget exhausted with `0 < n < K`
-        # — reachable in Chunk E for K>1 (the diversity-impossible scenario
-        # is one driver, but any K>1 run that runs out of budget mid-fill
-        # also lands here).
+    selected, diversity_rejected_count = _select_spread_diverse(pool, alternatives, diversity)
+
+    if selected:
+        accepted_layouts = [c.layout for c in selected]
+        min_gaps = tuple(c.min_gap for c in selected)
         status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
         # Tow-plan every returned layout (best-effort enrichment, #197). The
         # v1 planner (Dubins-only + bounded Hybrid-A* — #222 under ADR-0007)
@@ -320,6 +316,8 @@ def solve(
                 diversity_impossible=diversity_impossible,
                 diversity_rejected_count=diversity_rejected_count,
                 unroutable_planes=tuple(unroutable),
+                min_pairwise_gap_m=min_gaps,
+                valid_basins_found=len(pool),
             ),
         )
     bp = check_layout(best_partial_layout) if best_partial_layout is not None else None
@@ -334,6 +332,7 @@ def solve(
             seed=resolved_seed,
             diversity_impossible=diversity_impossible,
             diversity_rejected_count=diversity_rejected_count,
+            valid_basins_found=len(pool),
         ),
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -226,3 +226,14 @@ class TestFleetHangarOverrides:
         captured = capsys.readouterr()
         assert captured.out == ""
         assert "error:" in captured.err
+
+
+def test_solve_human_output_shows_min_gap(capsys):
+    from hangarfit.cli import main
+
+    rc = main(
+        ["solve", "tests/fixtures/solve_fresh_six_planes.yaml", "--seed", "7", "--budget", "5"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "min gap" in out  # per-layout spread quality line

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -237,3 +237,29 @@ def test_solve_human_output_shows_min_gap(capsys):
     out = capsys.readouterr().out
     assert rc == 0
     assert "min gap" in out  # per-layout spread quality line
+
+
+def test_solve_json_output_has_spread_diagnostics(capsys):
+    import json
+
+    from hangarfit.cli import main
+
+    rc = main(
+        [
+            "solve",
+            "tests/fixtures/solve_fresh_six_planes.yaml",
+            "--seed",
+            "7",
+            "--budget",
+            "5",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    diag = payload["diagnostics"]
+    assert "min_pairwise_gap_m" in diag
+    assert "valid_basins_found" in diag
+    assert len(diag["min_pairwise_gap_m"]) == len(payload["layouts"])
+    # finite floats stay numbers; single-plane inf becomes null
+    assert all(g is None or isinstance(g, (int, float)) for g in diag["min_pairwise_gap_m"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,3 +263,30 @@ def test_solve_json_output_has_spread_diagnostics(capsys):
     assert len(diag["min_pairwise_gap_m"]) == len(payload["layouts"])
     # finite floats stay numbers; single-plane inf becomes null
     assert all(g is None or isinstance(g, (int, float)) for g in diag["min_pairwise_gap_m"])
+
+
+def test_solve_json_single_plane_min_gap_is_null(capsys):
+    """A single-plane layout has no plane pairs → min_pairwise_gap_m is
+    math.inf internally, which MUST serialize as JSON null (not the invalid
+    token `Infinity`). Guards the inf→null mapping in _emit_solve_json."""
+    import json
+
+    from hangarfit.cli import main
+
+    rc = main(
+        [
+            "solve",
+            "tests/fixtures/solve_trivial_single_plane.yaml",
+            "--seed",
+            "7",
+            "--budget",
+            "5",
+            "--json",
+        ]
+    )
+    raw = capsys.readouterr().out
+    assert rc == 0
+    assert "Infinity" not in raw  # would be invalid JSON
+    payload = json.loads(raw)  # must parse
+    gaps = payload["diagnostics"]["min_pairwise_gap_m"]
+    assert gaps == [None]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1095,3 +1095,65 @@ def test_solver_diagnostics_spread_fields_default_and_validate():
             seed=0,
             valid_basins_found=-1,
         )
+
+
+def test_solver_diagnostics_rejects_negative_or_nan_gap():
+    import math
+
+    import pytest
+
+    from hangarfit.models import SolverDiagnostics
+
+    with pytest.raises(ValueError, match="min_pairwise_gap_m"):
+        SolverDiagnostics(
+            restarts_attempted=1,
+            wall_time_s=0.0,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=0,
+            min_pairwise_gap_m=(-1.0,),
+        )
+    with pytest.raises(ValueError, match="min_pairwise_gap_m"):
+        SolverDiagnostics(
+            restarts_attempted=1,
+            wall_time_s=0.0,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=0,
+            min_pairwise_gap_m=(math.nan,),
+        )
+    # math.inf is allowed (single-plane sentinel) — must NOT raise:
+    SolverDiagnostics(
+        restarts_attempted=1,
+        wall_time_s=0.0,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=0,
+        min_pairwise_gap_m=(math.inf,),
+    )
+
+
+def test_solve_result_rejects_misaligned_min_pairwise_gap_m():
+    """SolveResult.__post_init__ rejects non-empty min_pairwise_gap_m whose
+    length differs from layouts (the parity guard added in #267)."""
+    import pytest
+
+    from hangarfit.models import SolverDiagnostics, SolveResult
+
+    layout = _make_valid_layout()
+    # diagnostics carries 2 gap entries but SolveResult has 1 layout — mismatch.
+    diag = SolverDiagnostics(
+        restarts_attempted=1,
+        wall_time_s=0.1,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=42,
+        min_pairwise_gap_m=(1.0, 2.0),
+    )
+    with pytest.raises(ValueError, match="min_pairwise_gap_m"):
+        SolveResult(
+            status="found",
+            layouts=(layout,),
+            plans=(None,),
+            diagnostics=diag,
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1057,3 +1057,41 @@ class TestSolveResultPlans:
         stray = MovesPlan(target_layout=_make_valid_layout(), moves=())
         with pytest.raises(ValueError, match="plans"):
             SolveResult(status="exhausted_budget", layouts=(), plans=(stray,), diagnostics=diag)
+
+
+def test_solver_diagnostics_spread_fields_default_and_validate():
+    from hangarfit.models import SolverDiagnostics
+
+    d = SolverDiagnostics(
+        restarts_attempted=3,
+        wall_time_s=1.0,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=7,
+    )
+    assert d.min_pairwise_gap_m == ()
+    assert d.valid_basins_found == 0
+
+    d2 = SolverDiagnostics(
+        restarts_attempted=3,
+        wall_time_s=1.0,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=7,
+        min_pairwise_gap_m=(2.5,),
+        valid_basins_found=12,
+    )
+    assert d2.min_pairwise_gap_m == (2.5,)
+    assert d2.valid_basins_found == 12
+
+    import pytest
+
+    with pytest.raises(ValueError, match="valid_basins_found"):
+        SolverDiagnostics(
+            restarts_attempted=0,
+            wall_time_s=0.0,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=0,
+            valid_basins_found=-1,
+        )

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -343,7 +343,13 @@ def test_solve_is_deterministic_for_same_seed():
 
     assert r1.status == r2.status
     assert r1.diagnostics.seed == r2.diagnostics.seed == 42
-    assert r1.diagnostics.restarts_attempted == r2.diagnostics.restarts_attempted
+    # NOTE: `restarts_attempted` is NOT asserted equal here. Since #267,
+    # solve() no longer breaks on the first valid layout — it runs the
+    # restart loop to the full wall-clock `budget_s` (best-of-all-basins),
+    # so for a wall-clock-bounded run the restart count is timing-dependent
+    # (how many restarts fit in 5 s), not a stable function of the seed.
+    # The substantive determinism contract (ADR-0003, spec §4.8) is "same
+    # seed → same *selected* layout", asserted on placements below.
     # Compare actual layout placements element-wise — Layout's fleet is
     # wrapped in MappingProxyType so direct equality would compare proxy
     # identity in some corner cases.
@@ -362,31 +368,35 @@ def test_solve_is_deterministic_through_descent_loop():
     set-iteration order (``sorted(conflicting)`` in ``_descent_step``).
     The canary suite parametrizes determinism over fixtures; this test
     parametrizes determinism over a *codepath*, asserting that
-    ``restarts_attempted`` matches across runs — a check the canary
-    suite deliberately omits because it is wall-clock-dependent for
-    ``status=exhausted_budget`` but is in fact deterministic-by-seed
-    for ``status=found`` (the run terminates at the restart that
-    succeeds, regardless of wall-clock).
+    ``restarts_attempted`` matches across runs.
 
-    Budget is set high enough that the search reliably ends in
-    ``found``; if a slow CI runner cannot reach ``found`` within
-    ``budget_s`` the test will fail with a status mismatch — bump the
-    budget or skip rather than weakening the assertion.
+    Since #267, ``solve()`` no longer breaks on the first valid layout —
+    it runs the restart loop to its termination gate (best-of-all-basins),
+    so ``restarts_attempted`` is only seed-deterministic when the loop is
+    bounded by ``max_restarts`` rather than wall-clock ``budget_s``. We
+    therefore cap restarts with a deterministic ``max_restarts`` and give a
+    generous ``budget_s`` so the bound is the restart count, not the clock:
+    every run does exactly ``max_restarts`` restarts and the seeded RNG
+    must yield identical selected layouts and restart counts. A slow CI
+    runner that cannot finish ``max_restarts`` within ``budget_s`` would
+    surface as a status mismatch — bump ``budget_s`` rather than weakening
+    the assertion.
     """
     from hangarfit.loader import load_scenario
     from hangarfit.models import SearchConfig
     from hangarfit.solver import solve
 
     s = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
-    r1 = solve(s, budget_s=10.0, alternatives=1, seed=42, search=SearchConfig(spread=False))
-    r2 = solve(s, budget_s=10.0, alternatives=1, seed=42, search=SearchConfig(spread=False))
+    cfg = SearchConfig(spread=False, max_restarts=20)
+    r1 = solve(s, budget_s=30.0, alternatives=1, seed=42, search=cfg)
+    r2 = solve(s, budget_s=30.0, alternatives=1, seed=42, search=cfg)
 
     # Status mismatch here almost certainly means the CI runner is too
-    # slow to reach `found` within budget_s, not a determinism break —
-    # the canary suite catches actual non-determinism with a smaller
-    # surface. Bump budget if this trips.
+    # slow to finish max_restarts within budget_s, not a determinism
+    # break — the canary suite catches actual non-determinism with a
+    # smaller surface. Bump budget if this trips.
     assert r1.status == r2.status == "found", (
-        f"expected both runs to find within 10 s; got {r1.status!r} / {r2.status!r}. "
+        f"expected both runs to find within 30 s; got {r1.status!r} / {r2.status!r}. "
         f"Likely cause: CI runner is slow; bump budget_s."
     )
     assert r1.diagnostics.seed == r2.diagnostics.seed == 42

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -1,6 +1,11 @@
-"""solve()-level tests for the inter-plane spread phase (#145)."""
+"""solve()-level tests for the inter-plane spread phase (#145).
+
+Also covers the _resolve_spread_scale / _spread_quality helpers (#267).
+"""
 
 from __future__ import annotations
+
+import math
 
 import pytest
 
@@ -117,3 +122,51 @@ def test_solve_nine_plane_canary_spread_valid_and_not_worse():
     on = solve(s, budget_s=15.0, seed=42, search=SearchConfig(spread=True))
     assert off.layouts and on.layouts
     assert _min_pairwise_gap(on.layouts[0], s) >= _min_pairwise_gap(off.layouts[0], s)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_spread_scale / _spread_quality helpers (#267)
+# ---------------------------------------------------------------------------
+
+
+def _placements(scenario, specs):
+    """Build a {plane_id: Placement} from (plane_id, x, y, heading) specs."""
+    from hangarfit.models import Placement
+
+    return {
+        pid: Placement(plane_id=pid, x_m=x, y_m=y, heading_deg=h, on_carts=False)
+        for (pid, x, y, h) in specs
+    }
+
+
+def test_spread_quality_energy_matches_inter_plane_energy():
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import SearchConfig
+    from hangarfit.solver import (
+        _inter_plane_energy,
+        _resolve_spread_scale,
+        _spread_quality,
+    )
+
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    pids = list(scenario.fleet_in)
+    placements = _placements(scenario, [(pids[0], 2.0, 2.0, 0.0), (pids[1], 12.0, 9.0, 0.0)])
+    scale = _resolve_spread_scale(scenario, SearchConfig())
+    min_gap, energy = _spread_quality(placements, scenario, scale)
+    assert energy == _inter_plane_energy(placements, scenario, scale)
+    assert math.isfinite(min_gap) and min_gap >= 0.0
+
+
+def test_spread_quality_single_plane_is_inf_zero():
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import SearchConfig
+    from hangarfit.solver import (
+        _resolve_spread_scale,
+        _spread_quality,
+    )
+
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    pid = scenario.fleet_in[0]
+    placements = _placements(scenario, [(pid, 2.0, 2.0, 0.0)])
+    scale = _resolve_spread_scale(scenario, SearchConfig())
+    assert _spread_quality(placements, scenario, scale) == (math.inf, 0.0)

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -10,8 +10,8 @@ import math
 import pytest
 
 from hangarfit.loader import load_scenario
-from hangarfit.models import DiversityConfig, Layout
-from hangarfit.solver import _select_spread_diverse, _SpreadCandidate
+from hangarfit.models import DiversityConfig, Layout, SearchConfig
+from hangarfit.solver import _select_spread_diverse, _SpreadCandidate, solve
 
 
 @pytest.fixture(autouse=True)
@@ -70,19 +70,27 @@ def test_solve_spread_on_widens_min_gap_vs_off():
 
 
 def test_solve_default_enables_spread():
-    """Fast: bare solve() == explicit spread=True (default is on).
+    """Fast: default-spread solve() == explicit spread=True (default is on).
 
-    Verifies that SearchConfig().spread is True and that the same seed
-    produces identical placements whether spread is implicit or explicit.
-    seed=0 verified: default == explicit_on (same placements).
+    Verifies that ``SearchConfig().spread`` is True by running two same-seed
+    solves whose only differing field is an explicit ``spread=True``, and
+    asserting identical selected placements.
+
+    Both solves are bounded by ``max_restarts`` (not wall-clock ``budget_s``):
+    since #267, ``solve()`` no longer breaks on the first valid layout — it
+    collects every valid basin found within its termination gate and selects
+    the best-spread one. Under a wall-clock budget the *number* of basins
+    collected is timing-dependent, so two same-seed runs can select different
+    winners; bounding by ``max_restarts`` makes the basin pool — and hence the
+    selected layout — a deterministic function of the seed (ADR-0003).
     """
     from hangarfit.loader import load_scenario
     from hangarfit.models import SearchConfig
     from hangarfit.solver import solve
 
     s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
-    default = solve(s, budget_s=5.0, seed=0)
-    explicit_on = solve(s, budget_s=5.0, seed=0, search=SearchConfig(spread=True))
+    default = solve(s, budget_s=30.0, seed=0, search=SearchConfig(max_restarts=20))
+    explicit_on = solve(s, budget_s=30.0, seed=0, search=SearchConfig(max_restarts=20, spread=True))
     assert default.layouts and explicit_on.layouts
     assert [(p.x_m, p.y_m, p.heading_deg) for p in default.layouts[0].placements] == [
         (p.x_m, p.y_m, p.heading_deg) for p in explicit_on.layouts[0].placements
@@ -243,3 +251,29 @@ def test_select_enforces_diversity_and_counts_rejects():
 def test_select_empty_pool_returns_empty():
     selected, rejected = _select_spread_diverse([], alternatives=2, diversity=DiversityConfig())
     assert selected == [] and rejected == 0
+
+
+def test_solve_populates_spread_diagnostics():
+    scenario = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    r = solve(scenario, seed=7, search=SearchConfig(max_restarts=20), plan_paths=False)
+    assert r.status in ("found", "found_partial")
+    d = r.diagnostics
+    assert len(d.min_pairwise_gap_m) == len(r.layouts)
+    assert d.valid_basins_found >= len(r.layouts)
+    assert all(g > 0.0 for g in d.min_pairwise_gap_m)
+
+
+def test_solve_spread_selection_is_deterministic():
+    scenario = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    cfg = SearchConfig(max_restarts=20)
+    a = solve(scenario, seed=7, search=cfg, plan_paths=False)
+    b = solve(scenario, seed=7, search=cfg, plan_paths=False)
+    assert a.diagnostics.min_pairwise_gap_m == b.diagnostics.min_pairwise_gap_m
+    assert [_layout_key(lay) for lay in a.layouts] == [_layout_key(lay) for lay in b.layouts]
+
+
+def _layout_key(layout):
+    return tuple(
+        (p.plane_id, round(p.x_m, 6), round(p.y_m, 6), round(p.heading_deg, 6))
+        for p in layout.placements
+    )

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -277,3 +277,44 @@ def _layout_key(layout):
         (p.plane_id, round(p.x_m, 6), round(p.y_m, 6), round(p.heading_deg, 6))
         for p in layout.placements
     )
+
+
+@pytest.mark.slow
+def test_best_of_all_never_worse_than_first_basin_over_sweep():
+    """End-to-end confidence for #267: with the same seed, best-of-all (a
+    larger restart budget) selects from a pool that is a *superset* of the
+    single-restart pool, so its achieved min plan-view gap is never worse than
+    the first-found basin (max_restarts=1 ≈ the old first-valid behavior) — and
+    on this nesting-prone 6-plane fill it is strictly better for several seeds,
+    demonstrating the fix reduces nested pairs.
+
+    It does NOT (and cannot) eliminate nesting on a space-tight fill: when every
+    reachable basin nests, best-of-all still returns 0.0 — the roomiest available.
+    The pure ``_select_spread_diverse`` tests are the deterministic regression;
+    this is end-to-end wiring confidence. Excluded from the default run (slow).
+    """
+    scenario = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    improved = 0
+    checked = 0
+    for seed in range(1, 10):
+        first = solve(scenario, seed=seed, search=SearchConfig(max_restarts=1), plan_paths=False)
+        best = solve(scenario, seed=seed, search=SearchConfig(max_restarts=8), plan_paths=False)
+        if first.status not in ("found", "found_partial") or best.status not in (
+            "found",
+            "found_partial",
+        ):
+            continue
+        checked += 1
+        first_gap = min(first.diagnostics.min_pairwise_gap_m, default=math.inf)
+        best_gap = min(best.diagnostics.min_pairwise_gap_m, default=math.inf)
+        assert best_gap >= first_gap - 1e-9, (
+            f"seed {seed}: best-of-all min gap {best_gap} is worse than "
+            f"first-basin {first_gap} — selection should never regress"
+        )
+        if best_gap > first_gap + 1e-9:
+            improved += 1
+    assert checked >= 4, f"too few seeds reached a layout ({checked}); fixture/budget issue"
+    assert improved > 0, (
+        "best-of-all improved no seed over first-basin — the fix is not being "
+        "exercised on this fixture (expected several nesting-prone seeds to improve)"
+    )

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -88,9 +88,11 @@ def test_solve_default_enables_spread():
     from hangarfit.models import SearchConfig
     from hangarfit.solver import solve
 
-    s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
-    default = solve(s, budget_s=30.0, seed=0, search=SearchConfig(max_restarts=20))
-    explicit_on = solve(s, budget_s=30.0, seed=0, search=SearchConfig(max_restarts=20, spread=True))
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    default = solve(scenario, seed=7, search=SearchConfig(max_restarts=5), plan_paths=False)
+    explicit_on = solve(
+        scenario, seed=7, search=SearchConfig(spread=True, max_restarts=5), plan_paths=False
+    )
     assert default.layouts and explicit_on.layouts
     assert [(p.x_m, p.y_m, p.heading_deg) for p in default.layouts[0].placements] == [
         (p.x_m, p.y_m, p.heading_deg) for p in explicit_on.layouts[0].placements

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -9,6 +9,10 @@ import math
 
 import pytest
 
+from hangarfit.loader import load_scenario
+from hangarfit.models import DiversityConfig, Layout
+from hangarfit.solver import _select_spread_diverse, _SpreadCandidate
+
 
 @pytest.fixture(autouse=True)
 def _stub_towplanning(monkeypatch):
@@ -170,3 +174,72 @@ def test_spread_quality_single_plane_is_inf_zero():
     placements = _placements(scenario, [(pid, 2.0, 2.0, 0.0)])
     scale = _resolve_spread_scale(scenario, SearchConfig())
     assert _spread_quality(placements, scenario, scale) == (math.inf, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# _select_spread_diverse (#267)
+# ---------------------------------------------------------------------------
+
+
+def _layout(scenario, specs):
+    """A valid Layout from (plane_id, x, y, heading) specs. Layout.__post_init__
+    enforces only structural invariants (no collision check), so arbitrary
+    positions are fine for selection/diversity tests."""
+    return Layout(
+        fleet=scenario.fleet,
+        hangar=scenario.hangar,
+        placements=tuple(_placements(scenario, specs).values()),
+        maintenance_plane=None,
+    )
+
+
+def test_select_nested_pair_loses_to_spread():
+    """The core regression: a nested basin (min_gap 0.0) must never be chosen
+    over a well-spread one (min_gap 2.0), even with a worse restart_index."""
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    p = list(scenario.fleet_in)
+    nested = _layout(scenario, [(p[0], 2.0, 2.0, 0.0), (p[1], 2.0, 2.0, 0.0)])
+    spread = _layout(scenario, [(p[0], 2.0, 2.0, 0.0), (p[1], 12.0, 9.0, 0.0)])
+    pool = [
+        _SpreadCandidate(layout=nested, min_gap=0.0, energy=5.0, restart_index=0),
+        _SpreadCandidate(layout=spread, min_gap=2.0, energy=1.0, restart_index=1),
+    ]
+    selected, rejected = _select_spread_diverse(pool, alternatives=1, diversity=DiversityConfig())
+    assert [c.min_gap for c in selected] == [2.0]
+    assert rejected == 0
+
+
+def test_select_energy_breaks_min_gap_ties():
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    p = list(scenario.fleet_in)
+    a = _layout(scenario, [(p[0], 2.0, 2.0, 0.0), (p[1], 12.0, 9.0, 0.0)])
+    b = _layout(scenario, [(p[0], 2.0, 2.0, 0.0), (p[1], 12.0, 9.0, 0.0)])
+    pool = [
+        _SpreadCandidate(layout=a, min_gap=2.0, energy=3.0, restart_index=0),
+        _SpreadCandidate(layout=b, min_gap=2.0, energy=1.0, restart_index=1),
+    ]
+    selected, _ = _select_spread_diverse(pool, alternatives=1, diversity=DiversityConfig())
+    assert selected[0].energy == 1.0  # lower energy wins the tie
+
+
+def test_select_enforces_diversity_and_counts_rejects():
+    """K=2: the top-spread basin is picked; a near-identical second basin is
+    rejected by the diversity gate; a genuinely different one is accepted."""
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    p = list(scenario.fleet_in)
+    base = _layout(scenario, [(p[0], 2.0, 2.0, 0.0), (p[1], 12.0, 9.0, 0.0)])
+    twin = _layout(scenario, [(p[0], 2.1, 2.0, 0.0), (p[1], 12.1, 9.0, 0.0)])
+    diff = _layout(scenario, [(p[0], 6.0, 5.0, 0.0), (p[1], 16.0, 12.0, 0.0)])
+    pool = [
+        _SpreadCandidate(layout=base, min_gap=3.0, energy=1.0, restart_index=0),
+        _SpreadCandidate(layout=twin, min_gap=2.5, energy=1.0, restart_index=1),
+        _SpreadCandidate(layout=diff, min_gap=2.0, energy=1.0, restart_index=2),
+    ]
+    selected, rejected = _select_spread_diverse(pool, alternatives=2, diversity=DiversityConfig())
+    assert [c.min_gap for c in selected] == [3.0, 2.0]  # base, then diff; twin skipped
+    assert rejected == 1
+
+
+def test_select_empty_pool_returns_empty():
+    selected, rejected = _select_spread_diverse([], alternatives=2, diversity=DiversityConfig())
+    assert selected == [] and rejected == 0

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -254,18 +254,23 @@ def test_select_empty_pool_returns_empty():
 
 
 def test_solve_populates_spread_diagnostics():
-    scenario = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
-    r = solve(scenario, seed=7, search=SearchConfig(max_restarts=20), plan_paths=False)
+    # 2-plane fixture + small restart bound keeps this wiring check fast and
+    # deterministic; it verifies the diagnostics are populated and aligned, not
+    # the (space-dependent) achievement of a positive gap.
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    r = solve(scenario, seed=7, search=SearchConfig(max_restarts=5), plan_paths=False)
     assert r.status in ("found", "found_partial")
     d = r.diagnostics
     assert len(d.min_pairwise_gap_m) == len(r.layouts)
     assert d.valid_basins_found >= len(r.layouts)
-    assert all(g > 0.0 for g in d.min_pairwise_gap_m)
+    # gaps are real edge-to-edge distances: non-negative (inf only for <2 planes,
+    # which this 2-plane fixture never produces).
+    assert all(g >= 0.0 for g in d.min_pairwise_gap_m)
 
 
 def test_solve_spread_selection_is_deterministic():
-    scenario = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
-    cfg = SearchConfig(max_restarts=20)
+    scenario = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    cfg = SearchConfig(max_restarts=5)
     a = solve(scenario, seed=7, search=cfg, plan_paths=False)
     b = solve(scenario, seed=7, search=cfg, plan_paths=False)
     assert a.diagnostics.min_pairwise_gap_m == b.diagnostics.min_pairwise_gap_m


### PR DESCRIPTION
## Summary

Fixes the seed-fragility in the inter-plane spread post-pass: `solve()` used to return the **first** valid basin it found and `_spread`-polish only that one, so ~1/3 of seeds settled with a nested pair (0.0 m plan-view gap) while others spread to 1.7–2.5 m — pure seed luck.

This replaces first-valid-then-break with a **collect-then-select pool**: the restart loop now records *every* valid spread-polished basin, and a new pure function `_select_spread_diverse` selects the layout(s) with the largest **minimum pairwise plan-view gap** (energy tiebreak), subject to the existing diversity gate (ADR-0004). `alternatives=1` is just the K=1 case.

Design: `docs/superpowers/specs/2026-05-27-solver-spread-robustness-design.md` · Plan: `docs/superpowers/plans/2026-05-27-solver-spread-robustness.md`.

## What changed

- **`solver.py`** — new `_resolve_spread_scale`, `_spread_quality` (min-gap + energy in one pairwise pass), `_SpreadCandidate`, and the pure `_select_spread_diverse`. `solve()`'s restart loop restructured into the pool + selection. `_spread`'s algorithm is unchanged — robustness comes from choosing among basins, not a smarter climb.
- **`models.py`** — `SolverDiagnostics` gains `min_pairwise_gap_m` (index-aligned with `layouts`, `inf` for <2 planes) and `valid_basins_found` (pool size).
- **`cli.py`** — the human summary shows `min gap N.NN m` per layout; `--json` carries `min_pairwise_gap_m` (with `inf → null`) and `valid_basins_found`. Additive — no JSON schema bump.

## ⚠️ Two accepted behavior changes (please confirm you're happy with these)

1. **Determinism is now `max_restarts`-scoped, not wall-clock-scoped.** Because the loop runs to its termination gate instead of breaking on first-valid, the number of restarts that fit a wall-clock `--budget` depends on machine speed → pool size varies → on near-tied basins the selected layout can differ across machines. Same seed + same `max_restarts` is still byte-identical; same seed + same machine/load under `--budget` is reproducible. This is a deliberate tradeoff (robustness-of-spread over wall-clock-independent determinism for the default CLI path) — **ADR-0003 amended** to document it.
2. **K>1 alternatives are now returned best-spread-first**, not discovery-order (`layouts[0]` is the roomiest).

## Known limitation (best-effort, space-bounded)

Best-of-all returns the roomiest *available* basin — it can't manufacture space. On a space-tight fill where every reachable basin nests, it still returns 0.0 m. Empirically true for some seeds on the tight 6-plane fixture (and visible in the manual smoke). Spread is a soft preference, not a guarantee — documented in the ADR-0008 addendum.

## Testing

- **Primary regression (pure, deterministic, instant):** `_select_spread_diverse` unit tests directly encode "a nested basin never wins," plus diversity enforcement, K-partial, empty pool, tiebreaks; `_spread_quality` min-gap math + `<2-plane → inf`.
- **Wiring/determinism:** diagnostics populated/aligned + same-seed reproducibility (fast 2-plane fixture, bounded restarts).
- **`@slow` sweep:** best-of-all is never worse than a single restart (pool-superset guarantee) and strictly better for several seeds on the nesting-prone 6-plane fill.
- Single-plane `--json` `inf → null` regression test (guards against invalid `Infinity` in JSON).

## Verification

- `pytest -m ""` (default **+** slow): **660 passed**, 0 failures.
- `ruff check` + `ruff format --check`: clean. `mypy src/hangarfit`: clean.
- Manual smoke: human `min gap` line + `--json` diagnostics render correctly.

## Docs

ADR-0008 addendum (best-of-all + space-bound limit) · ADR-0003 amendment (determinism scoping) · design spec determinism section corrected · CLI `--seed` help note on the wall-clock reproducibility caveat.

Closes #267
