### PR TITLE
feat: wheel positions as canonical per-aircraft data (#322)

### DIFF
--- a/data/fleet.yaml
+++ b/data/fleet.yaml
@@ -8,12 +8,19 @@
 # Conventions (see `docs/architecture/08-crosscutting-concepts.md`
 # "The coordinate convention" and "The parts model" for the full version):
 # - Plane-local coords: +x = forward (toward nose), +y = right (toward right wingtip)
-# - Origin of plane-local frame = main-gear / cart centroid
+# - Origin of plane-local frame = a per-aircraft anchor used as the placement
+#   reference (where Placement.x_m/y_m positions the plane in world coords).
+#   The main-gear centroid is a *derived* point, accessible as
+#   (wheels.main_offset_x_m, 0) in plane-local coords. See ADR-0013.
 # - Each Part is an oriented rectangle: length_m runs along plane +x,
 #   width_m runs along plane +y
 # - Heights z_bottom_m / z_top_m are above-ground in world coords
 # - struts block (optional) is expanded by the loader into two mirrored
 #   strut Parts; cantilever aircraft omit the block entirely
+# - wheels block (required) declares the β-schema main_offset_x_m, track_m,
+#   and third_wheel_offset_x_m fields per aircraft (see ADR-0013). Monowheel
+#   aircraft set only main_offset_x_m. The loader cross-checks the
+#   wheel-derived wheelbase against turn_radius_m for own-gear aircraft.
 # - a `kind: fuselage` part is auto-split by the loader into a
 #   `fuselage_front` (cockpit) + `fuselage_aft` (tail) pair at the wing
 #   trailing-edge station (`wing.offset_x_m - wing.length_m/2`); no per-plane

--- a/data/fleet.yaml
+++ b/data/fleet.yaml
@@ -59,6 +59,8 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.1
+    wheels:
+      main_offset_x_m: 0.0
 
   # ----------------------------------------------------------------------------
   # TAILWHEEL HIGH-WING — strut-braced, always on own gear
@@ -91,6 +93,10 @@ aircraft:
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.8
       width_m: 0.05
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 2.0
+      third_wheel_offset_x_m: -4.80
 
   # ----------------------------------------------------------------------------
   # LOW-WING — cantilever, nosewheel, always on own gear. ONLY low-wing in fleet.
@@ -118,6 +124,10 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 0.8
         z_top_m: 1.1
+    wheels:
+      main_offset_x_m: -0.40
+      track_m: 2.5
+      third_wheel_offset_x_m: 1.60
 
   # ----------------------------------------------------------------------------
   # ULTRALIGHT HIGH-WING — strut-braced, always on carts
@@ -150,6 +160,10 @@ aircraft:
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.6
       width_m: 0.05
+    wheels:
+      main_offset_x_m: -0.10
+      track_m: 1.5
+      third_wheel_offset_x_m: 1.40
 
   # ----------------------------------------------------------------------------
   # TAILWHEEL HIGH-WING — strut-braced, always on carts
@@ -182,6 +196,10 @@ aircraft:
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.5
       width_m: 0.05
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 1.8
+      third_wheel_offset_x_m: -4.30
 
   # ----------------------------------------------------------------------------
   # CART-ELIGIBLE — high-wing tailwheel, strut-braced (V-strut → one per side)
@@ -215,6 +233,10 @@ aircraft:
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.7
       width_m: 0.05
+    wheels:
+      main_offset_x_m: 0.50
+      track_m: 2.1
+      third_wheel_offset_x_m: -3.80
 
   # ----------------------------------------------------------------------------
   # CART-ELIGIBLE — high-wing nosewheel, strut-braced
@@ -247,6 +269,10 @@ aircraft:
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.8
       width_m: 0.05
+    wheels:
+      main_offset_x_m: -0.20
+      track_m: 2.3
+      third_wheel_offset_x_m: 1.30
 
   # ----------------------------------------------------------------------------
   # CART-ELIGIBLE — high-wing nosewheel, cantilever (no struts)
@@ -274,6 +300,10 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.2
+    wheels:
+      main_offset_x_m: -0.10
+      track_m: 1.7
+      third_wheel_offset_x_m: 1.40
 
   # ----------------------------------------------------------------------------
   # CART-ELIGIBLE — high-wing nosewheel, strut-braced
@@ -306,3 +336,7 @@ aircraft:
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.6
       width_m: 0.05
+    wheels:
+      main_offset_x_m: -0.10
+      track_m: 1.4
+      third_wheel_offset_x_m: 1.40

--- a/docs/adr/0012-fuselage-front-aft-split.md
+++ b/docs/adr/0012-fuselage-front-aft-split.md
@@ -163,8 +163,11 @@ at zero (only a header comment) and the break a single derived value.
   the aft *region* includes the tail, so a separate tail segment would add a
   kind with no distinct rule).
 - The visualizer tints `fuselage_front` a darker shade of the wing-position
-  fill so the cockpit boundary reads at a glance; `_draw_gear_glyph`
-  reconstructs the full fuselage span from both segments.
+  fill so the cockpit boundary reads at a glance. (At the time of this ADR
+  `_draw_gear_glyph` reconstructed the full fuselage span from both segments to
+  place the gear heuristically; [ADR-0013](0013-wheels-canonical-data.md) later
+  replaced that with canonical per-aircraft wheel data, so the gear glyph no
+  longer depends on the fuselage segments.)
 
 ## Compliance
 

