### PR TITLE
docs(adr): reconcile ADR-0011 — supersede with ADR-0014 (merge-commit-only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ If you find yourself about to write a domain assertion in this file, **don't** �
 | `release/<version>` | Cut from `develop`, PR'd into both `main` and `develop`. Use `/release-cut version=X.Y.Z` to automate this. | No, only via PR |
 | `hotfix/<slug>` | Only if needed; off `main`. | No, only via PR |
 
-`required_linear_history` must **never** be enabled — it blocks GitFlow's release flow, which merges each `release/*` into both `main` and `develop`. Feature PRs land as merge commits too (squash/rebase merging is disabled repo-wide). The trade-off is analyzed in [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md) *(Proposed — its squash-feature-merge premise is under reconciliation in #344)*.
+`required_linear_history` must **never** be enabled — it blocks GitFlow's release flow, which merges each `release/*` into both `main` and `develop`. Feature PRs land as merge commits too (squash/rebase merging is disabled repo-wide as a release-safety guardrail). The strategy is recorded in [ADR-0014](docs/adr/0014-merge-commit-only-history-strategy.md), superseding the never-adopted [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md).
 
 ### Per-PR process
 

--- a/docs/adr/0011-linear-history-strategy-under-gitflow.md
+++ b/docs/adr/0011-linear-history-strategy-under-gitflow.md
@@ -1,8 +1,19 @@
 # ADR-0011: Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline
 
-- **Status:** Proposed
+- **Status:** Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md)
 - **Date:** 2026-05-27
 - **Deciders:** Patrick Kuhn (DocGerd)
+
+> **Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md) (2026-05-29) — never adopted.**
+> This ADR's chosen Option 1 (*feature PRs land as squash merges*) was never put
+> into effect: squash and rebase merging were disabled repo-wide as a
+> release-safety guardrail after the v0.7.0 cascade, so feature PRs land as **merge
+> commits**. ADR-0014 records the in-effect **merge-commit-only** strategy. The
+> Q1–Q4 research below — why `required_linear_history` is incompatible with
+> GitFlow, the rulesets community-#80952 historical-commits bug, and the
+> merge-base cost of squashed back-merges — **remains valid** and is the analysis
+> ADR-0014 builds on. Read the Decision Outcome below as the *proposal that was not
+> taken*, not current policy.
 
 ## Context & Problem Statement
 

--- a/docs/adr/0011-linear-history-strategy-under-gitflow.md
+++ b/docs/adr/0011-linear-history-strategy-under-gitflow.md
@@ -4,16 +4,24 @@
 - **Date:** 2026-05-27
 - **Deciders:** Patrick Kuhn (DocGerd)
 
-> **Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md) (2026-05-29) — never adopted.**
-> This ADR's chosen Option 1 (*feature PRs land as squash merges*) was never put
-> into effect: squash and rebase merging were disabled repo-wide as a
-> release-safety guardrail after the v0.7.0 cascade, so feature PRs land as **merge
-> commits**. ADR-0014 records the in-effect **merge-commit-only** strategy. The
-> Q1–Q4 research below — why `required_linear_history` is incompatible with
-> GitFlow, the rulesets community-#80952 historical-commits bug, and the
-> merge-base cost of squashed back-merges — **remains valid** and is the analysis
-> ADR-0014 builds on. Read the Decision Outcome below as the *proposal that was not
-> taken*, not current policy.
+> **Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md) (2026-05-29) — never adopted as policy.**
+> ADR-0011 stayed `Proposed` and was never ratified. Its central decision
+> (*feature PRs land as squash merges*) no longer matches reality: after it was
+> drafted, squash and rebase merging were disabled repo-wide as a release-safety
+> guardrail, so feature PRs land as **merge commits**. ADR-0014 records the
+> in-effect **merge-commit-only** strategy.
+>
+> Read the **Decision Drivers and Decision Outcome** below as the *proposal that
+> was not taken*, not current policy. In particular, the Decision Driver claiming
+> the squash/rebase-disable *"was already tried and reverted … [it] broke the
+> release flow"* is **not** carried forward — that early, narrowly-scoped attempt
+> was later re-applied repo-wide and **kept** as the standing guardrail ADR-0014
+> records.
+>
+> The **Q1–Q4 research** (why `required_linear_history` is incompatible with
+> GitFlow, the rulesets community-#80952 historical-commits bug, and the merge-base
+> cost of squashed back-merges) **remains valid** and is the analysis ADR-0014
+> builds on.
 
 ## Context & Problem Statement
 

