### PR TITLE
feat: configurable cart inventory via hangar.max_carts + --max-carts (#210)

### DIFF
--- a/data/hangar.yaml
+++ b/data/hangar.yaml
@@ -25,3 +25,9 @@ maintenance_bay:
 
 clearance_m: 0.3        # minimum horizontal gap between any two aircraft parts
 wing_layer_clearance_m: 0.2  # minimum vertical gap between two parts at the same XY
+
+# Spare carts available to the cart_eligible pool. Bounds how many
+# cart_eligible planes may sit on carts in one layout; always_cart planes
+# get their own carts and do not draw from this pool. Absent => 1 (the
+# original single-cart rule). Overridable per-invocation with --max-carts.
+max_carts: 1

--- a/docs/adr/0007-tow-path-planner-v1-scope.md
+++ b/docs/adr/0007-tow-path-planner-v1-scope.md
@@ -231,6 +231,42 @@ gate; `collisions.check` semantics are still untouched. See the updated
 for the live behaviour. This is a refinement *within* this ADR's framing, not a
 reversal of any decision recorded here.
 
+### 2026-05-27 — cart inventory configurable, per-layout binding (#210)
+
+The *Open question* above ("Cart inventory for `cart_eligible` planes") is now
+resolved. The resolution **agrees with** this ADR's framing — carts are a finite
+resource for the eligible pool only, `always_cart` planes stay outside the
+accounting, and `MovesPlan` still carries no cart-usage tally — so it is recorded
+here rather than as a new ADR.
+
+1. **Configurable size — resolved: yes.** The hard-coded single-cart limit
+   becomes `Hangar.max_carts` (a new site scalar on `data/hangar.yaml`, default
+   `1`, so absence reproduces today's behaviour byte-for-byte). A cart is
+   site equipment in the same category as `clearance_m`, so it lives on the
+   hangar floor plan, not on the (hangar-portable) fleet. A `--max-carts N` CLI
+   flag overrides the loaded value for what-if exploration; the override mutates
+   the resolved `Hangar` before any `Layout` is built, reaching the cap check via
+   the same `self.hangar.max_carts` read. `max_carts = 0` means "no spare carts
+   for the eligible pool" (any `cart_eligible`-on-cart is rejected; `always_cart`
+   planes are unaffected).
+
+2. **Per-layout vs per-sequence — resolved: per-layout (unchanged).** The cap
+   stays bound per `Layout`. The K alternatives a `solve` returns are a
+   mutually-exclusive *menu* — the hangar ends up in exactly one — so binding the
+   inventory across never-coexisting alternatives would reject a perfectly
+   buildable layout because a different, never-built one also wanted the cart.
+   `MovesPlan` stays tally-free; if a future multi-layout *rearrangement* feature
+   ever needs cross-layout cart accounting, it belongs on a new additive
+   diagnostic, never folded into `MovesPlan`.
+
+This rests on the **dolly** reading of carts (a carted plane *rests* on its cart
+in the final layout, consistent with `Placement.on_carts` being a resting-state
+field and `always_cart` planes occupying their carts permanently), under which the
+per-layout *count* is exactly the right invariant. The alternative *tug* reading
+(one cart towed out and reused serially) would make the count the wrong invariant
+and is explicitly **not** adopted here; it would warrant its own ADR. Full
+reasoning: the [cart-inventory design doc](../superpowers/specs/2026-05-27-cart-inventory-design.md).
+
 ## More Information
 
 - Related spike: [Tow-path planning (#180)](../spikes/tow-path-planning.md) — the

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -70,7 +70,8 @@ neither needs to special-case the occupant.
 
 `__post_init__` enforces all invariants that cannot be expressed via
 the type system — the cart rule (`movement_mode` ↔ `on_carts`
-consistency, at most one cart-eligible plane actually on carts), the
+consistency, at most `hangar.max_carts` cart-eligible planes actually on
+carts), the
 maintenance-plane-is-in-fleet rule, the
 maintenance-plane-is-not-in-placements rule. A constructed instance is
 guaranteed structurally valid; nothing downstream re-checks.

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -205,6 +205,17 @@ collision checker reads them once per `check()` call from
 `layout.hangar`; changing them at runtime means editing the YAML
 file. Hard-coding them anywhere outside `data/hangar.yaml` is a bug.
 
+`data/hangar.yaml` carries one more defaulted site scalar that is *not*
+a clearance: `max_carts` (default `1`). It is the number of spare carts
+available to the `cart_eligible` pool and is enforced by
+`Layout.__post_init__` (not the collision checker) — at most `max_carts`
+`cart_eligible` planes may sit on carts in one layout, while `always_cart`
+planes get their own carts and never draw from this pool. It is
+overridable per-invocation with the `--max-carts` CLI flag, which
+replaces the value on the loaded `Hangar` before any layout is built. See
+[ADR-0007](../adr/0007-tow-path-planner-v1-scope.md) (cart-inventory
+amendment).
+
 The two-clause predicate is symmetric in the two clearances: a
 collision requires *both* the plan-view and the height-gap thresholds
 to be violated simultaneously. This is what lets a high-wing's

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -63,6 +63,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Override the hangar data file. Cannot be combined with a layout that already embeds a hangar path.",  # noqa: E501
     )
     check.add_argument(
+        "--max-carts",
+        type=int,
+        metavar="N",
+        default=None,
+        help="Override the hangar's spare-cart count for the cart_eligible pool (default: the hangar.yaml value, or 1 if unset).",  # noqa: E501
+    )
+    check.add_argument(
         "--json",
         action="store_true",
         help=f"Emit JSON on stdout (schema: {_JSON_SCHEMA}).",
@@ -148,6 +155,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Override the hangar data file (refused if scenario YAML also sets 'hangar').",
     )
     solve.add_argument(
+        "--max-carts",
+        type=int,
+        metavar="N",
+        default=None,
+        dest="max_carts",
+        help="Override the hangar's spare-cart count for the cart_eligible pool (default: the hangar.yaml value, or 1 if unset).",  # noqa: E501
+    )
+    solve.add_argument(
         "--no-spread",
         action="store_false",
         dest="spread",
@@ -195,7 +210,12 @@ def cmd_check(args: argparse.Namespace) -> int:
     try:
         fleet_override = load_fleet(args.fleet) if args.fleet is not None else None
         hangar_override = load_hangar(args.hangar) if args.hangar is not None else None
-        layout = load_layout(args.layout, fleet=fleet_override, hangar=hangar_override)
+        layout = load_layout(
+            args.layout,
+            fleet=fleet_override,
+            hangar=hangar_override,
+            max_carts=args.max_carts,
+        )
     except LoaderError as e:
         print(f"error: {e}", file=sys.stderr)
         return 2
@@ -344,7 +364,12 @@ def cmd_solve(args: argparse.Namespace) -> int:
     try:
         fleet_override = load_fleet(args.fleet) if args.fleet is not None else None
         hangar_override = load_hangar(args.hangar) if args.hangar is not None else None
-        scenario = load_scenario(args.scenario, fleet=fleet_override, hangar=hangar_override)
+        scenario = load_scenario(
+            args.scenario,
+            fleet=fleet_override,
+            hangar=hangar_override,
+            max_carts=args.max_carts,
+        )
     except LoaderError as e:
         print(f"error: {e}", file=sys.stderr)
         return 2

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -67,6 +67,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         metavar="N",
         default=None,
+        dest="max_carts",
         help="Override the hangar's spare-cart count for the cart_eligible pool (default: the hangar.yaml value, or 1 if unset).",  # noqa: E501
     )
     check.add_argument(

--- a/src/hangarfit/collisions.py
+++ b/src/hangarfit/collisions.py
@@ -24,10 +24,10 @@ upstream:
    *different* aircraft, conflict iff both (a) their polygons are within
    ``hangar.clearance_m`` in plan view AND (b) their z-ranges are within
    ``hangar.wing_layer_clearance_m`` in height.
-4. **Cart rule** (upstream, *not here*) — at most one ``cart_eligible``
-   plane has ``on_carts=True``. :class:`Layout.__post_init__` rejects
-   violations at construction, so by the time a Layout reaches the
-   checker this rule has been satisfied.
+4. **Cart rule** (upstream, *not here*) — at most ``hangar.max_carts``
+   ``cart_eligible`` planes have ``on_carts=True``.
+   :class:`Layout.__post_init__` rejects violations at construction, so by
+   the time a Layout reaches the checker this rule has been satisfied.
 
 Conflict ``kind`` taxonomy for pairwise rules is the two part kinds
 sorted alphabetically and joined by ``"_"`` with the ``"_overlap"``

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -23,6 +23,7 @@ a mis-cased id slip through to a late, generic model-invariant error.
 
 from __future__ import annotations
 
+import dataclasses
 import difflib
 import math
 from collections.abc import Collection, Iterable
@@ -81,6 +82,19 @@ def _to_bool(value: Any, field_name: str) -> bool:
         raise LoaderError(
             f"{field_name!r}: expected boolean (unquoted true/false), "
             f"got {value!r} ({type(value).__name__})"
+        )
+    return value
+
+
+def _to_int(value: Any, field_name: str) -> int:
+    """Coerce a YAML scalar to ``int`` strictly. Rejects ``bool`` (it is an
+    ``int`` subclass, so ``True`` would silently read as ``1``) and any
+    non-int value (floats, strings) so a fractional or mistyped count fails
+    loudly with the field name rather than silently truncating
+    (``int(1.5) == 1``)."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise LoaderError(
+            f"{field_name!r}: expected integer, got {value!r} ({type(value).__name__})"
         )
     return value
 
@@ -162,6 +176,7 @@ def load_hangar(path: Path | str) -> Hangar:
             wing_layer_clearance_m=_to_float(
                 raw.get("wing_layer_clearance_m", 0.2), "wing_layer_clearance_m"
             ),
+            max_carts=_to_int(raw.get("max_carts", 1), "max_carts"),
         )
     except (ValueError, TypeError) as e:
         raise LoaderError(f"{path}: {e}") from e
@@ -172,6 +187,7 @@ def load_layout(
     *,
     fleet: dict[str, Aircraft] | None = None,
     hangar: Hangar | None = None,
+    max_carts: int | None = None,
 ) -> Layout:
     """Load a layout YAML.
 
@@ -217,6 +233,14 @@ def load_layout(
             f"{path}: 'hangar' field is set in YAML but a hangar override was also "
             f"provided programmatically; remove one to disambiguate"
         )
+
+    # A ``--max-carts`` override (CLI) reaches ``Layout.__post_init__`` via the
+    # hangar it reads. Apply it to the resolved hangar *before* the Layout is
+    # built, so a loosening override is honoured instead of being rejected at
+    # construction against the data-file cap. See ADR-0007 (cart-inventory
+    # amendment) / #210.
+    if max_carts is not None:
+        hangar = dataclasses.replace(hangar, max_carts=max_carts)
 
     placements_data = raw.get("placements", [])
     if not isinstance(placements_data, list):
@@ -267,6 +291,7 @@ def load_scenario(
     *,
     fleet: dict[str, Aircraft] | None = None,
     hangar: Hangar | None = None,
+    max_carts: int | None = None,
 ) -> Scenario:
     """Load a scenario YAML into a validated :class:`Scenario`.
 
@@ -328,6 +353,13 @@ def load_scenario(
             f"{path}: 'hangar' field is set in YAML but a hangar override was also "
             f"provided programmatically; remove one to disambiguate"
         )
+
+    # A ``--max-carts`` override (CLI) is applied to the resolved hangar here;
+    # the solver builds every candidate Layout from ``scenario.hangar``, so the
+    # cart cap each Layout enforces is this overridden value. See ADR-0007
+    # (cart-inventory amendment) / #210.
+    if max_carts is not None:
+        hangar = dataclasses.replace(hangar, max_carts=max_carts)
 
     for pid in fleet_in:
         _resolve_known_plane_id(pid, fleet, role="fleet_in entry", path=path)

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -237,10 +237,16 @@ def load_layout(
     # A ``--max-carts`` override (CLI) reaches ``Layout.__post_init__`` via the
     # hangar it reads. Apply it to the resolved hangar *before* the Layout is
     # built, so a loosening override is honoured instead of being rejected at
-    # construction against the data-file cap. See ADR-0007 (cart-inventory
-    # amendment) / #210.
+    # construction against the data-file cap. ``replace`` re-runs
+    # ``Hangar.__post_init__``, so a negative override is rejected — wrap that
+    # ValueError into a LoaderError to keep the exit-2 contract (a raw
+    # ValueError would crash the CLI with a traceback). See ADR-0007
+    # (cart-inventory amendment) / #210.
     if max_carts is not None:
-        hangar = dataclasses.replace(hangar, max_carts=max_carts)
+        try:
+            hangar = dataclasses.replace(hangar, max_carts=max_carts)
+        except ValueError as e:
+            raise LoaderError(f"{path}: {e}") from e
 
     placements_data = raw.get("placements", [])
     if not isinstance(placements_data, list):
@@ -356,10 +362,15 @@ def load_scenario(
 
     # A ``--max-carts`` override (CLI) is applied to the resolved hangar here;
     # the solver builds every candidate Layout from ``scenario.hangar``, so the
-    # cart cap each Layout enforces is this overridden value. See ADR-0007
-    # (cart-inventory amendment) / #210.
+    # cart cap each Layout enforces is this overridden value. ``replace``
+    # re-runs ``Hangar.__post_init__``; wrap a negative-value ValueError into a
+    # LoaderError to keep the exit-2 contract. See ADR-0007 (cart-inventory
+    # amendment) / #210.
     if max_carts is not None:
-        hangar = dataclasses.replace(hangar, max_carts=max_carts)
+        try:
+            hangar = dataclasses.replace(hangar, max_carts=max_carts)
+        except ValueError as e:
+            raise LoaderError(f"{path}: {e}") from e
 
     for pid in fleet_in:
         _resolve_known_plane_id(pid, fleet, role="fleet_in entry", path=path)

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -272,6 +272,13 @@ class Hangar:
     door wall, ``+y`` deeper into the hangar. See
     ``docs/architecture/08-crosscutting-concepts.md`` "The coordinate
     convention".
+
+    ``max_carts`` is the number of spare carts available to the
+    ``cart_eligible`` pool — a property of the site's equipment, not of
+    any airframe. It bounds how many ``cart_eligible`` planes may sit on
+    carts in a single :class:`Layout` (``always_cart`` planes get their
+    own carts and never draw from this pool). Defaults to ``1``, which
+    reproduces the original hard-coded single-cart rule.
     """
 
     length_m: float
@@ -280,6 +287,7 @@ class Hangar:
     maintenance_bay: MaintenanceBay
     clearance_m: float
     wing_layer_clearance_m: float
+    max_carts: int = 1
 
     def __post_init__(self) -> None:
         if self.length_m <= 0:
@@ -293,6 +301,8 @@ class Hangar:
                 f"Hangar.wing_layer_clearance_m must be non-negative, "
                 f"got {self.wing_layer_clearance_m}"
             )
+        if self.max_carts < 0:
+            raise ValueError(f"Hangar.max_carts must be non-negative, got {self.max_carts}")
         door_left = self.door.center_x_m - self.door.width_m / 2
         door_right = self.door.center_x_m + self.door.width_m / 2
         if door_left < 0 or door_right > self.width_m:
@@ -341,7 +351,8 @@ class Layout:
     - every placement's ``plane_id`` exists in ``fleet``,
     - the fleet dict's keys equal their ``Aircraft.id`` (no key/id drift),
     - no duplicate placements,
-    - the cart rule (at most one ``cart_eligible`` plane on carts),
+    - the cart rule (at most ``hangar.max_carts`` ``cart_eligible`` planes
+      on carts; ``always_cart`` planes are exempt from this pool),
     - ``always_cart`` ↔ ``on_carts=True`` consistency,
     - ``always_own_gear`` ↔ ``on_carts=False`` consistency,
     - the maintenance plane (if set) is in the fleet **and is NOT in
@@ -399,9 +410,11 @@ class Layout:
             for p in self.placements
             if p.on_carts and self.fleet[p.plane_id].movement_mode == "cart_eligible"
         )
