### PR TITLE
feat(cli): auto-fall-back to no-spread when --render-paths can't route a spread layout (#280)

### DIFF
--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import secrets
 import sys
 from typing import TYPE_CHECKING
 
@@ -350,14 +351,57 @@ def cmd_solve(args: argparse.Namespace) -> int:
     # plan_paths=False: the library bundle (SolveResult.plans) is available to
     # callers, but the CLI would just pay the per-plane Hybrid-A* search cost
     # for output it never draws.
+    #
+    # Resolve the seed ONCE here (rather than letting each solve() call draw its
+    # own from system entropy when --seed is omitted) so the spread run and any
+    # no-spread fallback share an identical, reproducible seed. This keeps the
+    # ADR-0003 determinism contract intact across the two-pass fallback: a given
+    # --seed (or a given resolved entropy seed) yields the same fallback result.
+    resolved_seed = args.seed if args.seed is not None else secrets.randbits(32)
+
     result = solve(
         scenario,
         budget_s=args.budget,
         alternatives=args.alternatives,
-        seed=args.seed,
+        seed=resolved_seed,
         search=SearchConfig(spread=args.spread),
         plan_paths=args.render_paths,
     )
+
+    # #280 — spread-vs-towability fallback. The ADR-0008 spread post-pass
+    # (default ON) maximizes inter-plane gaps, which can push planes into
+    # positions the bounded tow planner (towplanner._MAX_EXPANSIONS) can no
+    # longer thread from the door cone: every plan comes back None and
+    # --render-paths would return a bare exit 3 ("untowable") — even though the
+    # SAME fleet+hangar routes cleanly with spread off. When the user did NOT
+    # explicitly pass --no-spread, automatically RE-SOLVE with spread disabled,
+    # tow-plan that, and — only if it actually routes at least one candidate —
+    # render the routable (tighter) arrangement instead. The swap is always
+    # reported on stderr (never silent: the user gets a different, tighter
+    # layout than a plain spread solve would yield). If the no-spread re-solve
+    # also routes nothing (genuinely too tight, e.g. the placeholder hangar),
+    # keep the original spread result so exit 3 stands unchanged.
+    if (
+        args.render_paths
+        and args.spread
+        and result.layouts
+        and all(plan is None for plan in result.plans)
+    ):
+        fallback = solve(
+            scenario,
+            budget_s=args.budget,
+            alternatives=args.alternatives,
+            seed=resolved_seed,
+            search=SearchConfig(spread=False),
+            plan_paths=True,
+        )
+        if fallback.layouts and any(plan is not None for plan in fallback.plans):
+            print(
+                "note: layout un-routable with inter-plane spread; re-solved "
+                "with spread disabled to produce tow paths",
+                file=sys.stderr,
+            )
+            result = fallback
 
     if args.json:
         _emit_solve_json(args.scenario, result)

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -111,7 +111,9 @@ def build_parser() -> argparse.ArgumentParser:
             "Overlay each plane's tow path on the --render PNG(s), one colour per "
             "plane (requires --render). Tow-plans every returned layout; a layout "
             "the tow planner cannot route is rendered without paths and a warning "
