### PR TITLE
docs: refresh stale doc layers and add core-concept diagrams

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,13 @@
 
 Welcome, and thanks for looking at the code. `hangarfit` is a small, focused
 tool — a collision checker for a flying club's hangar parking arrangements —
-maintained by [DocGerd](https://github.com/DocGerd). The full design context,
-coordinate conventions, and project philosophy live in [`CLAUDE.md`](CLAUDE.md).
-Read that before touching anything geometric; it will save you a round-trip on
-review.
+maintained by [DocGerd](https://github.com/DocGerd). The architectural canon —
+the coordinate convention, the parts-based collision model, and the decisions
+that shaped the substrate — lives in [`docs/architecture/`](docs/architecture/)
+(arc42) and [`docs/adr/`](docs/adr/); [`CLAUDE.md`](CLAUDE.md) is the
+*operational* guide (how we work: GitFlow, review, project-local config). Read
+[§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md) before
+touching anything geometric; it will save you a round-trip on review.
 
 ---
 
@@ -149,12 +152,19 @@ and it bypasses the maintainer's final check.
 
 ## Where the design lives
 
-- [`CLAUDE.md`](CLAUDE.md) — the full spec: fleet details, the parts-based
-  collision rule, the coordinate convention (including the non-obvious
-  heading transform), and the Phase 1 deliverables list.
-- [`README.md`](README.md) — quick-start, usage examples, and a pointer back
-  to `CLAUDE.md` for depth.
+- [`docs/architecture/`](docs/architecture/) — the arc42 architecture set: the
+  module map (§5), the runtime flows (§6), and the domain canon (§8: the parts
+  model, the coordinate convention, the maintenance-bay rule, the motion model).
+- [`docs/adr/`](docs/adr/) — the architecture decision records: *why* each
+  load-bearing choice was made and what alternatives were rejected (e.g.
+  [ADR-0001](docs/adr/0001-aircraft-parts-model.md) the parts model,
+  [ADR-0002](docs/adr/0002-determinant-minus-one-transform.md) the transform).
+- [`CLAUDE.md`](CLAUDE.md) — the *operational* guide: how we work together
+  (GitFlow, the PR-review process, project-local config). Not the design canon.
+- [`README.md`](README.md) — quick-start, usage examples, exit-code tables.
 
-If something in the codebase seems strange — especially around geometry — check
-`CLAUDE.md` first. The coordinate transform in particular has a non-obvious
-determinant-−1 property that is documented there and tested in the golden suite.
+If something in the codebase seems strange — especially around geometry — read
+[§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md) and
+[ADR-0002](docs/adr/0002-determinant-minus-one-transform.md) first. The
+coordinate transform in particular has a non-obvious determinant-−1 property
+documented there and tested in the golden suite.

--- a/data/fleet.yaml
+++ b/data/fleet.yaml
@@ -32,7 +32,7 @@
 #   loader does not split; an aircraft with a `fuselage` part needs a `wing`
 #   part to derive the break.)
 # - turn_radius_m: own-gear minimum taxi turn radius (m). LOAD-BEARING since
-#   Phase 3a — consumed by the `towplanner` module's Dubins / Hybrid-A*
+#   Phase 3a — consumed by the `towplanner` module's Reeds–Shepp / Hybrid-A*
 #   path planning (it was an unused placeholder through Phase 1/2a). `null`
 #   on always_cart planes: they have no own-gear taxi radius, so the
 #   towplanner substitutes 0 (pivot-in-place on the cart) via

--- a/docs/architecture/01-introduction-and-goals.md
+++ b/docs/architecture/01-introduction-and-goals.md
@@ -15,6 +15,30 @@ asked, searches for a valid arrangement itself.
 It is a CLI tool. It reads YAML, writes JSON and optional top-down PNG
 renders, and persists nothing between invocations.
 
+## Shipped phases
+
+Shipped capability by phase, tied to the release it landed in
+(authoritative version-to-date mapping in [`CHANGELOG.md`](../../CHANGELOG.md)):
+
+```mermaid
+timeline
+    title hangarfit phases (phase to shipped capability to release)
+    section Phase 1 substrate
+        v0.1.0 : hangarfit check : parts collision rule, hangar bounds, maintenance bay : top-down PNG render
+    section Phase 2a static solver
+        v0.6.0 : hangarfit solve : Random-Restart Monte-Carlo layout search : diversity metric (--alternatives)
+    section Phase 2b/2c solver polish
+        v0.7.0 : Phase 2b spread post-pass, maximise min inter-plane gap : Phase 2c collect-then-select pool, maximin selection
+    section Phase 3a/3b tow-path planning
+        v0.7.0 : Phase 3a solve --render-paths tow-path fill (Dubins arcs) : Phase 3b Reeds-Shepp reverse-capable tow, door entry-cone
+```
+
+*Phases map to the CLI surface: Phase 1 = `hangarfit check`; Phase 2a/2b/2c
+= `hangarfit solve`; Phase 3a/3b = `hangarfit solve --render-paths`. There
+were no v0.2.0–v0.5.0 tags — the Phase 2a solver shipped in v0.6.0; the
+spread-aware solver (2b/2c) and the full tow-path planner (3a/3b) all shipped
+in v0.7.0.*
+
 ## Quality goals
 
 In rough order of priority — earlier goals trump later ones when they

--- a/docs/architecture/03-context-and-scope.md
+++ b/docs/architecture/03-context-and-scope.md
@@ -75,11 +75,11 @@ The tool runs entirely on the user's local machine:
 
 | Out of scope | Why |
 |--------------|-----|
-| **Movement-sequence planning** — "in what order do I roll planes out and back in to reach this layout?" | The "Tower of Hanoi" reshuffling problem is harder than the static layout problem and was not the original need. The current tool finds *a* valid target; getting there is a human's job. |
+| **Movement-sequence planning** — "in what order do I roll planes out and back in to *re-sequence an already-parked* hangar?" | The "Tower of Hanoi" reshuffling of an already-occupied hangar is harder than the static layout problem and was not the original need; re-sequencing parked planes remains a human's job. This is **distinct from the empty-hangar tow-path fill** that *did* ship in Phase 3a/3b — `solve --render-paths` plans how each plane is towed into its slot from the door, one entry per plane ([ADR-0007](../adr/0007-tow-path-planner-v1-scope.md) / [ADR-0010](../adr/0010-reeds-shepp-motion-model.md)). |
 | **Tracking hangar state across runs.** | Each invocation is stateless. The scenario YAML carries everything. This is a deliberate constraint from §2; tracking state would invite an entire class of "what was true yesterday?" bugs. |
 | **GUI or web frontend.** | A CLI plus a PNG is the right shape for the actual usage (one operator, one decision, no audit trail needed yet). Anything browser-shaped is a separate project. |
 | **Live event stream** (late-arrival notifications, departure tracking). | The tool is invoked on demand against a hand-authored scenario. The club uses other tooling (radio, paper, eyeballs) to know who is back; `hangarfit` only checks whether a *proposed* layout is valid. |
-| **Soft constraints / preferences** ("prefer this region", "minimise total movement vs baseline"). | All constraints in v1 are HARD: pin, `force_on_carts`, maintenance plane. Soft-constraint optimization is a different problem; it would have its own ADR before being added. |
+| **Soft preferences *inside* the hard conflict-resolution loop** (a weighted "prefer this region" objective competing with collision penalties). | The conflict-resolution loop stays HARD-only (pin, `force_on_carts`, maintenance plane). Soft preferences are not banned outright — they ship as **isolated post-passes** that run only after a layout is already valid (the inter-plane spread post-pass, [ADR-0008](../adr/0008-inter-plane-spread-soft-preference.md)), each with its own ADR, never as a new key in the hard score tuple. |
 
 These boundaries are not "phase 1 limitations to be removed later." They
 are deliberate design choices that keep the tool small, correct, and

--- a/docs/architecture/04-solution-strategy.md
+++ b/docs/architecture/04-solution-strategy.md
@@ -8,10 +8,11 @@ to which ADR, not a re-derivation.
 
 ## Headline decisions
 
-Ordered roughly Phase 1 → Phase 2a → cross-cutting scope and operations
-choices: the geometric substrate first (parts model, transform), then
-the solver layered on top of it (algorithm, constraint posture), then
-the surrounding shape of the tool (delivery, documentation).
+Ordered roughly Phase 1 → Phase 2 → Phase 3 → cross-cutting scope and
+operations choices: the geometric substrate first (parts model,
+transform), then the solver layered on top of it (algorithm, constraint
+posture), then the tow-path planner layered on the solver, then the
+surrounding shape of the tool (delivery, documentation).
 
 ### Aircraft geometry as a list of parts, not a single bounding box
 
@@ -85,6 +86,26 @@ If further soft-constraint optimisation use cases materialise, each
 gets its own ADR and, if possible, its own isolated post-pass rather
 than a new key in the hard score tuple.
 
+### Tow-path planning as a bound-aware search over Reeds–Shepp motion
+
+`hangarfit solve --render-paths` does not just validate a static
+layout — it plans how each aircraft is towed into its slot from the
+door. The `towplanner` module fills the hangar back-to-front and routes
+each plane with a bound-aware Hybrid-A* search whose steering primitive
+is a closed-form **Reeds–Shepp** path (forward *and* reverse arcs),
+re-validated against the already-placed aircraft by the collision
+checker as it moves. Routing is best-effort: a plane the planner cannot
+route comes back as `plans[i] = None` rather than failing the whole
+layout, and the CLI exits 3 only when *no* candidate layout is fully
+tow-routable.
+
+A sampling-based planner (RRT / PRM) was rejected in favour of this
+closed-form motion vocabulary, which keeps the planner deterministic
+without an RNG. See [ADR-0007](../adr/0007-tow-path-planner-v1-scope.md)
+for the v1 scope and
+[ADR-0010](../adr/0010-reeds-shepp-motion-model.md) for the v2
+Reeds–Shepp motion model.
+
 ### CLI + JSON + optional PNG; nothing else
 
 `hangarfit` is a single-binary CLI invoked from a terminal. It reads
@@ -110,8 +131,11 @@ no MkDocs / Sphinx / Docusaurus build step. Mermaid diagrams render
 natively in GitHub Markdown.
 
 Choosing a documentation site generator is itself an architectural
-decision that would deserve its own ADR. Until that decision is made,
-GitHub's built-in rendering is enough — and the absence of a build step
+decision. It was evaluated in #372 and the decision recorded: stay with
+in-repo Markdown and treat GitHub Pages as deferred-not-rejected — the
+docs deliberately cross-link into source and config files outside
+`docs/`, which a static-site generator rooted at `docs/` cannot resolve.
+GitHub's built-in rendering is enough, and the absence of a build step
 removes one whole class of "did the docs publish?" failure modes.
 
 ## What the headline decisions do *not* cover

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -180,10 +180,12 @@ Internally:
   rectangle is enforced as a hard obstacle by the `bay_intrusion`
   collision rule, so no surrogate sample is needed.
 - **Initial placement** — random valid placements respecting pins.
-- **Descent step** — min-conflicts perturbation: identify the plane
-  with the largest conflict contribution (by `total_penetration_m2`),
-  perturb it to reduce its contribution, repeat until zero conflicts
-  or local minimum.
+- **Descent step** — min-conflicts perturbation: pick one conflicting
+  non-pinned plane *uniformly at random* (over a `sorted()` set, so the
+  RNG draw stays deterministic), generate `N` candidate moves for it
+  (small nudges + one large jump + one 180° flip) and greedily accept
+  the best-scoring one (ties broken by smallest displacement), repeat
+  until zero conflicts or a local minimum.
 - **Restart cycle** — when descent plateaus, restart with a new random
   placement.
 - **Acceptance gate** — every candidate runs through `collisions.check()`
@@ -204,6 +206,64 @@ across runs (compliance check:
 `tests/test_solver_canaries.py`). Tow-planning is RNG-free, so the
 bundled `(Layout, MovesPlan)` output preserves the same determinism
 contract.
+
+The `solve()` lifecycle as a state machine — the pre-search gate, the
+restart/descent inner loop, the post-acceptance spread + basin pool, and
+the four terminal `SolveStatus` outcomes:
+
+```mermaid
+stateDiagram-v2
+    direction TB
+    [*] --> PreSearchGate : solve(scenario, seed)
+
+    PreSearchGate : Pre-search infeasibility gate
+    PreSearchGate : (1) a plane bbox exceeds the hangar max dimension
+    PreSearchGate : (2) sum of bbox areas exceeds the hangar floor
+    PreSearchGate : (3) pin-only layout fails check()
+
+    PreSearchGate --> trivially_infeasible : a gate trips
+    PreSearchGate --> RestartLoop : all gates pass
+
+    state RestartLoop {
+        direction TB
+        [*] --> InitialPlacement
+        InitialPlacement : Initial placement
+        InitialPlacement : random (x, y, heading); pins verbatim
+        InitialPlacement : cart-bucket round-robin; maintenance plane excluded
+        InitialPlacement --> Descent
+        Descent : Min-conflicts descent
+        Descent : pick a conflicting non-pinned plane at random
+        Descent : try N moves (nudges + jump + 180 deg flip)
+        Descent : score = (conflict_count, penetration_m2)
+        Descent --> Descent : improved, greedy accept
+        Descent --> Spread : score reaches (0, 0.0)
+        Descent --> Restart : plateau or all conflicts pinned
+        Spread : Spread post-pass (ADR-0008)
+        Spread : minimise repulsion energy, valid moves only
+        Spread --> PoolAppend : append basin candidate
+        PoolAppend --> Restart : seek another basin
+        Restart --> InitialPlacement : restart_index under max_restarts, within budget_s
+    }
+
+    RestartLoop --> Select : budget_s or max_restarts reached
+    Select : Selection (ADR-0004, collect-then-select #267)
+    Select : sort by (-min_gap, energy, restart_index)
+    Select : diversity gate
+    Select --> found : selected count equals alternatives
+    Select --> found_partial : some but fewer than alternatives
+    Select --> exhausted_budget : pool empty
+
+    found --> [*]
+    found_partial --> [*]
+    exhausted_budget --> [*]
+    trivially_infeasible --> [*]
+```
+
+*RR-MC `solve()` state machine: pre-search gate → bounded random-restart
+loop (min-conflicts descent, spread post-pass once a layout reaches
+`(0, 0.0)`, basin pool) → collect-then-select maximin-gap + diversity
+selection → one of four `SolveStatus` outcomes. Sources:
+`src/hangarfit/solver.py`, ADR-0003, ADR-0004, ADR-0008.*
 
 ### `towplanner.py` — tow-path planning
 

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -228,8 +228,8 @@ stateDiagram-v2
         direction TB
         [*] --> InitialPlacement
         InitialPlacement : Initial placement
-        InitialPlacement : random (x, y, heading); pins verbatim
-        InitialPlacement : cart-bucket round-robin; maintenance plane excluded
+        InitialPlacement : random (x, y, heading), pins verbatim
+        InitialPlacement : cart-bucket round-robin, maintenance plane excluded
         InitialPlacement --> Descent
         Descent : Min-conflicts descent
         Descent : pick a conflicting non-pinned plane at random

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -234,7 +234,7 @@ stateDiagram-v2
         Descent : Min-conflicts descent
         Descent : pick a conflicting non-pinned plane at random
         Descent : try N moves (nudges + jump + 180 deg flip)
-        Descent : score = (conflict_count, penetration_m2)
+        Descent : score = (conflict_count, total_penetration_m2)
         Descent --> Descent : improved, greedy accept
         Descent --> Spread : score reaches (0, 0.0)
         Descent --> Restart : plateau or all conflicts pinned

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -192,7 +192,7 @@ sequenceDiagram
             Tow-->>Solver: MovesPlan
         else greedy stuck
             Tow-->>Solver: raise NoFeasiblePlanError(plane_id)
-            Note over Solver: plans[i] = None;<br/>plane → diagnostics.unroutable_planes
+            Note over Solver: plans[i] = None,<br/>plane named in diagnostics.unroutable_planes
         end
     end
     Solver-->>CLI: SolveResult(layouts, plans, diagnostics, status, seed)
@@ -205,7 +205,7 @@ sequenceDiagram
     Note over CLI: _warn_unroutable: stderr names each blocked plane
     alt no candidate routable (all plans None)
         CLI->>Op: exit 3
-    else ≥1 routable
+    else at least 1 routable
         CLI->>Op: exit 0 (or status-driven)
     end
 ```

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -89,7 +89,7 @@ sequenceDiagram
                     Note over Solver: Spread (if SearchConfig.spread, default on):<br/>_spread maximizes inter-plane separation, only valid moves
                     Note over Solver: append valid (spread-polished) basin to pool
                 else conflicts > 0
-                    Note over Solver: perturb plane with max<br/>penetration contribution
+                    Note over Solver: perturb a conflicting non-pinned<br/>plane (chosen uniformly at random)
                 end
             end
         end

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -159,6 +159,59 @@ from `check()` into the solver other than structural failure (which
 would indicate a bug in the random-placement generator), and that
 bubbles up as exit code 2.
 
+## Scenario 3: `hangarfit solve scenario.yaml --render out_{i}.png --render-paths`
+
+The Phase 3a/3b path — a zoom-in on the `opt plan_paths` step that
+Scenario 2 abstracts as a single call. The operator wants the solver's
+layouts *plus* a per-plane tow path overlaid on each PNG; `--render-paths`
+turns on the best-effort tow bundle and the exit-3 routability check.
+
+```mermaid
+sequenceDiagram
+    participant Op as Operator
+    participant CLI as cli.py
+    participant Solver as solver.py
+    participant Tow as towplanner.py
+    participant Coll as collisions.py
+    participant Viz as visualize.py
+    participant FS as Filesystem
+
+    Op->>CLI: hangarfit solve scenario.yaml --render out_{i}.png --render-paths
+    Note over CLI: --render-paths requires a --render PATTERN<br/>(else: CLI usage error)
+    CLI->>Solver: solve(scenario, ..., plan_paths=True)
+    Note over Solver: search + spread + diversity select<br/>(Scenario 2) → accepted layouts
+    loop per accepted layout (best-effort, #197)
+        Solver->>Tow: plan_fill(layout)
+        Note over Tow: back_first_order: deepest slot first<br/>(y desc, x asc, plane_id asc)
+        loop per plane, deepest first
+            Tow->>Tow: plan_path (Hybrid-A* over Reeds–Shepp arcs)
+            Tow->>Coll: re-validate final arc (path_first_conflict → check)
+            Coll-->>Tow: per-pose clear / Conflict
+        end
+        alt all planes routed
+            Tow-->>Solver: MovesPlan
+        else greedy stuck
+            Tow-->>Solver: raise NoFeasiblePlanError(plane_id)
+            Note over Solver: plans[i] = None;<br/>plane → diagnostics.unroutable_planes
+        end
+    end
+    Solver-->>CLI: SolveResult(layouts, plans, diagnostics, status, seed)
+
+    loop per returned layout
+        CLI->>Viz: render_layout(layout, moves_plan=plans[i])
+        Note over Viz: _draw_tow_paths samples each arc<br/>(un-routable → no overlay)
+        Viz->>FS: write out_i.png
+    end
+    Note over CLI: _warn_unroutable: stderr names each blocked plane
+    alt no candidate routable (all plans None)
+        CLI->>Op: exit 3
+    else ≥1 routable
+        CLI->>Op: exit 0 (or status-driven)
+    end
+```
+
+*Scenario 3 — `solve --render-paths`: `solve(plan_paths=True)` tow-plans each accepted layout via `plan_fill` (back-first order; per-plane Hybrid-A\* over Reeds–Shepp arcs, the final arc re-validated by `collisions.check`). Routing is best-effort — a layout the bounded planner can't route keeps `plans[i]=None` and the blocked plane is recorded in `diagnostics.unroutable_planes` rather than dropping the valid static layout. The CLI overlays each routable path and exits 3 only when no returned candidate is tow-routable (#193/#197, ADR-0007/ADR-0010).*
+
 ## What is *not* a runtime concern
 
 - **Long-running state.** Each invocation is stateless. There is no

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -36,6 +36,41 @@ the uniform two-clause predicate. See
 [ADR-0012](../adr/0012-fuselage-front-aft-split.md) for the rationale
 and rejected alternatives.
 
+The wing-over-tail-but-not-cockpit rule in plan view, with the height
+band that makes the aft case a pass-through:
+
+```text
+PLAN VIEW (top-down).  World frame: +x along the door, +y INTO the hangar.
+Plane B parked nose-in (heading_deg = 0 -> nose toward +y).  Plane-local +x = nose.
+Split station x_break = wing.offset_x_m - wing.length_m/2  (the wing TRAILING edge):
+  fuselage_front = nose side [x_break .. nose]   |   fuselage_aft = tail side [tail .. x_break]
+
+           nose (+y, deeper in)                         nose (+y, deeper in)
+              ^   Plane B fuselage                          ^   Plane B fuselage
+              |                                             |
+        +-----------+  ... fuselage_front (COCKPIT)   +-----------+
+        |::::: A :::|                                 |           |
+   - - -|:::::::::::|- - - x_break (wing TE) - - - - - |           |- - - x_break - - -
+        |           |  ... fuselage_aft (TAIL)        |::::: A :::|
+        |           |                                 |:::::::::::|
+        +-----------+                                 +-----------+
+              |   tail (-y)                                 |   tail (-y)
+   [::: A :::] = Plane A's WING footprint overhanging Plane B in plan view
+
+      CASE B:  wing over fuselage_front          CASE A:  wing over fuselage_aft
+      => HARD CONFLICT, z-gap IGNORED            => LEGAL iff heights disjoint
+         (fuselage_front_wing_overlap)              (height-disjoint pass-through)
+
+HEIGHT BAND (side view, both cases): A's wing sits ABOVE B's fuselage with a
+z-gap >= wing_layer_clearance_m.   Case A: the gap makes it pass.  Case B: the
+gap is irrelevant -- the cockpit rule drops clause (2) entirely (ADR-0012, D1).
+
+         A wing  ----========----    (z_bottom_m .. z_top_m, the upper layer)
+                        | z-gap >= wing_layer_clearance_m
+         B fuselage  [############]   (lower layer)
+```
+*A wingtip may overhang a parked plane's aft fuselage / tail (Case A: legal when heights are disjoint, the two-clause `wing × fuselage_aft` rule) but never its cockpit / front fuselage (Case B: a hard `fuselage_front_wing_overlap` conflict at any nesting height). The loader auto-splits a `fuselage` part at the wing trailing edge `x_break`; front is the nose side, aft the tail side.*
+
 The closed set of `PartKind` values is `{"fuselage_front",
 "fuselage_aft", "wing", "strut", "tail"}`. The legacy `"fuselage"` is
 **not** a constructed kind — it survives only as a transient YAML keyword
@@ -81,6 +116,37 @@ that the back-`y` edge is *inherited* from the hangar boundary
 re-tested here. Any vertex of a non-occupant part that lies strictly
 inside that rectangle fires a `bay_intrusion` conflict on the owning
 plane — one conflict per offending part.
+
+Top-down, with the placeholder `data/hangar.yaml` values made concrete
+(the bay is the back-right 9 m × 9 m corner):
+
+```text
+ back wall  y = length_m = 25.0   (bay back edge: INHERITED, INCLUSIVE -> y = 25 is INSIDE)
+ x=0                                          x=9            x=13.5          x=18
+  +==========================================+=============================+   y = 25.0  [INSIDE]
+  |                                          |#############################|
+  |                                          |#  MAINTENANCE BAY (closed)  #|   right edge x=18
+  |          normal hangar floor             |#  back-anchored, partial-w  #|   == hangar wall
+  |                                          |#  x in (9.0, 18.0)          #|
+  |                                          |#  y in (16.0, 25.0]         #|
+  |                                          |#  any non-occupant vertex   #|
+  |                                          |#  STRICTLY inside  =>  one   #|
+  |                                          |#  bay_intrusion per part    #|
+  +------------------------------------------+#############################+   y = 16.0  (= 25 - 9)
+  |              side aisle                   ^ left edge x=9   front edge y=16  (both STRICT:
+  |        (a vertex ON x=9 or y=16                                              a vertex ON the
+  |         counts as OUTSIDE the bay)                                           edge is OUTSIDE)
+  |                                                                          |
+  |        +x runs right along the door --->        +y runs into hangar      |
+  +=========================[  door  ]=======================================+   y = 0.0
+ x=0          door center_x=9.0, width=12.0  (x in [3, 15])               x=18
+ front wall   heading_deg = 0 points toward +y (into the hangar)
+
+ In-bay predicate:  (9.0 < x < 18.0)  AND  (16.0 < y <= 25.0)
+   strict < on the left / right / front edges; inclusive <= on the back edge
+   (inherited from _hangar_bounds_conflicts, so y = 25 is not re-tested here)
+```
+*Maintenance-bay geometry on the placeholder hangar (`length_m`=25, `width_m`=18; bay `center_x_m`=13.5, `width_m`=9, `depth_m`=9): the back-right 9×9 m corner, `x ∈ (9.0, 18.0)`, `y ∈ (16.0, 25.0]`. The left/right/front edges are strict `<` (a vertex on the edge is in the aisle, not the bay); the back-`y` edge is inclusive because it coincides with the hangar back wall and is inherited from `_hangar_bounds_conflicts`. When a maintenance occupant is set, any non-occupant part vertex strictly inside fires one `bay_intrusion` conflict per offending part.*
 
 This rule replaced the earlier "fuselage centroid in the back strip"
 rule during the bay-walling work that completed in
@@ -153,6 +219,60 @@ headings (near 180°) are out of scope here; they belong to the Reeds–Shepp
 motion issue (#261). This replaces the earlier v1 single-ray reduction (one
 clamped target-x, heading 0°) described in ADR-0007 Q6.
 
+The motion vocabulary and the door entry-cone the planner searches over:
+
+```text
+REEDS-SHEPP MOTION MODEL (towplanner._primitives, ADR-0010)
+World frame: +x runs ALONG the door, +y runs INTO the hangar.
+A pose heading_deg=0 points nose-first toward +y (straight in).
+
+(1) REVERSE-CAPABLE REORIENT vs CART PIVOT-IN-PLACE
+---------------------------------------------------------------------
+ OWN GEAR (turn_radius_m = r > 0): 6 primitives, fixed order
+   forward:  Lf   Sf   Rf      reverse:  Lr   Sr   Rr   (gear = -1)
+   reverse legs cost _REVERSE_COST_FACTOR = 1.5 x  -> forward preferred
+
+   A turned goal a forward-only Dubins car can't reach in-bounds:
+
+      forward-only Dubins          Reeds-Shepp (fwd arc-line-arc + reverse)
+      must drive a full            backs up to reorient, then pulls in
+      turning-circle loop          (measured: an 18 m reverse beats a 32 m
+        .--->--.                    loop; even at the 1.5x weight it wins)
+       /        \                       Sf      Lr (reverse arc)
+      |  ~32 m   |  goal             >------>  .<......
+       \        /   X (turned)              \ '-.    : reverse retreats
+        '--<---'                       Lf arc   '--> X   around the steer centre
+
+ CART (turn_radius_m = 0): 4 primitives  ->  Lf  Sf  Rf  Sr
+   pivot-in-place (r = 0, zero translation) + reverse-straight (Sr).
+   Reverse PIVOTS (Lr/Rr) are omitted: a reverse pivot rotates heading the
+   same way as the OPPOSITE forward pivot -> exact duplicate, always loses
+   the best_g race. Only the reverse *straight* (Sr) is a genuinely new move.
+
+        ^ pivot CCW (Lf)    pivot CW (Rf)        Sr: back straight
+        |  .-.                .-.                 out of a slot
+        | (   ) spin in place (   )            <===== [plane] ======
+
+(2) DOOR ENTRY-CONE  (entry_poses, #262)  -- 3 x-samples x 5 headings
+---------------------------------------------------------------------
+ All surviving cone poses are seeded into the Hybrid-A* frontier at g=0
+ simultaneously; A* then returns the shortest path across the whole cone.
+
+  x-samples (within door interval): door-centre | clamped-target-x | midpoint
+  headings (forward-admissible, straight-in +/-30 deg in 15 deg steps):
+        330   345    0    15    30        (0 = straight into +y)
+
+  front wall (y=0) ===door-gap=== along +x ============================
+        x0          x1(target)         x2(mid)
+      \ | /        \ | /              \ | /        each fan = 5 headings
+       \|/          \|/                \|/         {330,345,0,15,30}
+        *            *                  *          = up to 15 seed poses
+                     |                              (duplicates removed;
+                     v  +y into hangar               poses clipping the
+                                                      side/back walls dropped)
+```
+*Reeds–Shepp gives every plane reverse legs (6 own-gear primitives `Lf Sf Rf Lr Sr Rr`, reverse weighted 1.5×; carts get 4: `Lf Sf Rf` + reverse-straight `Sr`), and the planner seeds the Hybrid-A\* search from a 3×5 door-cone fan instead of a single straight-in ray.*
+
 ## The coordinate convention
 
 The single most contributor-confusing concept in the project. Read
@@ -202,6 +322,44 @@ review-time subagent are the project's combined defense against a
 well-meaning contributor "fixing" it.
 
 If you're tempted to simplify the matrix, read ADR-0002 first.
+
+The picture below makes the handedness flip concrete: at the 45° canary
+heading the plane-local axes are overlaid on the world frame. The nose
+*and* the right wingtip both land in `+x` (to the right), but the wingtip
+lands *clockwise* of the nose, in `−y` (toward the door) — the opposite
+of where a pure (det = +1) rotation would send it.
+
+```text
+heading_deg = 45   (compass heading, CW from world +y; plane at the origin)
+plane-local axes:  +u = nose (forward),   +v = right wingtip (starboard)
+
+det = -1 map (local -> world), ADR-0002 / geometry.py:
+    world_x = x + u*sin(h) + v*cos(h)
+    world_y = y + u*cos(h) - v*sin(h)        at h = 45deg, sin h = cos h = 0.71
+
+                        +y  (deeper into hangar)
+                        ^
+                        |        N      nose:    (u=1, v=0) -> (+0.71, +0.71)
+                        |       /              ...lands in the (+x, +y) quadrant
+                        |      /
+                        |     /         sweeping nose -> right wingtip is +90deg
+                        |    /          IN THE PLANE, but in the WORLD the
+   -x ------------------+--------------> +x   (right, along the door wall)
+                        |    \          wingtip lands CLOCKWISE of the nose
+                        |     \
+                        |      \
+                        |       \
+                        |        R      wingtip: (u=0, v=1) -> (+0.71, -0.71)
+                        v              ...lands in the (+x, -y) quadrant
+                       -y  (front of door)         (right AND toward the door)
+
+THE FLIP:  a right-handed (det = +1) CCW rotation would instead send the
+           wingtip to (-0.71, +0.71) = the (-x, +y) quadrant -- mirrored,
+           WRONG. The nose probe alone cannot catch this (sin45 = cos45, so
+           the row swap is invisible at 45deg for u=1,v=0); only the wingtip
+           sign-flip reveals it. That is what the 45deg canary test pins.
+```
+*Plane-local frame (+u = nose, +v = right wingtip) overlaid on the world frame at the 45° canary heading. Both probes land in `+x`; the nose at (+0.71, +0.71) and the right wingtip at (+0.71, −0.71). A pure rotation would mirror the wingtip to (−0.71, +0.71). That reflected handedness is the determinant −1 (ADR-0002).*
 
 ### Fuselage offset signs
 

--- a/docs/openssf-best-practices-badge-silver.md
+++ b/docs/openssf-best-practices-badge-silver.md
@@ -120,7 +120,7 @@ also [`SECURITY.md`](../SECURITY.md) and [`security-posture.md`](security-postur
 
 | Criterion | Status | Justification + evidence |
 |---|---|---|
-| `documentation_roadmap` (MUST) | **Met** | README "Scope" (Phase 1/2a shipped + explicit out-of-scope list) + public [milestones](https://github.com/DocGerd/hangarfit/milestones). |
+| `documentation_roadmap` (MUST) | **Met** | README "Scope" + the phase timeline in [arc42 §1](architecture/01-introduction-and-goals.md) (Phases 1 → 3b shipped, v0.1.0 → v0.8.0) + the explicit out-of-scope list + public [milestones](https://github.com/DocGerd/hangarfit/milestones). |
 | `documentation_architecture` (MUST) | **Met** | [`docs/architecture/`](architecture/) (arc42) + [`docs/adr/`](adr/). |
 | `documentation_security` (MUST) | **Met** | [`SECURITY.md`](../SECURITY.md) + [`security-posture.md`](security-posture.md) + the assurance case above. |
 | `documentation_quick_start` (MUST) | **Met** | README "Install" + "Usage" (`pip install -e .`; `hangarfit check …`). |
@@ -139,7 +139,7 @@ also [`SECURITY.md`](../SECURITY.md) and [`security-posture.md`](security-postur
 
 | Criterion | Status | Justification + evidence |
 |---|---|---|
-| `maintenance_or_update` (MUST) | **Met** | Actively maintained: tagged releases (v0.1.0, v0.6.0, v0.6.1), recent commits, `[Unreleased]` section in [`CHANGELOG.md`](../CHANGELOG.md). |
+| `maintenance_or_update` (MUST) | **Met** | Actively maintained: regular tagged releases from v0.1.0 to the current **v0.8.0** (2026-05-29), recent commits, `[Unreleased]` section in [`CHANGELOG.md`](../CHANGELOG.md). |
 
 ## 5. Reporting
 

--- a/docs/openssf-best-practices-badge.md
+++ b/docs/openssf-best-practices-badge.md
@@ -27,7 +27,7 @@ alert #4) once the entry reaches Passing — see
 
 ## 0. Items that need *your* decision in the live form
 
-Everything else is mechanical. These three need a human:
+Everything else is mechanical. These need a human:
 
 1. **`know_secure_design` / `know_common_errors`** (Security) — self-attestation
    that the maintainer understands secure-design principles and common
@@ -35,9 +35,10 @@ Everything else is mechanical. These three need a human:
    threat-surface reasoning in [`SECURITY.md`](../SECURITY.md) and the
    determinant-trap / input-validation handling in the ADRs. (Only you can
    truthfully assert this — it's true.)
-2. **`dynamic_analysis`** (Analysis, *SUGGESTED*) — currently **Unmet**; fuzzing
-   the YAML loader is tracked in **#143** (parked). SUGGESTED does not block
-   Passing — mark Unmet with the #143 reference, or N/A.
+2. **`dynamic_analysis`** (Analysis, *SUGGESTED*) — **now Met** (no longer a
+   pending decision): nightly Atheris + Hypothesis fuzzing of the YAML loader
+   runs in `fuzz.yml` (#143, closed; the geometry/collisions harness was added
+   in #363). Mark **Met** with the `fuzz.yml` reference.
 3. **Contact email** — the form asks for a project contact. Use whatever address
    you want public; SECURITY.md routes vulnerabilities through GitHub private
    advisories rather than email.
@@ -72,7 +73,7 @@ Everything else is mechanical. These three need a human:
 | `repo_distributed` | **Met** | Git (a distributed VCS). |
 | `version_unique` | **Met** | Unique version per release. |
 | `version_semver` | **Met** | Semantic Versioning; declared in CHANGELOG. <https://github.com/DocGerd/hangarfit/blob/develop/CHANGELOG.md> |
-| `version_tags` | **Met** | Git tags `v0.1.0`, `v0.6.0`, `v0.6.1`. <https://github.com/DocGerd/hangarfit/tags> |
+| `version_tags` | **Met** | Git tags `v0.1.0`, `v0.6.0`, `v0.6.1`, `v0.7.0`, `v0.7.1`, `v0.7.2`, `v0.8.0`. <https://github.com/DocGerd/hangarfit/tags> |
 | `release_notes` | **Met** | CHANGELOG.md (Keep a Changelog format) + GitHub Releases. <https://github.com/DocGerd/hangarfit/releases> |
 | `release_notes_vulns` | **Met** | No vulnerabilities to date; release notes would call out any security fix per the CHANGELOG's "Fixed" section convention. |
 
@@ -136,9 +137,9 @@ Everything else is mechanical. These three need a human:
 | `static_analysis_common_vulnerabilities` | **Met** | CodeQL's default Python query suite covers common vulnerability classes. |
 | `static_analysis_fixed` | **Met** | CodeQL/ruff/mypy findings are fixed before merge (CI-gated). |
 | `static_analysis_often` | **Met** | Runs on every PR into `develop`/`main`. |
-| `dynamic_analysis` | **Unmet** (SUGGESTED) | No fuzzing yet; tracked in **#143** (fuzz the YAML loader). Does not block Passing. <https://github.com/DocGerd/hangarfit/issues/143> |
+| `dynamic_analysis` | **Met** (SUGGESTED) | Nightly Atheris + Hypothesis fuzzing of the YAML loader, extended to a geometry/collisions harness (#363), via [`fuzz.yml`](../.github/workflows/fuzz.yml); #143 closed. <https://github.com/DocGerd/hangarfit/blob/develop/.github/workflows/fuzz.yml> |
 | `dynamic_analysis_unsafe` | **N/A** | No unsafe-language memory bugs (pure Python). |
-| `dynamic_analysis_enable_assertions` | **N/A** | Follows from `dynamic_analysis` being deferred. |
+| `dynamic_analysis_enable_assertions` | **N/A** | The Atheris/Hypothesis harness runs under standard CPython with assertions active; there is no separate instrumented build to toggle. |
 
 ---
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -9,6 +9,12 @@ the current implementation supports:
 - K-diverse alternatives + termination (§4.5-§4.7)  [Chunk E]
 - inter-plane spread post-pass (``_spread`` / ``_inter_plane_energy``; ADR-0008,
   default on via ``SearchConfig.spread``)
+- collect-then-select pool with maximin-gap selection across restarts, surfacing
+  ``min_pairwise_gap_m`` / ``valid_basins_found`` (Phase 2c, #267; determinism is
+  now ``max_restarts``-scoped per the ADR-0003 amendment)
+- best-effort tow-path bundling: with ``plan_paths=True`` each returned layout is
+  paired with a per-plane tow plan from ``hangarfit.towplanner``; an un-routable
+  plane is kept as ``plans[i] = None`` (Phase 3a, ADR-0007 / ADR-0010)
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes #371.

Documentation-only refresh + a diagram-addition campaign. A pre-work audit found the docs **broadly current** through v0.8.0, so this is a *targeted* stale-fix sweep plus 7 new diagrams — not a rewrite.

## Track 1 — stale fixes

| File | Fix |
|---|---|
| `CONTRIBUTING.md` | Repoint the "design canon" pointers from CLAUDE.md (now operational-only) to `docs/architecture/` + `docs/adr/`; drop the stale "Phase 1 deliverables list" framing (3 spots). |
| `docs/openssf-best-practices-badge.md` | `version_tags` now lists v0.7.0–v0.8.0; **`dynamic_analysis` flipped Unmet→Met** — fuzzing shipped (nightly `fuzz.yml`, #143 closed, geometry/collision harness in #363). *(Beyond the audit's flagged version-list fix — caught while editing.)* |
| `docs/openssf-best-practices-badge-silver.md` | `documentation_roadmap` + `maintenance_or_update` evidence refreshed through v0.8.0; roadmap now points at the new §1 phase timeline. |
| arc42 §4 | Add the tow-path-planner headline (Reeds–Shepp, ADR-0007/0010); record the #372 Pages decision; widen the Phase ordering note. |
| arc42 §3 | Distinguish still-out-of-scope occupied-hangar *reshuffling* from the shipped empty-hangar tow *fill*; correct the soft-preferences row (spread post-pass shipped via ADR-0008). |
| arc42 §5 | **Fix a doc/code bug**: descent-step prose said "pick the plane with the largest `total_penetration_m2`" — the code picks a conflicting plane *at random* over a `sorted()` set (`solver.py:1289`). The new state-machine diagram follows the code. |
| `data/fleet.yaml` | `turn_radius_m` comment: Dubins → Reeds–Shepp. |
| `solver.py` docstring | Note the Phase-2c collect-then-select pool and Phase-3a tow bundling. |

## Track 2 — 7 diagrams (native mermaid / fenced ASCII; GitHub-renderable, binary-free)

- **§8** parts-model fuselage front/aft split · det=−1 transform trap · maintenance-bay rectangle · Reeds–Shepp motion + door-cone *(ASCII)*
- **§5** RR-MC solver state machine *(mermaid `stateDiagram-v2`)*
- **§6** Scenario 3 tow-planning runtime sequence *(mermaid `sequenceDiagram`)*
- **§1** phase → capability → version timeline *(mermaid `timeline`)*

## Reviewer call-outs

1. **Diagram orientation varies.** The det−1 sketch (a coordinate-algebra diagram, where math-standard +y-up is clearest) and the §8 floor-plans draw +y *up*; the existing §8 convention box and the Reeds–Shepp cone draw +y *down*. Each diagram is explicitly axis-labeled, so none is incorrect — but if uniform orientation is wanted I can flip the floor-plans in a follow-up. (Held off flipping blind since ASCII can't be render-verified here.)
2. **`timeline` mermaid** is the newest construct used — worth confirming it renders in the GitHub preview.
3. Deliberately **skipped** the optional README version badge (avoids another flaky dynamic shields badge, per prior maintainer pushback) and left `security-posture.md`'s "Maintained ~2026-08-19" note as-is (still accurate; self-resolves).

## Verification

- `ruff check` + `ruff format --check` on `solver.py`: clean. Pre-commit hooks: all passed.
- All added relative links resolve; all fenced code blocks balanced.
- No behaviour change — docs/comments/docstring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
