### PR TITLE
feat(solver): back-of-hangar fill bias (#320)

### DIFF
--- a/docs/adr/0008-inter-plane-spread-soft-preference.md
+++ b/docs/adr/0008-inter-plane-spread-soft-preference.md
@@ -189,3 +189,53 @@ separation.
 **Determinism.** See the ADR-0003 amendment dated 2026-05-27 for the precise
 scoping: reproducible under a `max_restarts` bound; timing-dependent under a
 pure wall-clock `budget_s` bound.
+
+### 2026-06-01 — back-of-hangar fill bias (issue #320)
+
+**Background.** The repulsion energy is *position-symmetric*: it rewards
+inter-plane separation but is indifferent to *where* in the hangar that
+separation sits. So a lone plane settles mid-hangar, and multi-plane fills can
+leave free space wasted in the *middle* (between two filled bands) rather than
+at the door, where it is operationally useful — for the next exit, or for an
+out-of-band plane that needs to enter. This is also the lead lever of the
+tow-friendly-placement work ([#280](https://github.com/DocGerd/hangarfit/issues/280),
+Direction A): keeping the door-side approach corridors clear is what lets the
+bounded tow planner thread a path to each slot.
+
+**Change.** A secondary **back-bias** term is folded into the `_spread`
+hill-climb energy:
+
+```
+E_total = Σ_{i<j} exp(−gap_ij / scale)  +  back_bias_weight · Σ_p (length_m − y_p) / length_m
+          └─────────── spread (unchanged) ──────────┘     └──────── back bias B (#320) ───────┘
+```
+
+`B` is minimized when planes park deep (large `y`, toward the back wall at
+`y = hangar.length_m`), normalized by `length_m` so a single weight reads
+consistently across hangar sizes. It is a **secondary** term, not a hard
+back-wall snap: the smooth gradient and the "only valid moves accepted"
+invariant of the original `_spread` are preserved, and `min_pairwise_gap_m`
+remains the **primary** basin-selection key (#267) — the back-bias only
+re-ranks candidates *within* a basin's hill-climb. The `<2 planes` no-op guard
+is relaxed when back-bias is active so a lone plane is still pulled to the back
+wall (with `<2` planes the inter-plane energy is identically 0, so only the
+back-bias drives the climb).
+
+Because the back-bias scales ~linearly with plane count while the repulsion sum
+scales ~quadratically, a single weight is gentler on crowded hangars (where
+spread genuinely matters) and stronger on sparse ones — the intended behavior.
+
+**Default & toggle.** `SearchConfig.back_bias_weight` defaults to **0.0**
+(neutral — the raw spread mechanism and the `spread=False` determinism canaries
+stay byte-unchanged). The **CLI enables it by default** at weight `1.0`
+(`--no-back-fill` sets it to 0.0; no effect under `--no-spread`, since the bias
+rides the spread post-pass). `1.0` was chosen from a sweep over the acceptance
+fixtures as the smallest weight that breaks the mid-hangar symmetry (a lone
+plane reaches the back wall; the 2-plane `scenario_minimal` fill clears the
+door) while staying a secondary term that does not collapse the inter-plane gap.
+
+**Determinism.** The back-bias is RNG-free re-ranking: it adds no random draws
+and does not change the draw count or order (candidate generation is unchanged),
+so same-seed output stays byte-identical (`tests/test_solver_search.py::
+test_spread_back_fill_is_deterministic_for_same_seed`). No `determinism-guard`
+amendment is required.

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -34,6 +34,14 @@ if TYPE_CHECKING:
 _JSON_SCHEMA = "hangarfit.check/v1"
 _SOLVE_JSON_SCHEMA = "hangarfit.solve/v1"
 
+# #320 back-of-hangar fill bias: the SearchConfig.back_bias_weight the CLI passes
+# when back-fill is enabled (the default; --no-back-fill sets it to 0.0). Chosen
+# from a sweep over the acceptance fixtures (single plane → back wall; the
+# scenario_minimal 2-plane fill clears the door) as the smallest weight that
+# breaks the mid-hangar symmetry while staying a secondary term below the spread
+# objective — it does not collapse the inter-plane gap. See ADR-0008 (amended).
+_BACK_FILL_DEFAULT_WEIGHT = 1.0
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the argparse parser with the ``check`` and ``solve`` subcommands."""
@@ -180,6 +188,18 @@ def build_parser() -> argparse.ArgumentParser:
         dest="spread",
         default=True,
         help="Disable the inter-plane spread post-pass (default: spread enabled).",
+    )
+    solve.add_argument(
+        "--no-back-fill",
+        action="store_false",
+        dest="back_fill",
+        default=True,
+        help=(
+            "Disable the back-of-hangar fill bias (#320). By default the spread "
+            "post-pass also biases planes toward the back wall, leaving free space "
+            "at the door; pass this to keep the symmetric spread only. (No effect "
+            "with --no-spread, since the bias rides on the spread post-pass.)"
+        ),
     )
     # ── Experimental tow-planner knobs (towplanner-v2 routability spike, #332) ──
     # Behind opt-in flags; defaults reproduce the shipped planner byte-for-byte.
@@ -429,7 +449,10 @@ def cmd_solve(args: argparse.Namespace) -> int:
         budget_s=args.budget,
         alternatives=args.alternatives,
         seed=resolved_seed,
-        search=SearchConfig(spread=args.spread),
+        search=SearchConfig(
+            spread=args.spread,
+            back_bias_weight=_BACK_FILL_DEFAULT_WEIGHT if args.back_fill else 0.0,
+        ),
         plan_paths=args.render_paths,
         tow_heuristic=args.tow_heuristic,
         tow_max_expansions=args.tow_max_expansions,

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -996,7 +996,20 @@ class SearchConfig:
     mid-hangar; the ``<2 planes`` no-op guard is also relaxed so a lone plane is
     still pulled to the back wall. ``min_pairwise_gap_m`` remains the primary
     basin-selection key — this only re-ranks candidates *within* a basin's
-    hill-climb. The CLI enables it by default (``--no-back-fill`` opts out)."""
+    hill-climb. The CLI enables it by default (``--no-back-fill`` opts out).
+
+    This is a **dimensionless relative weight** balancing the back-bias term
+    (normalized to ``[0, 1]`` per plane) against the inter-plane spread energy
+    (a sum of ``O(1)`` ``exp`` terms); ``~1.0`` is the tuned operating point, and
+    large values subordinate spread to back-fill (collapsing gaps), so keep it a
+    *secondary* term. **No effect when ``spread=False``** — the bias is folded
+    into the spread post-pass, which only runs under ``spread=True`` (a
+    ``spread=False, back_bias_weight>0`` config is a silent no-op by design; the
+    CLI never builds one). Modeled as ``float = 0.0`` rather than ``float |
+    None`` deliberately: ``0.0`` is the exact identity of ``weight · B``
+    (contributes nothing), not a degenerate value, so no distinct opt-out
+    sentinel is warranted — ``None`` stays the *only* sentinel in this dataclass
+    (on ``max_restarts``)."""
 
     def __post_init__(self) -> None:
         if self.candidates_per_iter < 1:

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -985,6 +985,19 @@ class SearchConfig:
     keeping the kernel sensitive across hangar sizes. When set explicitly,
     must be ``> 0``."""
 
+    back_bias_weight: float = 0.0
+    """Strength of the back-of-hangar fill bias folded into the spread post-pass
+    (#320, ADR-0008 amendment). ``0.0`` (default) ⇒ pure inter-plane spread — the
+    pre-#320 behaviour, so the raw spread mechanism and the determinism canaries
+    (which run ``spread=False``) stay byte-unchanged. When ``> 0`` the spread
+    hill-climb additionally minimizes a secondary term
+    ``B = Σ (hangar.length_m − y_p) / hangar.length_m`` that rewards parking deep
+    (large ``y``), so free space accumulates at the door end rather than
+    mid-hangar; the ``<2 planes`` no-op guard is also relaxed so a lone plane is
+    still pulled to the back wall. ``min_pairwise_gap_m`` remains the primary
+    basin-selection key — this only re-ranks candidates *within* a basin's
+    hill-climb. The CLI enables it by default (``--no-back-fill`` opts out)."""
+
     def __post_init__(self) -> None:
         if self.candidates_per_iter < 1:
             raise ValueError(
@@ -1015,4 +1028,9 @@ class SearchConfig:
             raise ValueError(
                 f"SearchConfig.spread_scale_m must be positive when set "
                 f"(pass None for the adaptive default), got {self.spread_scale_m}"
+            )
+        if self.back_bias_weight < 0.0:
+            raise ValueError(
+                f"SearchConfig.back_bias_weight must be >= 0 "
+                f"(0 disables the back-of-hangar fill bias), got {self.back_bias_weight}"
             )

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -838,6 +838,20 @@ def _inter_plane_energy(
     return energy
 
 
+def _back_bias_energy(placements: dict[str, Placement], scenario: Scenario) -> float:
+    """Back-of-hangar fill bias ``B = Σ (length_m − y_p) / length_m`` (#320).
+
+    Minimized when planes park deep (large ``y``, toward the back wall at
+    ``y = hangar.length_m``), so the spread hill-climb leaves free space at the
+    door end (``y ≈ 0``) instead of mid-hangar. Normalized by ``length_m`` so a
+    single ``back_bias_weight`` reads consistently across hangar sizes. Summed
+    over ALL placements — pinned planes add a constant offset that cannot change
+    the per-target argmin. RNG-free. See ADR-0008 (amended) and #320.
+    """
+    length = scenario.hangar.length_m
+    return sum((length - p.y_m) / length for p in placements.values())
+
+
 def _resolve_spread_scale(scenario: Scenario, search: SearchConfig) -> float:
     """Repulsion length-scale for spread (spec §4): explicit override or
     20% of the smaller hangar dimension. Single source so ``_spread`` and
@@ -904,12 +918,23 @@ def _spread(
     scale = _resolve_spread_scale(scenario, search)
 
     movable = sorted(pid for pid in placements if pid not in pinned_planes)
-    if not movable or len(placements) < 2:
-        # Nothing to optimize: all planes pinned (no movable target) or
-        # <2 planes (energy is identically 0.0).
+    back_fill = search.back_bias_weight > 0.0
+    if not movable or (len(placements) < 2 and not back_fill):
+        # Nothing to optimize: no movable target, or <2 planes with no back-fill
+        # bias (inter-plane energy is identically 0.0). With back-fill active a
+        # lone plane is still pulled to the back wall, so we do NOT bail there.
         return placements
 
-    current_energy = _inter_plane_energy(placements, scenario, scale)
+    def _energy(trial: dict[str, Placement]) -> float:
+        # Spread repulsion, plus the #320 back-of-hangar bias when active. The
+        # back-bias re-ranks candidates *within* this hill-climb; basin selection
+        # stays min-gap-primary (ADR-0008 amended).
+        e = _inter_plane_energy(trial, scenario, scale)
+        if back_fill:
+            e += search.back_bias_weight * _back_bias_energy(trial, scenario)
+        return e
+
+    current_energy = _energy(placements)
     last_improved = 0
 
     for iter_count in range(10000):  # large cap; real exit via stall/budget
@@ -954,7 +979,7 @@ def _spread(
                 continue
             if _score(trial_layout) != (0, 0.0):
                 continue  # must STAY valid
-            e = _inter_plane_energy(trial, scenario, scale)
+            e = _energy(trial)
             disp = (
                 (cand.x_m - placements[target].x_m) ** 2 + (cand.y_m - placements[target].y_m) ** 2
             ) ** 0.5

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -849,7 +849,11 @@ def _back_bias_energy(placements: dict[str, Placement], scenario: Scenario) -> f
     the per-target argmin. RNG-free. See ADR-0008 (amended) and #320.
     """
     length = scenario.hangar.length_m
-    return sum((length - p.y_m) / length for p in placements.values())
+    # Iterate in sorted plane-id order (mirrors _inter_plane_energy /
+    # _spread_quality) so this float sum is order-stable even if a future
+    # refactor ever builds the placements dict from an unordered source — an
+    # ADR-0003 hardening; the dict is currently fleet_in-ordered already.
+    return sum((length - placements[pid].y_m) / length for pid in sorted(placements))
 
 
 def _resolve_spread_scale(scenario: Scenario, search: SearchConfig) -> float:

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -585,6 +585,37 @@ def test_solve_no_spread_flag_accepted_and_runs(tmp_path):
     assert out.exists()
 
 
+def test_solve_back_fill_defaults_on_and_no_back_fill_opts_out():
+    """`--no-back-fill` flips the ``back_fill`` namespace default (#320); absent,
+    it defaults ON (the back-of-hangar bias rides the spread post-pass)."""
+    from hangarfit.cli import build_parser
+
+    assert build_parser().parse_args(["solve", "s.yaml"]).back_fill is True
+    assert build_parser().parse_args(["solve", "s.yaml", "--no-back-fill"]).back_fill is False
+
+
+def test_solve_no_back_fill_flag_accepted_and_runs(tmp_path):
+    """`--no-back-fill` is accepted on `solve` and drives a successful run."""
+    from hangarfit.cli import main
+
+    out = tmp_path / "layout.yaml"
+    rc = main(
+        [
+            "solve",
+            "tests/fixtures/solve_all_nine_large_hangar.yaml",
+            "--seed",
+            "42",
+            "--budget",
+            "10",
+            "--no-back-fill",
+            "--write-yaml",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    assert out.exists()
+
+
 class TestSolveRenderPaths:
     """`--render-paths` flag: tow-path overlay rendering + exit-3 semantics (#193).
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1103,6 +1103,18 @@ class TestSearchConfig:
         assert SearchConfig(spread_scale_m=None).spread_scale_m is None
         assert SearchConfig(spread_scale_m=3.5).spread_scale_m == 3.5
 
+    def test_search_config_back_bias_weight_defaults_zero(self) -> None:
+        # Neutral library default (#320): pure spread, pre-back-fill behaviour.
+        # The CLI enables back-fill by default; --no-back-fill opts out.
+        assert SearchConfig().back_bias_weight == 0.0
+
+    def test_search_config_back_bias_weight_rejects_negative(self) -> None:
+        with pytest.raises(ValueError, match="back_bias_weight"):
+            SearchConfig(back_bias_weight=-0.1)
+        # zero (disabled) and positive are accepted
+        assert SearchConfig(back_bias_weight=0.0).back_bias_weight == 0.0
+        assert SearchConfig(back_bias_weight=2.5).back_bias_weight == 2.5
+
 
 # ---------------------------------------------------------------------------
 # SolveResult.plans — best-effort tow-plan bundle (#197)

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -1216,6 +1216,116 @@ def test_spread_runs_with_single_movable_among_pinned():
     assert _inter_plane_energy(out, s, scale) <= e_before
 
 
+def test_spread_back_fills_single_movable_plane_toward_the_back_wall():
+    """#320: with ``back_bias_weight > 0`` the ``<2 planes`` no-op guard is
+    relaxed and a lone movable plane is pulled DEEP toward the back wall (large
+    ``y``), where the back-bias term ``B = Σ (length_m − y) / length_m`` is
+    minimized. With the default ``back_bias_weight = 0.0`` the same call is a
+    no-op (see ``test_spread_noop_when_single_movable_plane``)."""
+    import random
+    import time
+
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import Placement, SearchConfig
+    from hangarfit.solver import _spread
+
+    s = load_scenario(REPO_ROOT / "tests" / "fixtures" / "solve_all_nine_large_hangar.yaml")
+    pid = next(p for p in s.fleet_in if p != s.maintenance_plane)
+    start = Placement(plane_id=pid, x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+
+    out = _spread(
+        {pid: start},
+        s,
+        random.Random(1),
+        SearchConfig(back_bias_weight=1.0),
+        start=time.monotonic(),
+        budget_s=10.0,
+        pinned_planes=frozenset(),
+    )
+    # Pulled deeper than it started, and into the back half of the hangar.
+    assert out[pid].y_m > start.y_m
+    assert out[pid].y_m > s.hangar.length_m / 2
+
+
+def test_spread_back_fill_is_deterministic_for_same_seed():
+    """#320: the back-bias is RNG-free re-ranking (it does not change the draw
+    count or order), so back-fill stays byte-identical across runs on a fixed
+    seed — the ADR-0003 belt-and-suspenders canary for the new term."""
+    import random
+    import time
+
+    from hangarfit.models import SearchConfig
+    from hangarfit.solver import _spread
+
+    s, placements = _valid_placements(seed=11)
+    cfg = SearchConfig(back_bias_weight=2.0)
+
+    a = _spread(
+        placements,
+        s,
+        random.Random(99),
+        cfg,
+        start=time.monotonic(),
+        budget_s=60.0,
+        pinned_planes=frozenset(),
+    )
+    b = _spread(
+        placements,
+        s,
+        random.Random(99),
+        cfg,
+        start=time.monotonic(),
+        budget_s=60.0,
+        pinned_planes=frozenset(),
+    )
+    assert {k: (v.x_m, v.y_m, v.heading_deg) for k, v in a.items()} == {
+        k: (v.x_m, v.y_m, v.heading_deg) for k, v in b.items()
+    }
+
+
+def test_spread_back_fill_packs_planes_deeper_than_spread_only():
+    """#320: with ``back_bias_weight > 0`` the spread hill-climb settles a
+    multi-plane layout DEEPER (larger mean ``y``) than pure spread, while
+    remaining a valid layout (the back-bias never overrides collision validity)."""
+    import random
+    import time
+    from statistics import mean
+
+    from hangarfit.models import Layout, SearchConfig
+    from hangarfit.solver import _score, _spread
+
+    s, placements = _valid_placements(seed=11)
+    assert len(placements) >= 2, "fixture sanity"
+
+    spread_only = _spread(
+        placements,
+        s,
+        random.Random(7),
+        SearchConfig(),
+        start=time.monotonic(),
+        budget_s=60.0,
+        pinned_planes=frozenset(),
+    )
+    back_filled = _spread(
+        placements,
+        s,
+        random.Random(7),
+        SearchConfig(back_bias_weight=3.0),
+        start=time.monotonic(),
+        budget_s=60.0,
+        pinned_planes=frozenset(),
+    )
+
+    assert mean(p.y_m for p in back_filled.values()) > mean(p.y_m for p in spread_only.values())
+    layout = Layout(
+        fleet=s.fleet,
+        hangar=s.hangar,
+        placements=tuple(back_filled.values()),
+        maintenance_plane=s.maintenance_plane,
+    )
+    assert _score(layout) == (0, 0.0)
+
+
 def test_plane_footprint_area_does_not_double_count_tail():
     """Regression guard for #317: a plane with a standalone ``tail`` part
     must not have its tail length both folded into the reconstructed

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -99,6 +99,42 @@ def test_solve_default_enables_spread():
     ]
 
 
+def test_solve_back_fill_parks_single_plane_at_back_wall():
+    """#320 acceptance: with back-fill a lone plane parks deep against the back
+    wall — and strictly deeper than with back-fill off, same seed. Bounded by
+    ``max_restarts`` so the basin pool (and selection) is seed-deterministic."""
+    s = load_scenario("tests/fixtures/solve_trivial_single_plane.yaml")
+    off = solve(
+        s, seed=42, search=SearchConfig(max_restarts=5, back_bias_weight=0.0), plan_paths=False
+    )
+    on = solve(
+        s, seed=42, search=SearchConfig(max_restarts=5, back_bias_weight=1.0), plan_paths=False
+    )
+    assert off.layouts and on.layouts
+    (p_off,) = off.layouts[0].placements
+    (p_on,) = on.layouts[0].placements
+    assert p_on.y_m > p_off.y_m  # back-fill pulls the lone plane deeper
+    assert p_on.y_m > 0.7 * s.hangar.length_m  # and up against the back wall
+
+
+def test_solve_back_fill_clears_the_door_on_two_plane_fill():
+    """#320 acceptance: on the 2-plane minimal fill, back-fill leaves free space
+    at the door — the front-most plane sits deeper than with back-fill off, and
+    no plane is parked in the front third of the hangar."""
+    s = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    off = solve(
+        s, seed=1, search=SearchConfig(max_restarts=5, back_bias_weight=0.0), plan_paths=False
+    )
+    on = solve(
+        s, seed=1, search=SearchConfig(max_restarts=5, back_bias_weight=1.0), plan_paths=False
+    )
+    assert off.layouts and on.layouts
+    front_off = min(p.y_m for p in off.layouts[0].placements)
+    front_on = min(p.y_m for p in on.layouts[0].placements)
+    assert front_on > front_off  # door-side cleared relative to the spread-only baseline
+    assert front_on > s.hangar.length_m / 3  # no plane left in the front (door) third
+
+
 def test_solve_k2_with_spread_never_invalid_and_diverse_if_found():
     """The spread/diversity interaction (spec known-interaction): with K=2 and
     spread on, every returned layout must be valid, and if status==found the


### PR DESCRIPTION
## What & why

Closes #320. Lead lever of the **#280** tow-friendly-placement work (Direction A): the ADR-0008 spread post-pass is *position-symmetric* — it rewards inter-plane separation but is indifferent to *where* in the hangar it sits, so a lone plane settles mid-hangar and multi-plane fills can waste free space in the *middle* rather than at the door (where it's operationally useful — next exit / out-of-band entry, and clear tow-approach corridors).

This folds a secondary **back-bias** term into the spread hill-climb:

```
E_total = Σ_{i<j} exp(−gap_ij / scale)  +  back_bias_weight · Σ_p (length_m − y_p) / length_m
          └────────── spread (unchanged) ─────────┘    └────────── back bias B (#320) ──────────┘
```

`B` is minimized when planes park deep (large `y`, toward the back wall), normalized by `length_m` so one weight reads consistently across hangar sizes.

## Design decisions

- **Secondary term, not a hard snap.** Preserves `_spread`'s smooth gradient and "only valid moves accepted" invariant. `min_pairwise_gap_m` stays the **primary** basin-selection key (#267) — the back-bias only re-ranks candidates *within* a basin's hill-climb.
- **`SearchConfig.back_bias_weight: float = 0.0` (neutral library default).** Keeps the raw spread mechanism and the `spread=False` determinism canaries byte-unchanged. The **CLI enables back-fill by default at weight `1.0`**; `--no-back-fill` opts out (no effect under `--no-spread`, since the bias rides the spread post-pass). `1.0` chosen from a sweep over the acceptance fixtures as the smallest weight that breaks the mid-hangar symmetry while staying a secondary term that does not collapse the inter-plane gap.
- **Relaxed `<2 planes` no-op guard** when back-bias is active, so a lone plane is still pulled to the back wall (with <2 planes the inter-plane energy is identically 0, so only the back-bias drives the climb).

## Determinism (ADR-0003)

RNG-free re-ranking: the back-bias adds no random draws and does not change the draw count or order (candidate generation is unchanged), so same-seed output stays **byte-identical**. **No `determinism-guard` amendment needed.** A `spread=True + back_bias` same-seed canary is added as belt-and-suspenders.

## Acceptance (from #320) — verified

- `solve_trivial_single_plane` (seed 42): lone plane parks against the **back wall** (y 5.9 → 24.6 in the 30 m hangar), not mid-hangar.
- `scenario_minimal` (seed 1): 2-plane fill **clears the door** — front-most plane y 4.3 → 11.4, the wasteful 12.9 m mid-gap reclaimed.
- Full default suite green (1127 passed); `spread=False` canaries byte-unchanged.

## Scope note

The *towability payoff* of tow-friendly placement is validated together with **#336** (grid-heuristic default + global bail-budget cap) — at the current euclidean@2000 default the planner can't yet route even tow-friendly layouts (`aviat_husky` needs ~6062 grid expansions). This PR delivers the placement change + its deterministic placement acceptance; #336 is the supporting planner work.

## Tests

- `tests/test_solver_search.py` — `_spread` unit: single-plane back-pack (guard relaxation), back-fill determinism canary, multi-plane "packs deeper than spread-only" + still valid.
- `tests/test_models.py` — `SearchConfig.back_bias_weight` default + validation (`>= 0`).
- `tests/test_solver_spread.py` — solve()-level acceptance (back wall / door clearance vs back-fill off, same seed).
- `tests/test_cli_solve.py` — `--no-back-fill` default-on parse + end-to-end run.
- `docs/adr/0008-*.md` — amendment recording the back-bias term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
