### PR TITLE
docs(readme): add Apache-2.0 license badge (#313)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![codecov](https://codecov.io/gh/DocGerd/hangarfit/branch/develop/graph/badge.svg)](https://codecov.io/gh/DocGerd/hangarfit)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/DocGerd/hangarfit/badge)](https://securityscorecards.dev/viewer/?uri=github.com/DocGerd/hangarfit)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12987/badge)](https://www.bestpractices.dev/projects/12987)
+[![License: Apache-2.0](https://img.shields.io/github/license/DocGerd/hangarfit)](LICENSE)
 
 An on-demand exception tool for a flying club's hangar parking.
 


### PR DESCRIPTION
Adds the missing License badge to the README badge row, as requested in #313.

## Change
One line in the badge block (after the OpenSSF Best Practices badge):

```markdown
[![License: Apache-2.0](https://img.shields.io/github/license/DocGerd/hangarfit)](LICENSE)
```

- **Dynamic** shields.io `github/license` endpoint — reads GitHub's detected license, so it tracks the actual `LICENSE` (Apache-2.0, per `pyproject.toml` `license = "Apache-2.0"`) and can't drift to a stale hard-coded label.
- Links to the repo-local `LICENSE` file (verified present), consistent with how the other badges link to their sources.
- Placed alongside the existing badges; no other README content changed.

Closes #313