-        if cart_count > 1:
+        if cart_count > self.hangar.max_carts:
             raise ValueError(
-                f"At most one cart_eligible plane may have on_carts=True (got {cart_count})"
+                f"At most {self.hangar.max_carts} cart_eligible plane(s) may have "
+                f"on_carts=True (got {cart_count}); the cart inventory is set by "
+                f"hangar.max_carts"
             )
 
         if self.maintenance_plane is not None:

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -13,6 +13,7 @@ the current implementation supports:
 
 from __future__ import annotations
 
+import itertools
 import logging
 import math
 import random as _random_module
@@ -426,20 +427,23 @@ def _check_trivially_infeasible(
             pinned_placements.append(constraint.pin)
 
     if pinned_placements:
-        # The cart rule (at most one cart_eligible plane on carts at a
-        # time) is enforced by Layout.__post_init__ but NOT by
+        # The cart rule (at most hangar.max_carts cart_eligible planes on
+        # carts at a time) is enforced by Layout.__post_init__ but NOT by
         # Scenario.__post_init__ — that's a cross-pin invariant Scenario
         # currently doesn't check. Guard explicitly here so we can return
         # a sharp `pin_cart_rule` conflict instead of silently absorbing
         # a generic Layout `ValueError`. Morally this check belongs in
         # Scenario; a follow-up could migrate it to Scenario.__post_init__
-        # so every caller (not just solve()) benefits.
+        # so every caller (not just solve()) benefits. The limit tracks
+        # scenario.hangar.max_carts so it agrees with the Layout invariant
+        # (and with any --max-carts override already applied to the hangar).
+        max_carts = scenario.hangar.max_carts
         cart_eligible_on_carts = sum(
             1
             for p in pinned_placements
             if p.on_carts and scenario.fleet[p.plane_id].movement_mode == "cart_eligible"
         )
-        if cart_eligible_on_carts > 1:
+        if cart_eligible_on_carts > max_carts:
             check = CheckResult(
                 conflicts=(
                     Conflict.single(
@@ -447,7 +451,7 @@ def _check_trivially_infeasible(
                         plane=pinned_placements[0].plane_id,
                         detail=(
                             f"{cart_eligible_on_carts} cart_eligible pins on "
-                            f"carts (cart rule allows at most 1)"
+                            f"carts (cart rule allows at most {max_carts})"
                         ),
                     ),
                 ),
@@ -794,9 +798,9 @@ def _initial_placements(
     """Sample initial placements for every plane in ``fleet_in``.
 
     ``cart_bucket`` is the set of cart_eligible planes that should be
-    ``on_carts=True`` for this restart (at most one element per the
-    enumeration in :func:`_enumerate_cart_buckets`). Per-plane
-    ``on_carts`` resolution:
+    ``on_carts=True`` for this restart (up to ``hangar.max_carts``
+    elements per the enumeration in :func:`_enumerate_cart_buckets`).
+    Per-plane ``on_carts`` resolution:
 
     1. ``constraint.force_on_carts`` (if set) — highest priority.
     2. ``constraint.pin.on_carts`` (if pinned).
@@ -842,36 +846,43 @@ def _initial_placements(
 def _enumerate_cart_buckets(scenario: Scenario) -> list[frozenset[str]]:
     """Enumerate the cart-assignment buckets to round-robin over (spec §4.2).
 
-    Returns ``C + 1`` buckets — the empty set plus a singleton for each
-    unlocked ``cart_eligible`` plane — when no cart_eligible plane is
-    pre-committed to ``on_carts=True``. If one IS pre-committed (by
-    ``force_on_carts=True`` or a pin with ``on_carts=True``), the
-    at-most-one cart-rule slot is already taken; the only feasible
-    bucket is ``[frozenset()]``, because any singleton would put a
-    second cart_eligible plane on carts and violate the rule.
+    A bucket is the set of *free* (unlocked) ``cart_eligible`` planes to
+    put ``on_carts=True`` for one restart. The buckets are every subset of
+    the free ``cart_eligible`` planes of size ``0 .. remaining``, where
+    ``remaining = hangar.max_carts − (cart_eligible planes already
+    committed to on_carts by a pin or force_on_carts)``. With the default
+    ``max_carts = 1`` and nothing pre-committed this is exactly the empty
+    set plus a singleton per free plane — the original behaviour, preserved
+    byte-for-byte (so the ADR-0003 determinism canaries are unaffected). A
+    larger ``max_carts`` additionally enumerates pairs, triples, … up to
+    the inventory size, so the search can actually reach multi-cart
+    layouts (#210).
 
-    Locked cart_eligible planes (any pin, or ``force_on_carts`` set)
+    Locked ``cart_eligible`` planes (any pin, or ``force_on_carts`` set)
     bypass round-robin: their ``on_carts`` state is fixed by the
-    constraint. The cart rule is enforced holistically by
-    ``Layout.__post_init__`` later — this enumeration just avoids
-    wasting restart budget on guaranteed-infeasible configurations.
+    constraint, and a pin/force that puts one on carts consumes one unit of
+    the inventory (shrinking ``remaining``). A pin with ``on_carts=False``
+    locks the plane out of every bucket but consumes no inventory. If
+    commitments already meet ``max_carts``, ``remaining`` is 0 and the only
+    bucket is the empty set; a genuine over-commit is caught earlier as
+    ``trivially_infeasible_pin_cart_rule``.
 
-    Note: a pin with ``on_carts=False`` also locks the plane (so it
-    can't appear in any bucket) but does NOT consume the on-carts slot
-    — other unlocked cart_eligibles can still be enumerated as
-    singletons.
+    The cart rule is still enforced holistically by
+    ``Layout.__post_init__`` later — this enumeration just avoids wasting
+    restart budget on guaranteed-infeasible configurations.
 
     Iteration is over ``scenario.fleet_in`` (a tuple), not
-    ``scenario.fleet`` (a ``MappingProxyType``-wrapped dict view) — so
-    bucket ordering is deterministic by construction.
+    ``scenario.fleet`` (a ``MappingProxyType``-wrapped dict view), and
+    combinations are generated in that order, so bucket ordering is
+    deterministic by construction.
     """
     free_cart_eligibles: list[str] = []
-    has_committed_cart_eligible_on_carts = False
+    committed_on_carts = 0
     for pid in scenario.fleet_in:
         if pid == scenario.maintenance_plane:
             # Occupant is treated as away — it never enters the layout, so
-            # round-robining a singleton cart bucket for it would be a no-op
-            # restart that wastes one slot of the C+1 rotation.
+            # round-robining a cart bucket for it would be a no-op restart
+            # that wastes one slot of the rotation.
             continue
         plane = scenario.fleet[pid]
         if not plane.is_cart_eligible:
@@ -880,21 +891,25 @@ def _enumerate_cart_buckets(scenario: Scenario) -> list[frozenset[str]]:
         if constraint is not None:
             if constraint.pin is not None:
                 # Any pin locks the plane out of round-robin. If the pin
-                # puts it on carts, the on-carts slot is consumed.
+                # puts it on carts, one unit of inventory is consumed.
                 if constraint.pin.on_carts:
-                    has_committed_cart_eligible_on_carts = True
+                    committed_on_carts += 1
                 continue
             if constraint.force_on_carts is not None:
-                # force_on_carts=True consumes the on-carts slot.
+                # force_on_carts=True consumes one unit of inventory.
                 if constraint.force_on_carts:
-                    has_committed_cart_eligible_on_carts = True
+                    committed_on_carts += 1
                 continue
         free_cart_eligibles.append(pid)
 
-    buckets: list[frozenset[str]] = [frozenset()]
-    if not has_committed_cart_eligible_on_carts:
-        for pid in free_cart_eligibles:
-            buckets.append(frozenset({pid}))
+    remaining = min(
+        max(0, scenario.hangar.max_carts - committed_on_carts),
+        len(free_cart_eligibles),
+    )
+    buckets: list[frozenset[str]] = []
+    for size in range(remaining + 1):
+        for combo in itertools.combinations(free_cart_eligibles, size):
+            buckets.append(frozenset(combo))
     return buckets
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,16 @@ class TestCheckLoadErrors:
         assert "At most" not in captured.err  # the cart-rule load error is gone
         assert exit_code != 2  # load succeeded; a non-zero would be a geometry verdict
 
+    def test_check_max_carts_negative_is_clean_exit_2(self, capsys):
+        # A negative --max-carts must surface as a clean exit-2 LoaderError,
+        # not a raw ValueError traceback from dataclasses.replace.
+        exit_code = main(["check", str(FIXTURES_DIR / "invalid_cart_rule.yaml"), "--max-carts=-1"])
+        assert exit_code == 2
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "error:" in captured.err
+        assert "max_carts" in captured.err
+
 
 class TestCheckJsonOutput:
     """--json emits the hangarfit.check/v1 schema on stdout."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,6 +107,17 @@ class TestCheckLoadErrors:
         assert "error:" in captured.err
         assert "cart" in captured.err.lower()
 
+    def test_check_max_carts_override_loosens_cart_rule(self, capsys):
+        # --max-carts 2 replaces the cap on the loaded hangar before the Layout
+        # is built, so the two-cart_eligible layout that exits 2 above now loads
+        # — the load-time cart-rule rejection is gone.
+        exit_code = main(
+            ["check", str(FIXTURES_DIR / "invalid_cart_rule.yaml"), "--max-carts", "2"]
+        )
+        captured = capsys.readouterr()
+        assert "At most" not in captured.err  # the cart-rule load error is gone
+        assert exit_code != 2  # load succeeded; a non-zero would be a geometry verdict
+
 
 class TestCheckJsonOutput:
     """--json emits the hangarfit.check/v1 schema on stdout."""

--- a/tests/test_collisions.py
+++ b/tests/test_collisions.py
@@ -147,7 +147,7 @@ class TestCartRule:
     """
 
     def test_case_10_two_cart_eligible_on_carts_rejected_at_load(self) -> None:
-        with pytest.raises(LoaderError, match="At most one cart_eligible"):
+        with pytest.raises(LoaderError, match=r"At most 1 cart_eligible"):
             _load("invalid_cart_rule")
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -18,6 +18,7 @@ from hangarfit.loader import (
     load_fleet,
     load_hangar,
     load_layout,
+    load_scenario,
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -213,6 +214,18 @@ class TestHangarMaxCarts:
         layout = load_layout(fixture, max_carts=2)
         assert layout.hangar.max_carts == 2
         assert len(layout.placements) == 2
+
+    def test_load_layout_negative_override_raises_loader_error(self) -> None:
+        """A negative override is rejected as a LoaderError (not a raw
+        ValueError from dataclasses.replace), preserving the exit-2 contract."""
+        fixture = REPO_ROOT / "tests" / "fixtures" / "invalid_cart_rule.yaml"
+        with pytest.raises(LoaderError, match="max_carts must be non-negative"):
+            load_layout(fixture, max_carts=-1)
+
+    def test_load_scenario_negative_override_raises_loader_error(self) -> None:
+        fixture = REPO_ROOT / "tests" / "fixtures" / "solve_infeasible_two_cart_pins.yaml"
+        with pytest.raises(LoaderError, match="max_carts must be non-negative"):
+            load_scenario(fixture, max_carts=-1)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -31,6 +31,16 @@ def _write(path: Path, text: str) -> Path:
     return path
 
 
+# A minimal, otherwise-valid hangar YAML body. Tests append a `max_carts:`
+# line (or omit it) to exercise the loader's coercion + default.
+_MIN_HANGAR = (
+    "length_m: 25.0\n"
+    "width_m: 18.0\n"
+    "door: {center_x_m: 9.0, width_m: 12.0}\n"
+    "maintenance_bay: {center_x_m: 13.5, width_m: 9.0, depth_m: 9.0}\n"
+)
+
+
 # ----------------------------------------------------------------------------
 # Happy-path: load the real bundled data files.
 # ----------------------------------------------------------------------------
@@ -150,6 +160,7 @@ class TestRealDataFiles:
         assert hangar.maintenance_bay.center_x_m == 13.5
         assert hangar.maintenance_bay.width_m == 9.0
         assert hangar.maintenance_bay.depth_m == 9.0
+        assert hangar.max_carts == 1  # bundled data/hangar.yaml sets it explicitly
 
     def test_load_example_layout(self) -> None:
         layout = load_layout(EXAMPLE_LAYOUT)
@@ -160,6 +171,48 @@ class TestRealDataFiles:
         assert len(layout.placements) == 5
         assert layout.maintenance_plane == "scheibe_falke"
         assert "scheibe_falke" not in {p.plane_id for p in layout.placements}
+
+
+class TestHangarMaxCarts:
+    """Loader handling of the optional `max_carts` site scalar (#210)."""
+
+    def test_absent_defaults_to_one(self, tmp_path: Path) -> None:
+        """A hangar.yaml with no max_carts loads as 1 — the backward-compat
+        guarantee (absence reproduces the original single-cart rule)."""
+        path = _write(tmp_path / "h.yaml", _MIN_HANGAR)
+        assert load_hangar(path).max_carts == 1
+
+    def test_explicit_value(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "h.yaml", _MIN_HANGAR + "max_carts: 3\n")
+        assert load_hangar(path).max_carts == 3
+
+    @pytest.mark.parametrize("bad", ['"two"', "1.5", "true"])
+    def test_non_int_rejected(self, tmp_path: Path, bad: str) -> None:
+        """Strings, floats, and bools are rejected (no silent truncation or
+        the bool-is-int footgun) with the field named."""
+        path = _write(tmp_path / "h.yaml", _MIN_HANGAR + f"max_carts: {bad}\n")
+        with pytest.raises(LoaderError, match="max_carts"):
+            load_hangar(path)
+
+    def test_negative_rejected(self, tmp_path: Path) -> None:
+        """A negative count is rejected — the loader wraps the Hangar
+        __post_init__ ValueError into a LoaderError."""
+        path = _write(tmp_path / "h.yaml", _MIN_HANGAR + "max_carts: -1\n")
+        with pytest.raises(LoaderError, match="max_carts must be non-negative"):
+            load_hangar(path)
+
+    def test_load_layout_override_loosens_cap_before_build(self) -> None:
+        """The load_layout(max_carts=…) override is applied to the resolved
+        hangar before the Layout is built, so a layout the data-file cap (1)
+        would reject now loads — the path the CLI --max-carts flag uses."""
+        fixture = REPO_ROOT / "tests" / "fixtures" / "invalid_cart_rule.yaml"
+        # Two cart_eligible planes on carts: rejected under the default cap.
+        with pytest.raises(LoaderError, match="cart_eligible"):
+            load_layout(fixture)
+        # With the override the Layout constructs and carries the new cap.
+        layout = load_layout(fixture, max_carts=2)
+        assert layout.hangar.max_carts == 2
+        assert len(layout.placements) == 2
 
 
 # ----------------------------------------------------------------------------
@@ -909,7 +962,7 @@ placements:
   - {plane: b, x_m: 10, y_m: 5, heading_deg: 0, on_carts: true}
 """,
         )
-        with pytest.raises(LoaderError, match="At most one cart_eligible"):
+        with pytest.raises(LoaderError, match=r"At most 1 cart_eligible"):
             load_layout(layout_path)
 
     def test_fleet_and_hangar_overrides(self, tmp_path: Path) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -61,7 +61,7 @@ def _ok_aircraft(
     )
 
 
-def _ok_hangar() -> Hangar:
+def _ok_hangar(max_carts: int = 1) -> Hangar:
     return Hangar(
         length_m=25.0,
         width_m=18.0,
@@ -69,6 +69,7 @@ def _ok_hangar() -> Hangar:
         maintenance_bay=MaintenanceBay(center_x_m=9.0, width_m=4.0, depth_m=9.0),
         clearance_m=0.3,
         wing_layer_clearance_m=0.2,
+        max_carts=max_carts,
     )
 
 
@@ -669,7 +670,7 @@ class TestLayout:
     def test_cart_rule_rejects_two_cart_eligible_on_carts(self) -> None:
         a = _ok_aircraft("foo", movement_mode="cart_eligible", turn_radius_m=4.0)
         b = _ok_aircraft("bar", movement_mode="cart_eligible", turn_radius_m=4.0)
-        with pytest.raises(ValueError, match="At most one cart_eligible"):
+        with pytest.raises(ValueError, match=r"At most 1 cart_eligible"):
             Layout(
                 fleet=self._fleet_of(a, b),
                 hangar=_ok_hangar(),
@@ -678,6 +679,105 @@ class TestLayout:
                     Placement(plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=True),
                 ),
             )
+
+    def test_max_carts_default_is_one(self) -> None:
+        """A hangar built without max_carts defaults to 1, reproducing the
+        original single-cart rule (the backward-compat anchor)."""
+        assert _ok_hangar().max_carts == 1
+
+    def test_max_carts_two_allows_two_eligible_on_carts(self) -> None:
+        a = _ok_aircraft("foo", movement_mode="cart_eligible", turn_radius_m=4.0)
+        b = _ok_aircraft("bar", movement_mode="cart_eligible", turn_radius_m=4.0)
+        layout = Layout(
+            fleet=self._fleet_of(a, b),
+            hangar=_ok_hangar(max_carts=2),
+            placements=(
+                Placement(plane_id="foo", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                Placement(plane_id="bar", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=True),
+            ),
+        )
+        assert len(layout.placements) == 2
+
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_max_carts_n_allows_n_rejects_n_plus_one(self, n: int) -> None:
+        fleet = self._fleet_of(
+            *(
+                _ok_aircraft(f"p{i}", movement_mode="cart_eligible", turn_radius_m=4.0)
+                for i in range(n + 1)
+            )
+        )
+        # N eligible planes on carts: valid.
+        ok = tuple(
+            Placement(plane_id=f"p{i}", x_m=float(i), y_m=0.0, heading_deg=0.0, on_carts=True)
+            for i in range(n)
+        )
+        built = Layout(fleet=fleet, hangar=_ok_hangar(max_carts=n), placements=ok)
+        assert len(built.placements) == n
+        # N+1 eligible planes on carts: rejected, naming the limit N.
+        too_many = ok + (
+            Placement(plane_id=f"p{n}", x_m=float(n), y_m=0.0, heading_deg=0.0, on_carts=True),
+        )
+        with pytest.raises(ValueError, match=rf"At most {n} cart_eligible"):
+            Layout(fleet=fleet, hangar=_ok_hangar(max_carts=n), placements=too_many)
+
+    def test_always_cart_excluded_from_inventory(self) -> None:
+        """always_cart planes get their own carts and never draw from the
+        cart_eligible pool — so any number of them on carts plus max_carts
+        eligible planes is valid; one more eligible plane is not."""
+        g1 = _ok_aircraft("g1", movement_mode="always_cart", turn_radius_m=None)
+        g2 = _ok_aircraft("g2", movement_mode="always_cart", turn_radius_m=None)
+        e1 = _ok_aircraft("e1", movement_mode="cart_eligible", turn_radius_m=4.0)
+        e2 = _ok_aircraft("e2", movement_mode="cart_eligible", turn_radius_m=4.0)
+        # Two always_cart on carts + one cart_eligible on a cart, max_carts=1: valid.
+        layout = Layout(
+            fleet=self._fleet_of(g1, g2, e1, e2),
+            hangar=_ok_hangar(max_carts=1),
+            placements=(
+                Placement(plane_id="g1", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                Placement(plane_id="g2", x_m=2.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                Placement(plane_id="e1", x_m=4.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                Placement(plane_id="e2", x_m=6.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+            ),
+        )
+        assert len(layout.placements) == 4
+        # A second cart_eligible on a cart exceeds the pool of 1.
+        with pytest.raises(ValueError, match=r"At most 1 cart_eligible"):
+            Layout(
+                fleet=self._fleet_of(g1, g2, e1, e2),
+                hangar=_ok_hangar(max_carts=1),
+                placements=(
+                    Placement(plane_id="g1", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                    Placement(plane_id="g2", x_m=2.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                    Placement(plane_id="e1", x_m=4.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                    Placement(plane_id="e2", x_m=6.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                ),
+            )
+
+    def test_max_carts_zero_forbids_eligible_carts_but_not_always_cart(self) -> None:
+        g1 = _ok_aircraft("g1", movement_mode="always_cart", turn_radius_m=None)
+        e1 = _ok_aircraft("e1", movement_mode="cart_eligible", turn_radius_m=4.0)
+        # always_cart on a cart is fine even at max_carts=0 (it's exempt).
+        layout = Layout(
+            fleet=self._fleet_of(g1),
+            hangar=_ok_hangar(max_carts=0),
+            placements=(
+                Placement(plane_id="g1", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+            ),
+        )
+        assert len(layout.placements) == 1
+        # A cart_eligible on a cart is rejected at max_carts=0.
+        with pytest.raises(ValueError, match=r"At most 0 cart_eligible"):
+            Layout(
+                fleet=self._fleet_of(e1),
+                hangar=_ok_hangar(max_carts=0),
+                placements=(
+                    Placement(plane_id="e1", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True),
+                ),
+            )
+
+    def test_hangar_max_carts_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match="max_carts must be non-negative"):
+            _ok_hangar(max_carts=-1)
 
     def test_maintenance_plane_must_be_in_fleet(self) -> None:
         a = _ok_aircraft("foo", movement_mode="always_own_gear", turn_radius_m=5.0)

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -127,6 +127,70 @@ def test_cart_buckets_enumerates_unlocked_cart_eligibles_plus_none():
         assert frozenset({pid}) in buckets
 
 
+def test_cart_buckets_enumerate_combinations_when_max_carts_gt_one():
+    """With max_carts=N the enumeration emits every subset of the unlocked
+    cart_eligible planes up to size N — so the search can actually reach
+    multi-cart layouts (#210). For the default max_carts=1 it stays the
+    empty set plus singletons (covered by the test above)."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _enumerate_cart_buckets
+
+    # 3 unlocked cart_eligibles. max_carts=1 ⇒ 4 buckets (∅ + 3 singletons);
+    # max_carts=2 ⇒ + C(3,2)=3 pairs = 7; max_carts=3 ⇒ + 1 triple = 8.
+    s1 = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    assert len(_enumerate_cart_buckets(s1)) == 4  # default unchanged
+
+    s2 = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml", max_carts=2)
+    buckets2 = _enumerate_cart_buckets(s2)
+    assert len(buckets2) == 7
+    pairs = [b for b in buckets2 if len(b) == 2]
+    assert len(pairs) == 3
+
+    s3 = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml", max_carts=3)
+    buckets3 = _enumerate_cart_buckets(s3)
+    assert len(buckets3) == 8
+    assert any(len(b) == 3 for b in buckets3)
+
+
+def test_cart_buckets_committed_pin_reduces_remaining_budget():
+    """A cart_eligible already committed on_carts (force/pin) consumes one
+    unit of max_carts. At max_carts=1 that leaves only the empty bucket;
+    bumping to max_carts=2 re-opens a slot for the other unlocked plane."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import _enumerate_cart_buckets
+
+    # cessna_140 is force_on_carts=True (1 committed); ctsl unlocked.
+    s1 = load_scenario("tests/fixtures/scenario_with_force_carts.yaml")
+    assert _enumerate_cart_buckets(s1) == [frozenset()]  # remaining 1-1=0
+
+    s2 = load_scenario("tests/fixtures/scenario_with_force_carts.yaml", max_carts=2)
+    buckets2 = _enumerate_cart_buckets(s2)  # remaining 2-1=1
+    assert len(buckets2) > 1
+    assert frozenset({"ctsl"}) in buckets2
+
+
+def test_pin_cart_rule_check_honors_max_carts():
+    """The solver's pin pre-check counts against hangar.max_carts, not a
+    hard-coded 1. Two cart_eligible planes pinned on carts is trivially
+    infeasible at the default cap but admissible at max_carts=2 (#210)."""
+    from hangarfit.loader import load_scenario
+    from hangarfit.solver import solve
+
+    fixture = "tests/fixtures/solve_infeasible_two_cart_pins.yaml"
+    # Default cap: the pin pre-check fires with the cart-rule conflict kind.
+    r1 = solve(load_scenario(fixture), budget_s=5.0, seed=42)
+    assert r1.status == "trivially_infeasible"
+    assert r1.diagnostics.best_partial.conflicts[0].kind == "trivially_infeasible_pin_cart_rule"
+    # max_carts=2: the pin cart-rule pre-check no longer fires. (These two
+    # planes pinned 5 m apart still collide, so the pinned-layout check fails
+    # with a *geometric* conflict — but never the cart-rule one. That kind
+    # disappearing is the proof the cap is now read from hangar.max_carts.)
+    r2 = solve(load_scenario(fixture, max_carts=2), budget_s=5.0, seed=42)
+    partial = r2.diagnostics.best_partial
+    kinds = {c.kind for c in partial.conflicts} if partial is not None else set()
+    assert "trivially_infeasible_pin_cart_rule" not in kinds
+
+
 def test_cart_bucket_for_restart_is_deterministic_round_robin():
     """Restart index R selects bucket R % len(buckets)."""
     from hangarfit.loader import load_scenario


### PR DESCRIPTION
Implements the ratified design in `docs/superpowers/specs/2026-05-27-cart-inventory-design.md` (PR #308) — the cart-resource half of towplanner v2.

## What
Replaces the hard-coded "at most **1** `cart_eligible` plane on a cart" rule with a configurable `Hangar.max_carts`.

- **`max_carts` on `Hangar`** (default `1`): absence reproduces today's behaviour byte-for-byte. A cart is site equipment (same category as `clearance_m`), so it lives on `data/hangar.yaml`. `Layout.__post_init__` now checks `cart_count > self.hangar.max_carts`.
- **`always_cart` planes stay exempt** from the pool; **`MovesPlan` stays tally-free** (preserves the ADR-0007 non-breaking guarantee).
- **`--max-carts N` CLI override** on `check` and `solve`: replaces the cap on the loaded `Hangar` *before* any `Layout` is built (via `dataclasses.replace`), so a loosening override is honoured rather than rejected at construction.
- **`max_carts = 0`** forbids any `cart_eligible`-on-cart (`always_cart` unaffected); negatives rejected.

## Decisions (ratified by @DocGerd, recorded in the design doc + ADR-0007 amendment)
- **Dolly** reading (carted plane rests on its cart) ⇒ per-layout *count* is the right invariant.
- **Per-layout** binding (the K solve alternatives are a mutually-exclusive menu).
- `max_carts` source = `hangar.yaml` **+** `--max-carts` CLI override in scope now.
- Governance = **amend ADR-0007** (not a new ADR).

## Files
`models.py` (field + validation + invariant), `loader.py` (strict `_to_int`, `load_hangar`, override on `load_layout`/`load_scenario`), `cli.py` (`--max-carts`), `data/hangar.yaml`, arc42 §8, ADR-0007 amendment, tests across models/loader/cli/collisions.

## Verification
- `1035 passed, 8 deselected`; ruff + ruff-format + mypy clean.
- Manual: `check invalid_cart_rule.yaml --max-carts 2` now passes the cart gate and returns the genuine geometry verdict (exit 1 — those two planes actually overlap), proving the override lands before the cap check.

Reviews to run (per CLAUDE.md): `type-design-analyzer` (models.py), `silent-failure-hunter` (loader.py).

Closes #210