### PR TITLE
refactor(solver): extract shared _generate_candidates (dedup descent/spread) (#357)

### DIFF
--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -757,35 +757,12 @@ def _spread(
         target = rng.choice(movable)
 
         # Same candidate mix as _descent_step: (N-2) small nudges + 1 large + 1 flip.
-        candidates: list[Placement] = []
-        n_small = max(0, search.candidates_per_iter - 2)
-        for _ in range(n_small):
-            candidates.append(
-                _perturb_plane(
-                    current=placements[target],
-                    scenario=scenario,
-                    rng=rng,
-                    search=search,
-                    large_jump=False,
-                )
-            )
-        candidates.append(
-            _perturb_plane(
-                current=placements[target],
-                scenario=scenario,
-                rng=rng,
-                search=search,
-                large_jump=True,
-            )
-        )
-        candidates.append(
-            Placement(
-                plane_id=target,
-                x_m=placements[target].x_m,
-                y_m=placements[target].y_m,
-                heading_deg=(placements[target].heading_deg + 180.0) % 360.0,
-                on_carts=placements[target].on_carts,
-            )
+        candidates = _generate_candidates(
+            current=placements[target],
+            target=target,
+            scenario=scenario,
+            rng=rng,
+            search=search,
         )
 
         # Pick the lowest-(energy, displacement) VALID candidate. Adopt it
@@ -1036,6 +1013,61 @@ def _perturb_plane(
     )
 
 
+def _generate_candidates(
+    *,
+    current: Placement,
+    target: str,
+    scenario: Scenario,
+    rng: _random_module.Random,
+    search: SearchConfig,
+) -> list[Placement]:
+    """Build the standard candidate mix for one plane (spec §4.3 step 4).
+
+    ``N = candidates_per_iter`` candidates, generated in a fixed order that
+    pins the RNG draw sequence: ``N - 2`` small Gaussian nudges, then 1 large
+    global jump, then 1 deterministic 180° heading flip. The two RNG-driven
+    variants (small nudges, large jump) consume entropy in exactly this order;
+    the flip draws nothing.
+
+    Shared verbatim by :func:`_descent_step` (min-conflicts descent) and
+    :func:`_spread` (the inter-plane spread post-pass) — both need the identical
+    mix. The extraction is byte-for-byte behaviour-preserving: keeping the draw
+    order (small × ``n_small`` → large → flip) is what preserves the ADR-0003
+    determinism contract, so do not reorder the appends.
+    """
+    candidates: list[Placement] = []
+    n_small = max(0, search.candidates_per_iter - 2)
+    for _ in range(n_small):
+        candidates.append(
+            _perturb_plane(
+                current=current,
+                scenario=scenario,
+                rng=rng,
+                search=search,
+                large_jump=False,
+            )
+        )
+    candidates.append(
+        _perturb_plane(
+            current=current,
+            scenario=scenario,
+            rng=rng,
+            search=search,
+            large_jump=True,
+        )
+    )
+    candidates.append(
+        Placement(
+            plane_id=target,
+            x_m=current.x_m,
+            y_m=current.y_m,
+            heading_deg=(current.heading_deg + 180.0) % 360.0,
+            on_carts=current.on_carts,
+        )
+    )
+    return candidates
+
+
 def _descent_step(
     *,
     placements: dict[str, Placement],
@@ -1101,35 +1133,14 @@ def _descent_step(
     target = rng.choice(sorted(conflicting))
 
     # Generate N candidate perturbations: (N-2) small + 1 large + 1 flip
-    candidates: list[Placement] = []
-    n_small = max(0, search.candidates_per_iter - 2)
-    for _ in range(n_small):
-        candidates.append(
-            _perturb_plane(
-                current=placements[target],
-                scenario=scenario,
-                rng=rng,
-                search=search,
-                large_jump=False,
-            )
-        )
-    candidates.append(
-        _perturb_plane(
-            current=placements[target],
-            scenario=scenario,
-            rng=rng,
-            search=search,
-            large_jump=True,
-        )
+    # (shared with _spread; see _generate_candidates for the draw-order contract).
+    candidates = _generate_candidates(
+        current=placements[target],
+        target=target,
+        scenario=scenario,
+        rng=rng,
+        search=search,
     )
-    flipped = Placement(
-        plane_id=target,
-        x_m=placements[target].x_m,
-        y_m=placements[target].y_m,
-        heading_deg=(placements[target].heading_deg + 180.0) % 360.0,
-        on_carts=placements[target].on_carts,
-    )
-    candidates.append(flipped)
 
     # Score each candidate. Tie-break by displacement from the current
     # state (encourages smooth trajectories — spec §4.3 step 4).


### PR DESCRIPTION
## Summary

First of the three items in **#357**: extract the candidate-generation logic that `_descent_step` (min-conflicts descent) and `_spread` (the inter-plane spread post-pass) **duplicated verbatim** — `_spread`'s copy was even commented *"Same candidate mix as `_descent_step`."* Both now call a single `_generate_candidates` helper.

**Behaviour-preserving, no `src` logic change** beyond the extraction. Net diff: a 62-line helper (with docstring) replaces two ~31-line blocks.

## Why this is determinism-safe (ADR-0003)

The candidate mix is RNG-driven, so the **draw order is the contract**. `_generate_candidates` keeps it byte-for-byte: `N-2` small Gaussian nudges (`_perturb_plane(large_jump=False)`) → 1 large global jump (`_perturb_plane(large_jump=True)`) → 1 deterministic 180° flip (draws no RNG). The docstring explicitly warns not to reorder the appends.

## Verification

- **`tests/test_solver_canaries.py`** — the authoritative `max_restarts`-scoped determinism oracle (#267 amendment): **5 passed**, unchanged.
- **`tests/test_solver_spread.py`** — exercises the `_spread` call site: **passed** (16 passed combined with canaries).
- **Independent twice-identical probe**, `max_restarts`-scoped (not wall-clock, which is inherently flaky here) with **spread enabled**: byte-identical `SolveResult` on `solve_fresh_six_planes` (seed 42) and `solve_fresh_alternatives_three` (seed 7).
- `ruff check` / `ruff format --check` / `mypy src/hangarfit/` clean.
- A `determinism-guard` subagent review is running; the full slow solver suite is running locally as defense-in-depth (CI runs it too).

> Note: I initially used a wall-clock-budget probe and saw a hash diff — then confirmed it was **the probe** that was flaky (identical code gave different hashes run-to-run, because wall-clock budget ≠ the `max_restarts`-scoped contract). Switching to the `max_restarts`-scoped oracle the canaries use showed byte-stable output. Calling this out for transparency.

## Scope

This PR is **only** item 1 of #357. The `solve()` and `_check_trivially_infeasible()` decompositions are deliberately left as separate follow-up PRs (per the issue's "land as separate small PRs" recommendation), each behind its own determinism-guard pass.

Refs #357

https://claude.ai/code/session_01QtxTH8ptc5UtrUbrcHJV6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtxTH8ptc5UtrUbrcHJV6U)_