-            "names the blocking plane. Exit 3 if NO candidate is tow-routable."
+            "names the blocking plane. Exit 3 if NO candidate is tow-routable. "
+            "May run a second solve with inter-plane spread disabled if the "
+            "spread layout can't be routed, up to ~2x the --budget."
         ),
     )
     solve.add_argument(
@@ -381,6 +383,12 @@ def cmd_solve(args: argparse.Namespace) -> int:
     # layout than a plain spread solve would yield). If the no-spread re-solve
     # also routes nothing (genuinely too tight, e.g. the placeholder hangar),
     # keep the original spread result so exit 3 stands unchanged.
+    #
+    # ``spread_fallback_applied`` records whether the swap actually executed.
+    # Non-interactive consumers (--json, --write-yaml) need a durable signal
+    # that a tighter no-spread arrangement was substituted (#280 "never silently
+    # swapped" for machines, not just the human stderr note).
+    spread_fallback_applied = False
     if (
         args.render_paths
         and args.spread
@@ -402,9 +410,10 @@ def cmd_solve(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             result = fallback
+            spread_fallback_applied = True
 
     if args.json:
-        _emit_solve_json(args.scenario, result)
+        _emit_solve_json(args.scenario, result, spread_fallback_applied=spread_fallback_applied)
     else:
         _emit_solve_human(result, alternatives=args.alternatives)
 
@@ -426,7 +435,13 @@ def cmd_solve(args: argparse.Namespace) -> int:
                 )
             if args.write_yaml is not None:
                 fleet_ref, hangar_ref = _resolve_fleet_hangar_refs(args)
-                _write_yamls(result.layouts, args.write_yaml, fleet_ref, hangar_ref)
+                _write_yamls(
+                    result.layouts,
+                    args.write_yaml,
+                    fleet_ref,
+                    hangar_ref,
+                    spread_fallback_applied=spread_fallback_applied,
+                )
         except OSError as e:
             print(f"error: write failed: {e}", file=sys.stderr)
             return 2
@@ -561,6 +576,8 @@ def _write_yamls(
     pattern: str,
     fleet_ref: str,
     hangar_ref: str,
+    *,
+    spread_fallback_applied: bool = False,
 ) -> None:
     """Write each layout to PATTERN with ``{i}`` substituted.
 
@@ -568,6 +585,13 @@ def _write_yamls(
     round-trips through ``hangarfit check``. Fleet/hangar refs are
     embedded as absolute paths so the written file is location-
     independent.
+
+    When ``spread_fallback_applied`` is True the written layout is the tighter
+    no-spread arrangement substituted by the --render-paths fallback (#280); a
+    leading ``# note:`` comment marks that provenance. The comment is a YAML
+    comment line, so the file still round-trips through ``hangarfit check``
+    (the structured ``spread_fallback_applied`` JSON field carries the same
+    signal for parsers; this header is for a human reading the .yaml later).
     """
     import yaml
 
@@ -590,6 +614,10 @@ def _write_yamls(
         ]
         path = _expand_pattern(pattern, i)
         with open(path, "w") as f:
+            if spread_fallback_applied:
+                f.write(
+                    "# note: produced with inter-plane spread disabled (auto-fallback, see #280)\n"
+                )
             yaml.safe_dump(payload, f, sort_keys=False)
 
 
@@ -618,8 +646,20 @@ def _check_result_to_dict(result: CheckResult) -> dict:
     }
 
 
-def _emit_solve_json(scenario_path: str, result: SolveResult) -> None:
-    """Write the hangarfit.solve/v1 payload to stdout."""
+def _emit_solve_json(
+    scenario_path: str,
+    result: SolveResult,
+    *,
+    spread_fallback_applied: bool = False,
+) -> None:
+    """Write the hangarfit.solve/v1 payload to stdout.
+
+    ``spread_fallback_applied`` is threaded in from ``cmd_solve`` rather than
+    read off ``SolverDiagnostics`` — the swap is a CLI-level decision (#280),
+    not a solver fact, so it does not belong on ``SolverDiagnostics``. It is
+    emitted as an always-present (default False) additive diagnostics field so
+    non-interactive consumers can rely on it without a schema bump.
+    """
     d = result.diagnostics
     payload = {
         "schema": _SOLVE_JSON_SCHEMA,
@@ -647,6 +687,11 @@ def _emit_solve_json(scenario_path: str, result: SolveResult) -> None:
             # choose from. Backward-compatible — no schema bump.
             "min_pairwise_gap_m": [g if math.isfinite(g) else None for g in d.min_pairwise_gap_m],
             "valid_basins_found": d.valid_basins_found,
+            # Additive (#280): True when --render-paths re-solved with spread
+            # disabled and substituted that tighter, tow-routable arrangement.
+            # Always present (False in the normal no-swap case) so consumers can
+            # rely on it. Backward-compatible — no schema bump.
+            "spread_fallback_applied": spread_fallback_applied,
         },
     }
     print(json.dumps(payload, indent=2))

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -1005,6 +1005,61 @@ class TestSolveRenderPathsSpreadFallback:
         assert len(calls) == 1  # no re-solve
         assert "re-solved" not in capsys.readouterr().err
 
