### PR TITLE
chore(release): v0.8.0 readiness — backfill CHANGELOG + fix __version__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,21 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Wheel positions are now canonical per-aircraft data.** A new `Wheels` dataclass carries each aircraft's measured wheel positions in `fleet.yaml`, replacing the renderer's heuristic fuselage-fraction guesses; at load time `turn_radius_m` is cross-checked against the wheelbase (a 0.5×–5× sanity band). Documented in ADR-0013 (#322).
+- Opt-in, default-off obstacle-aware A\* heuristic seam (`heuristic=` / `stats=`) on the tow-path planner, plus a reproducible routability benchmark and the towplanner-v2 spike write-up under `docs/superpowers/specs/`. The spike characterised why tight multi-plane fills are un-routable (budget-exhausted on tight finite-width maneuvering, not obstacle clutter) and found the obstacle-aware grid heuristic buys no extra routability (#332).
+
 ### Changed
 
+- **BREAKING (pre-1.0):** `Aircraft.wheels` is now a required field — the loader raises a `LoaderError` on a missing or malformed `wheels:` block. All nine fleet aircraft carry a backfilled `wheels:` block (#322).
+- Tow-path overlay now uses the CVD-safe Okabe–Ito 8-colour palette; the mid-wing colour moves to vermillion (`#d55e00`) for better protanopic separation from the low-wing yellow; and conflict overdraw is signalled with a hatch fill and dashed outline in addition to colour, so it survives greyscale and colour-blind viewing (#326).
+- Cart-borne aircraft (`on_carts=True`) render as a small pallet under each wheel, oriented with the aircraft, instead of one body-sized deck rectangle — matching the physical cart geometry (#321).
+- Hybrid-A\* per-plane node-expansion budget (`_MAX_EXPANSIONS`) raised 700 → 2000 — the empirical knee from a budget sweep — so more tight fills route; the slow-test per-plane perf ceiling was raised to match (#335).
+- README badge row gains a CodeQL badge (slot 2) and the CI badge is now a clickable link, consistent with the other badges (#339).
+- Release documentation prep is split into a dedicated `/release-prep` skill (CHANGELOG promotion + doc-freshness audit on its own focused-review PR into `develop`); `/release-cut` gains a Check E that refuses to cut until the CHANGELOG has been promoted (#325).
+
 ### Fixed
+
+- `hangarfit.__version__` was a stale hard-coded `"0.0.1"` that never tracked `pyproject.toml`; it is now sourced from the installed package metadata via `importlib.metadata.version("hangarfit")`, with a `PackageNotFoundError` fallback for an uninstalled source tree, so it stays in sync with the release version (#341).
 
 ## [0.7.2] — 2026-05-28
 

--- a/src/hangarfit/__init__.py
+++ b/src/hangarfit/__init__.py
@@ -1,3 +1,11 @@
 """Hangar arrangement helper for a flying club fleet."""
 
-__version__ = "0.0.1"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
+
+try:
+    __version__ = _version("hangarfit")
+except PackageNotFoundError:  # pragma: no cover - source tree without an install
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,20 @@
+"""The package ``__version__`` is sourced from installed metadata, not hard-coded.
+
+Guards the #341 fix: ``__version__`` used to be a literal ``"0.0.1"`` that drifted
+from ``pyproject.toml`` across every release. It now derives from
+``importlib.metadata`` so the two cannot disagree.
+"""
+
+from importlib.metadata import version
+
+import hangarfit
+
+
+def test_version_matches_installed_metadata() -> None:
+    """``hangarfit.__version__`` reflects the installed distribution version."""
+    assert hangarfit.__version__ == version("hangarfit")
+
+
+def test_version_is_not_the_stale_placeholder() -> None:
+    """Regression: the old hard-coded ``0.0.1`` placeholder is gone."""
+    assert hangarfit.__version__ != "0.0.1"


### PR DESCRIPTION
Closes #341

Pre-cut readiness for **v0.8.0**, so `/release-prep version=0.8.0` can run (it fail-fasts on an empty `[Unreleased]` and only *promotes* — it does not author entries).

## 1. Backfill `CHANGELOG.md [Unreleased]`
The 7 PRs merged to `develop` since v0.7.2 never added CHANGELOG entries (the v0.7.2 prep reset `[Unreleased]` to empty). Backfilled from #322 (wheels-canonical, incl. the breaking `Aircraft.wheels`-required change), #326 (CVD palette + conflict signal), #321 (cart-at-wheels), #335 (`_MAX_EXPANSIONS` 700→2000), #332 (routability spike + heuristic seam), #325 (`/release-prep` split), #339 (CodeQL badge).

## 2. Fix stale `__version__`
`src/hangarfit/__init__.py` hard-coded `__version__ = "0.0.1"`, drifted from `pyproject.toml` across every release. Now sourced from `importlib.metadata.version("hangarfit")` with a `PackageNotFoundError` fallback. New `tests/test_version.py` compares to the installed metadata (not a literal), so it survives version bumps.

## Verification
- `ruff check` + `ruff format` clean.
- Full non-slow suite: **1106 passed**, 8 slow deselected.

## Next (after merge)
1. `/release-prep version=0.8.0` — promotes `[Unreleased]` → `[0.8.0]`, doc audit.
2. `/release-cut version=0.8.0` — release branch, `pyproject` bump, PRs to main+develop, signed GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)