### PR TITLE
docs(spec): tow-pivot (`tow_pivotable`) design — folded into #263

### DIFF
--- a/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
+++ b/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
@@ -1,0 +1,229 @@
+# Free-castering tow-pivot capability — design
+
+- **Date:** 2026-05-29
+- **Status:** Proposed (awaiting user spec review → implementation plan)
+- **Target milestone:** #28 (v0.9.0)
+- **Subsystem:** `towplanner` motion model (via `models.py` accessor + fleet data)
+- **Related:** [ADR-0010](../../adr/0010-reeds-shepp-motion-model.md) (Reeds–Shepp motion),
+  [ADR-0007](../../adr/0007-tow-path-planner-v1-scope.md) (cart = own-gear with `turn_radius_m = 0`),
+  [ADR-0013](../../adr/0013-wheels-canonical-data.md) (canonical per-aircraft data),
+  issue **#263** (nose-out — enabled by this), issue **#320** (back-bias — complemented by this).
+
+---
+
+## 1. Problem
+
+The tow-path planner models every own-gear plane as a car-like Reeds–Shepp vehicle with a
+fixed minimum turning radius (`Aircraft.turn_radius_m`). For the Aviat Husky that radius is
+`5.0 m`. But the Husky is a **free-castering taildragger**: when towed by hand or a tail-tug,
+its tailwheel swivels freely and the airframe rotates essentially *within its own length*
+about the main-gear axle. The `5.0 m` figure models **powered self-taxi**, not **towing** —
+and the planner's job is to plan *tows*.
+
+The consequence is observable. In the six-plane fill (`tests/fixtures/solve_fresh_six_planes.yaml`,
+`--no-spread --seed 1`) the planner returns **exit 3**, and the blocking plane is *literally the
+Husky*:
+
+```
+layout not tow-routable by the tow-path planner: plane 'aviat_husky' blocked
+(no_feasible_path: no in-bounds tow path found within 2000 expansions)
+```
+
+The static layout is valid; the planner just can't thread a 5.0 m-radius car through the gap a
+real handler would pivot the Husky into. The model is **conservative to the point of being wrong
+for the towing use case.**
+
+## 2. Goal & non-goals
+
+**Goal.** Let a plane declared free-castering be planned with the realistic *towing* motion —
+pivot in place, push straight, pivot — which is both physically faithful for a hand/tail-tug
+tow and the thing that makes tight fills routable.
+
+**Non-goals.**
+- Not modelling powered taxi (the `turn_radius_m` arc stays as the documented powered figure).
+- Not adding a probabilistic planner (RRT-Connect remains deferred per ADR-0010).
+- Not re-centering the pivot on an arbitrary main-gear offset (see §4.3 alternative (b), deferred).
+- Not changing which planes ride carts or the cart-eligibility rules.
+
+## 3. Decision summary
+
+| Axis | Decision | Why |
+|---|---|---|
+| Objective | Model realistic towing (pivot + push), which also maximizes routability | A tow planner should model towing; pivot+push is how a free-caster is actually towed |
+| Declaration | Explicit per-plane `free_castering: bool` flag in `fleet.yaml`, default `false` | ADR-0013 ethos: declare canonical capability, don't infer from `gear` (steerable/lockable tailwheels don't fully caster) |
+| Data-model shape | **Orthogonal boolean, NOT a new `MovementMode`** | Keeps `on_carts`/`movement_mode` invariants and cart-pool accounting untouched (§4.1) |
+| Motion realization | Reuse the existing `turn_radius_m == 0` cart-pivot machinery | No new primitive / word / cost constant / geometry math → determinism surface unchanged |
+| Pivot center | About the plane **datum** (existing behavior); main-gear-offset pivot deferred | 0.20 m error for the Husky (main gear ≈ datum); offsetting would touch motion math + trigger geometry-guard |
+
+## 4. Design
+
+### 4.1 Data model — orthogonal boolean, not a movement mode (load-bearing)
+
+`free_castering` is a capability **orthogonal to `movement_mode`**, added as a new boolean field
+on `Aircraft` (default `False`). It is deliberately **not** a new `MovementMode` value:
+
+- A free-castering Husky is **still on its own gear** — `on_carts = False`. The `Layout`
+  consistency invariant (`always_cart ↔ on_carts`, `models.py:488`) and the solver's cart-pool
+  accounting key off `movement_mode`. A new movement mode would tangle with both; an orthogonal
+  boolean touches neither.
+- It composes: `always_own_gear + free_castering` (the Husky today) and
+  `cart_eligible + free_castering` (a tailwheel that pivots on its own gear *and* can ride a
+  cart) both fall out correctly with no special-casing. `always_cart + free_castering` is
+  redundant but harmless (already `0.0`); the loader stays permissive (the flag is gear- and
+  mode-agnostic, since free-castering nosewheels also exist).
+
+### 4.2 The accessor — the single behavioral change
+
+`Aircraft.effective_turn_radius_m()` (`models.py:299`) is the *one* place the planner resolves a
+plane's planning radius. Today:
+
+```python
+if self.movement_mode == "always_cart":
+    return 0.0
+return self.required_turn_radius_m()
+```
+
+becomes:
+
+```python
+if self.movement_mode == "always_cart" or self.free_castering:
+    return 0.0
+return self.required_turn_radius_m()
+```
+
+A flagged plane returns `0.0`, and from `plan_path:1679` (`r = mover.effective_turn_radius_m()`)
+that `0.0` flows through the **existing** cart-pivot path with no further branching:
+
+- `_primitives(0.0)` → the 4-primitive fan (pivot-L, straight-fwd, pivot-R, straight-rev)
+- `DubinsArc.pose_at` r==0 branch → pivot-in-place integration (position fixed, heading steps)
+- `DubinsArc.sample` r==0 branch → angular density for collision sampling of the pivot
+- `_seg_cost` r==0 branch → pivot cost in radians × `_TURN_PENALTY`
+- `plan_reeds_shepp(turn_radius_m=0.0)` → delegates to `_plan_cart` (pivot → push → pivot,
+  reverse-enabled)
+
+`required_turn_radius_m()` and the `__post_init__` validation are unchanged: a free-castering
+own-gear plane still carries a positive `turn_radius_m` (the documented powered-taxi figure); the
+planner simply stops consulting it.
+
+### 4.3 Pivot center
+
+The r==0 pivot rotates about the plane's **datum** (local origin, `local_to_world`,
+`geometry.py:119`). The physically-true center is the **main-gear axle** (`main_offset_x_m`).
+
+- **(a) Pivot about the datum — CHOSEN.** Reuse the machinery verbatim; `towplanner.py` and
+  `geometry.py` are untouched, so **no geometry-invariant-guard review is required**. Faithful
+  for the Husky: its main gear sits at `main_offset_x_m = 0.20 m`, i.e. 20 cm (sub-wheel-width)
+  from the datum. Documented assumption: *accurate when datum ≈ main gear; the flag is opt-in, so
+  only flag planes where this holds.*
+- **(b) Pivot about `main_offset_x_m` — DEFERRED.** Physically general, but requires offsetting
+  the pivot center inside `pose_at` → touches motion math → triggers the geometry-invariant-guard
+  sign-flip review and a new heading canary, and breaks the "planner untouched" property — for a
+  0.20 m gain on the only currently-flagged plane. Recorded in the ADR as the future refinement if
+  a plane with a far-offset datum is ever flagged.
+
+### 4.4 Change surface
+
+| File | Change | Notes |
+|---|---|---|
+| `src/hangarfit/models.py` | Add `free_castering: bool = False` to `Aircraft`; add `or self.free_castering` to the `0.0` branch of `effective_turn_radius_m()` | `MovementMode` and `__post_init__` unchanged |
+| `src/hangarfit/loader.py` | Parse `free_castering` (default `False`) | Boolean; no coupling to `gear` |
+| `data/fleet.yaml` | `aviat_husky: free_castering: true` + comment; update header doc block | Other planes default `false`; club fills in as known |
+| `src/hangarfit/towplanner.py` | **None** | The headline property — flagged planes reuse the existing deterministic r==0 path |
+| `src/hangarfit/geometry.py`, `collisions.py` | **None** | No motion math change under decision (a) |
+
+## 5. Determinism
+
+The tow planner is **RNG-free**; determinism is structural (fixed primitive-fan order, fixed
+Reeds–Shepp word order with strict-`<` tie-break, a monotonic `(f, counter, node)` heap
+tie-break, total-order sorts). Because flagged planes reuse the **existing** r==0 path, this
+change adds **no new primitive, word, cost constant, ordering surface, or RNG**. The determinism
+contract (ADR-0003, `max_restarts`-scoped per the #267 amendment) holds by construction.
+
+A determinism canary (§7) proves it empirically: a free-castering-Husky scenario must produce a
+**byte-identical `MovesPlan`** across two runs of the same scenario + seed.
+
+## 6. Real-world basis
+
+A free-castering tailwheel has no rudder linkage; the aircraft is steered by differential braking
+and, with the tailwheel free-swivelling, can be rotated about a main wheel **within its own
+length** (FAA *Airplane Flying Handbook* ch. 14; EAA; AOPA). A tail-tug makes the tailwheel a
+steered, pushed rear point (trailer kinematics); the handler swings the tail and the body rotates
+about the main-gear line. The faithful planner abstraction is therefore **rotation about the
+main-gear axle with near-zero translation**, with the **wingtips** sweeping the binding circle.
+
+Key numbers (Aviat Husky): wingspan **10.82 m** (the value already in `fleet.yaml`'s wing
+`width_m`), so the swept circle has radius ≈ **5.4 m** — *wingtips*, not the tail, dominate the
+footprint. The existing pivot already samples the full angular sweep for collision checking
+(`DubinsArc.sample` r==0 branch), so the wingtip sweep is collision-checked. Because the Husky's
+main gear is ~0 m from its datum, the datum pivot (§4.3a) is a faithful main-gear pivot for it.
+
+## 7. Testing
+
+- **Unit (`models`):** `effective_turn_radius_m()` returns `0.0` for a free-castering own-gear
+  plane; field defaults `False`; `cart_eligible + free_castering → 0.0`.
+- **Loader:** `free_castering` parsed; defaults `False`; round-trips.
+- **Planner integration:** a flagged own-gear plane yields a pivot-style path (a `turn_radius_m == 0`
+  `DubinsArc` containing pivot segments).
+- **🎯 Payoff test:** with `aviat_husky.free_castering = true`, the six-plane fill
+  (`solve_fresh_six_planes`, `--no-spread --seed 1`) routes the Husky — turning the observed
+  exit-3 into a fully-routed fill. Directly measurable against the motivating failure.
+- **Determinism canary:** a free-castering-Husky scenario produces a byte-identical `MovesPlan`
+  across two runs (extends the canary suite); passes by construction, proven by the test.
+
+## 8. ADR & docs
+
+A new ADR — *"Free-castering tow-pivot capability"* — records the orthogonal-flag decision, the
+datum-pivot approximation with (b) as the deferred alternative, and the towing-vs-powered-taxi
+rationale. It cross-references ADR-0010 (motion), ADR-0007 (cart = r=0), and ADR-0013 (canonical
+per-aircraft data — same ethos). **Number allocated via `/new-adr` at implementation time**
+(committed ADRs stop at 0013; 0014 is earmarked for #263 in an issue comment, so this will likely
+be 0015 or later). The ADR lands **with** the implementation PR, per the project's #320/#263
+convention. Also: `fleet.yaml` header note + a one-line CLAUDE.md/arc42 pointer.
+
+*Alternative considered:* amend ADR-0010 instead. Rejected — this adds a fleet-schema field and a
+capability concept (ADR-0013-shaped), so a new ADR reads cleaner than bolting it onto the
+motion-vocabulary ADR.
+
+## 9. Interactions with deferred milestone-#28 work
+
+- **#320 (back-bias):** complementary, no conflict. Back-packing leaves the door cone clear;
+  tighter turns only raise its towability floor. Neither reasons about turn geometry. Any order.
+- **#263 (nose-out):** this is a direct **enabler**. #263 names the tailwheel gear class and
+  depends on the planner cheaply realizing nose-out exits; the free-castering pivot makes that
+  cheaper still. Sequence tow-pivot first for maximal nose-out payoff; #263 ships correctly
+  without it. No #263 assumption changes.
+
+## 10. Review plan
+
+- `pr-review-toolkit:code-reviewer` — main pass.
+- `pr-review-toolkit:type-design-analyzer` — `models.py` changes (new field + accessor).
+- `determinism-guard` — planner *behavior* changes via the accessor (even though `towplanner.py`
+  is untouched), so the byte-identical-plan contract is re-verified.
+- **No `geometry-invariant-guard`** — decision (a) touches no geometry math. *(Decision (b) would
+  require it.)*
+
+## 11. Caveats & known limitations
+
+- **`DubinsArc.length_m` mixes radians (pivot segments) and metres (straights)** — a pre-existing
+  quirk that, with this change, appears in an *own-gear* plane's path for the first time. The
+  renderer consumes paths via `sample()` (pose-based), not `length_m`, so visuals are unaffected.
+  A code comment will warn against treating a flagged plane's `length_m` as a physical distance.
+- **Datum-pivot approximation** (§4.3a): faithful only where the datum ≈ main gear. True for the
+  Husky; the opt-in flag keeps it from being applied where it isn't.
+- **`cart_eligible`-on-a-cart pre-existing gap:** `effective_turn_radius_m()` keys on the
+  `always_cart` movement mode, not a placement's `on_carts` state, so a `cart_eligible` plane
+  placed on a cart is *not* given pivot motion today. Out of scope here; noted for completeness.
+
+## 12. Out of scope / future
+
+- Main-gear-offset pivot (§4.3b) — a fidelity ADR if a far-offset-datum plane is ever flagged.
+- Flagging planes beyond the Husky — a club data call as real measurements arrive.
+- Modelling powered self-taxi distinctly from towing.
+
+## 13. Process
+
+- Branch: `feature/free-castering-tow-pivot` off `develop`.
+- Tracking issue: file in milestone #28 at implementation time (`Closes #N` in the PR body), per
+  "no code without an issue".
+- Supervised work only (touches determinism-guarded planner behavior); no unattended worktree
+  dispatch.

--- a/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
+++ b/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
@@ -107,11 +107,15 @@ documented powered-taxi figure); the planner just stops consulting it.
 
 ### 4.3 Pivot center
 
