### PR TITLE
feat(cli): add a top-level --version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ This installs the package in editable mode along with the test dependencies (`py
 # Install from a checkout (add "[dev]" if you will run the tests)
 pip install -e .
 
+# Print the version and exit
+hangarfit --version
+
 # Check a hand-authored layout
 hangarfit check layouts/example.yaml
 ```

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -20,7 +20,7 @@ import secrets
 import sys
 from typing import TYPE_CHECKING
 
-from hangarfit import collisions, visualize
+from hangarfit import __version__, collisions, visualize
 from hangarfit.loader import LoaderError, load_fleet, load_hangar, load_layout
 from hangarfit.models import CheckResult, Conflict, DiversityConfig, Layout, SolveResult
 
@@ -39,6 +39,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="hangarfit",
         description="Check a hand-authored hangar layout for validity.",
+    )
+    # Top-level so `hangarfit --version` works before any subcommand. The
+    # version action fires (and exits 0) during parse, ahead of the
+    # required-subparser check below, so no `cmd` is needed. The string is
+    # sourced from the installed package metadata (hangarfit.__version__) so
+    # it can never drift from pyproject.toml's [project] version.
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
 

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface for hangarfit.
 
 Implements:
+    hangarfit [--version]
     hangarfit check LAYOUT [--render OUT.png] [--fleet PATH] [--hangar PATH] [--json]
 
 See ``docs/superpowers/specs/2026-05-21-cli-design.md`` for the design.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from hangarfit import __version__
 from hangarfit.cli import main
 
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
@@ -28,6 +29,17 @@ class TestArgparseUsageErrors:
         with pytest.raises(SystemExit) as exc_info:
             main(["nope"])
         assert exc_info.value.code == 2
+
+    def test_version_flag_exits_0_and_prints_version(self, capsys):
+        """`hangarfit --version` exits 0 (the version action fires before the
+        required-subparser check) and prints `hangarfit <version>` to stdout,
+        sourced from the packaged metadata so it tracks pyproject.toml."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--version"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == f"hangarfit {__version__}"
+        assert captured.err == ""
 
 
 class TestCheckHappyPath:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,7 +38,9 @@ class TestArgparseUsageErrors:
             main(["--version"])
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
-        assert captured.out.strip() == f"hangarfit {__version__}"
+        # Exact, un-stripped match pins the `%(prog)s {__version__}` template,
+        # the single trailing newline, and the absence of any extra output.
+        assert captured.out == f"hangarfit {__version__}\n"
         assert captured.err == ""
 
 


### PR DESCRIPTION
## Summary

Adds a top-level `--version` flag to the `hangarfit` CLI.

```console
$ hangarfit --version
hangarfit 0.8.0
```

## Details

- The argument is on the **top-level** parser, ahead of the `required=True` subparser. The argparse `version` action fires (and exits 0) during parse, before the "missing command" check — so `hangarfit --version` needs no subcommand.
- The version string is sourced from `hangarfit.__version__` (which reads `importlib.metadata.version("hangarfit")`, with a `0.0.0+unknown` fallback for an uninstalled source tree). **Single source of truth** — it can't drift from `pyproject.toml`'s `[project] version`.
- New test `test_version_flag_exits_0_and_prints_version` follows the existing `pytest.raises(SystemExit)` + `capsys` pattern in `tests/test_cli.py`; it asserts against `f"hangarfit {__version__}"` so it survives version bumps.

## Validation

- `tests/test_cli.py`: 24 passed.
- `hangarfit --version` smoke → `hangarfit 0.8.0`.
- `ruff check` + `ruff format --check` clean; `mypy src/hangarfit/` clean.

Closes #356

https://claude.ai/code/session_01QtxTH8ptc5UtrUbrcHJV6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtxTH8ptc5UtrUbrcHJV6U)_