### PR TITLE
docs(security-posture): develop drops up-to-date-before-merge (#305)

### DIFF
--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -88,17 +88,27 @@ the same reason — even though the repo does ship a
 code-owner for the whole tree (GitHub suppresses the code-owner review
 request on the author's own PR, which here is essentially every PR).
 
-Everything that *can* be enforced without a second human already is, on
-both protected branches (`develop` and `main`):
+Everything that *can* be enforced without a second human is enforced on
+both protected branches (`develop` and `main`), with one deliberate
+workflow exception called out below (up-to-date-before-merge on `develop`):
 
 - **Admin enforcement** — the rules apply to the maintainer too
   (`enforce_admins`), so protection cannot be silently bypassed.
-- **Required status checks, strict** — PRs must pass the configured CI
-  gate (the test suite on every supported Python and both lockfile-drift
-  guards, plus CodeQL on `develop`) and be up to date with the base branch
-  before merge. The exact required-check set is configured per branch and
-  reconciled at each release cut, so `develop` and `main` are not always
-  byte-identical (e.g. CodeQL runs on `develop` PRs only).
+- **Required status checks** — PRs must pass the configured CI gate (the
+  test suite on every supported Python and both lockfile-drift guards, plus
+  CodeQL on `develop`) before merge. On `main` this is **strict** (the branch
+  must also be up to date with the base before merge). On `develop` the
+  up-to-date / `strict` requirement is **deliberately disabled**: with it on,
+  merging any PR forced every *other* open PR to "Update branch" and re-run the
+  full required-check set before it could merge — pure churn for a
+  single-maintainer flow whose PRs are usually file-disjoint. The
+  `push`-to-`develop` CI run re-validates the integrated result within seconds
+  of each merge, so integration regressions still surface immediately; this
+  trades a small slice of the Scorecard branch-protection tier (up-to-date is
+  one of the credited sub-criteria) for merge throughput. The exact
+  required-check set is otherwise configured per branch and reconciled at each
+  release cut, so `develop` and `main` are not always byte-identical (e.g.
+  CodeQL runs on `develop` PRs only).
 - **Stale-review dismissal** — approvals are dismissed on new pushes (a
   no-op today given the reviewer count, but already correct for the day a
   co-maintainer joins).

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -95,8 +95,8 @@ workflow exception called out below (up-to-date-before-merge on `develop`):
 - **Admin enforcement** — the rules apply to the maintainer too
   (`enforce_admins`), so protection cannot be silently bypassed.
 - **Required status checks** — PRs must pass the configured CI gate (the
-  test suite on every supported Python and both lockfile-drift guards, plus
-  CodeQL on `develop`) before merge. On `main` this is **strict** (the branch
+  test suite on every supported Python and all three lockfile-drift guards,
+  plus CodeQL on `develop`) before merge. On `main` this is **strict** (the branch
   must also be up to date with the base before merge). On `develop` the
   up-to-date / `strict` requirement is **deliberately disabled**: with it on,
   merging any PR forced every *other* open PR to "Update branch" and re-run the


### PR DESCRIPTION
Closes #305

## What

Updates `docs/security-posture.md` §Branch-Protection to match a config change applied out-of-band today: the `strict` (up-to-date-before-merge) required-status-checks flag was **disabled on `develop`** (all five required checks preserved; `main` unchanged).

## Why the setting changed

With `strict` on, merging any PR forced every *other* open PR to "Update branch" (a new commit) and re-run the full required-check set before it could merge — even for diffs that can't affect those checks. That's pure churn for a single-maintainer, mostly-file-disjoint flow. The `push`-to-`develop` CI run (`ci.yml` triggers on `push: [develop, main]`) re-validates the integrated result within seconds of each merge, so integration regressions still surface immediately.

## Doc changes
- Rewrote the "Required status checks" bullet: required checks still gate every PR on both branches; `main` stays **strict**; `develop` is non-strict, with the post-merge-CI rationale.
- Honestly recorded the tradeoff: up-to-date-before-merge is one of the Scorecard branch-protection sub-criteria, so dropping it on `develop` forgoes a small slice of that tier in exchange for merge throughput.
- Softened the "everything that *can* be enforced … already is" framing to flag this one deliberate exception.

Docs-only; no code/CI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)