--- a/docs/adr/0013-wheels-canonical-data.md
+++ b/docs/adr/0013-wheels-canonical-data.md
@@ -1,0 +1,191 @@
+# ADR-0013: Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load
+
+- **Status:** Proposed
+  <!-- Proposed at PR-open; flip to Accepted at PR-merge. -->
+- **Date:** 2026-05-28
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+Two surface representations of the same physical property — *where each
+aircraft's wheels are* — disagreed, with nothing linking them:
+
+- `data/fleet.yaml` carried `turn_radius_m` per aircraft (load-bearing for the
+  Reeds–Shepp tow-path planner since Phase 3a — [ADR-0007](0007-tow-path-planner-v1-scope.md) /
+  [ADR-0010](0010-reeds-shepp-motion-model.md)), but **no wheel positions**.
+- `src/hangarfit/visualize.py` invented wheel-glyph positions on the fly from
+  heuristic fractions of fuselage half-length (`_NOSE_GEAR_FRAC` and friends).
+  The module itself flagged the fractions as "intentionally approximate".
+
+A contributor could change `turn_radius_m` without touching the rendered
+wheelbase, or move the rendered wheels without touching the radius, and nothing
+noticed — the property was modelled twice and the two could drift apart
+silently. Surfaced during the v0.7.2 pre-release visual smoke (2026-05-28,
+[#322](https://github.com/DocGerd/hangarfit/issues/322)).
+
+A coupled latent inconsistency: the `fleet.yaml` header asserted *"Origin =
+main-gear / cart centroid"*, which the data did not honor — `visualize.py` drew
+mains offset from origin and the fleet entries followed that convention.
+
+## Decision Drivers
+
+- **One source of truth for wheel positions.** The same property must not have
+  two independent surface representations that can disagree.
+- **Honesty over false precision.** Every fleet dimension is a guess
+  (`measured: false`). The model should not claim a derivation it cannot
+  actually justify from the data we have.
+- **Determinism contract is sacred.** [ADR-0003](0003-rr-mc-solver-algorithm.md):
+  same scenario + seed ⇒ bit-identical output. The change must not perturb
+  `turn_radius_m` values, or every Reeds–Shepp solution and canary baseline
+  shifts.
+- **Unblock the dependent work.** [#321](https://github.com/DocGerd/hangarfit/issues/321)
+  (cart glyph at wheel positions) needs canonical wheel coordinates to consume.
+- **Consistency with existing idioms.** The `struts:` and `kind: fuselage`
+  blocks already establish "readable YAML expanded/validated by the loader,
+  one ADR per load-bearing decision" ([ADR-0001](0001-aircraft-parts-model.md),
+  [ADR-0012](0012-fuselage-front-aft-split.md)).
+
+## Considered Options
+
+### D1 — what wheels become
+
+1. **Canonical per-aircraft data + load-time cross-check of `turn_radius_m`**
+   *(chosen)*. Wheels are first-class `fleet.yaml` data; the renderer reads
+   them; the loader sanity-checks `turn_radius_m` against the wheel-derived
+   wheelbase.
+2. **Render-only data, no cross-check.** Wheels become render data but
+   `turn_radius_m` is left unlinked.
+3. **Collision participation.** Wheels become Parts in the collision model so a
+   wing cannot overhang another plane's main gear.
+
+### D2 — the wheels schema
+
+1. **β-schema: `main_offset_x_m` + `track_m` + `third_wheel_offset_x_m`**
+   *(chosen)*. Compact, intent-documenting, symmetry-enforcing. Monowheel sets
+   only `main_offset_x_m`.
+2. **α-schema: explicit per-wheel `(x, y)` pairs.** Verbose; the loader must
+   enforce left/right symmetry by convention rather than by structure.
+
+### D3 — `turn_radius_m`
+
+1. **Keep it as an independent empirical value, cross-checked only** *(chosen)*.
+2. **Derive it from wheelbase + steering geometry.**
+
+### D4 — the origin-documentation inconsistency
+
+1. **Reconcile the docs: origin is a per-aircraft anchor; main-gear centroid is
+   derived** *(chosen)*.
+2. **Re-anchor every aircraft so `origin = main-gear centroid` (schema γ).**
+
+## Decision Outcome
+
+**Chosen: D1.1, D2.1, D3.1, D4.1.**
+
+**D1.1**, because the framing is "two representations disagree" — render-only
+(D1.2) leaves the drift in place, and collision participation (D1.3) is a
+larger parts-model change with its own canary re-bake, out of scope here. The
+cross-check is the cheapest thing that makes drift *loud*.
+
+**D2.1**, because the β-schema documents intent (this is a wheelbase, this is a
+track) and makes a left/right mismatch structurally impossible, where α would
+re-introduce the mirror-the-numbers-by-hand burden ADR-0001 rejected for struts.
+
+**D3.1**, because deriving `turn_radius_m` (D3.2) needs a per-aircraft
+`max_steer_angle_deg` we don't have, and the real relationship is non-trivial
+(a taildragger pivots differently than a tricycle). The empirical number we
+already carry is more honest than a model-derived one — and *crucially* keeping
+it unchanged is what preserves the determinism contract.
+
+**D4.1**, because re-anchoring (D4.2) would churn every fixture with a
+hard-coded placement coordinate for no functional gain; reconciling the header
+comment is a zero-data-diff fix.
+
+The contract:
+
+- **Schema.** `wheels:` is **required** on every aircraft.
+  ```yaml
+  wheels:
+    main_offset_x_m: <float>          # mains' plane-local +x station
+    track_m: <float>                  # tricycle/tailwheel only; full track, > 0
+    third_wheel_offset_x_m: <float>   # tricycle/tailwheel only; sign by gear
+  ```
+  Monowheel sets only `main_offset_x_m`. Sign rule: a nosewheel's third wheel
+  is **forward** of the mains (`third > main`); a tailwheel's is **aft**
+  (`third < main`). `Wheels.positions` yields the plane-local `(x, y)` of every
+  wheel (mains at `(main_offset_x_m, ±track_m/2)`, then the third at
+  `(third_wheel_offset_x_m, 0)`); `Wheels.wheelbase_m` is
+  `abs(third − main)`, or `None` for monowheel.
+- **Cross-check.** For own-gear, non-monowheel aircraft the loader requires
+  `0.5 × wheelbase ≤ turn_radius_m ≤ 5 × wheelbase`; a violation is a hard
+  `LoaderError`. Skipped for `always_cart` (`turn_radius_m` is `None`) and for
+  monowheel (no wheelbase). The band is deliberately **loose** — a sanity guard
+  against a fat-fingered radius or coordinate, not a derivation, and wide enough
+  not to false-positive on the `measured: false` estimates.
+- **Rendering.** `_draw_gear_glyph` loops over `aircraft.wheels.positions`
+  through `local_to_world`; the heuristic fraction constants are deleted.
+
+## Consequences
+
+### Positive
+
+- One source of truth: the rendered wheelbase and the planner's `turn_radius_m`
+  can no longer drift silently — the loader fails loudly if they diverge wildly.
+- `visualize.py` drops `_NOSE_GEAR_FRAC` / `_MAIN_GEAR_FWD_FRAC` /
+  `_MAIN_GEAR_TAILDRAGGER_FWD_FRAC` / `_MAIN_GEAR_LATERAL_FRAC` and the
+  fuselage-segment reconstruction; `_draw_gear_glyph` becomes a short loop.
+- [#321](https://github.com/DocGerd/hangarfit/issues/321) consumes
+  `wheels.positions` directly — no new heuristic surface to maintain.
+- The main-gear centroid, a useful reference for future motion work (e.g.
+  [#263](https://github.com/DocGerd/hangarfit/issues/263) nose-out parking), is
+  available as `(wheels.main_offset_x_m, 0)` in plane-local coords.
+
+### Negative
+
+- `Aircraft.wheels` is a **required** field — a breaking change to the model
+  and the loader; every inline `Aircraft(...)` in tests had to pass `wheels=`
+  (absorbed via the `tests/conftest.py::make_test_aircraft` helper), and a
+  `fleet.yaml` entry with no `wheels:` block is now a hard load error.
+- The backfilled wheel numbers are still estimates (`measured: false` stays);
+  the cross-check guards plausibility, not correctness.
+
+### Neutral
+
+- **Determinism contract unchanged** — `turn_radius_m` values are not modified,
+  so Reeds–Shepp solutions and `test_solver_canaries.py` baselines are
+  byte-identical (verified: zero canary diff).
+- Wheel collision participation (D1.3) remains a future decision; if revisited,
+  this ADR is the starting point.
+- This supersedes the neutral-consequence note in
+  [ADR-0012](0012-fuselage-front-aft-split.md) that `_draw_gear_glyph`
+  reconstructs the fuselage span from both segments — it no longer does.
+
+## Compliance
+
+- **`tests/test_loader_wheels.py`** — `TestWheelsLoadingHappyPath` /
+  `TestWheelsLoadingErrorPaths` pin the schema, the gear-keyed key sets, and the
+  nose-forward / tail-aft sign rules; `TestCrossCheck` pins the 0.5×–5× band and
+  the `always_cart` / monowheel skips; `test_no_wheels_block_now_raises` pins
+  the required-field flip.
+- **`tests/test_visualize_wheels.py`** — pins that the renderer draws one wheel
+  per `wheels.positions` entry at the `local_to_world`-mapped coordinates, and
+  that `on_carts=True` takes the cart path (regression guard for #321).
+- **`Wheels.__post_init__`** rejects `track_m ≤ 0` and the monowheel/tricycle
+  field XOR; the loader wraps the `ValueError` as a `LoaderError`.
+- **`determinism-guard`** confirms `test_solver_canaries.py` and the towplanner
+  suites are byte-identical (towplanner.py is untouched by this change).
+
+## More Information
+
+- Related issue: [#322](https://github.com/DocGerd/hangarfit/issues/322) (this
+  decision); [#321](https://github.com/DocGerd/hangarfit/issues/321) (cart glyph
+  — consumes wheels); [#79](https://github.com/DocGerd/hangarfit/issues/79)
+  (real fleet measurements).
+- Related spec: [`docs/superpowers/specs/2026-05-28-wheels-canonical-design.md`](../superpowers/specs/2026-05-28-wheels-canonical-design.md).
+- [ADR-0001: Aircraft geometry as a list of parts](0001-aircraft-parts-model.md)
+  — same shape: explicit data over heuristic, loader-validated.
+- [ADR-0007: Tow-path planner v1 scope](0007-tow-path-planner-v1-scope.md) —
+  introduced `turn_radius_m` as load-bearing.
+- [ADR-0010: Reeds–Shepp motion model](0010-reeds-shepp-motion-model.md) — the
+  arcs that consume `turn_radius_m`.
+- [ADR-0012: Fuselage front/aft split](0012-fuselage-front-aft-split.md) — the
+  prior ADR whose gear-glyph note this supersedes.

--- a/docs/adr/0013-wheels-canonical-data.md
+++ b/docs/adr/0013-wheels-canonical-data.md
@@ -115,10 +115,14 @@ The contract:
   wheel (mains at `(main_offset_x_m, ±track_m/2)`, then the third at
   `(third_wheel_offset_x_m, 0)`); `Wheels.wheelbase_m` is
   `abs(third − main)`, or `None` for monowheel.
-- **Cross-check.** For own-gear, non-monowheel aircraft the loader requires
+- **Cross-check.** For any non-monowheel aircraft carrying a `turn_radius_m`
+  (i.e. `always_own_gear` *and* `cart_eligible`, both of which keep a real
+  radius and wheelbase) the loader requires
   `0.5 × wheelbase ≤ turn_radius_m ≤ 5 × wheelbase`; a violation is a hard
-  `LoaderError`. Skipped for `always_cart` (`turn_radius_m` is `None`) and for
-  monowheel (no wheelbase). The band is deliberately **loose** — a sanity guard
+  `LoaderError`. The skip keys off `turn_radius_m is None` (every `always_cart`
+  entry today) and monowheel (no wheelbase) — not off `movement_mode`, so a
+  stray radius on an `always_cart` plane would still be checked. The band is
+  deliberately **loose** — a sanity guard
   against a fat-fingered radius or coordinate, not a derivation, and wide enough
   not to false-positive on the `measured: false` estimates.
 - **Rendering.** `_draw_gear_glyph` loops over `aircraft.wheels.positions`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -89,3 +89,5 @@ manual workflow above is canonical.
 | 0009 | [Single supported Python — 3.12, anchored to the distro LTS](0009-single-supported-python-version.md) | Accepted |
 | 0010 | [Reeds–Shepp motion model — towplanner v2](0010-reeds-shepp-motion-model.md) | Accepted |
 | 0011 | [Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline](0011-linear-history-strategy-under-gitflow.md) | Proposed |
+| 0012 | [Split the fuselage into front/aft so a wing may overhang a tail but not a cockpit](0012-fuselage-front-aft-split.md) | Accepted |
+| 0013 | [Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load](0013-wheels-canonical-data.md) | Proposed |

--- a/docs/superpowers/plans/2026-05-28-wheels-canonical.md
+++ b/docs/superpowers/plans/2026-05-28-wheels-canonical.md
@@ -1,0 +1,1510 @@
+# Wheels-canonical-data Implementation Plan (#322)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make wheel positions first-class per-aircraft data in `fleet.yaml` with a compact β-schema, a loose loader cross-check against `turn_radius_m`, and a single accessor that visualize.py consumes — closing the docs-vs-data inconsistency that motivates #322.
+
+**Architecture:** New `Wheels` dataclass in `models.py`; `Aircraft.wheels` becomes a required field. Loader parses a required `wheels:` block per aircraft and runs a 0.5×–5× wheelbase plausibility check against `turn_radius_m` (skipped for `always_cart` and `monowheel`). visualize.py's `_NOSE_GEAR_FRAC` / `_MAIN_GEAR_*_FRAC` heuristic constants get deleted; wheel-glyph drawing reduces to a loop over `aircraft.wheels.positions`. A new ADR-0013 records the decision.
+
+**Tech Stack:** Python 3.12, `@dataclass(frozen=True, slots=True)` pattern (matches existing models.py), PyYAML loader, matplotlib (Agg backend, headless), pytest. No new dependencies.
+
+**Spec:** [`docs/superpowers/specs/2026-05-28-wheels-canonical-design.md`](../specs/2026-05-28-wheels-canonical-design.md) — every decision and tradeoff in §5 of the spec is locked in; do not re-litigate.
+
+**Ordering rationale:** Tasks 1–4 are additive (no breaking changes — `wheels` stays optional). Task 5 is the atomic flip-to-required moment where fleet.yaml, the loader, and the test surface must all be coherent simultaneously. Tasks 6–10 are post-flip cleanups.
+
+---
+
+## Task 0: Rename the branch and confirm baseline
+
+**Files:** none (git only)
+
+**Context:** The spec was committed on `feature/wheels-canonical-design-322`. Implementation continues on the same line of history but the branch name should reflect that it now covers more than just the design.
+
+- [ ] **Step 1: Rename the branch**
+
+```bash
+git switch feature/wheels-canonical-design-322
+git branch -m feature/wheels-canonical-322
+```
+
+- [ ] **Step 2: Confirm the spec commit is present**
+
+```bash
+git log --oneline -1
+```
+
+Expected: `260da09 docs(spec): design for #322 — wheels as canonical per-aircraft data` (sha may differ if rebased).
+
+- [ ] **Step 3: Confirm baseline tests are green before any code change**
+
+```bash
+pytest -q
+ruff check src/ tests/
+mypy src/hangarfit/
+```
+
+Expected: all green. If anything fails on a clean develop, stop and surface the failure — it is not from this plan.
+
+---
+
+## Task 1: Add the `Wheels` dataclass to models.py
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (add a new dataclass near the other geometry types)
+- Test: `tests/test_models.py` (extend)
+
+**Context:** `Wheels` is a small frozen dataclass holding the β-schema fields (`main_offset_x_m`, optional `track_m`, optional `third_wheel_offset_x_m`). Two derived properties: `positions` (the (x, y) list every consumer reads) and `wheelbase_m` (the absolute longitudinal distance between mains and third wheel, or `None` for monowheel). Validation is structural only at this stage — the relationship to `gear` is enforced in the loader (Task 3), not here, because `Wheels` does not know which `Gear` it belongs to.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_models.py`:
+
+```python
+import pytest
+
+from hangarfit.models import Wheels
+
+
+class TestWheels:
+    def test_monowheel_positions_single(self) -> None:
+        w = Wheels(main_offset_x_m=0.0, track_m=None, third_wheel_offset_x_m=None)
+        assert w.positions == [(0.0, 0.0)]
+        assert w.wheelbase_m is None
+
+    def test_monowheel_offset_non_zero_main(self) -> None:
+        w = Wheels(main_offset_x_m=-0.5, track_m=None, third_wheel_offset_x_m=None)
+        assert w.positions == [(-0.5, 0.0)]
+
+    def test_nosewheel_three_positions_in_order(self) -> None:
+        w = Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50)
+        assert w.positions == [(-0.10, 0.90), (-0.10, -0.90), (2.50, 0.0)]
+        assert w.wheelbase_m == pytest.approx(2.60)
+
+    def test_tailwheel_three_positions_in_order(self) -> None:
+        w = Wheels(main_offset_x_m=0.20, track_m=1.80, third_wheel_offset_x_m=-3.40)
+        assert w.positions == [(0.20, 0.90), (0.20, -0.90), (-3.40, 0.0)]
+        assert w.wheelbase_m == pytest.approx(3.60)
+
+    def test_rejects_track_without_third_wheel(self) -> None:
+        with pytest.raises(ValueError, match="track_m requires third_wheel_offset_x_m"):
+            Wheels(main_offset_x_m=0.0, track_m=1.5, third_wheel_offset_x_m=None)
+
+    def test_rejects_third_wheel_without_track(self) -> None:
+        with pytest.raises(ValueError, match="third_wheel_offset_x_m requires track_m"):
+            Wheels(main_offset_x_m=0.0, track_m=None, third_wheel_offset_x_m=2.0)
+
+    def test_rejects_non_positive_track(self) -> None:
+        with pytest.raises(ValueError, match="track_m must be positive"):
+            Wheels(main_offset_x_m=0.0, track_m=0.0, third_wheel_offset_x_m=2.0)
+        with pytest.raises(ValueError, match="track_m must be positive"):
+            Wheels(main_offset_x_m=0.0, track_m=-1.0, third_wheel_offset_x_m=2.0)
+
+    def test_rejects_non_finite_values(self) -> None:
+        import math
+
+        with pytest.raises(ValueError, match="must be finite"):
+            Wheels(main_offset_x_m=math.inf, track_m=None, third_wheel_offset_x_m=None)
+        with pytest.raises(ValueError, match="must be finite"):
+            Wheels(main_offset_x_m=0.0, track_m=math.nan, third_wheel_offset_x_m=2.0)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_models.py::TestWheels -v
+```
+
+Expected: `ImportError` or `AttributeError: module 'hangarfit.models' has no attribute 'Wheels'`.
+
+- [ ] **Step 3: Implement `Wheels`**
+
+In `src/hangarfit/models.py`, add the dataclass alongside the other geometry types. Suggested placement: right above `Aircraft` (so the reader sees `Wheels` before the field that uses it). Match the existing `@dataclass(frozen=True, slots=True)` style.
+
+```python
+@dataclass(frozen=True, slots=True)
+class Wheels:
+    """Plane-local wheel positions for one aircraft.
+
+    Origin is the per-aircraft anchor that ``Placement.x_m / y_m`` refers to —
+    the same origin every other Part offset is measured from. Each main wheel
+    sits at ``(main_offset_x_m, ±track_m/2)``; the third (nose or tail) wheel,
+    if present, sits at ``(third_wheel_offset_x_m, 0)``.
+
+    ``track_m`` and ``third_wheel_offset_x_m`` are both ``None`` for monowheel
+    aircraft (only the central main wheel is modelled; outriggers stay
+    render-only via the wing footprint). For tricycle and tailwheel aircraft,
+    both fields are required — the loader enforces this against ``gear``.
+    """
+
+    main_offset_x_m: float
+    track_m: float | None
+    third_wheel_offset_x_m: float | None
+
+    def __post_init__(self) -> None:
+        import math
+
+        if not math.isfinite(self.main_offset_x_m):
+            raise ValueError(
+                f"Wheels.main_offset_x_m must be finite, got {self.main_offset_x_m!r}"
+            )
+        if (self.track_m is None) != (self.third_wheel_offset_x_m is None):
+            # XOR: both present (tricycle/tailwheel) or both absent (monowheel).
+            if self.track_m is None:
+                raise ValueError(
+                    "Wheels.third_wheel_offset_x_m requires track_m to also be set "
+                    "(both present for tricycle/tailwheel, both None for monowheel)"
+                )
+            raise ValueError(
+                "Wheels.track_m requires third_wheel_offset_x_m to also be set "
+                "(both present for tricycle/tailwheel, both None for monowheel)"
+            )
+        if self.track_m is not None:
+            if not math.isfinite(self.track_m):
+                raise ValueError(f"Wheels.track_m must be finite, got {self.track_m!r}")
+            if self.track_m <= 0.0:
+                raise ValueError(f"Wheels.track_m must be positive, got {self.track_m!r}")
+        if self.third_wheel_offset_x_m is not None and not math.isfinite(
+            self.third_wheel_offset_x_m
+        ):
+            raise ValueError(
+                f"Wheels.third_wheel_offset_x_m must be finite, "
+                f"got {self.third_wheel_offset_x_m!r}"
+            )
+
+    @property
+    def positions(self) -> list[tuple[float, float]]:
+        """Plane-local ``(x, y)`` of every wheel.
+
+        Returns 1 entry for monowheel (``(main_offset_x_m, 0)``) or 3 entries
+        for tricycle/tailwheel (two mains at ``(main_offset_x_m, ±track_m/2)``
+        then the third wheel at ``(third_wheel_offset_x_m, 0)``). The order is
+        stable: mains first (``+y`` then ``-y``), then the third wheel.
+        """
+        if self.track_m is None:
+            return [(self.main_offset_x_m, 0.0)]
+        assert self.third_wheel_offset_x_m is not None  # narrowed by __post_init__
+        half_track = self.track_m / 2.0
+        return [
+            (self.main_offset_x_m, half_track),
+            (self.main_offset_x_m, -half_track),
+            (self.third_wheel_offset_x_m, 0.0),
+        ]
+
+    @property
+    def wheelbase_m(self) -> float | None:
+        """``abs(third_wheel_offset_x_m - main_offset_x_m)``, or ``None`` for monowheel."""
+        if self.third_wheel_offset_x_m is None:
+            return None
+        return abs(self.third_wheel_offset_x_m - self.main_offset_x_m)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/test_models.py::TestWheels -v
+```
+
+Expected: all 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_models.py
+git commit -m "feat(models): add Wheels dataclass for canonical per-aircraft wheel positions (#322)"
+```
+
+---
+
+## Task 2: Add `Aircraft.wheels` as optional (transitional)
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (Aircraft dataclass)
+- Test: `tests/test_models.py` (extend)
+
+**Context:** Add the new field as `Wheels | None = None` so existing call sites compile and existing tests stay green. The flip to required happens in Task 5, after fleet.yaml is backfilled and the loader is wired up.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_models.py`:
+
+```python
+def test_aircraft_wheels_defaults_to_none() -> None:
+    """Transitional state: existing Aircraft constructions still work."""
+    from hangarfit.models import Aircraft, Part
+
+    parts = (
+        Part(kind="fuselage_front", length_m=1.0, width_m=0.5,
+             offset_x_m=0.5, offset_y_m=0.0, z_bottom_m=0.0, z_top_m=1.0),
+        Part(kind="fuselage_aft", length_m=1.0, width_m=0.5,
+             offset_x_m=-0.5, offset_y_m=0.0, z_bottom_m=0.0, z_top_m=1.0),
+        Part(kind="wing", length_m=0.5, width_m=4.0,
+             offset_x_m=0.0, offset_y_m=0.0, z_bottom_m=2.0, z_top_m=2.2),
+    )
+    a = Aircraft(
+        id="test_plane",
+        name="Test",
+        wing_position="high",
+        gear="nosewheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=5.0,
+        measured=False,
+        notes=None,
+        parts=parts,
+    )
+    assert a.wheels is None
+
+
+def test_aircraft_accepts_wheels() -> None:
+    from hangarfit.models import Aircraft, Part, Wheels
+
+    parts = (
+        Part(kind="fuselage_front", length_m=1.0, width_m=0.5,
+             offset_x_m=0.5, offset_y_m=0.0, z_bottom_m=0.0, z_top_m=1.0),
+        Part(kind="fuselage_aft", length_m=1.0, width_m=0.5,
+             offset_x_m=-0.5, offset_y_m=0.0, z_bottom_m=0.0, z_top_m=1.0),
+        Part(kind="wing", length_m=0.5, width_m=4.0,
+             offset_x_m=0.0, offset_y_m=0.0, z_bottom_m=2.0, z_top_m=2.2),
+    )
+    wheels = Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50)
+    a = Aircraft(
+        id="test_plane",
+        name="Test",
+        wing_position="high",
+        gear="nosewheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=5.0,
+        measured=False,
+        notes=None,
+        parts=parts,
+        wheels=wheels,
+    )
+    assert a.wheels is wheels
+```
+
+> **Note:** Adjust the `Aircraft(...)` kwargs to match the actual field set in `src/hangarfit/models.py` (read the existing dataclass before pasting; field set may have evolved). The two tests above prove the field exists and accepts both `None` and a `Wheels` value.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_models.py::test_aircraft_wheels_defaults_to_none tests/test_models.py::test_aircraft_accepts_wheels -v
+```
+
+Expected: `TypeError: Aircraft.__init__() got an unexpected keyword argument 'wheels'` and similar.
+
+- [ ] **Step 3: Add the field**
+
+In `src/hangarfit/models.py`, locate the `Aircraft` dataclass and add the field. Put it after `parts` (last existing field) and before any `__post_init__`. Use `Wheels | None = None`.
+
+```python
+@dataclass(frozen=True, slots=True)
+class Aircraft:
+    # ... existing fields ...
+    parts: tuple[Part, ...]
+    wheels: Wheels | None = None  # transitional — Task 5 flips to required
+```
+
+If `Aircraft` has a `__post_init__` that runs whole-aircraft validation, do not touch it yet — wheel/gear coherence is enforced in the loader (Task 3), not here.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest tests/test_models.py -v
+```
+
+Expected: all tests pass, including the two new ones. The existing `Aircraft` construction tests must still pass — `wheels` defaults to `None`.
+
+- [ ] **Step 5: Type-check**
+
+```bash
+mypy src/hangarfit/
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_models.py
+git commit -m "feat(models): add Aircraft.wheels field as transitional optional (#322)"
+```
+
+---
+
+## Task 3: Add `_parse_wheels` to the loader (transitional — block optional)
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (add helper + call it from per-aircraft parse path)
+- Test: `tests/test_loader_wheels.py` (create)
+
+**Context:** Parser is structural: it validates that the key set matches `gear`, enforces sign rules (nose forward of mains, tail aft of mains), and produces a `Wheels` instance. **At this stage the block is still optional** — if a fleet entry has no `wheels:` key, `_parse_wheels` returns `None` and `Aircraft.wheels` stays `None`. This keeps every existing test green while we wire the new code. Task 5 flips the absence path to raise.
+
+- [ ] **Step 1: Create the failing test file**
+
+Create `tests/test_loader_wheels.py`:
+
+```python
+"""Loader tests for the wheels: block (#322).
+
+These tests exercise the wheels parsing path in isolation by loading
+single-aircraft fleet YAMLs from in-memory strings.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from hangarfit.loader import InvalidFleetError, load_fleet_from_string
+
+
+# Minimal valid aircraft body — the wheels: block is appended per test.
+_NOSEWHEEL_BODY = textwrap.dedent(
+    """\
+    aircraft:
+      - id: testplane
+        name: "Test Plane"
+        wing_position: high
+        gear: nosewheel
+        movement_mode: always_own_gear
+        turn_radius_m: 4.0
+        measured: false
+        parts:
+          - kind: fuselage
+            length_m: 6.0
+            width_m: 0.8
+            offset_x_m: 0.0
+            offset_y_m: 0.0
+            z_bottom_m: 0.0
+            z_top_m: 1.4
+          - kind: wing
+            length_m: 1.2
+            width_m: 9.0
+            offset_x_m: 0.5
+            offset_y_m: 0.0
+            z_bottom_m: 2.0
+            z_top_m: 2.2
+    """
+)
+
+
+def _with_wheels(yaml_block: str) -> str:
+    """Append a wheels: block (or any sub-yaml) to the test aircraft body."""
+    indented = textwrap.indent(yaml_block, "    ")
+    return _NOSEWHEEL_BODY + indented
+
+
+class TestWheelsLoadingHappyPath:
+    def test_nosewheel_loads(self) -> None:
+        yaml = _with_wheels(
+            "wheels:\n"
+            "  main_offset_x_m: -0.10\n"
+            "  track_m: 1.80\n"
+            "  third_wheel_offset_x_m: 2.50\n"
+        )
+        fleet = load_fleet_from_string(yaml)
+        a = fleet.aircraft["testplane"]
+        assert a.wheels is not None
+        assert a.wheels.main_offset_x_m == -0.10
+        assert a.wheels.track_m == 1.80
+        assert a.wheels.third_wheel_offset_x_m == 2.50
+
+    def test_no_wheels_block_yields_none_for_now(self) -> None:
+        """Transitional: missing wheels: block leaves Aircraft.wheels == None.
+
+        Task 5 flips this to raise InvalidFleetError.
+        """
+        fleet = load_fleet_from_string(_NOSEWHEEL_BODY)
+        assert fleet.aircraft["testplane"].wheels is None
+
+
+class TestWheelsLoadingErrorPaths:
+    def test_nosewheel_missing_track(self) -> None:
+        yaml = _with_wheels(
+            "wheels:\n"
+            "  main_offset_x_m: -0.10\n"
+            "  third_wheel_offset_x_m: 2.50\n"
+        )
+        with pytest.raises(InvalidFleetError, match="wheels.*track_m"):
+            load_fleet_from_string(yaml)
+
+    def test_nosewheel_missing_third_wheel(self) -> None:
+        yaml = _with_wheels(
+            "wheels:\n"
+            "  main_offset_x_m: -0.10\n"
+            "  track_m: 1.80\n"
+        )
+        with pytest.raises(InvalidFleetError, match="wheels.*third_wheel_offset_x_m"):
+            load_fleet_from_string(yaml)
+
+    def test_monowheel_with_track_rejected(self) -> None:
+        yaml = (
+            _NOSEWHEEL_BODY.replace("gear: nosewheel", "gear: monowheel")
+            + "    wheels:\n"
+            "      main_offset_x_m: 0.0\n"
+            "      track_m: 1.80\n"
+            "      third_wheel_offset_x_m: 2.50\n"
+        )
+        with pytest.raises(InvalidFleetError, match="monowheel.*track_m"):
+            load_fleet_from_string(yaml)
+
+    def test_nosewheel_third_wheel_behind_mains_rejected(self) -> None:
+        """A nosewheel plane must have third_wheel_offset_x_m > main_offset_x_m."""
+        yaml = _with_wheels(
+            "wheels:\n"
+            "  main_offset_x_m: 0.0\n"
+            "  track_m: 1.80\n"
+            "  third_wheel_offset_x_m: -2.50\n"  # WRONG: nose should be forward
+        )
+        with pytest.raises(InvalidFleetError, match="nosewheel.*forward"):
+            load_fleet_from_string(yaml)
+
+    def test_tailwheel_third_wheel_forward_of_mains_rejected(self) -> None:
+        yaml = (
+            _NOSEWHEEL_BODY.replace("gear: nosewheel", "gear: tailwheel")
+            .replace("turn_radius_m: 4.0", "turn_radius_m: 5.0")
+            + "    wheels:\n"
+            "      main_offset_x_m: 0.20\n"
+            "      track_m: 1.80\n"
+            "      third_wheel_offset_x_m: 3.00\n"  # WRONG: tail should be aft
+        )
+        with pytest.raises(InvalidFleetError, match="tailwheel.*aft"):
+            load_fleet_from_string(yaml)
+
+    def test_unknown_keys_rejected(self) -> None:
+        yaml = _with_wheels(
+            "wheels:\n"
+            "  main_offset_x_m: -0.10\n"
+            "  track_m: 1.80\n"
+            "  third_wheel_offset_x_m: 2.50\n"
+            "  bogus_field: 1.0\n"
+        )
+        with pytest.raises(InvalidFleetError, match="unknown.*bogus_field"):
+            load_fleet_from_string(yaml)
+```
+
+> **Note:** `load_fleet_from_string` may not exist as a public helper. If only `load_fleet` (file-based) exists, either (a) add a tiny `load_fleet_from_string` helper to `loader.py` that wraps `yaml.safe_load` + the existing dict-based parse path, or (b) write a `_tmp_yaml(tmp_path, body)` pytest fixture that writes and loads from disk. Pick whichever matches existing test idioms in `tests/test_loader.py` — do NOT introduce a new file-IO style if a string-based path already exists.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_loader_wheels.py -v
+```
+
+Expected: all tests fail with errors like `InvalidFleetError` not raised or `aircraft.wheels is None` (because `_parse_wheels` doesn't exist yet).
+
+- [ ] **Step 3: Implement `_parse_wheels` in loader.py**
+
+In `src/hangarfit/loader.py`:
+
+```python
+from hangarfit.models import Wheels  # add to imports if not already present
+
+_WHEELS_KEYS_BY_GEAR: dict[str, frozenset[str]] = {
+    "monowheel": frozenset({"main_offset_x_m"}),
+    "nosewheel": frozenset({"main_offset_x_m", "track_m", "third_wheel_offset_x_m"}),
+    "tailwheel": frozenset({"main_offset_x_m", "track_m", "third_wheel_offset_x_m"}),
+}
+
+
+def _parse_wheels(
+    entry: Mapping[str, Any] | None,
+    gear: str,
+    aircraft_id: str,
+) -> Wheels | None:
+    """Parse a ``wheels:`` block into a :class:`Wheels`.
+
+    Returns ``None`` if ``entry`` is ``None`` (transitional — Task 5 flips
+    this to raise ``InvalidFleetError``).
+
+    Validates that the key set exactly matches ``_WHEELS_KEYS_BY_GEAR[gear]``
+    and that nose-vs-tail sign rules hold for tricycle/tailwheel gear.
+    """
+    if entry is None:
+        return None  # TODO(#322 Task 5): raise InvalidFleetError
+
+    if gear not in _WHEELS_KEYS_BY_GEAR:
+        raise InvalidFleetError(
+            f"Aircraft {aircraft_id!r}: unsupported gear {gear!r} for wheels parsing"
+        )
+
+    expected = _WHEELS_KEYS_BY_GEAR[gear]
+    seen = frozenset(entry.keys())
+    missing = expected - seen
+    unknown = seen - expected
+    if missing:
+        raise InvalidFleetError(
+            f"Aircraft {aircraft_id!r}: wheels: block missing required key(s) for "
+            f"gear={gear!r}: {sorted(missing)}"
+        )
+    if unknown:
+        # For monowheel, the most common mistake is adding track_m / third_wheel_offset_x_m;
+        # surface those specifically.
+        if gear == "monowheel" and unknown & {"track_m", "third_wheel_offset_x_m"}:
+            raise InvalidFleetError(
+                f"Aircraft {aircraft_id!r}: monowheel wheels: block must not set "
+                f"track_m or third_wheel_offset_x_m (got {sorted(unknown)})"
+            )
+        raise InvalidFleetError(
+            f"Aircraft {aircraft_id!r}: wheels: block has unknown key(s): "
+            f"{sorted(unknown)}"
+        )
+
+    main_offset_x_m = _to_float(entry["main_offset_x_m"], "wheels.main_offset_x_m")
+    if gear == "monowheel":
+        wheels = Wheels(
+            main_offset_x_m=main_offset_x_m,
+            track_m=None,
+            third_wheel_offset_x_m=None,
+        )
+    else:
+        track_m = _to_float(entry["track_m"], "wheels.track_m")
+        third = _to_float(entry["third_wheel_offset_x_m"], "wheels.third_wheel_offset_x_m")
+        # Sign rule per gear:
+        #   nosewheel → third (nose) must be forward of mains (greater x)
+        #   tailwheel → third (tail) must be aft of mains    (lesser x)
+        if gear == "nosewheel" and not third > main_offset_x_m:
+            raise InvalidFleetError(
+                f"Aircraft {aircraft_id!r}: nosewheel third_wheel_offset_x_m must be "
+                f"forward of mains (greater than main_offset_x_m={main_offset_x_m}); "
+                f"got {third}"
+            )
+        if gear == "tailwheel" and not third < main_offset_x_m:
+            raise InvalidFleetError(
+                f"Aircraft {aircraft_id!r}: tailwheel third_wheel_offset_x_m must be "
+                f"aft of mains (less than main_offset_x_m={main_offset_x_m}); got {third}"
+            )
+        try:
+            wheels = Wheels(
+                main_offset_x_m=main_offset_x_m,
+                track_m=track_m,
+                third_wheel_offset_x_m=third,
+            )
+        except ValueError as exc:
+            raise InvalidFleetError(
+                f"Aircraft {aircraft_id!r}: invalid wheels block: {exc}"
+            ) from exc
+
+    return wheels
+```
+
+Wire it into the per-aircraft parse path. Locate the function that builds an `Aircraft` from a dict (likely `_parse_aircraft` or similar — read `loader.py` first). Pass `entry.get("wheels")` to `_parse_wheels` and assign the result to the `wheels=` kwarg when constructing `Aircraft`.
+
+> **Note on `Mapping[str, Any]` import:** `Mapping` from `collections.abc` should already be imported in loader.py; if not, add it.
+
+> **Note on `_to_float`:** This helper already exists at `loader.py:~660`; reuse it.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest tests/test_loader_wheels.py -v
+pytest tests/test_loader.py -v
+```
+
+Expected: all `test_loader_wheels.py` tests pass; existing `test_loader.py` tests still pass (because missing `wheels:` returns `None`, no break).
+
+- [ ] **Step 5: Type-check**
+
+```bash
+mypy src/hangarfit/
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader_wheels.py
+git commit -m "feat(loader): parse optional wheels: block with structural validation (#322)"
+```
+
+---
+
+## Task 4: Backfill `data/fleet.yaml` wheels blocks (all 9 aircraft)
+
+**Files:**
+- Modify: `data/fleet.yaml` (add `wheels:` block to every entry)
+
+**Context:** Every aircraft gets a `wheels:` block using published-spec wheelbases and tracks where available, conservative estimates otherwise. The block sits between `notes:`/`parts:` — whichever pattern reads cleanest given the existing layout. **Critical guard:** the wheelbase implied by your numbers MUST satisfy `0.5 × wheelbase ≤ turn_radius_m ≤ 5 × wheelbase` for every own-gear aircraft, otherwise Task 6's cross-check will fail the load. Verify each entry by hand before the commit.
+
+The 9 aircraft and reference numbers (published specs or fleet-typical estimates — use these as a starting point, refine to taste if you find better sources):
+
+| id | gear | turn_radius_m | wheelbase target | track target | notes |
+|---|---|---|---|---|---|
+| scheibe_falke | monowheel | null | n/a | n/a | main wheel at origin |
+| aviat_husky | tailwheel | 5.0 | ~5.0 m | ~2.0 m | main at ~+0.2, tail at ~−4.8 (Husky has long tail moment) |
+| fuji | nosewheel | 7.0 | ~2.0 m | ~2.5 m | low-wing, retractable not modelled; mains at ~−0.4, nose at ~+1.6 |
+| wild_thing | nosewheel | null | ~1.5 m | ~1.5 m | always_cart; cross-check skipped, but data still required |
+| zlin_savage | tailwheel | null | ~4.5 m | ~1.8 m | always_cart; cross-check skipped |
+| cessna_140 | tailwheel | 5.5 | ~4.3 m | ~2.1 m | mains at ~+0.5, tail at ~−3.8 |
+| cessna_150 | nosewheel | 4.5 | ~1.5 m | ~2.3 m | mains at ~−0.2, nose at ~+1.3 |
+| ctsl | nosewheel | 4.0 | ~1.5 m | ~1.7 m | LSA; mains at ~−0.1, nose at ~+1.4 |
+| fk9_mkii | nosewheel | 4.0 | ~1.5 m | ~1.4 m | LSA; mains at ~−0.1, nose at ~+1.4 |
+
+> The "target" columns are **starting estimates**, not gospel. Look up published specs (Pilot's Operating Handbook, type certificate data sheets, manufacturer marketing pages) for each aircraft and adjust. The cross-check band (0.5×–5×) is loose enough to absorb refinement.
+
+- [ ] **Step 1: Add wheels blocks to all 9 aircraft**
+
+For each aircraft entry in `data/fleet.yaml`, append a `wheels:` block. Example for `aviat_husky`:
+
+```yaml
+  - id: aviat_husky
+    name: "Aviat Husky A-1"
+    # ... existing fields unchanged ...
+    parts:
+      # ... unchanged ...
+    struts:
+      # ... unchanged ...
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 2.0
+      third_wheel_offset_x_m: -4.80
+```
+
+For `scheibe_falke` (monowheel):
+
+```yaml
+    wheels:
+      main_offset_x_m: 0.0
+```
+
+Do all 9 entries. Place `wheels:` after `parts:` (and after `struts:` where present) so it reads as "geometry + struts + wheels".
+
+- [ ] **Step 2: Verify each wheelbase passes the 0.5×–5× band by hand**
+
+For each own-gear aircraft (Husky, Fuji, Cessna 140, Cessna 150, CTSL, FK9 — six total), compute `wheelbase = abs(third_wheel_offset_x_m - main_offset_x_m)` and confirm `0.5 × wheelbase ≤ turn_radius_m ≤ 5 × wheelbase`. Skip the always_cart and monowheel entries.
+
+Example: Husky main=+0.20, third=−4.80 → wheelbase=5.0; turn_radius_m=5.0; band [2.5, 25.0]; 5.0 ∈ band ✓.
+
+- [ ] **Step 3: Confirm fleet loads cleanly with the additions**
+
+```bash
+python -c "from hangarfit.loader import load_fleet; f = load_fleet('data/fleet.yaml'); [print(k, v.wheels) for k, v in f.aircraft.items()]"
+```
+
+Expected: every aircraft's `Wheels(...)` printed, no exception.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+pytest -q
+```
+
+Expected: all green. The existing fleet-loading tests now produce Aircraft with `wheels` populated; nothing else changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add data/fleet.yaml
+git commit -m "data(fleet): backfill wheels: block on all 9 aircraft (#322)"
+```
+
+---
+
+## Task 5: Flip `Aircraft.wheels` to required + raise on missing block
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (drop the `= None` default)
+- Modify: `src/hangarfit/loader.py` (`_parse_wheels` raises on `entry is None`)
+- Modify: `tests/test_loader_wheels.py` (replace the "yields None for now" test)
+- Search: any inline `Aircraft(...)` constructions in tests/ — add `wheels=` kwarg
+
+**Context:** This is the atomic flip. Until now, `wheels` has been optional; from this commit onward, every fleet entry and every test-constructed Aircraft must carry one. Any inline `Aircraft(...)` in tests that doesn't pass `wheels=` will break. Tasks 1–4 prepared the ground so this commit is a clean change of contract.
+
+- [ ] **Step 1: Find every inline Aircraft construction**
+
+```bash
+grep -rn "Aircraft(" tests/ --include='*.py'
+grep -rn "from hangarfit.models import" tests/ --include='*.py' | grep Aircraft
+```
+
+Expected output: a list of test files. The ones found in the survey (Task 0) were:
+`tests/test_visualize.py, tests/test_towplanner_motion.py, tests/test_geometry.py, tests/test_towplanner_fill.py, tests/test_towplanner_dubins.py, tests/test_towplanner_search.py, tests/test_models.py, tests/test_solver_search.py, tests/test_towplanner_entry_cone.py, tests/test_collisions.py, tests/fuzz/strategies.py`.
+
+For each match: either (a) it's a test that loads from `data/fleet.yaml` (no change needed — fleet already has wheels), or (b) it constructs `Aircraft(...)` inline with literal field values (needs `wheels=Wheels(...)` added).
+
+- [ ] **Step 2: Add a test helper to absorb the boilerplate**
+
+Create or extend `tests/conftest.py`:
+
+```python
+from hangarfit.models import Aircraft, Part, Wheels
+
+
+_DEFAULT_PARTS: tuple[Part, ...] = (
+    Part(kind="fuselage_front", length_m=1.0, width_m=0.5,
+         offset_x_m=0.5, offset_y_m=0.0, z_bottom_m=0.0, z_top_m=1.0),
+    Part(kind="fuselage_aft", length_m=1.0, width_m=0.5,
+         offset_x_m=-0.5, offset_y_m=0.0, z_bottom_m=0.0, z_top_m=1.0),
+    Part(kind="wing", length_m=0.5, width_m=4.0,
+         offset_x_m=0.0, offset_y_m=0.0, z_bottom_m=2.0, z_top_m=2.2),
+)
+
+
+def make_test_aircraft(
+    *,
+    id: str = "test_plane",
+    gear: str = "nosewheel",
+    movement_mode: str = "always_own_gear",
+    turn_radius_m: float | None = 4.0,
+    wheels: Wheels | None = None,
+    parts: tuple[Part, ...] = _DEFAULT_PARTS,
+    **overrides: object,
+) -> Aircraft:
+    """Build a minimal valid Aircraft for tests with sensible wheel defaults.
+
+    For tricycle/tailwheel gear, `wheels` defaults to a plausible β-schema
+    block whose wheelbase satisfies the 0.5×–5× cross-check against
+    `turn_radius_m=4.0`. Override `wheels=` to test specific positions.
+    """
+    if wheels is None:
+        if gear == "monowheel":
+            wheels = Wheels(main_offset_x_m=0.0, track_m=None, third_wheel_offset_x_m=None)
+        elif gear == "tailwheel":
+            wheels = Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0)
+        else:  # nosewheel
+            wheels = Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=2.0)
+    kwargs: dict[str, object] = dict(
+        id=id,
+        name="Test",
+        wing_position="high",
+        gear=gear,
+        movement_mode=movement_mode,
+        turn_radius_m=turn_radius_m,
+        measured=False,
+        notes=None,
+        parts=parts,
+        wheels=wheels,
+    )
+    kwargs.update(overrides)
+    return Aircraft(**kwargs)  # type: ignore[arg-type]
+```
+
+> Check `conftest.py` first — if it already exports a helper of this shape (`make_aircraft`, `_aircraft`, etc.), extend the existing one rather than introducing a new name.
+
+- [ ] **Step 3: Migrate inline Aircraft constructions to the helper**
+
+For each test file in the survey, replace literal `Aircraft(...)` calls with `make_test_aircraft(...)` calls. The helper's `**overrides` lets each test still set whatever fields it cares about. Test bodies that are testing the dataclass constructor itself (e.g. `tests/test_models.py::test_aircraft_*` cases) stay literal — those are testing the contract directly.
+
+```bash
+pytest -q  # before flipping to required, the suite must still be green
+```
+
+Expected: green. If any test fails here, it's because the migration missed a call site or the helper's defaults conflict with that test's expectations — fix before continuing.
+
+- [ ] **Step 4: Flip `Aircraft.wheels` to required**
+
+In `src/hangarfit/models.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class Aircraft:
+    # ... existing fields, no defaults ...
+    parts: tuple[Part, ...]
+    wheels: Wheels   # required — no default
+```
+
+In `src/hangarfit/loader.py`, in `_parse_wheels`, replace the `if entry is None: return None` early-return with a raise:
+
+```python
+def _parse_wheels(
+    entry: Mapping[str, Any] | None,
+    gear: str,
+    aircraft_id: str,
+) -> Wheels:
+    if entry is None:
+        raise InvalidFleetError(
+            f"Aircraft {aircraft_id!r}: wheels: block is required "
+            f"(see fleet.yaml header for the schema)"
+        )
+    # ... rest unchanged ...
+```
+
+Update the function return type annotation from `Wheels | None` to `Wheels`. Update the call site so it no longer needs to handle `None`.
+
+- [ ] **Step 5: Update the transitional test to assert the new behaviour**
+
+In `tests/test_loader_wheels.py`, replace `test_no_wheels_block_yields_none_for_now`:
+
+```python
+def test_no_wheels_block_now_raises(self) -> None:
+    """After Task 5 flip: a missing wheels: block is a load error."""
+    with pytest.raises(InvalidFleetError, match="wheels: block is required"):
+        load_fleet_from_string(_NOSEWHEEL_BODY)
+```
+
+Remove the `test_aircraft_wheels_defaults_to_none` test in `tests/test_models.py` (or update it to assert `wheels` is now positional/required).
+
+- [ ] **Step 6: Run tests**
+
+```bash
+pytest -q
+mypy src/hangarfit/
+```
+
+Expected: green and clean. mypy in particular should complain if any caller forgot to pass `wheels=`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hangarfit/models.py src/hangarfit/loader.py tests/
+git commit -m "feat(models)!: make Aircraft.wheels required; loader raises on missing block (#322)
+
+BREAKING: every Aircraft construction must now pass wheels=Wheels(...).
+Fleet YAML files must include a wheels: block per aircraft."
+```
+
+> The `!` and `BREAKING:` are conventional-commits format for a schema-breaking change. This is the only commit in the plan that warrants the marker.
+
+---
+
+## Task 6: Add the loader cross-check (0.5×–5× wheelbase band)
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (add `_validate_wheels_vs_turn_radius` + call site)
+- Modify: `tests/test_loader_wheels.py` (extend with cross-check tests)
+
+**Context:** Cross-check runs after the full Aircraft is constructed — needs both `aircraft.wheels.wheelbase_m` and `aircraft.turn_radius_m`. Skips `always_cart` (no own-gear radius) and monowheel (no wheelbase). Hard error on band violation.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_loader_wheels.py`:
+
+```python
+class TestCrossCheck:
+    def test_own_gear_within_band_passes(self) -> None:
+        # wheelbase = abs(2.5 - (-0.1)) = 2.6; turn_radius_m=4.0 ∈ [1.3, 13.0]
+        yaml = _with_wheels(
+            "wheels:\n"
+            "  main_offset_x_m: -0.10\n"
+            "  track_m: 1.80\n"
+            "  third_wheel_offset_x_m: 2.50\n"
+        )
+        load_fleet_from_string(yaml)  # no raise
+
+    def test_turn_radius_below_band_rejected(self) -> None:
+        # wheelbase = 10.0; band [5.0, 50.0]; turn_radius_m=4.0 too small
+        yaml = _with_wheels(
+            "wheels:\n"
+            "  main_offset_x_m: -5.0\n"
+            "  track_m: 1.80\n"
+            "  third_wheel_offset_x_m: 5.0\n"
+        )
+        with pytest.raises(InvalidFleetError, match="implausible.*wheelbase"):
+            load_fleet_from_string(yaml)
+
+    def test_turn_radius_above_band_rejected(self) -> None:
+        # wheelbase = 0.4; band [0.2, 2.0]; turn_radius_m=4.0 too big
+        yaml = _with_wheels(
+            "wheels:\n"
+            "  main_offset_x_m: -0.10\n"
+            "  track_m: 1.80\n"
+            "  third_wheel_offset_x_m: 0.30\n"
+        )
+        with pytest.raises(InvalidFleetError, match="implausible.*wheelbase"):
+            load_fleet_from_string(yaml)
+
+    def test_always_cart_skips_cross_check(self) -> None:
+        """always_cart aircraft (turn_radius_m: null) skip the band check."""
+        yaml = textwrap.dedent(
+            """\
+            aircraft:
+              - id: cart_plane
+                name: "Cart Test"
+                wing_position: high
+                gear: nosewheel
+                movement_mode: always_cart
+                turn_radius_m: null
+                measured: false
+                parts:
+                  - kind: fuselage
+                    length_m: 6.0
+                    width_m: 0.8
+                    offset_x_m: 0.0
+                    offset_y_m: 0.0
+                    z_bottom_m: 0.0
+                    z_top_m: 1.4
+                  - kind: wing
+                    length_m: 1.2
+                    width_m: 9.0
+                    offset_x_m: 0.5
+                    offset_y_m: 0.0
+                    z_bottom_m: 2.0
+                    z_top_m: 2.2
+                wheels:
+                  main_offset_x_m: -5.0
+                  track_m: 1.8
+                  third_wheel_offset_x_m: 5.0
+            """
+        )
+        load_fleet_from_string(yaml)  # no raise even though wheelbase=10 vs radius=null
+
+    def test_monowheel_skips_cross_check(self) -> None:
+        """Monowheel aircraft have no wheelbase concept; check is skipped."""
+        yaml = textwrap.dedent(
+            """\
+            aircraft:
+              - id: mono_plane
+                name: "Mono Test"
+                wing_position: high
+                gear: monowheel
+                movement_mode: always_own_gear
+                turn_radius_m: 100.0
+                measured: false
+                parts:
+                  - kind: fuselage
+                    length_m: 6.0
+                    width_m: 0.7
+                    offset_x_m: 0.0
+                    offset_y_m: 0.0
+                    z_bottom_m: 0.0
+                    z_top_m: 1.4
+                  - kind: wing
+                    length_m: 1.2
+                    width_m: 18.0
+                    offset_x_m: 1.5
+                    offset_y_m: 0.0
+                    z_bottom_m: 2.0
+                    z_top_m: 2.2
+                wheels:
+                  main_offset_x_m: 0.0
+            """
+        )
+        load_fleet_from_string(yaml)  # no raise — no wheelbase to check against
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_loader_wheels.py::TestCrossCheck -v
+```
+
+Expected: `test_turn_radius_below_band_rejected` and `test_turn_radius_above_band_rejected` fail (cross-check not implemented yet, no raise).
+
+- [ ] **Step 3: Implement the cross-check**
+
+In `src/hangarfit/loader.py`:
+
+```python
+_WHEELBASE_BAND_LOW = 0.5
+_WHEELBASE_BAND_HIGH = 5.0
+
+
+def _validate_wheels_vs_turn_radius(aircraft: Aircraft) -> None:
+    """Raise if turn_radius_m is implausible given the wheel-derived wheelbase.
+
+    Skipped for always_cart (turn_radius_m is None) and for monowheel
+    (no wheelbase concept). See ADR-0013 for the rationale on the loose band.
+    """
+    if aircraft.turn_radius_m is None:
+        return
+    wheelbase = aircraft.wheels.wheelbase_m
+    if wheelbase is None:
+        return
+    low = _WHEELBASE_BAND_LOW * wheelbase
+    high = _WHEELBASE_BAND_HIGH * wheelbase
+    r = aircraft.turn_radius_m
+    if not (low <= r <= high):
+        raise InvalidFleetError(
+            f"Aircraft {aircraft.id!r}: turn_radius_m={r} is implausible given "
+            f"wheelbase={wheelbase:.2f}m (expected {low:.2f}..{high:.2f}). "
+            f"Either fix the wheel positions or fix turn_radius_m."
+        )
+```
+
+Call it from the per-aircraft parse path right after the `Aircraft(...)` is constructed. Pseudocode:
+
+```python
+aircraft = Aircraft(..., wheels=wheels, ...)
+_validate_wheels_vs_turn_radius(aircraft)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest tests/test_loader_wheels.py -v
+pytest -q
+```
+
+Expected: all green, including the new cross-check tests and the full suite.
+
+- [ ] **Step 5: Sanity-check the real fleet still loads**
+
+```bash
+python -c "from hangarfit.loader import load_fleet; load_fleet('data/fleet.yaml'); print('OK')"
+```
+
+Expected: `OK`. If this raises, the Task 4 backfill numbers don't satisfy the band — fix the backfill (preferred) before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader_wheels.py
+git commit -m "feat(loader): cross-check turn_radius_m against wheelbase (0.5×–5× band) (#322)"
+```
+
+---
+
+## Task 7: Simplify `visualize.py` to consume `aircraft.wheels.positions`
+
+**Files:**
+- Modify: `src/hangarfit/visualize.py` (replace `_draw_gear_glyph` body; delete heuristic constants)
+- Test: `tests/test_visualize_wheels.py` (create)
+
+**Context:** With wheel positions now first-class, the `_draw_gear_glyph` `if/elif aircraft.gear` ladder collapses into a single loop. The heuristic constants (`_NOSE_GEAR_FRAC`, `_MAIN_GEAR_FWD_FRAC`, `_MAIN_GEAR_TAILDRAGGER_FWD_FRAC`, `_MAIN_GEAR_LATERAL_FRAC`) get deleted along with the fuselage-segment reconstruction inside the function. `_draw_cart_glyph` and the cart-deck constants stay untouched — that surface belongs to #321.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_visualize_wheels.py`:
+
+```python
+"""Visualize tests for wheel glyph placement (#322)."""
+
+from __future__ import annotations
+
+import pytest
+
+# Import everything via the tests/conftest helper.
+from tests.conftest import make_test_aircraft
+
+from hangarfit.models import Placement, Wheels
+from hangarfit.visualize import _draw_gear_glyph
+
+
+@pytest.fixture
+def fake_ax(monkeypatch):
+    """Capture every (wx, wy) passed to _add_wheel."""
+    from hangarfit import visualize
+
+    captured: list[tuple[float, float]] = []
+
+    def fake_add(ax, wx, wy):
+        captured.append((wx, wy))
+        return None
+
+    monkeypatch.setattr(visualize, "_add_wheel", fake_add)
+    return captured
+
+
+class TestOwnGearWheelPositions:
+    def test_nosewheel_three_wheels_at_world_coords(self, fake_ax) -> None:
+        a = make_test_aircraft(
+            gear="nosewheel",
+            wheels=Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50),
+        )
+        # Heading 0 (north / +y): plane-local +x maps to world +y, plane +y to world -x
+        # (or whatever the ADR-0002 convention is; the assertion is on count + reflection).
+        placement = Placement(plane_id=a.id, x_m=10.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+        _draw_gear_glyph(None, placement, a)
+        assert len(fake_ax) == 3
+
+    def test_monowheel_single_wheel(self, fake_ax) -> None:
+        a = make_test_aircraft(
+            gear="monowheel",
+            turn_radius_m=None,
+            movement_mode="always_cart",
+            wheels=Wheels(main_offset_x_m=0.0, track_m=None, third_wheel_offset_x_m=None),
+        )
+        # always_cart means on_carts=True draws cart glyph; this test forces on_carts=False
+        # to exercise the own-gear path even though it's physically unusual.
+        placement = Placement(plane_id=a.id, x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        _draw_gear_glyph(None, placement, a)
+        assert len(fake_ax) == 1
+
+    def test_tailwheel_three_wheels(self, fake_ax) -> None:
+        a = make_test_aircraft(
+            gear="tailwheel",
+            wheels=Wheels(main_offset_x_m=0.20, track_m=1.80, third_wheel_offset_x_m=-3.40),
+        )
+        placement = Placement(plane_id=a.id, x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        _draw_gear_glyph(None, placement, a)
+        assert len(fake_ax) == 3
+
+
+class TestCartGlyphUnchanged:
+    def test_on_carts_falls_through_to_cart_glyph(self, monkeypatch) -> None:
+        """Regression guard for #321: on_carts=True must NOT draw own-gear wheels."""
+        from hangarfit import visualize
+
+        called: list[str] = []
+        monkeypatch.setattr(visualize, "_add_wheel", lambda *a, **k: called.append("wheel"))
+        monkeypatch.setattr(visualize, "_draw_cart_glyph", lambda *a, **k: called.append("cart"))
+
+        a = make_test_aircraft(
+            gear="nosewheel",
+            movement_mode="cart_eligible",
+            wheels=Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50),
+        )
+        placement = Placement(plane_id=a.id, x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True)
+        _draw_gear_glyph(None, placement, a)
+
+        # Cart was drawn; own-gear wheels were NOT.
+        assert "cart" in called
+        # _draw_cart_glyph internally calls _add_wheel four times — those are the cart corner
+        # wheels, not the plane's gear. We don't assert "wheel" not in called because
+        # the cart path still drops 4 wheels; what matters is the cart path was taken.
+```
+
+> **Note on `Placement` import path:** `Placement` may live in `hangarfit.models` or in a different module. Read the file before importing — match what visualize.py imports today.
+
+> **Note on the cart-path assertion:** The original `_draw_cart_glyph` calls `_add_wheel` four times for corner wheels (see `visualize.py:539-542`). The fake-monkeypatch above replaces `_draw_cart_glyph` itself, so those corner-wheel calls don't fire — the cart path is exercised via the captured `"cart"` marker.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_visualize_wheels.py -v
+```
+
+Expected: failures vary — the existing heuristic code path may still emit 3 wheel calls for nosewheel/tailwheel by coincidence, but the monowheel single-wheel and cart-glyph assertions should distinguish behaviour clearly.
+
+- [ ] **Step 3: Rewrite `_draw_gear_glyph`**
+
+In `src/hangarfit/visualize.py`:
+
+Delete the constants block (currently `visualize.py:141-152`):
+
+```python
+# DELETE these four constants:
+_NOSE_GEAR_FRAC = 0.85
+_MAIN_GEAR_FWD_FRAC = 0.30
+_MAIN_GEAR_TAILDRAGGER_FWD_FRAC = 0.45
+_MAIN_GEAR_LATERAL_FRAC = 1.6
+```
+
+(Keep the comment block above the constants that explains the wheel/cart colour scheme — that's still relevant.)
+
+Replace the body of `_draw_gear_glyph` (currently `visualize.py:432-506`) with:
+
+```python
+def _draw_gear_glyph(ax: Any, placement: Placement, aircraft: Aircraft) -> None:
+    """Draw landing-gear wheels or a cart glyph depending on ``placement.on_carts``.
+
+    Wheel positions come from ``aircraft.wheels.positions`` (ADR-0013). When the
+    plane rides on a cart (``placement.on_carts=True``), the cart-deck glyph is
+    drawn instead of the plane's own gear (see ``_draw_cart_glyph``).
+    """
+    if placement.on_carts:
+        _draw_cart_glyph(ax, placement)
+        return
+    for u, v in aircraft.wheels.positions:
+        wx, wy = local_to_world(u, v, placement)
+        _add_wheel(ax, wx, wy)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pytest tests/test_visualize_wheels.py -v
+pytest tests/test_visualize.py -v
+pytest -q
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Type-check and lint**
+
+```bash
+mypy src/hangarfit/
+ruff check src/ tests/
+```
+
+Expected: clean. `ruff` will likely flag the unused `_NOSE_GEAR_FRAC` etc. as already-removed; if the constants were exported in any `__all__`, sync that too.
+
+- [ ] **Step 6: Render a smoke PNG to eyeball the result**
+
+```bash
+hangarfit check layouts/example.yaml --render /tmp/wheels-smoke.png
+```
+
+Expected: PNG renders without error. Open it (or move to a viewable location) and confirm wheels are at sensible positions relative to fuselages.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hangarfit/visualize.py tests/test_visualize_wheels.py
+git commit -m "refactor(visualize): drop heuristic gear constants; read wheels from data (#322)"
+```
+
+---
+
+## Task 8: Reconcile `fleet.yaml` header documentation
+
+**Files:**
+- Modify: `data/fleet.yaml` (header comment block)
+
+**Context:** The header comment currently asserts *"Origin of plane-local frame = main-gear / cart centroid"*, which the data doesn't actually honor (visualize.py historically drew mains offset from origin, and the existing fleet entries follow that convention). Replace with an honest description: origin is a per-aircraft anchor; main-gear centroid is derived from `wheels.main_offset_x_m`.
+
+- [ ] **Step 1: Edit the header**
+
+In `data/fleet.yaml`, find the existing header block (lines ~1–34) and replace the paragraph about origin with:
+
+```yaml
+# - Plane-local coords: +x = forward (toward nose), +y = right (toward right wingtip)
+# - Origin of plane-local frame = a per-aircraft anchor used as the placement
+#   reference (where Placement.x_m/y_m positions the plane in world coords).
+#   The main-gear centroid is a *derived* point, accessible as
+#   (wheels.main_offset_x_m, 0) in plane-local coords. See ADR-0013.
+# - Each Part is an oriented rectangle: length_m runs along plane +x,
+#   width_m runs along plane +y
+# - Heights z_bottom_m / z_top_m are above-ground in world coords
+# - struts block (optional) is expanded by the loader into two mirrored
+#   strut Parts; cantilever aircraft omit the block entirely
+# - wheels block (required) declares the β-schema main_offset_x_m,
+#   track_m, and third_wheel_offset_x_m fields per aircraft (see ADR-0013).
+#   Monowheel aircraft set only main_offset_x_m. The loader cross-checks
+#   wheel-derived wheelbase against turn_radius_m for own-gear aircraft.
+```
+
+(Keep the rest of the header — the `kind: fuselage` paragraph and the `turn_radius_m` paragraph — unchanged.)
+
+- [ ] **Step 2: Verify the fleet still loads**
+
+```bash
+python -c "from hangarfit.loader import load_fleet; load_fleet('data/fleet.yaml'); print('OK')"
+pytest -q
+```
+
+Expected: green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add data/fleet.yaml
+git commit -m "docs(fleet): reconcile header origin convention with wheels: block (#322)"
+```
+
+---
+
+## Task 9: Write ADR-0013 — Wheels as canonical data
+
+**Files:**
+- Create: `docs/adr/0013-wheels-canonical-data.md`
+- Modify: `docs/adr/README.md` (if it lists ADRs by number)
+
+**Context:** Peer to ADR-0001 (parts model), ADR-0012 (fuselage split). Records the decision so future contributors don't re-litigate the empirical-vs-derived `turn_radius_m` tradeoff.
+
+- [ ] **Step 1: Read the existing ADR template**
+
+```bash
+cat docs/adr/template.md
+cat docs/adr/0012-fuselage-front-aft-split.md
+```
+
+Use the template structure; match the tone of ADR-0012.
+
+- [ ] **Step 2: Write the ADR**
+
+Create `docs/adr/0013-wheels-canonical-data.md`:
+
+```markdown
+# ADR-0013: Wheels as canonical per-aircraft data
+
+Date: 2026-05-28
+Status: Accepted
+
+## Context
+
+Two surface representations of the same physical property — *where the wheels
+of each aircraft are* — disagreed:
+
+- `data/fleet.yaml` carried `turn_radius_m` per aircraft (load-bearing for the
+  Reeds–Shepp tow-path planner since Phase 3a, ADR-0007/ADR-0010). No wheel
+  positions.
+- `src/hangarfit/visualize.py` invented wheel-glyph positions on the fly from
+  heuristic fractions of fuselage half-length. The module itself flagged the
+  fractions as "intentionally approximate".
+
+There was no link between the two: a contributor could change `turn_radius_m`
+without touching the rendered wheelbase, or vice versa, and nothing noticed.
+
+A separate latent inconsistency: the `fleet.yaml` header asserted *"Origin =
+main-gear / cart centroid"*, which the data did not honor — visualize.py drew
+mains offset from origin, and existing fleet entries followed that convention.
+
+## Decision
+
+Make wheel positions **first-class per-aircraft data** in `fleet.yaml`. Render
+from the data; cross-check `turn_radius_m` against the wheel-derived wheelbase
+at load time; reconcile the origin documentation.
+
+Schema (β — compact, symmetry-enforcing):
+
+```yaml
+wheels:
+  main_offset_x_m: <float>
+  track_m: <float>                 # tricycle/tailwheel only
+  third_wheel_offset_x_m: <float>  # tricycle/tailwheel only; sign by gear
+```
+
+Cross-check: `0.5 × wheelbase ≤ turn_radius_m ≤ 5 × wheelbase` (own-gear,
+non-monowheel only; hard error on violation).
+
+`turn_radius_m` remains an **independent empirical value** — not derived from
+wheel geometry. The cross-check is a sanity guard, not a derivation.
+
+## Alternatives considered
+
+- **Render-only (option A):** Wheels become render data; no cross-check. Cheap,
+  unblocks #321 cleanly. Rejected because it doesn't resolve the "two
+  representations disagree" framing — drift could still accumulate silently.
+- **Collision participation (option C):** Wheels become Parts in the collision
+  model; a wing can't overhang another plane's main gear. Rejected as
+  out-of-scope for this PR; the parts-model extension and canary re-bake make
+  it a separate ADR if/when wheel-pad collisions become relevant.
+- **Derive `turn_radius_m` from wheelbase + steering:** Requires a per-aircraft
+  `max_steer_angle_deg` field we don't have, and the real relationship is
+  non-trivial (taildraggers pivot differently than tricycles). The empirical
+  number we already carry is more honest than a model-derived one.
+- **Explicit per-wheel `(x, y)` pairs (schema α):** Verbose; loader must
+  enforce left/right symmetry by convention rather than structure.
+  Rejected — the β schema documents intent (this is a wheelbase, this is a
+  track) and makes left/right mismatch structurally impossible.
+- **Re-anchor every aircraft to `origin = main-gear centroid` (schema γ):**
+  Would honor the original header docs, but the data churn touches every
+  fixture file with a hard-coded placement coordinate, for no functional gain.
+  Rejected; reconciled the docs instead.
+
+## Consequences
+
+- visualize.py drops `_NOSE_GEAR_FRAC` / `_MAIN_GEAR_*_FRAC` / `_MAIN_GEAR_LATERAL_FRAC`
+  and reduces `_draw_gear_glyph` to a loop over `aircraft.wheels.positions`.
+- #321 (cart glyph at wheel positions) consumes `wheels.positions` directly;
+  no new heuristic surface to maintain.
+- Determinism contract unchanged — `turn_radius_m` values are not modified by
+  this change, so Reeds–Shepp solutions and canary baselines are stable.
+- The main-gear centroid, a useful reference point for future motion-model
+  work (e.g. #263 nose-out parking), is available as
+  `(aircraft.wheels.main_offset_x_m, 0)` in plane-local coords.
+- Wheel-collision participation remains a future decision (see "Alternatives
+  considered, option C"). If revisited, this ADR is the starting point.
+
+## References
+
+- #322 (this issue)
+- #321 (cart glyph at wheel positions — consumes wheels)
+- ADR-0001 (Aircraft parts model)
+- ADR-0007 (Tow-path planner v1 scope — introduced `turn_radius_m` as load-bearing)
+- ADR-0010 (Reeds–Shepp motion model)
+- ADR-0012 (Fuselage front/aft split — same architectural shape: explicit data over heuristic)
+- Spec: `docs/superpowers/specs/2026-05-28-wheels-canonical-design.md`
+```
+
+- [ ] **Step 3: Update the ADR index if one exists**
+
+```bash
+cat docs/adr/README.md
+```
+
+If the README lists ADRs by number, add the new entry: `- ADR-0013 — Wheels as canonical per-aircraft data`. Match the existing format.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/adr/0013-wheels-canonical-data.md docs/adr/README.md
+git commit -m "docs(adr): ADR-0013 wheels as canonical per-aircraft data (#322)"
+```
+
+---
+
+## Task 10: Final guardrail run + push + open PR
+
+**Files:** none (CI / git only)
+
+- [ ] **Step 1: Full guardrail run**
+
+```bash
+pytest -q
+ruff check src/ tests/
+ruff format --check src/ tests/
+mypy src/hangarfit/
+```
+
+Expected: all green/clean. If `ruff format --check` reports unformatted files, run `ruff format src/ tests/` and commit the format-only change as `style(format): apply ruff format (#322)`.
+
+- [ ] **Step 2: Confirm canary fixtures untouched**
+
+```bash
+git diff develop...HEAD -- tests/test_solver_canaries.py tests/test_towplanner_*.py | wc -l
+```
+
+Expected: `0`. If non-zero, something in the implementation perturbed determinism — investigate before pushing (the design explicitly forbids canary churn).
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feature/wheels-canonical-322
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create \
+  --base develop \
+  --title "feat: wheel positions as canonical per-aircraft data (#322)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds a required `wheels:` block to every aircraft in `data/fleet.yaml` using the β-schema (`main_offset_x_m`, `track_m`, `third_wheel_offset_x_m`).
+- New `Wheels` dataclass + `Aircraft.wheels` required field.
+- Loader cross-checks `turn_radius_m` against wheel-derived wheelbase (0.5×–5× band; hard error; skipped for `always_cart` and monowheel).
+- `visualize.py` reads wheel positions from data — `_NOSE_GEAR_FRAC` and friends are deleted.
+- `fleet.yaml` header origin paragraph reconciled with the actual data convention.
+- ADR-0013 records the decision.
+
+## Determinism impact
+
+None. `turn_radius_m` values are unchanged, so Reeds–Shepp solutions and canary baselines are stable. The `determinism-guard` subagent should confirm canaries are byte-identical.
+
+## Spec
+
+[`docs/superpowers/specs/2026-05-28-wheels-canonical-design.md`](docs/superpowers/specs/2026-05-28-wheels-canonical-design.md)
+
+## Test plan
+
+- [ ] Full `pytest -q` green on develop merge
+- [ ] `ruff check` clean
+- [ ] `mypy src/hangarfit/` clean
+- [ ] `hangarfit check layouts/example.yaml --render /tmp/smoke.png` produces a PNG with wheels at sensible positions
+- [ ] Manual eyeball of the smoke PNG vs v0.7.2's smoke (regression check on cart-glyph placement, which is untouched)
+
+Closes #322.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Set assignee, label, milestone**
+
+(Per the [[feedback-pr-metadata]] memory: `gh pr edit` is broken in this repo; use `gh api -X PATCH`.)
+
+```bash
+PR=$(gh pr view --json number -q .number)
+gh api -X PATCH "repos/DocGerd/hangarfit/issues/$PR" \
+  -f assignees='["DocGerd"]' \
+  -f labels='["enhancement"]'
+```
+
+Milestone assignment: if a milestone is open that covers wheel-realism / Phase 3 follow-ups, set it. Otherwise leave unset and ask the user in the PR comment.
+
+- [ ] **Step 6: Run `/pr-review` and surface findings on the PR**
+
+After the PR is open, invoke `/pr-review` (or the `pr-review-toolkit:review-pr` skill) with the reviewer set named in the spec §6:
+
+- `geometry-invariant-guard` (defense in depth — geometry coords flow through `local_to_world`)
+- `determinism-guard` (sanity check — towplanner.py is untouched, canaries should be byte-identical)
+- `pr-review-toolkit:code-reviewer`
+- `pr-review-toolkit:type-design-analyzer` (new `Wheels` dataclass)
+- `pr-review-toolkit:silent-failure-hunter` (loader gained error paths)
+- `pr-review-toolkit:comment-analyzer` (fleet.yaml header + ADR)
+
+Convert every finding into a review thread on the diff. Resolve every thread (fix the code, or reply with rationale + mark resolved). Tell the user the PR is **clean and ready for final review** when threads are closed. **Never `gh pr merge` from this session.**
+
+---
+
+## Notes on what is deliberately NOT in this plan
+
+- **Canary regeneration.** The design predicts no canary churn. If Task 10 Step 2 ever fails, stop and surface — that's a design-violation signal, not a routine task.
+- **`gh pr merge`.** The user is the only merger.
+- **Cart glyph relocation.** That's #321; do not touch `_draw_cart_glyph` or `_CART_DECK_*` constants in this PR.
+- **Real fleet measurements.** Backfill uses estimates from public specs; the `measured: false` flag stays. Real measurements are #79.

--- a/docs/superpowers/specs/2026-05-28-wheels-canonical-design.md
+++ b/docs/superpowers/specs/2026-05-28-wheels-canonical-design.md
@@ -1,0 +1,272 @@
+# Wheels as canonical per-aircraft data (#322)
+
+Status: **DESIGN APPROVED 2026-05-28** — awaiting implementation plan.
+
+Issue: [#322 fleet/geometry: wheel positions should be physically realistic](https://github.com/DocGerd/hangarfit/issues/322).
+Blocks: [#321](https://github.com/DocGerd/hangarfit/issues/321) (cart glyph at wheel positions), partially conditions [#320](https://github.com/DocGerd/hangarfit/issues/320) (back-bias placement).
+
+---
+
+## 1. Problem
+
+Two surface representations of the same physical property — *where the wheels of each aircraft are* — disagree in the current code:
+
+- `data/fleet.yaml` carries `turn_radius_m` per aircraft, used by the Reeds–Shepp tow-path planner since Phase 3a. No wheel positions.
+- `src/hangarfit/visualize.py` invents wheel-glyph positions on the fly via heuristic fractions of fuselage half-length (`_NOSE_GEAR_FRAC = 0.85`, `_MAIN_GEAR_FWD_FRAC = 0.30`, `_MAIN_GEAR_TAILDRAGGER_FWD_FRAC = 0.45`, `_MAIN_GEAR_LATERAL_FRAC = 1.6`). The module's own comment admits these are "intentionally approximate".
+
+There is no link between the two: a contributor can change `turn_radius_m` to a value that doesn't match the rendered wheelbase, or vice versa, and nothing notices.
+
+A separate latent inconsistency: the `fleet.yaml` header comment states *"Origin of plane-local frame = main-gear / cart centroid"*, but visualize.py draws the main gear *offset* from origin by `_MAIN_GEAR_FWD_FRAC * fus_half_len`. The data follows visualize.py's convention (origin ≈ a per-aircraft anchor near CG/wing-root), not the header's stated rule. The header is aspirational.
+
+## 2. Goals
+
+Make wheel positions **first-class per-aircraft data** in `fleet.yaml`, with the following properties:
+
+1. Wheels are the canonical source for the renderer (visualize.py reads them; no heuristic).
+2. `turn_radius_m` remains independent (empirical taxi radius, not derived from wheelbase + steering geometry), but is **cross-checked at load time** against the wheel-derived wheelbase for plausibility.
+3. The schema is compact and symmetry-enforcing (no left/right mismatch possible).
+4. The `fleet.yaml` header docs are reconciled with the data.
+
+### Non-goals
+
+- **Wheel collision participation.** Wheels do not enter the parts model. If/when wheel-pad collisions become relevant, that is a separate ADR + parts-model extension.
+- **`turn_radius_m` derivation.** No `max_steer_angle_deg` field; no derived radius; no removal of `turn_radius_m`. The empirical-vs-derived tradeoff was settled in favour of empirical (see §5 — Decisions).
+- **Cart glyph relocation.** That is #321's job. This design leaves the cart code (`_draw_cart_glyph`) untouched.
+- **Origin re-anchoring.** Moving every aircraft's part-offsets so the plane-local origin lands exactly at the main-gear centroid was considered (schema option γ) and rejected — the data churn would touch every fixture file with hard-coded placement coordinates and yields no functional gain under the chosen scope.
+- **Towplanner pivot-point refinement.** The pivot stays at `placement.x_m / y_m` (the plane-local origin), as today. Future work (#263 nose-out) might want the pivot to be the main-gear centroid; that is out of scope here.
+- **Real wheel measurements.** Backfill values come from published specs and conservative estimates. The `measured: false` flag stays as-is — real measurements continue under #79 and the broader audit.
+
+## 3. Schema
+
+A new **required** `wheels:` block on every aircraft. Three shapes by `gear`:
+
+```yaml
+# tailwheel (Husky, Zlin, Cessna 140)
+wheels:
+  main_offset_x_m: 0.20          # plane-local +x: forward of origin
+  track_m: 1.80                  # mains lateral spread (each main at y = ±0.90)
+  third_wheel_offset_x_m: -3.40  # NEGATIVE = tail wheel (aft of origin)
+
+# nosewheel (Fuji, Wild Thing, Cessna 150, CTSL, FK9)
+wheels:
+  main_offset_x_m: -0.10
+  track_m: 1.80
+  third_wheel_offset_x_m: 2.50   # POSITIVE = nose wheel (forward of origin)
+
+# monowheel (Falke)
+wheels:
+  main_offset_x_m: 0.0
+  # NO track_m, NO third_wheel_offset_x_m
+  # Outriggers remain render-only via the wing footprint (current behaviour).
+```
+
+**Loader rules** (`src/hangarfit/loader.py`):
+
+- A `wheels:` block is **required**. Missing → `InvalidFleetError`.
+- Key set depends on `gear`:
+  - `monowheel` → exactly `{main_offset_x_m}`.
+  - `nosewheel` / `tailwheel` → exactly `{main_offset_x_m, track_m, third_wheel_offset_x_m}`.
+- Extra or missing keys for the gear type → `InvalidFleetError` with a clear message.
+- `track_m > 0`, `main_offset_x_m` and `third_wheel_offset_x_m` finite, `track_m` finite.
+- For `nosewheel`: `third_wheel_offset_x_m > main_offset_x_m` (nose is forward of mains).
+- For `tailwheel`: `third_wheel_offset_x_m < main_offset_x_m` (tail is aft of mains).
+
+## 4. Cross-check
+
+After parsing, for each aircraft with `turn_radius_m is not None` (i.e. not `always_cart`) and a defined wheelbase (i.e. not monowheel):
+
+```python
+wheelbase = abs(third_wheel_offset_x_m - main_offset_x_m)
+if not (0.5 * wheelbase <= turn_radius_m <= 5.0 * wheelbase):
+    raise InvalidFleetError(
+        f"Aircraft {aircraft.id!r}: turn_radius_m={turn_radius_m} is "
+        f"implausible given wheelbase={wheelbase:.2f}m "
+        f"(expected {0.5*wheelbase:.2f}..{5.0*wheelbase:.2f}). "
+        f"Either fix the wheel positions or fix turn_radius_m."
+    )
+```
+
+**Skipped** for:
+
+- `always_cart` aircraft (Falke, Wild Thing, Zlin Savage) — `turn_radius_m` is `null`; the cart pivots in place.
+- Monowheel aircraft — no third wheel, no wheelbase concept. Falke happens to be both `always_cart` and `monowheel`, so it is skipped on both counts.
+
+**Why this band:** The real physical relationship is `turn_radius ≈ wheelbase / tan(max_steer_angle)`. For typical small-aircraft steer angles (20–35°), this puts the multiplier in the 1.4×–2.7× range. A 0.5×–5× band catches the failure modes that matter (unit mixups, swapped main/third offsets, typos producing nonsense wheelbases) without forcing a steering model into the data or requiring per-aircraft fudge factors. Adjust the constants only if a real-fleet measurement reveals a band-edge case.
+
+**Hard error, not warning:** silent warnings get ignored in CI logs. A fleet that doesn't pass the band has either bad wheel data or a bad `turn_radius_m`; both need to be looked at before the data ships.
+
+## 5. Decisions and alternatives
+
+| Decision | Choice | Rejected alternative | Why |
+|---|---|---|---|
+| Scope of motion-model coupling | **B — render + cross-check** | A (render-only): doesn't fully resolve the "two representations disagree" framing. C (collision participation): forces a parts-model extension + canary re-bake; too much blast radius for one PR. | B closes the inconsistency at the schema level without forcing a motion-model rewrite. Wheel-collision can become a follow-up ADR if/when needed. |
+| Schema shape | **β — compact measurements** | α (explicit per-wheel x/y): verbose; loader must enforce L/R symmetry by convention rather than structure. γ (compact + re-anchor origins): data churn across every fleet entry and every test fixture with a hard-coded placement coordinate, with no functional payoff. | β documents intent (this is a wheelbase, this is a track), encodes symmetry structurally, stays compact. |
+| `turn_radius_m` policy | **Independent + cross-checked** | Derive from wheelbase + steering model: requires a `max_steer_angle_deg` field we don't have and that varies per aircraft. Replace entirely: same problem. | `turn_radius_m` is empirical (measured taxi radius). Modelling steering geometry honestly needs more data than we have; keeping `turn_radius_m` as an independent empirical value is more truthful. |
+| Cross-check strictness | **Loose band, hard error** | Tight steered-tricycle band (1.73× wheelbase ± 50%): would force a per-aircraft override for taildraggers. Warning-only: silent rot. No automated check (test-only): doesn't fail at the CLI for downstream users. | Loose-and-hard is the smallest mechanism that catches the failure modes that actually happen. |
+| `wheels:` block presence | **Required** | Optional with heuristic fallback: leaves a known landmine (any future aircraft missing the block falls back to the heuristic, recreating the inconsistency). | Single source of truth. visualize.py's heuristic constants delete cleanly. |
+| `measured` flag granularity | **Single existing flag** | New `wheels_measured` sub-flag: more bookkeeping for no current benefit (we don't have a partial-measurement workflow). | Wheel positions are just more dimensions; `measured: false` already covers everything until it's flipped to `true`. |
+| Origin convention | **Keep per-aircraft anchor, fix the docs** | Re-anchor every aircraft so origin = main-gear centroid (option γ): data churn across all fixtures. Leave the docs wrong: known landmine. | Cheapest fix that ends the latent docs-vs-data contradiction. The "origin = main-gear centroid" intent is recovered as a *derived* point via `wheels.main_offset_x_m`, accessible whenever the planner needs it (e.g. for future #263). |
+
+## 6. Components
+
+### 6.1 `src/hangarfit/models.py`
+
+```python
+@dataclass(frozen=True)
+class Wheels:
+    """Plane-local wheel positions for one aircraft.
+
+    Origin is the per-aircraft anchor that ``Placement.x_m / y_m`` refers to —
+    the same origin every other Part offset is measured from. Each main wheel
+    sits at ``(main_offset_x_m, ±track_m/2)``; the third (nose or tail) wheel,
+    if present, sits at ``(third_wheel_offset_x_m, 0)``.
+    """
+
+    main_offset_x_m: float
+    track_m: float | None
+    third_wheel_offset_x_m: float | None
+
+    @property
+    def positions(self) -> list[tuple[float, float]]:
+        """Plane-local ``(x, y)`` of every wheel.
+
+        Returns 1 entry for monowheel (``(main_offset_x_m, 0)``) or 3 entries
+        for tricycle/tailwheel (two mains at ``(main_offset_x_m, ±track_m/2)``
+        plus the third wheel at ``(third_wheel_offset_x_m, 0)``). The order is
+        stable: mains first (``+y`` then ``-y``), then the third wheel.
+        """
+
+    @property
+    def wheelbase_m(self) -> float | None:
+        """``abs(third - main)``, or ``None`` for monowheel."""
+```
+
+`Wheels.positions` is the **only** accessor every consumer should use. Visualize, future #321 cart-glyph relocation, and any future towplanner pivot-point work all go through it.
+
+```python
+@dataclass(frozen=True)
+class Aircraft:
+    # ... existing fields ...
+    wheels: Wheels   # required (no default)
+```
+
+### 6.2 `src/hangarfit/loader.py`
+
+- New `_parse_wheels(entry: Mapping[str, Any], gear: Gear, aircraft_id: str) -> Wheels` helper.
+- Called from the existing per-aircraft parse path.
+- After the full `Aircraft` is constructed, a `_validate_wheels_vs_turn_radius(aircraft)` runs the §4 cross-check.
+- All errors raise `InvalidFleetError` with a `f"Aircraft {id!r}: …"` prefix matching the existing loader convention.
+
+### 6.3 `src/hangarfit/visualize.py`
+
+**Delete:**
+
+- `_NOSE_GEAR_FRAC`, `_MAIN_GEAR_FWD_FRAC`, `_MAIN_GEAR_TAILDRAGGER_FWD_FRAC`, `_MAIN_GEAR_LATERAL_FRAC` constants.
+- The `if/elif aircraft.gear` branches inside `_draw_gear_glyph` (~30 lines).
+- The fuselage-segment reconstruction (`nose_x`, `fus_aft_x`, `fus_cx`, `fus_half_len`, `fus_half_wid`) inside `_draw_gear_glyph` — no longer needed once wheel positions are data-driven.
+
+**Replace `_draw_gear_glyph` body with:**
+
+```python
+def _draw_gear_glyph(ax, placement, aircraft):
+    if placement.on_carts:
+        _draw_cart_glyph(ax, placement)
+        return
+    for u, v in aircraft.wheels.positions:
+        wx, wy = local_to_world(u, v, placement)
+        _add_wheel(ax, wx, wy)
+```
+
+`_draw_cart_glyph`, `_CART_DECK_HALF_LENGTH_M`, `_CART_DECK_HALF_WIDTH_M` are **not** touched — that is #321's surface.
+
+### 6.4 `data/fleet.yaml`
+
+- Backfill each of the 9 aircraft with a `wheels:` block (see §7).
+- Update the header comment block: replace the "Origin = main-gear / cart centroid" paragraph with one stating that origin is a per-aircraft anchor and that the main-gear centroid is `(wheels.main_offset_x_m, 0)`.
+
+### 6.5 New ADR
+
+`docs/adr/0013-wheels-canonical-data.md`, peer to ADR-0001 (parts model) and ADR-0012 (fuselage split). Captures:
+
+- **Decision:** Wheels are explicit data in `fleet.yaml`; `turn_radius_m` is independent + cross-checked.
+- **Context:** the docs-vs-data inconsistency described in §1.
+- **Alternatives considered:** §5 table.
+- **Consequences:** cart-glyph rework (#321) becomes mechanical; #263 nose-out gets a documented main-gear-centroid accessor when it eventually needs one; wheel-collision is left as a future ADR.
+
+## 7. Fleet data backfill
+
+For each of the 9 fleet entries, supply a `wheels:` block whose values come from:
+
+- **Published specifications** where available: Cessna 140 / 150, Fuji FA-200, Aviat Husky, Flight Design CTSL, FK9 Mk II, Scheibe SF-25E Falke.
+- **Conservative estimates** for the ultralight subset (Wild Thing, Zlin Savage) — derive from fuselage dimensions and class-typical wheelbase/track.
+
+**Acceptance for backfill:** every current `turn_radius_m` value passes the 0.5×–5× cross-check against the backfilled wheelbase. If any aircraft fails the band, prefer adjusting the wheel positions (we are reading those off published specs anyway) over adjusting `turn_radius_m` — adjusting `turn_radius_m` would shift Reeds–Shepp solutions and re-shuffle canaries.
+
+`measured: false` stays on every aircraft — wheel positions inherit the same flag.
+
+## 8. Determinism / canary impact
+
+**Expected: none.** Option B was deliberately chosen so `turn_radius_m` values don't change, which means:
+
+- Reeds–Shepp solutions don't shift.
+- `tests/test_solver_canaries.py` and `tests/test_towplanner_*.py` baselines unchanged.
+- The `determinism-guard` subagent passes without canary regeneration.
+
+**Risk:** if a single fleet entry can't be backfilled with a wheelbase that keeps the current `turn_radius_m` inside the band (and the band itself is correct per §4), we have to either fudge that aircraft's wheelbase, widen the band, or accept a canary re-bake. The expected case from spec-checking is that all 9 entries fit the loose 0.5×–5× band comfortably; that judgment is deferred to backfill time and is the gate that decides whether this PR stays small or grows.
+
+## 9. Tests
+
+### New
+
+- `tests/test_loader_wheels.py`:
+  - Happy path: every gear type loads a valid aircraft.
+  - Missing `wheels:` block → `InvalidFleetError`.
+  - Wrong key set for `gear` (e.g. `track_m` on monowheel, missing `third_wheel_offset_x_m` on nosewheel) → `InvalidFleetError`.
+  - Sign-direction violations (nosewheel with negative `third_wheel_offset_x_m`, tailwheel with positive) → `InvalidFleetError`.
+  - Cross-check pass and fail (both ends of the band) → respectively load and `InvalidFleetError`.
+  - Cross-check skipped for `always_cart` (no error even when wheelbase would otherwise fail).
+
+- `tests/test_visualize_wheels.py`:
+  - Loaded aircraft renders without exception.
+  - Glyph circles land at expected world coords (use `_add_wheel` mock or capture Axes children).
+  - `on_carts=True` still falls through to `_draw_cart_glyph` (regression guard for the #321 surface).
+
+### Extended
+
+- `tests/test_models.py`: `Wheels.positions` returns the right list for each gear type; `Wheels.wheelbase_m` is `None` for monowheel.
+
+### Helper
+
+`tests/conftest.py`:
+
+```python
+def make_test_aircraft(*, gear: Gear = "nosewheel", **overrides) -> Aircraft:
+    """Build a minimal valid Aircraft for tests, with sensible wheel defaults."""
+```
+
+Existing inline-aircraft fixtures migrate to this helper to absorb the new boilerplate. Fixtures that deliberately construct invalid aircraft (loader error tests) keep their explicit dict-of-dict form.
+
+## 10. PR shape
+
+- **Branch:** `feature/wheels-canonical-322`, off `develop`.
+- **Base:** `develop`.
+- **Expected size:** ~600 LOC, dominated by `fleet.yaml` data + the new ADR.
+- **Review subagents:**
+  - `geometry-invariant-guard` — defense in depth, even though geometry.py is not edited (wheel coords feed through `local_to_world`).
+  - `determinism-guard` — sanity check that towplanner.py is untouched.
+  - `pr-review-toolkit:code-reviewer` — main pass.
+  - `pr-review-toolkit:type-design-analyzer` — models.py adds a new dataclass.
+  - `pr-review-toolkit:silent-failure-hunter` — loader gains error paths.
+  - `pr-review-toolkit:comment-analyzer` — fleet.yaml header rewrite + ADR text.
+- **Unblocks:** #321 (cart glyph at wheel positions). Partially conditions #320 (back-bias placement) by making wheel-derived turn radius accessible for future tow-routability checks.
+
+## 11. Acceptance criteria
+
+1. `data/fleet.yaml` carries a `wheels:` block on every aircraft.
+2. `src/hangarfit/loader.py` rejects an aircraft missing `wheels:` or with a wrong key set for its gear.
+3. `src/hangarfit/loader.py` rejects an aircraft whose `turn_radius_m` falls outside the 0.5×–5× wheelbase band (own-gear, non-monowheel only).
+4. `src/hangarfit/visualize.py` reads wheel positions from `aircraft.wheels.positions`; the `_NOSE_GEAR_FRAC` / `_MAIN_GEAR_*_FRAC` constants are deleted.
+5. `data/fleet.yaml` header comment block reconciled with the actual origin convention.
+6. New ADR-0013 committed under `docs/adr/`.
+7. `pytest -q` green; `ruff check` and `ruff format --check` clean; `mypy src/hangarfit/` clean.
+8. Determinism canaries unchanged (or, if any fleet entry forces a re-bake, that re-bake is in this PR with the determinism-guard subagent's blessing).

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -623,6 +623,13 @@ def _parse_wheels(
     if entry is None:
         raise LoaderError("wheels: block is required (see fleet.yaml header for the schema)")
 
+    if not isinstance(entry, Mapping):
+        # YAML can hand us a list/scalar/string here (e.g. a mis-indented
+        # block). Guard before .keys() so the user gets an attributed
+        # LoaderError, not a bare AttributeError that escapes load_fleet's
+        # catch tuple — mirrors the isinstance(dict) guard on 'struts'.
+        raise LoaderError(f"wheels: block must be a mapping, got {type(entry).__name__}")
+
     if gear not in _WHEELS_KEYS_BY_GEAR:
         raise LoaderError(f"wheels: unsupported gear {gear!r}")
 
@@ -687,8 +694,11 @@ _WHEELBASE_BAND_HIGH = 5.0
 def _validate_wheels_vs_turn_radius(aircraft: Aircraft) -> None:
     """Raise ``LoaderError`` if turn_radius_m is implausible vs the wheelbase.
 
-    Skipped for always_cart (``turn_radius_m`` is ``None``) and for monowheel
-    (no ``wheelbase_m``). The message carries no ``aircraft 'id'`` prefix — the
+    Skipped whenever ``turn_radius_m`` is ``None`` (every always_cart entry
+    today, though the model permits a non-None value there too — which would
+    then be checked) and for monowheel (no ``wheelbase_m``). Cart-eligible
+    planes carry a real radius and wheelbase, so they ARE checked. The message
+    carries no ``aircraft 'id'`` prefix — the
     ``load_fleet`` loop wraps per-aircraft errors with that attribution, so
     adding it here would double-decorate (mirrors :func:`_parse_wheels`).
     See ADR-0013 for the rationale on the loose band.

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -675,6 +675,40 @@ def _parse_wheels(
         raise LoaderError(f"wheels: {exc}") from exc
 
 
+# Plausibility band for turn_radius_m against the wheel-derived wheelbase.
+# Deliberately loose (0.5×–5×): a sanity guard against a fat-fingered radius or
+# wheel coordinate, NOT a derivation. turn_radius_m stays an empirical value
+# (ADR-0013). Most fleet entries are still ``measured: false`` estimates, so a
+# tight band would produce false positives.
+_WHEELBASE_BAND_LOW = 0.5
+_WHEELBASE_BAND_HIGH = 5.0
+
+
+def _validate_wheels_vs_turn_radius(aircraft: Aircraft) -> None:
+    """Raise ``LoaderError`` if turn_radius_m is implausible vs the wheelbase.
+
+    Skipped for always_cart (``turn_radius_m`` is ``None``) and for monowheel
+    (no ``wheelbase_m``). The message carries no ``aircraft 'id'`` prefix — the
+    ``load_fleet`` loop wraps per-aircraft errors with that attribution, so
+    adding it here would double-decorate (mirrors :func:`_parse_wheels`).
+    See ADR-0013 for the rationale on the loose band.
+    """
+    if aircraft.turn_radius_m is None:
+        return
+    wheelbase = aircraft.wheels.wheelbase_m
+    if wheelbase is None:
+        return
+    low = _WHEELBASE_BAND_LOW * wheelbase
+    high = _WHEELBASE_BAND_HIGH * wheelbase
+    r = aircraft.turn_radius_m
+    if not (low <= r <= high):
+        raise LoaderError(
+            f"turn_radius_m={r} is implausible given wheelbase={wheelbase:.2f}m "
+            f"(expected {low:.2f}..{high:.2f}). Either fix the wheel positions "
+            f"or fix turn_radius_m."
+        )
+
+
 def _build_aircraft(entry: Any) -> Aircraft:
     if not isinstance(entry, dict):
         raise LoaderError(f"aircraft entry must be a mapping, got {type(entry).__name__}")
@@ -745,7 +779,7 @@ def _build_aircraft(entry: Any) -> Aircraft:
     turn_radius_raw = entry.get("turn_radius_m")
     turn_radius_m = None if turn_radius_raw is None else _to_float(turn_radius_raw, "turn_radius_m")
 
-    return Aircraft(
+    aircraft = Aircraft(
         id=entry["id"],
         name=entry["name"],
         wing_position=entry["wing_position"],
@@ -757,6 +791,8 @@ def _build_aircraft(entry: Any) -> Aircraft:
         notes=entry.get("notes", ""),
         wheels=_parse_wheels(entry.get("wheels"), entry["gear"]),
     )
+    _validate_wheels_vs_turn_radius(aircraft)
+    return aircraft
 
 
 def _build_part(data: Any, index: int) -> Part:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import dataclasses
 import difflib
 import math
-from collections.abc import Collection, Iterable
+from collections.abc import Collection, Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -53,6 +53,7 @@ from .models import (
     PlaneConstraint,
     Scenario,
     StrutsSpec,
+    Wheels,
 )
 
 
@@ -596,6 +597,82 @@ def _resolve_known_plane_id(
     raise LoaderError(f"{path}: {role} references unknown plane id {candidate!r}{tail}")
 
 
+_WHEELS_KEYS_BY_GEAR: dict[str, frozenset[str]] = {
+    "monowheel": frozenset({"main_offset_x_m"}),
+    "nosewheel": frozenset({"main_offset_x_m", "track_m", "third_wheel_offset_x_m"}),
+    "tailwheel": frozenset({"main_offset_x_m", "track_m", "third_wheel_offset_x_m"}),
+}
+
+
+def _parse_wheels(
+    entry: Mapping[str, Any] | None,
+    gear: str,
+    aircraft_id: str,
+) -> Wheels | None:
+    """Parse a ``wheels:`` block into a :class:`Wheels`.
+
+    Returns ``None`` if ``entry`` is ``None`` (transitional — Task 5 flips
+    this to raise ``LoaderError``).
+
+    Validates that the key set exactly matches ``_WHEELS_KEYS_BY_GEAR[gear]``
+    and that nose-vs-tail sign rules hold for tricycle/tailwheel gear.
+    """
+    if entry is None:
+        return None  # TODO(#322 Task 5): raise LoaderError
+
+    if gear not in _WHEELS_KEYS_BY_GEAR:
+        raise LoaderError(f"wheels: unsupported gear {gear!r}")
+
+    expected = _WHEELS_KEYS_BY_GEAR[gear]
+    seen = frozenset(entry.keys())
+    missing = expected - seen
+    unknown = seen - expected
+    if missing:
+        raise LoaderError(
+            f"wheels: block missing required key(s) for gear={gear!r}: {sorted(missing)}"
+        )
+    if unknown:
+        if gear == "monowheel" and unknown & {"track_m", "third_wheel_offset_x_m"}:
+            raise LoaderError(
+                f"wheels: monowheel block must not set track_m or "
+                f"third_wheel_offset_x_m (got {sorted(unknown)})"
+            )
+        raise LoaderError(f"wheels: block has unknown key(s): {sorted(unknown)}")
+
+    main_offset_x_m = _to_float(entry["main_offset_x_m"], "wheels.main_offset_x_m")
+    if gear == "monowheel":
+        try:
+            return Wheels(
+                main_offset_x_m=main_offset_x_m, track_m=None, third_wheel_offset_x_m=None
+            )
+        except ValueError as exc:
+            raise LoaderError(f"wheels: {exc}") from exc
+
+    track_m = _to_float(entry["track_m"], "wheels.track_m")
+    third = _to_float(entry["third_wheel_offset_x_m"], "wheels.third_wheel_offset_x_m")
+    # Sign rule:
+    #   nosewheel → third (nose) must be forward of mains (greater x)
+    #   tailwheel → third (tail) must be aft of mains    (lesser x)
+    if gear == "nosewheel" and not third > main_offset_x_m:
+        raise LoaderError(
+            f"wheels: nosewheel third_wheel_offset_x_m must be forward of mains "
+            f"(greater than main_offset_x_m={main_offset_x_m}); got {third}"
+        )
+    if gear == "tailwheel" and not third < main_offset_x_m:
+        raise LoaderError(
+            f"wheels: tailwheel third_wheel_offset_x_m must be aft of mains "
+            f"(less than main_offset_x_m={main_offset_x_m}); got {third}"
+        )
+    try:
+        return Wheels(
+            main_offset_x_m=main_offset_x_m,
+            track_m=track_m,
+            third_wheel_offset_x_m=third,
+        )
+    except ValueError as exc:
+        raise LoaderError(f"wheels: {exc}") from exc
+
+
 def _build_aircraft(entry: Any) -> Aircraft:
     if not isinstance(entry, dict):
         raise LoaderError(f"aircraft entry must be a mapping, got {type(entry).__name__}")
@@ -676,6 +753,7 @@ def _build_aircraft(entry: Any) -> Aircraft:
         measured=_to_bool(entry.get("measured", False), "measured"),
         parts=tuple(parts),
         notes=entry.get("notes", ""),
+        wheels=_parse_wheels(entry.get("wheels"), entry["gear"], entry["id"]),
     )
 
 

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -607,7 +607,6 @@ _WHEELS_KEYS_BY_GEAR: dict[str, frozenset[str]] = {
 def _parse_wheels(
     entry: Mapping[str, Any] | None,
     gear: str,
-    aircraft_id: str,
 ) -> Wheels | None:
     """Parse a ``wheels:`` block into a :class:`Wheels`.
 
@@ -616,6 +615,10 @@ def _parse_wheels(
 
     Validates that the key set exactly matches ``_WHEELS_KEYS_BY_GEAR[gear]``
     and that nose-vs-tail sign rules hold for tricycle/tailwheel gear.
+
+    Errors are raised without an ``aircraft 'id': ...`` prefix — the outer
+    ``load_fleet`` loop wraps every per-aircraft error with that attribution
+    (see :func:`load_fleet`), so adding it here would double-decorate.
     """
     if entry is None:
         return None  # TODO(#322 Task 5): raise LoaderError
@@ -641,29 +644,28 @@ def _parse_wheels(
 
     main_offset_x_m = _to_float(entry["main_offset_x_m"], "wheels.main_offset_x_m")
     if gear == "monowheel":
-        try:
-            return Wheels(
-                main_offset_x_m=main_offset_x_m, track_m=None, third_wheel_offset_x_m=None
-            )
-        except ValueError as exc:
-            raise LoaderError(f"wheels: {exc}") from exc
+        # _to_float already rejects non-finite; Wheels.__post_init__'s only other
+        # ValueError path for monowheel is also a finiteness check, so no wrap needed.
+        return Wheels(main_offset_x_m=main_offset_x_m, track_m=None, third_wheel_offset_x_m=None)
 
     track_m = _to_float(entry["track_m"], "wheels.track_m")
     third = _to_float(entry["third_wheel_offset_x_m"], "wheels.third_wheel_offset_x_m")
     # Sign rule:
     #   nosewheel → third (nose) must be forward of mains (greater x)
     #   tailwheel → third (tail) must be aft of mains    (lesser x)
-    if gear == "nosewheel" and not third > main_offset_x_m:
+    if gear == "nosewheel" and third <= main_offset_x_m:
         raise LoaderError(
             f"wheels: nosewheel third_wheel_offset_x_m must be forward of mains "
             f"(greater than main_offset_x_m={main_offset_x_m}); got {third}"
         )
-    if gear == "tailwheel" and not third < main_offset_x_m:
+    if gear == "tailwheel" and third >= main_offset_x_m:
         raise LoaderError(
             f"wheels: tailwheel third_wheel_offset_x_m must be aft of mains "
             f"(less than main_offset_x_m={main_offset_x_m}); got {third}"
         )
     try:
+        # Wheels.__post_init__ still validates `track_m > 0` — wrap so the loader
+        # surfaces a LoaderError rather than leaking ValueError to the caller.
         return Wheels(
             main_offset_x_m=main_offset_x_m,
             track_m=track_m,
@@ -753,7 +755,7 @@ def _build_aircraft(entry: Any) -> Aircraft:
         measured=_to_bool(entry.get("measured", False), "measured"),
         parts=tuple(parts),
         notes=entry.get("notes", ""),
-        wheels=_parse_wheels(entry.get("wheels"), entry["gear"], entry["id"]),
+        wheels=_parse_wheels(entry.get("wheels"), entry["gear"]),
     )
 
 

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -607,11 +607,11 @@ _WHEELS_KEYS_BY_GEAR: dict[str, frozenset[str]] = {
 def _parse_wheels(
     entry: Mapping[str, Any] | None,
     gear: str,
-) -> Wheels | None:
+) -> Wheels:
     """Parse a ``wheels:`` block into a :class:`Wheels`.
 
-    Returns ``None`` if ``entry`` is ``None`` (transitional — Task 5 flips
-    this to raise ``LoaderError``).
+    Raises ``LoaderError`` when ``entry`` is ``None`` — every aircraft
+    must declare a ``wheels:`` block (ADR-0013).
 
     Validates that the key set exactly matches ``_WHEELS_KEYS_BY_GEAR[gear]``
     and that nose-vs-tail sign rules hold for tricycle/tailwheel gear.
@@ -621,7 +621,7 @@ def _parse_wheels(
     (see :func:`load_fleet`), so adding it here would double-decorate.
     """
     if entry is None:
-        return None  # TODO(#322 Task 5): raise LoaderError
+        raise LoaderError("wheels: block is required (see fleet.yaml header for the schema)")
 
     if gear not in _WHEELS_KEYS_BY_GEAR:
         raise LoaderError(f"wheels: unsupported gear {gear!r}")

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -234,6 +234,7 @@ class Aircraft:
     measured: bool
     parts: tuple[Part, ...]
     notes: str = ""
+    wheels: Wheels | None = None  # transitional — Task 5 flips to required
 
     def __post_init__(self) -> None:
         if not self.id:

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -223,6 +223,10 @@ class Aircraft:
     ``turn_radius_m`` is required for any non-``always_cart`` aircraft
     (the future Dubins-path planner needs it for own-gear motion).
     For ``always_cart`` it may be ``None`` (or any value — it is ignored).
+
+    ``wheels`` is transitionally optional (defaults to ``None``) while the
+    #322 series lands in stages; Task 5 of that series flips it to required
+    once the loader populates it from a per-aircraft ``wheels:`` block.
     """
 
     id: str

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -133,6 +133,78 @@ class StrutsSpec:
 
 
 @dataclass(frozen=True, slots=True)
+class Wheels:
+    """Plane-local wheel positions for one aircraft.
+
+    Origin is the per-aircraft anchor that ``Placement.x_m / y_m`` refers to —
+    the same origin every other Part offset is measured from. Each main wheel
+    sits at ``(main_offset_x_m, ±track_m/2)``; the third (nose or tail) wheel,
+    if present, sits at ``(third_wheel_offset_x_m, 0)``.
+
+    ``track_m`` and ``third_wheel_offset_x_m`` are both ``None`` for monowheel
+    aircraft (only the central main wheel is modelled; outriggers stay
+    render-only via the wing footprint). For tricycle and tailwheel aircraft,
+    both fields are required — the loader enforces this against ``gear``.
+    """
+
+    main_offset_x_m: float
+    track_m: float | None
+    third_wheel_offset_x_m: float | None
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.main_offset_x_m):
+            raise ValueError(f"Wheels.main_offset_x_m must be finite, got {self.main_offset_x_m!r}")
+        if (self.track_m is None) != (self.third_wheel_offset_x_m is None):
+            # XOR: both present (tricycle/tailwheel) or both absent (monowheel).
+            if self.track_m is None:
+                raise ValueError(
+                    "Wheels.third_wheel_offset_x_m requires track_m to also be set "
+                    "(both present for tricycle/tailwheel, both None for monowheel)"
+                )
+            raise ValueError(
+                "Wheels.track_m requires third_wheel_offset_x_m to also be set "
+                "(both present for tricycle/tailwheel, both None for monowheel)"
+            )
+        if self.track_m is not None:
+            if not math.isfinite(self.track_m):
+                raise ValueError(f"Wheels.track_m must be finite, got {self.track_m!r}")
+            if self.track_m <= 0.0:
+                raise ValueError(f"Wheels.track_m must be positive, got {self.track_m!r}")
+        if self.third_wheel_offset_x_m is not None and not math.isfinite(
+            self.third_wheel_offset_x_m
+        ):
+            raise ValueError(
+                f"Wheels.third_wheel_offset_x_m must be finite, got {self.third_wheel_offset_x_m!r}"
+            )
+
+    @property
+    def positions(self) -> list[tuple[float, float]]:
+        """Plane-local ``(x, y)`` of every wheel.
+
+        Returns 1 entry for monowheel (``(main_offset_x_m, 0)``) or 3 entries
+        for tricycle/tailwheel (two mains at ``(main_offset_x_m, ±track_m/2)``
+        then the third wheel at ``(third_wheel_offset_x_m, 0)``). The order is
+        stable: mains first (``+y`` then ``-y``), then the third wheel.
+        """
+        if self.track_m is None:
+            return [(self.main_offset_x_m, 0.0)]
+        assert self.third_wheel_offset_x_m is not None  # narrowed by __post_init__
+        half_track = self.track_m / 2.0
+        return [
+            (self.main_offset_x_m, half_track),
+            (self.main_offset_x_m, -half_track),
+            (self.third_wheel_offset_x_m, 0.0),
+        ]
+
+    @property
+    def wheelbase_m(self) -> float | None:
+        """``abs(third_wheel_offset_x_m - main_offset_x_m)``, or ``None`` for monowheel."""
+        if self.third_wheel_offset_x_m is None:
+            return None
+        return abs(self.third_wheel_offset_x_m - self.main_offset_x_m)
+
+
+@dataclass(frozen=True, slots=True)
 class Aircraft:
     """One plane in the fleet.
 

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -178,7 +178,7 @@ class Wheels:
             )
 
     @property
-    def positions(self) -> list[tuple[float, float]]:
+    def positions(self) -> tuple[tuple[float, float], ...]:
         """Plane-local ``(x, y)`` of every wheel.
 
         Returns 1 entry for monowheel (``(main_offset_x_m, 0)``) or 3 entries
@@ -187,14 +187,16 @@ class Wheels:
         stable: mains first (``+y`` then ``-y``), then the third wheel.
         """
         if self.track_m is None:
-            return [(self.main_offset_x_m, 0.0)]
-        assert self.third_wheel_offset_x_m is not None  # narrowed by __post_init__
+            return ((self.main_offset_x_m, 0.0),)
+        # __post_init__ guarantees third_wheel_offset_x_m is set whenever track_m is set;
+        # re-bind to a local so mypy can narrow float|None → float.
+        third_x: float = self.third_wheel_offset_x_m  # type: ignore[assignment]
         half_track = self.track_m / 2.0
-        return [
+        return (
             (self.main_offset_x_m, half_track),
             (self.main_offset_x_m, -half_track),
-            (self.third_wheel_offset_x_m, 0.0),
-        ]
+            (third_x, 0.0),
+        )
 
     @property
     def wheelbase_m(self) -> float | None:

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -17,7 +17,7 @@ import typing
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 if TYPE_CHECKING:
     from hangarfit.towplanner import MovesPlan
@@ -188,9 +188,10 @@ class Wheels:
         """
         if self.track_m is None:
             return ((self.main_offset_x_m, 0.0),)
-        # __post_init__ guarantees third_wheel_offset_x_m is set whenever track_m is set;
-        # re-bind to a local so mypy can narrow float|None → float.
-        third_x: float = self.third_wheel_offset_x_m  # type: ignore[assignment]
+        # __post_init__'s XOR rule guarantees third_wheel_offset_x_m is set whenever
+        # track_m is set; cast makes that invariant visible to mypy without an assert
+        # (which would get stripped under -O).
+        third_x = cast(float, self.third_wheel_offset_x_m)
         half_track = self.track_m / 2.0
         return (
             (self.main_offset_x_m, half_track),

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -224,9 +224,11 @@ class Aircraft:
     (the future Dubins-path planner needs it for own-gear motion).
     For ``always_cart`` it may be ``None`` (or any value — it is ignored).
 
-    ``wheels`` is transitionally optional (defaults to ``None``) while the
-    #322 series lands in stages; Task 5 of that series flips it to required
-    once the loader populates it from a per-aircraft ``wheels:`` block.
+    ``wheels`` is the canonical source of per-aircraft wheel positions
+    (ADR-0013). The loader populates it from a required per-aircraft
+    ``wheels:`` block in ``fleet.yaml`` and rejects any entry missing it.
+    Consumers (visualize, tow-path planner) read positions exclusively
+    through :meth:`Wheels.positions`.
     """
 
     id: str
@@ -237,8 +239,8 @@ class Aircraft:
     turn_radius_m: float | None
     measured: bool
     parts: tuple[Part, ...]
+    wheels: Wheels
     notes: str = ""
-    wheels: Wheels | None = None  # transitional — Task 5 flips to required
 
     def __post_init__(self) -> None:
         if not self.id:

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -138,19 +138,6 @@ _WHEEL_RADIUS_M = 0.18
 _CART_DECK_HALF_LENGTH_M = 1.3
 _CART_DECK_HALF_WIDTH_M = 0.55
 
-# Fraction of fuselage forward half where nose-wheel / main-gear land.
-# Nose wheel: near the fuselage nose tip. Main-gear (nosewheel config):
-# placed at ~35% back from nose toward CG. Main-gear (tailwheel config):
-# placed at ~40% forward from origin (CG). Tailwheel: at aft tip.
-# These are intentionally approximate — real gear positions are unknown
-# (fleet.yaml has measured:false everywhere) and these fractions give a
-# visually convincing top-down silhouette.
-_NOSE_GEAR_FRAC = 0.85  # fraction of forward half-fuselage for nose wheel
-_MAIN_GEAR_FWD_FRAC = 0.30  # fraction of forward half for nosewheel mains
-_MAIN_GEAR_TAILDRAGGER_FWD_FRAC = 0.45  # fraction of forward half for tailwheel mains
-# Main-gear lateral offset as a multiple of fuselage half-width.
-_MAIN_GEAR_LATERAL_FRAC = 1.6
-
 
 def render_layout(
     layout: Layout,
@@ -432,78 +419,21 @@ def _add_wheel(ax: Any, wx: float, wy: float) -> MplCircle:
 def _draw_gear_glyph(ax: Any, placement: Placement, aircraft: Aircraft) -> None:
     """Draw landing-gear wheels or a cart glyph depending on ``placement.on_carts``.
 
-    Geometry is approximated from the full fuselage's ``offset_x_m`` and
-    ``length_m``, reconstructed from the aircraft's ``fuselage_front`` +
-    ``fuselage_aft`` segments (the fuselage is split front/aft at load time —
-    ADR-0012, so there is no single ``fuselage`` part). The reconstructed span
-    is the union of every fuselage segment: nose tip = max segment
-    ``offset_x_m + length_m/2``, tail tip = min segment ``offset_x_m −
-    length_m/2``. ``tail`` parts are included so an aircraft that declares a
-    separate empennage still anchors its tail wheel correctly.
+    Wheel positions come straight from ``aircraft.wheels.positions`` — the
+    canonical per-aircraft plane-local coordinates (ADR-0013), no longer
+    reconstructed from heuristic fuselage fractions. Each is mapped to world
+    coords through ``local_to_world`` so the gear rotates with the aircraft
+    heading.
 
-    **Own-gear (``on_carts=False``):** wheel positions per ``aircraft.gear``:
-
-    - ``nosewheel`` (tricycle): one nose wheel near the fuselage nose tip, two
-      main wheels behind the CG at ±lateral offset.
-    - ``tailwheel``: two main wheels ahead of the CG, one tailwheel near the
-      fuselage aft tip.
-    - ``monowheel``: a single centred main wheel at the CG origin.
-
-    **Cart-borne (``on_carts=True``):** a dolly-deck rectangle (lighter gray,
-    translucent) centred at the origin with four small corner wheel circles,
-    drawn in the same world-transform path as parts so it rotates with the
-    aircraft heading.
+    When the plane rides on a cart (``placement.on_carts=True``), the cart-deck
+    glyph is drawn instead of the plane's own gear (see ``_draw_cart_glyph``).
     """
-    # Reconstruct the full fuselage span from its front/aft segments (the
-    # fuselage is split at load time — ADR-0012, so there is no single
-    # ``fuselage`` part). ``tail`` is folded in so a separate empennage still
-    # anchors the tail wheel.
-    fuselage_segments = [
-        p for p in aircraft.parts if p.kind in ("fuselage_front", "fuselage_aft", "tail")
-    ]
-    if not fuselage_segments:
-        # No fuselage segment found — skip silently. Defensive: every fleet
-        # entry today has a fuselage, but we should not crash on novel entries.
-        return
-
-    nose_x = max(p.offset_x_m + p.length_m / 2.0 for p in fuselage_segments)  # +x: nose tip
-    fus_aft_x = min(p.offset_x_m - p.length_m / 2.0 for p in fuselage_segments)  # −x: tail tip
-    fus_cx = (nose_x + fus_aft_x) / 2.0  # local +x centre of full fuselage
-    fus_half_len = (nose_x - fus_aft_x) / 2.0
-    # Width is uniform across segments (the split is purely longitudinal); use
-    # the widest segment so a separate narrow tail doesn't shrink the lateral
-    # main-gear offset.
-    fus_half_wid = max(p.width_m for p in fuselage_segments) / 2.0
-
     if placement.on_carts:
         _draw_cart_glyph(ax, placement)
-    elif aircraft.gear == "nosewheel":
-        # Nose wheel — near the nose tip
-        nose_u = fus_cx + fus_half_len * _NOSE_GEAR_FRAC
-        wx, wy = local_to_world(nose_u, 0.0, placement)
+        return
+    for u, v in aircraft.wheels.positions:
+        wx, wy = local_to_world(u, v, placement)
         _add_wheel(ax, wx, wy)
-        # Main gear pair — slightly aft of CG (behind the wing root)
-        main_u = fus_cx - fus_half_len * _MAIN_GEAR_FWD_FRAC
-        lateral = fus_half_wid * _MAIN_GEAR_LATERAL_FRAC
-        for v in (+lateral, -lateral):
-            wx, wy = local_to_world(main_u, v, placement)
-            _add_wheel(ax, wx, wy)
-    elif aircraft.gear == "tailwheel":
-        # Main gear pair — forward of CG, ahead of the wing root
-        main_u = fus_cx + fus_half_len * _MAIN_GEAR_TAILDRAGGER_FWD_FRAC
-        lateral = fus_half_wid * _MAIN_GEAR_LATERAL_FRAC
-        for v in (+lateral, -lateral):
-            wx, wy = local_to_world(main_u, v, placement)
-            _add_wheel(ax, wx, wy)
-        # Tailwheel — near the aft tip
-        tail_u = fus_aft_x + fus_half_len * (1.0 - _NOSE_GEAR_FRAC)
-        wx, wy = local_to_world(tail_u, 0.0, placement)
-        _add_wheel(ax, wx, wy)
-    elif aircraft.gear == "monowheel":
-        # Single centred main wheel at the gear/cart origin
-        wx, wy = local_to_world(0.0, 0.0, placement)
-        _add_wheel(ax, wx, wy)
-    # No else needed — Gear is a closed Literal; mypy and the model guard all values.
 
 
 def _draw_cart_glyph(ax: Any, placement: Placement) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,99 @@
+"""Project-wide pytest helpers for hangarfit tests.
+
+Kept deliberately lazy: no module-level model construction. The 6-plane
+solver determinism canary uses a wall-clock budget (``budget_s=5.0``) and
+even a few milliseconds of extra pytest-collection cost can perturb the
+two runs into producing different layout counts. So every helper here
+constructs its objects inside its own body, on demand.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hangarfit.models import Aircraft, Gear, Part, Wheels
+
+
+def _default_parts() -> tuple[Part, ...]:
+    """Minimal valid parts tuple for a test aircraft. Built on demand to
+    keep pytest collection cheap (see module docstring)."""
+    return (
+        Part(
+            kind="fuselage_front",
+            length_m=1.0,
+            width_m=0.5,
+            offset_x_m=0.5,
+            offset_y_m=0.0,
+            angle_deg=0.0,
+            z_bottom_m=0.0,
+            z_top_m=1.0,
+        ),
+        Part(
+            kind="fuselage_aft",
+            length_m=1.0,
+            width_m=0.5,
+            offset_x_m=-0.5,
+            offset_y_m=0.0,
+            angle_deg=0.0,
+            z_bottom_m=0.0,
+            z_top_m=1.0,
+        ),
+        Part(
+            kind="wing",
+            length_m=0.5,
+            width_m=4.0,
+            offset_x_m=0.0,
+            offset_y_m=0.0,
+            angle_deg=0.0,
+            z_bottom_m=2.0,
+            z_top_m=2.2,
+        ),
+    )
+
+
+def default_wheels_for(gear: Gear) -> Wheels:
+    """Sensible default Wheels for each gear type — wheelbase 2.0 m,
+    satisfies the 0.5×–5× cross-check against ``turn_radius_m=4.0``."""
+    if gear == "monowheel":
+        return Wheels(main_offset_x_m=0.0, track_m=None, third_wheel_offset_x_m=None)
+    if gear == "tailwheel":
+        return Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0)
+    return Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=2.0)
+
+
+def make_test_aircraft(
+    *,
+    id: str = "test_plane",
+    name: str = "Test",
+    wing_position: str = "high",
+    gear: Gear = "nosewheel",
+    movement_mode: str = "always_own_gear",
+    turn_radius_m: float | None = 4.0,
+    measured: bool = False,
+    parts: tuple[Part, ...] | None = None,
+    notes: str = "",
+    wheels: Wheels | None = None,
+    **overrides: Any,
+) -> Aircraft:
+    """Build a minimal valid Aircraft for tests.
+
+    ``wheels`` defaults to a gear-appropriate Wheels via :func:`default_wheels_for`
+    when not supplied. ``**overrides`` are forwarded as additional Aircraft kwargs.
+    """
+    if wheels is None:
+        wheels = default_wheels_for(gear)
+    if parts is None:
+        parts = _default_parts()
+    return Aircraft(
+        id=id,
+        name=name,
+        wing_position=wing_position,  # type: ignore[arg-type]
+        gear=gear,
+        movement_mode=movement_mode,  # type: ignore[arg-type]
+        turn_radius_m=turn_radius_m,
+        measured=measured,
+        parts=parts,
+        notes=notes,
+        wheels=wheels,
+        **overrides,
+    )

--- a/tests/fuzz/strategies.py
+++ b/tests/fuzz/strategies.py
@@ -22,7 +22,7 @@ from hypothesis import strategies as st
 
 from hangarfit import loader
 from hangarfit.loader import LoaderError
-from hangarfit.models import Aircraft, Door, Hangar, MaintenanceBay, Part
+from hangarfit.models import Aircraft, Door, Hangar, MaintenanceBay, Part, Wheels
 
 # --- valid in-memory fixtures used as fleet/hangar overrides for layout/scenario.
 # Built directly with model constructors so they pass __post_init__; this lets
@@ -56,6 +56,7 @@ VALID_FLEET: dict[str, Aircraft] = {
         turn_radius_m=None,
         measured=False,
         parts=(_FUSELAGE,),
+        wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=2.0),
     ),
     "p2": Aircraft(
         id="p2",
@@ -66,6 +67,7 @@ VALID_FLEET: dict[str, Aircraft] = {
         turn_radius_m=None,
         measured=False,
         parts=(_FUSELAGE,),
+        wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
     ),
 }
 

--- a/tests/test_collisions.py
+++ b/tests/test_collisions.py
@@ -289,6 +289,7 @@ class TestBayIntrusion:
             MaintenanceBay,
             Part,
             Placement,
+            Wheels,
         )
 
         # 1×1 m wing at z=2..2.3 — a single-rectangle part lets us reason
@@ -313,6 +314,7 @@ class TestBayIntrusion:
                     z_top_m=2.3,
                 ),
             ),
+            wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
         )
         # Bay: x ∈ (10, 18), y ∈ (16, 25].
         hangar = Hangar(
@@ -359,6 +361,7 @@ class TestBayIntrusion:
                     z_top_m=1.0,
                 ),
             ),
+            wheels=Wheels(main_offset_x_m=0.0, track_m=None, third_wheel_offset_x_m=None),
         )
         return Layout(
             fleet={"probe": small_wing, "occupant": occupant},

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -21,7 +21,7 @@ from hangarfit.geometry import (
     polygon_overlap,
     polygon_overlap_area,
 )
-from hangarfit.models import Aircraft, Part, Placement
+from hangarfit.models import Aircraft, Part, Placement, Wheels
 
 SQRT2_2 = math.sqrt(2) / 2  # ≈ 0.7071...
 
@@ -197,6 +197,7 @@ def _aircraft_with_one_part(
         turn_radius_m=turn_radius_m,
         measured=False,
         parts=(part,),
+        wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
     )
 
 
@@ -505,6 +506,7 @@ class TestWorldPartMetadata:
             turn_radius_m=5.0,
             measured=False,
             parts=parts,
+            wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
         )
         pl = Placement(plane_id="multipart", x_m=5.0, y_m=10.0, heading_deg=37.0, on_carts=False)
         worlds = aircraft_parts_world(ac, pl)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -452,6 +452,10 @@ aircraft:
         width_m: 9.0
         z_bottom_m: 2.0
         z_top_m: 2.3
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 1.8
+      third_wheel_offset_x_m: -2.0
 """,
         )
         with pytest.raises(LoaderError, match="movement_mode must be one of"):
@@ -481,6 +485,10 @@ aircraft:
         width_m: 9.0
         z_bottom_m: 2.0
         z_top_m: 2.3
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 1.8
+      third_wheel_offset_x_m: -2.0
 """,
         )
         with pytest.raises(LoaderError, match="aircraft 'bad_husky'.*turn_radius_m is required"):
@@ -647,6 +655,10 @@ aircraft:
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.8
       width_m: 0.05
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 1.8
+      third_wheel_offset_x_m: -2.0
 """,
         )
         fleet = load_fleet(path)
@@ -702,6 +714,10 @@ aircraft:
       fuselage_attach_z_m: 0.5
       wing_attach_y_m: 1.8
       width_m: 0.05
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 1.8
+      third_wheel_offset_x_m: -2.0
 """,
         )
         fleet = load_fleet(path)
@@ -799,6 +815,10 @@ aircraft:
         offset_x_m: {wing_offset_x}
         z_bottom_m: 2.0
         z_top_m: 2.3
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 1.8
+      third_wheel_offset_x_m: -2.0
 """
 
     def test_fuselage_splits_into_one_front_one_aft(self, tmp_path: Path) -> None:
@@ -942,6 +962,8 @@ aircraft:
         offset_x_m: -2.5
         z_bottom_m: 0.0
         z_top_m: 1.5
+    wheels:
+      main_offset_x_m: 0.0
 """,
         )
         a = load_fleet(path)["explicit"]
@@ -1557,6 +1579,10 @@ def _aircraft_entry(
         width_m: 9.0
         z_bottom_m: 2.0
         z_top_m: 2.3
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 1.8
+      third_wheel_offset_x_m: -2.0
 """
 
 

--- a/tests/test_loader_wheels.py
+++ b/tests/test_loader_wheels.py
@@ -143,6 +143,114 @@ class TestWheelsLoadingErrorPaths:
             load_fleet(_write(tmp_path / "f.yaml", body))
 
 
+class TestCrossCheck:
+    """Loader cross-check: turn_radius_m must be plausible vs wheel-derived wheelbase.
+
+    Band is 0.5×–5× wheelbase (own-gear, non-monowheel). always_cart
+    (turn_radius_m=None) and monowheel (no wheelbase) are skipped. See ADR-0013.
+    """
+
+    def test_own_gear_within_band_passes(self, tmp_path: Path) -> None:
+        # wheelbase = abs(2.5 - (-0.1)) = 2.6; turn_radius_m=4.0 ∈ [1.3, 13.0]
+        body = _with_wheels_block(
+            "    wheels:\n"
+            "      main_offset_x_m: -0.10\n"
+            "      track_m: 1.80\n"
+            "      third_wheel_offset_x_m: 2.50\n"
+        )
+        load_fleet(_write(tmp_path / "f.yaml", body))  # no raise
+
+    def test_turn_radius_below_band_rejected(self, tmp_path: Path) -> None:
+        # wheelbase = 10.0; band [5.0, 50.0]; turn_radius_m=4.0 too small
+        body = _with_wheels_block(
+            "    wheels:\n"
+            "      main_offset_x_m: -5.0\n"
+            "      track_m: 1.80\n"
+            "      third_wheel_offset_x_m: 5.0\n"
+        )
+        with pytest.raises(LoaderError, match=r"implausible.*wheelbase"):
+            load_fleet(_write(tmp_path / "f.yaml", body))
+
+    def test_turn_radius_above_band_rejected(self, tmp_path: Path) -> None:
+        # wheelbase = 0.4; band [0.2, 2.0]; turn_radius_m=4.0 too big
+        body = _with_wheels_block(
+            "    wheels:\n"
+            "      main_offset_x_m: -0.10\n"
+            "      track_m: 1.80\n"
+            "      third_wheel_offset_x_m: 0.30\n"
+        )
+        with pytest.raises(LoaderError, match=r"implausible.*wheelbase"):
+            load_fleet(_write(tmp_path / "f.yaml", body))
+
+    def test_always_cart_skips_cross_check(self, tmp_path: Path) -> None:
+        """always_cart aircraft (turn_radius_m: null) skip the band check."""
+        body = dedent(
+            """\
+            aircraft:
+              - id: cart_plane
+                name: "Cart Test"
+                wing_position: high
+                gear: nosewheel
+                movement_mode: always_cart
+                turn_radius_m: null
+                measured: false
+                parts:
+                  - kind: fuselage
+                    length_m: 6.0
+                    width_m: 0.8
+                    offset_x_m: 0.0
+                    offset_y_m: 0.0
+                    z_bottom_m: 0.0
+                    z_top_m: 1.4
+                  - kind: wing
+                    length_m: 1.2
+                    width_m: 9.0
+                    offset_x_m: 0.5
+                    offset_y_m: 0.0
+                    z_bottom_m: 2.0
+                    z_top_m: 2.2
+                wheels:
+                  main_offset_x_m: -5.0
+                  track_m: 1.8
+                  third_wheel_offset_x_m: 5.0
+            """
+        )
+        load_fleet(_write(tmp_path / "f.yaml", body))  # no raise: wheelbase=10 vs radius=null
+
+    def test_monowheel_skips_cross_check(self, tmp_path: Path) -> None:
+        """Monowheel aircraft have no wheelbase concept; check is skipped."""
+        body = dedent(
+            """\
+            aircraft:
+              - id: mono_plane
+                name: "Mono Test"
+                wing_position: high
+                gear: monowheel
+                movement_mode: always_own_gear
+                turn_radius_m: 100.0
+                measured: false
+                parts:
+                  - kind: fuselage
+                    length_m: 6.0
+                    width_m: 0.7
+                    offset_x_m: 0.0
+                    offset_y_m: 0.0
+                    z_bottom_m: 0.0
+                    z_top_m: 1.4
+                  - kind: wing
+                    length_m: 1.2
+                    width_m: 18.0
+                    offset_x_m: 1.5
+                    offset_y_m: 0.0
+                    z_bottom_m: 2.0
+                    z_top_m: 2.2
+                wheels:
+                  main_offset_x_m: 0.0
+            """
+        )
+        load_fleet(_write(tmp_path / "f.yaml", body))  # no raise — no wheelbase to check
+
+
 class TestMonowheelHappyPath:
     """Monowheel construction path was previously only exercised via error tests."""
 

--- a/tests/test_loader_wheels.py
+++ b/tests/test_loader_wheels.py
@@ -120,6 +120,14 @@ class TestWheelsLoadingErrorPaths:
         with pytest.raises(LoaderError, match=r"tailwheel.*aft"):
             load_fleet(_write(tmp_path / "f.yaml", body))
 
+    def test_non_mapping_wheels_block_wraps_to_loader_error(self, tmp_path: Path) -> None:
+        """A non-mapping ``wheels:`` value (e.g. a mis-indented string) raises
+        an attributed LoaderError, not a bare AttributeError that escapes
+        load_fleet's per-aircraft catch tuple."""
+        body = _NOSEWHEEL_BODY + '    wheels: "not a mapping"\n'
+        with pytest.raises(LoaderError, match=r"wheels.*must be a mapping"):
+            load_fleet(_write(tmp_path / "f.yaml", body))
+
     def test_unknown_keys_rejected(self, tmp_path: Path) -> None:
         body = _with_wheels_block(
             "    wheels:\n"

--- a/tests/test_loader_wheels.py
+++ b/tests/test_loader_wheels.py
@@ -1,0 +1,135 @@
+"""Loader tests for the wheels: block (#322)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from hangarfit.loader import LoaderError, load_fleet
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# Reusable per-test body. Tests can append a `    wheels:` block (note the
+# 4-space indent so it sits at the same level as `parts:`).
+_NOSEWHEEL_BODY = dedent(
+    """\
+    aircraft:
+      - id: testplane
+        name: "Test Plane"
+        wing_position: high
+        gear: nosewheel
+        movement_mode: always_own_gear
+        turn_radius_m: 4.0
+        measured: false
+        parts:
+          - kind: fuselage
+            length_m: 6.0
+            width_m: 0.8
+            offset_x_m: 0.0
+            offset_y_m: 0.0
+            z_bottom_m: 0.0
+            z_top_m: 1.4
+          - kind: wing
+            length_m: 1.2
+            width_m: 9.0
+            offset_x_m: 0.5
+            offset_y_m: 0.0
+            z_bottom_m: 2.0
+            z_top_m: 2.2
+    """
+)
+
+
+def _with_wheels_block(extra_yaml: str) -> str:
+    """Append ``extra_yaml`` (already 4-space indented) to the body."""
+    return _NOSEWHEEL_BODY + extra_yaml
+
+
+class TestWheelsLoadingHappyPath:
+    def test_nosewheel_loads(self, tmp_path: Path) -> None:
+        body = _with_wheels_block(
+            "    wheels:\n"
+            "      main_offset_x_m: -0.10\n"
+            "      track_m: 1.80\n"
+            "      third_wheel_offset_x_m: 2.50\n"
+        )
+        fleet = load_fleet(_write(tmp_path / "f.yaml", body))
+        a = fleet["testplane"]
+        assert a.wheels is not None
+        assert a.wheels.main_offset_x_m == -0.10
+        assert a.wheels.track_m == 1.80
+        assert a.wheels.third_wheel_offset_x_m == 2.50
+
+    def test_no_wheels_block_yields_none_for_now(self, tmp_path: Path) -> None:
+        """Transitional (Task 3): missing wheels: block leaves Aircraft.wheels == None.
+
+        Task 5 flips this to raise LoaderError.
+        """
+        fleet = load_fleet(_write(tmp_path / "f.yaml", _NOSEWHEEL_BODY))
+        assert fleet["testplane"].wheels is None
+
+
+class TestWheelsLoadingErrorPaths:
+    def test_nosewheel_missing_track(self, tmp_path: Path) -> None:
+        body = _with_wheels_block(
+            "    wheels:\n      main_offset_x_m: -0.10\n      third_wheel_offset_x_m: 2.50\n"
+        )
+        with pytest.raises(LoaderError, match=r"wheels.*track_m"):
+            load_fleet(_write(tmp_path / "f.yaml", body))
+
+    def test_nosewheel_missing_third_wheel(self, tmp_path: Path) -> None:
+        body = _with_wheels_block(
+            "    wheels:\n      main_offset_x_m: -0.10\n      track_m: 1.80\n"
+        )
+        with pytest.raises(LoaderError, match=r"wheels.*third_wheel_offset_x_m"):
+            load_fleet(_write(tmp_path / "f.yaml", body))
+
+    def test_monowheel_with_track_rejected(self, tmp_path: Path) -> None:
+        body = (
+            _NOSEWHEEL_BODY.replace("gear: nosewheel", "gear: monowheel") + "    wheels:\n"
+            "      main_offset_x_m: 0.0\n"
+            "      track_m: 1.80\n"
+            "      third_wheel_offset_x_m: 2.50\n"
+        )
+        with pytest.raises(LoaderError, match=r"monowheel.*track_m"):
+            load_fleet(_write(tmp_path / "f.yaml", body))
+
+    def test_nosewheel_third_wheel_behind_mains_rejected(self, tmp_path: Path) -> None:
+        body = _with_wheels_block(
+            "    wheels:\n"
+            "      main_offset_x_m: 0.0\n"
+            "      track_m: 1.80\n"
+            "      third_wheel_offset_x_m: -2.50\n"  # WRONG sign for nosewheel
+        )
+        with pytest.raises(LoaderError, match=r"nosewheel.*forward"):
+            load_fleet(_write(tmp_path / "f.yaml", body))
+
+    def test_tailwheel_third_wheel_forward_of_mains_rejected(self, tmp_path: Path) -> None:
+        body = (
+            _NOSEWHEEL_BODY.replace("gear: nosewheel", "gear: tailwheel").replace(
+                "turn_radius_m: 4.0", "turn_radius_m: 5.0"
+            )
+            + "    wheels:\n"
+            "      main_offset_x_m: 0.20\n"
+            "      track_m: 1.80\n"
+            "      third_wheel_offset_x_m: 3.00\n"  # WRONG sign for tailwheel
+        )
+        with pytest.raises(LoaderError, match=r"tailwheel.*aft"):
+            load_fleet(_write(tmp_path / "f.yaml", body))
+
+    def test_unknown_keys_rejected(self, tmp_path: Path) -> None:
+        body = _with_wheels_block(
+            "    wheels:\n"
+            "      main_offset_x_m: -0.10\n"
+            "      track_m: 1.80\n"
+            "      third_wheel_offset_x_m: 2.50\n"
+            "      bogus_field: 1.0\n"
+        )
+        with pytest.raises(LoaderError, match=r"unknown.*bogus_field"):
+            load_fleet(_write(tmp_path / "f.yaml", body))

--- a/tests/test_loader_wheels.py
+++ b/tests/test_loader_wheels.py
@@ -133,3 +133,39 @@ class TestWheelsLoadingErrorPaths:
         )
         with pytest.raises(LoaderError, match=r"unknown.*bogus_field"):
             load_fleet(_write(tmp_path / "f.yaml", body))
+
+    def test_non_positive_track_wraps_to_loader_error(self, tmp_path: Path) -> None:
+        """Wheels.__post_init__ raises ValueError on track_m<=0; loader wraps it."""
+        body = _with_wheels_block(
+            "    wheels:\n"
+            "      main_offset_x_m: -0.10\n"
+            "      track_m: 0.0\n"
+            "      third_wheel_offset_x_m: 2.50\n"
+        )
+        with pytest.raises(LoaderError, match=r"track_m must be positive"):
+            load_fleet(_write(tmp_path / "f.yaml", body))
+
+
+class TestMonowheelHappyPath:
+    """Monowheel construction path was previously only exercised via error tests."""
+
+    def test_monowheel_loads_with_only_main_offset(self, tmp_path: Path) -> None:
+        body = (
+            _NOSEWHEEL_BODY.replace("gear: nosewheel", "gear: monowheel").replace(
+                "movement_mode: always_own_gear", "movement_mode: always_cart"
+            )
+            + "    turn_radius_m: null\n"  # always_cart requires null
+            + "    wheels:\n"
+            "      main_offset_x_m: 0.0\n"
+        )
+        # Strip the inline turn_radius_m: 4.0 line that came from _NOSEWHEEL_BODY —
+        # we override it above to null for always_cart.
+        body = body.replace("    turn_radius_m: 4.0\n", "")
+        fleet = load_fleet(_write(tmp_path / "f.yaml", body))
+        a = fleet["testplane"]
+        assert a.wheels is not None
+        assert a.wheels.main_offset_x_m == 0.0
+        assert a.wheels.track_m is None
+        assert a.wheels.third_wheel_offset_x_m is None
+        assert a.wheels.positions == ((0.0, 0.0),)
+        assert a.wheels.wheelbase_m is None

--- a/tests/test_loader_wheels.py
+++ b/tests/test_loader_wheels.py
@@ -66,13 +66,10 @@ class TestWheelsLoadingHappyPath:
         assert a.wheels.track_m == 1.80
         assert a.wheels.third_wheel_offset_x_m == 2.50
 
-    def test_no_wheels_block_yields_none_for_now(self, tmp_path: Path) -> None:
-        """Transitional (Task 3): missing wheels: block leaves Aircraft.wheels == None.
-
-        Task 5 flips this to raise LoaderError.
-        """
-        fleet = load_fleet(_write(tmp_path / "f.yaml", _NOSEWHEEL_BODY))
-        assert fleet["testplane"].wheels is None
+    def test_no_wheels_block_now_raises(self, tmp_path: Path) -> None:
+        """A missing ``wheels:`` block is a hard load error (#322 ADR-0013)."""
+        with pytest.raises(LoaderError, match=r"wheels: block is required"):
+            load_fleet(_write(tmp_path / "f.yaml", _NOSEWHEEL_BODY))
 
 
 class TestWheelsLoadingErrorPaths:

--- a/tests/test_loader_wheels.py
+++ b/tests/test_loader_wheels.py
@@ -120,6 +120,18 @@ class TestWheelsLoadingErrorPaths:
         with pytest.raises(LoaderError, match=r"tailwheel.*aft"):
             load_fleet(_write(tmp_path / "f.yaml", body))
 
+    def test_unsupported_gear_rejected(self, tmp_path: Path) -> None:
+        """An unknown gear value reaches _parse_wheels (evaluated before
+        Aircraft validates gear) and raises an attributed LoaderError."""
+        body = _NOSEWHEEL_BODY.replace("gear: nosewheel", "gear: skid") + (
+            "    wheels:\n"
+            "      main_offset_x_m: -0.10\n"
+            "      track_m: 1.80\n"
+            "      third_wheel_offset_x_m: 2.50\n"
+        )
+        with pytest.raises(LoaderError, match=r"wheels.*unsupported gear 'skid'"):
+            load_fleet(_write(tmp_path / "f.yaml", body))
+
     def test_non_mapping_wheels_block_wraps_to_loader_error(self, tmp_path: Path) -> None:
         """A non-mapping ``wheels:`` value (e.g. a mis-indented string) raises
         an attributed LoaderError, not a bare AttributeError that escapes

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,6 +51,8 @@ def _ok_aircraft(
     turn_radius_m: float | None = 5.0,
     **overrides: object,
 ) -> Aircraft:
+    if "wheels" not in overrides:
+        overrides["wheels"] = Wheels(main_offset_x_m=0.20, track_m=1.8, third_wheel_offset_x_m=-2.0)
     return Aircraft(
         id=plane_id,
         name=f"Test Plane {plane_id}",
@@ -222,6 +224,7 @@ class TestAircraft:
                 turn_radius_m=None,
                 measured=False,
                 parts=(_ok_part(),),
+                wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
             )
 
     def test_empty_parts_rejected(self) -> None:
@@ -235,6 +238,7 @@ class TestAircraft:
                 turn_radius_m=None,
                 measured=False,
                 parts=(),
+                wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
             )
 
     def test_own_gear_requires_turn_radius(self) -> None:
@@ -302,6 +306,7 @@ class TestAircraft:
                 turn_radius_m=None,
                 measured=False,
                 parts=(_ok_part(),),
+                wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
             )
 
     @pytest.mark.parametrize("gear", ["", "skis", "Tailwheel", "floats", "TRICYCLE"])
@@ -316,6 +321,7 @@ class TestAircraft:
                 turn_radius_m=None,
                 measured=False,
                 parts=(_ok_part(),),
+                wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
             )
 
     @pytest.mark.parametrize(
@@ -332,6 +338,7 @@ class TestAircraft:
                 turn_radius_m=5.0,
                 measured=False,
                 parts=(_ok_part(),),
+                wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
             )
 
 
@@ -1309,11 +1316,6 @@ class TestWheels:
 
 
 class TestAircraftWheels:
-    def test_aircraft_wheels_defaults_to_none(self) -> None:
-        """Transitional state: existing Aircraft constructions still work without wheels."""
-        a = _ok_aircraft()
-        assert a.wheels is None
-
     def test_aircraft_accepts_wheels(self) -> None:
         """Aircraft accepts a Wheels instance when supplied."""
         w = Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,6 +20,7 @@ from hangarfit.models import (
     SolverDiagnostics,
     SolveResult,
     StrutsSpec,
+    Wheels,
 )
 
 
@@ -1260,3 +1261,46 @@ def test_solve_result_rejects_misaligned_min_pairwise_gap_m():
             plans=(None,),
             diagnostics=diag,
         )
+
+
+class TestWheels:
+    def test_monowheel_positions_single(self) -> None:
+        w = Wheels(main_offset_x_m=0.0, track_m=None, third_wheel_offset_x_m=None)
+        assert w.positions == [(0.0, 0.0)]
+        assert w.wheelbase_m is None
+
+    def test_monowheel_offset_non_zero_main(self) -> None:
+        w = Wheels(main_offset_x_m=-0.5, track_m=None, third_wheel_offset_x_m=None)
+        assert w.positions == [(-0.5, 0.0)]
+
+    def test_nosewheel_three_positions_in_order(self) -> None:
+        w = Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50)
+        assert w.positions == [(-0.10, 0.90), (-0.10, -0.90), (2.50, 0.0)]
+        assert w.wheelbase_m == pytest.approx(2.60)
+
+    def test_tailwheel_three_positions_in_order(self) -> None:
+        w = Wheels(main_offset_x_m=0.20, track_m=1.80, third_wheel_offset_x_m=-3.40)
+        assert w.positions == [(0.20, 0.90), (0.20, -0.90), (-3.40, 0.0)]
+        assert w.wheelbase_m == pytest.approx(3.60)
+
+    def test_rejects_track_without_third_wheel(self) -> None:
+        with pytest.raises(ValueError, match="track_m requires third_wheel_offset_x_m"):
+            Wheels(main_offset_x_m=0.0, track_m=1.5, third_wheel_offset_x_m=None)
+
+    def test_rejects_third_wheel_without_track(self) -> None:
+        with pytest.raises(ValueError, match="third_wheel_offset_x_m requires track_m"):
+            Wheels(main_offset_x_m=0.0, track_m=None, third_wheel_offset_x_m=2.0)
+
+    def test_rejects_non_positive_track(self) -> None:
+        with pytest.raises(ValueError, match="track_m must be positive"):
+            Wheels(main_offset_x_m=0.0, track_m=0.0, third_wheel_offset_x_m=2.0)
+        with pytest.raises(ValueError, match="track_m must be positive"):
+            Wheels(main_offset_x_m=0.0, track_m=-1.0, third_wheel_offset_x_m=2.0)
+
+    def test_rejects_non_finite_values(self) -> None:
+        import math
+
+        with pytest.raises(ValueError, match="must be finite"):
+            Wheels(main_offset_x_m=math.inf, track_m=None, third_wheel_offset_x_m=None)
+        with pytest.raises(ValueError, match="must be finite"):
+            Wheels(main_offset_x_m=0.0, track_m=math.nan, third_wheel_offset_x_m=2.0)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1313,6 +1313,8 @@ class TestWheels:
             Wheels(main_offset_x_m=math.inf, track_m=None, third_wheel_offset_x_m=None)
         with pytest.raises(ValueError, match="must be finite"):
             Wheels(main_offset_x_m=0.0, track_m=math.nan, third_wheel_offset_x_m=2.0)
+        with pytest.raises(ValueError, match="third_wheel_offset_x_m must be finite"):
+            Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=math.inf)
 
 
 class TestAircraftWheels:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1266,21 +1266,21 @@ def test_solve_result_rejects_misaligned_min_pairwise_gap_m():
 class TestWheels:
     def test_monowheel_positions_single(self) -> None:
         w = Wheels(main_offset_x_m=0.0, track_m=None, third_wheel_offset_x_m=None)
-        assert w.positions == [(0.0, 0.0)]
+        assert w.positions == ((0.0, 0.0),)
         assert w.wheelbase_m is None
 
     def test_monowheel_offset_non_zero_main(self) -> None:
         w = Wheels(main_offset_x_m=-0.5, track_m=None, third_wheel_offset_x_m=None)
-        assert w.positions == [(-0.5, 0.0)]
+        assert w.positions == ((-0.5, 0.0),)
 
     def test_nosewheel_three_positions_in_order(self) -> None:
         w = Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50)
-        assert w.positions == [(-0.10, 0.90), (-0.10, -0.90), (2.50, 0.0)]
+        assert w.positions == ((-0.10, 0.90), (-0.10, -0.90), (2.50, 0.0))
         assert w.wheelbase_m == pytest.approx(2.60)
 
     def test_tailwheel_three_positions_in_order(self) -> None:
         w = Wheels(main_offset_x_m=0.20, track_m=1.80, third_wheel_offset_x_m=-3.40)
-        assert w.positions == [(0.20, 0.90), (0.20, -0.90), (-3.40, 0.0)]
+        assert w.positions == ((0.20, 0.90), (0.20, -0.90), (-3.40, 0.0))
         assert w.wheelbase_m == pytest.approx(3.60)
 
     def test_rejects_track_without_third_wheel(self) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -49,6 +49,7 @@ def _ok_aircraft(
     *,
     movement_mode: str = "always_own_gear",
     turn_radius_m: float | None = 5.0,
+    **overrides: object,
 ) -> Aircraft:
     return Aircraft(
         id=plane_id,
@@ -59,6 +60,7 @@ def _ok_aircraft(
         turn_radius_m=turn_radius_m,
         measured=False,
         parts=(_ok_part(),),
+        **overrides,  # type: ignore[arg-type]
     )
 
 
@@ -1304,3 +1306,16 @@ class TestWheels:
             Wheels(main_offset_x_m=math.inf, track_m=None, third_wheel_offset_x_m=None)
         with pytest.raises(ValueError, match="must be finite"):
             Wheels(main_offset_x_m=0.0, track_m=math.nan, third_wheel_offset_x_m=2.0)
+
+
+class TestAircraftWheels:
+    def test_aircraft_wheels_defaults_to_none(self) -> None:
+        """Transitional state: existing Aircraft constructions still work without wheels."""
+        a = _ok_aircraft()
+        assert a.wheels is None
+
+    def test_aircraft_accepts_wheels(self) -> None:
+        """Aircraft accepts a Wheels instance when supplied."""
+        w = Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50)
+        a = _ok_aircraft(wheels=w)
+        assert a.wheels is w

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -1232,7 +1232,7 @@ def test_plane_footprint_area_does_not_double_count_tail():
     instead of max-of-lengths, or any path that surfaces the duplicate)
     can't silently regress.
     """
-    from hangarfit.models import Aircraft, Part
+    from hangarfit.models import Aircraft, Part, Wheels
     from hangarfit.solver import _plane_footprint_area
 
     # Geometry: post-split fuselage segments + a standalone tail + a wing.
@@ -1287,6 +1287,7 @@ def test_plane_footprint_area_does_not_double_count_tail():
         turn_radius_m=6.0,
         measured=False,
         parts=(fuselage_front, fuselage_aft, tail, wing),
+        wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
     )
 
     # Expected: reconstructed fuselage span runs from the tail's tail-end

--- a/tests/test_towplanner_dubins.py
+++ b/tests/test_towplanner_dubins.py
@@ -13,7 +13,7 @@ import math
 import pytest
 
 from hangarfit.geometry import aircraft_parts_world
-from hangarfit.models import Aircraft, Part, Placement
+from hangarfit.models import Aircraft, Part, Placement, Wheels
 from hangarfit.towplanner import Pose, _dubins_shortest, compass_to_math_rad, plan_dubins
 
 
@@ -48,6 +48,7 @@ def _canary_aircraft(*, offset_y_m: float, turn_radius_m: float = 5.0) -> Aircra
         turn_radius_m=turn_radius_m,
         measured=False,
         parts=(part,),
+        wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
     )
 
 

--- a/tests/test_towplanner_entry_cone.py
+++ b/tests/test_towplanner_entry_cone.py
@@ -23,6 +23,7 @@ from hangarfit.models import (
     MaintenanceBay,
     Part,
     Placement,
+    Wheels,
 )
 from hangarfit.towplanner import (
     Pose,
@@ -80,6 +81,7 @@ def _box_plane(pid: str, *, turn_radius_m: float = 4.0) -> Aircraft:
                 z_top_m=1.0,
             ),
         ),
+        wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
     )
 
 
@@ -115,6 +117,7 @@ def _wide_plane(pid: str, *, span_m: float = 6.0, turn_radius_m: float = 3.0) ->
                 z_top_m=1.8,
             ),
         ),
+        wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
     )
 
 

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -20,8 +20,11 @@ from hangarfit.models import (
     MaintenanceBay,
     Part,
     Placement,
+    Wheels,
 )
 from hangarfit.towplanner import MovesPlan, NoFeasiblePlanError, Pose, entry_pose, plan_fill
+
+_TAIL_WHEELS = Wheels(main_offset_x_m=0.20, track_m=1.8, third_wheel_offset_x_m=-2.0)
 
 
 def _fuselage_box() -> Part:
@@ -51,6 +54,7 @@ def _box_plane(plane_id: str, *, turn_radius_m: float = 4.0) -> Aircraft:
         turn_radius_m=turn_radius_m,
         measured=False,
         parts=(_fuselage_box(),),
+        wheels=_TAIL_WHEELS,
     )
 
 
@@ -65,6 +69,7 @@ def _always_cart_plane(plane_id: str) -> Aircraft:
         turn_radius_m=None,
         measured=False,
         parts=(_fuselage_box(),),
+        wheels=_TAIL_WHEELS,
     )
 
 
@@ -277,6 +282,7 @@ def test_plan_fill_routes_origin_spanning_planes() -> None:
                     z_top_m=1.0,
                 ),
             ),
+            wheels=_TAIL_WHEELS,
         )
 
     # 30 × 30 m hangar so both slots are well inside the back wall.

