### PR TITLE
ci(fuzz): wire geometry/collision Atheris harness into nightly workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -14,12 +14,12 @@ concurrency:
 
 jobs:
   fuzz:
-    name: Fuzz YAML loader
+    name: Fuzz YAML loader + geometry/collisions
     runs-on: ubuntu-latest
-    # The Atheris step is time-boxed to 300s and the Hypothesis deep run is
-    # ~100s; this ceiling fails a stuck nightly fast instead of riding the
-    # 6h default job timeout.
-    timeout-minutes: 15
+    # Two Atheris steps (loader + geometry/collisions) are each time-boxed to
+    # 300s and the Hypothesis deep run is ~100s; this ceiling fails a stuck
+    # nightly fast instead of riding the 6h default job timeout.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -51,3 +51,6 @@ jobs:
 
       - name: Atheris coverage-guided run (time-boxed)
         run: python -m tests.fuzz.atheris_loader_harness -max_total_time=300
+
+      - name: Atheris geometry/collisions run (time-boxed)
+        run: python -m tests.fuzz.atheris_geometry_harness -max_total_time=300


### PR DESCRIPTION
## What

Adds the geometry/collision Atheris coverage-guided step to the nightly `fuzz` job — the follow-up #362 deferred because its push token lacked the GitHub OAuth `workflow` scope.

## Changes (`.github/workflows/fuzz.yml`)

- **New step** after the loader Atheris step: `python -m tests.fuzz.atheris_geometry_harness -max_total_time=300`.
- **Timeout** `15 → 25` min to cover the second 300s Atheris box plus the Hypothesis deep run; job `name:` + comment refreshed to mention geometry/collisions.

The Hypothesis property suite (`tests/fuzz/test_geometry_fuzz.py`) already gets the nightly deep run via the existing `pytest tests/fuzz/` step and per-PR coverage via the main CI pytest glob — only the Atheris step needed adding. No dependency change (Atheris is already in `requirements-fuzz.txt`).

## Verification

- `fuzz.yml` parses; job has 9 steps, the last two being the loader + geometry Atheris runs; `timeout-minutes: 25`.
- Harness smoke-run locally to completion: **14,615 execs, growing coverage, exit 0** at `-max_total_time=12`.
- Manual `workflow_dispatch` run triggered on this branch to confirm the nightly job goes green end-to-end (linked in a comment).

Nightly-only; does not gate PRs. Low risk (~4 lines + timeout/name tweak).

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)