### PR TITLE
docs(towplanner): retire stale "v1 planner"/"Dubins-only" wording (ADR-0010 v2)

### DIFF
--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -109,7 +109,7 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Overlay each plane's tow path on the --render PNG(s), one colour per "
             "plane (requires --render). Tow-plans every returned layout; a layout "
-            "the v1 planner cannot route is rendered without paths and a warning "
+            "the tow planner cannot route is rendered without paths and a warning "
             "names the blocking plane. Exit 3 if NO candidate is tow-routable."
         ),
     )
@@ -365,8 +365,8 @@ def cmd_solve(args: argparse.Namespace) -> int:
         _emit_solve_human(result, alternatives=args.alternatives)
 
     # Structured tow-path warnings: name the plane that blocked each layout the
-    # v1 planner could not route (best-effort — the layout is still valid and is
-    # rendered, just without a path overlay; ADR-0007 / #197).
+    # tow planner could not route (best-effort — the layout is still valid and
+    # is rendered, just without a path overlay; ADR-0007 + ADR-0010 / #197).
     if args.render_paths:
         _warn_unroutable(result)
 
@@ -390,7 +390,7 @@ def cmd_solve(args: argparse.Namespace) -> int:
     # Exit code (spec §5.2). Precedence: no layouts > no-tow-order > strict-k.
     if not result.layouts:
         return 1
-    # --render-paths only: exit 3 when the v1 planner could route NO candidate
+    # --render-paths only: exit 3 when the tow planner could route NO candidate
     # (spike Q8/Q2 "no feasible order for any candidate"). A valid layout still
     # rendered, so this is distinct from exit 1 (no layout at all). Checked
     # before --strict-k: "can't tow anything" is the more actionable failure.
