### PR TITLE
chore: back-merge v0.7.2 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+### Fixed
+
+## [0.7.2] — 2026-05-28
+
+Housekeeping cut. Two doc/test items left over from the v0.7.0/v0.7.1 release campaign — no behavioural change to `check`, `solve`, or `solve --render-paths` output for any existing scenario.
+
+### Changed
+
 - `tests/test_solver_search.py` now anchors every fixture / layout / data load on `Path(__file__).resolve().parent.parent` rather than process cwd, so pytest can be invoked from any directory and the tests still resolve the right files. Matches the existing convention in `tests/test_loader.py` (#317).
+- README status section updated to reflect Phase 3a (tow-path planner v1) and Phase 3b (Reeds–Shepp v2) having shipped in v0.7.0/v0.7.1; removed the stale "No movement-sequence planning" out-of-scope claim and the stale "the example layout fails validation" parenthetical.
 
 ### Fixed
 
@@ -111,7 +120,8 @@ First Phase 1 cut — substrate for arranging the flying club fleet in a stack-s
 - Apache-2.0 license, public-audience README, CI matrix (Python 3.11 + 3.12), branch protection on develop + main (#13, #14, #15, #16).
 - Strut-aware golden tests + all-9-planes fixture using larger test-only hangar to accommodate strut-bracing geometry on placeholder dimensions (#5).
 
-[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/DocGerd/hangarfit/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/DocGerd/hangarfit/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/DocGerd/hangarfit/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/DocGerd/hangarfit/compare/v0.6.0...v0.6.1

--- a/README.md
+++ b/README.md
@@ -20,19 +20,23 @@ It also renders a top-down PNG so a human can sanity-check the result by eye.
 
 **Phase 2a — shipped.** Added the static layout solver: `hangarfit solve` takes a scenario YAML (fleet, hangar, constraints, optional pins) and searches for up to K diverse valid layouts using random-restart hill climbing with min-conflicts descent. Acceptance runs through `collisions.check()` as its gate — the solver does not bypass the collision rule.
 
+**Phase 3a — shipped.** Tow-path planner v1: `hangarfit solve --render-paths` plans a per-plane tow path (Dubins) from the door to the parked pose, plus a tow order; the static-layout PNG overlays each plane's path so a human can sanity-check the route. Best-effort: a layout the planner can't fully route still renders (without paths) and a stderr warning names the blocking plane; exit code 3 fires only when no candidate layout is tow-routable. See [ADR-0007](docs/adr/0007-tow-path-planner-v1-scope.md).
+
+**Phase 3b — shipped.** Tow-path planner v2: a Reeds–Shepp motion model (reverse arcs eliminate the reorientation loops Dubins introduced) plus a door entry-cone search over heading × offset. See [ADR-0010](docs/adr/0010-reeds-shepp-motion-model.md).
+
 **Still explicitly out of scope:**
 
-- No movement-sequence planning ("in what order do I roll planes out and back in to reach this layout").
 - No tracking of hangar state across runs — each invocation is stateless.
 - No soft constraints / preferences. Constraints are HARD: pin, force_on_carts, maintenance plane.
 - No GUI or web frontend.
 - No handling of late arrivals as a live event stream.
+- Multi-plane *rearrangement* (move planes around an already-occupied hangar). The tow planner only handles **empty-hangar fill** — every plane enters once. Rearrangement is planner v2+ territory.
 
 These boundaries are deliberate.
 
 ## Status
 
-Pre-release. Phase 1 + Phase 2a are feature-complete (`hangarfit check` and `hangarfit solve`). All dimensions in `data/` are placeholders pending real measurement and are flagged as such in the YAML; checker output on the current data is illustrative, not authoritative — and so are any layouts the solver finds against it.
+All shipped phases are feature-complete: `hangarfit check` (Phase 1), `hangarfit solve` (Phase 2a/b/c), and `hangarfit solve --render-paths` (Phase 3a/b). All dimensions in `data/` are placeholders pending real measurement and are flagged as such in the YAML; checker output on the current data is illustrative, not authoritative — and so are any layouts the solver finds and any tow paths the planner draws against it.
 
 Follow progress in [GitHub Issues](https://github.com/DocGerd/hangarfit/issues) and milestones.
 
@@ -56,7 +60,7 @@ pip install -e .
 hangarfit check layouts/example.yaml
 ```
 
-> Note: against the current placeholder fleet/hangar measurements (see Status), the example layout fails validation. That's expected — Phase 1 ships the substrate; real measurements are tracked separately.
+> Note: `layouts/example.yaml` is a deliberate 6-plane subset that fits inside the current placeholder hangar — running `check` on it returns `valid` (exit code 0). To see a conflict diagnosis (red overlay in the PNG render, exit code 1), point at one of the `tests/fixtures/invalid_*.yaml` fixtures. All dimensions in `data/` remain placeholders pending real measurement (see Status), so any verdict on the current data is illustrative.
 
 ```bash
 # Render the layout (works on invalid layouts too — conflicts highlighted in red)
@@ -100,6 +104,9 @@ hangarfit solve scenario.yaml --alternatives 3 --strict-k
 
 # Budget the search to 5 wall-clock seconds (default 30)
 hangarfit solve scenario.yaml --budget 5
+
+# Plan + overlay each plane's tow path on the rendered PNG (Phase 3a/b)
+hangarfit solve scenario.yaml --render out.png --render-paths
 ```
 
 A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which planes are present), an optional `maintenance:` block (which plane is in the back bay), and an optional `constraints:` mapping (per-plane pins or `force_on_carts` locks). See `tests/fixtures/solve_*.yaml` for ready-to-read examples covering each constraint kind.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hangarfit"
-version = "0.7.1"
+version = "0.7.2"
 description = "Helper tool for arranging the flying club fleet in a stack-style hangar — collision checker + visualizer (Phase 1)."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Back-merge v0.7.2 into develop

Merges the `release/0.7.2` branch back into `develop` to keep the
branches in sync after the release.

**Merge AFTER the main release PR (#323) is merged**, so the back-merge
includes the version-bump commit on a `main`-aligned base.