### PR TITLE
docs: sweep stale diversity_rejected_count mechanism (selection-time) (#274)

### DIFF
--- a/docs/adr/0004-diversity-metric.md
+++ b/docs/adr/0004-diversity-metric.md
@@ -74,11 +74,16 @@ feature could ship. Diversity-by-what is the question this ADR answers.
 
 **Chosen option: edit count with per-plane thresholds**, with defaults
 `min_planes_moved = 2`, `position_threshold_m = 0.5 m`, and
-`heading_threshold_deg = 30°`. The filter is applied between RR-MC
-acceptance and the final `SolveResult` return, in
-[`_is_diverse_enough()`](../../src/hangarfit/solver.py); rejected
-candidates increment `SolverDiagnostics.diversity_rejected_count` so
-inefficient runs are observable.
+`heading_threshold_deg = 30°`. Since the best-of-all-basins change
+(#267), the filter is applied at *selection* time — after the restart
+loop has collected every valid spread-polished basin into a pool — in
+[`_select_spread_diverse()`](../../src/hangarfit/solver.py), which sorts
+the pool by separation quality and greedily admits layouts using the
+[`_is_diverse_enough()`](../../src/hangarfit/solver.py) predicate. Pool
+candidates the gate turns away (examined in best-spread order until the
+`alternatives` quota is met) increment
+`SolverDiagnostics.diversity_rejected_count` so inefficient runs are
+observable; the count is always `0` for `alternatives == 1`.
 
 Concretely: a plane is considered "moved" iff its position differs by
 ≥ 0.5 m *or* its heading differs by ≥ 30° (short-arc — so 359° and 0°
@@ -181,7 +186,7 @@ coexist as alternative filter strategies.
   defaults without changing the solver source.
 - **Observable.** `SolverDiagnostics.diversity_rejected_count` surfaces
   filter activity: a high reject count signals a tight scenario where
-  the solver keeps re-finding the same minimum, suggesting either
+  the basin pool holds many near-identical layouts, suggesting either
   loosening `DiversityConfig` or raising `budget_s`.
 
 ### Negative

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -79,7 +79,7 @@ sequenceDiagram
     alt trivially infeasible
         Solver-->>CLI: SolveResult(status=trivially_infeasible)
     else feasible
-        loop until K accepted or budget exhausted
+        loop restart until budget_s / max_restarts
             Note over Solver: Random initial placement
             loop descent (min-conflicts)
                 Solver->>Coll: check(candidate)
@@ -87,26 +87,22 @@ sequenceDiagram
                 alt zero conflicts
                     Note over Solver: candidate is valid
                     Note over Solver: Spread (if SearchConfig.spread, default on):<br/>_spread maximizes inter-plane separation, only valid moves
+                    Note over Solver: append valid (spread-polished) basin to pool
                 else conflicts > 0
                     Note over Solver: perturb plane with max<br/>penetration contribution
                 end
             end
-            Note over Solver: Diversity filter:<br/>compare candidate to<br/>already-accepted layouts
-            alt diverse enough
-                Note over Solver: append to accepted
-            else too similar
-                Note over Solver: increment<br/>diversity_rejected_count
-            end
         end
+        Note over Solver: Select (best-of-all, #267):<br/>sort pool by min plan-view gap (energy tiebreak),<br/>greedily pick K diverse — rejects increment diversity_rejected_count
         opt plan_paths (default on) — applies to found & found_partial
             Solver->>Tow: plan_fill(layout) per accepted layout
             Tow-->>Solver: MovesPlan or None (best-effort)
         end
-        alt K accepted before budget
+        alt K selected from pool
             Solver-->>CLI: SolveResult(status=found, layouts, plans, diagnostics, seed)
-        else some-but-fewer-than-K accepted, budget exhausted
+        else fewer than K selected (diversity-limited or budget exhausted)
             Solver-->>CLI: SolveResult(status=found_partial, layouts, plans, diagnostics, seed)
-        else zero accepted, budget exhausted
+        else pool empty (no valid basin found)
             Solver-->>CLI: SolveResult(status=exhausted_budget, layouts=[], plans=[], diagnostics, seed)
         end
     end


### PR DESCRIPTION
## Summary

Follow-up to #273 (#267, best-of-all-basins spread). The diversity filter moved from a per-restart accept/reject inside the descent loop to **selection time** over the collected basin pool (`_select_spread_diverse`). Two living doc layers still described the old per-restart mechanism:

- **ADR-0004** (`docs/adr/0004-diversity-metric.md`) — mechanism paragraph now states the filter runs at selection time in `_select_spread_diverse` (using the `_is_diverse_enough` predicate), counting pool candidates the gate turns away (examined in best-spread order until the `alternatives` quota; always 0 for K=1). Observability bullet reworded ("pool holds many near-identical layouts").
- **arc42 §6** (`docs/architecture/06-runtime-view.md`) — solve sequence diagram: the in-loop "diverse enough → append / too similar → increment" block becomes "append valid basin to pool"; a post-loop **Select (best-of-all)** step does the maximin-gap pick + diversity counting. Loop header and status alts updated to the pool/select framing.

Consistent now with the `SolverDiagnostics.diversity_rejected_count` field docstring and the `_select_spread_diverse` docstring shipped in #273.

## Scope note
The historical v0.6.0 implementation plan (`docs/superpowers/plans/2026-05-22-...`) also mentions the old per-restart increment, but it is a **point-in-time record** of the v0.6.0 work and is intentionally left unchanged.

## Verification
Docs-only; mermaid `alt`/`loop`/`end` nesting verified balanced. No code touched.

Closes #274