### PR TITLE
feat(brand): apply DocGerdSoft Horizon identity (CVD-safe palette, marks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,5 +169,4 @@ Licensed under the [Apache License 2.0](LICENSE).
 
 (C) 2026 Patrick Kuhn. The brand identity (the Horizon-blue accent, the abstract
 delta mark, and the assets under [`docs/assets/`](docs/assets/)) is part of the
-DocGerdSoft design system. DocGerdSoft is a personal brand of Patrick Kuhn, not a
-company.
+DocGerdSoft design system. DocGerdSoft is a personal brand of Patrick Kuhn.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![hangarfit](docs/assets/banner.svg)
+
 # hangarfit
 
 [![CI](https://github.com/DocGerd/hangarfit/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/DocGerd/hangarfit/actions/workflows/ci.yml)
@@ -164,3 +166,8 @@ Architecture lives in [`docs/architecture/`](docs/architecture/) and [`docs/adr/
 ## License
 
 Licensed under the [Apache License 2.0](LICENSE).
+
+(C) 2026 Patrick Kuhn. The brand identity (the Horizon-blue accent, the abstract
+delta mark, and the assets under [`docs/assets/`](docs/assets/)) is part of the
+DocGerdSoft design system. DocGerdSoft is a personal brand of Patrick Kuhn, not a
+company.

--- a/docs/assets/avatar.svg
+++ b/docs/assets/avatar.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="hangarfit">
+  <!-- White delta on the hangarfit Horizon accent circle, mark at ~52%.
+       Circle fill swapped from the shared #0D0E10 to #0079B5; mark kept white
+       at translate(24,24) scale(0.52). GitHub/package avatar source. -->
+  <circle cx="50" cy="50" r="50" fill="#0079B5"/>
+  <g transform="translate(24,24) scale(0.52)" fill="#FFFFFF">
+    <path d="M50 17.09 L69.87 51.5 L30.13 51.5 Z"/>
+    <path d="M26.96 57 L73.04 57 L88 82.91 L12 82.91 Z"/>
+  </g>
+</svg>

--- a/docs/assets/banner.svg
+++ b/docs/assets/banner.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 400" width="1280" height="400" role="img" aria-label="hangarfit — validate, solve, and render a flying club's hangar-parking layouts, from above">
+  <!--
+    hangarfit README banner — ON-BRAND VECTOR STOPGAP (DocGerdSoft brand handoff,
+    Deliverable 2, Composition A "Split"). The pixel-accurate PNG is the canonical
+    deliverable and is deferred to a Claude Design export; this SVG is a faithful
+    vector approximation. The wordmark falls back to system-ui because Geist is not
+    installed locally, so this is NOT pixel-identical to the design comp.
+    Canvas 1280x400. No (R)/(TM); DocGerdSoft is a personal brand, not a company.
+  -->
+  <defs>
+    <linearGradient id="horizonRule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#0079B5"/>
+      <stop offset="1" stop-color="#0079B5" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="gridMask" cx="78%" cy="30%" r="72%">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="1"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid40" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0 L0 0 L0 40" fill="none" stroke="#E6E9EC" stroke-width="1"/>
+    </pattern>
+    <mask id="gridFade">
+      <rect width="1280" height="400" fill="url(#gridMask)"/>
+    </mask>
+  </defs>
+
+  <!-- Background: Paper + faint 40px grid masked by a radial fade toward the right. -->
+  <rect width="1280" height="400" fill="#FBFBFC"/>
+  <rect width="1280" height="400" fill="url(#grid40)" mask="url(#gridFade)"/>
+
+  <!-- Right column: abstract top-down hangar schematic, bleeding off the right edge.
+       Three solid walls + a front wall with a central door gap, plus a faint
+       back-strip maintenance bay. Schematic only — never the brand mark. -->
+  <g transform="translate(760,60)" opacity="0.9">
+    <!-- floor -->
+    <rect x="0" y="0" width="560" height="280" fill="#FFFFFF" stroke="none"/>
+    <!-- back-strip maintenance bay (~13% opacity maint colour) -->
+    <rect x="0" y="0" width="560" height="46" fill="#7B63A3" opacity="0.13"/>
+    <!-- back wall -->
+    <line x1="0" y1="0" x2="560" y2="0" stroke="#3B4046" stroke-width="3"/>
+    <!-- left + right walls -->
+    <line x1="0" y1="0" x2="0" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="560" y1="0" x2="560" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <!-- front wall split around a central door gap -->
+    <line x1="0" y1="280" x2="210" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="350" y1="280" x2="560" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="210" y1="280" x2="350" y2="280" stroke="#bdc3c7" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <!-- a few abstract plane-slot tiles, brand palette, ink outline (never hue alone) -->
+    <rect x="60"  y="70"  width="120" height="40" rx="6" fill="#0079B5" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="220" y="120" width="120" height="40" rx="6" fill="#D55E00" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="380" y="80"  width="120" height="40" rx="6" fill="#009E73" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="110" y="180" width="120" height="40" rx="6" fill="#B45CA6" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="330" y="200" width="120" height="40" rx="6" fill="#4C4C9E" stroke="#14161A" stroke-width="1.5"/>
+  </g>
+
+  <!-- Left column (fixed 560px), padding 56 48, vertically centered. -->
+  <g transform="translate(48,118)">
+    <!-- Lockup: delta mark 54x54 (#0079B5) + wordmark. -->
+    <g transform="translate(0,0)">
+      <g transform="scale(0.54)" fill="#0079B5">
+        <path d="M50 17.09 L69.87 51.5 L30.13 51.5 Z"/>
+        <path d="M26.96 57 L73.04 57 L88 82.91 L12 82.91 Z"/>
+      </g>
+      <text x="70" y="48" font-family="Geist, system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
+            font-size="52" font-weight="600" letter-spacing="-1.5">
+        <tspan fill="#14161A">hangar</tspan><tspan fill="#0079B5">fit</tspan>
+      </text>
+    </g>
+
+    <!-- Horizon rule: 120x2 gradient. -->
+    <rect x="2" y="78" width="120" height="2" fill="url(#horizonRule)"/>
+
+    <!-- Tagline, ~23px, graphite-strong. -->
+    <text x="0" y="120" font-family="Geist, system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
+          font-size="23" font-weight="400" fill="#3B4046">
+      <tspan x="0" dy="0">Validate, solve, and render a flying club's</tspan>
+      <tspan x="0" dy="32">hangar-parking layouts — from above.</tspan>
+    </text>
+
+    <!-- Mono command block, ~16px, graphite. $ in accent, check + verdict in valid green. -->
+    <text x="0" y="206" font-family="'Geist Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace"
+          font-size="16" fill="#5E646B">
+      <tspan fill="#0079B5">$</tspan><tspan> hangarfit check layouts/example.yaml</tspan>
+    </text>
+    <text x="0" y="232" font-family="'Geist Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace"
+          font-size="16" fill="#5E646B">
+      <tspan fill="#0F7C72">-</tspan><tspan> valid  // 9 planes . 0 conflicts</tspan>
+    </text>
+  </g>
+</svg>

--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="hangarfit">
+  <!-- White delta on the hangarfit Horizon accent tile, container radius 22%
+       (tokens.radius.faviconContainer). Tile fill swapped from the shared
+       #0D0E10 to #0079B5; mark kept white at translate(19,19) scale(0.62).
+       Generate 48/32 PNG + ICO from this; use mark-line below 24px. -->
+  <rect width="100" height="100" rx="22" fill="#0079B5"/>
+  <g transform="translate(19,19) scale(0.62)" fill="#FFFFFF">
+    <path d="M50 17.09 L69.87 51.5 L30.13 51.5 Z"/>
+    <path d="M26.96 57 L73.04 57 L88 82.91 L12 82.91 Z"/>
+  </g>
+</svg>

--- a/docs/assets/mark.svg
+++ b/docs/assets/mark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="#0079B5" role="img" aria-label="hangarfit">
+  <!-- DocGerdSoft delta mark, recoloured to the hangarfit Horizon accent #0079B5.
+       Geometry reused verbatim from /home/pkuhn/brand/logo/mark-solid.svg:
+       an abstract equilateral delta split by a horizontal datum line. -->
+  <path d="M50 17.09 L69.87 51.5 L30.13 51.5 Z"/>
+  <path d="M26.96 57 L73.04 57 L88 82.91 L12 82.91 Z"/>
+</svg>

--- a/docs/assets/monogram.svg
+++ b/docs/assets/monogram.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88 88" width="88" height="88" role="img" aria-label="hangarfit">
+  <!-- "hf" monogram: white on the hangarfit Horizon accent tile, radius 10px
+       (tokens.radius.md). Geist Mono 600 per the handoff; system monospace
+       fallback since Geist Mono may be absent locally. For tight horizontal
+       lockups / package avatars (handoff Deliverable 1, concept B). -->
+  <rect width="88" height="88" rx="10" fill="#0079B5"/>
+  <text x="44" y="44" fill="#FFFFFF"
+        font-family="'Geist Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace"
+        font-size="42" font-weight="600" letter-spacing="-1"
+        text-anchor="middle" dominant-baseline="central">hf</text>
+</svg>

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -8,10 +8,12 @@ maintenance bay rendered conditionally on ``layout.maintenance_plane``
 placed aircraft drawn as its world :class:`Part` polygons (fuselage
 near-opaque — ``fuselage_front``/cockpit a darker tint than
 ``fuselage_aft``/tail — wing translucent so overlapping wings show their
-stack, struts as thin lines). Aircraft are color-keyed by ``wing_position``.
-If a
+stack, struts as thin lines). Each plane gets one colour from the
+DocGerdSoft CVD-safe ``PLANES`` brand palette, keyed per plane by sorted
+``plane_id``; every part also carries an ink outline so identity never rests
+on hue alone. If a
 :class:`CheckResult` is supplied, the parts of conflicting planes are
-overdrawn in red.
+overdrawn in the conflict colour with a hatch + dashed edge.
 
 The renderer's job is to give a human something to eyeball — visual
 quality is intentionally not asserted in tests. The smoke tests verify
@@ -39,7 +41,7 @@ from matplotlib.patches import Circle as MplCircle  # noqa: E402
 from matplotlib.patches import Polygon as MplPolygon  # noqa: E402
 
 from .geometry import WorldPart, aircraft_parts_world, local_to_world  # noqa: E402
-from .models import Aircraft, CheckResult, Layout, Placement, WingPosition  # noqa: E402
+from .models import Aircraft, CheckResult, Layout, Placement  # noqa: E402
 
 if TYPE_CHECKING:
     # Annotation-only import: the runtime code in _draw_tow_paths is duck-typed
@@ -48,32 +50,86 @@ if TYPE_CHECKING:
     # visualize, so this is safe under TYPE_CHECKING either way.
     from .towplanner import MovesPlan
 
-_WING_COLORS: dict[WingPosition, str] = {
-    "high": "#3498db",  # blue (retained — good contrast at all positions)
-    "mid": "#d55e00",  # Okabe–Ito vermillion — replaces #e67e22 (orange) for
-    # better luminance separation from the low-wing yellow #f4d03f under
-    # protanopia; #e67e22 and #f4d03f can merge for red-blind viewers.
-    "low": "#f4d03f",  # yellow
+# ── DocGerdSoft brand palette (Horizon-blue expression) ─────────────────────
+# Lifted verbatim from the authoritative DocGerdSoft brand handoff for
+# hangarfit ("Deliverable 4 — matplotlib Diagram Palette", README "Drop-in"
+# block). The categorical set is derived from the Okabe–Ito CVD-safe palette
+# (https://jfly.uni-koeln.de/color/) and tuned so every fill also clears
+# ≥3:1 contrast on white (WCAG non-text threshold). Identity must never rest
+# on hue alone: every plane also carries an ink outline (``_INK_EDGE``) and a
+# mono id label, and conflicts always add a hatch + ink edge (see
+# :func:`_draw_conflict_overlay`).
+#
+# PLANES — one colour per aircraft, ordered for max pairwise CVD separation.
+PLANES = [
+    "#0079B5",  # 01 Horizon (the hangarfit accent)
+    "#D55E00",  # 02 Vermillion
+    "#009E73",  # 03 Sea green
+    "#B45CA6",  # 04 Orchid
+    "#B37903",  # 05 Amber
+    "#108FAA",  # 06 Cyan
+    "#4C4C9E",  # 07 Indigo
+    "#8A542D",  # 08 Sienna
+    "#5E646B",  # 09 Graphite
+]
+# STATUS — status & structure inks. Key is "wall" per the authoritative README
+# drop-in (NOT "datum" as in the page's hangarfit.js): wall/door/datum all map
+# to the one graphite-strong ink #3B4046.
+STATUS = {
+    "valid": "#0F7C72",  # 5.06:1 on white
+    "conflict": "#C8442C",  # 4.86:1 — always pair with a hatch + ink edge
+    "maint": "#7B63A3",  # 5.05:1 — maintenance-bay fill
+    "wall": "#3B4046",  # 10.5:1 — wall · door · datum ink
 }
-# Defensive: ``WingPosition`` is closed at ``Literal["high", "mid", "low"]``
-# and ``_WING_COLORS`` covers all three, so this fallback is unreachable
-# today. It exists so that adding a new wing_position literal to the model
-# doesn't blow up the renderer with KeyError before someone updates the map.
+# PLANES_DARK — lifted fills for the dark-figure variant (drawn at ~92%
+# opacity on #0D0E10). Same ordering as PLANES.
+PLANES_DARK = [
+    "#3FA3D6",
+    "#E8794A",
+    "#33B894",
+    "#CE7EC0",
+    "#D29A2E",
+    "#3FB6CE",
+    "#8585C9",
+    "#BC8154",
+    "#9AA0A8",
+]
+
+# Plane / part outline ink (#14161A) — the "never hue alone" guarantee: every
+# plane part is stroked in this ink so the silhouette reads without colour.
+# Distinct from the wall ink (STATUS["wall"] = #3B4046), which is the
+# hangar/door/datum structure colour.
+_INK_EDGE = "#14161A"
+
+# Retained for back-compat with the wing-position concept and as the
+# unreachable-by-default fallback when a placement cannot be mapped to a
+# PLANES index (see :func:`_draw_aircraft`). Kept gray so a stray placement is
+# visibly "uncoloured" rather than masquerading as a real plane hue.
 _FALLBACK_COLOR = "#95a5a6"  # gray
 
-_CONFLICT_COLOR = "#e74c3c"  # red
+# Conflict ink, sourced from the brand STATUS map. Was #e74c3c pre-brand; the
+# constant NAME is preserved so importers (tests read to_rgba(_CONFLICT_COLOR))
+# keep resolving. The conflict overlay pairs this edge with a hatch + dashed
+# stroke (non-colour redundancy) — see :func:`_draw_conflict_overlay`.
+_CONFLICT_COLOR = STATUS["conflict"]  # "#C8442C"
 
 # Tow-path overlay palette (#192). One colour per plane, cycled by sorted
-# plane_id. Deliberately excludes the conflict red (#e74c3c) and the gray
-# fallback so a path never blurs into a conflict highlight or a placeholder
-# part. Eight entries cover the fleet (<=9 planes); a 9th plane reuses the
-# first colour — acceptable since each path terminates at its annotated slot.
+# plane_id. Deliberately excludes the conflict colour and the gray fallback so
+# a path never blurs into a conflict highlight or a placeholder part. Eight
+# entries cover the fleet (<=9 planes); a 9th plane reuses the first colour —
+# acceptable since each path terminates at its annotated slot.
+#
+# TODO(brand): the DocGerdSoft handoff specifies tow paths coloured by the
+# plane's index in the 9-colour ``PLANES`` set. Repointing here is deferred:
+# ``test_colour_cycle_wraps_beyond_palette`` pins ``len(set) == len(
+# _TOW_PATH_COLORS)`` (exactly 8 distinct on a 9-plane fleet), which a 9-entry
+# palette would break. Aligning to PLANES needs that test updated deliberately.
 #
 # Palette: Okabe–Ito 8-colour CVD-safe set (https://jfly.uni-koeln.de/color/).
 # This palette is distinguishable under deuteranopia, protanopia, and
-# tritanopia simultaneously, and reads in grey-scale. The conflict red
-# (#e74c3c) is excluded from this cycle as noted above; it is not part of
-# the Okabe–Ito set either.
+# tritanopia simultaneously, and reads in grey-scale. The conflict colour is
+# excluded from this cycle as noted above; it is not part of the Okabe–Ito set
+# either.
 _TOW_PATH_COLORS = (
     "#000000",  # black
     "#e69f00",  # orange
@@ -118,7 +174,11 @@ _BAY_WALL_EDGE = "#641e16"
 _BAY_WALL_ALPHA = 0.55
 _BAY_WALL_HATCH = "///"
 _BAY_LABEL_COLOR = "#ffffff"
-_HANGAR_EDGE = "#2c3e50"  # near-black
+# Wall / door / datum ink, sourced from the brand STATUS map (#3B4046,
+# 10.5:1 on white). The handoff folds wall, door, and datum onto this one
+# graphite-strong ink. The door is then *lightened* (``_DOOR_EDGE``) so the
+# opening reads as "open" rather than a wall.
+_HANGAR_EDGE = STATUS["wall"]  # "#3B4046" — wall · door · datum ink
 _DOOR_EDGE = "#bdc3c7"  # light gray — visually "open"
 
 # ── Wheel / cart glyph constants ────────────────────────────────────────────
@@ -327,10 +387,22 @@ def _draw_maintenance_bay(ax: Any, layout: Layout) -> None:
 
 
 def _draw_aircraft(ax: Any, layout: Layout) -> None:
-    """Draw each placed plane as its world parts, color-keyed by wing position."""
+    """Draw each placed plane as its world parts, one brand colour per plane.
+
+    Colour is keyed *per plane* from the DocGerdSoft ``PLANES`` categorical set
+    (handoff Deliverable 4) — a shift from the pre-brand scheme, which keyed
+    three colours off ``wing_position``. Each placement gets a stable index by
+    enumerating ``layout.placements`` sorted by ``plane_id`` (the same
+    deterministic sorted-id approach :func:`_draw_tow_paths` uses), so a given
+    layout always renders the same plane in the same colour regardless of
+    placement order. The 9-colour palette wraps with ``idx % len(PLANES)`` for
+    fleets beyond nine. Identity never rests on hue alone: every part also
+    carries the ``_INK_EDGE`` outline and a mono id label.
+    """
+    colour_for = _plane_colour_map(layout)
     for placement in layout.placements:
         aircraft = layout.fleet[placement.plane_id]
-        color = _WING_COLORS.get(aircraft.wing_position, _FALLBACK_COLOR)
+        color = colour_for.get(placement.plane_id, _FALLBACK_COLOR)
         world_parts = aircraft_parts_world(aircraft, placement)
         # Gear/cart glyph drawn before parts so the fuselage patch (zorder=2)
         # sits on top — wheels peek out at nose/tail/sides.
@@ -340,10 +412,22 @@ def _draw_aircraft(ax: Any, layout: Layout) -> None:
         _annotate_plane(ax, placement, aircraft.id)
 
 
+def _plane_colour_map(layout: Layout) -> dict[str, str]:
+    """Map each placed ``plane_id`` to a stable colour from ``PLANES``.
+
+    Indices are assigned by *sorted* ``plane_id`` so the mapping is independent
+    of placement order (ADR-0003 determinism spirit), mirroring
+    :func:`_draw_tow_paths`. Wraps with ``idx % len(PLANES)`` so fleets larger
+    than the nine-colour palette never raise.
+    """
+    plane_ids = sorted({p.plane_id for p in layout.placements})
+    return {pid: PLANES[i % len(PLANES)] for i, pid in enumerate(plane_ids)}
+
+
 def _darken(color: str, factor: float = _FUSELAGE_FRONT_DARKEN) -> tuple[float, float, float]:
     """Return ``color`` with each RGB channel multiplied by ``factor`` (toward
     black). Used to tint ``fuselage_front`` a darker shade of the plane's
-    wing-position fill so the cockpit boundary is legible (ADR-0012)."""
+    brand fill so the cockpit boundary is legible (ADR-0012)."""
     from matplotlib.colors import to_rgb
 
     r, g, b = to_rgb(color)
@@ -353,11 +437,15 @@ def _darken(color: str, factor: float = _FUSELAGE_FRONT_DARKEN) -> tuple[float, 
 def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
     """Render a single world part. Fuselage segments are near-opaque (two
     fuselages overlapping is always a conflict; no value in seeing through) —
-    ``fuselage_front`` (cockpit) a darker tint of the wing-position fill,
+    ``fuselage_front`` (cockpit) a darker tint of the plane's brand fill,
     ``fuselage_aft`` (tail) the plain fill — wing translucent (so stacked
     wings show their plan-view overlap visually), strut as a thin outlined
     polygon (struts are physically thin, a fill would be near-invisible), tail
     rendered like a small fuselage (same z-tier, same conflict semantics).
+
+    Solid parts are stroked in ``_INK_EDGE`` (#14161A), the brand "never hue
+    alone" outline — so a plane's silhouette reads even in greyscale or under
+    colour-vision deficiency, independent of its fill hue.
 
     Any other ``PartKind`` value raises ``ValueError`` rather than falling
     through to a generic style. ``PartKind`` is closed at the type level,
@@ -370,7 +458,7 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
             coords,
             closed=True,
             facecolor=_darken(color),
-            edgecolor=_HANGAR_EDGE,
+            edgecolor=_INK_EDGE,
             alpha=_FUSELAGE_ALPHA,
             lw=0.5,
             zorder=2,
@@ -380,7 +468,7 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
             coords,
             closed=True,
             facecolor=color,
-            edgecolor=_HANGAR_EDGE,
+            edgecolor=_INK_EDGE,
             alpha=_FUSELAGE_ALPHA,
             lw=0.5,
             zorder=2,
@@ -400,7 +488,7 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
             coords,
             closed=True,
             facecolor="none",
-            edgecolor=_HANGAR_EDGE,
+            edgecolor=_INK_EDGE,
             lw=_STRUT_LINEWIDTH,
             zorder=3,
         )
@@ -503,7 +591,7 @@ def _annotate_plane(ax: Any, placement: Placement, plane_id: str) -> None:
             placement.y_m + dy * _NOSE_ARROW_LENGTH_M,
         ),
         xytext=(placement.x_m, placement.y_m),
-        arrowprops=dict(arrowstyle="->", color=_HANGAR_EDGE, lw=1),
+        arrowprops=dict(arrowstyle="->", color=_INK_EDGE, lw=1),
         zorder=4,
     )
     ax.text(
@@ -513,7 +601,7 @@ def _annotate_plane(ax: Any, placement: Placement, plane_id: str) -> None:
         ha="center",
         va="top",
         fontsize=7,
-        color=_HANGAR_EDGE,
+        color=_INK_EDGE,
         zorder=4,
     )
 
@@ -525,9 +613,18 @@ def _draw_conflict_overlay(ax: Any, layout: Layout, check_result: CheckResult) -
 
     Non-colour redundancy: ``hatch="xxx"`` (dense cross pattern) plus
     ``linestyle="--"`` (dashed stroke) ensure "this part is in conflict" is
-    legible without relying on the red edge colour alone.  The red edge is
-    *kept* as a fast visual signal for colour-normal viewers — the non-colour
-    signals are additive, not replacements.
+    legible without relying on the conflict colour alone.  The conflict edge
+    (``_CONFLICT_COLOR`` = ``STATUS["conflict"]``) is *kept* as a fast visual
+    signal for colour-normal viewers — the non-colour signals are additive,
+    not replacements.
+
+    TODO(brand): the DocGerdSoft handoff calls for a 45° hatch (``"////"``)
+    paired with the conflict fill + ink edge. The current overlay uses
+    ``hatch="xxx"`` on a ``facecolor="none"`` overdraw, which satisfies the
+    "never colour alone" rule and the existing accessibility regression test
+    (``test_conflict_overlay_carries_non_colour_redundancy`` asserts a truthy
+    hatch, not a specific pattern). Switching to the 45° fill+hatch form is a
+    deliberate visual change deferred to avoid any subtle test interaction.
     """
     conflicting_planes: set[str] = set()
     for conflict in check_result.conflicts:

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1042,3 +1042,85 @@ class TestGearGlyph:
 
         # Three wheels (two mains + nose) drawn from wheels.positions.
         assert ax.add_patch.call_count == 3
+
+
+class TestBrandPalette:
+    """Pin the DocGerdSoft brand palette lifted into ``visualize`` (handoff
+    Deliverable 4). Guards a regression that silently drifts a hex away from
+    the authoritative handoff "Drop-in" block, and that the per-plane colour
+    keying still draws every part of every placed plane.
+    """
+
+    def test_planes_palette_is_the_handoff_nine(self) -> None:
+        from hangarfit.visualize import PLANES
+
+        assert PLANES == [
+            "#0079B5",
+            "#D55E00",
+            "#009E73",
+            "#B45CA6",
+            "#B37903",
+            "#108FAA",
+            "#4C4C9E",
+            "#8A542D",
+            "#5E646B",
+        ]
+
+    def test_planes_dark_palette_is_the_handoff_nine(self) -> None:
+        from hangarfit.visualize import PLANES_DARK
+
+        assert PLANES_DARK == [
+            "#3FA3D6",
+            "#E8794A",
+            "#33B894",
+            "#CE7EC0",
+            "#D29A2E",
+            "#3FB6CE",
+            "#8585C9",
+            "#BC8154",
+            "#9AA0A8",
+        ]
+
+    def test_status_map_matches_handoff_drop_in(self) -> None:
+        # Key is "wall" per the authoritative README drop-in (NOT "datum").
+        from hangarfit.visualize import STATUS
+
+        assert STATUS == {
+            "valid": "#0F7C72",
+            "conflict": "#C8442C",
+            "maint": "#7B63A3",
+            "wall": "#3B4046",
+        }
+
+    def test_conflict_colour_is_sourced_from_status(self) -> None:
+        from hangarfit.visualize import _CONFLICT_COLOR, STATUS
+
+        assert _CONFLICT_COLOR == STATUS["conflict"] == "#C8442C"
+
+    def test_plane_parts_drawn_per_part_with_ink_outline(self) -> None:
+        """Each placed plane's parts are still drawn one ``_draw_part`` call
+        per part, and solid parts carry the brand ink outline (#14161A) so
+        identity never rests on hue alone.
+        """
+        import matplotlib.colors
+
+        from hangarfit.geometry import aircraft_parts_world
+        from hangarfit.visualize import _INK_EDGE, _draw_aircraft
+
+        layout = _load("valid_two_separated")
+        expected_parts = sum(
+            len(aircraft_parts_world(layout.fleet[p.plane_id], p)) for p in layout.placements
+        )
+        ax = MagicMock()
+
+        _draw_aircraft(ax, layout)
+
+        # One add_patch per part, plus the per-wheel gear glyphs. At minimum,
+        # every part must have produced a patch.
+        assert ax.add_patch.call_count >= expected_parts
+        ink = matplotlib.colors.to_rgba(_INK_EDGE)
+        # At least one solid (fuselage/strut) part must be stroked in the ink.
+        edges = [c.args[0].get_edgecolor() for c in ax.add_patch.call_args_list]
+        assert any(e[:3] == ink[:3] for e in edges), (
+            "at least one plane part must carry the _INK_EDGE outline"
+        )


### PR DESCRIPTION
Applies the **DocGerdSoft** brand identity to hangarfit — Horizon accent, the CVD-safe matplotlib palette, and the abstract delta marks. Produced in Claude Design, integrated via its "Hand off to Claude Code" bundle. Source of truth: `DocGerd/brand`.

Closes #379.

## Code (the substantive change)
- **`src/hangarfit/visualize.py`** — lifted the CVD-safe (Okabe–Ito-derived) brand palette verbatim as module constants: `PLANES` (9), `PLANES_DARK` (9), `STATUS` (valid/conflict/maint/wall). Plane fill is now keyed **per aircraft** (sorted `plane_id` → `PLANES[idx % 9]`) instead of the old 3-way wing-position keying; `_CONFLICT_COLOR` and the wall/door/datum ink now source from `STATUS`; added `_INK_EDGE` (`#14161A`) so identity never rests on hue alone (ink outline + mono index label retained).
  - ⚠️ **Deliberate visual change:** rendered plane colours now differ — 9 distinct CVD-safe hues per the brand spec (handoff Deliverable 4), not the previous 3 wing-position colours. No test asserts plane fill; the full suite stays green.
- **`tests/test_visualize.py`** — new `TestBrandPalette` pinning the palette hexes and the ink-edge outline.

## Assets
- `docs/assets/` — delta `mark.svg` (Horizon `#0079B5`), `favicon.svg`, `avatar.svg`, `monogram.svg`, and a vector `banner.svg`.
- README banner reference added above the heading; License section carries "© 2026 Patrick Kuhn" and clarifies DocGerdSoft is a personal brand (not a company).

## Local checks
ruff ✓ · `ruff format --check` ✓ · mypy ✓ · `pytest` full non-hypothesis suite **1080 passed** · pre-commit hooks passed (no `--no-verify`).

## Deferred — raster (follow-ups, not code)
- Pixel-accurate README banner **PNG 1280×400** (export from Claude Design; then swap the README `<img>` from `banner.svg` → `banner.png`).
- **Social preview 1280×640** — upload via repo **Settings → Social preview**.
- Favicon/avatar raster set (PNG/ICO at 48/32 + 16px line variant).

## Known TODOs (tracked in code as `TODO(brand)`)
- Repoint the tow-path palette to the `PLANES` index, and switch the conflict overlay to the handoff's 45° `////` hatch — both deferred to avoid silently changing tests that pin the current non-colour redundancy; to be done in a deliberate test-update follow-up.

© 2026 Patrick Kuhn — DocGerdSoft is a personal brand, not a company. No ®/™.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
