### PR TITLE
feat(visualize): CVD-safe Okabe–Ito palette + non-colour conflict signal

### DIFF
--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -346,6 +346,36 @@ ADR.
 
 The hard score tuple `(conflict_count, total_penetration_m2)` measures only illegal overlap. The first **soft** preference — inter-plane spread (maximize separation once valid) — ships as an isolated post-pass (`solver._spread`), deliberately *outside* the hard tuple so the conflict-resolution determinism contract ([ADR-0003](../adr/0003-rr-mc-solver-algorithm.md)) is unaffected. See [ADR-0008](../adr/0008-inter-plane-spread-soft-preference.md) for the repulsion-energy metric and why it is a post-pass rather than a third score key.
 
+## Visualizer colour accessibility
+
+The PNG renderer (`src/hangarfit/visualize.py`) must stay usable by
+people with colour vision deficiency (CVD). Roughly 1 in 12 men have
+red–green CVD; a purely red-vs-green signal is the single most common
+accessibility failure in technical diagrams.
+
+**Two invariants that must not regress:**
+
+1. **The tow-path palette (`_TOW_PATH_COLORS`) is the Okabe–Ito 8-colour
+   CVD-safe set** (source: https://jfly.uni-koeln.de/color/). This palette
+   is distinguishable under deuteranopia, protanopia, and tritanopia, and
+   degrades gracefully in greyscale. Any future palette extension or
+   substitution must remain CVD-safe — verify with a simulation tool
+   (e.g., Coblis) before committing.
+
+2. **The conflict overdraw carries a non-colour redundancy channel.** The
+   red edge (`_CONFLICT_COLOR = "#e74c3c"`) is retained as a fast signal
+   for colour-normal viewers, but conflict patches also carry `hatch="xxx"`
+   (dense cross pattern) and `linestyle="--"` (dashed stroke) so "this
+   part is in conflict" reads on a B&W printout and for red-blind viewers.
+   A future refactor that drops the hatch and dashes while keeping only the
+   red edge is a regression, even if the layout looks correct at colour-normal
+   rendering.
+
+The wing-position triad (`_WING_COLORS`) uses `#d55e00` (Okabe–Ito
+vermillion) for mid-wing rather than the original `#e67e22` (orange),
+because orange and the low-wing yellow `#f4d03f` can merge under
+protanopia. The blue (`#3498db`) and yellow are retained.
+
 ## Testing posture
 
 ### Fixture-driven over Python literals

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -49,8 +49,10 @@ if TYPE_CHECKING:
     from .towplanner import MovesPlan
 
 _WING_COLORS: dict[WingPosition, str] = {
-    "high": "#3498db",  # blue
-    "mid": "#e67e22",  # orange
+    "high": "#3498db",  # blue (retained — good contrast at all positions)
+    "mid": "#d55e00",  # Okabe–Ito vermillion — replaces #e67e22 (orange) for
+    # better luminance separation from the low-wing yellow #f4d03f under
+    # protanopia; #e67e22 and #f4d03f can merge for red-blind viewers.
     "low": "#f4d03f",  # yellow
 }
 # Defensive: ``WingPosition`` is closed at ``Literal["high", "mid", "low"]``
@@ -66,15 +68,21 @@ _CONFLICT_COLOR = "#e74c3c"  # red
 # fallback so a path never blurs into a conflict highlight or a placeholder
 # part. Eight entries cover the fleet (<=9 planes); a 9th plane reuses the
 # first colour — acceptable since each path terminates at its annotated slot.
+#
+# Palette: Okabe–Ito 8-colour CVD-safe set (https://jfly.uni-koeln.de/color/).
+# This palette is distinguishable under deuteranopia, protanopia, and
+# tritanopia simultaneously, and reads in grey-scale. The conflict red
+# (#e74c3c) is excluded from this cycle as noted above; it is not part of
+# the Okabe–Ito set either.
 _TOW_PATH_COLORS = (
-    "#1f77b4",  # blue
-    "#ff7f0e",  # orange
-    "#2ca02c",  # green
-    "#9467bd",  # purple
-    "#8c564b",  # brown
-    "#17becf",  # cyan
-    "#bcbd22",  # olive
-    "#e377c2",  # pink
+    "#000000",  # black
+    "#e69f00",  # orange
+    "#56b4e9",  # sky blue
+    "#009e73",  # bluish green
+    "#f0e442",  # yellow
+    "#0072b2",  # blue
+    "#d55e00",  # vermillion
+    "#cc79a7",  # reddish purple
 )
 _TOW_PATH_LINEWIDTH = 1.6
 
@@ -120,7 +128,7 @@ _DOOR_EDGE = "#bdc3c7"  # light gray — visually "open"
 _GLYPH_ZORDER = 1.5  # between wings (1) and fuselage (2)
 #
 # COLOUR: neutral dark-gray that reads on the off-white floor, stays clear of
-# the wing-position palette (#3498db/#e67e22/#f4d03f), the conflict-red
+# the wing-position palette (#3498db/#d55e00/#f4d03f), the conflict-red
 # (#e74c3c), and the tow-path colours. A second shade is used for the cart
 # pallets so each dolly square is distinct from its wheel disc.
 _WHEEL_COLOR = "#566573"  # dark slate-gray — individual wheel discs
@@ -512,7 +520,15 @@ def _annotate_plane(ax: Any, placement: Placement, plane_id: str) -> None:
 
 def _draw_conflict_overlay(ax: Any, layout: Layout, check_result: CheckResult) -> None:
     """Redraw every part of every plane named in any conflict, in red,
-    with a thicker edge so the conflict reads at a glance."""
+    with a thicker dashed edge and a cross hatch so the conflict reads at
+    a glance — even on a B&W printout or for red-green colour-blind viewers.
+
+    Non-colour redundancy: ``hatch="xxx"`` (dense cross pattern) plus
+    ``linestyle="--"`` (dashed stroke) ensure "this part is in conflict" is
+    legible without relying on the red edge colour alone.  The red edge is
+    *kept* as a fast visual signal for colour-normal viewers — the non-colour
+    signals are additive, not replacements.
+    """
     conflicting_planes: set[str] = set()
     for conflict in check_result.conflicts:
         conflicting_planes.update(conflict.planes)
@@ -528,6 +544,8 @@ def _draw_conflict_overlay(ax: Any, layout: Layout, check_result: CheckResult) -
                 facecolor="none",
                 edgecolor=_CONFLICT_COLOR,
                 lw=2,
+                linestyle="--",
+                hatch="xxx",
                 zorder=5,
             )
             ax.add_patch(patch)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -32,8 +32,10 @@ from hangarfit.visualize import (
     _BAY_WALL_FACE,
     _CART_DECK_COLOR,
     _CART_PALLET_HALF_EXTENT_M,
+    _CONFLICT_COLOR,
     _GLYPH_ZORDER,
     _WHEEL_COLOR,
+    _draw_conflict_overlay,
     _draw_gear_glyph,
     _draw_maintenance_bay,
     nose_direction,
@@ -107,6 +109,50 @@ class TestRenderLayout:
         out = tmp_path / "clean_with_result.png"
         render_layout(layout, out, check_result=result)
         _assert_valid_png(out)
+
+    def test_conflict_overlay_carries_non_colour_redundancy(self) -> None:
+        """Every conflict overdraw patch must signal "in conflict" through
+        non-colour channels — a hatch pattern *and* a dashed stroke — in
+        addition to the red edge, so the conflict reads on a B&W printout and
+        for red-green colour-blind viewers (#326).
+
+        Guards the accessibility invariant documented in arc42 §8 ("Visualizer
+        colour accessibility") against a refactor that drops the hatch/dash and
+        leaves only ``_CONFLICT_COLOR`` — a regression that would still render a
+        plausible-looking PNG and so would pass every other test in this file.
+        Mirrors :meth:`TestConditionalBayRendering
+        .test_closed_bay_adds_hatched_red_patch_and_label`, the other
+        non-colour-redundancy guard in this suite.
+        """
+        import matplotlib.colors
+
+        layout = _load("invalid_wing_wing_same_height")
+        result = check(layout)
+        assert not result.valid, "fixture precondition: layout should have conflicts"
+        ax = MagicMock()
+
+        _draw_conflict_overlay(ax, layout, result)
+
+        assert ax.add_patch.call_count >= 1, (
+            "conflict overlay must redraw at least one offending part"
+        )
+        expected_edge = matplotlib.colors.to_rgba(_CONFLICT_COLOR)
+        for call in ax.add_patch.call_args_list:
+            patch = call.args[0]
+            assert isinstance(patch, MplPolygon)
+            assert patch.get_hatch(), (
+                f"conflict patch must carry a hatch pattern; got {patch.get_hatch()!r}"
+            )
+            assert patch.get_linestyle() in ("--", "dashed"), (
+                "conflict patch must use a dashed (non-solid) stroke; "
+                f"got {patch.get_linestyle()!r}"
+            )
+            # The red edge is *retained* as the fast signal for colour-normal
+            # viewers — the hatch/dash are additive, not a replacement.
+            edge = patch.get_edgecolor()
+            assert edge[:3] == expected_edge[:3], (
+                f"conflict patch must keep the {_CONFLICT_COLOR} edge; got {edge!r}"
+            )
 
     def test_title_is_optional(self, tmp_path: Path) -> None:
         layout = _load("valid_two_separated")


### PR DESCRIPTION
## Summary

- **Tow-path palette** (`_TOW_PATH_COLORS`): swapped from matplotlib default cycle to the **Okabe–Ito 8-colour CVD-safe set** (`#000000`, `#e69f00`, `#56b4e9`, `#009e73`, `#f0e442`, `#0072b2`, `#d55e00`, `#cc79a7`). Source: https://jfly.uni-koeln.de/color/. This palette is distinguishable under deuteranopia, protanopia, and tritanopia simultaneously and degrades gracefully in greyscale.
- **Mid-wing colour** (`_WING_COLORS["mid"]`): `#e67e22` (orange) → `#d55e00` (Okabe–Ito vermillion). The original orange and the low-wing yellow `#f4d03f` can merge for protanopic viewers; vermillion has better luminance separation.
- **Conflict overdraw non-colour redundancy**: added `hatch="xxx"` (dense cross pattern) and `linestyle="--"` (dashed stroke) to the conflict overlay patches **in addition** to the existing red edge (`#e74c3c`). "This part is in conflict" now reads on a B&W printout and for red-blind viewers without removing the red signal for colour-normal viewers.
- **Accessibility constraint documented** in `docs/architecture/08-crosscutting-concepts.md` (new "Visualizer colour accessibility" sub-section): records the CVD-safe palette invariant and the non-colour conflict channel requirement so future visualizer work cannot silently regress either.

## Palette rationale

Roughly 1 in 12 men have red–green colour vision deficiency. The previous tow-path palette was matplotlib's default cycle, which includes `#2ca02c` (green) and `#1f77b4` (blue) — these can blend under deuteranopia. The original conflict overlay relied solely on red edge colour, invisible to protanopic viewers. Option A (default-safe, no CLI flag) was selected by the maintainer.

## Conflict redundancy approach

`hatch="xxx"` + `linestyle="--"` applied to every conflict overdraw polygon. Dense-cross hatch reads in greyscale printing; dashed stroke distinguishes conflict boundary from normal plane outline (solid). Red edge retained as primary signal.

## Doc note location

`docs/architecture/08-crosscutting-concepts.md` — new top-level section "Visualizer colour accessibility" inserted before "Testing posture". Records two invariants: CVD-safe palette and non-colour conflict channel.

## Screenshot regeneration status

No screenshot images are committed to this repository (docs reference `--render` CLI examples only). No regeneration needed.

## Test plan

- [x] `PYTHONPATH=src pytest -m "" tests/` — all palette/visualize tests pass; 1 pre-existing failure in `test_cli_solve.py::TestSolveRenderPathsSpreadFallback::test_real_solve_spread_fallback_end_to_end` (spread-fallback solver test, pre-dates this PR, unrelated to visualizer)
- [x] `ruff check src/ tests/` — `All checks passed\!`
- [x] `ruff format --check src/ tests/` — `42 files already formatted`
- [x] `mypy src/hangarfit/` — `Success: no issues found in 9 source files`
- [x] Pre-commit hooks pass (trim-whitespace, ruff check, ruff format)

Closes #326

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)