--- a/tests/test_towplanner_motion.py
+++ b/tests/test_towplanner_motion.py
@@ -36,8 +36,19 @@ from __future__ import annotations
 
 import pytest
 
-from hangarfit.models import Aircraft, Door, Hangar, Layout, MaintenanceBay, Part, Placement
+from hangarfit.models import (
+    Aircraft,
+    Door,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    Placement,
+    Wheels,
+)
 from hangarfit.towplanner import Pose, path_first_conflict, plan_dubins
+
+_TAIL_WHEELS = Wheels(main_offset_x_m=0.20, track_m=1.8, third_wheel_offset_x_m=-2.0)
 
 
 def _fuselage_box() -> Part:
@@ -69,6 +80,7 @@ def _box_plane(plane_id: str, *, turn_radius_m: float = 4.0) -> Aircraft:
         turn_radius_m=turn_radius_m,
         measured=False,
         parts=(_fuselage_box(),),
+        wheels=_TAIL_WHEELS,
     )
 
 
@@ -84,6 +96,7 @@ def _cart_plane(plane_id: str, *, turn_radius_m: float = 4.0) -> Aircraft:
         turn_radius_m=turn_radius_m,
         measured=False,
         parts=(_fuselage_box(),),
+        wheels=_TAIL_WHEELS,
     )
 
 
