### PR TITLE
feat(visualize): cart pallet under each wheel, not a body-sized deck (#321)

### DIFF
--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -122,21 +122,23 @@ _GLYPH_ZORDER = 1.5  # between wings (1) and fuselage (2)
 # COLOUR: neutral dark-gray that reads on the off-white floor, stays clear of
 # the wing-position palette (#3498db/#e67e22/#f4d03f), the conflict-red
 # (#e74c3c), and the tow-path colours. A second shade is used for the cart
-# deck so the dolly rectangle is distinct from its wheel circles.
+# pallets so each dolly square is distinct from its wheel disc.
 _WHEEL_COLOR = "#566573"  # dark slate-gray — individual wheel discs
-_CART_DECK_COLOR = "#aab7b8"  # lighter gray — cart/dolly deck rectangle
+_CART_DECK_COLOR = "#aab7b8"  # lighter gray — cart/dolly pallet squares
 _CART_DECK_ALPHA = 0.85
 
 # Wheel disc radius in meters. Visually "a tyre" at ~6–9 m fuselage scale
 # inside an 18–30 m hangar. Mirror the _NOSE_ARROW_LENGTH_M tuning idiom.
 _WHEEL_RADIUS_M = 0.18
 
-# Cart deck half-dimensions in meters. The deck rectangle is drawn under the
-# fuselage centroid. Full width is 2 × 0.55 = 1.1 m, which is ~1.3× a typical
-# 0.85 m fuselage width, so it reads as "something underneath"; length is
-# shorter (~40% of a typical 6.5 m fuselage) so it is clearly not the fuselage.
-_CART_DECK_HALF_LENGTH_M = 1.3
-_CART_DECK_HALF_WIDTH_M = 0.55
+# Cart pallet half-extent in meters (#321). A cart-borne plane no longer draws
+# one body-sized deck rectangle; instead each wheel sits on its own small
+# pallet, drawn as a square centred on the wheel position (from
+# ``aircraft.wheels.positions``) and rotated with the aircraft. At 0.4 m the
+# pallet (0.8 m across) reads as "a pallet under a tyre" — comfortably larger
+# than the 0.18 m wheel disc it backs, yet far smaller than the ~6.5 m
+# fuselage, so it never masquerades as the body.
+_CART_PALLET_HALF_EXTENT_M = 0.4
 
 
 def render_layout(
@@ -425,38 +427,36 @@ def _draw_gear_glyph(ax: Any, placement: Placement, aircraft: Aircraft) -> None:
     coords through ``local_to_world`` so the gear rotates with the aircraft
     heading.
 
-    When the plane rides on a cart (``placement.on_carts=True``), the cart-deck
-    glyph is drawn instead of the plane's own gear (see ``_draw_cart_glyph``).
+    When the plane rides on a cart (``placement.on_carts=True``), a small cart
+    pallet is drawn under each wheel instead of the plane's own bare gear (see
+    ``_draw_cart_glyph``).
     """
     if placement.on_carts:
-        _draw_cart_glyph(ax, placement)
+        _draw_cart_glyph(ax, placement, aircraft)
         return
     for u, v in aircraft.wheels.positions:
         wx, wy = local_to_world(u, v, placement)
         _add_wheel(ax, wx, wy)
 
 
-def _draw_cart_glyph(ax: Any, placement: Placement) -> None:
-    """Draw a four-wheel dolly/cart glyph centred at the gear origin.
+def _add_cart_pallet(ax: Any, u: float, v: float, placement: Placement) -> MplPolygon:
+    """Add one small square cart pallet centred on plane-local wheel ``(u, v)``.
 
-    The deck rectangle is sized by the module constants
-    ``_CART_DECK_HALF_LENGTH_M`` / ``_CART_DECK_HALF_WIDTH_M`` and rotated
-    with ``placement.heading_deg`` via the standard world-transform.  Four
-    small wheel discs sit at the deck corners so the glyph reads as a
-    wheeled dolly rather than a coloured rectangle.
+    The pallet's four corners are offset by ``±_CART_PALLET_HALF_EXTENT_M`` in
+    plane-local space and mapped to world coordinates via ``local_to_world`` so
+    the pallet rotates with ``placement.heading_deg`` — exactly the transform
+    the own-gear wheel loop uses for the disc centres.
     """
-    # Deck corners in plane-local coordinates (centred at origin, ±L, ±W).
-    hl = _CART_DECK_HALF_LENGTH_M
-    hw = _CART_DECK_HALF_WIDTH_M
-    corner_locals = [
-        (+hl, +hw),
-        (+hl, -hw),
-        (-hl, -hw),
-        (-hl, +hw),
-    ]
-    deck_world = [local_to_world(u, v, placement) for u, v in corner_locals]
-    deck_patch = MplPolygon(
-        deck_world,
+    h = _CART_PALLET_HALF_EXTENT_M
+    corner_locals = (
+        (u + h, v + h),
+        (u + h, v - h),
+        (u - h, v - h),
+        (u - h, v + h),
+    )
+    corner_world = [local_to_world(cu, cv, placement) for cu, cv in corner_locals]
+    pallet = MplPolygon(
+        corner_world,
         closed=True,
         facecolor=_CART_DECK_COLOR,
         edgecolor=_WHEEL_COLOR,
@@ -464,10 +464,23 @@ def _draw_cart_glyph(ax: Any, placement: Placement) -> None:
         lw=0.8,
         zorder=_GLYPH_ZORDER,
     )
-    ax.add_patch(deck_patch)
+    ax.add_patch(pallet)
+    return pallet
 
-    # Four corner wheel discs.
-    for u, v in corner_locals:
+
+def _draw_cart_glyph(ax: Any, placement: Placement, aircraft: Aircraft) -> None:
+    """Draw a cart pallet under each wheel of a cart-borne aircraft (#321).
+
+    Physically the cart sits under the wheels: each wheel rides on its own
+    pallet. This draws a small square pallet (``_CART_PALLET_HALF_EXTENT_M``)
+    centred on every wheel position from ``aircraft.wheels.positions`` — the
+    same canonical plane-local coordinates the own-gear path consumes — with a
+    wheel disc on top of each. The number of pallets therefore equals the wheel
+    count: 1 for a monowheel, 3 for a tricycle/tailwheel. The old single
+    body-sized deck rectangle is gone; nothing here spans the fuselage.
+    """
+    for u, v in aircraft.wheels.positions:
+        _add_cart_pallet(ax, u, v, placement)
         wx, wy = local_to_world(u, v, placement)
         _add_wheel(ax, wx, wy)
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -31,6 +31,7 @@ from hangarfit.models import Aircraft, Placement
 from hangarfit.visualize import (
     _BAY_WALL_FACE,
     _CART_DECK_COLOR,
+    _CART_PALLET_HALF_EXTENT_M,
     _GLYPH_ZORDER,
     _WHEEL_COLOR,
     _draw_gear_glyph,
@@ -602,7 +603,9 @@ class TestGearGlyph:
         * ``nosewheel`` + ``on_carts=False`` → 3 wheel circles (1 nose + 2 mains)
         * ``tailwheel`` + ``on_carts=False`` → 3 wheel circles (2 mains + 1 tail)
         * ``monowheel`` + ``on_carts=False`` → 1 wheel circle
-        * ``on_carts=True`` (any gear) → 1 deck Polygon + 4 corner wheel circles
+        * ``on_carts=True`` (#321) → one small pallet Polygon + one wheel circle
+          per wheel position (3 of each for tricycle/tailwheel, 1 each for
+          monowheel); never a single body-sized deck rectangle
 
     Patch counting is feasible here (unlike pixel tests) because the glyph
     functions make a bounded, deterministic number of ``ax.add_patch`` calls.
@@ -776,9 +779,54 @@ class TestGearGlyph:
 
     # ── cart glyph ─────────────────────────────────────────────────────────────
 
-    def test_on_carts_adds_deck_polygon_plus_four_wheel_circles(self) -> None:
-        """Cart glyph: 1 deck Polygon + 4 corner Circle patches = 5 total."""
+    def test_on_carts_draws_one_pallet_and_wheel_per_wheel_position(self) -> None:
+        """#321: cart glyph draws one small pallet Polygon + one wheel Circle per
+        wheel position. A tailwheel plane has 3 wheels → 3 pallets + 3 wheels = 6
+        patches (never a single body-sized deck rectangle)."""
         from matplotlib.patches import Circle
+        from matplotlib.patches import Polygon as MplPolygon
+
+        aircraft = self._aircraft("tailwheel", movement_mode="always_cart")
+        n = len(aircraft.wheels.positions)
+        assert n == 3, "tailwheel fixture should expose 3 wheel positions"
+        placement = self._placement(on_carts=True)
+        ax = MagicMock()
+
+        _draw_gear_glyph(ax, placement, aircraft)
+
+        patches = [c.args[0] for c in ax.add_patch.call_args_list]
+        polygon_count = sum(1 for p in patches if isinstance(p, MplPolygon))
+        circle_count = sum(1 for p in patches if isinstance(p, Circle))
+        assert polygon_count == n, f"expected {n} pallet Polygons; got {polygon_count}"
+        assert circle_count == n, f"expected {n} wheel Circles; got {circle_count}"
+        assert ax.add_patch.call_count == 2 * n, (
+            f"cart glyph expects {2 * n} patches ({n} pallets + {n} wheels); "
+            f"got {ax.add_patch.call_count}"
+        )
+
+    def test_on_carts_monowheel_draws_single_pallet(self) -> None:
+        """#321: a monowheel cart-borne plane draws exactly 1 pallet + 1 wheel."""
+        from matplotlib.patches import Circle
+        from matplotlib.patches import Polygon as MplPolygon
+
+        aircraft = self._aircraft("monowheel", movement_mode="always_cart")
+        assert len(aircraft.wheels.positions) == 1
+        placement = self._placement(on_carts=True)
+        ax = MagicMock()
+
+        _draw_gear_glyph(ax, placement, aircraft)
+
+        patches = [c.args[0] for c in ax.add_patch.call_args_list]
+        assert sum(1 for p in patches if isinstance(p, MplPolygon)) == 1
+        assert sum(1 for p in patches if isinstance(p, Circle)) == 1
+        assert ax.add_patch.call_count == 2
+
+    def test_on_carts_pallet_is_not_body_sized(self) -> None:
+        """#321 regression: each pallet is small (per-wheel), not a body-spanning
+        rectangle. Pallet world extent must be far below the ~7 m fuselage span —
+        bounded by the pallet diagonal (2·√2·half-extent)."""
+        import math
+
         from matplotlib.patches import Polygon as MplPolygon
 
         aircraft = self._aircraft("tailwheel", movement_mode="always_cart")
@@ -787,17 +835,20 @@ class TestGearGlyph:
 
         _draw_gear_glyph(ax, placement, aircraft)
 
-        assert ax.add_patch.call_count == 5, (
-            f"cart glyph expects 5 patches (1 deck + 4 wheels); got {ax.add_patch.call_count}"
-        )
-        patches = [c.args[0] for c in ax.add_patch.call_args_list]
-        polygon_count = sum(1 for p in patches if isinstance(p, MplPolygon))
-        circle_count = sum(1 for p in patches if isinstance(p, Circle))
-        assert polygon_count == 1, f"expected 1 deck Polygon; got {polygon_count}"
-        assert circle_count == 4, f"expected 4 corner Circle wheels; got {circle_count}"
+        max_pallet_span = 2.0 * math.sqrt(2.0) * _CART_PALLET_HALF_EXTENT_M
+        for call in ax.add_patch.call_args_list:
+            patch = call.args[0]
+            if not isinstance(patch, MplPolygon):
+                continue
+            xy = patch.get_xy()
+            xs = [p[0] for p in xy]
+            ys = [p[1] for p in xy]
+            assert (max(xs) - min(xs)) <= max_pallet_span + 1e-9
+            assert (max(ys) - min(ys)) <= max_pallet_span + 1e-9
 
-    def test_on_carts_deck_uses_cart_deck_color(self) -> None:
-        """The cart deck Polygon must use _CART_DECK_COLOR as its facecolor (RGB channels).
+    def test_on_carts_pallet_uses_cart_deck_color(self) -> None:
+        """Each cart pallet Polygon must use _CART_DECK_COLOR as its facecolor
+        (RGB channels).
 
         The alpha channel is set independently via the ``alpha`` kwarg, so
         ``get_facecolor()`` returns ``(r, g, b, alpha)`` — we compare only
@@ -812,24 +863,28 @@ class TestGearGlyph:
 
         _draw_gear_glyph(ax, placement, aircraft)
 
-        deck = next(
+        pallets = [
             c.args[0] for c in ax.add_patch.call_args_list if isinstance(c.args[0], MplPolygon)
-        )
+        ]
+        assert pallets, "expected at least one pallet Polygon"
         expected_rgb = matplotlib.colors.to_rgba(_CART_DECK_COLOR)[:3]
-        actual_rgb = deck.get_facecolor()[:3]
-        assert actual_rgb == pytest.approx(expected_rgb, abs=1e-3), (
-            f"cart deck RGB must match _CART_DECK_COLOR; got {actual_rgb!r} vs {expected_rgb!r}"
-        )
+        for pallet in pallets:
+            actual_rgb = pallet.get_facecolor()[:3]
+            assert actual_rgb == pytest.approx(expected_rgb, abs=1e-3), (
+                f"pallet RGB must match _CART_DECK_COLOR; got {actual_rgb!r} vs {expected_rgb!r}"
+            )
 
-    def test_on_carts_suppresses_own_gear_wheels(self) -> None:
-        """``on_carts=True`` must draw the cart glyph, not own-gear wheels.
+    def test_on_carts_suppresses_bare_own_gear_wheels(self) -> None:
+        """``on_carts=True`` must draw the cart glyph (pallet + wheel per
+        position), not the bare own-gear wheels.
 
-        For a nosewheel plane: own-gear would add 3 circles, cart adds 1
-        polygon + 4 circles.  The distinguishing check is the polygon count.
-        """
+        For a nosewheel plane: bare own-gear would add 3 circles and 0 polygons,
+        whereas the cart adds one pallet polygon per wheel.  The distinguishing
+        check is that polygons are present (one per wheel)."""
         from matplotlib.patches import Polygon as MplPolygon
 
         aircraft = self._aircraft("nosewheel", movement_mode="cart_eligible")
+        n = len(aircraft.wheels.positions)
         placement = self._placement(on_carts=True)
         ax = MagicMock()
 
@@ -837,12 +892,11 @@ class TestGearGlyph:
 
         patches = [c.args[0] for c in ax.add_patch.call_args_list]
         polygon_count = sum(1 for p in patches if isinstance(p, MplPolygon))
-        assert polygon_count == 1, (
-            f"on_carts=True must use cart glyph (1 deck polygon); got {polygon_count} polygons"
+        assert polygon_count == n, (
+            f"on_carts=True must draw one pallet polygon per wheel; "
+            f"got {polygon_count} polygons for {n} wheels"
         )
-        assert ax.add_patch.call_count == 5, (
-            f"cart glyph expects 5 patches total; got {ax.add_patch.call_count}"
-        )
+        assert ax.add_patch.call_count == 2 * n
 
     def test_glyph_zorder_above_wing_layer(self) -> None:
         """All gear/cart patches must have zorder > 1 (the wing layer) so wings
@@ -878,10 +932,11 @@ class TestGearGlyph:
         )
 
     def test_cart_glyph_rotates_with_heading(self) -> None:
-        """Cart deck corners must rotate with the heading via the world transform.
+        """Cart pallet corners must rotate with the heading via the world
+        transform.
 
-        At heading 90°, the local +x (forward) axis maps to world +x.  The
-        deck's forward-half corner (positive local-u) must have a world-x
+        At heading 90°, the local +x (forward) axis maps to world +x. The
+        forward-most pallet (the nose wheel at local +u) must have a world-x
         coordinate greater than the placement's x — confirming the rotation
         applied rather than a static axis-aligned rectangle.
         """
@@ -893,15 +948,16 @@ class TestGearGlyph:
 
         _draw_gear_glyph(ax, placement, aircraft)
 
-        deck = next(
+        pallets = [
             c.args[0] for c in ax.add_patch.call_args_list if isinstance(c.args[0], MplPolygon)
-        )
-        # At heading 90° the forward (+u) axis maps to world +x.
-        # Some deck corners have +u > 0 → their world-x must exceed placement.x_m.
-        xs = [v[0] for v in deck.get_xy()]
-        assert max(xs) > placement.x_m, (
-            f"cart deck must extend in +x at heading 90°; "
-            f"max x={max(xs)}, placement.x={placement.x_m}"
+        ]
+        assert pallets, "expected at least one pallet Polygon"
+        # At heading 90° the forward (+u) axis maps to world +x. The nose-wheel
+        # pallet (largest +u) must reach world-x beyond placement.x_m.
+        all_xs = [pt[0] for pallet in pallets for pt in pallet.get_xy()]
+        assert max(all_xs) > placement.x_m, (
+            f"cart pallets must extend in +x at heading 90°; "
+            f"max x={max(all_xs)}, placement.x={placement.x_m}"
         )
 
     # ── no fuselage defensive path ─────────────────────────────────────────────

--- a/tests/test_visualize_wheels.py
+++ b/tests/test_visualize_wheels.py
@@ -75,9 +75,9 @@ class TestOwnGearWheelPositions:
         assert fake_ax == expected
 
 
-class TestCartGlyphUnchanged:
-    def test_on_carts_draws_cart_not_own_gear(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Regression guard for #321: on_carts=True takes the cart path."""
+class TestCartGlyphPerWheel:
+    def test_on_carts_takes_cart_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """on_carts=True dispatches to the cart path, not the bare own-gear loop."""
         from hangarfit import visualize
 
         called: list[str] = []
@@ -92,6 +92,62 @@ class TestCartGlyphUnchanged:
         placement = Placement(plane_id=a.id, x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=True)
         _draw_gear_glyph(None, placement, a)
 
-        # Cart path taken; own-gear wheels NOT drawn (cart corner wheels are
-        # internal to the patched-out _draw_cart_glyph, so none leak through here).
+        # Cart path taken; bare own-gear wheels NOT drawn directly (the cart
+        # path's per-wheel discs are internal to the patched-out
+        # _draw_cart_glyph, so none leak through here).
         assert called == ["cart"]
+
+    @pytest.mark.parametrize(
+        ("gear", "wheels", "expected"),
+        [
+            (
+                "nosewheel",
+                Wheels(main_offset_x_m=-0.10, track_m=1.80, third_wheel_offset_x_m=2.50),
+                3,
+            ),
+            (
+                "tailwheel",
+                Wheels(main_offset_x_m=0.20, track_m=1.80, third_wheel_offset_x_m=-3.40),
+                3,
+            ),
+            (
+                "monowheel",
+                Wheels(main_offset_x_m=0.0, track_m=None, third_wheel_offset_x_m=None),
+                1,
+            ),
+        ],
+    )
+    def test_one_pallet_per_wheel_position(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        gear: str,
+        wheels: Wheels,
+        expected: int,
+    ) -> None:
+        """#321: the cart glyph draws one pallet per wheel position — equal to
+        ``len(aircraft.wheels.positions)`` — not a single body-sized rectangle."""
+        from hangarfit import visualize
+
+        pallets: list[tuple[float, float]] = []
+        monkeypatch.setattr(
+            visualize,
+            "_add_cart_pallet",
+            lambda ax, u, v, placement: pallets.append((u, v)),
+        )
+        # Wheels are drawn through _add_wheel; stub it to keep this focused.
+        monkeypatch.setattr(visualize, "_add_wheel", lambda *a, **k: None)
+
+        movement_mode = "always_cart" if gear == "monowheel" else "cart_eligible"
+        turn_radius = None if gear == "monowheel" else 4.0
+        a = make_test_aircraft(
+            gear=gear,  # type: ignore[arg-type]
+            movement_mode=movement_mode,
+            turn_radius_m=turn_radius,
+            wheels=wheels,
+        )
+        placement = Placement(plane_id=a.id, x_m=3.0, y_m=2.0, heading_deg=30.0, on_carts=True)
+        _draw_gear_glyph(None, placement, a)
+
+        assert len(pallets) == expected == len(a.wheels.positions)
+        # Pallets are centred on the wheel positions, not on the body origin.
+        assert pallets == list(a.wheels.positions)


### PR DESCRIPTION
## Summary

A cart-borne plane (`on_carts=True`) was drawn as a single body-sized yellow-ish deck rectangle spanning the fuselage. Physically the cart is under the wheels — each wheel rides on its own pallet. This PR replaces the one-rectangle deck with a small square pallet centred on **each** wheel position, oriented with the aircraft, with a wheel disc on top.

The pallet count now equals the wheel count: **1 for monowheel, 3 for tricycle/tailwheel**. The body-spanning rectangle is gone.

This **consumes #322's canonical `aircraft.wheels.positions`** (plane-local `(u, v)` tuples) — the exact same data the own-gear wheel loop reads — mapped to world via `local_to_world`, so pallets rotate with heading.

## Changes (`src/hangarfit/visualize.py`)

- `_draw_cart_glyph(ax, placement)` → `_draw_cart_glyph(ax, placement, aircraft)`; call site in `_draw_gear_glyph` updated to pass `aircraft`.
- New `_add_cart_pallet(ax, u, v, placement)` helper: draws one small square pallet (corners offset by `±_CART_PALLET_HALF_EXTENT_M` in plane-local space, mapped through `local_to_world`).
- Replaced `_CART_DECK_HALF_LENGTH_M` (1.3) / `_CART_DECK_HALF_WIDTH_M` (0.55) with a single **`_CART_PALLET_HALF_EXTENT_M = 0.4`** (0.8 m square — larger than the 0.18 m wheel disc it backs, far smaller than the ~6.5 m fuselage). Colour constants (`_CART_DECK_COLOR`, `_CART_DECK_ALPHA`, `_WHEEL_COLOR`) kept.
- **The own-gear path (`_draw_gear_glyph`'s non-cart loop, #322's surface) is untouched.**

## Test plan

- `tests/test_visualize.py` `TestGearGlyph`: the old single-deck cart tests were **deliberately updated** (the old behavior — 1 deck polygon + 4 corner wheels — no longer exists) to pin the new contract: one pallet polygon + one wheel circle per wheel position; pallet not body-sized (bounded by the pallet diagonal); pallet colour; rotation; monowheel single-pallet case.
- `tests/test_visualize_wheels.py` `TestCartGlyphPerWheel`: parametrized guard that pallet count `== len(aircraft.wheels.positions)` and pallets are centred on the wheel positions, across nosewheel / tailwheel / monowheel.
- Full suite: **1089 passed, 8 deselected**. `ruff check` + `ruff format --check` + `mypy` clean.
- Smoke render of `layouts/example.yaml` (the `fuji`, `zlin_savage`, `wild_thing` planes are on carts) renders without error; pallets read as small per-wheel squares.

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)