@@ -433,9 +433,9 @@ def _write_renders(
 
 
 def _warn_unroutable(result: SolveResult) -> None:
-    """Emit one stderr warning per returned layout the v1 planner could not
+    """Emit one stderr warning per returned layout the tow planner could not
     tow-route, naming the blocking plane (best-effort; the layout is still
-    valid and rendered, just without a path overlay — ADR-0007 / #197).
+    valid and rendered, just without a path overlay — ADR-0007 + ADR-0010 / #197).
 
     ``diagnostics.unroutable_planes`` is a *compacted* list (one entry per
     ``None`` plan, in returned-layout order), so the j-th ``None`` plan pairs

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -687,17 +687,18 @@ class SolverDiagnostics:
     records.
 
     ``unroutable_planes`` is a flat, advisory list of the blocking plane
-    ids for the layouts the v1 tow-path planner could not route, in
+    ids for the layouts the tow planner could not route, in
     returned-layout order. There is one entry per ``None`` in
     :attr:`SolveResult.plans`, but the tuple is **compacted** (only the
     failing layouts contribute) — it is *not* positionally indexable to
     ``plans``/``layouts``; to attribute a failure to a specific layout,
     read the ``None`` positions in ``plans``. Empty when every returned
     layout was tow-planned, or when tow-planning was not attempted
-    (``solve(..., plan_paths=False)``). Advisory: the v1 planner
-    (Dubins-only + bounded Hybrid-A* — #222 under ADR-0007) has documented
-    false-negatives, so an un-routable layout is still a valid static
-    arrangement — the entry flags a planning gap, not an invalid layout.
+    (``solve(..., plan_paths=False)``). Advisory: the v2 planner
+    (Reeds–Shepp arcs + bounded Hybrid-A* — #222/#261 under ADR-0007 +
+    ADR-0010) has documented false-negatives, so an un-routable layout is
+    still a valid static arrangement — the entry flags a planning gap, not
+    an invalid layout.
 
     ``min_pairwise_gap_m`` is index-aligned with :attr:`SolveResult.layouts`:
     the achieved minimum plan-view gap (m) between any two planes in that
@@ -762,12 +763,13 @@ class SolveResult:
 
     ``plans`` is index-aligned with ``layouts``: ``plans[i]`` is the
     :class:`~hangarfit.towplanner.MovesPlan` for ``layouts[i]``, or
-    ``None`` when the v1 tow-path planner could not route that layout
-    (best-effort enrichment — see ADR-0007). It is also all-``None`` when
-    tow-planning was skipped (``solve(..., plan_paths=False)``). A ``None``
-    entry does **not** invalidate the corresponding layout: the static
-    arrangement remains valid; only its tow plan is unavailable. For
-    statuses with empty ``layouts`` the field is always ``()``.
+    ``None`` when the tow planner could not route that layout
+    (best-effort enrichment — see ADR-0007 + ADR-0010). It is also
+    all-``None`` when tow-planning was skipped
+    (``solve(..., plan_paths=False)``). A ``None`` entry does **not**
+    invalidate the corresponding layout: the static arrangement remains
+    valid; only its tow plan is unavailable. For statuses with empty
+    ``layouts`` the field is always ``()``.
     """
 
     status: SolveStatus
@@ -788,7 +790,7 @@ class SolveResult:
         # statuses therefore require empty plans too, and this subsumes the
         # found/found_partial cardinality check (layouts is already forced
         # non-empty for those by the first guard). Entries may be None
-        # (best-effort: the v1 planner couldn't route that layout), but the
+        # (best-effort: the tow planner couldn't route that layout), but the
         # length must still match.
         if len(self.plans) != len(self.layouts):
             raise ValueError(

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -288,13 +288,13 @@ def solve(
         min_gaps = tuple(c.min_gap for c in selected)
         status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
         # Tow-plan every returned layout (best-effort enrichment, #197). The
-        # v1 planner (Dubins-only + bounded Hybrid-A* — #222 under ADR-0007)
-        # cannot route dense multi-plane fills and has documented
-        # false-negatives, so an un-routable layout is recorded as plans[i]=None
-        # rather than discarding the otherwise-valid static arrangement — the
-        # layout is the headline answer; the tow plan is advisory (spike
-        # Risk #8). The `status` stays search-driven: tow-planning never changes
-        # found/found_partial.
+        # v2 planner (Reeds–Shepp arcs + bounded Hybrid-A* — #222/#261 under
+        # ADR-0007 + ADR-0010) cannot route dense multi-plane fills and has
+        # documented false-negatives, so an un-routable layout is recorded as
+        # plans[i]=None rather than discarding the otherwise-valid static
+        # arrangement — the layout is the headline answer; the tow plan is
+        # advisory (spike Risk #8). The `status` stays search-driven:
+        # tow-planning never changes found/found_partial.
         plans: tuple[MovesPlan | None, ...]
         unroutable: list[str] = []
         if plan_paths:
@@ -310,7 +310,7 @@ def solve(
                     # budget exhaustion (a known false-negative class), which
                     # call for different operator responses.
                     _logger.warning(
-                        "layout not tow-routable by the v1 planner: plane %r blocked "
+                        "layout not tow-routable by the tow-path planner: plane %r blocked "
                         "(%s: %s); returning the valid static layout without a tow plan",
                         e.plane_id,
                         e.conflict.kind,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1028,7 +1028,7 @@ class TestSolveResultPlans:
             SolveResult(status="found", layouts=(layout,), plans=(), diagnostics=diag)
 
     def test_solveresult_plans_allows_none_entries(self) -> None:
-        # Best-effort: a returned layout whose tow plan the v1 planner could
+        # Best-effort: a returned layout whose tow plan the tow planner could
         # not compute is recorded as plans[i]=None — still aligned, still valid.
         from hangarfit.towplanner import MovesPlan
 

--- a/tests/test_solver_towplanner.py
+++ b/tests/test_solver_towplanner.py
@@ -2,10 +2,11 @@
 
 Verifies that ``solve()`` returns a ``MovesPlan`` (or ``None``) per accepted
 layout (index-aligned in ``SolveResult.plans``) and that the **best-effort**
-behaviour is correct: a layout the v1 planner cannot route is recorded as
+behaviour is correct: a layout the tow planner cannot route is recorded as
 ``plans[i] is None`` (with the blocking plane in
 ``diagnostics.unroutable_planes``) and the valid static layout is still
-returned — the tow plan is advisory enrichment, never a gate (ADR-0007).
+returned — the tow plan is advisory enrichment, never a gate (ADR-0007 +
+ADR-0010).
 """
 
 from __future__ import annotations
@@ -98,14 +99,14 @@ def test_solve_plan_paths_false_skips_planning(solvable_scenario, monkeypatch):
 
 @pytest.mark.slow
 def test_solve_best_effort_real_planner_on_untowable_fill():
-    """End-to-end: the real v1 planner on a dense fill it cannot route.
+    """End-to-end: the real tow planner on a dense fill it cannot route.
 
     ``solve_fresh_six_planes`` packs six planes into the tight placeholder
-    hangar — a valid static layout the Dubins-only + bounded Hybrid-A*
-    planner cannot fully route in v1 (spike Risk #1). Best-effort must
-    still return the layout(s) with a ``None`` plan and name the blocking
-    plane, rather than failing the whole solve. Slow (real per-plane
-    search), so excluded from the default suite.
+    hangar — a valid static layout the Reeds–Shepp + bounded Hybrid-A*
+    planner cannot fully route (spike Risk #1). Best-effort must still
+    return the layout(s) with a ``None`` plan and name the blocking plane,
+    rather than failing the whole solve. Slow (real per-plane search), so
+    excluded from the default suite.
     """
     from hangarfit.loader import load_scenario
     from hangarfit.solver import solve
@@ -116,8 +117,8 @@ def test_solve_best_effort_real_planner_on_untowable_fill():
     assert result.status in ("found", "found_partial")
     assert len(result.layouts) >= 1
     assert len(result.plans) == len(result.layouts)
-    # The dense fill is un-routable in v1, so the plan is None and the
-    # blocking plane is recorded — but the valid layout is preserved.
+    # The dense fill is un-routable, so the plan is None and the blocking
+    # plane is recorded — but the valid layout is preserved.
     assert any(p is None for p in result.plans)
     assert len(result.diagnostics.unroutable_planes) == sum(1 for p in result.plans if p is None)
     assert result.diagnostics.unroutable_planes  # non-empty


### PR DESCRIPTION
## Summary

- Phase 3b shipped the Reeds–Shepp motion model (ADR-0010), advancing the tow-path planner to v2. Several user-facing strings, docstrings, and inline comments still called it "the v1 planner" or "Dubins-only" — both now inaccurate.
- User-facing strings (stderr warning, `--render-paths` help text) updated to version-agnostic "tow planner" / "tow-path planner" to avoid going stale again on a future v3.
- Internal comments and docstrings where the version label is informative updated to "v2 planner (Reeds–Shepp arcs + bounded Hybrid-A* — #222/#261 under ADR-0007 + ADR-0010)".
- Prose-only changes to tests (docstrings and comments); no assert, test logic, or test data was touched.
- JSON schema versions (`solve/v1`, `check/v1`), `towplanner.py` historical notes, and `SearchConfig` "v1 defaults" are intentionally unchanged.

## Test plan

- [x] `ruff check src/ tests/` — all checks passed
- [x] `ruff format --check src/ tests/` — 38 files already formatted
- [x] `PYTHONPATH=$PWD/src python3 -m pytest tests/test_solver_towplanner.py tests/test_models.py -q` — 142 passed, 1 deselected
- [x] `grep -rn "solve/v1\|check/v1" src/` — confirmed unchanged (still present only in their correct JSON-schema locations)

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)