@@ -116,6 +129,7 @@ def _spanning_plane(plane_id: str, *, turn_radius_m: float = 4.0) -> Aircraft:
         turn_radius_m=turn_radius_m,
         measured=False,
         parts=(_spanning_fuselage(),),
+        wheels=_TAIL_WHEELS,
     )
 
 

--- a/tests/test_towplanner_search.py
+++ b/tests/test_towplanner_search.py
@@ -2,7 +2,16 @@ import math
 
 import pytest
 
-from hangarfit.models import Aircraft, Door, Hangar, Layout, MaintenanceBay, Part, Placement
+from hangarfit.models import (
+    Aircraft,
+    Door,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    Placement,
+    Wheels,
+)
 from hangarfit.towplanner import (
     DubinsArc,
     NoFeasiblePlanError,
@@ -15,6 +24,8 @@ from hangarfit.towplanner import (
     path_first_conflict,
     plan_path,
 )
+
+_TAIL_WHEELS = Wheels(main_offset_x_m=0.20, track_m=1.8, third_wheel_offset_x_m=-2.0)
 
 
 def test_primitives_own_gear_are_six_in_lf_sf_rf_lr_sr_rr_order() -> None:
@@ -125,6 +136,7 @@ def _winged_plane(pid: str, *, span_m: float = 10.0, turn_radius_m: float = 5.0)
                 z_top_m=1.8,
             ),
         ),