-The r==0 pivot rotates about the plane's **datum** (local origin, `geometry.py:119`).
+The r==0 pivot rotates about the plane's **datum** (the `Pose` `x_m`/`y_m`, which is the
+plane-local origin). The mechanism is `DubinsArc.pose_at` (`towplanner.py:140-145`): for an `L`/`R`
+segment at `r==0`, position is held fixed and only the heading `theta` advances. (Note:
+`geometry.local_to_world`, `geometry.py:119`, is *unrelated* — it maps part vertices for the
+collision/visualize code, not for path integration.)
 
-- **(a) Pivot about the datum — CHOSEN.** Reuse the machinery verbatim; `towplanner.py` and
-  `geometry.py` untouched → **no geometry-invariant-guard review required**. Faithful here (all
-  flagged planes' main gear is ≤0.5 m from the datum).
+- **(a) Pivot about the datum — CHOSEN.** Reuse the machinery verbatim; the `pose_at` integrator
+  and `geometry.py` are untouched → **no geometry-invariant-guard review required**. Faithful here
+  (all flagged planes' main gear is ≤0.5 m from the datum).
 - **(b) Pivot about `main_offset_x_m` — DEFERRED.** General, but offsetting the pivot inside
   `pose_at` touches motion math → triggers the geometry sign-flip guard + a new canary, for a
   sub-metre gain on the current fleet. ADR records it as the future refinement.

--- a/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
+++ b/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
@@ -1,229 +1,220 @@
-# Free-castering tow-pivot capability — design
+# Tow-pivot capability (`tow_pivotable`) — design
 
 - **Date:** 2026-05-29
-- **Status:** Proposed (awaiting user spec review → implementation plan)
-- **Target milestone:** #28 (v0.9.0)
-- **Subsystem:** `towplanner` motion model (via `models.py` accessor + fleet data)
+- **Status:** **Shelved as a standalone change — to be implemented *together with* [#263](https://github.com/DocGerd/hangarfit/issues/263) (nose-out parked heading).** Design + characterization complete; coupled to #263 because the pivot's functional payoff is the nose-out motion.
+- **Target milestone:** #28 (v0.9.0), folded into #263.
+- **Subsystem:** `towplanner` motion model (via a `models.py` accessor + a fleet-data flag).
 - **Related:** [ADR-0010](../../adr/0010-reeds-shepp-motion-model.md) (Reeds–Shepp motion),
   [ADR-0007](../../adr/0007-tow-path-planner-v1-scope.md) (cart = own-gear with `turn_radius_m = 0`),
   [ADR-0013](../../adr/0013-wheels-canonical-data.md) (canonical per-aircraft data),
-  issue **#263** (nose-out — enabled by this), issue **#320** (back-bias — complemented by this).
+  **#263** (nose-out — the motion this enables), #320 (back-bias — complemented).
+
+> **Naming note.** An earlier draft called the flag `free_castering`. It is renamed
+> **`tow_pivotable`** because the capability is reached by *two* mechanisms (see §3): a
+> free-castering tailwheel, **or** pressing the tail down to lift a nosewheel off the ground.
+> The planner-relevant fact is "can be pivoted about the main gear when towed," not the gear type.
 
 ---
 
-## 1. Problem
+## 1. Origin & honest problem statement
 
-The tow-path planner models every own-gear plane as a car-like Reeds–Shepp vehicle with a
-fixed minimum turning radius (`Aircraft.turn_radius_m`). For the Aviat Husky that radius is
-`5.0 m`. But the Husky is a **free-castering taildragger**: when towed by hand or a tail-tug,
-its tailwheel swivels freely and the airframe rotates essentially *within its own length*
-about the main-gear axle. The `5.0 m` figure models **powered self-taxi**, not **towing** —
-and the planner's job is to plan *tows*.
+This started from an observation that the planner models every own-gear plane as a car-like
+Reeds–Shepp vehicle with a fixed `turn_radius_m` (5.0 m for the Husky), which models *powered
+self-taxi* — not *towing*. The hypothesis was that this conservatism is **why dense fills are
+un-towable**.
 
-The consequence is observable. In the six-plane fill (`tests/fixtures/solve_fresh_six_planes.yaml`,
-`--no-spread --seed 1`) the planner returns **exit 3**, and the blocking plane is *literally the
-Husky*:
+**That hypothesis was tested and falsified** (see §6 Characterization). Modelling the Husky as a
+zero-radius pivot does **not** make the six-plane fill routable: the binding constraint there is
+**wing-transit geometry** (a 10.82 m wingspan cannot thread the corridor between already-placed
+planes), which no turn-radius change addresses. A valid static layout does not guarantee an
+evacuation path — which is exactly why the tow planner is a separate stage.
 
-```
-layout not tow-routable by the tow-path planner: plane 'aviat_husky' blocked
-(no_feasible_path: no in-bounds tow path found within 2000 expansions)
-```
-
-The static layout is valid; the planner just can't thread a 5.0 m-radius car through the gap a
-real handler would pivot the Husky into. The model is **conservative to the point of being wrong
-for the towing use case.**
+**What the capability *is* good for** (also measured, §6): physical **fidelity** of the towing
+motion, **shorter/cleaner reorientation paths** (a 180° nose-out flip plans ~15% shorter as a
+pivot than as an arc loop), and being the **enabler for #263 nose-out** — facing-the-door parking
+becomes a cheap in-place pivot instead of a wide loop. Because that payoff is realized *through*
+#263, this design is shelved as a standalone PR and folded into #263.
 
 ## 2. Goal & non-goals
 
-**Goal.** Let a plane declared free-castering be planned with the realistic *towing* motion —
-pivot in place, push straight, pivot — which is both physically faithful for a hand/tail-tug
-tow and the thing that makes tight fills routable.
+**Goal.** Let a plane *declared* tow-pivotable be planned with the realistic towing motion —
+pivot in place, push straight, pivot — modelling how it is actually hand/tail-tug manoeuvred.
 
 **Non-goals.**
-- Not modelling powered taxi (the `turn_radius_m` arc stays as the documented powered figure).
-- Not adding a probabilistic planner (RRT-Connect remains deferred per ADR-0010).
-- Not re-centering the pivot on an arbitrary main-gear offset (see §4.3 alternative (b), deferred).
-- Not changing which planes ride carts or the cart-eligibility rules.
+- **Not** a dense-fill towability fix (falsified — §6). That needs corridor-aware packing or the
+  deferred #336 RRT-Connect, not this.
+- Not modelling powered taxi (`turn_radius_m` stays as the documented powered figure).
+- Not re-centering the pivot on an arbitrary main-gear offset (§4.3 alternative (b), deferred).
+- Not changing cart-eligibility or which planes ride carts.
 
-## 3. Decision summary
+## 3. The capability and its two mechanisms
 
-| Axis | Decision | Why |
-|---|---|---|
-| Objective | Model realistic towing (pivot + push), which also maximizes routability | A tow planner should model towing; pivot+push is how a free-caster is actually towed |
-| Declaration | Explicit per-plane `free_castering: bool` flag in `fleet.yaml`, default `false` | ADR-0013 ethos: declare canonical capability, don't infer from `gear` (steerable/lockable tailwheels don't fully caster) |
-| Data-model shape | **Orthogonal boolean, NOT a new `MovementMode`** | Keeps `on_carts`/`movement_mode` invariants and cart-pool accounting untouched (§4.1) |
-| Motion realization | Reuse the existing `turn_radius_m == 0` cart-pivot machinery | No new primitive / word / cost constant / geometry math → determinism surface unchanged |
-| Pivot center | About the plane **datum** (existing behavior); main-gear-offset pivot deferred | 0.20 m error for the Husky (main gear ≈ datum); offsetting would touch motion math + trigger geometry-guard |
+`tow_pivotable` means **the airframe can be rotated about its main-gear axle in place when
+towed**, reached by either:
+
+1. **Free-castering tailwheel** — the tailwheel swivels freely; lock/load one main and swing the
+   tail, the airframe rotates within its own length (Aviat Husky).
+2. **Nose-lift** — press the tail down so the nosewheel leaves the ground; the plane then pivots
+   on its mains exactly like (1) (light nosewheel types — **FK9, CTSL** per the club operator).
+
+Both are operational facts about ground handling, not gear-type inferences — hence an explicit,
+declared flag (ADR-0013 ethos), not a `gear == "tailwheel"` heuristic.
+
+### Scope (initial flag values)
+
+| Plane | Gear | Wingspan | Main gear vs datum | `tow_pivotable` | Mechanism |
+|---|---|---|---|---|---|
+| aviat_husky | tailwheel | 10.82 m | +0.20 m | **true** | free-castering tailwheel |
+| fk9_mkii | nosewheel | 9.85 m | −0.10 m | **true** | tail-down nose-lift |
+| ctsl | nosewheel | 8.59 m | −0.10 m | **true** | tail-down nose-lift |
+| cessna_140 | tailwheel | 10.16 m | +0.50 m | *club data call* | (tailwheel — likely, unconfirmed) |
+| *(all others)* | — | — | — | false (default) | — |
+
+The datum-pivot approximation (§4.3) holds for all of these — main gear within 0.5 m of the datum.
 
 ## 4. Design
 
 ### 4.1 Data model — orthogonal boolean, not a movement mode (load-bearing)
 
-`free_castering` is a capability **orthogonal to `movement_mode`**, added as a new boolean field
-on `Aircraft` (default `False`). It is deliberately **not** a new `MovementMode` value:
+`tow_pivotable` is a capability **orthogonal to `movement_mode`**, added as a `bool` field on
+`Aircraft` (default `False`). It is deliberately **not** a new `MovementMode` value:
 
-- A free-castering Husky is **still on its own gear** — `on_carts = False`. The `Layout`
+- A tow-pivotable Husky is **still on its own gear** — `on_carts = False`. The `Layout`
   consistency invariant (`always_cart ↔ on_carts`, `models.py:488`) and the solver's cart-pool
   accounting key off `movement_mode`. A new movement mode would tangle with both; an orthogonal
   boolean touches neither.
-- It composes: `always_own_gear + free_castering` (the Husky today) and
-  `cart_eligible + free_castering` (a tailwheel that pivots on its own gear *and* can ride a
-  cart) both fall out correctly with no special-casing. `always_cart + free_castering` is
-  redundant but harmless (already `0.0`); the loader stays permissive (the flag is gear- and
-  mode-agnostic, since free-castering nosewheels also exist).
+- It composes: `always_own_gear + tow_pivotable` (the Husky) and `cart_eligible + tow_pivotable`
+  (FK9, CTSL — pivot on own gear *and* can ride a cart) both fall out with no special-casing.
+  `always_cart + tow_pivotable` is redundant-but-harmless (already `0.0`); the loader stays
+  permissive (the flag is gear- and mode-agnostic).
 
 ### 4.2 The accessor — the single behavioral change
 
 `Aircraft.effective_turn_radius_m()` (`models.py:299`) is the *one* place the planner resolves a
-plane's planning radius. Today:
+plane's planning radius:
 
 ```python
-if self.movement_mode == "always_cart":
+if self.movement_mode == "always_cart" or self.tow_pivotable:
     return 0.0
 return self.required_turn_radius_m()
 ```
 
-becomes:
-
-```python
-if self.movement_mode == "always_cart" or self.free_castering:
-    return 0.0
-return self.required_turn_radius_m()
-```
-
-A flagged plane returns `0.0`, and from `plan_path:1679` (`r = mover.effective_turn_radius_m()`)
-that `0.0` flows through the **existing** cart-pivot path with no further branching:
-
-- `_primitives(0.0)` → the 4-primitive fan (pivot-L, straight-fwd, pivot-R, straight-rev)
-- `DubinsArc.pose_at` r==0 branch → pivot-in-place integration (position fixed, heading steps)
-- `DubinsArc.sample` r==0 branch → angular density for collision sampling of the pivot
-- `_seg_cost` r==0 branch → pivot cost in radians × `_TURN_PENALTY`
-- `plan_reeds_shepp(turn_radius_m=0.0)` → delegates to `_plan_cart` (pivot → push → pivot,
-  reverse-enabled)
-
-`required_turn_radius_m()` and the `__post_init__` validation are unchanged: a free-castering
-own-gear plane still carries a positive `turn_radius_m` (the documented powered-taxi figure); the
-planner simply stops consulting it.
+A flagged plane returns `0.0`, and from `plan_path:1679` that flows through the **existing**
+cart-pivot path with no further branching (`_primitives(0.0)`, the `pose_at`/`sample`/`_seg_cost`
+r==0 branches, `plan_reeds_shepp → _plan_cart`). `required_turn_radius_m()` and `__post_init__`
+are unchanged — a tow-pivotable own-gear plane still carries its positive `turn_radius_m` (the
+documented powered-taxi figure); the planner just stops consulting it.
 
 ### 4.3 Pivot center
 
-The r==0 pivot rotates about the plane's **datum** (local origin, `local_to_world`,
-`geometry.py:119`). The physically-true center is the **main-gear axle** (`main_offset_x_m`).
+The r==0 pivot rotates about the plane's **datum** (local origin, `geometry.py:119`).
 
 - **(a) Pivot about the datum — CHOSEN.** Reuse the machinery verbatim; `towplanner.py` and
-  `geometry.py` are untouched, so **no geometry-invariant-guard review is required**. Faithful
-  for the Husky: its main gear sits at `main_offset_x_m = 0.20 m`, i.e. 20 cm (sub-wheel-width)
-  from the datum. Documented assumption: *accurate when datum ≈ main gear; the flag is opt-in, so
-  only flag planes where this holds.*
-- **(b) Pivot about `main_offset_x_m` — DEFERRED.** Physically general, but requires offsetting
-  the pivot center inside `pose_at` → touches motion math → triggers the geometry-invariant-guard
-  sign-flip review and a new heading canary, and breaks the "planner untouched" property — for a
-  0.20 m gain on the only currently-flagged plane. Recorded in the ADR as the future refinement if
-  a plane with a far-offset datum is ever flagged.
+  `geometry.py` untouched → **no geometry-invariant-guard review required**. Faithful here (all
+  flagged planes' main gear is ≤0.5 m from the datum).
+- **(b) Pivot about `main_offset_x_m` — DEFERRED.** General, but offsetting the pivot inside
+  `pose_at` touches motion math → triggers the geometry sign-flip guard + a new canary, for a
+  sub-metre gain on the current fleet. ADR records it as the future refinement.
 
 ### 4.4 Change surface
 
 | File | Change | Notes |
 |---|---|---|
-| `src/hangarfit/models.py` | Add `free_castering: bool = False` to `Aircraft`; add `or self.free_castering` to the `0.0` branch of `effective_turn_radius_m()` | `MovementMode` and `__post_init__` unchanged |
-| `src/hangarfit/loader.py` | Parse `free_castering` (default `False`) | Boolean; no coupling to `gear` |
-| `data/fleet.yaml` | `aviat_husky: free_castering: true` + comment; update header doc block | Other planes default `false`; club fills in as known |
-| `src/hangarfit/towplanner.py` | **None** | The headline property — flagged planes reuse the existing deterministic r==0 path |
-| `src/hangarfit/geometry.py`, `collisions.py` | **None** | No motion math change under decision (a) |
+| `src/hangarfit/models.py` | Add `tow_pivotable: bool = False` to `Aircraft`; add `or self.tow_pivotable` to the `0.0` branch of `effective_turn_radius_m()` | `MovementMode`, `__post_init__` unchanged |
+| `src/hangarfit/loader.py` | Parse `tow_pivotable` (default `False`) | Boolean; no coupling to `gear` |
+| `data/fleet.yaml` | `tow_pivotable: true` on `aviat_husky`, `fk9_mkii`, `ctsl` + comments; header doc | Others default `false` |
+| `src/hangarfit/towplanner.py` | **None** | Flagged planes reuse the existing deterministic r==0 path |
+| `geometry.py`, `collisions.py` | **None** | No motion math change under decision (a) |
 
 ## 5. Determinism
 
 The tow planner is **RNG-free**; determinism is structural (fixed primitive-fan order, fixed
 Reeds–Shepp word order with strict-`<` tie-break, a monotonic `(f, counter, node)` heap
-tie-break, total-order sorts). Because flagged planes reuse the **existing** r==0 path, this
-change adds **no new primitive, word, cost constant, ordering surface, or RNG**. The determinism
-contract (ADR-0003, `max_restarts`-scoped per the #267 amendment) holds by construction.
+tie-break). Reusing the **existing** r==0 path adds **no new primitive, word, cost constant,
+ordering surface, or RNG** — the determinism contract (ADR-0003, `max_restarts`-scoped per #267)
+holds by construction. A canary (§7) proves byte-identical `MovesPlan` across two runs.
 
-A determinism canary (§7) proves it empirically: a free-castering-Husky scenario must produce a
-**byte-identical `MovesPlan`** across two runs of the same scenario + seed.
+## 6. Characterization (the evidence; 2026-05-29)
 
-## 6. Real-world basis
+Method: monkeypatch `effective_turn_radius_m → 0.0` for the flagged set and compare against
+baseline, on real fixtures and constructed goals.
 
-A free-castering tailwheel has no rudder linkage; the aircraft is steered by differential braking
-and, with the tailwheel free-swivelling, can be rotated about a main wheel **within its own
-length** (FAA *Airplane Flying Handbook* ch. 14; EAA; AOPA). A tail-tug makes the tailwheel a
-steered, pushed rear point (trailer kinematics); the handler swings the tail and the body rotates
-about the main-gear line. The faithful planner abstraction is therefore **rotation about the
-main-gear axle with near-zero translation**, with the **wingtips** sweeping the binding circle.
+**(a) Routability — pivot converts ZERO cases, regresses none.**
 
-Key numbers (Aviat Husky): wingspan **10.82 m** (the value already in `fleet.yaml`'s wing
-`width_m`), so the swept circle has radius ≈ **5.4 m** — *wingtips*, not the tail, dominate the
-footprint. The existing pivot already samples the full angular sweep for collision checking
-(`DubinsArc.sample` r==0 branch), so the wingtip sweep is collision-checked. Because the Husky's
-main gear is ~0 m from its datum, the datum pivot (§4.3a) is a faithful main-gear pivot for it.
+| Fixture | baseline un-routable | pivot un-routable | converted |
+|---|---|---|---|
+| 3-plane | none | none | — |
+| bay-3 | none | none | — |
+| 6-plane | `aviat_husky` | `aviat_husky` | **none** |
 
-## 7. Testing
+**(b) Geometry — why.** At the 6-plane parked slots, rotational headroom is tight for the
+big-wing planes (`aviat_husky 11/72`, `ctsl 15/72`, `cessna_140 17/72` clear headings;
+`fk9 37/72`, `fuji 49/72`). And the Husky can translate only 2.0 m toward the door before a wing
+hits `fuji`. The block is **wing transit through the inter-plane corridor**, not turn radius. The
+pivot's swept disc = wingspan (~10.8 m), so the window where a pivot fits but an arc-loop doesn't
+is narrow for these aircraft.
 
-- **Unit (`models`):** `effective_turn_radius_m()` returns `0.0` for a free-castering own-gear
-  plane; field defaults `False`; `cart_eligible + free_castering → 0.0`.
-- **Loader:** `free_castering` parsed; defaults `False`; round-trips.
-- **Planner integration:** a flagged own-gear plane yields a pivot-style path (a `turn_radius_m == 0`
-  `DubinsArc` containing pivot segments).
-- **🎯 Payoff test:** with `aviat_husky.free_castering = true`, the six-plane fill
-  (`solve_fresh_six_planes`, `--no-spread --seed 1`) routes the Husky — turning the observed
-  exit-3 into a fully-routed fill. Directly measurable against the motivating failure.
-- **Determinism canary:** a free-castering-Husky scenario produces a byte-identical `MovesPlan`
-  across two runs (extends the canary suite); passes by construction, proven by the test.
+**(c) Path quality / nose-out — the real win.** In open space, a 180° nose-out flip plans as
+**23.7 m (pivot)** vs **27.8 m (arc loop)** — ~15% shorter and cleaner. Straight-in is equivalent
+(~12 m). This is the #263 motion; the pivot is what makes nose-out cheap.
+
+**Conclusion:** `tow_pivotable` is a **fidelity + path-quality + #263-enabler** change, **not** a
+towability unlock. Hence: fold into #263.
+
+## 7. Testing (when implemented with #263)
+
+- **Unit (`models`):** `effective_turn_radius_m()` returns `0.0` for a tow-pivotable own-gear
+  plane; field defaults `False`; `cart_eligible + tow_pivotable → 0.0`.
+- **Loader:** `tow_pivotable` parsed; defaults `False`; round-trips.
+- **Planner integration:** a flagged own-gear plane yields a pivot-style path (a `turn_radius_m ==
+  0` `DubinsArc` with pivot segments).
+- **Path-quality (the honest payoff test):** a nose-out 180° goal plans **shorter** as a pivot
+  than as an arc (the 23.7 vs 27.8 m result), in an empty hangar with a feasible (in-bounds-wing)
+  goal.
+- **No-regression:** the 3-plane and bay-3 fills route identically with the flag on (converted/
+  regressed both empty).
+- **Determinism canary:** a tow-pivotable scenario produces a byte-identical `MovesPlan` across
+  two runs.
+- **NOT a test:** "the six-plane fill becomes routable" — falsified (§6); do not assert it.
 
 ## 8. ADR & docs
 
-A new ADR — *"Free-castering tow-pivot capability"* — records the orthogonal-flag decision, the
-datum-pivot approximation with (b) as the deferred alternative, and the towing-vs-powered-taxi
-rationale. It cross-references ADR-0010 (motion), ADR-0007 (cart = r=0), and ADR-0013 (canonical
-per-aircraft data — same ethos). **Number allocated via `/new-adr` at implementation time**
-(committed ADRs stop at 0013; 0014 is earmarked for #263 in an issue comment, so this will likely
-be 0015 or later). The ADR lands **with** the implementation PR, per the project's #320/#263
-convention. Also: `fleet.yaml` header note + a one-line CLAUDE.md/arc42 pointer.
+The tow-pivot decision is recorded **in #263's ADR** (the nose-out ADR, earmarked ADR-0014) as a
+sub-section — the orthogonal-flag decision, the datum-pivot approximation with (b) deferred, and
+the towing-vs-powered-taxi rationale — rather than a separate ADR, since the two ship together.
+Cross-references ADR-0010 / ADR-0007 / ADR-0013. Plus a `fleet.yaml` header note and a one-line
+CLAUDE.md/arc42 pointer.
 
-*Alternative considered:* amend ADR-0010 instead. Rejected — this adds a fleet-schema field and a
-capability concept (ADR-0013-shaped), so a new ADR reads cleaner than bolting it onto the
-motion-vocabulary ADR.
+## 9. Interactions
 
-## 9. Interactions with deferred milestone-#28 work
+- **#263 (nose-out):** the pivot is the **enabler** — nose-out flips become ~15% cheaper in-place
+  pivots. Implement together. The pivot has no standalone consumer until #263 exists.
+- **#320 (back-bias):** complementary, no conflict; neither reasons about turn geometry.
 
-- **#320 (back-bias):** complementary, no conflict. Back-packing leaves the door cone clear;
-  tighter turns only raise its towability floor. Neither reasons about turn geometry. Any order.
-- **#263 (nose-out):** this is a direct **enabler**. #263 names the tailwheel gear class and
-  depends on the planner cheaply realizing nose-out exits; the free-castering pivot makes that
-  cheaper still. Sequence tow-pivot first for maximal nose-out payoff; #263 ships correctly
-  without it. No #263 assumption changes.
+## 10. Review plan (when built)
 
-## 10. Review plan
-
-- `pr-review-toolkit:code-reviewer` — main pass.
-- `pr-review-toolkit:type-design-analyzer` — `models.py` changes (new field + accessor).
-- `determinism-guard` — planner *behavior* changes via the accessor (even though `towplanner.py`
-  is untouched), so the byte-identical-plan contract is re-verified.
-- **No `geometry-invariant-guard`** — decision (a) touches no geometry math. *(Decision (b) would
-  require it.)*
+`code-reviewer` (main) + `type-design-analyzer` (`models.py`) + `determinism-guard` (planner
+behavior changes via the accessor). **No `geometry-invariant-guard`** under decision (a).
 
 ## 11. Caveats & known limitations
 
-- **`DubinsArc.length_m` mixes radians (pivot segments) and metres (straights)** — a pre-existing
-  quirk that, with this change, appears in an *own-gear* plane's path for the first time. The
-  renderer consumes paths via `sample()` (pose-based), not `length_m`, so visuals are unaffected.
-  A code comment will warn against treating a flagged plane's `length_m` as a physical distance.
-- **Datum-pivot approximation** (§4.3a): faithful only where the datum ≈ main gear. True for the
-  Husky; the opt-in flag keeps it from being applied where it isn't.
+- **`DubinsArc.length_m` mixes radians (pivots) and metres (straights)** — pre-existing; appears
+  in an own-gear path for the first time with this change. The renderer uses `sample()` (poses),
+  not `length_m`, so visuals are fine; a comment will warn consumers.
+- **Datum-pivot approximation** (§4.3a): faithful where datum ≈ main gear (true for all flagged
+  planes); the opt-in flag keeps it from misapplying.
 - **`cart_eligible`-on-a-cart pre-existing gap:** `effective_turn_radius_m()` keys on the
-  `always_cart` movement mode, not a placement's `on_carts` state, so a `cart_eligible` plane
-  placed on a cart is *not* given pivot motion today. Out of scope here; noted for completeness.
+  `always_cart` mode, not a placement's `on_carts`, so a `cart_eligible` plane *placed on a cart*
+  is not given pivot motion today. Out of scope; noted.
 
 ## 12. Out of scope / future
 
-- Main-gear-offset pivot (§4.3b) — a fidelity ADR if a far-offset-datum plane is ever flagged.
-- Flagging planes beyond the Husky — a club data call as real measurements arrive.
-- Modelling powered self-taxi distinctly from towing.
+- Main-gear-offset pivot (§4.3b) — fidelity refinement if a far-offset-datum plane is flagged.
+- The actual dense-fill towability lever: corridor/wingspan-aware packing in the solver, or #336
+  RRT-Connect. This spec explicitly does **not** address that.
 
 ## 13. Process
 
-- Branch: `feature/free-castering-tow-pivot` off `develop`.
-- Tracking issue: file in milestone #28 at implementation time (`Closes #N` in the PR body), per
-  "no code without an issue".
-- Supervised work only (touches determinism-guarded planner behavior); no unattended worktree
-  dispatch.
+- Design committed on `feature/free-castering-tow-pivot` (this spec).
+- Durable design + characterization summary posted as a comment on **#263**.
+- Implementation happens with #263 (supervised; determinism-guarded planner behavior).


### PR DESCRIPTION
Refs #263 (does **not** close it — this preserves the design; implementation ships with #263).

## What

Adds the committed design spec for the **`tow_pivotable`** tow-pivot capability:
`docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md`. Docs-only — no code.

## Why a spec, why now

Explored from "does the planner know the Husky free-casters?". Designed a per-plane
`tow_pivotable` flag (reuses the existing `always_cart` zero-radius pivot path; one-line
`effective_turn_radius_m()` change; `towplanner.py` untouched; determinism surface unchanged).

A characterization pass **falsified** the original "this fixes dense-fill towability" premise:
modelling the flagged planes (Husky / FK9 / CTSL) as `r=0` converts **zero** un-routable
fixtures — the 6-plane block is **wing-transit geometry** (10.82 m span can't thread the
inter-plane corridor), not turn radius. The real value is **fidelity + ~15% shorter nose-out
flip (23.7 vs 27.8 m) + enabling #263**, whose nose-out motion is the pivot's only consumer.

Hence: shelved as a standalone change, **folded into #263**. This PR just lands the durable
design record in `develop` so it isn't lost on a local branch; the same summary lives as a
[#263 comment](https://github.com/DocGerd/hangarfit/issues/263#issuecomment-4577118559).

## Not in this PR

No `models.py` / `loader.py` / `fleet.yaml` changes — those land **with #263**. The actual
dense-fill towability lever (corridor/wingspan-aware packing, or #336 RRT-Connect) is out of
scope and called out as such in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)