### PR TITLE
fix(license): fill the Apache-2.0 copyright placeholder (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Fixed
 
+- LICENSE Apache-2.0 copyright line was the unfilled `[yyyy] [name of copyright owner]` template placeholder; now reads `Copyright 2026 DocGerdSoft (Patrick Kuhn)` (#310).
+
 ## [0.7.1] — 2026-05-27
 
 First published release of the 0.7.x line. v0.7.0 was tagged on `main` but its GitHub Release could not be published — the tag was consumed by an immutable release during the release cut and is permanently reserved — so v0.7.1 supersedes it with identical features plus the release-workflow fix below.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 DocGerdSoft (Patrick Kuhn)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

`LICENSE` shipped the Apache-2.0 boilerplate with the appendix copyright line
(line 190) left as the literal unfilled template:

```
Copyright [yyyy] [name of copyright owner]
```

For a public OSS repo this is a real defect — the license text is ambiguous
about who holds copyright and is granting the Apache-2.0 grant. Replace with
the concrete attribution decided 2026-05-27 for the sibling
`DocGerd/pantry-tracker` repo, which used hangarfit as its public-template
reference:

```
Copyright 2026 DocGerdSoft (Patrick Kuhn)
```

## Why now

Surfaced while open-sourcing `DocGerd/pantry-tracker` — hangarfit was the
canonical public-repo template and this was the one item that didn't carry
over cleanly. Filed as #310 on 2026-05-27; picked up as part of the v0.7.2
housekeeping cut.

## Scope

- `LICENSE` — single line edit (190)
- `CHANGELOG.md` — `[Unreleased]` → **Fixed** entry referencing #310

No code, no tests, no docstrings touched. CI runs unchanged.

## Test plan

- [ ] CI green
- [ ] `head -195 LICENSE | tail -10` shows `Copyright 2026 DocGerdSoft (Patrick Kuhn)` on line 190

Closes #310.