### PR TITLE
test(fuzz): deepen loader fuzz reach — ref-resolution + rare error branches

### DIFF
--- a/tests/fuzz/strategies.py
+++ b/tests/fuzz/strategies.py
@@ -10,7 +10,9 @@ finding.
 
 from __future__ import annotations
 
+import contextlib
 import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -435,6 +437,72 @@ def _write_raw_tmp(doc: Any) -> Path:
     return p
 
 
+def _write_fleet_yaml(tmpdir: Path) -> Path:
+    """Write a minimal valid fleet YAML to *tmpdir* and return its path.
+
+    Used by the ref-resolving run-helpers so they can write a layout/scenario
+    YAML that references the fleet by relative path — exercising
+    ``load_fleet((path.parent / fleet_ref).resolve())`` inside ``load_layout``
+    / ``load_scenario`` rather than the override-kwarg shortcut.
+    """
+    fleet_doc = {
+        "aircraft": [
+            {
+                "id": "p1",
+                "name": "Plane One",
+                "wing_position": "high",
+                "gear": "nosewheel",
+                "movement_mode": "always_cart",
+                "measured": False,
+                "parts": [
+                    {
+                        "kind": "fuselage",
+                        "length_m": 6.0,
+                        "width_m": 1.2,
+                        "z_bottom_m": 0.0,
+                        "z_top_m": 2.0,
+                    }
+                ],
+            },
+            {
+                "id": "p2",
+                "name": "Plane Two",
+                "wing_position": "low",
+                "gear": "tailwheel",
+                "movement_mode": "always_cart",
+                "measured": False,
+                "parts": [
+                    {
+                        "kind": "fuselage",
+                        "length_m": 6.0,
+                        "width_m": 1.2,
+                        "z_bottom_m": 0.0,
+                        "z_top_m": 2.0,
+                    }
+                ],
+            },
+        ]
+    }
+    p = tmpdir / "fleet.yaml"
+    p.write_text(yaml.safe_dump(fleet_doc, allow_unicode=True), encoding="utf-8")
+    return p
+
+
+def _write_hangar_yaml(tmpdir: Path) -> Path:
+    """Write a minimal valid hangar YAML to *tmpdir* and return its path."""
+    hangar_doc = {
+        "length_m": 40.0,
+        "width_m": 20.0,
+        "door": {"center_x_m": 10.0, "width_m": 8.0},
+        "maintenance_bay": {"center_x_m": 10.0, "width_m": 6.0, "depth_m": 5.0},
+        "clearance_m": 0.3,
+        "wing_layer_clearance_m": 0.2,
+    }
+    p = tmpdir / "hangar.yaml"
+    p.write_text(yaml.safe_dump(hangar_doc, allow_unicode=True), encoding="utf-8")
+    return p
+
+
 def run_fleet(doc: Any) -> None:
     p = _write_yaml_tmp(doc)
     try:
@@ -485,6 +553,950 @@ def run_raw(doc: Any) -> None:
         p.unlink(missing_ok=True)
 
 