--- a/docs/adr/0014-merge-commit-only-history-strategy.md
+++ b/docs/adr/0014-merge-commit-only-history-strategy.md
@@ -1,0 +1,150 @@
+# ADR-0014: Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail
+
+- **Status:** Proposed
+
+- **Date:** 2026-05-29
+- **Deciders:** Patrick Kuhn (DocGerd)
+
+## Context & Problem Statement
+
+[ADR-0011](0011-linear-history-strategy-under-gitflow.md) (Proposed, 2026-05-27)
+chose **Option 1** — *feature PRs land as squash merges (single parent),
+release/back-merge PRs land as merge commits* — and named a follow-up
+(**Option 5**) to enforce squash-only on `feature/*`→`develop` via a GitHub
+merge-method ruleset. Its whole "clean first-parent mainline" rationale rests on
+*one squash commit per feature PR*.
+
+After ADR-0011 was drafted, **squash and rebase merging were disabled repo-wide**
+as a guardrail. The trigger was the v0.7.0 release cascade, where a squash-merge
+on #283 contributed to the burned-tag mess (see the v0.7.0 / v0.7.1 release
+history). The repo's current merge-button settings are:
+
+```
+allow_merge_commit:  true
+allow_squash_merge:  false   ← squash DISABLED
+allow_rebase_merge:  false   ← rebase DISABLED
+```
+
+So ADR-0011's central premise is now **false**: feature PRs land as **merge
+commits**, not squash merges, and the Option-5 squash-only ruleset is impossible
+to configure (squash is off). This ADR reconciles the documented strategy with
+the in-effect reality (#344). It supersedes ADR-0011's *decision*; ADR-0011's
+Q1–Q4 research — why `required_linear_history` is incompatible with GitFlow, the
+rulesets community-#80952 historical-commits bug, and the merge-base cost of
+squashed back-merges — **remains valid and is the analysis this ADR builds on**.
+
+## Decision Drivers
+
+- **Release-flow safety.** The squash-disable guardrail closed a concrete failure
+  mode: a wrong merge method chosen during a release cut corrupting the release
+  DAG (the #283 / v0.7.0 cascade). The guardrail must not be reopened casually.
+- **One merge method = no foot-gun.** With only "Create a merge commit" enabled,
+  no contributor or release operator can accidentally pick squash/rebase at a
+  moment it would damage the release topology. The safe path is the *only* path.
+- **Machine-enforcement over convention.** ADR-0011's squash-only goal was a
+  social convention with no automated check (its own Compliance section says so).
+  The merge-commit-only reality is enforced by the repo merge-button settings —
+  strictly stronger than a convention.
+- **`required_linear_history` is still incompatible with GitFlow.** Unchanged from
+  ADR-0011 Q1–Q4: the release flow PRs each `release/*` into **both** `main` and
+  `develop`, producing merge commits that `required_linear_history` forbids; the
+  rulesets variant additionally trips community-#80952. It stays **off**.
+
+## Considered Options
+
+1. **Merge-commit-only (squash + rebase disabled) — the chosen option.** Every PR
+   — feature and release alike — lands as a merge commit. The guardrail stays as
+   the machine-enforced policy.
+2. **Re-enable squash for feature merges** (revert to ADR-0011 Option 1 and pursue
+   the Option-5 squash-only ruleset).
+3. **Squash all merges, including releases** (ADR-0011 Option 4).
+4. **Enable `required_linear_history`** (classic branch protection or the rulesets
+   rule) (ADR-0011 Options 2/3).
+
+## Decision Outcome
+
+**Chosen option: Option 1 (merge-commit-only),** because the squash-disable
+guardrail is a deliberate, machine-enforced safety measure born of a real
+release-cascade incident, and the readability benefit of squashed feature commits
+does not outweigh reopening that risk. `required_linear_history` stays off for the
+reasons ADR-0011 established.
+
+We accept that `git log --first-parent develop` now carries a two-parent merge
+commit per feature PR rather than ADR-0011's hoped-for single squashed commit.
+That is the readability cost of the guardrail, and it is small: each feature merge
+commit still names its PR number and feature branch, so the first-parent log
+remains a usable high-level changelog with release merges as landmarks.
+
+### Why not Option 2 (re-enable squash for features)?
+
+It reopens exactly the foot-gun the guardrail closed — a squash/rebase chosen at
+the wrong moment during a release cut. ADR-0011's clean-single-parent-per-feature
+log is a readability nicety, not a correctness requirement, and the pre-v0.7.0
+two-parent feature merges already make the non-`--first-parent` log noisy
+regardless. The cost (reintroduced release risk) exceeds the benefit (slightly
+tidier first-parent log). If the release process is ever hardened so the
+wrong-method foot-gun is closed another way, this is the option a future ADR would
+revisit.
+
+### Why not Option 3 (squash all merges) or Option 4 (`required_linear_history`)?
+
+Both were already rejected by ADR-0011 and nothing has changed. Squashing the
+`release/*`→`develop` back-merge destroys `git merge-base` semantics between `main`
+and `develop` (ADR-0011 Q3). `required_linear_history` forbids the GitFlow release
+double-merge entirely, and its rulesets form trips the unresolved historical-commits
+bug community-#80952 on a repo that already has merge commits (ADR-0011 Q1/Q2).
+This ADR carries those rejections forward unchanged.
+
+## Consequences
+
+### Positive
+
+- Eliminates the wrong-merge-method-during-release foot-gun, **machine-enforced**
+  by the repo merge-button settings (not a convention that can silently lapse).
+- The GitFlow release flow and its back-merge topology are preserved exactly as
+  ADR-0011 Q3 requires — `git merge-base`, `git log main..develop`, and
+  `git branch --merged` stay semantically meaningful.
+- The rationale for `required_linear_history` being off is preserved and still
+  cross-referenced from `docs/security-posture.md`, so a future maintainer won't
+  re-enable it chasing a Scorecard point.
+
+### Negative
+
+- `git log --first-parent develop` shows a two-parent merge commit per feature PR,
+  noisier than ADR-0011's single squashed commit. The clean-single-parent-per-feature
+  goal is given up.
+- ADR-0011's Option-5 squash-only ruleset is moot/shelved while squash is disabled.
+
+### Neutral
+
+- If the release process is ever hardened enough to close the wrong-method foot-gun
+  independently, re-enabling squash for `feature/*` (and revisiting ADR-0011's
+  Option 5) could be reconsidered in a future ADR that would supersede this one.
+
+## Compliance
+
+Machine-enforced by the repo merge-button settings. Verify:
+
+```
+gh api repos/:owner/:repo --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'
+# expected: {"merge": true, "squash": false, "rebase": false}
+```
+
+Any feature PR that lands as a squash or rebase commit means the guardrail was
+changed — investigate before assuming it was intentional. The human-facing rule is
+documented in [`CLAUDE.md`](../../CLAUDE.md#development-workflow) (Branching).
+
+## More Information
+
+- Supersedes [ADR-0011](0011-linear-history-strategy-under-gitflow.md). ADR-0011's
+  Q1–Q4 research (the `required_linear_history` / rulesets / merge-base analysis)
+  remains the authoritative technical background and is incorporated here by
+  reference.
+- Reconciliation issue: [#344](https://github.com/DocGerd/hangarfit/issues/344)
+- Guardrail origin: the v0.7.0 release cascade (#283 squash-merge; #285 / #286
+  immutable-release tombstone) that prompted disabling squash + rebase repo-wide.
+- Related issues: [#141](https://github.com/DocGerd/hangarfit/issues/141) (branch
+  protection applied), [#202](https://github.com/DocGerd/hangarfit/issues/202)
+  (the spike that produced ADR-0011).
+- Related docs: [`docs/security-posture.md`](../security-posture.md) — the
+  "A note on linear history" section.

--- a/docs/adr/0014-merge-commit-only-history-strategy.md
+++ b/docs/adr/0014-merge-commit-only-history-strategy.md
@@ -1,7 +1,6 @@
 # ADR-0014: Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail
 
 - **Status:** Proposed
-
 - **Date:** 2026-05-29
 - **Deciders:** Patrick Kuhn (DocGerd)
 
@@ -15,9 +14,11 @@ merge-method ruleset. Its whole "clean first-parent mainline" rationale rests on
 *one squash commit per feature PR*.
 
 After ADR-0011 was drafted, **squash and rebase merging were disabled repo-wide**
-as a guardrail. The trigger was the v0.7.0 release cascade, where a squash-merge
-on #283 contributed to the burned-tag mess (see the v0.7.0 / v0.7.1 release
-history). The repo's current merge-button settings are:
+as a guardrail. The trigger was the v0.7.0 release cascade: a squash-merge was
+mistakenly applied to the #283 release PR and had to be reset and re-merged as a
+proper merge commit, contributing to the burned-tag mess (the squash artifact was
+caught before it reached tagged history; the mechanism is documented in ADR-0011
+Q3's release-table footnote). The repo's current merge-button settings are:
 
 ```
 allow_merge_commit:  true
@@ -25,9 +26,9 @@ allow_squash_merge:  false   ← squash DISABLED
 allow_rebase_merge:  false   ← rebase DISABLED
 ```
 
-So ADR-0011's central premise is now **false**: feature PRs land as **merge
-commits**, not squash merges, and the Option-5 squash-only ruleset is impossible
-to configure (squash is off). This ADR reconciles the documented strategy with
+So ADR-0011's central premise no longer matches reality: feature PRs land as
+**merge commits**, not squash merges, and its Option-5 squash-only ruleset is
+impossible to configure (squash is off). This ADR reconciles the documented strategy with
 the in-effect reality (#344). It supersedes ADR-0011's *decision*; ADR-0011's
 Q1–Q4 research — why `required_linear_history` is incompatible with GitFlow, the
 rulesets community-#80952 historical-commits bug, and the merge-base cost of
@@ -132,7 +133,7 @@ gh api repos/:owner/:repo --jq '{merge: .allow_merge_commit, squash: .allow_squa
 
 Any feature PR that lands as a squash or rebase commit means the guardrail was
 changed — investigate before assuming it was intentional. The human-facing rule is
-documented in [`CLAUDE.md`](../../CLAUDE.md#development-workflow) (Branching).
+documented in [`CLAUDE.md`](../../CLAUDE.md#branching) (Branching).
 
 ## More Information
 

--- a/docs/adr/0014-merge-commit-only-history-strategy.md
+++ b/docs/adr/0014-merge-commit-only-history-strategy.md
@@ -17,8 +17,9 @@ After ADR-0011 was drafted, **squash and rebase merging were disabled repo-wide*
 as a guardrail. The trigger was the v0.7.0 release cascade: a squash-merge was
 mistakenly applied to the #283 release PR and had to be reset and re-merged as a
 proper merge commit, contributing to the burned-tag mess (the squash artifact was
-caught before it reached tagged history; the mechanism is documented in ADR-0011
-Q3's release-table footnote). The repo's current merge-button settings are:
+caught before it reached tagged history; the resulting tombstoned v0.7.0 release is
+recorded in ADR-0011 Q3's release-table footnote). The repo's current merge-button
+settings are:
 
 ```
 allow_merge_commit:  true

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -88,6 +88,7 @@ manual workflow above is canonical.
 | 0008 | [Inter-plane spread soft preference (repulsion-energy surrogate for maximin)](0008-inter-plane-spread-soft-preference.md) | Accepted |
 | 0009 | [Single supported Python — 3.12, anchored to the distro LTS](0009-single-supported-python-version.md) | Accepted |
 | 0010 | [Reeds–Shepp motion model — towplanner v2](0010-reeds-shepp-motion-model.md) | Accepted |
-| 0011 | [Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline](0011-linear-history-strategy-under-gitflow.md) | Proposed |
+| 0011 | [Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline](0011-linear-history-strategy-under-gitflow.md) | Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md) |
 | 0012 | [Split the fuselage into front/aft so a wing may overhang a tail but not a cockpit](0012-fuselage-front-aft-split.md) | Accepted |
 | 0013 | [Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load](0013-wheels-canonical-data.md) | Proposed |
+| 0014 | [Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail](0014-merge-commit-only-history-strategy.md) | Proposed |

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -123,6 +123,8 @@ second-person-gated — the cap this section describes.
 **off**. Enabling it would forbid the merge commits the GitFlow release
 flow depends on (`release/*` → `main`, and the back-merge to `develop`).
 The trade-off was explored in spike [#202] and the decision is recorded in
+[ADR-0014](adr/0014-merge-commit-only-history-strategy.md) — with the detailed
+`required_linear_history` analysis preserved in the superseded
 [ADR-0011](adr/0011-linear-history-strategy-under-gitflow.md); do not "fix"
 this to chase a Scorecard point.
 


### PR DESCRIPTION
## Summary
Reconciles **ADR-0011** with reality (#344). ADR-0011 (Proposed) chose *"feature PRs land as squash merges"*, but squash + rebase merging are **disabled repo-wide** (`gh api`: `merge=true, squash=false, rebase=false`) — a release-safety guardrail added after the v0.7.0 cascade (a squash-merge on #283 contributed to the burned-tag mess). So feature PRs land as **merge commits** today, ADR-0011's premise is false, and its Option-5 squash-only ruleset is impossible to configure.

Per #344's **recommended option (a)**: a new **ADR-0014** documents the in-effect *merge-commit-only* strategy, and **ADR-0011 is marked `Superseded`** (kept in place — never deleted).

## The decision being ratified
**Merge-commit-only history under GitFlow** — squash/rebase stay disabled; `required_linear_history` stays off. The cost we accept: `git log --first-parent develop` now carries a two-parent merge commit per feature PR (rather than ADR-0011's hoped-for single squashed commit). The benefit: the wrong-merge-method-during-a-release foot-gun is **machine-enforced** away, and the release back-merge topology is preserved.

> ⚠️ **This is a genuine strategy decision, not just a doc edit.** ADR-0011 actively *argued for* squashing feature merges (clean first-parent log); the operational guardrail went the other way. ADR-0014 is **Proposed** — **merging it ratifies the decision** (which is why I've left it for you and not merged). The explicit alternative, laid out in ADR-0014's "Why not Option 2", is to **re-enable squash for feature merges** and guard the release foot-gun another way. If you prefer that, say so and I'll rework it instead.

## Why supersede (option a) rather than rewrite-in-place (option b)?
#344 offered both. I chose **(a) supersede** because:
- It respects the repo's strict **immutable-ADR convention** (`docs/adr/README.md`: numbers never reused; superseded ADRs stay as the record of *what we believed at the time*).
- ADR-0011's **Q1–Q4 research is still 100% valid** (the `required_linear_history`/GitFlow incompatibility, the rulesets #80952 historical-commits bug, the merge-base cost of squashed back-merges). Superseding preserves it as a citable record; ADR-0014 builds on it by reference rather than duplicating it.
- ADR-0011 went **Proposed → Superseded** (never Accepted/adopted); a banner at the top of ADR-0011 makes that explicit so no one reads its Decision Outcome as policy.

## Files changed (5)
| File | Change |
|---|---|
| `docs/adr/0014-merge-commit-only-history-strategy.md` | **NEW** — the merge-commit-only ADR (Proposed; 4 considered options) |
| `docs/adr/0011-…md` | Status → `Superseded by ADR-0014` + a "never adopted" banner |
| `docs/adr/README.md` | Index: 0011 status updated; 0014 row appended |
| `CLAUDE.md` | Branching pointer → ADR-0014 (PR #350 deliberately left this line forward-referencing #344) |
| `docs/security-posture.md` | Linear-history note → ADR-0014 (ADR-0011 still cited for the detailed analysis) |

## Flagged follow-up (out of scope here)
`.claude/skills/new-adr/SKILL.md` uses the ADR-0011 row as its "current last row" example (lines ~152, ~211). Editing it is **blocked as protected agent-config** and needs your explicit go-ahead. Low-harm — it's illustrative and the skill instructs reading the live index. I left it untouched rather than work around the block; happy to update it on your say-so (or it could be made number-agnostic so it never goes stale again).

## Notes
- **Supersession done in this PR, not a follow-up.** `docs/adr/README.md` suggests marking an ADR `Superseded` in a *follow-up* PR. This PR consciously collapses that into one atomic change: ADR-0011 + ADR-0014 are a single tightly-coupled reconciliation (#344), and the project's own convention is that an ADR's status flips to `Accepted` on merge — so ADR-0011's `Superseded by ADR-0014` link and ADR-0014's `Proposed → Accepted` flip resolve **together** when you merge. (Flagged by the review; calling it out so this PR isn't read as the convention.)
- **Docs only** — no code paths touched; lockfiles unaffected.
- All relative links verified to resolve; the `CLAUDE.md#branching` anchor is unique.

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)
