### PR TITLE
feat(towplanner): grid heuristic default + global fill-budget cap (#336)

### DIFF
--- a/docs/adr/0007-tow-path-planner-v1-scope.md
+++ b/docs/adr/0007-tow-path-planner-v1-scope.md
@@ -267,6 +267,36 @@ per-layout *count* is exactly the right invariant. The alternative *tug* reading
 and is explicitly **not** adopted here; it would warrant its own ADR. Full
 reasoning: the [cart-inventory design doc](../superpowers/specs/2026-05-27-cart-inventory-design.md).
 
+### 2026-06-01 — grid heuristic default + global fill-budget cap (#336)
+
+The planner originally defaulted to a straight-line (euclidean) Hybrid-A\*
+heuristic with a per-plane expansion budget (`_MAX_EXPANSIONS`); the #332 spike
+exposed `grid` (obstacle-aware) as an opt-in seam. A spike-first go/no-go on the
+deferred RRT-Connect fallback (also #336) found the standard fixtures are all
+*feasible* — Hybrid-A\* routes them given budget — so **RRT-Connect was retired as
+unjustified**, and the cheap planner levers that dig surfaced were adopted:
+
+- **`grid` is now the default heuristic** for `plan_fill` / `solve` / the CLI
+  (`plan_path`'s primitive default stays `euclidean`; callers choose). Euclidean
+  ignores walls and floods the frontier in tight quarters (`aviat_husky`: ~13.5k
+  expansions); the obstacle-aware grid geodesic threads the same maneuver in
+  ~6062. Pass `--tow-heuristic euclidean` to opt out.
+- **Per-plane `_MAX_EXPANSIONS` raised 2000 → 8000** — the budget grid needs to
+  route the tight-but-feasible cases (the earlier "infeasible even at 4000" note
+  was a euclidean-heuristic artifact, not geometry).
+- **New deterministic global fill cap `_MAX_FILL_EXPANSIONS` (16000)** on the sum
+  of expansions across every `plan_path` call in a fill. A high per-plane budget
+  is needed to *route* tight planes but makes an un-routable fill expensive to
+  *disprove* (~per-plane × greedy-scan-retries); the cap bounds that worst case
+  (the default `spread=True` six-plane fill: ~997 s uncapped → ~334 s capped,
+  under the 400 s perf gate). Overridable via `plan_fill(max_total_expansions=)`.
+
+All RNG-free, so the ADR-0003 determinism contract is preserved (same scenario +
+seed → bit-identical `MovesPlan`). Multi-plane *fill* routability is dominated by
+placement, not the planner — the spread-vs-towability tension is tracked
+separately under [#280](https://github.com/DocGerd/hangarfit/issues/280)
+(back-fill [#320](https://github.com/DocGerd/hangarfit/issues/320)).
+
 ## More Information
 
 - Related spike: [Tow-path planning (#180)](../spikes/tow-path-planning.md) — the

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -206,13 +206,14 @@ def build_parser() -> argparse.ArgumentParser:
     solve.add_argument(
         "--tow-heuristic",
         choices=("euclidean", "grid"),
-        default="euclidean",
+        default="grid",
         dest="tow_heuristic",
         help=(
-            "EXPERIMENTAL (#332): A* tow-path heuristic. 'euclidean' (default) is "
-            "the shipped straight-line heuristic; 'grid' is the obstacle-aware "
-            "free-space geodesic that routes around placed planes (only affects "
-            "--render-paths runs). Deterministic; the path is exact-oracle-validated."
+            "A* tow-path heuristic. 'grid' (default since #336) is the "
+            "obstacle-aware free-space geodesic that threads tight maneuvers in "
+            "far fewer expansions; 'euclidean' is the older straight-line "
+            "heuristic (opt out). Only affects --render-paths runs; deterministic, "
+            "and the path is exact-oracle-validated."
         ),
     )
     solve.add_argument(
@@ -222,9 +223,9 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         dest="tow_max_expansions",
         help=(
-            "EXPERIMENTAL (#332): per-plane Hybrid-A* expansion budget for tow "
-            "planning (default: the module _MAX_EXPANSIONS=700). Raise to trade "
-            "time for routability on hard fills."
+            "Per-plane Hybrid-A* expansion budget for tow planning (default: the "
+            "module _MAX_EXPANSIONS=8000). Raise to trade time for routability on "
+            "hard fills; a global per-fill cap bounds the worst case (#336)."
         ),
     )
 

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -201,8 +201,9 @@ def build_parser() -> argparse.ArgumentParser:
             "with --no-spread, since the bias rides on the spread post-pass.)"
         ),
     )
-    # ── Experimental tow-planner knobs (towplanner-v2 routability spike, #332) ──
-    # Behind opt-in flags; defaults reproduce the shipped planner byte-for-byte.
+    # ── Tow-planner knobs (grid heuristic default + global fill cap since #336;
+    # spike #332). --tow-heuristic defaults to the shipped grid planner and
+    # --tow-max-expansions widens the per-plane budget; both RNG-free (ADR-0003).
     solve.add_argument(
         "--tow-heuristic",
         choices=("euclidean", "grid"),

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -57,7 +57,7 @@ def solve(
     diversity: DiversityConfig | None = None,
     search: SearchConfig | None = None,
     plan_paths: bool = True,
-    tow_heuristic: Literal["euclidean", "grid"] = "euclidean",
+    tow_heuristic: Literal["euclidean", "grid"] = "grid",
     tow_max_expansions: int | None = None,
 ) -> SolveResult:
     """Solve a Scenario into up to ``alternatives`` diverse valid Layouts.
@@ -93,11 +93,11 @@ def solve(
     contract (ADR-0003) end-to-end through the bundle.
 
     ``tow_heuristic`` and ``tow_max_expansions`` are forwarded verbatim to
-    :func:`~hangarfit.towplanner.plan_fill` (towplanner-v2 routability spike,
-    #332). The defaults (``"euclidean"`` / module ``_MAX_EXPANSIONS``) reproduce
-    the shipped planner byte-for-byte; ``tow_heuristic="grid"`` opts into the
-    obstacle-aware free-space heuristic and a larger ``tow_max_expansions`` opts
-    into a bigger per-plane search budget — both RNG-free, so determinism holds.
+    :func:`~hangarfit.towplanner.plan_fill` (#332/#336). Since #336 the shipped
+    default is ``tow_heuristic="grid"`` (the obstacle-aware free-space heuristic)
+    with the module per-plane and global fill budgets; pass
+    ``tow_heuristic="euclidean"`` to opt out, or a larger ``tow_max_expansions``
+    to widen the per-plane budget. All RNG-free, so determinism holds (ADR-0003).
     """
     if diversity is None:
         diversity = DiversityConfig()
@@ -385,11 +385,13 @@ def _tow_plan_layouts(
     unroutable: list[str] = []
     for layout in accepted_layouts:
         try:
-            # Default path calls ``plan_fill(layout)`` EXACTLY as before
-            # (byte-identical; #332 spike params are opt-in), so the ADR-0003
-            # determinism canaries — and any test that stubs ``plan_fill`` with a
-            # target-only signature — are untouched.
-            if tow_heuristic == "euclidean" and tow_max_expansions is None:
+            # Default path calls ``plan_fill(layout)`` with NO kwargs, so the
+            # ADR-0003 determinism canaries — and any test that stubs
+            # ``plan_fill`` with a target-only signature — stay untouched. Since
+            # #336 the shipped default is grid + the module budgets, which is
+            # exactly what a bare ``plan_fill(layout)`` applies; an explicit
+            # euclidean / custom budget takes the kwargs path below.
+            if tow_heuristic == "grid" and tow_max_expansions is None:
                 built.append(plan_fill(layout))
             else:
                 built.append(

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1068,16 +1068,27 @@ class NoFeasiblePlanError(Exception):
 def plan_fill(
     target: Layout,
     *,
-    heuristic: Literal["euclidean", "grid"] = "euclidean",
+    heuristic: Literal["euclidean", "grid"] = "grid",
     max_expansions: int | None = None,
+    max_total_expansions: int | None = None,
 ) -> MovesPlan:
     """Plan a collision-free entry order + per-plane path for an empty fill.
 
-    ``heuristic`` and ``max_expansions`` are forwarded to :func:`plan_path` for
-    every plane (towplanner-v2 routability spike, #332). The defaults reproduce
-    the shipped planner byte-for-byte (``max_expansions=None`` ⇒ the module
-    ``_MAX_EXPANSIONS`` budget); ``heuristic="grid"`` and/or a raised
-    ``max_expansions`` are the opt-in routability experiments.
+    ``heuristic`` selects the per-plane :func:`plan_path` heuristic. ``"grid"``
+    (the default since #336) is the obstacle-aware free-space geodesic, which
+    threads tight-clearance maneuvers in far fewer expansions than the
+    straight-line ``"euclidean"`` (which ignores walls and floods the frontier);
+    pass ``heuristic="euclidean"`` to opt out. ``max_expansions`` (``None`` ⇒ the
+    module ``_MAX_EXPANSIONS`` per-plane budget) caps each plane's search.
+
+    ``max_total_expansions`` (``None`` ⇒ the module ``_MAX_FILL_EXPANSIONS``) is
+    a deterministic GLOBAL cap on the expansions summed across *every*
+    :func:`plan_path` call in the whole fill — including the failed candidates of
+    the greedy scan. A high per-plane budget is needed to *route* tight-feasible
+    planes, but it makes an un-routable fill expensive to *disprove*
+    (~per-plane × scan-retries); the global cap bounds that worst case so the
+    planner bails in bounded time instead of running away, while a routable fill
+    finishes well under it. RNG-free, so the cap is seed-deterministic (#336).
 
     Walks :func:`back_first_order` (deepest slot first); for each plane searches
     for an in-bounds path from the door-cone entry poses (:func:`entry_poses`) to
@@ -1102,6 +1113,8 @@ def plan_fill(
     :class:`MovesPlan`.
     """
     budget = _MAX_EXPANSIONS if max_expansions is None else max_expansions
+    total_budget = _MAX_FILL_EXPANSIONS if max_total_expansions is None else max_total_expansions
+    total_used = 0
     ordered = list(back_first_order(target.placements))
     fleet = target.fleet
     hangar = target.hangar
@@ -1126,13 +1139,29 @@ def plan_fill(
             maintenance_plane=target.maintenance_plane,
         )
         for idx, slot in enumerate(ordered):
+            remaining = total_budget - total_used
+            if remaining <= 0:
+                # Global fill-expansion budget exhausted (#336): bail in bounded
+                # time rather than paying per-plane budget × scan-retries on an
+                # un-routable fill. Name the deepest still-unplaced plane.
+                raise NoFeasiblePlanError(
+                    ordered[0].plane_id,
+                    Conflict.single(
+                        kind="no_feasible_path",
+                        plane=ordered[0].plane_id,
+                        detail=f"global fill expansion budget ({total_budget}) exhausted",
+                    ),
+                )
             plane = fleet[slot.plane_id]
+            stats: dict[str, object] = {}
             try:
                 # The full door cone drives the multi-start search (#262). Compute
                 # it once and pass it as `entries=`; the positional `entry` arg is
                 # ignored by plan_path whenever `entries` is set, so reuse cone[0]
                 # for it rather than recomputing entry_pose() (which plan_path would
-                # never read here).
+                # never read here). Each call is capped at the smaller of the
+                # per-plane budget and the global remainder, and its expansions are
+                # charged to the global total whether it succeeds or fails (#336).
                 cone = entry_poses(slot, hangar)
                 arc = plan_path(
                     plane,
@@ -1143,14 +1172,19 @@ def plan_fill(
                     mover_on_carts=slot.on_carts,
                     entries=cone,
                     heuristic=heuristic,
-                    max_expansions=budget,
+                    max_expansions=min(budget, remaining),
+                    stats=stats,
                 )
             except NoFeasiblePlanError as exc:
                 # This plane cannot be routed against the current obstacles; try
                 # the next candidate. Remember its conflict for the bail message.
+                exp = stats.get("expansions", 0)
+                total_used += exp if isinstance(exp, int) else 0
                 if deepest_conflict is None:
                     deepest_conflict = exc.conflict
                 continue
+            exp = stats.get("expansions", 0)
+            total_used += exp if isinstance(exp, int) else 0
             chosen, chosen_arc = idx, arc
             break
         if chosen is None:
@@ -1174,31 +1208,34 @@ _GRID_XY_M = 0.5  # (x, y) cell size for state binning
 _GRID_DEG = 15.0  # heading cell size; 360 / 15 = 24 heading bins
 _HEADING_BINS = round(360.0 / _GRID_DEG)
 _TURN_PENALTY = 0.1  # per-radian g-cost penalty to prefer straighter paths
-_MAX_EXPANSIONS = 2000  # node-expansion budget per plane before bailing (#335).
-# Raised 700 → 2000 based on a budget sweep over the standard fixtures
-# (placeholder 25×18 hangar, solve_fresh_six_planes seed=1, 5 floor planes):
+_MAX_EXPANSIONS = 8000  # node-expansion budget per plane before bailing (#336).
+# Raised 2000 → 8000 when the GRID heuristic became the plan_fill default (#336).
+# The earlier euclidean sweep concluded aviat_husky (first in back-first order at
+# seed=1) was "un-routable even at 4000 — genuine tight-geometry exhaustion."
+# That was a HEURISTIC artifact, NOT infeasibility: euclidean ignores walls and
+# floods the frontier, needing ~13.5k expansions, whereas the obstacle-aware grid
+# heuristic threads the same maneuver in ~6062. So with grid the routability knee
+# moves to ~6100, and 8000 gives headroom to route it (the seed=1 fill reaches
+# 5/5, ~8.4k total expansions).
 #
-#   Budget | Routed (seed=1) | plan_fill wall-clock (seed=7)
-#   -------|-----------------|-----------------------------
-#      700 |  3/5            |  ~108 s
-#     1000 |  3/5 (no gain)  |  ~137 s
-#     1500 |  3/5 (no gain)  |  ~215 s
-#     2000 |  4/5 (+1, KNEE) |  ~271 s
-#     3000 |  4/5 (no gain)  |  ~441 s
-#     4000 |  4/5 (no gain)  |  ~540 s+ (extrapolated)
-#
-# The knee is at 2000: routed count improves from 3→4 and does not improve
-# further at 3000 or 4000.  The aviat_husky (first in back-first order at
-# seed=1) remains un-routable even at budget 4000 — genuine tight-geometry
-# budget exhaustion that a larger budget alone cannot fix, not a false negative.
-#
-# Deterministic (machine-independent) bound on worst-case search cost. The flip
-# side: budget exhaustion can also report a genuinely-feasible-but-hard layout
-# as NoFeasiblePlanError (a false negative). Accepted v2 tradeoff — see the
-# design spec's failure semantics; retune once real (measured) hangar geometry
-# is available, or once issue #336 (RRT-Connect v2) extends the motion model.
-# Overridable per-invocation via the ``--tow-max-expansions`` CLI flag and the
-# ``tow_max_expansions`` param on ``solve()``/``plan_fill()`` (#332).
+# Deterministic (machine-independent) bound on worst-case per-plane search cost.
+# Budget exhaustion can still report a genuinely-feasible-but-hard layout as
+# NoFeasiblePlanError (a false negative) — accepted v2 tradeoff; retune once real
+# (measured) hangar geometry lands. Overridable per-invocation via the
+# ``--tow-max-expansions`` CLI flag and the ``tow_max_expansions`` param on
+# ``solve()`` / ``plan_fill()`` (#332).
+
+_MAX_FILL_EXPANSIONS = 16000  # GLOBAL expansion budget across one whole fill (#336).
+# Bounds the worst-case wall-clock of an UN-routable fill. The higher per-plane
+# budget above is needed to ROUTE tight-but-feasible planes, but it makes an
+# un-routable fill expensive to disprove: the greedy back-first scan retries the
+# remaining planes, each burning up to the per-plane budget, so cost is
+# ~per-plane × scan-retries (the default spread=True six-plane fill measured
+# ~997 s at per-plane 8000 with NO global cap). Capping the SUM of expansions
+# across every plan_path call — failed candidates included — bounds that: the
+# same fill bails at the cap in ~334 s (< the 400 s perf gate), while a routable
+# fill (seed=1: ~8.4k total) finishes well under it. Deterministic / RNG-free.
+# Overridable via the ``max_total_expansions`` param on ``plan_fill()``.
 # Sampling resolution for the FAST in-search `_motion_clear` validity checks
 # (edges + the analytic-shot screen). Coarser than the exact oracle's default
 # (0.05 m / 1°) to keep the search tractable: the worst case is a plane that can

--- a/tests/test_solver_towplanner.py
+++ b/tests/test_solver_towplanner.py
@@ -124,6 +124,35 @@ def test_solve_best_effort_real_planner_on_untowable_fill():
     assert result.diagnostics.unroutable_planes  # non-empty
 
 
+@pytest.mark.slow
+def test_six_plane_fresh_fill_fully_routes_at_shipped_defaults():
+    """#336: a tow-friendly (spread=False) fill of ``solve_fresh_six_planes``
+    (seed=1) is **fully** tow-routable under the SHIPPED default planner — the
+    obstacle-aware grid heuristic + the raised per-plane budget. Previously
+    un-routable: euclidean@2000 capped out on ``aviat_husky`` (which needs
+    ~6062 grid expansions to thread its 10.82 m wing into the back corner).
+
+    Scope: this asserts the *planner* improvement on a tow-friendly layout. The
+    default ``spread=True`` fill remaining hard is the separate #280 placement
+    tension (back-fill #320), not this issue. Slow (real per-plane search).
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import SearchConfig
+    from hangarfit.solver import solve
+
+    scenario = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    result = solve(
+        scenario, budget_s=15.0, alternatives=1, seed=1, search=SearchConfig(spread=False)
+    )
+    assert result.status in ("found", "found_partial")
+    assert len(result.layouts) == 1
+    assert all(p is not None for p in result.plans), (
+        f"fill not fully routed at shipped defaults: "
+        f"unroutable={result.diagnostics.unroutable_planes}"
+    )
+    assert result.diagnostics.unroutable_planes == ()
+
+
 def test_solve_k_gt_1_bundle_alignment_with_mixed_routability(monkeypatch):
     """K>1: the per-layout loop builds an aligned plans tuple with a mix of
     real plans and None, and unroutable_planes records exactly the failed

--- a/tests/test_towplanner_grid_heuristic.py
+++ b/tests/test_towplanner_grid_heuristic.py
@@ -15,16 +15,17 @@ towplanner-v2 routability spike:
 * the geodesic field is well-formed (0 at the goal, increasing with distance,
   finite where free, and absent — i.e. ``+inf``/fallback — where walled off).
 
-These pin the *correctness* and *determinism* of the seam — NOT a routability
-win. Whether the grid heuristic buys routability is an empirical question the
-spike benchmark (``docs/spikes/towplanner_v2_routability_bench.py``) and the spike
-doc answer, and the honest answer is "no, not on these fixtures": their failures
-are budget-exhausted *finite-width maneuvering*, not interior-obstacle clutter, so
-a 2-D cost-to-go heuristic (this one, or a learned one) is inert. There is
-therefore deliberately **no** "grid routes what euclidean cannot" test — it would
-not hold, on the fixtures *or* on constructed bug-traps (once a detour is forced,
-the tight-maneuver bottleneck defeats both heuristics within budget). The seam is
-kept as a tested, opt-in PoC and the home for a future clutter/learned heuristic.
+These pin the *correctness* and *determinism* of the grid seam. **Since #336 grid
+is the shipped default** for ``plan_fill`` / ``solve`` (``plan_path``'s own
+primitive default stays ``euclidean`` — callers choose). The earlier "grid is
+inert, so no 'grid beats euclidean' test can exist" conclusion was a budget-700/
+2000 artifact: at those budgets BOTH heuristics cap out on the tight cases, so
+grid bought no extra *routed count*. But grid roughly halves the *expansions*
+(aviat_husky ~13.5k euclidean → ~6062 grid), which converts to a routed plane once
+the per-plane budget clears ~6100 (#336 raised it to 8000). The end-to-end "grid
+routes a tight fill euclidean cannot, at the shipped default budget" proof now
+lives in ``tests/test_solver_towplanner.py::
+test_six_plane_fresh_fill_fully_routes_at_shipped_defaults``.
 """
 
 from __future__ import annotations
@@ -340,6 +341,18 @@ def test_plan_fill_accepts_grid_heuristic_and_explicit_budget() -> None:
     assert [m.plane_id for m in plan.moves] == ["B", "A"]  # deepest first
 
 
+def test_plan_fill_global_cap_bails_in_bounded_total_expansions() -> None:
+    """``max_total_expansions`` caps the SUM of expansions across the whole fill
+    (#336). A tiny global cap forces a fast, bounded bail with the cap-exhausted
+    conflict — instead of paying per-plane-budget × scan-retries on a fill the
+    bounded planner cannot route. ``valid_two_separated`` leads with the 18 m-wing
+    scheibe_falke, which cannot route in 10 expansions, so the global cap trips."""
+    layout = load_layout("tests/fixtures/valid_two_separated.yaml")
+    with pytest.raises(NoFeasiblePlanError) as ei:
+        plan_fill(layout, max_total_expansions=10)
+    assert "global fill expansion budget" in ei.value.conflict.detail
+
+
 def test_solve_accepts_grid_tow_heuristic() -> None:
     """``solve(..., tow_heuristic="grid", tow_max_expansions=N)`` runs the opt-in
     grid branch in the solver. The plane may or may not route (best-effort); the
@@ -439,11 +452,12 @@ def test_grid_field_blocks_cells_past_non_aligned_walls() -> None:
 # ── CLI flag wiring (the #332 experimental knobs) ────────────────────────────
 
 
-def test_cli_tow_flags_default_to_the_byte_identical_shipped_planner() -> None:
-    """No ``--tow-*`` flags ⇒ the namespace defaults that route ``solve()`` down
-    the unchanged ``plan_fill(layout)`` path (the byte-identical-default guard)."""
+def test_cli_tow_flags_default_to_grid_with_no_explicit_budget() -> None:
+    """No ``--tow-*`` flags ⇒ the shipped default is ``grid`` (since #336) with no
+    explicit per-plane budget, so ``solve()`` takes the bare ``plan_fill(layout)``
+    no-kwargs path (the stub-compatible default)."""
     args = build_parser().parse_args(["solve", "scenario.yaml"])
-    assert args.tow_heuristic == "euclidean"
+    assert args.tow_heuristic == "grid"
     assert args.tow_max_expansions is None
 
 

--- a/tests/test_towplanner_perf.py
+++ b/tests/test_towplanner_perf.py
@@ -40,8 +40,14 @@ from hangarfit.towplanner import NoFeasiblePlanError, path_first_conflict, plan_
 # exhausting the full budget, tried multiple times by the greedy scan) measured
 # ~271 s on the development machine.  400 s = ~271 s × 1.5 + rounding — keeps
 # the runaway guard meaningful while allowing for slower CI machines.  Tighten
-# once real (measured) hangar geometry is available or issue #336 (RRT-Connect
-# v2) extends the motion model.
+# once real (measured) hangar geometry is available.
+#
+# #336: the per-plane budget rose 2000 → 8000 (grid heuristic became the
+# plan_fill default) AND a GLOBAL per-fill expansion cap
+# (_MAX_FILL_EXPANSIONS = 16000) was added. The cap is what keeps this gate
+# green: grid@8000 with NO global cap measured ~997 s on the seed=7 fill
+# (blowing 400 s), but the cap bails it at ~334 s. So 400 s still holds — now
+# bounded by the global fill cap, not per-plane budget × scan-retries.
 _PLAN_FILL_CEILING_S = 400.0
 
 
@@ -55,7 +61,10 @@ _PLAN_FILL_CEILING_S = 400.0
 )
 def test_plan_fill_on_solved_layouts_completes_within_budget(scenario_path: str) -> None:
     scenario = load_scenario(scenario_path)
-    result = solve(scenario, budget_s=10.0, alternatives=1, seed=7)
+    # plan_paths=False: this gate times its OWN plan_fill calls below, so the
+    # layout search must NOT also tow-plan internally (wasted work that, since
+    # #336's grid default + larger budget, costs as much as the timed section).
+    result = solve(scenario, budget_s=10.0, alternatives=1, seed=7, plan_paths=False)
     if not result.layouts:
         pytest.skip(f"{scenario_path}: solve produced no layout (status={result.status})")
 


### PR DESCRIPTION
## What & why

Closes #336. Re-scoped from the deferred RRT-Connect fallback to a cheap, deterministic planner improvement: a spike-first go/no-go found every standard fixture is **feasible** (Hybrid-A\* routes them given budget), so RRT-Connect was unjustified. This is the planner-side support for the **#280** tow-friendly-placement umbrella (Direction A).

## Part 1 — grid heuristic becomes the default

Euclidean is a straight-line estimate that ignores walls and floods the frontier in tight quarters (`aviat_husky` needs ~13.5k expansions to thread its 10.82 m wing into a back corner); the obstacle-aware grid geodesic threads the same maneuver in ~6062. Graduated to the default for `plan_fill` / `solve` / the CLI (`plan_path`'s **primitive** default stays `euclidean` — callers choose). `--tow-heuristic euclidean` opts out. The shipped-default no-kwargs `plan_fill(layout)` call (stub-compatible for the determinism canaries) now maps to the grid default.

## Part 2 — per-plane budget + deterministic global fill cap

- Per-plane `_MAX_EXPANSIONS` **2000 → 8000** (the budget grid needs to route the tight-but-feasible cases; the old "infeasible at 4000" note was a euclidean-heuristic artifact, not geometry).
- New `_MAX_FILL_EXPANSIONS = 16000` (`plan_fill(max_total_expansions=)`) on the **sum** of expansions across every `plan_path` call in a fill — failed candidates included.

### Why both parts ship together
A high per-plane budget is needed to *route* tight planes but makes an un-routable fill expensive to *disprove* (~per-plane × greedy-scan-retries). grid+8000 **without** the cap measured **~997 s** on the un-routable default `seed=7` fill — blowing the 400 s perf gate and hanging the CLI ~17 min. The global cap brings it to **~334 s**. The cap is what makes the budget bump shippable.

## Measurements (six-plane fixture, grid)

| scenario | result | total expansions | wall-clock |
|---|---|---|---|
| seed=1 (routable, spread=False) | ROUTED 5/5 | 8,445 (< 16k cap) | 157 s |
| seed=7 (un-routable, default spread) | cap-bail | 16,000 | 334 s (< 400 s gate) |

## Determinism (ADR-0003)
RNG-free: the cap is integer arithmetic on deterministic per-plane expansion counts — no new draws, no reordering. Same scenario + seed → bit-identical `MovesPlan`. **No determinism-guard amendment.**

## Scope
Multi-plane *fill* routability is dominated by **placement** (the spread post-pass pushing planes into corners), tracked under #280 / #320 — this PR is the planner-side support. The default `spread=True` six-plane fill remains hard (now bails cleanly via the cap in 334 s instead of running away ~997 s); making *that* route is the #320 back-fill / #280 work.

## Tests / docs
- `test_six_plane_fresh_fill_fully_routes_at_shipped_defaults` — the RED→GREEN headline (spread=False six-plane fill: was un-routable, now 5/5 at shipped defaults).
- `test_plan_fill_global_cap_bails_in_bounded_total_expansions` — the cap mechanism (cap-exhausted conflict).
- CLI-default test → `grid`; the grid-heuristic test docstring corrected (the "grid is inert" claim was a budget-700/2000 artifact — grid halves *expansions*, which converts to a routed plane once the budget clears ~6100); perf-gate comment refreshed + `plan_paths=False` test-speed fix.
- **ADR-0007 amended** (grid default + global cap + RRT-retired rationale).
- Verified: **1129 default tests + 3 slow tow gates green**; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