+        wheels=_TAIL_WHEELS,
     )
 
 
@@ -314,6 +326,7 @@ def test_motion_clear_matches_oracle_on_small_positive_z_gap() -> None:
                     z_top_m=z_top,
                 ),
             ),
+            wheels=_TAIL_WHEELS,
         )
 
     a = _slab("A", z_bottom=1.6, z_top=2.0)
@@ -370,6 +383,7 @@ def test_motion_clear_matches_oracle_on_bay_intrusion() -> None:
                     z_top_m=1.0,
                 ),
             ),
+            wheels=_TAIL_WHEELS,
         )
 
     # "M" is the bay occupant: in the fleet but NOT in placements (Layout
@@ -443,6 +457,7 @@ def _slab_plane(pid: str, z_bottom: float, z_top: float) -> Aircraft:
                 z_top_m=z_top,
             ),
         ),
+        wheels=_TAIL_WHEELS,
     )
 
 
@@ -615,6 +630,7 @@ def test_plan_path_routes_around_a_parked_plane() -> None:
                     z_top_m=1.4,
                 ),
             ),
+            wheels=_TAIL_WHEELS,
         )
 
     h = Hangar(

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -906,8 +906,10 @@ class TestGearGlyph:
 
     # ── no fuselage defensive path ─────────────────────────────────────────────
 
-    def test_no_fuselage_part_is_a_noop(self) -> None:
-        """If an aircraft has no fuselage part (defensive path), no patches are added."""
+    def test_wheels_are_fuselage_independent(self) -> None:
+        """Post-ADR-0013 wheel placement reads ``aircraft.wheels.positions`` and
+        no longer depends on the fuselage parts — an aircraft with only a wing
+        still draws its three gear wheels from the canonical data."""
         from hangarfit.models import Aircraft, Part, Wheels
 
         wing = Part(
@@ -936,4 +938,5 @@ class TestGearGlyph:
 
         _draw_gear_glyph(ax, placement, aircraft)
 
-        ax.add_patch.assert_not_called()
+        # Three wheels (two mains + nose) drawn from wheels.positions.
+        assert ax.add_patch.call_count == 3

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -655,6 +655,8 @@ class TestGearGlyph:
             z_top_m=1.5,
         )
         turn_radius = None if movement_mode == "always_cart" else 5.0
+        from tests.conftest import default_wheels_for
+
         return Aircraft(
             id="probe",
             name="Probe",
@@ -664,6 +666,7 @@ class TestGearGlyph:
             turn_radius_m=turn_radius,
             measured=False,
             parts=(fuselage_front, fuselage_aft),
+            wheels=default_wheels_for(gear),  # type: ignore[arg-type]
         )
 
     # ── end-to-end smoke ───────────────────────────────────────────────────────
@@ -905,7 +908,7 @@ class TestGearGlyph:
 
     def test_no_fuselage_part_is_a_noop(self) -> None:
         """If an aircraft has no fuselage part (defensive path), no patches are added."""
-        from hangarfit.models import Aircraft, Part
+        from hangarfit.models import Aircraft, Part, Wheels
 
         wing = Part(
             kind="wing",
@@ -926,6 +929,7 @@ class TestGearGlyph:
             turn_radius_m=5.0,
             measured=False,
             parts=(wing,),
+            wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=2.0),
         )
         placement = self._placement(on_carts=False)
         ax = MagicMock()

