### PR TITLE
feat(towplanner): raise _MAX_EXPANSIONS 700 → 2000 per budget sweep (#335)

### DIFF
--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1174,12 +1174,31 @@ _GRID_XY_M = 0.5  # (x, y) cell size for state binning
 _GRID_DEG = 15.0  # heading cell size; 360 / 15 = 24 heading bins
 _HEADING_BINS = round(360.0 / _GRID_DEG)
 _TURN_PENALTY = 0.1  # per-radian g-cost penalty to prefer straighter paths
-_MAX_EXPANSIONS = 700  # node-expansion budget per plane before bailing.
+_MAX_EXPANSIONS = 2000  # node-expansion budget per plane before bailing (#335).
+# Raised 700 → 2000 based on a budget sweep over the standard fixtures
+# (placeholder 25×18 hangar, solve_fresh_six_planes seed=1, 5 floor planes):
+#
+#   Budget | Routed (seed=1) | plan_fill wall-clock (seed=7)
+#   -------|-----------------|-----------------------------
+#      700 |  3/5            |  ~108 s
+#     1000 |  3/5 (no gain)  |  ~137 s
+#     1500 |  3/5 (no gain)  |  ~215 s
+#     2000 |  4/5 (+1, KNEE) |  ~271 s
+#     3000 |  4/5 (no gain)  |  ~441 s
+#     4000 |  4/5 (no gain)  |  ~540 s+ (extrapolated)
+#
+# The knee is at 2000: routed count improves from 3→4 and does not improve
+# further at 3000 or 4000.  The aviat_husky (first in back-first order at
+# seed=1) remains un-routable even at budget 4000 — genuine tight-geometry
+# budget exhaustion that a larger budget alone cannot fix, not a false negative.
+#
 # Deterministic (machine-independent) bound on worst-case search cost. The flip
 # side: budget exhaustion can also report a genuinely-feasible-but-hard layout
-# as NoFeasiblePlanError (a false negative). Accepted v1 tradeoff — see the
-# design spec's failure semantics; retune once #197 exercises the planner
-# through solve() on real (measured) hangar geometry.
+# as NoFeasiblePlanError (a false negative). Accepted v2 tradeoff — see the
+# design spec's failure semantics; retune once real (measured) hangar geometry
+# is available, or once issue #336 (RRT-Connect v2) extends the motion model.
+# Overridable per-invocation via the ``--tow-max-expansions`` CLI flag and the
+# ``tow_max_expansions`` param on ``solve()``/``plan_fill()`` (#332).
 # Sampling resolution for the FAST in-search `_motion_clear` validity checks
 # (edges + the analytic-shot screen). Coarser than the exact oracle's default
 # (0.05 m / 1°) to keep the search tractable: the worst case is a plane that can

--- a/tests/test_towplanner_perf.py
+++ b/tests/test_towplanner_perf.py
@@ -32,15 +32,17 @@ from hangarfit.towplanner import NoFeasiblePlanError, path_first_conflict, plan_
 #
 # Bumped 30s → 75s for the Reeds–Shepp motion model (ADR-0010): the primitive
 # fan grew from 3 (forward L/S/R) to 6 (+ reverse L/S/R), so each expansion now
-# screens roughly twice the edges and the worst-case budget-exhaustion bail on
-# an un-towable layout (the six-plane fresh fill, where several planes are
-# un-routable at 700 expansions each) doubled to ~50s observed. 75s keeps the
-# runaway guard meaningful — it is still less than half the 177s pre-tuning
-# baseline — with margin over the observed worst case for slower machines.
-# Tighten once #197/v2 exercise the planner through solve() on real (measured)
-# hangar geometry, or once the primitive fan is pruned (e.g. dropping the
-# redundant reverse cart pivots, or gating reverse edges behind a heuristic).
-_PLAN_FILL_CEILING_S = 75.0
+# screens roughly twice the edges.
+#
+# Bumped 75s → 400s for the _MAX_EXPANSIONS 700 → 2000 raise (#335).  The
+# per-plane cost scales linearly with budget; with budget 2000 the worst-case
+# bail on the six-plane fresh fill (seed=7, two un-routable planes each
+# exhausting the full budget, tried multiple times by the greedy scan) measured
+# ~271 s on the development machine.  400 s = ~271 s × 1.5 + rounding — keeps
+# the runaway guard meaningful while allowing for slower CI machines.  Tighten
+# once real (measured) hangar geometry is available or issue #336 (RRT-Connect
+# v2) extends the motion model.
+_PLAN_FILL_CEILING_S = 400.0
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

Raises the Hybrid-A\* per-plane node-expansion budget (`_MAX_EXPANSIONS`) from
700 to **2000**, the empirical knee point identified by a budget sweep over the
standard tow-path fixtures.  Adjusts the slow-test perf gate ceiling
proportionally.  No other behavioural change.

Closes #335

---

## Budget sweep — placeholder 25×18 hangar, `solve_fresh_six_planes` seed=1 (5 floor planes)

| Budget | Routed (seed=1) | plan_fill wall-clock (seed=7) |
|-------:|:---------------:|------------------------------:|
|    700 | 3/5             | ~108 s                        |
|   1000 | 3/5 (no gain)   | ~137 s                        |
|   1500 | 3/5 (no gain)   | ~215 s                        |
| **2000** | **4/5 (+1, KNEE)** | **~271 s**                |
|   3000 | 4/5 (no gain)   | ~441 s                        |
|   4000 | 4/5 (no gain)   | ~540 s+ (extrapolated)        |

The knee is at **2000**: routed count improves 3→4 and does not improve
further at 3000 or 4000.  The remaining un-routed plane (`aviat_husky`,
first in back-first order at seed=1) exhausts even budget=4000 — genuine
tight-geometry budget exhaustion that a larger budget alone cannot fix.
This matches the characterisation in the #332 spike: every failure is
`budget_exhausted`, not `space_exhausted` (goal is always free-space
reachable), so the budget is the only lever.

## Code changes

- **`src/hangarfit/towplanner.py`**: `_MAX_EXPANSIONS` 700 → 2000.  Comment
  updated with the sweep table and the knee rationale.  All existing
  `tow_max_expansions` / `--tow-max-expansions` override plumbing (#332)
  continues to work unchanged.
- **`tests/test_towplanner_perf.py`**: `_PLAN_FILL_CEILING_S` 75 → 400 s.
  Worst-case observed at budget 2000 (seed=7, two planes exhaust budget,
  each tried multiple times by the greedy scan) = ~271 s; ceiling = 271 s ×
  1.5 + rounding = 400 s.

## Re-baselined assertions

No test assertions were flipped.  Key checks:

- **`test_solve_best_effort_real_planner_on_untowable_fill`** (`@slow`):
  asserts that `solve_fresh_six_planes` seed=7 still leaves some plans
  `None`.  **Still holds** — two planes (`cessna_140`, `fk9_mkii`) exhaust
  the 2000 budget in seed=7, so the fill remains partially un-routable.
  Test passes in 283 s.
- **`test_plan_fill_on_solved_layouts_completes_within_budget`** (both
  parameterised variants): passes under the new 400 s ceiling (worst case
  measured ~271 s).
- **Non-slow suite (1103 tests)**: all green, 0 failures.

## Determinism

The change is RNG-free: `_MAX_EXPANSIONS` only controls how many expansions
the deterministic Hybrid-A\* loop runs before bailing.  The primitive fan,
the tie-break counter, and the motion model are untouched.  The ADR-0003
byte-identical-plan contract is preserved for any given scenario + seed.
The `test_solver_canaries.py` canaries stub `plan_fill` and are unaffected.

## Verification output

```
ruff check src/ tests/          → All checks passed\!
ruff format --check src/ tests/ → 42 files already formatted
mypy src/hangarfit/             → Success: no issues found in 9 source files
PYTHONPATH=src pytest tests/ (non-slow, 1103 tests) → 1103 passed in 235.50s
PYTHONPATH=src pytest -m "" tests/test_towplanner_perf.py tests/test_solver_towplanner.py → 3 passed in 852.78s
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)