### PR TITLE
docs(release): prep v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+### Fixed
+
+## [0.9.0] — 2026-06-02
+
+### Added
+
+- **`hangarfit --version`.** A top-level `--version` flag prints the installed
+  package version and exits (#360).
+- **DocGerdSoft "Horizon" brand identity.** Brand mark assets — avatar, banner,
+  favicon, mark, and monogram SVGs under `docs/assets/` — and a brand identity
+  note in the README (#380).
+
+### Changed
+
 - **Solver — back-of-hangar fill bias (#320).** The CLI now biases the spread
   post-pass to pack planes toward the back wall (default on; `--no-back-fill`
   disables, no effect under `--no-spread`), keeping the door-side approach
@@ -30,8 +44,17 @@ All notable changes to this project are documented here. Format follows [Keep a 
   comment, never silently. With the #320 placement bias in play, multi-plane
   fills that were previously a bare exit 3 now route under default settings
   without the backstop firing at all. New ADR-0016.
+- **Tow-path render palette retuned to the brand "Horizon" set (#380).** The
+  renderer's per-plane colours move to the DocGerdSoft `PLANES` palette (Horizon
+  `#0079B5` first), still derived from the Okabe–Ito CVD-safe set so every fill
+  keeps maximal pairwise colour-blind separation.
 
-### Fixed
+### Security
+
+- **Nightly fuzzing extended to the geometry and collision layers (#362, #369).**
+  An Atheris + Hypothesis harness now fuzzes the oriented-rect transform and the
+  pairwise collision checker on the nightly schedule, alongside the existing
+  loader fuzzing.
 
 ## [0.8.0] — 2026-05-29
 
@@ -163,7 +186,8 @@ First Phase 1 cut — substrate for arranging the flying club fleet in a stack-s
 - Apache-2.0 license, public-audience README, CI matrix (Python 3.11 + 3.12), branch protection on develop + main (#13, #14, #15, #16).
 - Strut-aware golden tests + all-9-planes fixture using larger test-only hangar to accommodate strut-bracing geometry on placeholder dimensions (#5).
 
-[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/DocGerd/hangarfit/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/DocGerd/hangarfit/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/DocGerd/hangarfit/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/DocGerd/hangarfit/compare/v0.7.0...v0.7.1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It also renders a top-down PNG so a human can sanity-check the result by eye.
 **Still explicitly out of scope:**
 
 - No tracking of hangar state across runs — each invocation is stateless.
-- No user-defined soft constraints or weighted objectives — user-supplied constraints are HARD only (pin, force_on_carts, maintenance plane). The solver does apply one built-in soft spatial preference, inter-plane spread ([ADR-0008](docs/adr/0008-inter-plane-spread-soft-preference.md), default-on, toggleable with `--no-spread`), but it never overrides a hard constraint.
+- No user-defined soft constraints or weighted objectives — user-supplied constraints are HARD only (pin, force_on_carts, maintenance plane). The solver does apply two built-in soft spatial preferences — inter-plane spread ([ADR-0008](docs/adr/0008-inter-plane-spread-soft-preference.md), default-on, toggleable with `--no-spread`) and a back-of-hangar fill bias that keeps the door-side approach corridors clear ([ADR-0008 §Amendments, #320](docs/adr/0008-inter-plane-spread-soft-preference.md), default-on, toggleable with `--no-back-fill`) — but neither ever overrides a hard constraint.
 - No GUI or web frontend.
 - No handling of late arrivals as a live event stream.
 - Multi-plane *rearrangement* (move planes around an already-occupied hangar). The tow planner only handles **empty-hangar fill** — every plane enters once. Rearrangement is planner v2+ territory.
@@ -126,7 +126,7 @@ A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which
 | 2 | Could not solve (file not found, bad YAML, invariant violation, IO error during render/write, or `--render-paths` without `--render`) |
 | 3 | `--render-paths` only: valid layout(s) found but the v1 tow planner could not route **any** of them. The layouts still render (without path overlays); each blocked layout gets a stderr warning naming the plane. Distinct from code 1 (no layout at all). |
 
-`--render-paths` overlays each plane's tow path on the `--render` PNG(s) (one colour per plane). It tow-plans every returned layout; a layout the v1 planner cannot route is rendered without paths. If **at least one** candidate is routable the exit code is 0 (un-routable ones still warn); code 3 fires only when none are routable.
+`--render-paths` overlays each plane's tow path on the `--render` PNG(s) (one colour per plane). It tow-plans every returned layout; a layout the planner cannot route is rendered without paths. If **at least one** candidate is routable the exit code is 0 (un-routable ones still warn); code 3 fires only when none are routable. Under default settings, if a spread layout is fully un-routable the CLI first re-solves with spread disabled and renders that tighter arrangement instead (reported on stderr and in `--json`), preferring a towable layout before code 3 is returned ([ADR-0016](docs/adr/0016-spread-towability-fallback.md)).
 
 ### JSON schemas
 


### PR DESCRIPTION
## Release prep for v0.9.0

Promotes the CHANGELOG `[Unreleased]` block to `## [0.9.0] — 2026-06-02` and refreshes stale docs ahead of the release cut, so the doc work gets a focused review surface separate from the release-state PR.

### CHANGELOG
`[Unreleased]` → `[0.9.0] — 2026-06-02`, compare links retargeted (`v0.9.0...HEAD` + `v0.8.0...v0.9.0`), fresh empty `[Unreleased]`. The placement entries (#320/#336/#280) were already present from PR #382; this PR **backfills** the rest of the v0.9.0 user-facing work that had not been recorded as it landed (maintainer-chosen **Core + Security** scope):

- **Added:** `hangarfit --version` (#360); DocGerdSoft "Horizon" brand identity assets + README note (#380).
- **Changed:** tow-path render palette retuned to the brand `PLANES` set, still Okabe–Ito CVD-safe (#380).
- **Security:** nightly fuzzing extended to the geometry + collision layers (#362, #369).

Pure-docs/internal-refactor churn (#357, #364, #371-docs, etc.) intentionally omitted per Keep-a-Changelog convention.

### Doc-freshness audit
- **README.md** — fixed two stale items: the "soft spatial preference" list now names the back-fill bias (#320, `--no-back-fill`) beside spread; the `--render-paths` exit-code note now covers the #280 spread-off backstop (links ADR-0016).
- **SECURITY.md / CLAUDE.md / docs/architecture/** — audited, already current (no edits).

After this PR merges into `develop`, run `/release-cut version=0.9.0` to create the release branch and PRs.