### PR TITLE
docs(adr): flip ADR-0014 + ADR-0015 status to Accepted

### DIFF
--- a/docs/adr/0014-merge-commit-only-history-strategy.md
+++ b/docs/adr/0014-merge-commit-only-history-strategy.md
@@ -1,6 +1,6 @@
 # ADR-0014: Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-29
 - **Deciders:** Patrick Kuhn (DocGerd)
 

--- a/docs/adr/0015-wheels-not-in-collision-model.md
+++ b/docs/adr/0015-wheels-not-in-collision-model.md
@@ -1,6 +1,6 @@
 # ADR-0015: Wheels do not participate in the static collision model (gear stays render/motion data)
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-31
 - **Deciders:** [@DocGerd](https://github.com/DocGerd)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,5 +91,5 @@ manual workflow above is canonical.
 | 0011 | [Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline](0011-linear-history-strategy-under-gitflow.md) | Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md) |
 | 0012 | [Split the fuselage into front/aft so a wing may overhang a tail but not a cockpit](0012-fuselage-front-aft-split.md) | Accepted |
 | 0013 | [Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load](0013-wheels-canonical-data.md) | Accepted |
-| 0014 | [Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail](0014-merge-commit-only-history-strategy.md) | Proposed |
-| 0015 | [Wheels do not participate in the static collision model (gear stays render/motion data)](0015-wheels-not-in-collision-model.md) | Proposed |
+| 0014 | [Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail](0014-merge-commit-only-history-strategy.md) | Accepted |
+| 0015 | [Wheels do not participate in the static collision model (gear stays render/motion data)](0015-wheels-not-in-collision-model.md) | Accepted |


### PR DESCRIPTION
Flip ADR-0014 and ADR-0015 from **Proposed → Accepted** — the documented post-merge ratification step (ADR README convention: status flips to Accepted when the PR is merged). Both ADRs are already merged: ADR-0014 via #352, ADR-0015 via #364.

**4 one-line docs edits:**
- `docs/adr/0014-merge-commit-only-history-strategy.md` — header Status
- `docs/adr/0015-wheels-not-in-collision-model.md` — header Status
- `docs/adr/README.md` — index rows 0014 + 0015

No behavioural change; documentation lifecycle only.

Closes #367