### PR TITLE
docs(claude): link ADR-0011 from the CLAUDE.md branching policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ If you find yourself about to write a domain assertion in this file, **don't** �
 | `release/<version>` | Cut from `develop`, PR'd into both `main` and `develop`. Use `/release-cut version=X.Y.Z` to automate this. | No, only via PR |
 | `hotfix/<slug>` | Only if needed; off `main`. | No, only via PR |
 
+The rationale for this merge-commit model — squash feature merges, accept release merge commits, and **never enable `required_linear_history`** (it breaks the release-branch double-merge) — is captured in [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md) *(Proposed; not yet ratified)*.
+
 ### Per-PR process
 
 1. Branch `feature/<slug>` off `develop`. Work, commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ If you find yourself about to write a domain assertion in this file, **don't** �
 | `release/<version>` | Cut from `develop`, PR'd into both `main` and `develop`. Use `/release-cut version=X.Y.Z` to automate this. | No, only via PR |
 | `hotfix/<slug>` | Only if needed; off `main`. | No, only via PR |
 
-The rationale for this merge-commit model — squash feature merges, accept release merge commits, and **never enable `required_linear_history`** (it breaks the release-branch double-merge) — is captured in [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md) *(Proposed; not yet ratified)*.
+`required_linear_history` must **never** be enabled — it blocks GitFlow's release flow, which merges each `release/*` into both `main` and `develop`. Feature PRs land as merge commits too (squash/rebase merging is disabled repo-wide). The trade-off is analyzed in [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md) *(Proposed — its squash-feature-merge premise is under reconciliation in #344)*.
 
 ### Per-PR process
 


### PR DESCRIPTION
## Summary
Adds a pointer from the **Branching** table in `CLAUDE.md` to [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md), surfacing the firm operational rule that `required_linear_history` must **never** be enabled (it blocks GitFlow's release double-merge) — a lesson that previously lived only in auto-memory.

```diff
 | `hotfix/<slug>` | Only if needed; off `main`. | No, only via PR |
+
+`required_linear_history` must **never** be enabled — it blocks GitFlow's release flow, which merges each `release/*` into both `main` and `develop`. Feature PRs land as merge commits too (squash/rebase merging is disabled repo-wide). The trade-off is analyzed in [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md) *(Proposed — its squash-feature-merge premise is under reconciliation in #344)*.
```

## Notes
- **Docs only** — single paragraph, no code paths touched.
- ADR-0011 is **Proposed**, and its squash-feature-merge premise is *falsified* by current repo settings (`gh api`: `merge=true, squash=false, rebase=false`). **#344** tracks reconciling ADR-0011 — it may **supersede or rewrite** it, not merely ratify — so the link is caveated rather than promoted to the Quick Reference (reserved for ratified, architectural decisions; merge policy is operational).
- Surfaced by a `/claude-md-management:claude-md-improver` audit; **corrected after a 3-lens adversarial review** (see review thread) caught a must-fix in the first draft — the original wording asserted ADR-0011's unadopted "squash feature merges" premise as current practice.

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