+    def test_json_surfaces_spread_fallback_applied_true_after_swap(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # #280 — non-interactive consumers must get a structured signal that the
+        # tighter no-spread layout was substituted, not just the human stderr
+        # note. After a successful fallback swap, --json carries True.
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve_sequence(
+            monkeypatch,
+            [
+                self._result("found", (layout,), (None,), unroutable=("fuji",)),
+                self._result("found", (layout,), (plan,)),
+            ],
+        )
+        out = tmp_path / "p.png"
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--render",
+                str(out),
+                "--render-paths",
+                "--json",
+                "--seed",
+                "5",
+            ]
+        )
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["diagnostics"]["spread_fallback_applied"] is True
+
+    def test_json_spread_fallback_applied_false_when_no_swap(self, tmp_path, monkeypatch, capsys):
+        # The normal --render-paths --json case (spread layout routes on the
+        # first try): the field is present and False so consumers can rely on it.
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve_sequence(monkeypatch, [self._result("found", (layout,), (plan,))])
+        out = tmp_path / "p.png"
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--render",
+                str(out),
+                "--render-paths",
+                "--json",
+                "--seed",
+                "5",
+            ]
+        )
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["diagnostics"]["spread_fallback_applied"] is False
+
     @pytest.mark.slow
     def test_real_solve_spread_fallback_end_to_end(self, tmp_path, capsys):
         # Real, un-monkeypatched regression for #280. seed=5 on the 3-plane

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -1060,6 +1060,71 @@ class TestSolveRenderPathsSpreadFallback:
         payload = json.loads(capsys.readouterr().out)
         assert payload["diagnostics"]["spread_fallback_applied"] is False
 
+    def test_write_yaml_carries_provenance_header_after_swap(self, tmp_path, monkeypatch, capsys):
+        # #280 — a human reading the written .yaml later must see that it is the
+        # tighter no-spread arrangement, not what a plain spread solve yields.
+        # When --render-paths swaps in the no-spread fallback, --write-yaml emits
+        # a leading `# note:` provenance comment. Paired with the no-swap case
+        # below, this covers both branches of the `spread_fallback_applied`
+        # guard in `_write_yamls`.
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve_sequence(
+            monkeypatch,
+            [
+                self._result("found", (layout,), (None,), unroutable=("fuji",)),
+                self._result("found", (layout,), (plan,)),
+            ],
+        )
+        out_png = tmp_path / "p.png"
+        out_yaml = tmp_path / "fallback.yaml"
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--render",
+                str(out_png),
+                "--render-paths",
+                "--write-yaml",
+                str(out_yaml),
+                "--seed",
+                "5",
+            ]
+        )
+        assert rc == 0, f"expected fallback to route; stderr={capsys.readouterr().err}"
+        assert out_yaml.exists()
+        contents = out_yaml.read_text()
+        assert (
+            "# note: produced with inter-plane spread disabled (auto-fallback, see #280)"
+            in contents
+        )
+
+    def test_write_yaml_no_provenance_header_when_no_swap(self, tmp_path, monkeypatch, capsys):
+        # The normal no-swap path: the spread layout routes on the first try, so
+        # the written .yaml must NOT carry the fallback provenance header (False
+        # branch of the `spread_fallback_applied` guard).
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve_sequence(monkeypatch, [self._result("found", (layout,), (plan,))])
+        out_png = tmp_path / "p.png"
+        out_yaml = tmp_path / "no_swap.yaml"
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--render",
+                str(out_png),
+                "--render-paths",
+                "--write-yaml",
+                str(out_yaml),
+                "--seed",
+                "5",
+            ]
+        )
+        assert rc == 0
+        assert out_yaml.exists()
+        assert "auto-fallback, see #280" not in out_yaml.read_text()
+
     @pytest.mark.slow
     def test_real_solve_spread_fallback_end_to_end(self, tmp_path, capsys):
         # Real, un-monkeypatched regression for #280. seed=5 on the 3-plane

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -851,3 +851,181 @@ class TestSolveRenderPaths:
         )
         assert rc in (0, 3)
         assert out.exists() and out.stat().st_size > 0
