### PR TITLE
feat(claude): SessionStart hook to provision Python 3.12 in web sessions

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -22,7 +22,7 @@ The project pins a single supported interpreter, **Python 3.12** ([ADR-0009](../
 The `hooks/session-start.sh` script bridges that gap. On session start it:
 
 1. **no-ops outside the remote env** (`$CLAUDE_CODE_REMOTE != "true"`) — local 3.12 developers manage their own environment and are never touched — and no-ops when `HANGARFIT_SKIP_SESSIONSTART_HOOK` is set;
-2. creates (once) a 3.12 venv at `.venv312/` from `/usr/bin/python3.12` and installs the project + dev extras into it (idempotent — cheap to re-run, and the container caches the result);
+2. creates (once) a 3.12 venv at `.venv312/` from `python3.12` (resolved on `PATH`) and installs the project + dev extras into it. The install is skipped on `resume`/`clear`/`compact` once the venv exists, so only a fresh `startup` (or a missing venv) pays for it;
 3. prepends the venv's `bin/` to `PATH` (and sets `VIRTUAL_ENV`) via **`$CLAUDE_ENV_FILE`**, which Claude Code sources into every subsequent command. This is the key step: a hook runs in a subshell, so `source .venv312/bin/activate` would *not* survive to later tool calls — writing to `$CLAUDE_ENV_FILE` makes `python`, `pytest`, `ruff`, and `mypy` all resolve to the 3.12 venv for the rest of the session.
 
 It is **non-blocking**: a missing `python3.12` or a failed `pip install` is reported to stderr and the session still starts (exit `0`). It runs **synchronously** — the session waits until provisioning finishes, trading a slower start for the guarantee that the toolchain is ready before Claude runs anything. (It can be switched to async mode if faster startup is preferred.) Unlike the other three hooks it lives in a **script file** rather than an inline command, because the provisioning logic is too long to read inline.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -6,13 +6,26 @@ This directory holds **team-shared** [Claude Code](https://docs.claude.com/en/do
 
 | File | Status | Purpose |
 |---|---|---|
-| `settings.json` | committed | Team defaults — a `PreToolUse` guard that blocks hand-edits to the hash-pinned `requirements-*.txt` lockfiles, a `PostToolUse` hook that runs `ruff` + `pytest` after edits under `src/hangarfit/` or `tests/`, plus a `Stop` hook that runs `mypy` once when a turn finishes. |
+| `settings.json` | committed | Team defaults — a `SessionStart` hook that provisions Python 3.12 in web/remote sessions, a `PreToolUse` guard that blocks hand-edits to the hash-pinned `requirements-*.txt` lockfiles, a `PostToolUse` hook that runs `ruff` + `pytest` after edits under `src/hangarfit/` or `tests/`, plus a `Stop` hook that runs `mypy` once when a turn finishes. |
+| `hooks/session-start.sh` | committed | The `SessionStart` provisioner script (the one hook complex enough to warrant a file rather than an inline command). |
 | `settings.local.json` | **gitignored** | Optional per-contributor override (see below). |
 | `README.md` | committed | This file. |
 
 ## The hooks
 
-`settings.json` registers three hooks, all shared with every contributor on clone: two fire on the `Edit` and `Write` tools, and one fires when a turn finishes (`Stop`).
+`settings.json` registers four hooks, all shared with every contributor on clone: one fires when a session starts (`SessionStart`), two fire on the `Edit` and `Write` tools, and one fires when a turn finishes (`Stop`).
+
+### SessionStart — Python 3.12 provisioner (non-blocking, web/remote only)
+
+The project pins a single supported interpreter, **Python 3.12** ([ADR-0009](../docs/adr/0009-single-supported-python-version.md)). In the Claude Code **on-the-web / remote** container the default `python`/`python3` is 3.11, so a bare `pip install -e ".[dev]"` fails the `requires-python = ">=3.12"` gate — and the `PostToolUse` (ruff + pytest) and `Stop` (mypy) hooks below, which call those tools by bare name, can't run.
+
+The `hooks/session-start.sh` script bridges that gap. On session start it:
+
+1. **no-ops outside the remote env** (`$CLAUDE_CODE_REMOTE != "true"`) — local 3.12 developers manage their own environment and are never touched — and no-ops when `HANGARFIT_SKIP_SESSIONSTART_HOOK` is set;
+2. creates (once) a 3.12 venv at `.venv312/` from `/usr/bin/python3.12` and installs the project + dev extras into it (idempotent — cheap to re-run, and the container caches the result);
+3. prepends the venv's `bin/` to `PATH` (and sets `VIRTUAL_ENV`) via **`$CLAUDE_ENV_FILE`**, which Claude Code sources into every subsequent command. This is the key step: a hook runs in a subshell, so `source .venv312/bin/activate` would *not* survive to later tool calls — writing to `$CLAUDE_ENV_FILE` makes `python`, `pytest`, `ruff`, and `mypy` all resolve to the 3.12 venv for the rest of the session.
+
+It is **non-blocking**: a missing `python3.12` or a failed `pip install` is reported to stderr and the session still starts (exit `0`). It runs **synchronously** — the session waits until provisioning finishes, trading a slower start for the guarantee that the toolchain is ready before Claude runs anything. (It can be switched to async mode if faster startup is preferred.) Unlike the other three hooks it lives in a **script file** rather than an inline command, because the provisioning logic is too long to read inline.
 
 ### PreToolUse — lockfile guard (blocking)
 
@@ -35,10 +48,11 @@ When a turn finishes, this hook runs `mypy src/hangarfit` once and shows the tai
 
 ## Opting out (per contributor)
 
-Set the env var `HANGARFIT_SKIP_PYTEST_HOOK=1` in your shell init (`~/.bashrc`, `~/.zshrc`, etc.). The **PostToolUse** ruff + pytest hook detects this and exits immediately. The **Stop** mypy hook honours a separate `HANGARFIT_SKIP_MYPY_HOOK=1` so the two can be disabled independently. Unset (or restart your shell) to re-enable. The PreToolUse lockfile guard is intentionally **not** opt-out-able — it is a cheap safety rail and the legitimate regeneration path (`pip-compile` via Bash) is never blocked anyway.
+Set the env var `HANGARFIT_SKIP_PYTEST_HOOK=1` in your shell init (`~/.bashrc`, `~/.zshrc`, etc.). The **PostToolUse** ruff + pytest hook detects this and exits immediately. The **Stop** mypy hook honours a separate `HANGARFIT_SKIP_MYPY_HOOK=1`, and the **SessionStart** provisioner honours `HANGARFIT_SKIP_SESSIONSTART_HOOK=1`, so all three can be disabled independently (the SessionStart hook also already no-ops entirely outside the web/remote env). Unset (or restart your shell) to re-enable. The PreToolUse lockfile guard is intentionally **not** opt-out-able — it is a cheap safety rail and the legitimate regeneration path (`pip-compile` via Bash) is never blocked anyway.
 
 ```bash
 # ~/.bashrc or ~/.zshrc
+export HANGARFIT_SKIP_SESSIONSTART_HOOK=1
 export HANGARFIT_SKIP_PYTEST_HOOK=1
 export HANGARFIT_SKIP_MYPY_HOOK=1
 ```

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SessionStart hook — provision Python 3.12 for Claude Code web/remote sessions.
+#
+# Why this exists (#354): the project pins `requires-python = ">=3.12"`
+# (ADR-0009), but the Claude Code on-the-web container's default
+# `python`/`python3` is 3.11. A naive `pip install -e ".[dev]"` therefore
+# fails the version gate, and the team-shared PostToolUse (ruff+pytest) and
+# Stop (mypy) hooks — which call those tools by bare name — can't run.
+#
+# This hook builds (once) a 3.12 venv at `.venv312/`, installs the dev
+# extras into it, and — crucially — prepends the venv's `bin/` to `PATH`
+# via `$CLAUDE_ENV_FILE`. A hook runs in a subshell, so `source activate`
+# would not survive to later tool calls; `$CLAUDE_ENV_FILE` is sourced by
+# Claude Code into every subsequent command, so `python`, `pytest`, `ruff`,
+# and `mypy` all then resolve to the 3.12 venv for the rest of the session.
+#
+# It is idempotent (safe to re-run), non-interactive, and a no-op outside the
+# remote environment or when `HANGARFIT_SKIP_SESSIONSTART_HOOK` is set.
+set -euo pipefail
+
+# stdin carries the SessionStart JSON payload; we don't need it. Drain it so a
+# closed pipe never wedges the hook.
+cat >/dev/null 2>&1 || true
+
+# Per-contributor opt-out, matching the HANGARFIT_SKIP_* pattern of the other
+# hooks (see .claude/README.md).
+if [ -n "${HANGARFIT_SKIP_SESSIONSTART_HOOK:-}" ]; then
+  exit 0
+fi
+
+# Only needed in the web/remote container. Local 3.12 developers manage their
+# own environment; running here would risk clobbering it.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-.}"
+
+PY312="$(command -v python3.12 || true)"
+if [ -z "$PY312" ]; then
+  echo "[hangarfit session-start] python3.12 not found on PATH; cannot provision the" \
+    "3.12 venv this project requires (ADR-0009). Tests/linters may not run." >&2
+  exit 0
+fi
+
+VENV=".venv312"
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "[hangarfit session-start] creating $VENV with $PY312"
+  "$PY312" -m venv "$VENV"
+fi
+
+# Editable install of the project + dev extras. Cheap to re-run when already
+# satisfied, and the container caches the result after the hook completes.
+# Non-fatal: a transient failure should not wedge session start — the error is
+# surfaced and the session continues.
+"$VENV/bin/python" -m pip install --quiet --upgrade pip || true
+if ! "$VENV/bin/python" -m pip install --quiet -e ".[dev]"; then
+  echo "[hangarfit session-start] 'pip install -e .[dev]' failed; the 3.12 env may be" \
+    "incomplete (check network / logs above)." >&2
+  exit 0
+fi
+
+# Persist the interpreter choice for the whole session (see header note).
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo "export VIRTUAL_ENV=\"$PWD/$VENV\""
+    echo "export PATH=\"$PWD/$VENV/bin:\$PATH\""
+  } >>"$CLAUDE_ENV_FILE"
+fi
+
+echo "[hangarfit session-start] Python 3.12 venv ready at $VENV ($("$VENV/bin/python" -V))"
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -14,13 +14,20 @@
 # Claude Code into every subsequent command, so `python`, `pytest`, `ruff`,
 # and `mypy` all then resolve to the 3.12 venv for the rest of the session.
 #
-# It is idempotent (safe to re-run), non-interactive, and a no-op outside the
-# remote environment or when `HANGARFIT_SKIP_SESSIONSTART_HOOK` is set.
+# SessionStart fires on startup AND resume/clear/compact. The work here is
+# made idempotent across all of those: the venv is created once, the env-file
+# export is written once (guarded against duplicate appends that would bloat
+# PATH), and the expensive `pip install` is skipped on non-startup sources
+# when the venv already exists.
+#
+# Non-interactive, and a no-op outside the remote environment or when
+# `HANGARFIT_SKIP_SESSIONSTART_HOOK` is set.
 set -euo pipefail
 
-# stdin carries the SessionStart JSON payload; we don't need it. Drain it so a
-# closed pipe never wedges the hook.
-cat >/dev/null 2>&1 || true
+# stdin carries the SessionStart JSON payload. Capture it (rather than
+# discarding) so we can read `.source` (startup|resume|clear|compact) below.
+# `|| true` neutralizes a closed-pipe nonzero under `set -e`.
+PAYLOAD="$(cat 2>/dev/null || true)"
 
 # Per-contributor opt-out, matching the HANGARFIT_SKIP_* pattern of the other
 # hooks (see .claude/README.md).
@@ -34,8 +41,15 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-cd "${CLAUDE_PROJECT_DIR:-.}"
+# Guarded so a missing/unreadable project dir can't trip `set -e` — this hook
+# advertises itself as strictly non-blocking (always exit 0).
+cd "${CLAUDE_PROJECT_DIR:-.}" || {
+  echo "[hangarfit session-start] cannot cd to project dir; skipping." >&2
+  exit 0
+}
 
+# Resolve the interpreter via PATH (more robust than a hardcoded /usr/bin path:
+# tolerates /usr/local, a pyenv shim, etc.).
 PY312="$(command -v python3.12 || true)"
 if [ -z "$PY312" ]; then
   echo "[hangarfit session-start] python3.12 not found on PATH; cannot provision the" \
@@ -44,24 +58,37 @@ if [ -z "$PY312" ]; then
 fi
 
 VENV=".venv312"
+venv_existed=true
 if [ ! -x "$VENV/bin/python" ]; then
+  venv_existed=false
   echo "[hangarfit session-start] creating $VENV with $PY312"
   "$PY312" -m venv "$VENV"
 fi
 
-# Editable install of the project + dev extras. Cheap to re-run when already
-# satisfied, and the container caches the result after the hook completes.
-# Non-fatal: a transient failure should not wedge session start — the error is
-# surfaced and the session continues.
-"$VENV/bin/python" -m pip install --quiet --upgrade pip || true
-if ! "$VENV/bin/python" -m pip install --quiet -e ".[dev]"; then
-  echo "[hangarfit session-start] 'pip install -e .[dev]' failed; the 3.12 env may be" \
-    "incomplete (check network / logs above)." >&2
-  exit 0
+# Re-installing the dev extras on every resume/clear/compact adds latency for
+# no benefit once the env is built. Run the install on a fresh `startup`, or
+# whenever the venv had to be (re)created; otherwise skip it.
+source_field="$(printf '%s' "$PAYLOAD" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("source",""))' 2>/dev/null || true)"
+if [ "$source_field" = "startup" ] || [ "$venv_existed" = false ]; then
+  # Editable install of the project + dev extras. Deliberately NOT
+  # `--require-hashes` against requirements-dev.txt: this is a dev-convenience
+  # provisioner whose only job is a working ruff/pytest/mypy toolchain, and an
+  # unpinned resolve from pyproject.toml can't fail on lockfile skew. Do not
+  # "fix" it to the hash-pinned CI path. Non-fatal: a transient failure should
+  # not wedge session start — the error is surfaced and the session continues.
+  "$VENV/bin/python" -m pip install --quiet --upgrade pip || true
+  if ! "$VENV/bin/python" -m pip install --quiet -e ".[dev]"; then
+    echo "[hangarfit session-start] 'pip install -e .[dev]' failed; the 3.12 env may be" \
+      "incomplete (check network / logs above)." >&2
+    exit 0
+  fi
 fi
 
 # Persist the interpreter choice for the whole session (see header note).
-if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+# Append-once: SessionStart can fire repeatedly into the same env file, and an
+# unguarded `>>` would stack duplicate `export PATH=...` lines and bloat PATH.
+if [ -n "${CLAUDE_ENV_FILE:-}" ] && ! grep -qF "$PWD/$VENV/bin" "$CLAUDE_ENV_FILE" 2>/dev/null; then
   {
     echo "export VIRTUAL_ENV=\"$PWD/$VENV\""
     echo "export PATH=\"$PWD/$VENV/bin:\$PATH\""

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ dist/
 
 # Virtual environments
 .venv/
+# The SessionStart hook (.claude/hooks/session-start.sh, #354) provisions a
+# 3.12 venv at this exact path on web/remote sessions — keep it untracked.
+.venv312/
 venv/
 env/
 ENV/


### PR DESCRIPTION
## Summary

Adds a **SessionStart** hook so Claude Code **web/remote** sessions can run `pytest`, `ruff`, and `mypy` on Python 3.12.

**The problem:** the project pins Python 3.12 ([ADR-0009](https://github.com/DocGerd/hangarfit/blob/develop/docs/adr/0009-single-supported-python-version.md)), but the on-the-web container's default `python`/`python3` is **3.11**. A bare `pip install -e ".[dev]"` fails the `requires-python = ">=3.12"` gate, and the existing `PostToolUse` (ruff+pytest) and `Stop` (mypy) hooks — which call those tools by bare name — can't run. (Hit firsthand in the session that filed #354.)

## What it does

New `.claude/hooks/session-start.sh`, registered as a `SessionStart` hook in `.claude/settings.json`:

1. **no-ops outside the remote env** (`$CLAUDE_CODE_REMOTE != "true"`) so local 3.12 devs are never touched, and no-ops when `HANGARFIT_SKIP_SESSIONSTART_HOOK` is set;
2. creates (once) a 3.12 venv at `.venv312/` from `python3.12` and installs the project + dev extras — idempotent, container-cached;
3. **prepends the venv `bin/` to `PATH` via `$CLAUDE_ENV_FILE`** — the key step. A hook runs in a subshell, so `source .venv312/bin/activate` would *not* persist; `$CLAUDE_ENV_FILE` is sourced by Claude Code into every later command, so `python`/`pytest`/`ruff`/`mypy` all resolve to 3.12 for the rest of the session (this also fixes the other two hooks, which call those tools bare).

**Non-blocking**: a missing `python3.12` or a failed install is reported to stderr and the session still starts. **Synchronous** (waits for provisioning before the session runs — guarantees the toolchain is ready; can switch to async if faster startup is preferred). It's the one hook complex enough to live in a script file rather than an inline command.

## Validation (ran the hook as a remote session would)

| Check | Result |
|---|---|
| Hook execution (`CLAUDE_CODE_REMOTE=true`, real `$CLAUDE_ENV_FILE`) | ✅ exit 0; env file written; sourcing it makes `python -V` → 3.12.3 and `pytest`/`ruff`/`mypy` resolve to `.venv312/bin` |
| Linter (`ruff check src/hangarfit/cli.py`) | ✅ pass |
| Test (one CLI test under the venv) | ✅ 1 passed |
| No-op when non-remote (`CLAUDE_CODE_REMOTE` unset / `false`) | ✅ no output, exit 0 |
| No-op with `HANGARFIT_SKIP_SESSIONSTART_HOOK=1` | ✅ no output, exit 0 |
| Idempotent second run (venv exists) | ✅ exit 0 |
| `settings.json` valid JSON; `bash -n` syntax | ✅ |

`.claude/README.md` updated (new hook section, file table, opt-out list). No source/test/lockfile changes.

> **Heads-up:** this takes effect for future sessions only **after it merges to the default branch**.

Closes #354

https://claude.ai/code/session_01QtxTH8ptc5UtrUbrcHJV6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtxTH8ptc5UtrUbrcHJV6U)_