### PR TITLE
docs(CLAUDE.md): refresh post-v0.7.1 currency (Phase 3b/2c, Reeds–Shepp, hooks)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file is the durable **operational** context for the project: how we work, w
 
 `hangarfit` is an **on-demand exception tool** for a flying club: when the standard hangar parking layout breaks (delayed return, surprise maintenance, etc.), it helps find *a* valid alternative arrangement. The tool checks whether a hand-authored candidate layout is physically valid and renders a top-down PNG so a human can eyeball it; the solver searches for one when no candidate is in hand.
 
-**Status:** Phase 1 (substrate), Phase 2a (static layout solver, `hangarfit solve`), Phase 2c (spread/diversity polish), Phase 3a (tow-path planning, `hangarfit solve --render-paths`), and Phase 3b (Reeds–Shepp reverse-capable tow motion) have all shipped. Live milestone status lives in auto-memory and GitHub milestones, not here.
+**Status:** Phase 1 (substrate), Phase 2a (static layout solver, `hangarfit solve`), Phase 2b–2c (solver realism + spread/diversity polish), Phase 3a (tow-path planning, `hangarfit solve --render-paths`), and Phase 3b (Reeds–Shepp reverse-capable tow motion) have all shipped. Live milestone status lives in auto-memory and GitHub milestones, not here.
 
 ---
 
@@ -86,7 +86,7 @@ Most coding goes direct in-session. Subagent dispatch is for review work and iso
 
 ## Project-local Claude Code config
 
-The `.claude/` directory holds team-shared Claude Code settings (currently: a PostToolUse hook that runs ruff + pytest after edits under `src/hangarfit/` or `tests/`, plus a PreToolUse guard that blocks hand-edits to the hash-pinned `requirements-*.txt` lockfiles). See [.claude/README.md](.claude/README.md) for what's there and how to disable per-contributor via a gitignored `.claude/settings.local.json`.
+The `.claude/` directory holds team-shared Claude Code settings (currently: a PreToolUse guard that blocks hand-edits to the hash-pinned `requirements-*.txt` lockfiles, plus a PostToolUse hook that runs ruff + pytest after edits under `src/hangarfit/` or `tests/`). See [.claude/README.md](.claude/README.md) for what's there and how to disable per-contributor via a gitignored `.claude/settings.local.json`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file is the durable **operational** context for the project: how we work, w
 
 `hangarfit` is an **on-demand exception tool** for a flying club: when the standard hangar parking layout breaks (delayed return, surprise maintenance, etc.), it helps find *a* valid alternative arrangement. The tool checks whether a hand-authored candidate layout is physically valid and renders a top-down PNG so a human can eyeball it; the solver searches for one when no candidate is in hand.
 
-**Status:** Phase 1 (substrate), Phase 2a (static layout solver, `hangarfit solve`), and Phase 3a (tow-path planning, `hangarfit solve --render-paths`) have all shipped. Live milestone status lives in auto-memory and GitHub milestones, not here.
+**Status:** Phase 1 (substrate), Phase 2a (static layout solver, `hangarfit solve`), Phase 2c (spread/diversity polish), Phase 3a (tow-path planning, `hangarfit solve --render-paths`), and Phase 3b (Reeds–Shepp reverse-capable tow motion) have all shipped. Live milestone status lives in auto-memory and GitHub milestones, not here.
 
 ---
 
@@ -29,7 +29,7 @@ This file is the durable **operational** context for the project: how we work, w
 | RR-MC solver algorithm and the determinism contract | [ADR-0003](docs/adr/0003-rr-mc-solver-algorithm.md) |
 | Diversity metric (edit-count, thresholds) | [ADR-0004](docs/adr/0004-diversity-metric.md) |
 | **The spread post-pass** (maximize inter-plane gap once valid) | [ADR-0008](docs/adr/0008-inter-plane-spread-soft-preference.md) |
