### PR TITLE
docs(adr): ADR-0016 spread-vs-towability backstop + arc42/CHANGELOG (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- **Solver — back-of-hangar fill bias (#320).** The CLI now biases the spread
+  post-pass to pack planes toward the back wall (default on; `--no-back-fill`
+  disables, no effect under `--no-spread`), keeping the door-side approach
+  corridors clear so `solve --render-paths` can thread a tow path to each slot.
+  The bias is RNG-free re-ranking — same-seed output stays byte-identical.
+  Documented as the 2026-06-01 amendment to ADR-0008.
+- **Tow planner — `grid` heuristic is now the default, with a global
+  fill-budget cap (#336).** The obstacle-aware `grid` A\* heuristic (added
+  opt-in in v0.8.0) is now the default for `solve` / `plan_fill` / the CLI; a
+  deterministic global per-fill expansion budget bounds total planning work so a
+  fill never hangs (`_MAX_EXPANSIONS` raised to 8000). `--tow-heuristic
+  euclidean` opts back into the older straight-line heuristic. Documented as the
+  2026-06-01 amendment to ADR-0007.
+- **CLI `solve --render-paths` — spread-vs-towability backstop (#280).** When a
+  default (spread-on) layout is fully un-routable, the CLI now re-solves once
+  with spread disabled (reusing the same seed) and renders that tighter
+  arrangement *if it routes* — reporting the swap on stderr, in `--json`
+  (`diagnostics.spread_fallback_applied`), and as a `--write-yaml` provenance
+  comment, never silently. With the #320 placement bias in play, multi-plane
+  fills that were previously a bare exit 3 now route under default settings
+  without the backstop firing at all. New ADR-0016.
+
 ### Fixed
 
 ## [0.8.0] — 2026-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
   Documented as the 2026-06-01 amendment to ADR-0008.
 - **Tow planner — `grid` heuristic is now the default, with a global
   fill-budget cap (#336).** The obstacle-aware `grid` A\* heuristic (added
-  opt-in in v0.8.0) is now the default for `solve` / `plan_fill` / the CLI; a
-  deterministic global per-fill expansion budget bounds total planning work so a
-  fill never hangs (`_MAX_EXPANSIONS` raised to 8000). `--tow-heuristic
-  euclidean` opts back into the older straight-line heuristic. Documented as the
-  2026-06-01 amendment to ADR-0007.
+  opt-in in v0.8.0) is now the default for `solve` / `plan_fill` / the CLI; the
+  per-plane `_MAX_EXPANSIONS` is raised to 8000, and a *separate* deterministic
+  global fill cap (`_MAX_FILL_EXPANSIONS`, 16000) bounds the total expansions
+  across one fill so it never hangs. `--tow-heuristic euclidean` opts back into
+  the older straight-line heuristic. Documented as the 2026-06-01 amendment to
+  ADR-0007.
 - **CLI `solve --render-paths` — spread-vs-towability backstop (#280).** When a
   default (spread-on) layout is fully un-routable, the CLI now re-solves once
   with spread disabled (reusing the same seed) and renders that tighter

--- a/docs/adr/0016-spread-towability-fallback.md
+++ b/docs/adr/0016-spread-towability-fallback.md
@@ -36,8 +36,11 @@ placement is *not* enough.
   demonstrably exists.
 - **Never silently swap.** If the rendered arrangement is not the one a plain
   `solve` would emit, the user (and any machine consumer) must be told.
-- **Preserve the ADR-0003 determinism contract.** A given `--seed` must yield
-  the same result, including across the two-pass fallback.
+- **Preserve the ADR-0003 determinism contract.** The shared resolved seed must
+  drive both passes, so the fallback adds no nondeterminism beyond ADR-0003's
+  existing scoping — bit-identical under a `max_restarts` bound,
+  same-machine-reproducible under the wall-clock `budget_s` the CLI uses (the
+  #267 amendment).
 - **Do not couple the planner into the solver's hot loop.** The static solver
   stays collision-only; tow-routability must not become a term in the seeded
   candidate scoring (the ADR-0008 "isolate the soft logic" driver).
@@ -85,9 +88,12 @@ keeps the solver and planner decoupled — the fallback lives entirely in the CL
 
 The determinism contract holds because the seed is resolved **once**, up front
 (`resolved_seed = args.seed if args.seed is not None else secrets.randbits(32)`),
-and shared by both passes; each `solve()` call is individually deterministic for
-that seed (ADR-0003), and the fallback is a deterministic function of the first
-pass's outcome.
+and shared by both passes; each `solve()` call is as deterministic as ADR-0003
+specifies for its bound — bit-identical under a `max_restarts` bound,
+same-machine-reproducible under the wall-clock `budget_s` the CLI passes (the
+spread-OFF second pass is unconditionally reproducible per ADR-0003). The
+fallback adds no new entropy: it reuses the resolved seed and is a pure function
+of the first pass's outcome.
 
 Empirically (issue #280 acceptance probe, develop @ this ADR, seed 1, default
 grid heuristic + back-fill on): the 3-plane and 6-plane fills that were exit 3
@@ -117,9 +123,11 @@ automatic re-solve, so the path appears without a second manual invocation.
 A bigger budget is a band-aid: it does not address the geometry tension, costs
 deterministic worst-case search time on every routable plane, and the
 false-negatives persist for tight-enough corridors. (Separately, #336 *did* make
-`grid` the default heuristic and set a global fill-budget cap of 8000 — see the
-2026-06-01 amendment to [ADR-0007](0007-tow-path-planner-v1-scope.md) — but as an
-efficiency/never-hang measure, **not** as the spread-vs-towability fix.)
+`grid` the default heuristic, raise the per-plane `_MAX_EXPANSIONS` to 8000, and
+add a *separate* global fill cap `_MAX_FILL_EXPANSIONS` (16000) on the sum of
+expansions across one fill — see the 2026-06-01 amendment to
+[ADR-0007](0007-tow-path-planner-v1-scope.md) — but as efficiency/never-hang
+measures, **not** as the spread-vs-towability fix.)
 
 ### Why not a tow-aware spread axis (option 5)?
 

--- a/docs/adr/0016-spread-towability-fallback.md
+++ b/docs/adr/0016-spread-towability-fallback.md
@@ -1,0 +1,185 @@
+# ADR-0016: Spread-vs-towability — CLI re-solves spread-off as a backstop when a default-spread layout is un-routable
+
+- **Status:** Proposed
+
+- **Date:** 2026-06-02
+- **Deciders:** Patrick Kuhn (DocGerd)
+
+## Context & Problem Statement
+
+`hangarfit solve --render-paths` should produce "a valid layout **plus** a valid
+tow path for every plane". Two individually-correct, default-on features compose
+into a globally-worse default (issue [#280](https://github.com/DocGerd/hangarfit/issues/280)):
+the ADR-0008 spread post-pass *maximizes* inter-plane gaps (pushing planes toward
+walls/corners), while the bounded tow planner (ADR-0007 / ADR-0010, per-plane
+Hybrid-A\* with `towplanner._MAX_EXPANSIONS`) needs clear approach corridors from
+the door cone to each slot. Spread could push a plane into a slot whose approach
+lane the bounded search can no longer thread, so `plan_fill` returns
+`plans[i] = None`; with every candidate un-routable the CLI returns a bare exit 3
+("nothing is towable") — even though the *same* fleet and hangar route cleanly
+with `--no-spread`. The tool silently picked the *less* useful of two valid
+arrangements. This ADR records how `--render-paths` recovers a tow plan without
+making the user know to retry with `--no-spread`.
+
+This is the *backstop* half of the v0.9.0 "tow-friendly placement" work
+(Direction A). The *primary* lever is placement — the back-of-hangar fill bias
+([#320](https://github.com/DocGerd/hangarfit/issues/320), recorded as the
+2026-06-01 amendment to [ADR-0008](0008-inter-plane-spread-soft-preference.md))
+keeps the door-side approach corridors clear so the default-spread layout is
+tow-routable in the first place. This ADR covers what `--render-paths` does when
+placement is *not* enough.
+
+## Decision Drivers
+
+- **"Valid layout + valid path" is the headline UX.** A bare exit 3 reads as
+  "these planes can't be towed" when a towable arrangement of the same planes
+  demonstrably exists.
+- **Never silently swap.** If the rendered arrangement is not the one a plain
+  `solve` would emit, the user (and any machine consumer) must be told.
+- **Preserve the ADR-0003 determinism contract.** A given `--seed` must yield
+  the same result, including across the two-pass fallback.
+- **Do not couple the planner into the solver's hot loop.** The static solver
+  stays collision-only; tow-routability must not become a term in the seeded
+  candidate scoring (the ADR-0008 "isolate the soft logic" driver).
+- **Cheap in the common case.** With placement (#320) doing the heavy lifting,
+  the backstop should cost nothing when the first pass already routes.
+
+## Considered Options
+
+1. **Automatic spread-off fallback in `--render-paths` (chosen).** When a
+   default-spread layout is fully un-routable, re-solve once with `spread=False`,
+   tow-plan that, and render it instead — reporting the swap on every channel.
+2. **Towability as a soft factor in spread basin-selection.** Fold "is this
+   basin tow-routable?" into the ADR-0008 / #267 collect-then-select scoring so a
+   routable-but-tighter basin outranks an un-routable maximally-spread one.
+3. **Advisory hint only.** Keep exit 3, but emit a stderr hint telling the user
+   to retry with `--no-spread`.
+4. **Raise `_MAX_EXPANSIONS`.** Give the bounded planner more budget so it
+   threads the spread-widened corridors.
+5. **Tow-aware spread axis.** Spread only along axes that do not block the
+   door-approach corridors, so spread and towability never fight.
+
+## Decision Outcome
+
+**Chosen option: automatic spread-off fallback (option 1)**, because it restores
+the "+ valid path" guarantee fully automatically, preserves spread whenever spread
+*is* routable (the fallback only triggers on a fully un-routable first pass), and
+keeps the solver and planner decoupled — the fallback lives entirely in the CLI
+(`cmd_solve`), not the solver. Concretely:
+
+- **Trigger.** Only when `--render-paths` is set, spread was *not* explicitly
+  disabled (`args.spread` is true), the first solve returned at least one valid
+  layout, and **every** returned plan is `None`
+  (`all(plan is None for plan in result.plans)`).
+- **Action.** Re-solve once with `SearchConfig(spread=False)` and
+  `plan_paths=True`, reusing the **same resolved seed** as the spread pass.
+- **Guard.** Accept the swap **only if** the no-spread re-solve actually routes
+  at least one candidate (`any(plan is not None …)`). If it routes nothing
+  (genuinely too tight — e.g. the placeholder hangar), keep the original spread
+  result so exit 3 stands unchanged and no misleading note is printed.
+- **Report (never silent).** On a successful swap: a stderr note ("layout
+  un-routable with inter-plane spread; re-solved with spread disabled to produce
+  tow paths"), a structured `diagnostics.spread_fallback_applied: true` in
+  `--json`, and a provenance comment in any `--write-yaml` output. The rendered
+  layout is the tighter no-spread arrangement, and the user is told so.
+
+The determinism contract holds because the seed is resolved **once**, up front
+(`resolved_seed = args.seed if args.seed is not None else secrets.randbits(32)`),
+and shared by both passes; each `solve()` call is individually deterministic for
+that seed (ADR-0003), and the fallback is a deterministic function of the first
+pass's outcome.
+
+Empirically (issue #280 acceptance probe, develop @ this ADR, seed 1, default
+grid heuristic + back-fill on): the 3-plane and 6-plane fills that were exit 3
+*before* the #320 placement lever now route at **exit 0 with the fallback never
+firing** (`spread_fallback_applied=false`). So placement (#320) is what fixes the
+common case; this fallback is the backstop that keeps a stray un-routable
+spread-basin from ever reaching the user as a bare exit 3.
+
+### Why not towability as a soft factor in spread selection (option 2)?
+
+It would run `plan_fill` (a full Hybrid-A\* search) for *every* candidate basin
+inside the solver's selection loop — expensive, and it couples the tow planner
+into the static solver, violating the ADR-0008 driver that keeps the hard
+conflict loop collision-only and soft preferences isolated. The chosen fallback
+runs `plan_fill` at most twice total (once per pass), only on a fully un-routable
+first pass.
+
+### Why not an advisory hint only (option 3)?
+
+A pure hint keeps the bare exit 3 and puts the work on the user — they must know
+to retry with `--no-spread`, defeating the "valid layout + valid path" headline.
+The chosen option *adopts the hint* (the stderr note) but pairs it with the
+automatic re-solve, so the path appears without a second manual invocation.
+
+### Why not raise `_MAX_EXPANSIONS` (option 4)?
+
+A bigger budget is a band-aid: it does not address the geometry tension, costs
+deterministic worst-case search time on every routable plane, and the
+false-negatives persist for tight-enough corridors. (Separately, #336 *did* make
+`grid` the default heuristic and set a global fill-budget cap of 8000 — see the
+2026-06-01 amendment to [ADR-0007](0007-tow-path-planner-v1-scope.md) — but as an
+efficiency/never-hang measure, **not** as the spread-vs-towability fix.)
+
+### Why not a tow-aware spread axis (option 5)?
+
+It is the most principled long-term answer but the most complex: it requires the
+spread post-pass to know the door-approach geometry and constrain its descent
+directions accordingly, re-coupling the two modules. The back-fill bias (#320)
+captures most of the same benefit far more cheaply (bias planes toward the back
+wall, clearing the door side) without the spread pass needing planner knowledge.
+Left as possible future work if placement + fallback ever prove insufficient.
+
+## Consequences
+
+### Positive
+
+- `solve --render-paths` no longer emits a bare exit 3 for a fleet+hangar that is
+  towable under `--no-spread`; it routes (placement, the common case) or
+  transparently re-solves spread-off (the backstop).
+- The swap is reported on every channel (human stderr, `--json`, `--write-yaml`),
+  so neither a person nor a machine consumer is misled about which arrangement was
+  rendered.
+- Solver and planner stay decoupled; the static solver remains collision-only and
+  the ADR-0008 spread post-pass is unchanged.
+
+### Negative
+
+- Worst-case up to ~2× solve time — but **only** when the first (spread) pass is
+  fully un-routable, which the #320 placement lever makes rare.
+- The rendered layout after a swap is the *tighter* no-spread arrangement, not the
+  roomy spread one a plain `solve` (without `--render-paths`) would emit. This is
+  reported, not silent, but it does mean `--render-paths` and a plain `solve` can
+  return different layouts for the same scenario+seed.
+
+### Neutral
+
+- The fallback is CLI-only behavior; `solve()` as a library call is unchanged
+  (callers choose `spread` and `plan_paths` themselves).
+- When the no-spread re-solve also routes nothing (placeholder hangar, genuinely
+  too tight), behavior is identical to before this ADR: exit 3, original spread
+  layout kept, no note.
+
+## Compliance
+
+- **`tests/test_cli_solve.py`** — the spread-fallback test class pins: the
+  re-solve fires only on a fully un-routable spread pass; the swap is reported on
+  stderr; `--json` surfaces `spread_fallback_applied` true after a swap and false
+  otherwise; `--write-yaml` carries the provenance comment; a fallback that *also*
+  routes nothing keeps exit 3 with no misleading note; and the fallback reuses the
+  resolved seed (determinism across the two passes).
+
+## More Information
+
+- Related ADRs:
+  [ADR-0003 — RR-MC solver algorithm and determinism contract](0003-rr-mc-solver-algorithm.md);
+  [ADR-0007 — tow-path planner v1 scope](0007-tow-path-planner-v1-scope.md)
+  (2026-06-01 #336 amendment: grid default + fill-budget cap);
+  [ADR-0008 — inter-plane spread](0008-inter-plane-spread-soft-preference.md)
+  (2026-06-01 #320 amendment: back-of-hangar fill bias — the *primary* placement
+  lever this fallback backstops);
+  [ADR-0010 — Reeds–Shepp motion model](0010-reeds-shepp-motion-model.md).
+- Related issues / PRs:
+  [#280](https://github.com/DocGerd/hangarfit/issues/280) (umbrella),
+  [#320](https://github.com/DocGerd/hangarfit/issues/320) (placement lever),
+  [#336](https://github.com/DocGerd/hangarfit/issues/336) (planner efficiency).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -93,3 +93,4 @@ manual workflow above is canonical.
 | 0013 | [Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load](0013-wheels-canonical-data.md) | Accepted |
 | 0014 | [Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail](0014-merge-commit-only-history-strategy.md) | Accepted |
 | 0015 | [Wheels do not participate in the static collision model (gear stays render/motion data)](0015-wheels-not-in-collision-model.md) | Accepted |
+| 0016 | [Spread-vs-towability — CLI re-solves spread-off as a backstop when a default-spread layout is un-routable](0016-spread-towability-fallback.md) | Proposed |

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -299,7 +299,8 @@ the **empty-hangar fill** case — every plane enters once (ADR-0007).
 - **Failure is honest** — a layout it cannot route raises
   `NoFeasiblePlanError` naming the offending plane; `solve` records it
   best-effort (see the bundling bullet above), and the CLI's
-  `--render-paths` surfaces it (warning + exit code 3, [§6](06-runtime-view.md)).
+  `--render-paths` surfaces it (warning + exit code 3, [§6](06-runtime-view.md)) —
+  after first attempting the spread-off backstop ([ADR-0016](../adr/0016-spread-towability-fallback.md)).
 - **Deterministic** (no RNG): a given `Layout` always yields the same
   `MovesPlan`, preserving [ADR-0003](../adr/0003-rr-mc-solver-algorithm.md)'s
   contract through the bundle.

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -212,19 +212,17 @@ sequenceDiagram
     end
     Solver-->>CLI: SolveResult(layouts, plans, diagnostics, status, seed)
 
+    opt all plans None and spread was on (#280 backstop, ADR-0016)
+        Note over CLI: re-solve spread=False (same seed) and tow-plan<br/>swap in the tighter no-spread result iff it routes a candidate<br/>(swap reported via stderr, --json, --write-yaml)
+    end
+    Note over CLI: _warn_unroutable: stderr names each blocked plane
     loop per returned layout
         CLI->>Viz: render_layout(layout, moves_plan=plans[i])
         Note over Viz: _draw_tow_paths samples each arc<br/>(un-routable → no overlay)
         Viz->>FS: write out_i.png
     end
-    Note over CLI: _warn_unroutable: stderr names each blocked plane
-    alt no candidate routable (all plans None)
-        Note over CLI: spread backstop (#280, ADR-0016):<br/>if spread was on, re-solve spread=False (same seed) and tow-plan
-        alt re-solve routes a candidate
-            CLI->>Op: render tighter no-spread layout, exit 0<br/>(swap reported via stderr, --json, --write-yaml)
-        else still nothing routable
-            CLI->>Op: exit 3
-        end
+    alt no candidate routable (all plans None, after backstop)
+        CLI->>Op: exit 3
     else at least 1 routable
         CLI->>Op: exit 0 (or status-driven)
     end

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -153,6 +153,21 @@ Exit 3 is checked before the `--strict-k` exit-1 rule. Without
 `--render-paths` the CLI does not tow-plan, so tow-routability never
 affects the exit code.
 
+**Spread-vs-towability fallback (#280, [ADR-0016](../adr/0016-spread-towability-fallback.md)).**
+Before that exit 3 is returned, one backstop runs: if spread was *not*
+explicitly disabled and **every** plan came back un-routable, the CLI
+re-solves once with `spread=False` (reusing the same resolved seed) and,
+*only if that re-solve actually routes a candidate*, renders the tighter
+no-spread arrangement instead — reporting the swap on stderr, in
+`--json` (`diagnostics.spread_fallback_applied`), and as a `--write-yaml`
+provenance comment. If the no-spread re-solve also routes nothing
+(genuinely too tight — e.g. the placeholder hangar), the original spread
+result is kept and exit 3 stands. The *primary* reason default layouts
+are routable in the first place is the back-of-hangar fill bias
+([#320](https://github.com/DocGerd/hangarfit/issues/320), the 2026-06-01
+amendment to [ADR-0008](../adr/0008-inter-plane-spread-soft-preference.md));
+this fallback is the backstop for when placement is not enough.
+
 **No retries inside solve().** The solver does not retry on a single
 candidate's failure — it just restarts. There is no exception path
 from `check()` into the solver other than structural failure (which
@@ -204,7 +219,12 @@ sequenceDiagram
     end
     Note over CLI: _warn_unroutable: stderr names each blocked plane
     alt no candidate routable (all plans None)
-        CLI->>Op: exit 3
+        Note over CLI: spread backstop (#280, ADR-0016):<br/>if spread was on, re-solve spread=False (same seed) and tow-plan
+        alt re-solve routes a candidate
+            CLI->>Op: render tighter no-spread layout, exit 0<br/>(swap reported via stderr, --json, --write-yaml)
+        else still nothing routable
+            CLI->>Op: exit 3
+        end
     else at least 1 routable
         CLI->>Op: exit 0 (or status-driven)
     end


### PR DESCRIPTION
## What & why

Closes #280.

The v0.9.0 "tow-friendly placement" levers have all shipped on `develop`, but
the umbrella issue #280 stayed open on documentation debt. This PR closes that
debt for the placement work:

- **#320 back-fill bias** → already documented (2026-06-01 amendment to ADR-0008).
- **#336 grid-default + fill-budget cap** → already documented (2026-06-01 amendment to ADR-0007).
- **#280 CLI spread-off fallback** → **was undocumented** → this PR's new **ADR-0016**.

## Changes

| File | Change |
|---|---|
| `docs/adr/0016-spread-towability-fallback.md` | **New ADR.** The CLI re-solves `spread=False` (same seed) as a backstop when a default-spread layout is fully un-routable under `--render-paths`, renders the tighter result *only if it routes*, and reports the swap on stderr / `--json` / `--write-yaml`. 5 considered options from the #280 body, each with a "why not". |
| `docs/adr/README.md` | Index row for ADR-0016 (status **Proposed**). |
| `docs/architecture/05-building-block-view.md` | Cross-ref the fallback in the planner failure note. |
| `docs/architecture/06-runtime-view.md` | Add the fallback to the exit-3 note and the Scenario-3 sequence diagram (mermaid; no semicolons, per #371). |
| `CHANGELOG.md` | Promote `[Unreleased]` with the #320 / #336 / #280 placement entries. |

**Scope note:** the CHANGELOG here covers only the tow-friendly-placement work,
co-located with the ADR. The broader v0.9.0 sweep (brand #380, `--version` #360,
docs #373, fuzz #369) is deferred to `/release-prep`, matching the project's
backfill-at-release practice.

## Verification

- Full suite: **1134 passed, 0 failures** (slow set excluded per addopts).
- **Towability probe** (default settings — spread ON, back-fill ON, grid heuristic, 30×25 fixture):
  | fill | pre-#320 (#280 body) | now (default) |
  |---|---|---|
  | 3-plane spread ON | exit **3** | **exit 0**, fallback not needed |
  | 6-plane spread ON | exit **3** | **exit 0** at seeds 1/2/3, fallback not needed |

  The back-fill bias (#320) makes default layouts directly tow-routable; the #280
  backstop is a safety net that does not even fire on these fixtures — which is
  exactly what ADR-0016 records.

## Review

Docs-only; review arc to follow: `comment-analyzer` + `code-reviewer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)