+
+
+class TestSolveRenderPathsSpreadFallback:
+    """`--render-paths` auto-falls-back to no-spread when the spread layout is
+    un-routable (#280). Two individually-correct features (ADR-0008 spread,
+    bounded tow planner) compose into a worse default: spread pushes planes into
+    positions the bounded Hybrid-A* can no longer thread, so every plan is None
+    and the CLI returns a bare exit 3 — even though the same fleet+hangar routes
+    cleanly with spread off. The CLI re-solves with spread disabled, reports the
+    swap on stderr, and renders the routable arrangement instead.
+    """
+
+    @staticmethod
+    def _layout():
+        from hangarfit.loader import load_layout
+
+        return load_layout(FIXTURES_DIR / "valid_two_separated.yaml")
+
+    @staticmethod
+    def _plan(layout):
+        from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+
+        start = Pose(x_m=2.0, y_m=0.0, heading_deg=0.0)
+        end = Pose(x_m=2.0, y_m=5.0, heading_deg=0.0)
+        arc = DubinsArc(start=start, end=end, turn_radius_m=1.0, segments=(Segment("S", 5.0),))
+        return MovesPlan(
+            target_layout=layout, moves=(Move(plane_id="a", target_slot=end, path=arc),)
+        )
+
+    @staticmethod
+    def _result(status, layouts, plans, unroutable=()):
+        from hangarfit.models import SolverDiagnostics, SolveResult
+
+        diag = SolverDiagnostics(
+            restarts_attempted=1,
+            wall_time_s=0.1,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=42,
+            unroutable_planes=unroutable,
+        )
+        return SolveResult(status=status, layouts=layouts, plans=plans, diagnostics=diag)
+
+    @staticmethod
+    def _patch_solve_sequence(monkeypatch, results):
+        """Patch ``solve`` to return ``results[i]`` on the i-th call.
+
+        Records every call's ``search`` SearchConfig + ``seed`` so a test can
+        assert the fallback re-solve disabled spread while keeping the seed
+        (determinism). Calling more than ``len(results)`` times is a test-setup
+        error and raises.
+        """
+        import hangarfit.solver as solver_mod
+
+        calls: list[dict] = []
+        seq = list(results)
+
+        def fake_solve(scenario, **kwargs):
+            calls.append(kwargs)
+            if not seq:
+                raise AssertionError("solve() called more times than results provided")
+            return seq.pop(0)
+
+        monkeypatch.setattr(solver_mod, "solve", fake_solve)
+        return calls
+
+    def test_spread_unroutable_falls_back_to_no_spread_and_routes(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # Spread layout un-routable (all-None) -> re-solve with spread off,
+        # which routes -> exit 0, paths rendered, swap reported on stderr.
+        from hangarfit.models import SearchConfig
+
+        layout = self._layout()
+        plan = self._plan(layout)
+        calls = self._patch_solve_sequence(
+            monkeypatch,
+            [
+                self._result("found", (layout,), (None,), unroutable=("fuji",)),
+                self._result("found", (layout,), (plan,)),
+            ],
+        )
+        out = tmp_path / "p.png"
+        rc = main(["solve", SMOKE_FIXTURE, "--render", str(out), "--render-paths", "--seed", "5"])
+        assert rc == 0
+        err = capsys.readouterr().err
+        # The swap is reported, never silent (#280 acceptance).
+        assert "spread" in err and "re-solved" in err
+        # Two solve() calls: spread ON, then the fallback with spread OFF.
+        assert len(calls) == 2
+        assert isinstance(calls[0]["search"], SearchConfig) and calls[0]["search"].spread is True
+        assert calls[1]["search"].spread is False
+        # Determinism: the fallback re-solve reuses the same resolved seed.
+        assert calls[0]["seed"] == calls[1]["seed"] == 5
+        assert out.exists()
+
+    def test_explicit_no_spread_does_not_retry(self, tmp_path, monkeypatch, capsys):
+        # The user already asked for --no-spread; there is nothing to fall back
+        # FROM. One solve() call, exit 3 stands, no swap note.
+        layout = self._layout()
+        calls = self._patch_solve_sequence(
+            monkeypatch, [self._result("found", (layout,), (None,), unroutable=("fuji",))]
+        )
+        out = tmp_path / "p.png"
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--render",
+                str(out),
+                "--render-paths",
+                "--no-spread",
+                "--seed",
+                "5",
+            ]
+        )
+        assert rc == 3
+        assert len(calls) == 1
+        assert calls[0]["search"].spread is False
+        assert "re-solved" not in capsys.readouterr().err
+
+    def test_fallback_also_unroutable_keeps_exit_3_no_misleading_note(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # Genuinely too tight (e.g. placeholder hangar): both spread and
+        # no-spread route nothing. The fallback ran but did not help, so we keep
+        # the original spread result and exit 3 — and must NOT claim a swap that
+        # did not happen.
+        layout = self._layout()
+        calls = self._patch_solve_sequence(
+            monkeypatch,
+            [
+                self._result("found", (layout,), (None,), unroutable=("fuji",)),
+                self._result("found", (layout,), (None,), unroutable=("fuji",)),
+            ],
+        )
+        out = tmp_path / "p.png"
+        rc = main(["solve", SMOKE_FIXTURE, "--render", str(out), "--render-paths", "--seed", "5"])
+        assert rc == 3
+        assert len(calls) == 2  # the fallback was attempted
+        assert "re-solved" not in capsys.readouterr().err  # but not claimed
+
+    def test_spread_routable_does_not_retry(self, tmp_path, monkeypatch, capsys):
+        # Spread layout is already routable -> no fallback, no note, exit 0,
+        # spread arrangement preserved.
+        layout = self._layout()
+        plan = self._plan(layout)
+        calls = self._patch_solve_sequence(monkeypatch, [self._result("found", (layout,), (plan,))])
+        out = tmp_path / "p.png"
+        rc = main(["solve", SMOKE_FIXTURE, "--render", str(out), "--render-paths", "--seed", "5"])
+        assert rc == 0
+        assert len(calls) == 1  # no re-solve
+        assert "re-solved" not in capsys.readouterr().err
+
+    @pytest.mark.slow
+    def test_real_solve_spread_fallback_end_to_end(self, tmp_path, capsys):
+        # Real, un-monkeypatched regression for #280. seed=5 on the 3-plane
+        # 30x25 test hangar is exit-3-WITH-spread (fuji blocked) / exit-0-WITHOUT
+        # on develop. The fallback must turn that bare exit 3 into a routed exit 0
+        # with the swap reported on stderr.
+        out = tmp_path / "real.png"
+        rc = main(
+            [
+                "solve",
+                str(FIXTURES_DIR / "solve_fresh_alternatives_three.yaml"),
+                "--budget",
+                "15.0",
+                "--seed",
+                "5",
+                "--render",
+                str(out),
+                "--render-paths",
+            ]
+        )
+        assert rc == 0, f"expected fallback to route; stderr={capsys.readouterr().err}"
+        err = capsys.readouterr().err
+        assert "spread" in err and "re-solved" in err
+        assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
## What & why

`hangarfit solve --render-paths` returned a bare **exit 3 ("no candidate tow-routable")** on most multi-plane fills under DEFAULT settings, even though the same fleet+hangar routes cleanly (exit 0) with `--no-spread`. Two individually-correct features compose into a worse default:

- The **ADR-0008 spread post-pass** (default ON) *maximizes* inter-plane gaps, pushing planes toward walls/corners.
- The **bounded tow planner** (`towplanner._MAX_EXPANSIONS = 700`) needs clear approach corridors from the door cone. Spread pushes planes where the bounded Hybrid-A* can no longer thread within budget → every `plans[i] = None` → CLI exit 3.

The static layout was still valid; only the tow plan was lost. The headline `--render-paths` UX ("valid layout + valid path") silently picked the LESS useful of two valid arrangements.

## Approach (issue's recommended pair: 1 + 3)

- **(1) Automatic fallback.** When spread is enabled (default) and every candidate's tow plan is `None`, the CLI re-solves with spread DISABLED, tow-plans that, and — **only if it actually routes at least one candidate** — renders that routable (tighter) arrangement instead.
- **(3) Clear report.** The swap is always announced on stderr, never silent:
  `note: layout un-routable with inter-plane spread; re-solved with spread disabled to produce tow paths`

Guards:
- If the user **explicitly** passed `--no-spread`, there is nothing to fall back from → no retry.
- If even spread-disabled routes nothing (genuinely too tight, e.g. the placeholder hangar) → original spread result kept, exit 3 stands unchanged, and no misleading swap note is printed.
- **Determinism (ADR-0003, max_restarts-scoped):** the seed is resolved once in `cmd_solve` so the spread pass and the fallback share an identical, reproducible seed.
- No exceptions swallowed — the fallback `solve()` propagates loudly.

## solver.py

**Not touched.** The existing `solve(search=SearchConfig(spread=...), plan_paths=...)` API is sufficient; the fallback orchestration lives entirely in the CLI layer (option 2 — folding towability into basin selection — was rejected as too expensive, per the issue).

## Tests

- Regression reproduced on develop: **seed=5** on the 3-plane 30×25 test hangar (`tests/fixtures/solve_fresh_alternatives_three.yaml`) is **exit-3-with-spread** (fuji blocked) / **exit-0-without**.
- New `TestSolveRenderPathsSpreadFallback`: monkeypatched coverage for fall-back-and-route, explicit-`--no-spread`-no-retry, fallback-also-unroutable-keeps-3, spread-already-routable-no-retry, plus a slow real-solve end-to-end pinning the seed=5 case now exits 0 with the swap reported.

Full suite (989) + slow set (8) green; ruff check/format + mypy clean.

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)