--- a/tests/test_visualize_wheels.py
+++ b/tests/test_visualize_wheels.py
@@ -1,0 +1,97 @@
+"""Visualize tests for wheel glyph placement (#322).
+
+The renderer reads wheel positions from ``aircraft.wheels.positions`` (ADR-0013)
+rather than reconstructing them from heuristic fuselage fractions. These tests
+pin the count of wheel discs per gear type and guard that the cart path
+(``on_carts=True``) does not draw the plane's own gear.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.models import Placement, Wheels
+from hangarfit.visualize import _draw_gear_glyph
+from tests.conftest import make_test_aircraft
+
+
+@pytest.fixture
+def fake_ax(monkeypatch: pytest.MonkeyPatch) -> list[tuple[float, float]]:
+    """Capture every ``(wx, wy)`` passed to ``_add_wheel``."""
+    from hangarfit import visualize
+
+    captured: list[tuple[float, float]] = []
+
+    def fake_add(ax: object, wx: float, wy: float) -> None:
+        captured.append((wx, wy))
+        return None
+
+    monkeypatch.setattr(visualize, "_add_wheel", fake_add)
+    return captured
+
+
+class TestOwnGearWheelPositions:
+    def test_nosewheel_three_wheels(self, fake_ax: list[tuple[float, float]]) -> None:
+        a = make_test_aircraft(
+            gear="nosewheel",
+            wheels=Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50),
+        )
+        placement = Placement(plane_id=a.id, x_m=10.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+        _draw_gear_glyph(None, placement, a)
+        assert len(fake_ax) == 3
+
+    def test_monowheel_single_wheel(self, fake_ax: list[tuple[float, float]]) -> None:
+        a = make_test_aircraft(
+            gear="monowheel",
+            turn_radius_m=None,
+            movement_mode="always_cart",
+            wheels=Wheels(main_offset_x_m=0.0, track_m=None, third_wheel_offset_x_m=None),
+        )
+        # Force on_carts=False to exercise the own-gear path even though an
+        # always_cart monowheel is physically unusual.
+        placement = Placement(plane_id=a.id, x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        _draw_gear_glyph(None, placement, a)
+        assert len(fake_ax) == 1
+
+    def test_tailwheel_three_wheels(self, fake_ax: list[tuple[float, float]]) -> None:
+        a = make_test_aircraft(
+            gear="tailwheel",
+            wheels=Wheels(main_offset_x_m=0.20, track_m=1.80, third_wheel_offset_x_m=-3.40),
+        )
+        placement = Placement(plane_id=a.id, x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+        _draw_gear_glyph(None, placement, a)
+        assert len(fake_ax) == 3
+
+    def test_wheel_world_coords_reflect_positions(self, fake_ax: list[tuple[float, float]]) -> None:
+        """At heading 0 with no rotation, captured world coords are derivable
+        from the plane-local wheel positions via local_to_world."""
+        from hangarfit.geometry import local_to_world
+
+        wheels = Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50)
+        a = make_test_aircraft(gear="nosewheel", wheels=wheels)
+        placement = Placement(plane_id=a.id, x_m=10.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+        _draw_gear_glyph(None, placement, a)
+        expected = [local_to_world(u, v, placement) for u, v in wheels.positions]
+        assert fake_ax == expected
+
+
+class TestCartGlyphUnchanged:
+    def test_on_carts_draws_cart_not_own_gear(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression guard for #321: on_carts=True takes the cart path."""
+        from hangarfit import visualize
+
+        called: list[str] = []
+        monkeypatch.setattr(visualize, "_add_wheel", lambda *a, **k: called.append("wheel"))
+        monkeypatch.setattr(visualize, "_draw_cart_glyph", lambda *a, **k: called.append("cart"))
+
+        a = make_test_aircraft(
+            gear="nosewheel",
+            movement_mode="cart_eligible",
+            wheels=Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50),
+        )
+        placement = Placement(plane_id=a.id, x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True)
+        _draw_gear_glyph(None, placement, a)
+
+        # Cart path taken; own-gear wheels NOT drawn (cart corner wheels are
+        # internal to the patched-out _draw_cart_glyph, so none leak through here).
+        assert called == ["cart"]


