### PR TITLE
docs(security): make SECURITY.md phase-agnostic

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-`hangarfit` is a Phase 1 project. Only the `main` branch (current release) receives security updates. Older tagged versions do not receive backports.
+`hangarfit` is a single-maintainer hobby project. Only the latest release (the `main` branch) receives security updates; older tagged versions do not receive backports.
 
 | Version | Status |
 |---------|--------|


### PR DESCRIPTION
## Summary

- Replace the stale `Phase 1 project` self-description on line 5 of `SECURITY.md` with a phase-agnostic framing that matches the project's current state (Phases 1, 2a, 3a, and 3b have all shipped)
- The actual security policy is unchanged: only the latest release on `main` receives security updates; older tagged versions do not receive backports
- No other files touched; no code changes

## Test plan

- [ ] Confirm `git diff develop...HEAD` touches only `SECURITY.md`
- [ ] Read the new line 5 and verify it no longer says "Phase 1"
- [ ] Verify the security policy (supported versions, no-backports) reads correctly in the rendered Markdown on GitHub

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)