+# ---------------------------------------------------------------------------
+# Ref-resolving run-helpers
+#
+# The helpers above always pass valid fleet=/hangar= override kwargs, so the
+# ref-resolution branches inside load_layout / load_scenario are never reached:
+#   - "field required when no override" raise
+#   - path.parent / fleet_ref relative join
+#   - "set in YAML and override provided" conflict raise
+#
+# These helpers exercise those three branches by writing fleet/hangar files to
+# a temp directory and referencing them by relative path in the layout/scenario
+# YAML — mirroring the real on-disk usage pattern.
+# ---------------------------------------------------------------------------
+
+
+def run_layout_via_ref(doc: Any) -> None:
+    """Write fleet + hangar to a temp dir; inject relative refs into *doc*;
+    call load_layout with no override kwargs.
+
+    Covers:
+    - the relative-join path: ``(path.parent / fleet_ref).resolve()``
+    - (see run_layout_no_fleet_ref / run_layout_no_hangar_ref for the
+      "field required" raise paths)
+    """
+    tmpdir = Path(tempfile.mkdtemp(suffix="-fuzz-ref"))
+    try:
+        _write_fleet_yaml(tmpdir)
+        _write_hangar_yaml(tmpdir)
+        # Ensure doc is a dict; inject relative refs (relative names, no path
+        # component) so (path.parent / "fleet.yaml").resolve() resolves correctly.
+        if isinstance(doc, dict):
+            ref_doc = dict(doc)
+            ref_doc["fleet"] = "fleet.yaml"
+            ref_doc["hangar"] = "hangar.yaml"
+        else:
+            # Non-dict: will fail the top-level isinstance check → LoaderError
+            ref_doc = doc
+        main_path = tmpdir / "layout.yaml"
+        main_path.write_text(yaml.safe_dump(ref_doc, allow_unicode=True), encoding="utf-8")
+        with contextlib.suppress(LoaderError):
+            loader.load_layout(main_path)  # no fleet= / hangar= override
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def run_layout_no_fleet_ref(doc: Any) -> None:
+    """Call load_layout with NO fleet= override AND a YAML that omits 'fleet:'.
+
+    Covers: load_layout L187 — "fleet field is required when no override".
+    The YAML must have 'hangar:' so the loader reaches the fleet check before
+    raising for hangar.
+    """
+    tmpdir = Path(tempfile.mkdtemp(suffix="-fuzz-nofleet"))
+    try:
+        _write_hangar_yaml(tmpdir)
+        if isinstance(doc, dict):
+            ref_doc = {k: v for k, v in doc.items() if k not in ("fleet",)}
+            ref_doc["hangar"] = "hangar.yaml"
+        else:
+            ref_doc = doc
+        main_path = tmpdir / "layout.yaml"
+        main_path.write_text(yaml.safe_dump(ref_doc, allow_unicode=True), encoding="utf-8")
+        with contextlib.suppress(LoaderError):
+            loader.load_layout(main_path)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def run_layout_no_hangar_ref(doc: Any) -> None:
+    """Call load_layout with NO hangar= override AND a YAML that has 'fleet:'
+    but omits 'hangar:'.
+
+    Covers: load_layout L200 — "hangar field is required when no override".
+    Fleet resolves successfully first; then hangar_ref is None → raises.
+    """
+    tmpdir = Path(tempfile.mkdtemp(suffix="-fuzz-nohangar"))
+    try:
+        _write_fleet_yaml(tmpdir)
+        if isinstance(doc, dict):
+            ref_doc = {k: v for k, v in doc.items() if k not in ("hangar",)}
+            ref_doc["fleet"] = "fleet.yaml"
+        else:
+            ref_doc = doc
+        main_path = tmpdir / "layout.yaml"
+        main_path.write_text(yaml.safe_dump(ref_doc, allow_unicode=True), encoding="utf-8")
+        with contextlib.suppress(LoaderError):
+            loader.load_layout(main_path)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def run_layout_fleet_conflict(doc: Any) -> None:
+    """Supply a layout YAML with a 'fleet:' field AND pass fleet= override kwarg.
+
+    Covers: load_layout L192 — "fleet field is set but override also provided".
+    """
+    tmpdir = Path(tempfile.mkdtemp(suffix="-fuzz-fleet-conflict"))
+    try:
+        if isinstance(doc, dict):
+            conflict_doc = dict(doc)
+            conflict_doc["fleet"] = "fleet.yaml"
+            conflict_doc.pop("hangar", None)  # avoid hangar conflict in same call
+        else:
+            conflict_doc = doc
+        main_path = tmpdir / "layout.yaml"
+        main_path.write_text(yaml.safe_dump(conflict_doc, allow_unicode=True), encoding="utf-8")
+        with contextlib.suppress(LoaderError):
+            loader.load_layout(main_path, fleet=dict(VALID_FLEET))
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def run_layout_hangar_conflict(doc: Any) -> None:
+    """Supply a layout YAML with a 'hangar:' field AND pass hangar= override kwarg,
+    but supply a valid fleet ref so fleet resolves OK first.
+
+    Covers: load_layout L205 — "hangar field is set but override also provided".
+    Fleet must resolve (no fleet= override, valid fleet ref) → then hangar
+    conflict fires.
+    """
+    tmpdir = Path(tempfile.mkdtemp(suffix="-fuzz-hangar-conflict"))
+    try:
+        _write_fleet_yaml(tmpdir)
+        if isinstance(doc, dict):
+            conflict_doc = dict(doc)
+            conflict_doc["fleet"] = "fleet.yaml"
+            conflict_doc["hangar"] = "hangar.yaml"
+        else:
+            conflict_doc = doc
+        main_path = tmpdir / "layout.yaml"
+        main_path.write_text(yaml.safe_dump(conflict_doc, allow_unicode=True), encoding="utf-8")
+        # No fleet= override (so fleet resolves from file) + hangar= override
+        # while YAML also has 'hangar:' → conflict raise.
+        with contextlib.suppress(LoaderError):
+            loader.load_layout(main_path, hangar=VALID_HANGAR)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def run_layout_conflict(doc: Any) -> None:
+    """Pass a layout YAML that contains both 'fleet' and 'hangar' fields AND also
+    supply fleet= override kwarg — exercises the fleet conflict raise.
+    """
+    tmpdir = Path(tempfile.mkdtemp(suffix="-fuzz-conflict"))
+    try:
+        if isinstance(doc, dict):
+            conflict_doc = dict(doc)
+            conflict_doc["fleet"] = "fleet.yaml"
+            conflict_doc["hangar"] = "hangar.yaml"
+        else:
+            conflict_doc = doc
+        main_path = tmpdir / "layout.yaml"
+        main_path.write_text(yaml.safe_dump(conflict_doc, allow_unicode=True), encoding="utf-8")
+        # Supply fleet= override while YAML also has 'fleet:' → conflict error.
+        with contextlib.suppress(LoaderError):
+            loader.load_layout(main_path, fleet=dict(VALID_FLEET))
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def run_scenario_via_ref(doc: Any) -> None:
+    """Write fleet + hangar to a temp dir; inject relative refs into *doc*;
+    call load_scenario with no override kwargs.
+
+    Covers the same ref-resolution branches as run_layout_via_ref, but
+    for load_scenario (which also has the fleet_in required-field check before
+    the ref-resolution code, so the doc must carry fleet_in to reach those
+    branches).
+    """
+    tmpdir = Path(tempfile.mkdtemp(suffix="-fuzz-ref"))
+    try:
+        _write_fleet_yaml(tmpdir)
+        _write_hangar_yaml(tmpdir)
+        if isinstance(doc, dict):
+            ref_doc = dict(doc)
+            ref_doc["fleet"] = "fleet.yaml"
+            ref_doc["hangar"] = "hangar.yaml"
+            # Ensure fleet_in is present so we reach the ref-resolution code.
+            if "fleet_in" not in ref_doc:
+                ref_doc["fleet_in"] = ["p1"]
+        else:
+            ref_doc = doc
+        main_path = tmpdir / "scenario.yaml"
+        main_path.write_text(yaml.safe_dump(ref_doc, allow_unicode=True), encoding="utf-8")
+        with contextlib.suppress(LoaderError):
+            loader.load_scenario(main_path)  # no fleet= / hangar= override
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def run_scenario_no_fleet_ref(doc: Any) -> None:
+    """Call load_scenario with NO fleet= override AND a YAML that omits 'fleet:'.
+
+    Covers: load_scenario L298 — "fleet field is required when no override".
+    """
+    tmpdir = Path(tempfile.mkdtemp(suffix="-fuzz-nofleet"))
+    try:
+        _write_hangar_yaml(tmpdir)
+        if isinstance(doc, dict):
+            ref_doc = {k: v for k, v in doc.items() if k not in ("fleet",)}
+            ref_doc["hangar"] = "hangar.yaml"
+            if "fleet_in" not in ref_doc:
+                ref_doc["fleet_in"] = ["p1"]
+        else:
+            ref_doc = doc
+        main_path = tmpdir / "scenario.yaml"
+        main_path.write_text(yaml.safe_dump(ref_doc, allow_unicode=True), encoding="utf-8")
+        with contextlib.suppress(LoaderError):
+            loader.load_scenario(main_path)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def run_scenario_no_hangar_ref(doc: Any) -> None:
+    """Call load_scenario with NO hangar= override AND a YAML that has 'fleet:'
+    but omits 'hangar:'.
+
+    Covers: load_scenario L311 — "hangar field is required when no override".
+    """
+    tmpdir = Path(tempfile.mkdtemp(suffix="-fuzz-nohangar"))
+    try:
+        _write_fleet_yaml(tmpdir)
+        if isinstance(doc, dict):
+            ref_doc = {k: v for k, v in doc.items() if k not in ("hangar",)}
+            ref_doc["fleet"] = "fleet.yaml"
+            if "fleet_in" not in ref_doc:
+                ref_doc["fleet_in"] = ["p1"]
+        else:
+            ref_doc = doc
+        main_path = tmpdir / "scenario.yaml"
+        main_path.write_text(yaml.safe_dump(ref_doc, allow_unicode=True), encoding="utf-8")
+        with contextlib.suppress(LoaderError):
+            loader.load_scenario(main_path)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def run_scenario_hangar_conflict(doc: Any) -> None:
+    """Supply a scenario YAML with 'fleet:' and 'hangar:' fields + hangar= override kwarg.
+    Fleet resolves from file (no fleet= override); hangar conflict fires.
+
+    Covers: load_scenario L316 — "hangar field is set but override also provided".
+    """
+    tmpdir = Path(tempfile.mkdtemp(suffix="-fuzz-hangar-conflict"))
+    try:
+        _write_fleet_yaml(tmpdir)
+        if isinstance(doc, dict):
+            conflict_doc = dict(doc)
+            conflict_doc["fleet"] = "fleet.yaml"
+            conflict_doc["hangar"] = "hangar.yaml"
+            if "fleet_in" not in conflict_doc:
+                conflict_doc["fleet_in"] = ["p1"]
+        else:
+            conflict_doc = doc
+        main_path = tmpdir / "scenario.yaml"
+        main_path.write_text(yaml.safe_dump(conflict_doc, allow_unicode=True), encoding="utf-8")
+        with contextlib.suppress(LoaderError):
+            loader.load_scenario(main_path, hangar=VALID_HANGAR)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def run_scenario_conflict(doc: Any) -> None:
+    """Supply a scenario YAML with 'fleet:' field AND pass fleet= override kwarg.
+
+    Covers: load_scenario L303 — "fleet field is set but override also provided".
+    """
+    tmpdir = Path(tempfile.mkdtemp(suffix="-fuzz-conflict"))
+    try:
+        if isinstance(doc, dict):
+            conflict_doc = dict(doc)
+            conflict_doc["fleet"] = "fleet.yaml"
+            conflict_doc.pop("hangar", None)  # avoid hangar conflict
+            if "fleet_in" not in conflict_doc:
+                conflict_doc["fleet_in"] = ["p1"]
+        else:
+            conflict_doc = doc
+        main_path = tmpdir / "scenario.yaml"
+        main_path.write_text(yaml.safe_dump(conflict_doc, allow_unicode=True), encoding="utf-8")
+        with contextlib.suppress(LoaderError):
+            loader.load_scenario(main_path, fleet=dict(VALID_FLEET))
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Targeted document strategies for rare error branches
+#
+# Each targets a specific loader branch that the probabilistic fuzz rarely
+# reaches. These are _corrupt_one_field-style in spirit: start from a
+# well-formed document, then introduce the exact condition that triggers the
+# branch under test.
+# ---------------------------------------------------------------------------
+
+
+def hangar_model_invariant_violation_documents() -> st.SearchStrategy[Any]:
+    """Hangar YAML is structurally complete but violates a model invariant
+    (negative/zero numeric field) → load_hangar L156 (ValueError → LoaderError wrap).
+
+    All fields are present and parseable as floats; the failure happens inside
+    Hangar.__post_init__ or Door/MaintenanceBay.__post_init__.
+    """
+    return st.one_of(
+        # Hangar.length_m <= 0
+        st.just(
+            {
+                "length_m": -1.0,
+                "width_m": 20.0,
+                "door": {"center_x_m": 10.0, "width_m": 8.0},
+                "maintenance_bay": {"center_x_m": 10.0, "width_m": 6.0, "depth_m": 5.0},
+            }
+        ),
+        # Door.width_m <= 0
+        st.just(
+            {
+                "length_m": 40.0,
+                "width_m": 20.0,
+                "door": {"center_x_m": 10.0, "width_m": -1.0},
+                "maintenance_bay": {"center_x_m": 10.0, "width_m": 6.0, "depth_m": 5.0},
+            }
+        ),
+        # Bay depth >= length
+        st.just(
+            {
+                "length_m": 5.0,
+                "width_m": 20.0,
+                "door": {"center_x_m": 10.0, "width_m": 8.0},
+                "maintenance_bay": {"center_x_m": 10.0, "width_m": 6.0, "depth_m": 5.0},
+            }
+        ),
+    )
+
+
+def hangar_door_not_mapping_documents() -> st.SearchStrategy[Any]:
+    """Hangar YAML has length_m/width_m but door is not a dict
+    → load_hangar L118 ("door must be a mapping").
+    """
+    return st.builds(
+        lambda v: {
+            "length_m": 40.0,
+            "width_m": 20.0,
+            "door": v,
+            "maintenance_bay": {"center_x_m": 10.0, "width_m": 6.0, "depth_m": 5.0},
+        },
+        st.one_of(st.none(), st.integers(), _safe_text, st.booleans()),
+    )
+
+
+def hangar_bay_not_mapping_documents() -> st.SearchStrategy[Any]:
+    """Hangar YAML has a valid door dict but maintenance_bay is not a dict
+    → load_hangar L122 ("maintenance_bay must be a mapping").
+
+    load_hangar checks door first (L116-118) then maintenance_bay (L121-125).
+    To reach L122 we must pass the door check (door IS a dict) while
+    maintenance_bay is not a dict.
+    """
+    return st.builds(
+        lambda v: {
+            "length_m": 40.0,
+            "width_m": 20.0,
+            "door": {"center_x_m": 10.0, "width_m": 8.0},
+            "maintenance_bay": v,
+        },
+        st.one_of(st.none(), st.integers(), _safe_text, st.booleans()),
+    )
+
+
+def hangar_missing_required_field_documents() -> st.SearchStrategy[Any]:
+    """Hangar YAML is otherwise valid but missing one top-level required key
+    ('length_m' or 'width_m') or one required key inside door/maintenance_bay.
+
+    Covers load_hangar L129, L132, L135.
+    """
+    door_keys = ["center_x_m", "width_m"]
+    bay_keys = ["center_x_m", "width_m", "depth_m"]
+
+    @st.composite
+    def _build(draw: Any) -> dict[str, Any]:
+        full = {
+            "length_m": 40.0,
+            "width_m": 20.0,
+            "door": {"center_x_m": 10.0, "width_m": 8.0},
+            "maintenance_bay": {"center_x_m": 10.0, "width_m": 6.0, "depth_m": 5.0},
+        }
+        which = draw(st.sampled_from(["top_length", "top_width", "door_key", "bay_key"]))
+        doc = {k: v for k, v in full.items()}
+        if which == "top_length":
+            del doc["length_m"]
+        elif which == "top_width":
+            del doc["width_m"]
+        elif which == "door_key":
+            key = draw(st.sampled_from(door_keys))
+            doc["door"] = {k: v for k, v in full["door"].items() if k != key}
+        else:
+            key = draw(st.sampled_from(bay_keys))
+            doc["maintenance_bay"] = {k: v for k, v in full["maintenance_bay"].items() if k != key}
+        return doc
+
+    return _build()
+
+
+def fleet_parts_not_list_documents() -> st.SearchStrategy[Any]:
+    """Aircraft dict has 'parts' but the value is not a list (or is empty)
+    → _build_aircraft L546 ("parts must be a non-empty list").
+    """
+    return st.builds(
+        lambda v: {
+            "aircraft": [
+                {
+                    "id": "p1",
+                    "name": "Parts-non-list",
+                    "wing_position": "high",
+                    "gear": "nosewheel",
+                    "movement_mode": "always_cart",
+                    "measured": False,
+                    "parts": v,
+                }
+            ]
+        },
+        st.one_of(
+            st.none(),
+            st.integers(),
+            _safe_text,
+            st.just([]),  # empty list → not parts_data falsy
+            st.just({}),
+        ),
+    )
+
+
+def fleet_part_not_mapping_documents() -> st.SearchStrategy[Any]:
+    """A parts list entry is not a dict → _build_part L576 ("parts[i] must be a mapping")."""
+    non_dict = st.one_of(st.none(), st.integers(), _safe_text, st.booleans())
+    return st.builds(
+        lambda v: {
+            "aircraft": [
+                {
+                    "id": "p1",
+                    "name": "Part-non-dict",
+                    "wing_position": "high",
+                    "gear": "nosewheel",
+                    "movement_mode": "always_cart",
+                    "measured": False,
+                    "parts": [v],
+                }
+            ]
+        },
+        non_dict,
+    )
+
+
+def layout_always_cart_on_carts_false_documents() -> st.SearchStrategy[Any]:
+    """Place an always_cart plane with on_carts=False.
+
+    The loader does not pre-check this constraint; Layout.__post_init__
+    catches it and raises ValueError, which is then wrapped at L250-251.
+    """
+    return st.just(
+        {
+            "placements": [
+                {
+                    "plane": "p1",
+                    "x_m": 0.0,
+                    "y_m": 0.0,
+                    "heading_deg": 0.0,
+                    "on_carts": False,  # always_cart plane → Layout ValueError
+                }
+            ]
+        }
+    )
+
+
+def fleet_duplicate_aircraft_id_documents() -> st.SearchStrategy[Any]:
+    """Two aircraft entries share the same id → load_fleet L104 ("duplicate aircraft id")."""
+    plane = {
+        "id": "p1",
+        "name": "Plane",
+        "wing_position": "high",
+        "gear": "nosewheel",
+        "movement_mode": "always_cart",
+        "measured": False,
+        "parts": [
+            {"kind": "fuselage", "length_m": 6.0, "width_m": 1.2, "z_bottom_m": 0.0, "z_top_m": 2.0}
+        ],
+    }
+    return st.just({"aircraft": [plane, plane]})
+
+
+def fleet_aircraft_not_list_documents() -> st.SearchStrategy[Any]:
+    """'aircraft' present but not a list → line 90 in load_fleet."""
+    return st.builds(lambda v: {"aircraft": v}, st.one_of(_scalars, st.just({})))
+
+
+def fleet_aircraft_entry_not_mapping_documents() -> st.SearchStrategy[Any]:
+    """'aircraft' is a list but an entry is not a dict → line 95 in load_fleet."""
+    non_dict = st.one_of(st.none(), st.integers(), _safe_text, st.booleans())
+    return st.builds(lambda v: {"aircraft": [v]}, non_dict)
+
+
+def fleet_strut_without_wing_documents() -> st.SearchStrategy[Any]:
+    """Aircraft has a 'struts' block but no part with kind='wing'
+    → line 555: "struts block requires a part of kind 'wing'".
+
+    We provide a valid struts dict but only include a fuselage part (no wing).
+    """
+
+    @st.composite
+    def _build(draw: Any) -> dict[str, Any]:
+        return {
+            "aircraft": [
+                {
+                    "id": "p1",
+                    "name": "Strut-no-wing",
+                    "wing_position": "high",
+                    "gear": "nosewheel",
+                    "movement_mode": "always_cart",
+                    "measured": False,
+                    "parts": [
+                        # only a fuselage — no wing part, so _expand_struts can't find it
+                        {
+                            "kind": "fuselage",
+                            "length_m": draw(_positive),
+                            "width_m": draw(_positive),
+                            "z_bottom_m": 0.0,
+                            "z_top_m": draw(_positive),
+                        }
+                    ],
+                    "struts": {
+                        "fuselage_attach_x_m": 0.0,
+                        "fuselage_attach_y_m": 0.0,
+                        "fuselage_attach_z_m": 0.5,
+                        "wing_attach_y_m": 2.0,
+                        "width_m": draw(_positive),
+                    },
+                }
+            ]
+        }
+
+    return _build()
+
+
+def fleet_struts_missing_key_documents() -> st.SearchStrategy[Any]:
+    """Aircraft has a 'struts' block that omits one required struts key
+    → line 603 in _build_struts_spec."""
+    struts_keys = [
+        "fuselage_attach_x_m",
+        "fuselage_attach_y_m",
+        "fuselage_attach_z_m",
+        "wing_attach_y_m",
+        "width_m",
+    ]
+
+    @st.composite
+    def _build(draw: Any) -> dict[str, Any]:
+        full_struts = {
+            "fuselage_attach_x_m": 0.0,
+            "fuselage_attach_y_m": 0.0,
+            "fuselage_attach_z_m": 0.5,
+            "wing_attach_y_m": 2.0,
+            "width_m": 0.05,
+        }
+        # Drop exactly one key so the missing-key check fires.
+        drop_key = draw(st.sampled_from(struts_keys))
+        partial_struts = {k: v for k, v in full_struts.items() if k != drop_key}
+        return {
+            "aircraft": [
+                {
+                    "id": "p1",
+                    "name": "Strut-missing-key",
+                    "wing_position": "high",
+                    "gear": "nosewheel",
+                    "movement_mode": "always_cart",
+                    "measured": False,
+                    "parts": [
+                        {
+                            "kind": "wing",
+                            "length_m": 8.0,
+                            "width_m": 1.0,
+                            "z_bottom_m": 1.5,
+                            "z_top_m": 2.0,
+                        }
+                    ],
+                    "struts": partial_struts,
+                }
+            ]
+        }
+
+    return _build()
+
+
+def fleet_strut_invalid_geometry_documents() -> st.SearchStrategy[Any]:
+    """Aircraft with a 'struts' block that violates the geometry guards:
+    - wing.z_bottom_m <= fuselage_attach_z_m  → line 624 in _expand_struts
+    - wing_attach_y_m <= fuselage_attach_y_m  → line 631 in _expand_struts
+    """
+
+    @st.composite
+    def _z_guard_violation(draw: Any) -> dict[str, Any]:
+        """wing.z_bottom_m <= fuselage_attach_z_m."""
+        z = draw(st.floats(min_value=0.5, max_value=5.0, allow_nan=False, allow_infinity=False))
+        return {
+            "aircraft": [
+                {
+                    "id": "p1",
+                    "name": "Z-guard-violation",
+                    "wing_position": "high",
+                    "gear": "nosewheel",
+                    "movement_mode": "always_cart",
+                    "measured": False,
+                    "parts": [
+                        {
+                            "kind": "wing",
+                            "length_m": 8.0,
+                            "width_m": 1.0,
+                            "z_bottom_m": z,  # wing bottom at z
+                            "z_top_m": z + 0.5,
+                        }
+                    ],
+                    "struts": {
+                        "fuselage_attach_x_m": 0.0,
+                        "fuselage_attach_y_m": 0.0,
+                        "fuselage_attach_z_m": z,  # same as wing bottom → not strictly above
+                        "wing_attach_y_m": 2.0,
+                        "width_m": 0.05,
+                    },
+                }
+            ]
+        }
+
+    @st.composite
+    def _span_guard_violation(draw: Any) -> dict[str, Any]:
+        """wing_attach_y_m <= fuselage_attach_y_m (non-positive span)."""
+        fus_y = draw(st.floats(min_value=0.5, max_value=3.0, allow_nan=False, allow_infinity=False))
+        wing_y = draw(
+            st.floats(min_value=-1.0, max_value=fus_y, allow_nan=False, allow_infinity=False)
+        )
+        return {
+            "aircraft": [
+                {
+                    "id": "p1",
+                    "name": "Span-guard-violation",
+                    "wing_position": "high",
+                    "gear": "nosewheel",
+                    "movement_mode": "always_cart",
+                    "measured": False,
+                    "parts": [
+                        {
+                            "kind": "wing",
+                            "length_m": 8.0,
+                            "width_m": 1.0,
+                            "z_bottom_m": 2.0,
+                            "z_top_m": 2.5,
+                        }
+                    ],
+                    "struts": {
+                        "fuselage_attach_x_m": 0.0,
+                        "fuselage_attach_y_m": fus_y,
+                        "fuselage_attach_z_m": 0.5,
+                        "wing_attach_y_m": wing_y,  # <= fus_y → non-positive span
+                        "width_m": 0.05,
+                    },
+                }
+            ]
+        }
+
+    return st.one_of(_z_guard_violation(), _span_guard_violation())
+
+
+def fleet_aircraft_missing_required_field_documents() -> st.SearchStrategy[Any]:
+    """Aircraft dict is missing exactly one required key
+    → _build_aircraft L542 ("missing required field").
+
+    Note: load_fleet first checks isinstance(entry, dict) at L94 (→ L95),
+    so _build_aircraft is always called with a dict. L542 is therefore
+    reachable through normal load_fleet when an aircraft dict lacks a field.
+    """
+    required = ["id", "name", "wing_position", "gear", "movement_mode"]
+
+    @st.composite
+    def _build(draw: Any) -> dict[str, Any]:
+        drop_key = draw(st.sampled_from(required))
+        full = {
+            "id": "p1",
+            "name": "Test Plane",
+            "wing_position": "high",
+            "gear": "nosewheel",
+            "movement_mode": "always_cart",
+            "measured": False,
+            "parts": [
+                {
+                    "kind": "fuselage",
+                    "length_m": 6.0,
+                    "width_m": 1.2,
+                    "z_bottom_m": 0.0,
+                    "z_top_m": 2.0,
+                }
+            ],
+        }
+        return {"aircraft": [{k: v for k, v in full.items() if k != drop_key}]}
+
+    return _build()
+
+
+def fleet_struts_not_mapping_documents() -> st.SearchStrategy[Any]:
+    """Aircraft has 'struts' key but its value is not a dict
+    → _build_aircraft L551 ("struts must be a mapping").
+    """
+    non_dict_struts = st.one_of(st.integers(), _safe_text, st.booleans(), st.lists(st.integers()))
+    return st.builds(
+        lambda v: {
+            "aircraft": [
+                {
+                    "id": "p1",
+                    "name": "Struts-non-dict",
+                    "wing_position": "high",
+                    "gear": "nosewheel",
+                    "movement_mode": "always_cart",
+                    "measured": False,
+                    "parts": [
+                        {
+                            "kind": "fuselage",
+                            "length_m": 6.0,
+                            "width_m": 1.2,
+                            "z_bottom_m": 0.0,
+                            "z_top_m": 2.0,
+                        }
+                    ],
+                    "struts": v,
+                }
+            ]
+        },
+        non_dict_struts,
+    )
+
+
+def fleet_part_missing_required_field_documents() -> st.SearchStrategy[Any]:
+    """A part dict is missing exactly one required key
+    → _build_part L580 ("parts[i] missing required field").
+    """
+    required = ["kind", "length_m", "width_m", "z_bottom_m", "z_top_m"]
+
+    @st.composite
+    def _build(draw: Any) -> dict[str, Any]:
+        drop_key = draw(st.sampled_from(required))
+        full_part = {
+            "kind": "fuselage",
+            "length_m": 6.0,
+            "width_m": 1.2,
+            "z_bottom_m": 0.0,
+            "z_top_m": 2.0,
+        }
+        partial_part = {k: v for k, v in full_part.items() if k != drop_key}
+        return {
+            "aircraft": [
+                {
+                    "id": "p1",
+                    "name": "Part-missing-key",
+                    "wing_position": "high",
+                    "gear": "nosewheel",
+                    "movement_mode": "always_cart",
+                    "measured": False,
+                    "parts": [partial_part],
+                }
+            ]
+        }
+
+    return _build()
+
+
+def layout_placements_not_list_documents() -> st.SearchStrategy[Any]:
+    """'placements' key is present but its value is not a list
+    → load_layout L212 ("placements must be a list").
+    """
+    return st.builds(
+        lambda v: {"placements": v},
+        st.one_of(st.integers(), _safe_text, st.just({}), st.booleans()),
+    )
+
+
+def layout_maintenance_plane_in_placements_documents() -> st.SearchStrategy[Any]:
+    """The maintenance plane is also listed in placements
+    → load_layout L236-L241 pre-check (and Layout.__post_init__ backstop).
+
+    This exercises the loader-level "maintenance plane must NOT be placed"
+    check that surfaces a more actionable error than the bare model invariant.
+    """
+    placement = {"plane": "p1", "x_m": 0.0, "y_m": 0.0, "heading_deg": 0.0, "on_carts": True}
+    return st.just(
+        {
+            "placements": [placement],
+            "maintenance": {"plane": "p1"},
+        }
+    )
+
+
+def layout_placement_not_mapping_documents() -> st.SearchStrategy[Any]:
+    """'placements' list contains a non-dict entry
+    → line 664 in _build_placement."""
+    non_dict = st.one_of(st.none(), st.integers(), _safe_text, st.booleans())
+    return st.builds(
+        lambda v: {"placements": [v]},
+        non_dict,
+    )
+
+
+def layout_maintenance_shape_documents() -> st.SearchStrategy[Any]:
+    """Various malformed 'maintenance' block shapes to exercise
+    _extract_maintenance_plane branches (lines 448, 452, 455, 460, 465).
+
+    Covers:
+    - maintenance is a non-dict/non-None scalar       → line 448
+    - maintenance is a dict but lacks 'plane' key     → line 452
+    - maintenance.plane is None                       → line 455
+    - maintenance.plane is not a string               → line 460
+    - maintenance.plane is an empty string            → line 465
+    """
+    # Non-dict, non-None scalar (e.g. a bare string — the common author mistake)
+    non_dict_maintenance = st.builds(
+        lambda v: {"placements": [], "maintenance": v},
+        st.one_of(
+            st.integers(),
+            st.floats(allow_nan=False, allow_infinity=False),
+            _safe_text.filter(lambda s: s != ""),  # non-empty strings are the classic typo
+        ),
+    )
+    # Dict without 'plane' key
+    no_plane_key = st.just({"placements": [], "maintenance": {"aircraft": "p1"}})
+    # maintenance.plane = null
+    plane_is_null = st.just({"placements": [], "maintenance": {"plane": None}})
+    # maintenance.plane is a non-string (int/float/bool)
+    plane_non_string = st.builds(
+        lambda v: {"placements": [], "maintenance": {"plane": v}},
+        st.one_of(st.integers(), st.booleans()),
+    )
+    # maintenance.plane is an empty string
+    plane_empty = st.just({"placements": [], "maintenance": {"plane": ""}})
+    return st.one_of(
+        non_dict_maintenance,
+        no_plane_key,
+        plane_is_null,
+        plane_non_string,
+        plane_empty,
+    )
+
+
+def layout_case_insensitive_near_miss_documents() -> st.SearchStrategy[Any]:
+    """Placement plane id is a case-insensitive but not exact match for a valid id
+    → _suggest_plane_id L499 (case-insensitive branch).
+
+    'P1' and 'P2' match p1/p2 under casefold but are not in VALID_FLEET
+    (which uses lowercase ids), so the case-insensitive suggestion fires at L499.
+    """
+    return st.builds(
+        lambda pid: {
+            "placements": [
+                {"plane": pid, "x_m": 0.0, "y_m": 0.0, "heading_deg": 0.0, "on_carts": True}
+            ]
+        },
+        st.sampled_from(["P1", "P2"]),
+    )
+
+
+def layout_difflib_near_miss_documents() -> st.SearchStrategy[Any]:
+    """Placement plane id is a difflib-close but NOT case-insensitive match
+    for a valid id → _suggest_plane_id L502 (difflib branch).
+
+    'p1a' and 'pl1' score above 0.6 similarity to 'p1' with difflib but are
+    not case-insensitive matches, so the case-insensitive branch (L499) is
+    skipped and difflib fires at L502.
+    """
+    near_miss_ids = st.sampled_from(["p1a", "pl1", "p1_", "pp1"])
+    return st.builds(
+        lambda pid: {
+            "placements": [
+                {"plane": pid, "x_m": 0.0, "y_m": 0.0, "heading_deg": 0.0, "on_carts": True}
+            ]
+        },
+        near_miss_ids,
+    )
+
+
+def scenario_fleet_in_not_list_documents() -> st.SearchStrategy[Any]:
+    """'fleet_in' is present but not a list → line 291 in load_scenario."""
+    return st.builds(
+        lambda v: {"fleet_in": v},
+        st.one_of(st.none(), st.integers(), _safe_text, st.just({})),
+    )
+
+
+def scenario_constraints_not_mapping_documents() -> st.SearchStrategy[Any]:
+    """'constraints' is present but not a dict → lines 352/354 in load_scenario.
+
+    Includes explicit None (``constraints: ~`` → L352 sets it back to {}) and
+    non-dict values (list/int/str → L354 raises LoaderError).
+    """
+    return st.builds(
+        lambda v: {"fleet_in": ["p1"], "constraints": v},
+        st.one_of(
+            st.none(),  # explicit YAML null → L352: constraints_raw = {}
+            st.integers(),
+            _safe_text,
+            st.lists(st.integers(), max_size=3),
+        ),
+    )
+
+
+def scenario_constraint_non_dict_data_documents() -> st.SearchStrategy[Any]:
+    """'constraints' is a valid dict but a value is not a mapping
+    → line 411 in _build_plane_constraint."""
+    non_dict_val = st.one_of(st.integers(), _safe_text, st.none(), st.booleans())
+    return st.builds(
+        lambda v: {"fleet_in": ["p1"], "constraints": {"p1": v}},
+        non_dict_val,
+    )
+
+
+def scenario_pin_shape_documents() -> st.SearchStrategy[Any]:
+    """Pin field is present but not a mapping → line 417 in _build_plane_constraint.
+
+    Also exercises 'pin' missing a required field (line 423) and
+    'force_on_carts' _to_bool coercion (line 434).
+    """
+    # pin is a non-dict scalar
+    pin_non_dict = st.builds(
+        lambda v: {"fleet_in": ["p1"], "constraints": {"p1": {"pin": v}}},
+        st.one_of(st.integers(), _safe_text, st.booleans()),
+    )
+    # pin is a dict but missing one required key
+    required_pin_keys = ["x_m", "y_m", "heading_deg", "on_carts"]
+
+    @st.composite
+    def _pin_missing_key(draw: Any) -> dict[str, Any]:
+        full_pin = {"x_m": 0.0, "y_m": 0.0, "heading_deg": 0.0, "on_carts": True}
+        drop = draw(st.sampled_from(required_pin_keys))
+        partial_pin = {k: v for k, v in full_pin.items() if k != drop}
+        return {"fleet_in": ["p1"], "constraints": {"p1": {"pin": partial_pin}}}
+
+    # force_on_carts is not a bool (exercises _to_bool at line 434)
+    force_non_bool = st.builds(
+        lambda v: {"fleet_in": ["p1"], "constraints": {"p1": {"force_on_carts": v}}},
+        st.one_of(st.integers(), _safe_text, st.none()),
+    )
+    return st.one_of(pin_non_dict, _pin_missing_key(), force_non_bool)
+
+
 # --- tagged union for the Atheris single-target harness ---
 _RUNNERS = {
     "fleet": run_fleet,
@@ -492,16 +1504,134 @@ _RUNNERS = {
     "layout": run_layout,
     "scenario": run_scenario,
     "raw": run_raw,
+    # ref-resolving helpers
+    "layout_via_ref": run_layout_via_ref,
+    "layout_no_fleet_ref": run_layout_no_fleet_ref,
+    "layout_no_hangar_ref": run_layout_no_hangar_ref,
+    "layout_fleet_conflict": run_layout_fleet_conflict,
+    "layout_hangar_conflict": run_layout_hangar_conflict,
+    "layout_conflict": run_layout_conflict,
+    "scenario_via_ref": run_scenario_via_ref,
+    "scenario_no_fleet_ref": run_scenario_no_fleet_ref,
+    "scenario_no_hangar_ref": run_scenario_no_hangar_ref,
+    "scenario_hangar_conflict": run_scenario_hangar_conflict,
+    "scenario_conflict": run_scenario_conflict,
+    # targeted: hangar error branches
+    "hangar_model_invariant_violation": run_hangar,
+    "hangar_door_not_mapping": run_hangar,
+    "hangar_bay_not_mapping": run_hangar,
+    "hangar_missing_required_field": run_hangar,
+    # targeted: rare fleet error branches
+    "fleet_duplicate_aircraft_id": run_fleet,
+    "fleet_aircraft_not_list": run_fleet,
+    "fleet_aircraft_entry_not_mapping": run_fleet,
+    "fleet_aircraft_missing_required_field": run_fleet,
+    "fleet_parts_not_list": run_fleet,
+    "fleet_part_not_mapping": run_fleet,
+    "fleet_struts_not_mapping": run_fleet,
+    "fleet_strut_without_wing": run_fleet,
+    "fleet_struts_missing_key": run_fleet,
+    "fleet_strut_invalid_geometry": run_fleet,
+    "fleet_part_missing_required_field": run_fleet,
+    # targeted: rare layout error branches
+    "layout_placements_not_list": run_layout,
+    "layout_maintenance_plane_in_placements": run_layout,
+    "layout_always_cart_on_carts_false": run_layout,
+    "layout_placement_not_mapping": run_layout,
+    "layout_maintenance_shape": run_layout,
+    "layout_case_insensitive_near_miss": run_layout,
+    "layout_difflib_near_miss": run_layout,
+    # targeted: rare scenario error branches
+    "scenario_fleet_in_not_list": run_scenario,
+    "scenario_constraints_not_mapping": run_scenario,
+    "scenario_constraint_non_dict_data": run_scenario,
+    "scenario_pin_shape": run_scenario,
 }
 
 
 def tagged_documents() -> st.SearchStrategy[tuple[str, Any]]:
     return st.one_of(
+        # original strategies
         st.tuples(st.just("fleet"), fleet_documents()),
         st.tuples(st.just("hangar"), hangar_documents()),
         st.tuples(st.just("layout"), layout_documents()),
         st.tuples(st.just("scenario"), scenario_documents()),
         st.tuples(st.just("raw"), raw_documents()),
+        # ref-resolving helpers
+        st.tuples(st.just("layout_via_ref"), layout_documents()),
+        st.tuples(st.just("layout_no_fleet_ref"), layout_documents()),
+        st.tuples(st.just("layout_no_hangar_ref"), layout_documents()),
+        st.tuples(st.just("layout_fleet_conflict"), layout_documents()),
+        st.tuples(st.just("layout_hangar_conflict"), layout_documents()),
+        st.tuples(st.just("layout_conflict"), layout_documents()),
+        st.tuples(st.just("scenario_via_ref"), scenario_documents()),
+        st.tuples(st.just("scenario_no_fleet_ref"), scenario_documents()),
+        st.tuples(st.just("scenario_no_hangar_ref"), scenario_documents()),
+        st.tuples(st.just("scenario_hangar_conflict"), scenario_documents()),
+        st.tuples(st.just("scenario_conflict"), scenario_documents()),
+        # targeted: hangar error branches
+        st.tuples(
+            st.just("hangar_model_invariant_violation"),
+            hangar_model_invariant_violation_documents(),
+        ),
+        st.tuples(st.just("hangar_door_not_mapping"), hangar_door_not_mapping_documents()),
+        st.tuples(st.just("hangar_bay_not_mapping"), hangar_bay_not_mapping_documents()),
+        st.tuples(
+            st.just("hangar_missing_required_field"), hangar_missing_required_field_documents()
+        ),
+        # targeted: rare fleet error branches
+        st.tuples(st.just("fleet_duplicate_aircraft_id"), fleet_duplicate_aircraft_id_documents()),
+        st.tuples(st.just("fleet_aircraft_not_list"), fleet_aircraft_not_list_documents()),
+        st.tuples(
+            st.just("fleet_aircraft_entry_not_mapping"),
+            fleet_aircraft_entry_not_mapping_documents(),
+        ),
+        st.tuples(
+            st.just("fleet_aircraft_missing_required_field"),
+            fleet_aircraft_missing_required_field_documents(),
+        ),
+        st.tuples(st.just("fleet_parts_not_list"), fleet_parts_not_list_documents()),
+        st.tuples(st.just("fleet_part_not_mapping"), fleet_part_not_mapping_documents()),
+        st.tuples(st.just("fleet_struts_not_mapping"), fleet_struts_not_mapping_documents()),
+        st.tuples(st.just("fleet_strut_without_wing"), fleet_strut_without_wing_documents()),
+        st.tuples(st.just("fleet_struts_missing_key"), fleet_struts_missing_key_documents()),
+        st.tuples(
+            st.just("fleet_strut_invalid_geometry"), fleet_strut_invalid_geometry_documents()
+        ),
+        st.tuples(
+            st.just("fleet_part_missing_required_field"),
+            fleet_part_missing_required_field_documents(),
+        ),
+        # targeted: rare layout error branches
+        st.tuples(st.just("layout_placements_not_list"), layout_placements_not_list_documents()),
+        st.tuples(
+            st.just("layout_maintenance_plane_in_placements"),
+            layout_maintenance_plane_in_placements_documents(),
+        ),
+        st.tuples(
+            st.just("layout_always_cart_on_carts_false"),
+            layout_always_cart_on_carts_false_documents(),
+        ),
+        st.tuples(
+            st.just("layout_placement_not_mapping"), layout_placement_not_mapping_documents()
+        ),
+        st.tuples(st.just("layout_maintenance_shape"), layout_maintenance_shape_documents()),
+        st.tuples(
+            st.just("layout_case_insensitive_near_miss"),
+            layout_case_insensitive_near_miss_documents(),
+        ),
+        st.tuples(st.just("layout_difflib_near_miss"), layout_difflib_near_miss_documents()),
+        # targeted: rare scenario error branches
+        st.tuples(st.just("scenario_fleet_in_not_list"), scenario_fleet_in_not_list_documents()),
+        st.tuples(
+            st.just("scenario_constraints_not_mapping"),
+            scenario_constraints_not_mapping_documents(),
+        ),
+        st.tuples(
+            st.just("scenario_constraint_non_dict_data"),
+            scenario_constraint_non_dict_data_documents(),
+        ),
+        st.tuples(st.just("scenario_pin_shape"), scenario_pin_shape_documents()),
     )
 
 

--- a/tests/fuzz/strategies.py
+++ b/tests/fuzz/strategies.py
@@ -1143,14 +1143,25 @@ def fleet_struts_missing_key_documents() -> st.SearchStrategy[Any]:
 
 
 def fleet_strut_invalid_geometry_documents() -> st.SearchStrategy[Any]:
-    """Aircraft with a 'struts' block that violates the geometry guards:
-    - wing.z_bottom_m <= fuselage_attach_z_m  → line 624 in _expand_struts
-    - wing_attach_y_m <= fuselage_attach_y_m  → line 631 in _expand_struts
+    """Aircraft with a 'struts' block that violates the geometry guards in _expand_struts:
+
+    - _z_guard_violation:    wing.z_bottom_m <= fuselage_attach_z_m → _expand_struts L624
+    - _span_guard_violation: wing_attach_y_m == fuselage_attach_y_m (span == 0) → L631
+
+    The two variants are kept separate so each deterministically targets its own branch.
+
+    Span-guard design note:
+        StrutsSpec.__post_init__ (models.py L113) rejects wing_attach_y_m <= 0, and
+        L118 rejects wing_attach_y_m < fuselage_attach_y_m.  L631 is therefore only
+        reachable when wing_attach_y_m == fuselage_attach_y_m > 0 (span == 0 but both
+        values pass the model pre-checks).  Drawing a single y value and assigning it
+        to BOTH fields makes this deterministic — every draw reaches L631, not only the
+        boundary case where Hypothesis happens to pick the inclusive upper-bound float.
     """
 
     @st.composite
     def _z_guard_violation(draw: Any) -> dict[str, Any]:
-        """wing.z_bottom_m <= fuselage_attach_z_m."""
+        """wing.z_bottom_m <= fuselage_attach_z_m → _expand_struts L624."""
         z = draw(st.floats(min_value=0.5, max_value=5.0, allow_nan=False, allow_infinity=False))
         return {
             "aircraft": [
@@ -1183,11 +1194,15 @@ def fleet_strut_invalid_geometry_documents() -> st.SearchStrategy[Any]:
 
     @st.composite
     def _span_guard_violation(draw: Any) -> dict[str, Any]:
-        """wing_attach_y_m <= fuselage_attach_y_m (non-positive span)."""
-        fus_y = draw(st.floats(min_value=0.5, max_value=3.0, allow_nan=False, allow_infinity=False))
-        wing_y = draw(
-            st.floats(min_value=-1.0, max_value=fus_y, allow_nan=False, allow_infinity=False)
-        )
+        """wing_attach_y_m == fuselage_attach_y_m (zero span) → _expand_struts L631.
+
+        Both y values are drawn as the SAME float so the span is always exactly 0.
+        This bypasses StrutsSpec.__post_init__ (which only rejects wing_attach_y_m < 0
+        or wing_attach_y_m < fuselage_attach_y_m) and deterministically reaches L631
+        on every invocation rather than only when Hypothesis happens to pick the
+        inclusive upper bound.
+        """
+        y = draw(st.floats(min_value=0.1, max_value=3.0, allow_nan=False, allow_infinity=False))
         return {
             "aircraft": [
                 {
@@ -1208,9 +1223,9 @@ def fleet_strut_invalid_geometry_documents() -> st.SearchStrategy[Any]:
                     ],
                     "struts": {
                         "fuselage_attach_x_m": 0.0,
-                        "fuselage_attach_y_m": fus_y,
+                        "fuselage_attach_y_m": y,  # same value as wing_attach_y_m
                         "fuselage_attach_z_m": 0.5,
-                        "wing_attach_y_m": wing_y,  # <= fus_y → non-positive span
+                        "wing_attach_y_m": y,  # == fuselage_attach_y_m → span == 0 → L631
                         "width_m": 0.05,
                     },
                 }

--- a/tests/fuzz/test_loader_fuzz.py
+++ b/tests/fuzz/test_loader_fuzz.py
@@ -32,18 +32,23 @@ Targeted properties (#253 — closes rare loader error branches):
   test_fleet_aircraft_entry_not_mapping_…      → load_fleet L95
   test_fleet_strut_without_wing_…              → _build_aircraft L555
   test_fleet_struts_missing_key_…              → _build_struts_spec L603
-  test_fleet_strut_invalid_geometry_…          → _expand_struts L624/L631
+  test_fleet_strut_invalid_geometry_…          → _expand_struts L624 (z-guard) / L631 (span-guard)
+                                                  @example anchor pins L631 deterministically
   test_layout_placement_not_mapping_…          → _build_placement L664
   test_layout_maintenance_shape_…              → _extract_maintenance_plane L448-L465
   test_scenario_fleet_in_not_list_…            → load_scenario L291
   test_scenario_constraints_not_mapping_…      → load_scenario L352/L354
   test_scenario_constraint_non_dict_data_…     → _build_plane_constraint L411
   test_scenario_pin_shape_…                    → _build_plane_constraint L417/L423/L434
+
+@example anchors (follow-up — deterministic CI coverage for probabilistically-rare branches):
+  test_load_scenario_never_crashes   → load_scenario L337 (maintenance plane not in fleet_in)
+  test_fleet_strut_invalid_geometry… → _expand_struts L631 (span-guard, zero-span case)
 """
 
 from __future__ import annotations
 
-from hypothesis import given
+from hypothesis import example, given
 
 from tests.fuzz import strategies as s
 
@@ -67,6 +72,15 @@ def test_load_layout_never_crashes(doc):
     s.run_layout(doc)
 
 
+@example(
+    # Deterministic anchor for load_scenario L337:
+    # maintenance_plane is not None AND its id is not in fleet_in, so
+    # _resolve_known_plane_id raises LoaderError at L337 every run.
+    {
+        "fleet_in": ["p1"],
+        "maintenance": {"plane": "unknown_plane"},
+    }
+)
 @given(s.scenario_documents())
 def test_load_scenario_never_crashes(doc):
     s.run_scenario(doc)
@@ -262,6 +276,41 @@ def test_fleet_struts_missing_key_never_crashes(doc):
     s.run_fleet(doc)
 
 
+@example(
+    # Deterministic anchor for _expand_struts L631 (zero-span guard):
+    # wing_attach_y_m == fuselage_attach_y_m == 1.0 → strut_span == 0.
+    # StrutsSpec.__post_init__ passes (both > 0, neither < the other),
+    # so _expand_struts L623 passes (wing z_bottom=2.0 > fus_attach_z=0.5)
+    # and execution reaches L631 where strut_span <= 0 raises LoaderError.
+    {
+        "aircraft": [
+            {
+                "id": "p1",
+                "name": "Span-guard-violation",
+                "wing_position": "high",
+                "gear": "nosewheel",
+                "movement_mode": "always_cart",
+                "measured": False,
+                "parts": [
+                    {
+                        "kind": "wing",
+                        "length_m": 8.0,
+                        "width_m": 1.0,
+                        "z_bottom_m": 2.0,
+                        "z_top_m": 2.5,
+                    }
+                ],
+                "struts": {
+                    "fuselage_attach_x_m": 0.0,
+                    "fuselage_attach_y_m": 1.0,
+                    "fuselage_attach_z_m": 0.5,
+                    "wing_attach_y_m": 1.0,
+                    "width_m": 0.05,
+                },
+            }
+        ]
+    }
+)
 @given(s.fleet_strut_invalid_geometry_documents())
 def test_fleet_strut_invalid_geometry_never_crashes(doc):
     """Strut geometry violates z-ordering or positive-span guards → _expand_struts L624/L631."""

--- a/tests/fuzz/test_loader_fuzz.py
+++ b/tests/fuzz/test_loader_fuzz.py
@@ -8,6 +8,37 @@ exception propagates here and Hypothesis shrinks it to a minimal repro.
 
 Runs under the ``ci`` profile by default (fast, every PR); the nightly workflow
 sets HYPOTHESIS_PROFILE=nightly for a deep run.
+
+Test groups
+-----------
+Original properties (every PR, ~50 examples each):
+  test_load_fleet_never_crashes, test_load_hangar_never_crashes,
+  test_load_layout_never_crashes, test_load_scenario_never_crashes,
+  test_load_raw_input_never_crashes
+
+Ref-resolution properties (#253 — closes the fleet:/hangar: branch gap):
+  test_load_layout_via_ref_never_crashes
+    → load_layout called WITHOUT fleet=/hangar= overrides; YAML references
+      fleet.yaml / hangar.yaml by relative path.  Covers:
+        • the relative-join: (path.parent / fleet_ref).resolve()
+        • the "field required when no override" raise
+  test_load_layout_conflict_never_crashes
+    → YAML has 'fleet'/'hangar' fields AND override kwargs are passed.
+      Covers the "set in YAML and override provided" conflict raise.
+  test_load_scenario_via_ref_never_crashes / _conflict — same for load_scenario.
+
+Targeted properties (#253 — closes rare loader error branches):
+  test_fleet_aircraft_not_list_never_crashes   → load_fleet L90
+  test_fleet_aircraft_entry_not_mapping_…      → load_fleet L95
+  test_fleet_strut_without_wing_…              → _build_aircraft L555
+  test_fleet_struts_missing_key_…              → _build_struts_spec L603
+  test_fleet_strut_invalid_geometry_…          → _expand_struts L624/L631
+  test_layout_placement_not_mapping_…          → _build_placement L664
+  test_layout_maintenance_shape_…              → _extract_maintenance_plane L448-L465
+  test_scenario_fleet_in_not_list_…            → load_scenario L291
+  test_scenario_constraints_not_mapping_…      → load_scenario L352/L354
+  test_scenario_constraint_non_dict_data_…     → _build_plane_constraint L411
+  test_scenario_pin_shape_…                    → _build_plane_constraint L417/L423/L434
 """
 
 from __future__ import annotations
@@ -15,6 +46,10 @@ from __future__ import annotations
 from hypothesis import given
 
 from tests.fuzz import strategies as s
+
+# ---------------------------------------------------------------------------
+# Original properties (unchanged from #143)
+# ---------------------------------------------------------------------------
 
 
 @given(s.fleet_documents())
@@ -40,3 +75,287 @@ def test_load_scenario_never_crashes(doc):
 @given(s.raw_documents())
 def test_load_raw_input_never_crashes(doc):
     s.run_raw(doc)
+
+
+# ---------------------------------------------------------------------------
+# Ref-resolution properties (#253 — Gap 1)
+#
+# The existing helpers always pass valid fleet=/hangar= override kwargs, so
+# the branches inside load_layout / load_scenario that read 'fleet:' /
+# 'hangar:' YAML fields are never exercised.  These properties close that gap.
+# ---------------------------------------------------------------------------
+
+
+@given(s.layout_documents())
+def test_load_layout_via_ref_never_crashes(doc):
+    """load_layout WITHOUT override kwargs; YAML provides relative fleet/hangar refs.
+
+    Reaches: relative-join (path.parent / fleet_ref).resolve().
+    """
+    s.run_layout_via_ref(doc)
+
+
+@given(s.layout_documents())
+def test_load_layout_no_fleet_ref_never_crashes(doc):
+    """load_layout with no fleet= override AND no 'fleet:' in YAML.
+
+    Reaches: load_layout L187 — "fleet field is required when no override".
+    """
+    s.run_layout_no_fleet_ref(doc)
+
+
+@given(s.layout_documents())
+def test_load_layout_no_hangar_ref_never_crashes(doc):
+    """load_layout with valid fleet ref but no 'hangar:' in YAML and no hangar= override.
+
+    Reaches: load_layout L200 — "hangar field is required when no override".
+    """
+    s.run_layout_no_hangar_ref(doc)
+
+
+@given(s.layout_documents())
+def test_load_layout_fleet_conflict_never_crashes(doc):
+    """YAML has 'fleet:' field AND fleet= override kwarg supplied.
+
+    Reaches: load_layout L192 — "fleet field is set but override also provided".
+    """
+    s.run_layout_fleet_conflict(doc)
+
+
+@given(s.layout_documents())
+def test_load_layout_hangar_conflict_never_crashes(doc):
+    """YAML has valid fleet ref + 'hangar:' field AND hangar= override kwarg.
+
+    Reaches: load_layout L205 — "hangar field is set but override also provided".
+    """
+    s.run_layout_hangar_conflict(doc)
+
+
+@given(s.layout_documents())
+def test_load_layout_conflict_never_crashes(doc):
+    """YAML has 'fleet:' field AND fleet= override kwarg supplied (combined path)."""
+    s.run_layout_conflict(doc)
+
+
+@given(s.scenario_documents())
+def test_load_scenario_via_ref_never_crashes(doc):
+    """load_scenario WITHOUT override kwargs; YAML provides relative fleet/hangar refs.
+
+    Reaches: relative-join path in load_scenario.
+    """
+    s.run_scenario_via_ref(doc)
+
+
+@given(s.scenario_documents())
+def test_load_scenario_no_fleet_ref_never_crashes(doc):
+    """load_scenario with no fleet= override AND no 'fleet:' in YAML.
+
+    Reaches: load_scenario L298 — "fleet field is required when no override".
+    """
+    s.run_scenario_no_fleet_ref(doc)
+
+
+@given(s.scenario_documents())
+def test_load_scenario_no_hangar_ref_never_crashes(doc):
+    """load_scenario with valid fleet ref but no 'hangar:' and no hangar= override.
+
+    Reaches: load_scenario L311 — "hangar field is required when no override".
+    """
+    s.run_scenario_no_hangar_ref(doc)
+
+
+@given(s.scenario_documents())
+def test_load_scenario_hangar_conflict_never_crashes(doc):
+    """YAML has valid fleet ref + 'hangar:' AND hangar= override kwarg.
+
+    Reaches: load_scenario L316 — "hangar field is set but override also provided".
+    """
+    s.run_scenario_hangar_conflict(doc)
+
+
+@given(s.scenario_documents())
+def test_load_scenario_conflict_never_crashes(doc):
+    """YAML has 'fleet:' field AND fleet= override kwarg supplied (combined path)."""
+    s.run_scenario_conflict(doc)
+
+
+# ---------------------------------------------------------------------------
+# Targeted properties (#253 — Gap 2: rare error branches)
+# ---------------------------------------------------------------------------
+
+
+@given(s.hangar_model_invariant_violation_documents())
+def test_hangar_model_invariant_violation_never_crashes(doc):
+    """Hangar structurally valid but violates model invariant → load_hangar L156 ValueError wrap."""
+    s.run_hangar(doc)
+
+
+@given(s.hangar_door_not_mapping_documents())
+def test_hangar_door_not_mapping_never_crashes(doc):
+    """Hangar 'door' is not a dict → load_hangar L118."""
+    s.run_hangar(doc)
+
+
+@given(s.hangar_bay_not_mapping_documents())
+def test_hangar_bay_not_mapping_never_crashes(doc):
+    """Hangar has valid door dict but maintenance_bay is not a dict → load_hangar L122."""
+    s.run_hangar(doc)
+
+
+@given(s.hangar_missing_required_field_documents())
+def test_hangar_missing_required_field_never_crashes(doc):
+    """Hangar YAML missing one top-level or sub-dict required key → load_hangar L129/L132/L135."""
+    s.run_hangar(doc)
+
+
+@given(s.fleet_duplicate_aircraft_id_documents())
+def test_fleet_duplicate_aircraft_id_never_crashes(doc):
+    """Two aircraft entries share the same id → load_fleet L104 ("duplicate aircraft id")."""
+    s.run_fleet(doc)
+
+
+@given(s.fleet_aircraft_not_list_documents())
+def test_fleet_aircraft_not_list_never_crashes(doc):
+    """'aircraft' key present but value is not a list → load_fleet L90."""
+    s.run_fleet(doc)
+
+
+@given(s.fleet_aircraft_entry_not_mapping_documents())
+def test_fleet_aircraft_entry_not_mapping_never_crashes(doc):
+    """'aircraft' is a list but an entry is not a dict → load_fleet L95."""
+    s.run_fleet(doc)
+
+
+@given(s.fleet_aircraft_missing_required_field_documents())
+def test_fleet_aircraft_missing_required_field_never_crashes(doc):
+    """Aircraft dict missing exactly one required key → _build_aircraft L542."""
+    s.run_fleet(doc)
+
+
+@given(s.fleet_parts_not_list_documents())
+def test_fleet_parts_not_list_never_crashes(doc):
+    """Aircraft 'parts' value is not a list or is empty → _build_aircraft L546."""
+    s.run_fleet(doc)
+
+
+@given(s.fleet_part_not_mapping_documents())
+def test_fleet_part_not_mapping_never_crashes(doc):
+    """Parts list entry is not a dict → _build_part L576."""
+    s.run_fleet(doc)
+
+
+@given(s.fleet_struts_not_mapping_documents())
+def test_fleet_struts_not_mapping_never_crashes(doc):
+    """Aircraft has 'struts' key with a non-dict value → _build_aircraft L551."""
+    s.run_fleet(doc)
+
+
+@given(s.fleet_strut_without_wing_documents())
+def test_fleet_strut_without_wing_never_crashes(doc):
+    """Aircraft has 'struts' but no wing part → _build_aircraft L555."""
+    s.run_fleet(doc)
+
+
+@given(s.fleet_struts_missing_key_documents())
+def test_fleet_struts_missing_key_never_crashes(doc):
+    """Aircraft 'struts' dict is missing a required key → _build_struts_spec L603."""
+    s.run_fleet(doc)
+
+
+@given(s.fleet_strut_invalid_geometry_documents())
+def test_fleet_strut_invalid_geometry_never_crashes(doc):
+    """Strut geometry violates z-ordering or positive-span guards → _expand_struts L624/L631."""
+    s.run_fleet(doc)
+
+
+@given(s.fleet_part_missing_required_field_documents())
+def test_fleet_part_missing_required_field_never_crashes(doc):
+    """Part dict missing exactly one required key → _build_part L580."""
+    s.run_fleet(doc)
+
+
+@given(s.layout_placements_not_list_documents())
+def test_layout_placements_not_list_never_crashes(doc):
+    """'placements' value is not a list → load_layout L212."""
+    s.run_layout(doc)
+
+
+@given(s.layout_maintenance_plane_in_placements_documents())
+def test_layout_maintenance_plane_in_placements_never_crashes(doc):
+    """Maintenance plane also listed in placements → load_layout pre-check L236-L241."""
+    s.run_layout(doc)
+
+
+@given(s.layout_always_cart_on_carts_false_documents())
+def test_layout_always_cart_on_carts_false_never_crashes(doc):
+    """always_cart plane placed with on_carts=False → Layout.__post_init__ ValueError → L250-251."""
+    s.run_layout(doc)
+
+
+@given(s.layout_placement_not_mapping_documents())
+def test_layout_placement_not_mapping_never_crashes(doc):
+    """'placements' list contains a non-dict entry → _build_placement L664."""
+    s.run_layout(doc)
+
+
+@given(s.layout_maintenance_shape_documents())
+def test_layout_maintenance_shape_never_crashes(doc):
+    """Various malformed 'maintenance' block shapes → _extract_maintenance_plane L448-L465."""
+    s.run_layout(doc)
+
+
+@given(s.layout_case_insensitive_near_miss_documents())
+def test_layout_case_insensitive_near_miss_never_crashes(doc):
+    """Placement id is a case-insensitive match for a valid id → _suggest_plane_id L499."""
+    s.run_layout(doc)
+
+
+@given(s.layout_difflib_near_miss_documents())
+def test_layout_difflib_near_miss_never_crashes(doc):
+    """Placement id is a difflib near-match (not case-fold) → _suggest_plane_id L502."""
+    s.run_layout(doc)
+
+
+@given(s.scenario_fleet_in_not_list_documents())
+def test_scenario_fleet_in_not_list_never_crashes(doc):
+    """'fleet_in' is not a list → load_scenario L291."""
+    s.run_scenario(doc)
+
+
+@given(s.scenario_constraints_not_mapping_documents())
+def test_scenario_constraints_not_mapping_never_crashes(doc):
+    """'constraints' is null or not a mapping → load_scenario L352/L354."""
+    s.run_scenario(doc)
+
+
+@given(s.scenario_constraint_non_dict_data_documents())
+def test_scenario_constraint_non_dict_data_never_crashes(doc):
+    """Constraint value is not a mapping → _build_plane_constraint L411."""
+    s.run_scenario(doc)
+
+
+@given(s.scenario_pin_shape_documents())
+def test_scenario_pin_shape_never_crashes(doc):
+    """Pin is not a mapping, missing required key, or force_on_carts not bool
+    → _build_plane_constraint L417/L423/L434."""
+    s.run_scenario(doc)
+
+
+# ---------------------------------------------------------------------------
+# Branches documented as example-test-only
+#
+# The following loader branches are NOT exercised by this fuzz suite because
+# they are only reachable via direct Python API calls — the YAML entry-point
+# path has an upstream guard that prevents the input from ever reaching them:
+#
+# _build_aircraft L537: "aircraft entry must be a mapping, got ..."
+#   - Shadowed by load_fleet L94 which checks isinstance(entry, dict) BEFORE
+#     calling _build_aircraft(entry). _build_aircraft is only called on dicts.
+#   - Covered by direct-call tests in tests/test_loader.py.
+#
+# _read_yaml L683: "file not found: {path}"
+#   - All run-helpers write the YAML file to disk before calling the loader.
+#     A file-not-found error can only happen if the temp file is deleted
+#     between writing and reading, which doesn't occur in normal fuzz flow.
+#   - Covered by tests/test_loader.py::test_load_fleet_missing_file (or similar).
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #253.

Follow-up to #249 (the original polyglot fuzz suite). Closes two coverage gaps in \`hangarfit.loader\` identified by running \`--cov-report=term-missing\` against the existing fuzz tests.

## Gap 1 — Ref-resolution paths (fleet:/hangar: field branches)

The existing run-helpers always pass \`fleet=\`/\`hangar=\` override kwargs, so the ref-resolution branches inside \`load_layout\` / \`load_scenario\` were never exercised.

Added **ref-resolving run-helpers** that write valid fleet/hangar YAML files to a \`tempfile.mkdtemp()\` directory and reference them by relative path in the layout/scenario YAML, calling the loaders with no override kwargs. Each helper is paired with a \`@given\` property. Helpers added:

- \`run_layout_via_ref\` — exercises \`(path.parent / fleet_ref).resolve()\`
- \`run_layout_no_fleet_ref\` — "fleet field required when no override" (L187)
- \`run_layout_no_hangar_ref\` — "hangar field required when no override" (L200)
- \`run_layout_fleet_conflict\` — fleet field in YAML + fleet= kwarg (L192)
- \`run_layout_hangar_conflict\` — hangar field in YAML + hangar= kwarg (L205)
- \`run_scenario_via_ref\` / \`_no_fleet_ref\` / \`_no_hangar_ref\` / \`_hangar_conflict\` / \`_conflict\` — same three branches for \`load_scenario\` (L298/L303/L311/L316)

## Gap 2 — Targeted rare error branches

Added 19 targeted document strategies, each guaranteed to exercise one specific loader branch that the probabilistic 50-example CI budget doesn't reliably reach:

- \`hangar_model_invariant_violation_documents\` → \`load_hangar\` L156 (ValueError wrap)
- \`hangar_door_not_mapping_documents\` → L118
- \`hangar_bay_not_mapping_documents\` → L122
- \`hangar_missing_required_field_documents\` → L129/L132/L135
- \`fleet_duplicate_aircraft_id_documents\` → \`load_fleet\` L104
- \`fleet_aircraft_not_list_documents\` → L90
- \`fleet_aircraft_entry_not_mapping_documents\` → L95
- \`fleet_aircraft_missing_required_field_documents\` → \`_build_aircraft\` L542
- \`fleet_parts_not_list_documents\` → L546
- \`fleet_part_not_mapping_documents\` → \`_build_part\` L576
- \`fleet_struts_not_mapping_documents\` → \`_build_aircraft\` L551
- \`fleet_strut_without_wing_documents\` → L555
- \`fleet_struts_missing_key_documents\` → \`_build_struts_spec\` L603
- \`fleet_strut_invalid_geometry_documents\` → \`_expand_struts\` L624/L631
- \`layout_placements_not_list_documents\` → \`load_layout\` L212
- \`layout_maintenance_plane_in_placements_documents\` → L236–L241
- \`layout_always_cart_on_carts_false_documents\` → L250–L251 (Layout ValueError wrap)
- \`layout_placement_not_mapping_documents\` → \`_build_placement\` L664
- \`layout_maintenance_shape_documents\` → \`_extract_maintenance_plane\` L448–L465
- \`layout_case_insensitive_near_miss_documents\` → \`_suggest_plane_id\` L499
- \`layout_difflib_near_miss_documents\` → L502
- \`scenario_fleet_in_not_list_documents\` → \`load_scenario\` L291
- \`scenario_constraints_not_mapping_documents\` → L352/L354 (including explicit null)
- \`scenario_constraint_non_dict_data_documents\` → \`_build_plane_constraint\` L411
- \`scenario_pin_shape_documents\` → L417/L423/L434

## Coverage delta

| Metric | Before (#249) | After (#253) |
|---|---|---|
| Fuzz-only loader coverage | 75% | 99% |
| Missing lines | 55 | 2 (documented example-test-only) |
| Fuzz test count | 5 | 42 |

The 2 remaining uncovered lines (\`_build_aircraft\` L537 shadowed by \`load_fleet\` L94; \`_read_yaml\` L683 file-not-found) are documented in a comment block at the bottom of \`test_loader_fuzz.py\` explaining why they are architecturally unreachable via the YAML entry-point path and are covered by \`tests/test_loader.py\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)