### PR TITLE
chore(pyproject): refresh stale package description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "hangarfit"
 version = "0.8.0"
-description = "Helper tool for arranging the flying club fleet in a stack-style hangar — collision checker + visualizer (Phase 1)."
+description = "Helper tool for arranging a flying club's fleet in a stack-style hangar — collision checker, layout solver, tow-path planner, and top-down visualizer."
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [{ name = "Patrick Kuhn" }]


### PR DESCRIPTION
## Summary
Refreshes the stale `[project].description` in `pyproject.toml` — the PyPI package summary (also shown by `pip show`).

```diff
-description = "Helper tool for arranging the flying club fleet in a stack-style hangar — collision checker + visualizer (Phase 1)."
+description = "Helper tool for arranging a flying club's fleet in a stack-style hangar — collision checker, layout solver, tow-path planner, and top-down visualizer."
```

## Why
The old summary was stale on two counts (per #347):
1. **`(Phase 1)` marker** — the project is at Phase 3b; the parenthetical is long obsolete.
2. **Understated scope** — "collision checker + visualizer" omitted the **layout solver** (`hangarfit solve`, Phase 2a–2c) and the **tow-path planner** (`solve --render-paths`, Phase 3a/3b).

## Notes
- **One-line metadata change**, no code touched.
- **No dependency change** → the hash-pinned lockfiles and the `lockfile-drift` CI guards are unaffected.

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)