### PR DESCRIPTION
## Summary

Makes wheel positions **first-class per-aircraft data**, resolving the "two representations of the same property disagree" problem surfaced in the v0.7.2 pre-release visual smoke (2026-05-28). Previously `turn_radius_m` lived in `fleet.yaml` while the renderer invented wheel glyphs from heuristic fuselage fractions, with nothing linking them.

- New `Wheels` dataclass (`main_offset_x_m`, optional `track_m`, optional `third_wheel_offset_x_m`) with `positions` / `wheelbase_m` derived properties.
- `Aircraft.wheels` is now a **required** field (breaking change to the model); a `fleet.yaml` entry with no `wheels:` block is a hard load error.
- Loader `_parse_wheels` validates the gear-keyed key set and the nose-forward / tail-aft sign rules; all 9 fleet aircraft backfilled with β-schema blocks.
- Loader cross-checks `turn_radius_m` against the wheel-derived wheelbase (**0.5×–5× band**, hard error; skipped for `always_cart` and monowheel). Deliberately loose — a sanity guard against fat-fingered values, not a derivation.
- `visualize.py` reads wheel positions from data — `_NOSE_GEAR_FRAC` / `_MAIN_GEAR_FWD_FRAC` / `_MAIN_GEAR_TAILDRAGGER_FWD_FRAC` / `_MAIN_GEAR_LATERAL_FRAC` are deleted; `_draw_gear_glyph` is now a short loop over `wheels.positions`.
- `fleet.yaml` header origin paragraph reconciled with the actual data convention (origin is a per-aircraft anchor; main-gear centroid is *derived*).
- **ADR-0013** records the decision; the missing ADR-0012 index row was added and ADR-0012's stale `_draw_gear_glyph` note now points at ADR-0013.

