### PR TITLE
feat(.mcp.json): project-scope context7 for library docs (#299)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,10 @@
       "headers": {
         "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,11 @@ The `.claude/` directory holds team-shared Claude Code settings (currently: a Pr
 | Server | Transport | Purpose |
 |---|---|---|
 | `github` | HTTP (`https://api.githubcopilot.com/mcp/`) | Issue / PR / release inspection from Claude; complements the existing `gh` CLI. |
+| `context7` | HTTP (`https://mcp.context7.com/mcp`) | Live, version-correct library docs (shapely, matplotlib & other deps) pulled into context on demand, so doc lookups reflect the installed version rather than stale training data. |
 
 **Canonical upstream references (verify before editing `.mcp.json`):**
 - GitHub MCP: https://github.com/github/github-mcp-server
+- Context7 MCP: https://github.com/upstash/context7
 
 If a URL or env-var name in `.mcp.json` ever stops working, check these first.
 
@@ -108,10 +110,11 @@ If a URL or env-var name in `.mcp.json` ever stops working, check these first.
 - **GitHub MCP** — Requires `GITHUB_PERSONAL_ACCESS_TOKEN` in your shell environment. Minimum permissions depend on which PAT type you create:
   - **Classic PAT:** `repo` + `read:org` scopes are sufficient for read operations; add `write:discussion` if you want Claude to create issues or PRs via the MCP server rather than `gh`.
   - **Fine-grained PAT:** Repository permissions `Contents: Read`, `Issues: Read`, `Pull requests: Read`; plus Organization permissions `Members: Read` for org-level lookups. Add the corresponding `Write` levels for create operations. Fine-grained PATs use different UI checkboxes from classic — the scope names above are classic-only.
+- **Context7 MCP** — **Works keyless out of the box; no env var required.** The checked-in `.mcp.json` entry carries no auth header on purpose, so a fresh clone connects under Context7's anonymous rate limits with zero setup. A `${CONTEXT7_API_KEY}` header is deliberately *not* committed: Claude Code does not expand `${VAR}` in HTTP `headers` for an unset variable, so an unresolved placeholder would be sent literally and break the keyless default. To raise rate limits, get a free key at context7.com/dashboard and add it locally (not committed) via your own client config or a gitignored override — Context7 reads it from the `CONTEXT7_API_KEY` request header.
 
 ### Verifying the servers loaded
 
-After cloning and running `claude`, use the `/mcp` command. The `github` server should appear with status **connected**. If it shows **failed**, check that `GITHUB_PERSONAL_ACCESS_TOKEN` is set in your shell environment.
+After cloning and running `claude`, use the `/mcp` command. The `github` and `context7` servers should appear with status **connected**. If `github` shows **failed**, check that `GITHUB_PERSONAL_ACCESS_TOKEN` is set in your shell environment; `context7` needs no env var and should connect keyless.
 
 ---
 


### PR DESCRIPTION
Closes #299

## What

Adds the **Context7** (Upstash) MCP server to the checked-in `.mcp.json`, alongside the existing `github` entry, so every fresh-clone contributor gets live, version-correct library documentation (shapely, matplotlib & other deps) pulled into context on demand — no per-user setup step.

## The entry

```json
"context7": {
  "type": "http",
  "url": "https://mcp.context7.com/mcp"
}
```

Mirrors the existing `github` structure (`type: http` + `url`). The `github` entry is preserved byte-for-byte.

## Keyless out of the box (team-share rationale)

Context7's hosted Streamable-HTTP endpoint works **without an API key** under anonymous rate limits, so the committed entry carries **no auth header**. This is deliberate: Claude Code does not expand `${VAR}` in HTTP `headers` for an *unset* variable, so a committed `${CONTEXT7_API_KEY}` placeholder would be sent literally (or fail config load) and break the keyless default for anyone who hasn't set the var. Omitting the header guarantees a fresh clone connects with zero env vars.

Contributors who want higher limits add a free key locally (not committed) via the `CONTEXT7_API_KEY` request header — documented in CLAUDE.md's Auth requirements.

## Docs

Updated only CLAUDE.md's `## MCP servers` section: table row, canonical-upstream-reference bullet, keyless auth note, and the "verifying the servers loaded" line.

## Source verified

Endpoint, transport, keyless behavior, and the `CONTEXT7_API_KEY` header name confirmed against the upstream README at https://github.com/upstash/context7 — quote: *"To configure manually, use the Context7 server URL `https://mcp.context7.com/mcp` with your MCP client and pass your API key via the `CONTEXT7_API_KEY` header."* `.mcp.json` validates as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)