### PR TITLE
docs(readme): add CodeQL badge + make CI badge clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # hangarfit
 
-![CI](https://github.com/DocGerd/hangarfit/actions/workflows/ci.yml/badge.svg?branch=develop)
+[![CI](https://github.com/DocGerd/hangarfit/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/DocGerd/hangarfit/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/DocGerd/hangarfit/actions/workflows/codeql.yml/badge.svg?branch=develop)](https://github.com/DocGerd/hangarfit/actions/workflows/codeql.yml)
 [![codecov](https://codecov.io/gh/DocGerd/hangarfit/branch/develop/graph/badge.svg)](https://codecov.io/gh/DocGerd/hangarfit)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/DocGerd/hangarfit/badge)](https://securityscorecards.dev/viewer/?uri=github.com/DocGerd/hangarfit)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12987/badge)](https://www.bestpractices.dev/projects/12987)


### PR DESCRIPTION
Closes #339

## What

Adds the missing **CodeQL** badge to the README badge row and makes the **CI** badge a clickable link.

Badge order is now **CI → CodeQL → codecov → scorecard → best practices → license**, all clickable links.

```diff
-![CI](.../ci.yml/badge.svg?branch=develop)
+[![CI](.../ci.yml/badge.svg?branch=develop)](.../actions/workflows/ci.yml)
+[![CodeQL](.../codeql.yml/badge.svg?branch=develop)](.../actions/workflows/codeql.yml)
 [![codecov](...)](codecov.io/...)
 [![OpenSSF Scorecard](...)](...)
 [![OpenSSF Best Practices](...)](...)
 [![License: Apache-2.0](...)](LICENSE)
```

## Why

- A `codeql.yml` workflow runs on every push/PR but had no badge. The CodeQL badge SVG resolves live (HTTP 200).
- The CI badge was the only bare image in the row; the other badges are links. Making it clickable removes the inconsistency.

## Notes

- The `?branch=develop` pin mirrors the existing CI/codecov convention (GitHub default branch is `develop`; `main`'s README rides the next back-merge).
- Documentation only — no code, no workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)