`turn_radius_m` stays an **independent empirical value** (kept, not re-derived) — this is what preserves the determinism contract.

## Determinism impact

**None.** `turn_radius_m` values are unchanged, so Reeds–Shepp solutions and canary baselines are stable.

- `tests/test_solver_canaries.py` — **byte-identical** (0 lines changed vs develop).
- `tests/test_towplanner_*.py` — the only diff is the required-`wheels=` field migration (import additions + fixture construction); **no expected coordinate / heading / cost assertion changed**. The Task 10 "canary diff must be 0" check is non-zero solely because the required-field flip legitimately touched towplanner fixture *construction*; the `determinism-guard` subagent re-runs the solver to confirm byte-identical output authoritatively.

## Spec & ADR

- Design spec: [`docs/superpowers/specs/2026-05-28-wheels-canonical-design.md`](docs/superpowers/specs/2026-05-28-wheels-canonical-design.md)
- Implementation plan: [`docs/superpowers/plans/2026-05-28-wheels-canonical.md`](docs/superpowers/plans/2026-05-28-wheels-canonical.md)
- [ADR-0013](docs/adr/0013-wheels-canonical-data.md)

## Test plan

- [x] Full `pytest -q` green — 1082 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy src/hangarfit/` clean
- [x] `hangarfit check layouts/example.yaml --render` produces a PNG with wheels at sensible data-driven positions (mains straddle the fuselage, third wheel fore/aft per gear; `fuji` cart overlay untouched — that's #321)
- [x] Real `data/fleet.yaml` loads (all 9 aircraft pass the 0.5×–5× band)

## Deliberately NOT in this PR

- **Cart glyph relocation** — that's #321 (`_draw_cart_glyph` / `_CART_DECK_*` untouched here).
- **Wheel collision participation** — recorded as a future decision in ADR-0013.
- **Real fleet measurements** — backfill uses public-spec estimates; `measured: false` stays (#79).

Closes #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)