### PR TITLE
refactor(geometry): unify local→world transform into a single primitive (#293)

### DIFF
--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -116,6 +116,40 @@ def polygon_overlap_area(p1: Polygon, p2: Polygon) -> float:
     return p1.intersection(p2).area
 
 
+def local_to_world(u: float, v: float, placement: Placement) -> tuple[float, float]:
+    """Map a single plane-local point ``(u, v)`` to world coordinates.
+
+    This is the **one canonical definition** of the compass-style
+    plane-local → world transform. ``aircraft_parts_world`` routes every
+    vertex through it, and :mod:`hangarfit.visualize` imports it for its
+    gear/cart glyphs, so the determinant-``−1`` formula lives in exactly
+    one place (#293).
+
+    ``placement.heading_deg`` is the compass-style angle of the nose,
+    measured from world ``+y`` (deeper-into-hangar), CW positive. The
+    linear part of the map is:
+
+    .. code-block::
+
+        world_x = placement.x_m + u·sin(h) + v·cos(h)
+        world_y = placement.y_m + u·cos(h) − v·sin(h)
+
+    where ``h = radians(placement.heading_deg)`` and ``(+u, +v)`` is
+    plane-local ``(forward, right)``. The linear part has determinant
+    ``−1`` (a rotation composed with a reflection), reflecting (a) the
+    CW-positive compass convention vs CCW-positive math, and (b)
+    plane-local ``(forward, right)`` vs world ``(right, deeper)``. This is
+    deliberate — see ADR-0002 and ``CLAUDE.md`` for the full derivation.
+    Do **not** "fix" it to a det = +1 pure rotation.
+    """
+    h = math.radians(placement.heading_deg)
+    sin_h = math.sin(h)
+    cos_h = math.cos(h)
+    world_x = placement.x_m + u * sin_h + v * cos_h
+    world_y = placement.y_m + u * cos_h - v * sin_h
+    return world_x, world_y
+
+
 def aircraft_parts_world(
     aircraft: Aircraft,
     placement: Placement,
@@ -140,13 +174,10 @@ def aircraft_parts_world(
     the (a) CW-positive compass convention vs CCW-positive math, and
     (b) plane-local ``(forward, right)`` vs world ``(right, deeper)``.
     See ``CLAUDE.md`` for the full derivation.
-    """
-    h = math.radians(placement.heading_deg)
-    sin_h = math.sin(h)
-    cos_h = math.cos(h)
-    px = placement.x_m
-    py = placement.y_m
 
+    Each vertex is routed through :func:`local_to_world`, the single
+    canonical definition of this transform (#293).
+    """
     world_parts: list[WorldPart] = []
     for part in aircraft.parts:
         # Build the part's polygon in plane-local coordinates. ``angle_deg``
@@ -163,8 +194,7 @@ def aircraft_parts_world(
         # local_poly.exterior.coords includes the closing-point duplicate;
         # slice it off so Polygon() doesn't have to de-dup.
         world_coords = [
-            (px + u * sin_h + v * cos_h, py + u * cos_h - v * sin_h)
-            for u, v in list(local_poly.exterior.coords)[:-1]
+            local_to_world(u, v, placement) for u, v in list(local_poly.exterior.coords)[:-1]
         ]
         world_poly = Polygon(world_coords)
         world_parts.append(

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -36,7 +36,7 @@ import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.patches import Circle as MplCircle  # noqa: E402
 from matplotlib.patches import Polygon as MplPolygon  # noqa: E402
 
-from .geometry import WorldPart, aircraft_parts_world  # noqa: E402
+from .geometry import WorldPart, aircraft_parts_world, local_to_world  # noqa: E402
 from .models import Aircraft, CheckResult, Layout, Placement, WingPosition  # noqa: E402
 
 if TYPE_CHECKING:
@@ -386,32 +386,6 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
     ax.add_patch(patch)
 
 
-def _local_to_world(
-    u: float,
-    v: float,
-    placement: Placement,
-) -> tuple[float, float]:
-    """Apply the plane-local-to-world transform to a single point ``(u, v)``.
-
-    Mirrors the per-vertex formula in :func:`hangarfit.geometry.aircraft_parts_world`
-    (the same determinant-``-1`` compass transform):
-
-    .. code-block::
-
-        world_x = px + u·sin(h) + v·cos(h)
-        world_y = py + u·cos(h) − v·sin(h)
-
-    Used here so gear/cart glyphs rotate with the aircraft exactly as the
-    part polygons do, without having to build a full :class:`WorldPart`.
-    """
-    h = math.radians(placement.heading_deg)
-    sin_h = math.sin(h)
-    cos_h = math.cos(h)
-    wx = placement.x_m + u * sin_h + v * cos_h
-    wy = placement.y_m + u * cos_h - v * sin_h
-    return wx, wy
-
-
 def _add_wheel(ax: Any, wx: float, wy: float) -> MplCircle:
     """Add a single wheel-disc circle at world coordinates ``(wx, wy)``."""
     circle = MplCircle(
@@ -468,28 +442,28 @@ def _draw_gear_glyph(ax: Any, placement: Placement, aircraft: Aircraft) -> None:
     elif aircraft.gear == "nosewheel":
         # Nose wheel — near the nose tip
         nose_u = fus_cx + fus_half_len * _NOSE_GEAR_FRAC
-        wx, wy = _local_to_world(nose_u, 0.0, placement)
+        wx, wy = local_to_world(nose_u, 0.0, placement)
         _add_wheel(ax, wx, wy)
         # Main gear pair — slightly aft of CG (behind the wing root)
         main_u = fus_cx - fus_half_len * _MAIN_GEAR_FWD_FRAC
         lateral = fus_half_wid * _MAIN_GEAR_LATERAL_FRAC
         for v in (+lateral, -lateral):
-            wx, wy = _local_to_world(main_u, v, placement)
+            wx, wy = local_to_world(main_u, v, placement)
             _add_wheel(ax, wx, wy)
     elif aircraft.gear == "tailwheel":
         # Main gear pair — forward of CG, ahead of the wing root
         main_u = fus_cx + fus_half_len * _MAIN_GEAR_TAILDRAGGER_FWD_FRAC
         lateral = fus_half_wid * _MAIN_GEAR_LATERAL_FRAC
         for v in (+lateral, -lateral):
-            wx, wy = _local_to_world(main_u, v, placement)
+            wx, wy = local_to_world(main_u, v, placement)
             _add_wheel(ax, wx, wy)
         # Tailwheel — near the aft tip
         tail_u = fus_aft_x + fus_half_len * (1.0 - _NOSE_GEAR_FRAC)
-        wx, wy = _local_to_world(tail_u, 0.0, placement)
+        wx, wy = local_to_world(tail_u, 0.0, placement)
         _add_wheel(ax, wx, wy)
     elif aircraft.gear == "monowheel":
         # Single centred main wheel at the gear/cart origin
-        wx, wy = _local_to_world(0.0, 0.0, placement)
+        wx, wy = local_to_world(0.0, 0.0, placement)
         _add_wheel(ax, wx, wy)
     # No else needed — Gear is a closed Literal; mypy and the model guard all values.
 
@@ -512,7 +486,7 @@ def _draw_cart_glyph(ax: Any, placement: Placement) -> None:
         (-hl, -hw),
         (-hl, +hw),
     ]
-    deck_world = [_local_to_world(u, v, placement) for u, v in corner_locals]
+    deck_world = [local_to_world(u, v, placement) for u, v in corner_locals]
     deck_patch = MplPolygon(
         deck_world,
         closed=True,
@@ -526,7 +500,7 @@ def _draw_cart_glyph(ax: Any, placement: Placement) -> None:
 
     # Four corner wheel discs.
     for u, v in corner_locals:
-        wx, wy = _local_to_world(u, v, placement)
+        wx, wy = local_to_world(u, v, placement)
         _add_wheel(ax, wx, wy)
 
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -16,6 +16,7 @@ from shapely.geometry import Polygon
 
 from hangarfit.geometry import (
     aircraft_parts_world,
+    local_to_world,
     oriented_rect,
     polygon_overlap,
     polygon_overlap_area,
@@ -372,6 +373,90 @@ class TestAircraftPartsWorld:
         cx, cy = world.polygon.centroid.x, world.polygon.centroid.y
         assert _almost_equal(cx, 0.0, tol=1e-6)
         assert _almost_equal(cy, 1.0, tol=1e-6)
+
+
+class TestLocalToWorld:
+    """``local_to_world`` is the single canonical per-point transform (#293).
+
+    ``aircraft_parts_world`` routes every vertex through it and
+    :mod:`hangarfit.visualize` imports it for gear/cart glyphs, so a
+    regression here would surface in both the collision geometry and the
+    renders. These tests pin the determinant-``−1`` sign directly on the
+    primitive (independent of ``aircraft_parts_world``) and assert that the
+    two stay equivalent so the formula can never silently drift apart.
+    """
+
+    def test_heading_45_right_wingtip_is_distinguishing(self) -> None:
+        """🔬 The DEFINITIVE off-by-90° / determinant-sign probe, pinned on
+        the primitive itself.
+
+        Plane-local right wingtip ``(u=0, v=1)`` at heading 45° must land at
+        world ``(+√2/2, −√2/2)`` (right and toward the door). A textbook CCW
+        rotation would send it to ``(−√2/2, +√2/2)`` — upper-left — so this
+        single assertion catches a sign flip in ``local_to_world``.
+        """
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False)
+        wx, wy = local_to_world(0.0, 1.0, pl)
+        assert _almost_equal(wx, SQRT2_2, tol=1e-6), f"x expected {SQRT2_2}, got {wx}"
+        assert _almost_equal(wy, -SQRT2_2, tol=1e-6), f"y expected {-SQRT2_2}, got {wy}"
+
+    def test_heading_135_nose_is_distinguishing(self) -> None:
+        """🔬 Redundant guard at 135° where ``sin h ≠ cos h`` makes the nose
+        vector alone distinguish the correct transform from a CCW rotation.
+
+        Nose ``(u=1, v=0)`` → world ``(+√2/2, −√2/2)`` for the correct
+        det=−1 map; a CCW rotation would give ``(−√2/2, +√2/2)``.
+        """
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=135.0, on_carts=False)
+        wx, wy = local_to_world(1.0, 0.0, pl)
+        assert _almost_equal(wx, SQRT2_2, tol=1e-6), f"x expected {SQRT2_2}, got {wx}"
+        assert _almost_equal(wy, -SQRT2_2, tol=1e-6), f"y expected {-SQRT2_2}, got {wy}"
+
+    def test_placement_offset_applied(self) -> None:
+        """Placement translation is applied after the rotation/reflection."""
+        pl = Placement(plane_id="probe", x_m=10.0, y_m=20.0, heading_deg=0.0, on_carts=False)
+        wx, wy = local_to_world(1.0, 0.0, pl)  # nose forward at heading 0 → world +y
+        assert _almost_equal(wx, 10.0, tol=1e-6)
+        assert _almost_equal(wy, 21.0, tol=1e-6)
+
+    @pytest.mark.parametrize("heading_deg", [0.0, 37.0, 90.0, 135.0, 200.0, -90.0, 360.0])
+    def test_agrees_with_aircraft_parts_world_corners(self, heading_deg: float) -> None:
+        """🔬 Equivalence pin (#293): the per-point primitive must reproduce
+        exactly the corners ``aircraft_parts_world`` produces, at non-axis
+        and axis-aligned headings alike.
+
+        Builds a part, transforms it via ``aircraft_parts_world``, then
+        independently transforms the same plane-local corners via
+        ``local_to_world`` and asserts byte-for-byte agreement. If a future
+        convention change drifts one definition from the other, this fails.
+        """
+        part = Part(
+            kind="wing",
+            length_m=2.0,
+            width_m=8.0,
+            offset_x_m=0.5,
+            offset_y_m=-0.25,
+            angle_deg=20.0,  # non-trivial in-plane rotation
+            z_bottom_m=1.0,
+            z_top_m=2.5,
+        )
+        ac = _aircraft_with_one_part(part)
+        pl = Placement(plane_id="probe", x_m=3.0, y_m=-1.5, heading_deg=heading_deg, on_carts=False)
+        [world] = aircraft_parts_world(ac, pl)
+        world_corners = list(world.polygon.exterior.coords)[:-1]
+
+        # Reconstruct the plane-local corners independently and route them
+        # through the primitive; they must match exactly (no tolerance).
+        local_poly = oriented_rect(
+            cx=part.offset_x_m,
+            cy=part.offset_y_m,
+            length=part.length_m,
+            width=part.width_m,
+            angle_deg=part.angle_deg,
+        )
+        local_corners = list(local_poly.exterior.coords)[:-1]
+        expected = [local_to_world(u, v, pl) for u, v in local_corners]
+        assert world_corners == expected
 
 
 class TestWorldPartMetadata:


### PR DESCRIPTION
Closes #293

## What & why
Follow-up from PR #291 (#281). `visualize.py` gained a `_local_to_world(u, v, placement)` helper for the gear/cart glyphs that was verified sign-for-sign identical to the canonical transform in `geometry.aircraft_parts_world`. There was no behavioral bug — but the documented determinant-(−1) sign-flip formula (ADR-0002) now lived in **two** places, and a future convention change to one would silently drift from the other. The smoke tests would not catch a sign flip.

## The change — pure extract-and-route refactor
1. **New canonical primitive** `geometry.local_to_world(u, v, placement) -> tuple[float, float]` (public, since `visualize.py` imports it). It is the single definition of the compass-style plane-local → world transform:
   ```
   world_x = placement.x_m + u·sin(h) + v·cos(h)
   world_y = placement.y_m + u·cos(h) − v·sin(h)
   ```
2. **`aircraft_parts_world` routes through it per vertex** instead of inlining the formula. Same operands, same evaluation order, same `Polygon` construction → **byte-identical output** (no numeric change).
3. **`visualize._local_to_world` deleted**; `visualize.py` imports `geometry.local_to_world` and calls it at all seven glyph call sites.

## Behavior preservation
The det(−1) sign convention is preserved **sign-for-sign**. This is a refactor only — no numeric behavior changed. Verified by:
- New `TestLocalToWorld` in `tests/test_geometry.py`: the distinguishing **45° right-wingtip** and **135° nose** probes pinned directly on the primitive, plus an **equivalence test** asserting `local_to_world` reproduces *exactly* (no tolerance) the corners `aircraft_parts_world` produces across axis-aligned and non-axis-aligned headings.
- Existing 45°/135° canary tests in `TestAircraftPartsWorld` retained — the non-axis-aligned coverage that catches a CCW-rotation regression stays in place.

## Verification
- Full suite: **1019 passed, 8 deselected** (`PYTHONPATH=$(pwd)/src python -m pytest`)
- `ruff check src/ tests/` → All checks passed
- `ruff format --check src/ tests/` → all formatted
- `mypy src/hangarfit/` → no issues

## Review note
This touches `src/hangarfit/geometry.py` (the ADR-0002 sign-flip trap) → please run the **geometry-invariant-guard** subagent per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)