### PR TITLE
spike(towplanner): obstacle-aware A* heuristic seam + routability benchmark (#332)

### DIFF
--- a/docs/spikes/towplanner_v2_routability_bench.py
+++ b/docs/spikes/towplanner_v2_routability_bench.py
@@ -23,7 +23,7 @@ What it does, against a fixed set of deterministic target layouts:
    better heuristic fixes).
 
 2. BENCHMARK — route the same layouts plane-by-plane under four planner configs
-   (euclidean@700, euclidean@5000, grid@700, grid@5000) and report planes-routed
+   (euclidean@700, grid@700, euclidean@2000, grid@2000) and report planes-routed
    and wall-clock. This is the go/no-go table.
 
 Determinism: every layout target is reproducible (a fixed-seed ``solve`` with a
@@ -131,9 +131,7 @@ def route_in_order(
         except NoFeasiblePlanError:
             routed = False
         dt = time.monotonic() - t0
-        reachable = (
-            _goal_reachable_from_cone(layout, placed, slot) if characterise else False
-        )
+        reachable = _goal_reachable_from_cone(layout, placed, slot) if characterise else False
         out.append(
             PlaneResult(
                 plane_id=slot.plane_id,
@@ -151,8 +149,14 @@ def route_in_order(
 
 def _placeholder_six() -> Layout:
     sc = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
-    r = solve(sc, budget_s=15.0, alternatives=1, seed=1, search=SearchConfig(spread=False),
-              plan_paths=False)
+    r = solve(
+        sc,
+        budget_s=15.0,
+        alternatives=1,
+        seed=1,
+        search=SearchConfig(spread=False),
+        plan_paths=False,
+    )
     assert r.layouts, "placeholder six-plane solve produced no layout"
     return r.layouts[0]
 
@@ -160,10 +164,14 @@ def _placeholder_six() -> Layout:
 def _targets() -> list[tuple[str, Layout]]:
     return [
         ("placeholder-25x18  solve_fresh_six_planes seed=1 (5 floor planes)", _placeholder_six()),
-        ("roomy-30x25        valid_all_nine_planes (9 planes)",
-         load_layout("tests/fixtures/valid_all_nine_planes.yaml")),
-        ("placeholder-25x18  valid_two_separated (2 planes, control)",
-         load_layout("tests/fixtures/valid_two_separated.yaml")),
+        (
+            "roomy-30x25        valid_all_nine_planes (9 planes)",
+            load_layout("tests/fixtures/valid_all_nine_planes.yaml"),
+        ),
+        (
+            "placeholder-25x18  valid_two_separated (2 planes, control)",
+            load_layout("tests/fixtures/valid_two_separated.yaml"),
+        ),
     ]
 
 
@@ -179,13 +187,16 @@ def main() -> None:
     for name, layout in targets:
         print(f"\n### {name}")
         rows = route_in_order(layout, heuristic="euclidean", max_expansions=700, characterise=True)
-        print(f"{'plane':<16}{'routed':<8}{'exp':>6}{'cap?':>7}{'space?':>8}"
-              f"{'reach?':>8}{'secs':>8}")
+        print(
+            f"{'plane':<16}{'routed':<8}{'exp':>6}{'cap?':>7}{'space?':>8}{'reach?':>8}{'secs':>8}"
+        )
         for r in rows:
-            print(f"{r.plane_id:<16}{('yes' if r.routed else 'NO'):<8}{r.expansions:>6}"
-                  f"{('Y' if r.budget_exhausted else '-'):>7}"
-                  f"{('Y' if r.space_exhausted else '-'):>8}"
-                  f"{('Y' if r.goal_reachable else 'N'):>8}{r.seconds:>8.2f}")
+            print(
+                f"{r.plane_id:<16}{('yes' if r.routed else 'NO'):<8}{r.expansions:>6}"
+                f"{('Y' if r.budget_exhausted else '-'):>7}"
+                f"{('Y' if r.space_exhausted else '-'):>8}"
+                f"{('Y' if r.goal_reachable else 'N'):>8}{r.seconds:>8.2f}"
+            )
         nr = sum(1 for r in rows if r.routed)
         print(f"  --> routed {nr}/{len(rows)} planes")
 
@@ -201,7 +212,7 @@ def main() -> None:
         ("euclidean", 2000),
         ("grid", 2000),
     ]
-    header = f"{'target':<52}" + "".join(f"{h+'@'+str(b):>16}" for h, b in configs)
+    header = f"{'target':<52}" + "".join(f"{h + '@' + str(b):>16}" for h, b in configs)
     print(header)
     for name, layout in targets:
         cells = []

--- a/docs/spikes/towplanner_v2_routability_bench.py
+++ b/docs/spikes/towplanner_v2_routability_bench.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Reproducible characterisation + benchmark harness for the towplanner-v2
+routability spike (issue #332).
+
+NOT shipped, NOT imported by the package, NOT covered by CI lint/type gates
+(it lives under ``docs/spikes/``, outside ``src/`` and ``tests/``). It exists so
+the numbers in ``docs/superpowers/specs/2026-05-28-towplanner-v2-routability-spike.md``
+can be regenerated on demand:
+
+    PYTHONPATH=src python docs/spikes/towplanner_v2_routability_bench.py
+
+What it does, against a fixed set of deterministic target layouts:
+
+1. CHARACTERISE — walk ``back_first_order`` and, for each plane in its natural
+   back-first slot against the already-placed deeper planes, run the EXISTING
+   Hybrid-A* search (euclidean heuristic, default budget) with the new ``stats``
+   out-param. Reports per-plane: expansions used, routed?, and — when it failed —
+   whether it hit the expansion CAP (``budget_exhausted``) or emptied the open
+   heap first (``space_exhausted`` = genuine local infeasibility). Independently
+   computes the free-space (point-robot) geodesic field and asks whether the
+   goal is even REACHABLE from the door cone — separating "no heuristic can help"
+   (geometrically infeasible) from "the heuristic got lost" (a routability bug a
+   better heuristic fixes).
+
+2. BENCHMARK — route the same layouts plane-by-plane under four planner configs
+   (euclidean@700, euclidean@5000, grid@700, grid@5000) and report planes-routed
+   and wall-clock. This is the go/no-go table.
+
+Determinism: every layout target is reproducible (a fixed-seed ``solve`` with a
+``max_restarts`` cap, or a checked-in static layout fixture). The grid heuristic
+is RNG-free, so its routes are byte-stable across runs (asserted in
+``tests/test_towplanner_grid_heuristic.py``).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from hangarfit.loader import load_layout, load_scenario
+from hangarfit.models import Layout, Placement, SearchConfig
+from hangarfit.solver import solve
+from hangarfit.towplanner import (
+    _GRID_XY_M,
+    NoFeasiblePlanError,
+    Pose,
+    _build_grid_heuristic,
+    _build_obstacles,
+    _mover_motion_bounds_conflict,
+    back_first_order,
+    entry_poses,
+    plan_path,
+)
+
+
+def _xy_cell(p: Pose) -> tuple[int, int]:
+    """The 2D occupancy-grid cell of a pose (the grid field's key — NOT the
+    search's 3-tuple ``_cell`` which also bins heading)."""
+    return (round(p.x_m / _GRID_XY_M), round(p.y_m / _GRID_XY_M))
+
+
+@dataclass
+class PlaneResult:
+    plane_id: str
+    routed: bool
+    expansions: int
+    budget_exhausted: bool
+    space_exhausted: bool
+    seconds: float
+    goal_reachable: bool  # point-robot free-space reachability from the door cone
+
+
+def _goal_reachable_from_cone(layout: Layout, placed: list[Placement], slot: Placement) -> bool:
+    """Is the goal cell reachable from ANY surviving door-cone start cell in the
+    free-space (point-robot) occupancy grid? A NO here means even an
+    infinitely-agile point robot cannot get there — genuine infeasibility that no
+    heuristic, and no RRT-Connect, can route around."""
+    hangar = layout.hangar
+    mover = layout.fleet[slot.plane_id]
+    placed_layout = Layout(
+        fleet=layout.fleet,
+        hangar=hangar,
+        placements=tuple(placed),
+        maintenance_plane=layout.maintenance_plane,
+    )
+    obstacles = _build_obstacles(placed_layout, mover_id=mover.id)
+    field = _build_grid_heuristic(Pose.from_placement(slot), obstacles, hangar)
+    for cand in entry_poses(slot, hangar):
+        cand_pl = Placement(mover.id, cand.x_m, cand.y_m, cand.heading_deg, on_carts=False)
+        if _mover_motion_bounds_conflict(mover, cand_pl, hangar) is not None:
+            continue
+        if _xy_cell(cand) in field:
+            return True
+    return False
+
+
+def route_in_order(
+    layout: Layout, *, heuristic: str, max_expansions: int, characterise: bool = False
+) -> list[PlaneResult]:
+    """Place planes in back-first order; for each, try a tow path against the
+    already-placed deeper planes. Always advances to the next slot (records the
+    failure but keeps placing) so every plane is measured in its natural slot."""
+    ordered = back_first_order(layout.placements)
+    placed: list[Placement] = []
+    out: list[PlaneResult] = []
+    for slot in ordered:
+        mover = layout.fleet[slot.plane_id]
+        placed_layout = Layout(
+            fleet=layout.fleet,
+            hangar=layout.hangar,
+            placements=tuple(placed),
+            maintenance_plane=layout.maintenance_plane,
+        )
+        cone = entry_poses(slot, layout.hangar)
+        stats: dict[str, object] = {}
+        t0 = time.monotonic()
+        routed = True
+        try:
+            plan_path(
+                mover,
+                cone[0],
+                Pose.from_placement(slot),
+                hangar=layout.hangar,
+                placed=placed_layout,
+                mover_on_carts=slot.on_carts,
+                entries=cone,
+                heuristic=heuristic,  # type: ignore[arg-type]
+                max_expansions=max_expansions,
+                stats=stats,
+            )
+        except NoFeasiblePlanError:
+            routed = False
+        dt = time.monotonic() - t0
+        reachable = (
+            _goal_reachable_from_cone(layout, placed, slot) if characterise else False
+        )
+        out.append(
+            PlaneResult(
+                plane_id=slot.plane_id,
+                routed=routed,
+                expansions=int(stats.get("expansions", -1)),  # type: ignore[arg-type]
+                budget_exhausted=bool(stats.get("budget_exhausted", False)),
+                space_exhausted=bool(stats.get("space_exhausted", False)),
+                seconds=dt,
+                goal_reachable=reachable,
+            )
+        )
+        placed.append(slot)
+    return out
+
+
+def _placeholder_six() -> Layout:
+    sc = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    r = solve(sc, budget_s=15.0, alternatives=1, seed=1, search=SearchConfig(spread=False),
+              plan_paths=False)
+    assert r.layouts, "placeholder six-plane solve produced no layout"
+    return r.layouts[0]
+
+
+def _targets() -> list[tuple[str, Layout]]:
+    return [
+        ("placeholder-25x18  solve_fresh_six_planes seed=1 (5 floor planes)", _placeholder_six()),
+        ("roomy-30x25        valid_all_nine_planes (9 planes)",
+         load_layout("tests/fixtures/valid_all_nine_planes.yaml")),
+        ("placeholder-25x18  valid_two_separated (2 planes, control)",
+         load_layout("tests/fixtures/valid_two_separated.yaml")),
+    ]
+
+
+def main() -> None:
+    import sys
+
+    part1_only = "--part1" in sys.argv
+    targets = _targets()
+
+    print("=" * 100)
+    print("PART 1 — FAILURE CHARACTERISATION (euclidean heuristic, default budget=700)")
+    print("=" * 100)
+    for name, layout in targets:
+        print(f"\n### {name}")
+        rows = route_in_order(layout, heuristic="euclidean", max_expansions=700, characterise=True)
+        print(f"{'plane':<16}{'routed':<8}{'exp':>6}{'cap?':>7}{'space?':>8}"
+              f"{'reach?':>8}{'secs':>8}")
+        for r in rows:
+            print(f"{r.plane_id:<16}{('yes' if r.routed else 'NO'):<8}{r.expansions:>6}"
+                  f"{('Y' if r.budget_exhausted else '-'):>7}"
+                  f"{('Y' if r.space_exhausted else '-'):>8}"
+                  f"{('Y' if r.goal_reachable else 'N'):>8}{r.seconds:>8.2f}")
+        nr = sum(1 for r in rows if r.routed)
+        print(f"  --> routed {nr}/{len(rows)} planes")
+
+    if part1_only:
+        return
+
+    print("\n" + "=" * 100)
+    print("PART 2 — BENCHMARK: planes routed (and wall-clock) by planner config")
+    print("=" * 100)
+    configs = [
+        ("euclidean", 700),
+        ("grid", 700),
+        ("euclidean", 2000),
+        ("grid", 2000),
+    ]
+    header = f"{'target':<52}" + "".join(f"{h+'@'+str(b):>16}" for h, b in configs)
+    print(header)
+    for name, layout in targets:
+        cells = []
+        n_total = len(layout.placements)
+        for heuristic, budget in configs:
+            t0 = time.monotonic()
+            rows = route_in_order(layout, heuristic=heuristic, max_expansions=budget)
+            dt = time.monotonic() - t0
+            nr = sum(1 for r in rows if r.routed)
+            cells.append(f"{nr}/{n_total} ({dt:.1f}s)")
+        short = name.split("  ")[0] + " " + name.split("  ")[-1][:28]
+        print(f"{short:<52}" + "".join(f"{c:>16}" for c in cells))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/superpowers/specs/2026-05-28-towplanner-v2-routability-spike.md
+++ b/docs/superpowers/specs/2026-05-28-towplanner-v2-routability-spike.md
@@ -1,0 +1,314 @@
+# Towplanner-v2 routability spike — characterise → survey → prototype (#332)
+
+- **Date:** 2026-05-28
+- **Issue:** [#332](https://github.com/DocGerd/hangarfit/issues/332) (milestone #15 "Spikes & exploration")
+- **Status:** Spike. PoC behind an opt-in flag on a feature branch; **no default behaviour changed**. Recommendation + go/no-go below.
+- **Branch / PR:** `feature/towplanner-v2-spike-332` → draft PR into `develop`.
+- **Reproduce:** `PYTHONPATH=src python docs/spikes/towplanner_v2_routability_bench.py`
+
+> **Relationship to #332's framing.** #332 is filed as a *CNN-heuristic* spike and
+> asks for a **quantified routability baseline** and a **learned-heuristic-vs-
+> RRT-Connect** comparison. This doc answers those directly, and — rather than
+> stop at "a CNN *could* predict a cost-to-go field" — it **builds the classical
+> cost-to-go field the CNN would imitate**, plugs it into the real search, and
+> measures it. That experiment is the cheapest possible de-risking of the CNN
+> idea: the learned model's benefit ceiling is the *exact* field, so if the exact
+> field doesn't move routability on the real fixtures, neither will a learned
+> approximation of it. **It doesn't.** See below.
+
+---
+
+## TL;DR (read this first — the naive hypothesis was wrong)
+
+1. **The going-in hypothesis** — "multi-plane fills fail because the straight-line
+   A\* heuristic floods the dead pocket in front of parked planes; an
+   obstacle-aware heuristic will route around them" — **was tested and falsified
+   on the real fixtures.**
+2. **What actually fails:** *every* un-routed plane exits on the **expansion cap**
+   (`budget_exhausted`), *every* failed goal is **reachable in free space**
+   (a point robot could get there), and the un-routed planes are the
+   **wide-wing aircraft** (`aviat_husky` 10.82 m, `scheibe_falke` 18 m) maneuvering
+   in a tight hangar. The bottleneck is **finite-width / rotational maneuvering in
+   tight space**, *not* interior-obstacle clutter and *not* genuine geometric
+   infeasibility.
+3. **The prototyped obstacle-aware grid heuristic buys ZERO routability** on the
+   fixtures (placeholder six: 3/5 → 3/5; two-plane: 1/2 → 1/2) and *mildly hurts*
+   the already-routable cases (it added ~50 % more expansions to one success and
+   ~40 % more wall-clock from the per-call Dijkstra). A 2-D cost-to-go heuristic
+   speeds *clutter routing*, which is not the failure mode here.
+4. **By the same logic the CNN (#332) is unlikely to help these fixtures** — it
+   predicts the *same family* of 2-D cost-to-go field whose exact version we just
+   showed is inert here. **Strong evidence to keep #332 deferred.**
+5. **What *did* move routability: raising `_MAX_EXPANSIONS`** (placeholder six:
+   3/5 → 4/5 at budget 2000), confirming the failures are *false negatives*
+   (feasible-but-hard), not impossibilities — but it pays linearly in time and
+   still cannot route the genuinely-tight `scheibe_falke`.
+6. **Recommendation:** the real v2 routability fix is a **bidirectional sampler
+   (RRT-Connect over the existing Reeds–Shepp steering)** scoped to the tight-
+   maneuver cases, plus a **modest `_MAX_EXPANSIONS` bump** as a cheap immediate
+   win. **Defer the grid heuristic and the CNN** — both attack a failure mode
+   these fixtures don't have. The grid-heuristic seam is kept as a tested, opt-in
+   PoC (it *is* the apparatus #332 asked to prototype, and the home a future
+   learned/clutter heuristic would plug into), clearly labelled NO-GO-as-a-fix.
+
+---
+
+## 1. Context — what fails today
+
+`towplanner.plan_path` is a deterministic **Hybrid-A\*** search over closed-form
+**Reeds–Shepp** primitives (ADR-0007 v1 scope, ADR-0010 reverse-capable motion),
+bounded by `_MAX_EXPANSIONS = 700` node expansions per plane and *best-effort*:
+`plan_fill` walks `back_first_order` (deepest slot first) and, when no remaining
+plane routes against the placed ones, raises `NoFeasiblePlanError`;
+`solve(..., plan_paths=True)` records that layout's plan as `None` rather than
+discarding the valid static arrangement (`solver.py:300-320`).
+
+The documented pain (CLAUDE.md, the `--render-paths` spread-fallback in `cli.py`,
+the `slow` perf gate): **multi-plane fills are reported un-routable** in the
+placeholder 25×18 hangar (and solver-produced roomy layouts) for 3+ planes. The
+single A\* heuristic is **straight-line Euclidean distance** — admissible, but
+obstacle-blind, which is the textbook A\*-in-clutter failure and was the
+hypothesis this spike set out to confirm or kill.
+
+---
+
+## 2. Part 1 — Failure characterisation (the evidence)
+
+**Method** (`docs/spikes/towplanner_v2_routability_bench.py`, Part 1). For each
+target layout, walk `back_first_order`; place each plane in its natural slot
+against the already-placed deeper planes; run the **unchanged** Euclidean search
+at the default budget with a new diagnostic `stats` out-param, recording per
+plane:
+
+- `exp` — node expansions used.
+- `cap?` — `budget_exhausted`: hit `max_expansions` (a *false-negative* candidate —
+  feasible-but-hard).
+- `space?` — `space_exhausted`: the open heap emptied **before** the cap — every
+  reachable discretised state settled with no analytic shot closing to goal, i.e.
+  genuine local infeasibility within the grid/primitive resolution.
+- `reach?` — independently: is the goal cell reachable from any surviving door-cone
+  start in the **free-space (point-robot) occupancy grid**? `N` ⇒ *no planner of
+  any kind* can route it (a point can't even get there). `Y` + a failed route ⇒ a
+  search/budget problem, not geometry.
+
+> The `cap? / space? / reach?` triple separates "search got lost"
+> (`cap?=Y, reach?=Y`) from "search proved it stuck" (`space?=Y`) from
+> "geometrically impossible" (`reach?=N`).
+
+### Results (per plane, euclidean vs grid @ 700; reach? is point-robot)
+
+```
+placeholder-25x18  solve_fresh_six_planes seed=1   (5 floor planes)
+plane          euclidean@700        grid@700        reach?
+aviat_husky    FAIL exp=700 (cap)   FAIL exp=700    Y      ← deepest; routed vs NO interior obstacles → fails on WALLS
+ctsl           FAIL exp=700 (cap)   FAIL exp=700    Y
+fuji           OK   exp=254         OK   exp=388    Y      ← grid made a SUCCESS *slower* (+53 % expansions)
+fk9_mkii       OK   exp=2           OK   exp=2      Y
+cessna_140     OK   exp=0           OK   exp=0      Y
+  routed: euclidean 3/5, grid 3/5
+
+placeholder-25x18  valid_two_separated             (2 planes)
+plane          euclidean@700        grid@700        reach?
+scheibe_falke  FAIL exp=700 (cap)   FAIL exp=700    Y      ← 18 m wingspan in an 18 m-wide hangar
+ctsl           OK   exp=0           OK   exp=0      Y
+  routed: euclidean 1/2, grid 1/2
+
+roomy-30x25     valid_all_nine_planes              (9 planes)
+  routed: euclidean 9/9, grid 9/9   (fully towable — friendly hand-authored geometry; most planes close in 0–1 expansions)
+```
+
+### Reading
+
+- **No `space?` flags and no `reach?=N`.** Not a single failure is genuine
+  point-robot infeasibility, and not one is "search space exhausted". **Every
+  failure is `budget_exhausted` with the goal point-reachable** — i.e. a
+  *feasible-but-hard* false negative.
+- **The un-routed planes are the wide-wing ones.** `aviat_husky` is the *deepest*
+  slot, so it is routed against **zero interior obstacles** — its only opponents
+  are the **hangar walls**, yet it still burns the whole budget. `scheibe_falke`'s
+  18 m wing in an 18 m-wide hangar is the extreme case. The blocker is the
+  finite-width plane finding a **collision-free rotational maneuver** in tight
+  clearance, not navigating *around* other planes.
+- **The hand-authored roomy layout is fully towable** (9/9). The roomy
+  un-towability noted elsewhere is a property of *solver-produced spread* layouts
+  (which cluster planes), not of geometry that a human laid out with maneuvering
+  room. Worth recording: the planner is not broadly broken; it struggles on
+  *tight* arrangements.
+- **This kills the heuristic hypothesis.** A cost-to-go heuristic helps when the
+  search wastes expansions routing *around interior clutter*. Here the deepest
+  plane has no interior clutter at all and still fails — so a better global
+  heuristic cannot be the fix.
+
+---
+
+## 3. Part 2 — Benchmark (planes routed / total, wall-clock)
+
+**Method** (`bench`, Part 2). Route each target plane-by-plane (back-first, each
+against the already-placed deeper ones) under four configs:
+
+| target | euclidean@700 | grid@700 | euclidean@2000 | grid@2000 |
+|---|---|---|---|---|
+| placeholder-25×18 — `solve_fresh_six_planes` seed 1 (5 planes) | **3/5** (74 s) | **3/5** (76 s) | **4/5** (169 s) | **4/5** (187 s) |
+| roomy-30×25 — `valid_all_nine_planes` (9 planes) | 9/9 (7 s) | 9/9 (11 s) | 9/9 (7 s) | 9/9 (11 s) |
+| placeholder-25×18 — `valid_two_separated` (2 planes) | 1/2 (7 s) | 1/2 (7 s) | 1/2 (18 s) | 1/2 (19 s) |
+
+*(Wall-clock is illustrative — single un-pinned machine; the routed counts are the
+robust signal.)*
+
+### Reading
+
+- **Grid heuristic = no routability gain anywhere**, and a small *cost* (the
+  per-call Dijkstra adds ~40 % wall-clock; it added expansions to a success). It
+  is **not** the fix for these fixtures.
+- **Raising the budget is the only lever that moved a count** — placeholder six
+  3/5 → 4/5 going 700 → 2000 — confirming those are budget-limited false
+  negatives. But it pays linearly (74 s → 169 s) and **still cannot route
+  `scheibe_falke`** (1/2 at every budget): some tight cases are beyond what a
+  budget bump on the *current* search reaches.
+
+---
+
+## 4. Options surveyed against the evidence
+
+### Option A — Raise `_MAX_EXPANSIONS`
+
+**The only knob that moved routability here** (3/5 → 4/5). Cheap, deterministic,
+zero new code. But it pays linearly in time for every plane (routable or not — the
+bail time on an un-routable plane scales with the budget), and it does **not**
+reach the genuinely-tight cases (`scheibe_falke`). **Verdict: GO as a cheap,
+modest immediate bump (e.g. 700 → ~1500–2000), NOT as the whole answer.** Expose
+it (this spike adds `--tow-max-expansions` / `plan_fill(max_expansions=…)`), and
+let the operator trade time for routability on hard fills.
+
+### Option B — Obstacle-aware grid heuristic (PROTOTYPED) — NO-GO as a fix
+
+The free-space geodesic cost-to-go (deterministic Dijkstra over the search grid,
+goal-outward, placed planes + bay + walls as blocked), substituted for the
+Euclidean estimate. It is the exact classical analogue of #332's learned
+cost-to-go field, and it is **correct, deterministic, oracle-clean, and a genuine
+lower bound** (un-inflated point-robot ⇒ admissible-leaning; the exact-oracle
+`path_first_conflict` remains the sole validity authority — the proposer/verifier
+split #332 mandates). **But the benchmark shows it buys no routability** because
+the failure mode is tight maneuvering, not clutter routing. **Verdict: NO-GO as
+the routability fix.** Kept as a tested, opt-in seam (`heuristic="grid"`) — it is
+the apparatus #332 asked to prototype and the natural home for a future
+clutter/learned heuristic, and the spike's negative result *is* its deliverable.
+
+> Why it can even *hurt*: the discretised grid field is not perfectly *consistent*
+> with the continuous search steps, so it can trigger extra re-expansions; and its
+> multi-start ordering picks a different (sometimes longer) start. On a
+> clutter-dominated map the routing win would dominate that noise — but these
+> fixtures have little interior clutter, so only the noise shows.
+
+### Option C — RRT-Connect / bidirectional sampling fallback (RECOMMENDED for v2)
+
+The classical escape hatch named in ADR-0007/ADR-0010. RRT-Connect grows two trees
+(start + goal) and connects them; it is the bidirectional RRT variant, typically
+outperforms unidirectional RRT, and composes cleanly with the closed-form
+**Reeds–Shepp** steering this codebase already has (the RS-RRT / RRT\*-with-Reeds–
+Shepp line; OMPL ships RRT-Connect over SE(2)/Reeds–Shepp state spaces). Crucially,
+**a sampler is the right tool for *this* failure**: finding a feasible
+finite-width *maneuver* in tight clearance is exactly what randomised tree growth
+does well, where a budget-bounded directed A\* exhausts its expansions probing the
+same pocket. **Verdict: the recommended real v2 fix**, scoped to the
+tight-maneuver / budget-exhausted cases the Part 1 flags identify.
+
+**The cost is the determinism contract.** RRT-Connect is stochastic; ADR-0003
+demands byte-identical plans. The literature resolves this with **deterministic
+low-dispersion sampling sequences** (Halton/Sobol; Janson–Ichter–Pavone show
+deterministic sampling preserves optimality guarantees) plus a seeded RNG threaded
+from the existing scenario seed and a deterministic tree-merge/tie-break order. It
+is ~300–500 lines and a second planning paradigm — real, but bounded, and it
+attacks the failure the evidence actually shows.
+
+### Option D — Learned heuristic / CNN (#332's hypothesis) — DEFER (de-risked)
+
+A CNN predicting the cost-to-go field as the A\* heuristic (Neural A\*'s guidance
+map; TransPath; VIN; MPNet as a sampler). The published wins are real (~4× fewer
+A\* expansions at <0.3 % sub-optimality) and the training data is free (the
+deterministic planner + the closed-form RS distance as an analytic lower-bound
+label). **But this spike provides direct evidence to defer it:** the learned
+model's benefit ceiling is the *exact* cost-to-go field, and we measured the exact
+field to be **inert on the real fixtures** (Option B) because their failure is
+tight maneuvering, not clutter. A learned approximation cannot beat an exact field
+that already doesn't help. Add to that the ONNX-runtime dependency on a lean,
+lockfile-pinned CLI, the determinism reconciliation (fixed weights + pinned float
+ops, or scope the backend out of ADR-0003), and the need for real measurements
+(CLAUDE.md open question). **Verdict: DEFER (keep #332's "later" label).** Revisit
+only if a *clutter-dominated* routability need emerges (e.g. denser real layouts),
+at which point Option B is the cheaper first thing to try and the honest yardstick
+the CNN must beat.
+
+---
+
+## 5. Determinism & canary confirmation
+
+The PoC is **behind opt-in flags**; the default path is byte-for-byte unchanged.
+
+- `plan_path`/`plan_fill`/`solve` default to `heuristic="euclidean"`, whose A\*
+  heuristic expression is the identical `math.hypot(goal − pose)` as before; the
+  `stats` out-param is `None` by default (a pure no-op).
+- The grid Dijkstra and grid-mode search are **RNG-free** with fixed iteration
+  orders and monotonic-counter tie-breaks ⇒ `heuristic="grid"` is itself
+  byte-identical run-to-run (pinned by
+  `tests/test_towplanner_grid_heuristic.py::test_grid_heuristic_is_deterministic`).
+- The ADR-0003 canaries (`tests/test_solver_canaries.py`) and the full
+  `tests/test_towplanner_*.py` suite are **unchanged and green** (439 + canaries) —
+  see the canary-diff confirmation in the PR summary.
+
+---
+
+## 6. Risk register
+
+| # | Risk | Severity | Mitigation |
+|---|---|---|---|
+| 1 | Reader takes Option B's NO-GO as "obstacle-aware heuristics are useless" | Med | They are useless *for this failure mode*; they help clutter routing (not present here). The seam stays for that future case + the learned-heuristic home. |
+| 2 | Option A budget bump masks the genuinely-tight cases as "fixed" | Med | It only flips false negatives; `scheibe_falke` stays un-routable at any budget — track it as the RRT-Connect motivator, not a budget tune. |
+| 3 | RRT-Connect determinism (Option C) breaks ADR-0003 if added naively | High (for that follow-up) | Deterministic low-dispersion sampling + seeded RNG + deterministic merge order; pin with a determinism canary mirroring the existing ones. |
+| 4 | Results are illustrative until real measurements land (placeholder hangar/fleet) | Med | Inherits the CLAUDE.md disclaimer; the *mechanism/finding* (tight-maneuver, not clutter) is structural and unlikely to invert with real dims, but the exact counts will move. |
+| 5 | Grid Dijkstra per-call latency if the seam is ever used by default | Low | It is opt-in and NO-GO; if revived, memoise per (layout, goal). |
+
+---
+
+## 7. Recommendation & go/no-go
+
+| Option | Go/No-go | When / scope |
+|---|---|---|
+| **A. Raise `_MAX_EXPANSIONS`** | **GO (modest)** | Immediate: bump the default to ~1500–2000 (it flipped 3/5 → 4/5). Keep the new `--tow-max-expansions` override. Re-tune once real measurements land. |
+| **C. RRT-Connect bidirectional fallback** | **GO (the real v2 fix)** | Next routability milestone; scoped to the `cap? + reach?=Y` tight-maneuver cases; deterministic low-dispersion sampling for ADR-0003. |
+| **B. Obstacle-aware grid heuristic** | **NO-GO as a fix** | Kept as a tested opt-in seam for future clutter-dominated layouts / the learned-heuristic home. Do not enable by default. |
+| **D. CNN learned heuristic** | **DEFER (keep #332 "later")** | Only if a clutter-dominated routability need emerges; Option B is then the cheaper first try and the yardstick to beat. |
+
+**Headline:** the multi-plane-fill un-routability is a **tight-maneuver search**
+problem (every failure is budget-exhausted with the goal point-reachable; the
+victims are the wide-wing planes), **not** the interior-obstacle-clutter problem a
+cost-to-go heuristic — classical *or* learned — is built for. The cheapest honest
+next step is a modest budget bump; the right v2 fix is a **deterministic
+RRT-Connect** over the existing Reeds–Shepp steering. The grid-heuristic PoC's
+**negative result is the spike's most valuable output**: it redirects effort away
+from the CNN that #332 was leaning toward.
+
+---
+
+## 8. How to reproduce
+
+```bash
+python3.12 -m venv .venv && . .venv/bin/activate && pip install -e ".[dev]"
+PYTHONPATH=src python docs/spikes/towplanner_v2_routability_bench.py          # full table (~25 min)
+PYTHONPATH=src python docs/spikes/towplanner_v2_routability_bench.py --part1   # characterisation only (~2 min)
+# Try the opt-in seam end-to-end (default behaviour unchanged):
+hangarfit solve tests/fixtures/scenario_minimal.yaml --render out.png \
+    --render-paths --tow-heuristic grid --tow-max-expansions 2000
+```
+
+---
+
+## 9. References
+
+- Incumbent planner: `src/hangarfit/towplanner.py`; [ADR-0007](../../adr/0007-tow-path-planner-v1-scope.md) (v1 scope, the "why not RRT-Connect" deferral), [ADR-0010](../../adr/0010-reeds-shepp-motion-model.md) (Reeds–Shepp motion), [ADR-0003](../../adr/0003-rr-mc-solver-algorithm.md) (determinism contract).
+- Validity oracle: `src/hangarfit/collisions.py`; coordinate frame [ADR-0002](../../adr/0002-determinant-minus-one-transform.md).
+- OMPL planner catalogue (RRT-Connect, SE(2)/Reeds–Shepp state spaces): <https://ompl.kavrakilab.org/planners.html>
+- Deterministic sampling-based planning (buying back determinism for RRT-Connect): Janson, Ichter, Pavone, *Deterministic Sampling-Based Motion Planning*, <https://arxiv.org/pdf/1505.00023>
+- Reeds–Shepp + RRT for non-holonomic vehicles (RS-RRT / RRT\*): <https://ieeexplore.ieee.org/document/11102371/>
+- Learned heuristics: Neural A\* Search <https://arxiv.org/pdf/2009.07476>; TransPath <https://arxiv.org/pdf/2212.11730>; Value Iteration Networks <https://arxiv.org/pdf/1602.02867>; MPNet <https://arxiv.org/pdf/1907.06013>; "Learning heuristics for A\*" (≈4× fewer expansions, <0.3 % sub-optimal) <https://arxiv.org/pdf/2204.08938>.
+```

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -170,6 +170,32 @@ def build_parser() -> argparse.ArgumentParser:
         default=True,
         help="Disable the inter-plane spread post-pass (default: spread enabled).",
     )
+    # ── Experimental tow-planner knobs (towplanner-v2 routability spike, #332) ──
+    # Behind opt-in flags; defaults reproduce the shipped planner byte-for-byte.
+    solve.add_argument(
+        "--tow-heuristic",
+        choices=("euclidean", "grid"),
+        default="euclidean",
+        dest="tow_heuristic",
+        help=(
+            "EXPERIMENTAL (#332): A* tow-path heuristic. 'euclidean' (default) is "
+            "the shipped straight-line heuristic; 'grid' is the obstacle-aware "
+            "free-space geodesic that routes around placed planes (only affects "
+            "--render-paths runs). Deterministic; the path is exact-oracle-validated."
+        ),
+    )
+    solve.add_argument(
+        "--tow-max-expansions",
+        type=int,
+        metavar="N",
+        default=None,
+        dest="tow_max_expansions",
+        help=(
+            "EXPERIMENTAL (#332): per-plane Hybrid-A* expansion budget for tow "
+            "planning (default: the module _MAX_EXPANSIONS=700). Raise to trade "
+            "time for routability on hard fills."
+        ),
+    )
 
     return parser
 
@@ -394,6 +420,8 @@ def cmd_solve(args: argparse.Namespace) -> int:
         seed=resolved_seed,
         search=SearchConfig(spread=args.spread),
         plan_paths=args.render_paths,
+        tow_heuristic=args.tow_heuristic,
+        tow_max_expansions=args.tow_max_expansions,
     )
 
     # #280 — spread-vs-towability fallback. The ADR-0008 spread post-pass
@@ -428,6 +456,8 @@ def cmd_solve(args: argparse.Namespace) -> int:
             seed=resolved_seed,
             search=SearchConfig(spread=False),
             plan_paths=True,
+            tow_heuristic=args.tow_heuristic,
+            tow_max_expansions=args.tow_max_expansions,
         )
         if fallback.layouts and any(plan is not None for plan in fallback.plans):
             print(

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -20,7 +20,7 @@ import random as _random_module
 import secrets
 import sys
 import time
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 from hangarfit.collisions import check as check_layout
 from hangarfit.geometry import WorldPart, aircraft_parts_world
@@ -51,6 +51,8 @@ def solve(
     diversity: DiversityConfig | None = None,
     search: SearchConfig | None = None,
     plan_paths: bool = True,
+    tow_heuristic: Literal["euclidean", "grid"] = "euclidean",
+    tow_max_expansions: int | None = None,
 ) -> SolveResult:
     """Solve a Scenario into up to ``alternatives`` diverse valid Layouts.
 
@@ -83,6 +85,13 @@ def solve(
     fills. With it off, ``plans`` is all-``None`` (still index-aligned).
     Tow-planning is RNG-free, so it preserves the seeded determinism
     contract (ADR-0003) end-to-end through the bundle.
+
+    ``tow_heuristic`` and ``tow_max_expansions`` are forwarded verbatim to
+    :func:`~hangarfit.towplanner.plan_fill` (towplanner-v2 routability spike,
+    #332). The defaults (``"euclidean"`` / module ``_MAX_EXPANSIONS``) reproduce
+    the shipped planner byte-for-byte; ``tow_heuristic="grid"`` opts into the
+    obstacle-aware free-space heuristic and a larger ``tow_max_expansions`` opts
+    into a bigger per-plane search budget — both RNG-free, so determinism holds.
     """
     if diversity is None:
         diversity = DiversityConfig()
@@ -302,7 +311,20 @@ def solve(
             built: list[MovesPlan | None] = []
             for layout in accepted_layouts:
                 try:
-                    built.append(plan_fill(layout))
+                    # Default path calls ``plan_fill(layout)`` EXACTLY as before
+                    # (byte-identical; #332 spike params are opt-in), so the
+                    # ADR-0003 determinism canaries — and any test that stubs
+                    # ``plan_fill`` with a target-only signature — are untouched.
+                    if tow_heuristic == "euclidean" and tow_max_expansions is None:
+                        built.append(plan_fill(layout))
+                    else:
+                        built.append(
+                            plan_fill(
+                                layout,
+                                heuristic=tow_heuristic,
+                                max_expansions=tow_max_expansions,
+                            )
+                        )
                 except NoFeasiblePlanError as e:
                     built.append(None)
                     unroutable.append(e.plane_id)

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -25,7 +25,8 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Literal
 
-from shapely.geometry import Polygon
+from shapely import union_all
+from shapely.geometry import Point, Polygon
 
 # `_parts_conflict` is the exact oracle's per-pair predicate (collisions.py). The
 # fast in-search checker `_motion_clear` reuses it verbatim — rather than
@@ -1064,8 +1065,19 @@ class NoFeasiblePlanError(Exception):
         self.conflict = conflict
 
 
-def plan_fill(target: Layout) -> MovesPlan:
+def plan_fill(
+    target: Layout,
+    *,
+    heuristic: Literal["euclidean", "grid"] = "euclidean",
+    max_expansions: int | None = None,
+) -> MovesPlan:
     """Plan a collision-free entry order + per-plane path for an empty fill.
+
+    ``heuristic`` and ``max_expansions`` are forwarded to :func:`plan_path` for
+    every plane (towplanner-v2 routability spike, #332). The defaults reproduce
+    the shipped planner byte-for-byte (``max_expansions=None`` ⇒ the module
+    ``_MAX_EXPANSIONS`` budget); ``heuristic="grid"`` and/or a raised
+    ``max_expansions`` are the opt-in routability experiments.
 
     Walks :func:`back_first_order` (deepest slot first); for each plane searches
     for an in-bounds path from the door-cone entry poses (:func:`entry_poses`) to
@@ -1089,6 +1101,7 @@ def plan_fill(target: Layout) -> MovesPlan:
     scan are all RNG-free, so a given ``target`` always yields the same
     :class:`MovesPlan`.
     """
+    budget = _MAX_EXPANSIONS if max_expansions is None else max_expansions
     ordered = list(back_first_order(target.placements))
     fleet = target.fleet
     hangar = target.hangar
@@ -1129,6 +1142,8 @@ def plan_fill(target: Layout) -> MovesPlan:
                     placed=placed_layout,
                     mover_on_carts=slot.on_carts,
                     entries=cone,
+                    heuristic=heuristic,
+                    max_expansions=budget,
                 )
             except NoFeasiblePlanError as exc:
                 # This plane cannot be routed against the current obstacles; try
@@ -1467,6 +1482,113 @@ def _motion_clear(mover: Aircraft, pose: Pose, obstacles: _Obstacles, hangar: Ha
     return True
 
 
+# ── Obstacle-aware grid heuristic (towplanner-v2 routability spike, #332) ────
+#
+# A goal-aware cost-to-go field that REPLACES the straight-line Euclidean A*
+# heuristic when ``plan_path(..., heuristic="grid")``. The default planner is
+# UNCHANGED — ``heuristic="euclidean"`` (the default) computes the same
+# ``math.hypot`` heuristic byte-for-byte, so the ADR-0003 determinism canaries
+# are untouched.
+#
+# Motivation (the documented multi-plane-fill un-routability): the Euclidean
+# heuristic ignores obstacles, so when a goal sits behind an already-placed
+# plane the Hybrid-A* search floods the obstacle pocket and exhausts
+# ``_MAX_EXPANSIONS`` before routing around it. This field is the FREE-SPACE
+# GEODESIC distance from every grid cell to the goal, computed by a
+# deterministic Dijkstra over the SAME ``_GRID_XY_M`` occupancy grid the search
+# bins poses into — so the heuristic "knows the way around" and the search
+# beelines along the real corridor instead of flooding the dead pocket.
+#
+# Point-robot, un-inflated obstacles: a point can always take a route the
+# finite-width plane can (never fewer metres), so the field is a LOWER BOUND on
+# the true Reeds–Shepp path cost and stays admissible-leaning; the exact oracle
+# in ``plan_path`` remains the SOLE authority on the returned path's validity
+# (the #332 proposer-verifier contract). Deterministic (ADR-0003): fixed cell
+# iteration order + a monotonic-counter Dijkstra tie-break, RNG-free.
+
+# How far in front of the door (the y<0 apron, open during tow per #222) the
+# field extends, so entry/approach poses at small negative y still get a
+# geodesic value rather than the Euclidean fallback.
+_GRID_H_Y_PAD_M = 6.0
+
+
+def _build_grid_heuristic(
+    goal: Pose, obstacles: _Obstacles, hangar: Hangar
+) -> dict[tuple[int, int], float]:
+    """Free-space geodesic cost-to-go to ``goal`` over the search grid (#332).
+
+    A deterministic Dijkstra (8-connected, true Euclidean edge weights) from the
+    goal cell across every in-bounds, obstacle-free cell. Returns a mapping from
+    ``(ix, iy)`` cell (``round(x/_GRID_XY_M), round(y/_GRID_XY_M)`` — the same xy
+    binning as :func:`_cell`) to metres-to-goal. Cells absent from the map are
+    blocked or unreachable; :func:`plan_path` falls back to the Euclidean
+    heuristic there, so the field only ever RE-PRIORITISES the frontier, it
+    never makes a pose un-expandable.
+
+    Obstacles are the placed planes' footprints (un-inflated, point-robot) plus
+    the closed maintenance bay; the side/back walls bound the grid (the front
+    ``y < 0`` apron is open during tow). RNG-free and pure ⇒ ADR-0003-safe.
+    """
+    ix_max = round(hangar.width_m / _GRID_XY_M)
+    iy_min = -round(_GRID_H_Y_PAD_M / _GRID_XY_M)
+    iy_max = round(hangar.length_m / _GRID_XY_M)
+
+    # Union the static obstacle footprints once for fast point-in-region tests.
+    blocked_geom = (
+        union_all([wp.polygon for wp in obstacles.world_parts]) if (obstacles.world_parts) else None
+    )
+
+    def _cell_free(ix: int, iy: int) -> bool:
+        cx = ix * _GRID_XY_M
+        cy = iy * _GRID_XY_M
+        # Side/back walls (front y<0 is the open apron, #222). Mirrors the
+        # _mover_motion_bounds_conflict spirit: 0<=x<=width, y<=length.
+        if cx < 0.0 or cx > hangar.width_m or cy > hangar.length_m:
+            return False
+        # Closed maintenance-bay keep-out (same predicate as _motion_clear (C)).
+        if obstacles.bay_active and (
+            obstacles.bay_xmin < cx < obstacles.bay_xmax and cy > obstacles.bay_ymin
+        ):
+            return False
+        return blocked_geom is None or not blocked_geom.contains(Point(cx, cy))
+
+    # Seed the goal cell at 0 unconditionally — it is the target (a valid resting
+    # placement clear of obstacles by clearance), so its reference point is free
+    # regardless of how the coarse raster rounds it.
+    goal_cell = (round(goal.x_m / _GRID_XY_M), round(goal.y_m / _GRID_XY_M))
+    dist: dict[tuple[int, int], float] = {goal_cell: 0.0}
+    counter = 0
+    heap: list[tuple[float, int, tuple[int, int]]] = [(0.0, counter, goal_cell)]
+    diag = _GRID_XY_M * math.sqrt(2.0)
+    # 8-neighbour offsets in a FIXED order (determinism, ADR-0003).
+    neighbours = (
+        (1, 0, _GRID_XY_M),
+        (-1, 0, _GRID_XY_M),
+        (0, 1, _GRID_XY_M),
+        (0, -1, _GRID_XY_M),
+        (1, 1, diag),
+        (1, -1, diag),
+        (-1, 1, diag),
+        (-1, -1, diag),
+    )
+    while heap:
+        d, _, (ix, iy) = heapq.heappop(heap)
+        if d > dist.get((ix, iy), math.inf) + 1e-12:
+            continue  # stale heap entry
+        for dx, dy, w in neighbours:
+            nx, ny = ix + dx, iy + dy
+            if nx < 0 or nx > ix_max or ny < iy_min or ny > iy_max:
+                continue
+            if not _cell_free(nx, ny):
+                continue
+            nd = d + w
+            if nd < dist.get((nx, ny), math.inf) - 1e-12:
+                dist[(nx, ny)] = nd
+                counter += 1
+                heapq.heappush(heap, (nd, counter, (nx, ny)))
+    return dist
+
+
 def plan_path(
     mover: Aircraft,
     entry: Pose,
@@ -1477,6 +1599,8 @@ def plan_path(
     mover_on_carts: bool,
     entries: tuple[Pose, ...] | None = None,
     max_expansions: int = _MAX_EXPANSIONS,
+    heuristic: Literal["euclidean", "grid"] = "euclidean",
+    stats: dict[str, object] | None = None,
 ) -> DubinsArc:
     """Deterministic Hybrid-A* tow path from ``entry`` (or ``entries``) to ``goal``.
 
@@ -1516,11 +1640,47 @@ def plan_path(
     ``hangar`` is consumed directly by :func:`_motion_clear` (bounds, clearances,
     bay rectangle); ``placed.hangar`` is the same object and also reaches the
     exact-oracle safety net via :func:`path_first_conflict`.
+
+    ``heuristic`` selects the A* cost-to-go estimate (towplanner-v2 spike, #332):
+    ``"euclidean"`` (default) is the byte-identical straight-line lower bound the
+    planner has always used; ``"grid"`` swaps in the obstacle-aware free-space
+    geodesic field (:func:`_build_grid_heuristic`) that guides the search around
+    placed planes instead of flooding the dead pocket in front of them. Only the
+    node-expansion ORDER changes — the motion primitives, the validity checks,
+    and the exact-oracle safety net are untouched, so a ``"grid"`` path is just
+    as exact-oracle-clean as a ``"euclidean"`` one. Both modes are deterministic
+    (ADR-0003): the grid Dijkstra is RNG-free with a monotonic-counter tie-break.
+
+    ``stats`` is an optional out-parameter (diagnostics only; ``None`` ⇒ no-op,
+    no behaviour change): on return/raise it is populated with ``expansions``,
+    ``found``, ``budget_exhausted`` (hit ``max_expansions``) vs ``space_exhausted``
+    (open heap emptied first ⇒ genuine local infeasibility), ``start_poses``, and
+    the ``heuristic`` used — the #332 routability characterisation harness reads it.
     """
     r = mover.effective_turn_radius_m()
     # Static obstacle set, computed once: placed planes don't move while this one
     # is routed. Drives the fast per-pose `_motion_clear` used during search.
     obstacles = _build_obstacles(placed, mover_id=mover.id)
+
+    # A* heuristic seam (#332). ``euclidean`` (default) is the byte-identical
+    # straight-line lower bound the planner has always used. ``grid`` swaps in
+    # the obstacle-aware free-space geodesic field, falling back to Euclidean on
+    # any cell outside the field (blocked / off-grid). The default branch's
+    # expression is unchanged so the determinism canaries stay byte-identical.
+    if heuristic == "grid":
+        _field = _build_grid_heuristic(goal, obstacles, hangar)
+
+        def _h(p: Pose) -> float:
+            cell = (round(p.x_m / _GRID_XY_M), round(p.y_m / _GRID_XY_M))
+            g = _field.get(cell)
+            if g is None:
+                return math.hypot(goal.x_m - p.x_m, goal.y_m - p.y_m)
+            return g
+    else:
+
+        def _h(p: Pose) -> float:
+            return math.hypot(goal.x_m - p.x_m, goal.y_m - p.y_m)
+
     counter = 0
 
     # ── Build the effective start set ────────────────────────────────────────
@@ -1551,17 +1711,19 @@ def plan_path(
             start_poses = (Pose(x_m=hangar.door.center_x_m, y_m=0.0, heading_deg=0.0),)
 
     # ── Seed the open heap with all surviving start poses ───────────────────
-    # Heuristic: straight-line Euclidean distance. Deliberately looser than the
-    # spec's Dubins-distance suggestion — Euclidean ≤ Dubins length ≤ true cost
-    # and the g-cost turn penalty is ≥ 0, so it stays admissible (it may expand a
-    # few more nodes, never fewer; do NOT "tighten" it to the Dubins shot without
-    # re-checking admissibility and the determinism canary).
+    # Heuristic: ``_h`` — straight-line Euclidean distance by default (deliberately
+    # looser than the spec's Dubins-distance suggestion — Euclidean ≤ Dubins length
+    # ≤ true cost and the g-cost turn penalty is ≥ 0, so it stays admissible; it may
+    # expand a few more nodes, never fewer; do NOT "tighten" it to the Dubins shot
+    # without re-checking admissibility and the determinism canary). The opt-in
+    # ``heuristic="grid"`` seam (#332) swaps in the obstacle-aware free-space
+    # geodesic field (lower-bound, admissible-leaning) without touching the default.
     open_heap: list[tuple[float, int, _SearchNode]] = []
     best_g: dict[tuple[int, int, int], float] = {}
     for start_pose in start_poses:
         start_node = _SearchNode(start_pose, 0.0, None, None)
         start_key = _cell(start_pose)
-        h_start = math.hypot(goal.x_m - start_pose.x_m, goal.y_m - start_pose.y_m)
+        h_start = _h(start_pose)
         # Only seed if not already dominated by a cheaper start in the same cell.
         if best_g.get(start_key, math.inf) - 1e-9 > 0.0:
             best_g[start_key] = 0.0
@@ -1611,6 +1773,15 @@ def plan_path(
                 path_first_conflict(candidate, mover, mover_on_carts=mover_on_carts, placed=placed)
                 is None
             ):
+                if stats is not None:
+                    stats.update(
+                        expansions=expansions,
+                        found=True,
+                        budget_exhausted=False,
+                        space_exhausted=False,
+                        start_poses=len(start_poses),
+                        heuristic=heuristic,
+                    )
                 return candidate
         # else (fast screen failed, OR fast passed but the exact oracle rejected
         # the full path): do not ship; fall through to primitive expansion.
@@ -1634,7 +1805,7 @@ def plan_path(
             if child_g < best_g.get(child_key, math.inf) - 1e-9:
                 best_g[child_key] = child_g
                 counter += 1
-                h = math.hypot(goal.x_m - child_pose.x_m, goal.y_m - child_pose.y_m)
+                h = _h(child_pose)
                 heapq.heappush(
                     open_heap,
                     (child_g + h, counter, _SearchNode(child_pose, child_g, seg, node)),
@@ -1647,6 +1818,20 @@ def plan_path(
     # Report the honest ``no_feasible_path`` kind rather than mis-labelling it
     # ``hangar_bounds``, so a caller keying on ``conflict.kind`` (plan_fill / the
     # Wave 3 CLI) is not misled about the cause; the mover is still named.
+    if stats is not None:
+        # ``budget_exhausted`` (hit the cap) vs ``space_exhausted`` (the open
+        # heap emptied first — every reachable discretised state settled with no
+        # analytic shot closing to goal, i.e. genuine local infeasibility within
+        # the grid/primitive discretisation). The distinction is the whole point
+        # of the #332 failure characterisation.
+        stats.update(
+            expansions=expansions,
+            found=False,
+            budget_exhausted=expansions >= max_expansions,
+            space_exhausted=expansions < max_expansions,
+            start_poses=len(start_poses),
+            heuristic=heuristic,
+        )
     raise NoFeasiblePlanError(
         mover.id,
         Conflict.single(

--- a/tests/test_towplanner_grid_heuristic.py
+++ b/tests/test_towplanner_grid_heuristic.py
@@ -33,7 +33,7 @@ import math
 
 import pytest
 
-from hangarfit.loader import load_layout
+from hangarfit.loader import load_layout, load_scenario
 from hangarfit.models import (
     Aircraft,
     Door,
@@ -44,6 +44,7 @@ from hangarfit.models import (
     Placement,
     Wheels,
 )
+from hangarfit.solver import solve
 from hangarfit.towplanner import (
     DubinsArc,
     NoFeasiblePlanError,
@@ -52,6 +53,7 @@ from hangarfit.towplanner import (
     _build_obstacles,
     entry_poses,
     path_first_conflict,
+    plan_fill,
     plan_path,
 )
 
@@ -298,3 +300,119 @@ def test_stats_records_outcome_on_failure() -> None:
     # Either it hit the cap or it exhausted the reachable space; exactly one.
     assert bool(stats["budget_exhausted"]) != bool(stats["space_exhausted"])
     assert math.isfinite(float(stats["expansions"]))  # type: ignore[arg-type]
+
+
+# ── opt-in plumbing through plan_fill / solve (the #332 flags) ───────────────
+
+
+def test_plan_fill_accepts_grid_heuristic_and_explicit_budget() -> None:
+    """``plan_fill(..., heuristic="grid", max_expansions=N)`` routes a friendly
+    two-plane layout — exercises the grid forward + the explicit-budget path."""
+    h = _hangar(width_m=20.0, length_m=30.0)
+    fleet = {"A": _box_plane("A"), "B": _box_plane("B")}
+    layout = Layout(
+        fleet=fleet,
+        hangar=h,
+        placements=(
+            Placement("A", 8.0, 8.0, 0.0, on_carts=False),  # shallow
+            Placement("B", 12.0, 22.0, 0.0, on_carts=False),  # deep
+        ),
+    )
+    plan = plan_fill(layout, heuristic="grid", max_expansions=400)
+    assert [m.plane_id for m in plan.moves] == ["B", "A"]  # deepest first
+
+
+def test_solve_accepts_grid_tow_heuristic() -> None:
+    """``solve(..., tow_heuristic="grid", tow_max_expansions=N)`` runs the opt-in
+    grid branch in the solver. The plane may or may not route (best-effort); the
+    point is the layout is still returned and the grid code path is exercised."""
+    scenario = load_scenario("tests/fixtures/solve_feasible_smoke.yaml")
+    result = solve(
+        scenario,
+        budget_s=10.0,
+        alternatives=1,
+        seed=1,
+        plan_paths=True,
+        tow_heuristic="grid",
+        tow_max_expansions=80,
+    )
+    assert result.layouts  # a feasible single-plane scenario always yields a layout
+    assert len(result.plans) == len(result.layouts)  # plans index-aligned (None allowed)
+
+
+# ── grid-field branch coverage (bay keep-out, off-grid fallback, edge bounds) ─
+
+
+def _wall_plane(plane_id: str, *, width_m: float) -> Aircraft:
+    return Aircraft(
+        id=plane_id,
+        name=plane_id,
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=4.0,
+        measured=False,
+        parts=(
+            Part(
+                kind="fuselage_aft",
+                length_m=2.0,
+                width_m=width_m,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=3.0,
+            ),
+        ),
+        wheels=_TAIL_WHEELS,
+    )
+
+
+def test_grid_field_excludes_closed_maintenance_bay_cells() -> None:
+    """With a maintenance occupant set the bay is a keep-out: cells inside it are
+    absent from the field (covers the ``bay_active`` branch of ``_cell_free``)."""
+    h = _hangar(width_m=20.0, length_m=30.0)  # bay center x=10, width 2, depth 2 → x(9,11), y>28
+    fleet = {"A": _box_plane("A"), "M": _box_plane("M")}
+    goal = Pose(x_m=10.0, y_m=20.0, heading_deg=0.0)
+    bay_cell = (round(10.0 / 0.5), round(29.0 / 0.5))  # inside the back-anchored bay
+
+    open_layout = Layout(fleet=fleet, hangar=h, placements=())  # bay OPEN (no occupant)
+    open_field = _build_grid_heuristic(goal, _build_obstacles(open_layout, mover_id="A"), h)
+    assert bay_cell in open_field  # reachable when the bay is just floor
+
+    closed_layout = Layout(fleet=fleet, hangar=h, placements=(), maintenance_plane="M")
+    closed_field = _build_grid_heuristic(goal, _build_obstacles(closed_layout, mover_id="A"), h)
+    assert bay_cell not in closed_field  # the closed bay keeps the mover out
+
+
+def test_grid_search_falls_back_to_euclidean_off_grid() -> None:
+    """When the goal is walled off, the door-side start cells are absent from the
+    field, so the grid ``_h`` returns the Euclidean fallback (``g is None``); the
+    search then exhausts its (tiny) budget — covers the fallback path."""
+    h = _hangar(width_m=8.0, length_m=30.0)
+    wall = _wall_plane("W", width_m=10.0)  # spans the full 8 m width near mid-depth
+    layout = Layout(
+        fleet={"W": wall, "A": _box_plane("A")},
+        hangar=h,
+        placements=(
+            Placement("W", 4.0, 15.0, 0.0, on_carts=False),
+            Placement("A", 4.0, 25.0, 0.0, on_carts=False),  # behind the wall
+        ),
+    )
+    with pytest.raises(NoFeasiblePlanError):
+        _route_one(layout, "A", heuristic="grid", max_expansions=60)
+
+
+def test_grid_field_blocks_cells_past_non_aligned_walls() -> None:
+    """A hangar dimension that is not a multiple of the grid pitch puts an edge
+    cell centre just past the wall; ``_cell_free`` rejects it (covers the
+    side/back-wall bound in the field builder)."""
+    h = _hangar(width_m=8.3, length_m=12.7)  # neither a multiple of 0.5 m
+    empty = Layout(fleet={"A": _box_plane("A")}, hangar=h, placements=())
+    field = _build_grid_heuristic(
+        Pose(x_m=4.0, y_m=10.0, heading_deg=0.0), _build_obstacles(empty, mover_id="A"), h
+    )
+    # No field cell centre may lie outside the side/back walls.
+    assert all(0.0 <= ix * 0.5 <= h.width_m and iy * 0.5 <= h.length_m for (ix, iy) in field)
+    # The cell whose centre (8.5 m) overshoots the 8.3 m wall must be absent.
+    assert (round(8.5 / 0.5), round(10.0 / 0.5)) not in field

--- a/tests/test_towplanner_grid_heuristic.py
+++ b/tests/test_towplanner_grid_heuristic.py
@@ -1,0 +1,300 @@
+"""Obstacle-aware grid heuristic for the Hybrid-A* tow planner (#332 spike).
+
+These tests pin the contract of the opt-in ``heuristic="grid"`` seam added by the
+towplanner-v2 routability spike:
+
+* the DEFAULT (``"euclidean"``) path is byte-for-byte unchanged — adding the
+  ``stats`` out-param or passing ``heuristic="euclidean"`` explicitly produces an
+  identical :class:`~hangarfit.towplanner.DubinsArc` (the ADR-0003 determinism
+  contract; the existing canaries in ``test_solver_canaries.py`` and the other
+  ``test_towplanner_*`` files cover the rest);
+* ``heuristic="grid"`` is itself deterministic (RNG-free Dijkstra) — identical
+  bytes across repeat runs;
+* a ``"grid"`` path is exact-oracle-clean (the heuristic only re-orders the
+  frontier; the validity oracle is untouched — the #332 proposer-verifier split);
+* the geodesic field is well-formed (0 at the goal, increasing with distance,
+  finite where free, and absent — i.e. ``+inf``/fallback — where walled off).
+
+These pin the *correctness* and *determinism* of the seam — NOT a routability
+win. Whether the grid heuristic buys routability is an empirical question the
+spike benchmark (``docs/spikes/towplanner_v2_routability_bench.py``) and the spike
+doc answer, and the honest answer is "no, not on these fixtures": their failures
+are budget-exhausted *finite-width maneuvering*, not interior-obstacle clutter, so
+a 2-D cost-to-go heuristic (this one, or a learned one) is inert. There is
+therefore deliberately **no** "grid routes what euclidean cannot" test — it would
+not hold, on the fixtures *or* on constructed bug-traps (once a detour is forced,
+the tight-maneuver bottleneck defeats both heuristics within budget). The seam is
+kept as a tested, opt-in PoC and the home for a future clutter/learned heuristic.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from hangarfit.loader import load_layout
+from hangarfit.models import (
+    Aircraft,
+    Door,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    Placement,
+    Wheels,
+)
+from hangarfit.towplanner import (
+    DubinsArc,
+    NoFeasiblePlanError,
+    Pose,
+    _build_grid_heuristic,
+    _build_obstacles,
+    entry_poses,
+    path_first_conflict,
+    plan_path,
+)
+
+_TAIL_WHEELS = Wheels(main_offset_x_m=0.20, track_m=1.8, third_wheel_offset_x_m=-2.0)
+
+
+def _box_plane(plane_id: str, *, turn_radius_m: float = 4.0) -> Aircraft:
+    return Aircraft(
+        id=plane_id,
+        name=f"Plane {plane_id}",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=turn_radius_m,
+        measured=False,
+        parts=(
+            Part(
+                kind="fuselage_aft",
+                length_m=1.0,
+                width_m=0.6,
+                offset_x_m=0.5,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.0,
+            ),
+        ),
+        wheels=_TAIL_WHEELS,
+    )
+
+
+def _hangar(width_m: float = 20.0, length_m: float = 30.0) -> Hangar:
+    return Hangar(
+        length_m=length_m,
+        width_m=width_m,
+        door=Door(center_x_m=width_m / 2, width_m=6.0),
+        maintenance_bay=MaintenanceBay(center_x_m=width_m / 2, width_m=2.0, depth_m=2.0),
+        clearance_m=0.5,
+        wing_layer_clearance_m=0.3,
+    )
+
+
+def _route_one(
+    layout: Layout, mover_id: str, *, heuristic: str, max_expansions: int = 700, stats=None
+) -> DubinsArc:
+    """Route ``mover_id`` to its slot in ``layout`` against every OTHER plane as
+    an obstacle (a single-plane harness independent of plan_fill's ordering)."""
+    slot = next(p for p in layout.placements if p.plane_id == mover_id)
+    others = tuple(p for p in layout.placements if p.plane_id != mover_id)
+    placed = Layout(
+        fleet=layout.fleet,
+        hangar=layout.hangar,
+        placements=others,
+        maintenance_plane=layout.maintenance_plane,
+    )
+    cone = entry_poses(slot, layout.hangar)
+    return plan_path(
+        layout.fleet[mover_id],
+        cone[0],
+        Pose.from_placement(slot),
+        hangar=layout.hangar,
+        placed=placed,
+        mover_on_carts=slot.on_carts,
+        entries=cone,
+        heuristic=heuristic,  # type: ignore[arg-type]
+        max_expansions=max_expansions,
+        stats=stats,
+    )
+
+
+# ── default path is byte-identical (determinism contract) ────────────────────
+
+
+def test_default_heuristic_and_stats_do_not_change_the_path() -> None:
+    """Default == explicit euclidean == euclidean-with-stats, bit-for-bit."""
+    h = _hangar()
+    fleet = {"A": _box_plane("A")}
+    layout = Layout(
+        fleet=fleet, hangar=h, placements=(Placement("A", 10.0, 20.0, 0.0, on_carts=False),)
+    )
+
+    default = _route_one(layout, "A", heuristic="euclidean")
+    # The literal default (no heuristic kwarg at all) must match too.
+    slot = layout.placements[0]
+    cone = entry_poses(slot, h)
+    empty = Layout(fleet=fleet, hangar=h, placements=())
+    bare = plan_path(
+        fleet["A"],
+        cone[0],
+        Pose.from_placement(slot),
+        hangar=h,
+        placed=empty,
+        mover_on_carts=False,
+        entries=cone,
+    )
+    stats: dict[str, object] = {}
+    with_stats = _route_one(layout, "A", heuristic="euclidean", stats=stats)
+
+    assert default.segments == bare.segments
+    assert default.segments == with_stats.segments
+    assert default.start == bare.start == with_stats.start
+    # The stats out-param was populated without perturbing the result.
+    assert stats["found"] is True
+
+
+# ── grid mode determinism ────────────────────────────────────────────────────
+
+
+def test_grid_heuristic_is_deterministic() -> None:
+    """``heuristic="grid"`` is RNG-free ⇒ byte-identical across repeat runs."""
+    layout = load_layout("tests/fixtures/valid_all_nine_planes.yaml")
+    mover = min(layout.placements, key=lambda p: p.y_m).plane_id  # a shallow, routable plane
+    a = _route_one(layout, mover, heuristic="grid")
+    b = _route_one(layout, mover, heuristic="grid")
+    assert a.segments == b.segments
+    assert a.start == b.start
+    assert a.turn_radius_m == b.turn_radius_m
+
+
+# ── grid path is exact-oracle clean (proposer/verifier) ──────────────────────
+
+
+def test_grid_path_is_oracle_clean() -> None:
+    layout = load_layout("tests/fixtures/valid_all_nine_planes.yaml")
+    mover = min(layout.placements, key=lambda p: p.y_m).plane_id
+    others = tuple(p for p in layout.placements if p.plane_id != mover)
+    placed = Layout(
+        fleet=layout.fleet,
+        hangar=layout.hangar,
+        placements=others,
+        maintenance_plane=layout.maintenance_plane,
+    )
+    slot = next(p for p in layout.placements if p.plane_id == mover)
+    arc = _route_one(layout, mover, heuristic="grid")
+    assert (
+        path_first_conflict(arc, layout.fleet[mover], mover_on_carts=slot.on_carts, placed=placed)
+        is None
+    )
+
+
+# ── grid field is well-formed ────────────────────────────────────────────────
+
+
+def test_grid_field_zero_at_goal_and_increases_with_distance() -> None:
+    h = _hangar(width_m=20.0, length_m=30.0)
+    empty = Layout(fleet={"A": _box_plane("A")}, hangar=h, placements=())
+    obstacles = _build_obstacles(empty, mover_id="A")
+    goal = Pose(x_m=10.0, y_m=20.0, heading_deg=0.0)
+    field = _build_grid_heuristic(goal, obstacles, h)
+
+    goal_cell = (round(goal.x_m / 0.5), round(goal.y_m / 0.5))
+    near_cell = (round(10.0 / 0.5), round(15.0 / 0.5))  # 5 m shy in y
+    door_cell = (round(10.0 / 0.5), round(0.0 / 0.5))  # at the door
+
+    assert field[goal_cell] == pytest.approx(0.0)
+    assert field[near_cell] > field[goal_cell]
+    assert field[door_cell] > field[near_cell]
+    # Empty hangar: the geodesic equals the straight-line distance (no detour).
+    assert field[door_cell] == pytest.approx(20.0, abs=1.0)
+
+
+def test_grid_field_marks_unreachable_cells_absent() -> None:
+    """A goal walled off behind a full-width obstacle band is unreachable: the
+    door-side cells are simply absent from the field (the planner then falls back
+    to Euclidean there, and the search exhausts its budget — genuine
+    infeasibility, which no heuristic can fix)."""
+    h = _hangar(width_m=8.0, length_m=30.0)
+    # A wide, deep obstacle plane spanning the whole width near mid-depth.
+    wall = Aircraft(
+        id="W",
+        name="wall",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=4.0,
+        measured=False,
+        parts=(
+            Part(
+                kind="fuselage_aft",
+                length_m=4.0,
+                width_m=10.0,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=3.0,
+            ),
+        ),
+        wheels=_TAIL_WHEELS,
+    )
+    layout = Layout(
+        fleet={"W": wall, "A": _box_plane("A")},
+        hangar=h,
+        placements=(Placement("W", 4.0, 15.0, 0.0, on_carts=False),),
+    )
+    obstacles = _build_obstacles(layout, mover_id="A")
+    goal = Pose(x_m=4.0, y_m=25.0, heading_deg=0.0)  # behind the wall
+    field = _build_grid_heuristic(goal, obstacles, h)
+    door_cell = (round(4.0 / 0.5), round(0.0 / 0.5))
+    assert door_cell not in field  # walled off from the goal
+
+
+# ── stats out-param ──────────────────────────────────────────────────────────
+
+
+def test_stats_records_outcome_on_failure() -> None:
+    """A boxed-in goal at a tiny budget records found=False with the cap flag."""
+    h = _hangar(width_m=8.0, length_m=30.0)
+    wall = Aircraft(
+        id="W",
+        name="wall",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=4.0,
+        measured=False,
+        parts=(
+            Part(
+                kind="fuselage_aft",
+                length_m=4.0,
+                width_m=10.0,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=3.0,
+            ),
+        ),
+        wheels=_TAIL_WHEELS,
+    )
+    layout = Layout(
+        fleet={"W": wall, "A": _box_plane("A")},
+        hangar=h,
+        placements=(
+            Placement("W", 4.0, 15.0, 0.0, on_carts=False),
+            Placement("A", 4.0, 25.0, 0.0, on_carts=False),
+        ),
+    )
+    stats: dict[str, object] = {}
+    with pytest.raises(NoFeasiblePlanError):
+        _route_one(layout, "A", heuristic="euclidean", max_expansions=50, stats=stats)
+    assert stats["found"] is False
+    assert isinstance(stats["expansions"], int)
+    # Either it hit the cap or it exhausted the reachable space; exactly one.
+    assert bool(stats["budget_exhausted"]) != bool(stats["space_exhausted"])
+    assert math.isfinite(float(stats["expansions"]))  # type: ignore[arg-type]

--- a/tests/test_towplanner_grid_heuristic.py
+++ b/tests/test_towplanner_grid_heuristic.py
@@ -29,10 +29,9 @@ kept as a tested, opt-in PoC and the home for a future clutter/learned heuristic
 
 from __future__ import annotations
 
-import math
-
 import pytest
 
+from hangarfit.cli import build_parser
 from hangarfit.loader import load_layout, load_scenario
 from hangarfit.models import (
     Aircraft,
@@ -166,11 +165,18 @@ def test_grid_heuristic_is_deterministic() -> None:
     """``heuristic="grid"`` is RNG-free ⇒ byte-identical across repeat runs."""
     layout = load_layout("tests/fixtures/valid_all_nine_planes.yaml")
     mover = min(layout.placements, key=lambda p: p.y_m).plane_id  # a shallow, routable plane
-    a = _route_one(layout, mover, heuristic="grid")
+    stats: dict[str, object] = {}
+    a = _route_one(layout, mover, heuristic="grid", stats=stats)
     b = _route_one(layout, mover, heuristic="grid")
     assert a.segments == b.segments
     assert a.start == b.start
     assert a.turn_radius_m == b.turn_radius_m
+    # The stats payload the #332 harness reads is populated on a GRID success too
+    # (the success branch is only asserted on the euclidean path elsewhere).
+    assert stats["found"] is True
+    assert stats["heuristic"] == "grid"
+    assert stats["budget_exhausted"] is False and stats["space_exhausted"] is False
+    assert isinstance(stats["expansions"], int) and isinstance(stats["start_poses"], int)
 
 
 # ── grid path is exact-oracle clean (proposer/verifier) ──────────────────────
@@ -297,9 +303,21 @@ def test_stats_records_outcome_on_failure() -> None:
         _route_one(layout, "A", heuristic="euclidean", max_expansions=50, stats=stats)
     assert stats["found"] is False
     assert isinstance(stats["expansions"], int)
-    # Either it hit the cap or it exhausted the reachable space; exactly one.
-    assert bool(stats["budget_exhausted"]) != bool(stats["space_exhausted"])
-    assert math.isfinite(float(stats["expansions"]))  # type: ignore[arg-type]
+    # A tiny budget against a routable-but-hard goal hits the cap: this pins the
+    # ``budget_exhausted`` arm specifically (the XOR alone would pass either way).
+    assert stats["budget_exhausted"] is True
+    assert stats["space_exhausted"] is False
+    assert stats["expansions"] == 50  # the cap-break sets expansions == max_expansions
+    # NOTE on the OTHER arm: ``space_exhausted=True`` requires the open heap to
+    # drain before the cap — i.e. a FINITE reachable state set. With the #222
+    # front-gap exemption the apron (``y < 0``) is unbounded, so the mover can
+    # always reverse straight out the door onto fresh cells; the frontier never
+    # empties and the cap always fires first. The spike benchmark corroborates
+    # this — *every* un-routed plane exited ``budget_exhausted``, none on space.
+    # ``space_exhausted`` is therefore a latent/defensive branch (it would matter
+    # only if a future change bounded the apron), so there is intentionally no
+    # fixture exercising it: none exists that wouldn't have to fight the planner's
+    # own geometry. See the PR thread on this assertion for the rationale.
 
 
 # ── opt-in plumbing through plan_fill / solve (the #332 flags) ───────────────
@@ -416,3 +434,29 @@ def test_grid_field_blocks_cells_past_non_aligned_walls() -> None:
     assert all(0.0 <= ix * 0.5 <= h.width_m and iy * 0.5 <= h.length_m for (ix, iy) in field)
     # The cell whose centre (8.5 m) overshoots the 8.3 m wall must be absent.
     assert (round(8.5 / 0.5), round(10.0 / 0.5)) not in field
+
+
+# ── CLI flag wiring (the #332 experimental knobs) ────────────────────────────
+
+
+def test_cli_tow_flags_default_to_the_byte_identical_shipped_planner() -> None:
+    """No ``--tow-*`` flags ⇒ the namespace defaults that route ``solve()`` down
+    the unchanged ``plan_fill(layout)`` path (the byte-identical-default guard)."""
+    args = build_parser().parse_args(["solve", "scenario.yaml"])
+    assert args.tow_heuristic == "euclidean"
+    assert args.tow_max_expansions is None
+
+
+def test_cli_tow_flags_parse_the_opt_in_values() -> None:
+    """The opt-in values reach the namespace with the right dests/types."""
+    args = build_parser().parse_args(
+        ["solve", "scenario.yaml", "--tow-heuristic", "grid", "--tow-max-expansions", "2000"]
+    )
+    assert args.tow_heuristic == "grid"
+    assert args.tow_max_expansions == 2000
+
+
+def test_cli_tow_heuristic_rejects_unknown_choice() -> None:
+    """``choices`` guards against a typo silently flowing into the planner."""
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["solve", "scenario.yaml", "--tow-heuristic", "astar"])


### PR DESCRIPTION
## Towplanner-v2 routability spike (#332)

**Draft / spike — not for merge as-is.** Refs #332. Deliverables: a reproducible characterisation + benchmark, a prototyped opt-in heuristic seam (default-off), and the write-up `docs/superpowers/specs/2026-05-28-towplanner-v2-routability-spike.md`.

### TL;DR — the going-in hypothesis was falsified

The hypothesis ("multi-plane fills fail because the straight-line A\* heuristic floods the dead pocket in front of parked planes; an obstacle-aware heuristic will route around them") **does not hold on the real fixtures.** What actually fails:

- **Every** un-routed plane exits on the expansion **cap** (`budget_exhausted`), **every** failed goal is **reachable in free space** (a point robot could get there), and the victims are the **wide-wing aircraft** (`aviat_husky` 10.82 m; `scheibe_falke` 18 m) maneuvering in a tight hangar.
- So the bottleneck is **tight finite-width / rotational maneuvering**, *not* interior-obstacle clutter, and *not* genuine geometric infeasibility.

### Benchmark (planes routed / total)

| target | euclidean@700 | grid@700 | euclidean@2000 | grid@2000 |
|---|---|---|---|---|
| placeholder 25×18 — `solve_fresh_six_planes` seed 1 (5 planes) | **3/5** | **3/5** | **4/5** | **4/5** |
| roomy 30×25 — `valid_all_nine_planes` (9 planes) | 9/9 | 9/9 | 9/9 | 9/9 |
| placeholder 25×18 — `valid_two_separated` (2 planes) | 1/2 | 1/2 | 1/2 | 1/2 |

- **Grid heuristic = no routability gain anywhere**, and a mild *cost* (per-call Dijkstra; it added expansions to a success). The exact classical analogue of the #332 CNN cost-to-go field is **inert here** → strong evidence to **defer the CNN** (a learned approximation can't beat an exact field that doesn't help).
- **Raising `_MAX_EXPANSIONS` is the only lever that moved a count** (3/5 → 4/5), confirming budget-limited false negatives — but it pays linearly and still can't route `scheibe_falke`.

### Recommendation (go/no-go)

- **GO (modest):** bump the default `_MAX_EXPANSIONS` (~1500–2000); keep the new `--tow-max-expansions` override.
- **GO (real v2 fix):** deterministic **RRT-Connect** over the existing Reeds–Shepp steering, scoped to the tight-maneuver cases (low-dispersion sampling for ADR-0003).
- **NO-GO as a fix:** the grid heuristic — kept as a tested opt-in seam for future clutter-dominated layouts / the learned-heuristic home.
- **DEFER:** the CNN (#332's hypothesis), de-risked by the negative grid result.

### What's in the diff

- `towplanner.py`: `_build_grid_heuristic` (RNG-free Dijkstra free-space geodesic), `heuristic` + diagnostic `stats` params on `plan_path`, `heuristic` + `max_expansions` on `plan_fill`.
- `solver.py`: opt-in `tow_heuristic` / `tow_max_expansions` (the **default path calls `plan_fill(layout)` exactly as before**).
- `cli.py`: `--tow-heuristic` / `--tow-max-expansions` (experimental).
- `tests/test_towplanner_grid_heuristic.py`: 6 tests — seam correctness, grid determinism, oracle-cleanliness, field well-formedness, default-unchanged.
- `docs/spikes/towplanner_v2_routability_bench.py`: reproducible harness (`--part1` for the fast characterisation).

### Determinism (ADR-0003) — sacred constraint, verified

Default behaviour is **byte-identical**: `heuristic="euclidean"` uses the same `math.hypot(...)` expression; `stats` defaults to `None` (no-op); `solve()` still calls `plan_fill(layout)` unchanged unless opt-in params are set. Grid mode is itself RNG-free and byte-identical run-to-run.

- Full non-slow suite: **1094 passed, 1 skipped** (pre-existing acceptable), 8 slow-deselected.
- Determinism canaries (`tests/test_solver_canaries.py`) and `tests/test_towplanner_*` — **untouched and green.**
- Canary diff (`run twice → diff`): `default == euclidean == True`, `euclidean run1==run2 == True`, `grid run1==run2 == True`.
- `ruff check` / `ruff format --check` / `mypy src/hangarfit/` all clean.

### Reproduce

```bash
PYTHONPATH=src python docs/spikes/towplanner_v2_routability_bench.py --part1   # ~2 min characterisation
PYTHONPATH=src python docs/spikes/towplanner_v2_routability_bench.py           # ~25 min full table
```

https://claude.ai/code/session_01ARUMxAyUgSQ6AoVm6UcgxE

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARUMxAyUgSQ6AoVm6UcgxE)_