-| **The tow-path planner** (empty-hangar fill, Dubins arcs, `solve --render-paths`, exit-3 tow-routability) | [§5 Building Block View](docs/architecture/05-building-block-view.md) (`towplanner`) + [ADR-0007](docs/adr/0007-tow-path-planner-v1-scope.md) |
+| **The tow-path planner** (empty-hangar fill, Reeds–Shepp arcs, `solve --render-paths`, exit-3 tow-routability) | [§5 Building Block View](docs/architecture/05-building-block-view.md) (`towplanner`) + [ADR-0007](docs/adr/0007-tow-path-planner-v1-scope.md) (v1 scope) + [ADR-0010](docs/adr/0010-reeds-shepp-motion-model.md) (v2 Reeds–Shepp motion) |
 | Why the project targets a single Python (3.12), not a range | [ADR-0009](docs/adr/0009-single-supported-python-version.md) |
 | All architecture decisions, including superseded ones | [`docs/adr/`](docs/adr/) |
 
@@ -86,7 +86,7 @@ Most coding goes direct in-session. Subagent dispatch is for review work and iso
 
 ## Project-local Claude Code config
 
-The `.claude/` directory holds team-shared Claude Code settings (currently: a PostToolUse pytest hook that auto-runs tests after edits under `src/hangarfit/` or `tests/`). See [.claude/README.md](.claude/README.md) for what's there and how to disable per-contributor via a gitignored `.claude/settings.local.json`.
+The `.claude/` directory holds team-shared Claude Code settings (currently: a PostToolUse hook that runs ruff + pytest after edits under `src/hangarfit/` or `tests/`, plus a PreToolUse guard that blocks hand-edits to the hash-pinned `requirements-*.txt` lockfiles). See [.claude/README.md](.claude/README.md) for what's there and how to disable per-contributor via a gitignored `.claude/settings.local.json`.
 
 ---
 
@@ -229,7 +229,7 @@ pip-compile --generate-hashes --no-strip-extras --allow-unsafe -o requirements-p
 # Phase 1 acceptance smoke test
 hangarfit check layouts/example.yaml --render out.png
 
-# Phase 3a: solve + tow-path overlay. Best-effort: a layout the v1 planner
+# Phase 3a/3b: solve + tow-path overlay. Best-effort: a layout the planner
 # can't fully route renders without paths (blocking plane named on stderr);
 # exit 3 only if NO candidate layout is tow-routable.
 hangarfit solve tests/fixtures/scenario_minimal.yaml --render out.png --render-paths


### PR DESCRIPTION
Closes #294

## What

Four targeted currency fixes to the root `CLAUDE.md`, surfaced by a `/claude-md-management:claude-md-improver` audit. The file predated the Phase 3b / v0.7.1 release wave and had drifted in four verifiable spots.

| # | Spot | Before | After |
|---|---|---|---|
| 1 | Status line | Phase 1 / 2a / 3a shipped | + **Phase 2c** (spread/diversity polish) + **Phase 3b** (Reeds–Shepp reverse-capable tow motion) |
| 2 | Quick Reference tow-planner row | "Dubins arcs", links **ADR-0007** only | "Reeds–Shepp arcs", links **ADR-0007** (v1 scope) **+ ADR-0010** (v2 motion); ADR-0007 fork-2 "Dubins-only" is superseded by ADR-0010 |
| 3 | Useful-commands smoke-test comment | "the **v1 planner**" / Phase 3a | "the planner" (model-agnostic, won't re-stale) / Phase 3a/3b |
| 4 | `.claude/` config description | "a PostToolUse pytest hook" | "a PostToolUse **ruff + pytest** hook plus a PreToolUse **lockfile-edit guard**" — matches `.claude/README.md` |

## Verification

- All four claims checked against source: `pyproject.toml` (`version = "0.7.1"`), `docs/adr/0010-*` + ADR-0007 supersession header, `towplanner.py` docstring (Reeds–Shepp), `.claude/settings.json` (both hooks).
- New hook wording is verbatim-consistent with `.claude/README.md:9`.
- `layouts/example.yaml` "6-plane subset" claim re-verified as **correct** (5 placements + 1 maintenance = 6 of 9 fleet planes) — left untouched.

## Out of scope

ADR-0011 (linear-history process spike, just landed on develop) is **not** added to the Quick Reference — that table tracks system/domain architecture, not process decisions; the generic `docs/adr/` row already covers it.

Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)