### PR TITLE
release: v0.9.0

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -22,7 +22,7 @@ The project pins a single supported interpreter, **Python 3.12** ([ADR-0009](../
 The `hooks/session-start.sh` script bridges that gap. On session start it:
 
 1. **no-ops outside the remote env** (`$CLAUDE_CODE_REMOTE != "true"`) — local 3.12 developers manage their own environment and are never touched — and no-ops when `HANGARFIT_SKIP_SESSIONSTART_HOOK` is set;
-2. creates (once) a 3.12 venv at `.venv312/` from `/usr/bin/python3.12` and installs the project + dev extras into it (idempotent — cheap to re-run, and the container caches the result);
+2. creates (once) a 3.12 venv at `.venv312/` from `python3.12` (resolved on `PATH`) and installs the project + dev extras into it. The install is skipped on `resume`/`clear`/`compact` once the venv exists, so only a fresh `startup` (or a missing venv) pays for it;
 3. prepends the venv's `bin/` to `PATH` (and sets `VIRTUAL_ENV`) via **`$CLAUDE_ENV_FILE`**, which Claude Code sources into every subsequent command. This is the key step: a hook runs in a subshell, so `source .venv312/bin/activate` would *not* survive to later tool calls — writing to `$CLAUDE_ENV_FILE` makes `python`, `pytest`, `ruff`, and `mypy` all resolve to the 3.12 venv for the rest of the session.
 
 It is **non-blocking**: a missing `python3.12` or a failed `pip install` is reported to stderr and the session still starts (exit `0`). It runs **synchronously** — the session waits until provisioning finishes, trading a slower start for the guarantee that the toolchain is ready before Claude runs anything. (It can be switched to async mode if faster startup is preferred.) Unlike the other three hooks it lives in a **script file** rather than an inline command, because the provisioning logic is too long to read inline.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -6,13 +6,26 @@ This directory holds **team-shared** [Claude Code](https://docs.claude.com/en/do
 
 | File | Status | Purpose |
 |---|---|---|
-| `settings.json` | committed | Team defaults — a `PreToolUse` guard that blocks hand-edits to the hash-pinned `requirements-*.txt` lockfiles, a `PostToolUse` hook that runs `ruff` + `pytest` after edits under `src/hangarfit/` or `tests/`, plus a `Stop` hook that runs `mypy` once when a turn finishes. |
+| `settings.json` | committed | Team defaults — a `SessionStart` hook that provisions Python 3.12 in web/remote sessions, a `PreToolUse` guard that blocks hand-edits to the hash-pinned `requirements-*.txt` lockfiles, a `PostToolUse` hook that runs `ruff` + `pytest` after edits under `src/hangarfit/` or `tests/`, plus a `Stop` hook that runs `mypy` once when a turn finishes. |
+| `hooks/session-start.sh` | committed | The `SessionStart` provisioner script (the one hook complex enough to warrant a file rather than an inline command). |
 | `settings.local.json` | **gitignored** | Optional per-contributor override (see below). |
 | `README.md` | committed | This file. |
 
 ## The hooks
 
-`settings.json` registers three hooks, all shared with every contributor on clone: two fire on the `Edit` and `Write` tools, and one fires when a turn finishes (`Stop`).
+`settings.json` registers four hooks, all shared with every contributor on clone: one fires when a session starts (`SessionStart`), two fire on the `Edit` and `Write` tools, and one fires when a turn finishes (`Stop`).
+
+### SessionStart — Python 3.12 provisioner (non-blocking, web/remote only)
+
+The project pins a single supported interpreter, **Python 3.12** ([ADR-0009](../docs/adr/0009-single-supported-python-version.md)). In the Claude Code **on-the-web / remote** container the default `python`/`python3` is 3.11, so a bare `pip install -e ".[dev]"` fails the `requires-python = ">=3.12"` gate — and the `PostToolUse` (ruff + pytest) and `Stop` (mypy) hooks below, which call those tools by bare name, can't run.
+
+The `hooks/session-start.sh` script bridges that gap. On session start it:
+
+1. **no-ops outside the remote env** (`$CLAUDE_CODE_REMOTE != "true"`) — local 3.12 developers manage their own environment and are never touched — and no-ops when `HANGARFIT_SKIP_SESSIONSTART_HOOK` is set;
+2. creates (once) a 3.12 venv at `.venv312/` from `/usr/bin/python3.12` and installs the project + dev extras into it (idempotent — cheap to re-run, and the container caches the result);
+3. prepends the venv's `bin/` to `PATH` (and sets `VIRTUAL_ENV`) via **`$CLAUDE_ENV_FILE`**, which Claude Code sources into every subsequent command. This is the key step: a hook runs in a subshell, so `source .venv312/bin/activate` would *not* survive to later tool calls — writing to `$CLAUDE_ENV_FILE` makes `python`, `pytest`, `ruff`, and `mypy` all resolve to the 3.12 venv for the rest of the session.
+
+It is **non-blocking**: a missing `python3.12` or a failed `pip install` is reported to stderr and the session still starts (exit `0`). It runs **synchronously** — the session waits until provisioning finishes, trading a slower start for the guarantee that the toolchain is ready before Claude runs anything. (It can be switched to async mode if faster startup is preferred.) Unlike the other three hooks it lives in a **script file** rather than an inline command, because the provisioning logic is too long to read inline.
 
 ### PreToolUse — lockfile guard (blocking)
 
@@ -35,10 +48,11 @@ When a turn finishes, this hook runs `mypy src/hangarfit` once and shows the tai
 
 ## Opting out (per contributor)
 
-Set the env var `HANGARFIT_SKIP_PYTEST_HOOK=1` in your shell init (`~/.bashrc`, `~/.zshrc`, etc.). The **PostToolUse** ruff + pytest hook detects this and exits immediately. The **Stop** mypy hook honours a separate `HANGARFIT_SKIP_MYPY_HOOK=1` so the two can be disabled independently. Unset (or restart your shell) to re-enable. The PreToolUse lockfile guard is intentionally **not** opt-out-able — it is a cheap safety rail and the legitimate regeneration path (`pip-compile` via Bash) is never blocked anyway.
+Set the env var `HANGARFIT_SKIP_PYTEST_HOOK=1` in your shell init (`~/.bashrc`, `~/.zshrc`, etc.). The **PostToolUse** ruff + pytest hook detects this and exits immediately. The **Stop** mypy hook honours a separate `HANGARFIT_SKIP_MYPY_HOOK=1`, and the **SessionStart** provisioner honours `HANGARFIT_SKIP_SESSIONSTART_HOOK=1`, so all three can be disabled independently (the SessionStart hook also already no-ops entirely outside the web/remote env). Unset (or restart your shell) to re-enable. The PreToolUse lockfile guard is intentionally **not** opt-out-able — it is a cheap safety rail and the legitimate regeneration path (`pip-compile` via Bash) is never blocked anyway.
 
 ```bash
 # ~/.bashrc or ~/.zshrc
+export HANGARFIT_SKIP_SESSIONSTART_HOOK=1
 export HANGARFIT_SKIP_PYTEST_HOOK=1
 export HANGARFIT_SKIP_MYPY_HOOK=1
 ```

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SessionStart hook — provision Python 3.12 for Claude Code web/remote sessions.
+#
+# Why this exists (#354): the project pins `requires-python = ">=3.12"`
+# (ADR-0009), but the Claude Code on-the-web container's default
+# `python`/`python3` is 3.11. A naive `pip install -e ".[dev]"` therefore
+# fails the version gate, and the team-shared PostToolUse (ruff+pytest) and
+# Stop (mypy) hooks — which call those tools by bare name — can't run.
+#
+# This hook builds (once) a 3.12 venv at `.venv312/`, installs the dev
+# extras into it, and — crucially — prepends the venv's `bin/` to `PATH`
+# via `$CLAUDE_ENV_FILE`. A hook runs in a subshell, so `source activate`
+# would not survive to later tool calls; `$CLAUDE_ENV_FILE` is sourced by
+# Claude Code into every subsequent command, so `python`, `pytest`, `ruff`,
+# and `mypy` all then resolve to the 3.12 venv for the rest of the session.
+#
+# It is idempotent (safe to re-run), non-interactive, and a no-op outside the
+# remote environment or when `HANGARFIT_SKIP_SESSIONSTART_HOOK` is set.
+set -euo pipefail
+
+# stdin carries the SessionStart JSON payload; we don't need it. Drain it so a
+# closed pipe never wedges the hook.
+cat >/dev/null 2>&1 || true
+
+# Per-contributor opt-out, matching the HANGARFIT_SKIP_* pattern of the other
+# hooks (see .claude/README.md).
+if [ -n "${HANGARFIT_SKIP_SESSIONSTART_HOOK:-}" ]; then
+  exit 0
+fi
+
+# Only needed in the web/remote container. Local 3.12 developers manage their
+# own environment; running here would risk clobbering it.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-.}"
+
+PY312="$(command -v python3.12 || true)"
+if [ -z "$PY312" ]; then
+  echo "[hangarfit session-start] python3.12 not found on PATH; cannot provision the" \
+    "3.12 venv this project requires (ADR-0009). Tests/linters may not run." >&2
+  exit 0
+fi
+
+VENV=".venv312"
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "[hangarfit session-start] creating $VENV with $PY312"
+  "$PY312" -m venv "$VENV"
+fi
+
+# Editable install of the project + dev extras. Cheap to re-run when already
+# satisfied, and the container caches the result after the hook completes.
+# Non-fatal: a transient failure should not wedge session start — the error is
+# surfaced and the session continues.
+"$VENV/bin/python" -m pip install --quiet --upgrade pip || true
+if ! "$VENV/bin/python" -m pip install --quiet -e ".[dev]"; then
+  echo "[hangarfit session-start] 'pip install -e .[dev]' failed; the 3.12 env may be" \
+    "incomplete (check network / logs above)." >&2
+  exit 0
+fi
+
+# Persist the interpreter choice for the whole session (see header note).
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo "export VIRTUAL_ENV=\"$PWD/$VENV\""
+    echo "export PATH=\"$PWD/$VENV/bin:\$PATH\""
+  } >>"$CLAUDE_ENV_FILE"
+fi
+
+echo "[hangarfit session-start] Python 3.12 venv ready at $VENV ($("$VENV/bin/python" -V))"
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -14,13 +14,20 @@
 # Claude Code into every subsequent command, so `python`, `pytest`, `ruff`,
 # and `mypy` all then resolve to the 3.12 venv for the rest of the session.
 #
-# It is idempotent (safe to re-run), non-interactive, and a no-op outside the
-# remote environment or when `HANGARFIT_SKIP_SESSIONSTART_HOOK` is set.
+# SessionStart fires on startup AND resume/clear/compact. The work here is
+# made idempotent across all of those: the venv is created once, the env-file
+# export is written once (guarded against duplicate appends that would bloat
+# PATH), and the expensive `pip install` is skipped on non-startup sources
+# when the venv already exists.
+#
+# Non-interactive, and a no-op outside the remote environment or when
+# `HANGARFIT_SKIP_SESSIONSTART_HOOK` is set.
 set -euo pipefail
 
-# stdin carries the SessionStart JSON payload; we don't need it. Drain it so a
-# closed pipe never wedges the hook.
-cat >/dev/null 2>&1 || true
+# stdin carries the SessionStart JSON payload. Capture it (rather than
+# discarding) so we can read `.source` (startup|resume|clear|compact) below.
+# `|| true` neutralizes a closed-pipe nonzero under `set -e`.
+PAYLOAD="$(cat 2>/dev/null || true)"
 
 # Per-contributor opt-out, matching the HANGARFIT_SKIP_* pattern of the other
 # hooks (see .claude/README.md).
@@ -34,8 +41,15 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-cd "${CLAUDE_PROJECT_DIR:-.}"
+# Guarded so a missing/unreadable project dir can't trip `set -e` — this hook
+# advertises itself as strictly non-blocking (always exit 0).
+cd "${CLAUDE_PROJECT_DIR:-.}" || {
+  echo "[hangarfit session-start] cannot cd to project dir; skipping." >&2
+  exit 0
+}
 
+# Resolve the interpreter via PATH (more robust than a hardcoded /usr/bin path:
+# tolerates /usr/local, a pyenv shim, etc.).
 PY312="$(command -v python3.12 || true)"
 if [ -z "$PY312" ]; then
   echo "[hangarfit session-start] python3.12 not found on PATH; cannot provision the" \
@@ -44,24 +58,37 @@ if [ -z "$PY312" ]; then
 fi
 
 VENV=".venv312"
+venv_existed=true
 if [ ! -x "$VENV/bin/python" ]; then
+  venv_existed=false
   echo "[hangarfit session-start] creating $VENV with $PY312"
   "$PY312" -m venv "$VENV"
 fi
 
-# Editable install of the project + dev extras. Cheap to re-run when already
-# satisfied, and the container caches the result after the hook completes.
-# Non-fatal: a transient failure should not wedge session start — the error is
-# surfaced and the session continues.
-"$VENV/bin/python" -m pip install --quiet --upgrade pip || true
-if ! "$VENV/bin/python" -m pip install --quiet -e ".[dev]"; then
-  echo "[hangarfit session-start] 'pip install -e .[dev]' failed; the 3.12 env may be" \
-    "incomplete (check network / logs above)." >&2
-  exit 0
+# Re-installing the dev extras on every resume/clear/compact adds latency for
+# no benefit once the env is built. Run the install on a fresh `startup`, or
+# whenever the venv had to be (re)created; otherwise skip it.
+source_field="$(printf '%s' "$PAYLOAD" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("source",""))' 2>/dev/null || true)"
+if [ "$source_field" = "startup" ] || [ "$venv_existed" = false ]; then
+  # Editable install of the project + dev extras. Deliberately NOT
+  # `--require-hashes` against requirements-dev.txt: this is a dev-convenience
+  # provisioner whose only job is a working ruff/pytest/mypy toolchain, and an
+  # unpinned resolve from pyproject.toml can't fail on lockfile skew. Do not
+  # "fix" it to the hash-pinned CI path. Non-fatal: a transient failure should
+  # not wedge session start — the error is surfaced and the session continues.
+  "$VENV/bin/python" -m pip install --quiet --upgrade pip || true
+  if ! "$VENV/bin/python" -m pip install --quiet -e ".[dev]"; then
+    echo "[hangarfit session-start] 'pip install -e .[dev]' failed; the 3.12 env may be" \
+      "incomplete (check network / logs above)." >&2
+    exit 0
+  fi
 fi
 
 # Persist the interpreter choice for the whole session (see header note).
-if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+# Append-once: SessionStart can fire repeatedly into the same env file, and an
+# unguarded `>>` would stack duplicate `export PATH=...` lines and bloat PATH.
+if [ -n "${CLAUDE_ENV_FILE:-}" ] && ! grep -qF "$PWD/$VENV/bin" "$CLAUDE_ENV_FILE" 2>/dev/null; then
   {
     echo "export VIRTUAL_ENV=\"$PWD/$VENV\""
     echo "export PATH=\"$PWD/$VENV/bin:\$PATH\""

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -14,12 +14,12 @@ concurrency:
 
 jobs:
   fuzz:
-    name: Fuzz YAML loader
+    name: Fuzz YAML loader + geometry/collisions
     runs-on: ubuntu-latest
-    # The Atheris step is time-boxed to 300s and the Hypothesis deep run is
-    # ~100s; this ceiling fails a stuck nightly fast instead of riding the
-    # 6h default job timeout.
-    timeout-minutes: 15
+    # Two Atheris steps (loader + geometry/collisions) are each time-boxed to
+    # 300s and the Hypothesis deep run is ~100s; this ceiling fails a stuck
+    # nightly fast instead of riding the 6h default job timeout.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -51,3 +51,6 @@ jobs:
 
       - name: Atheris coverage-guided run (time-boxed)
         run: python -m tests.fuzz.atheris_loader_harness -max_total_time=300
+
+      - name: Atheris geometry/collisions run (time-boxed)
+        run: python -m tests.fuzz.atheris_geometry_harness -max_total_time=300

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ dist/
 
 # Virtual environments
 .venv/
+# The SessionStart hook (.claude/hooks/session-start.sh, #354) provisions a
+# 3.12 venv at this exact path on web/remote sessions — keep it untracked.
+.venv312/
 venv/
 env/
 ENV/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- **Solver — back-of-hangar fill bias (#320).** The CLI now biases the spread
+  post-pass to pack planes toward the back wall (default on; `--no-back-fill`
+  disables, no effect under `--no-spread`), keeping the door-side approach
+  corridors clear so `solve --render-paths` can thread a tow path to each slot.
+  The bias is RNG-free re-ranking — same-seed output stays byte-identical.
+  Documented as the 2026-06-01 amendment to ADR-0008.
+- **Tow planner — `grid` heuristic is now the default, with a global
+  fill-budget cap (#336).** The obstacle-aware `grid` A\* heuristic (added
+  opt-in in v0.8.0) is now the default for `solve` / `plan_fill` / the CLI; a
+  deterministic global per-fill expansion budget bounds total planning work so a
+  fill never hangs (`_MAX_EXPANSIONS` raised to 8000). `--tow-heuristic
+  euclidean` opts back into the older straight-line heuristic. Documented as the
+  2026-06-01 amendment to ADR-0007.
+- **CLI `solve --render-paths` — spread-vs-towability backstop (#280).** When a
+  default (spread-on) layout is fully un-routable, the CLI now re-solves once
+  with spread disabled (reusing the same seed) and renders that tighter
+  arrangement *if it routes* — reporting the swap on stderr, in `--json`
+  (`diagnostics.spread_fallback_applied`), and as a `--write-yaml` provenance
+  comment, never silently. With the #320 placement bias in play, multi-plane
+  fills that were previously a bare exit 3 now route under default settings
+  without the backstop firing at all. New ADR-0016.
+
 ### Fixed
 
 ## [0.8.0] — 2026-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
   Documented as the 2026-06-01 amendment to ADR-0008.
 - **Tow planner — `grid` heuristic is now the default, with a global
   fill-budget cap (#336).** The obstacle-aware `grid` A\* heuristic (added
-  opt-in in v0.8.0) is now the default for `solve` / `plan_fill` / the CLI; a
-  deterministic global per-fill expansion budget bounds total planning work so a
-  fill never hangs (`_MAX_EXPANSIONS` raised to 8000). `--tow-heuristic
-  euclidean` opts back into the older straight-line heuristic. Documented as the
-  2026-06-01 amendment to ADR-0007.
+  opt-in in v0.8.0) is now the default for `solve` / `plan_fill` / the CLI; the
+  per-plane `_MAX_EXPANSIONS` is raised to 8000, and a *separate* deterministic
+  global fill cap (`_MAX_FILL_EXPANSIONS`, 16000) bounds the total expansions
+  across one fill so it never hangs. `--tow-heuristic euclidean` opts back into
+  the older straight-line heuristic. Documented as the 2026-06-01 amendment to
+  ADR-0007.
 - **CLI `solve --render-paths` — spread-vs-towability backstop (#280).** When a
   default (spread-on) layout is fully un-routable, the CLI now re-solves once
   with spread disabled (reusing the same seed) and renders that tighter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+### Fixed
+
+## [0.9.0] — 2026-06-02
+
+### Added
+
+- **`hangarfit --version`.** A top-level `--version` flag prints the installed
+  package version and exits (#360).
+- **DocGerdSoft "Horizon" brand identity.** Brand mark assets — avatar, banner,
+  favicon, mark, and monogram SVGs under `docs/assets/` — and a brand identity
+  note in the README (#380).
+
+### Changed
+
 - **Solver — back-of-hangar fill bias (#320).** The CLI now biases the spread
   post-pass to pack planes toward the back wall (default on; `--no-back-fill`
   disables, no effect under `--no-spread`), keeping the door-side approach
@@ -30,8 +44,17 @@ All notable changes to this project are documented here. Format follows [Keep a 
   comment, never silently. With the #320 placement bias in play, multi-plane
   fills that were previously a bare exit 3 now route under default settings
   without the backstop firing at all. New ADR-0016.
+- **Tow-path render palette retuned to the brand "Horizon" set (#380).** The
+  renderer's per-plane colours move to the DocGerdSoft `PLANES` palette (Horizon
+  `#0079B5` first), still derived from the Okabe–Ito CVD-safe set so every fill
+  keeps maximal pairwise colour-blind separation.
 
-### Fixed
+### Security
+
+- **Nightly fuzzing extended to the geometry and collision layers (#362, #369).**
+  An Atheris + Hypothesis harness now fuzzes the oriented-rect transform and the
+  pairwise collision checker on the nightly schedule, alongside the existing
+  loader fuzzing.
 
 ## [0.8.0] — 2026-05-29
 
@@ -163,7 +186,8 @@ First Phase 1 cut — substrate for arranging the flying club fleet in a stack-s
 - Apache-2.0 license, public-audience README, CI matrix (Python 3.11 + 3.12), branch protection on develop + main (#13, #14, #15, #16).
 - Strut-aware golden tests + all-9-planes fixture using larger test-only hangar to accommodate strut-bracing geometry on placeholder dimensions (#5).
 
-[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/DocGerd/hangarfit/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/DocGerd/hangarfit/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/DocGerd/hangarfit/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/DocGerd/hangarfit/compare/v0.7.0...v0.7.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ If you find yourself about to write a domain assertion in this file, **don't** �
 | `release/<version>` | Cut from `develop`, PR'd into both `main` and `develop`. Use `/release-cut version=X.Y.Z` to automate this. | No, only via PR |
 | `hotfix/<slug>` | Only if needed; off `main`. | No, only via PR |
 
+The rationale for this merge-commit model — squash feature merges, accept release merge commits, and **never enable `required_linear_history`** (it breaks the release-branch double-merge) — is captured in [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md) *(Proposed; not yet ratified)*.
+
 ### Per-PR process
 
 1. Branch `feature/<slug>` off `develop`. Work, commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ If you find yourself about to write a domain assertion in this file, **don't** �
 | `release/<version>` | Cut from `develop`, PR'd into both `main` and `develop`. Use `/release-cut version=X.Y.Z` to automate this. | No, only via PR |
 | `hotfix/<slug>` | Only if needed; off `main`. | No, only via PR |
 
-`required_linear_history` must **never** be enabled — it blocks GitFlow's release flow, which merges each `release/*` into both `main` and `develop`. Feature PRs land as merge commits too (squash/rebase merging is disabled repo-wide). The trade-off is analyzed in [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md) *(Proposed — its squash-feature-merge premise is under reconciliation in #344)*.
+`required_linear_history` must **never** be enabled — it blocks GitFlow's release flow, which merges each `release/*` into both `main` and `develop`. Feature PRs land as merge commits too (squash/rebase merging is disabled repo-wide as a release-safety guardrail). The strategy is recorded in [ADR-0014](docs/adr/0014-merge-commit-only-history-strategy.md), superseding the never-adopted [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md).
 
 ### Per-PR process
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ If you find yourself about to write a domain assertion in this file, **don't** �
 | `release/<version>` | Cut from `develop`, PR'd into both `main` and `develop`. Use `/release-cut version=X.Y.Z` to automate this. | No, only via PR |
 | `hotfix/<slug>` | Only if needed; off `main`. | No, only via PR |
 
-The rationale for this merge-commit model — squash feature merges, accept release merge commits, and **never enable `required_linear_history`** (it breaks the release-branch double-merge) — is captured in [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md) *(Proposed; not yet ratified)*.
+`required_linear_history` must **never** be enabled — it blocks GitFlow's release flow, which merges each `release/*` into both `main` and `develop`. Feature PRs land as merge commits too (squash/rebase merging is disabled repo-wide). The trade-off is analyzed in [ADR-0011](docs/adr/0011-linear-history-strategy-under-gitflow.md) *(Proposed — its squash-feature-merge premise is under reconciliation in #344)*.
 
 ### Per-PR process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,13 @@
 
 Welcome, and thanks for looking at the code. `hangarfit` is a small, focused
 tool — a collision checker for a flying club's hangar parking arrangements —
-maintained by [DocGerd](https://github.com/DocGerd). The full design context,
-coordinate conventions, and project philosophy live in [`CLAUDE.md`](CLAUDE.md).
-Read that before touching anything geometric; it will save you a round-trip on
-review.
+maintained by [DocGerd](https://github.com/DocGerd). The architectural canon —
+the coordinate convention, the parts-based collision model, and the decisions
+that shaped the substrate — lives in [`docs/architecture/`](docs/architecture/)
+(arc42) and [`docs/adr/`](docs/adr/); [`CLAUDE.md`](CLAUDE.md) is the
+*operational* guide (how we work: GitFlow, review, project-local config). Read
+[§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md) before
+touching anything geometric; it will save you a round-trip on review.
 
 ---
 
@@ -149,12 +152,19 @@ and it bypasses the maintainer's final check.
 
 ## Where the design lives
 
-- [`CLAUDE.md`](CLAUDE.md) — the full spec: fleet details, the parts-based
-  collision rule, the coordinate convention (including the non-obvious
-  heading transform), and the Phase 1 deliverables list.
-- [`README.md`](README.md) — quick-start, usage examples, and a pointer back
-  to `CLAUDE.md` for depth.
+- [`docs/architecture/`](docs/architecture/) — the arc42 architecture set: the
+  module map (§5), the runtime flows (§6), and the domain canon (§8: the parts
+  model, the coordinate convention, the maintenance-bay rule, the motion model).
+- [`docs/adr/`](docs/adr/) — the architecture decision records: *why* each
+  load-bearing choice was made and what alternatives were rejected (e.g.
+  [ADR-0001](docs/adr/0001-aircraft-parts-model.md) the parts model,
+  [ADR-0002](docs/adr/0002-determinant-minus-one-transform.md) the transform).
+- [`CLAUDE.md`](CLAUDE.md) — the *operational* guide: how we work together
+  (GitFlow, the PR-review process, project-local config). Not the design canon.
+- [`README.md`](README.md) — quick-start, usage examples, exit-code tables.
 
-If something in the codebase seems strange — especially around geometry — check
-`CLAUDE.md` first. The coordinate transform in particular has a non-obvious
-determinant-−1 property that is documented there and tested in the golden suite.
+If something in the codebase seems strange — especially around geometry — read
+[§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md) and
+[ADR-0002](docs/adr/0002-determinant-minus-one-transform.md) first. The
+coordinate transform in particular has a non-obvious determinant-−1 property
+documented there and tested in the golden suite.

--- a/README.md
+++ b/README.md
@@ -169,5 +169,4 @@ Licensed under the [Apache License 2.0](LICENSE).
 
 (C) 2026 Patrick Kuhn. The brand identity (the Horizon-blue accent, the abstract
 delta mark, and the assets under [`docs/assets/`](docs/assets/)) is part of the
-DocGerdSoft design system. DocGerdSoft is a personal brand of Patrick Kuhn, not a
-company.
+DocGerdSoft design system. DocGerdSoft is a personal brand of Patrick Kuhn.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![hangarfit](docs/assets/banner.svg)
+
 # hangarfit
 
 [![CI](https://github.com/DocGerd/hangarfit/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/DocGerd/hangarfit/actions/workflows/ci.yml)
@@ -164,3 +166,8 @@ Architecture lives in [`docs/architecture/`](docs/architecture/) and [`docs/adr/
 ## License
 
 Licensed under the [Apache License 2.0](LICENSE).
+
+(C) 2026 Patrick Kuhn. The brand identity (the Horizon-blue accent, the abstract
+delta mark, and the assets under [`docs/assets/`](docs/assets/)) is part of the
+DocGerdSoft design system. DocGerdSoft is a personal brand of Patrick Kuhn, not a
+company.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It also renders a top-down PNG so a human can sanity-check the result by eye.
 **Still explicitly out of scope:**
 
 - No tracking of hangar state across runs — each invocation is stateless.
-- No user-defined soft constraints or weighted objectives — user-supplied constraints are HARD only (pin, force_on_carts, maintenance plane). The solver does apply one built-in soft spatial preference, inter-plane spread ([ADR-0008](docs/adr/0008-inter-plane-spread-soft-preference.md), default-on, toggleable with `--no-spread`), but it never overrides a hard constraint.
+- No user-defined soft constraints or weighted objectives — user-supplied constraints are HARD only (pin, force_on_carts, maintenance plane). The solver does apply two built-in soft spatial preferences — inter-plane spread ([ADR-0008](docs/adr/0008-inter-plane-spread-soft-preference.md), default-on, toggleable with `--no-spread`) and a back-of-hangar fill bias that keeps the door-side approach corridors clear ([ADR-0008 §Amendments, #320](docs/adr/0008-inter-plane-spread-soft-preference.md), default-on, toggleable with `--no-back-fill`) — but neither ever overrides a hard constraint.
 - No GUI or web frontend.
 - No handling of late arrivals as a live event stream.
 - Multi-plane *rearrangement* (move planes around an already-occupied hangar). The tow planner only handles **empty-hangar fill** — every plane enters once. Rearrangement is planner v2+ territory.
@@ -126,7 +126,7 @@ A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which
 | 2 | Could not solve (file not found, bad YAML, invariant violation, IO error during render/write, or `--render-paths` without `--render`) |
 | 3 | `--render-paths` only: valid layout(s) found but the v1 tow planner could not route **any** of them. The layouts still render (without path overlays); each blocked layout gets a stderr warning naming the plane. Distinct from code 1 (no layout at all). |
 
-`--render-paths` overlays each plane's tow path on the `--render` PNG(s) (one colour per plane). It tow-plans every returned layout; a layout the v1 planner cannot route is rendered without paths. If **at least one** candidate is routable the exit code is 0 (un-routable ones still warn); code 3 fires only when none are routable.
+`--render-paths` overlays each plane's tow path on the `--render` PNG(s) (one colour per plane). It tow-plans every returned layout; a layout the planner cannot route is rendered without paths. If **at least one** candidate is routable the exit code is 0 (un-routable ones still warn); code 3 fires only when none are routable. Under default settings, if a spread layout is fully un-routable the CLI first re-solves with spread disabled and renders that tighter arrangement instead (reported on stderr and in `--json`), preferring a towable layout before code 3 is returned ([ADR-0016](docs/adr/0016-spread-towability-fallback.md)).
 
 ### JSON schemas
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ This installs the package in editable mode along with the test dependencies (`py
 # Install from a checkout (add "[dev]" if you will run the tests)
 pip install -e .
 
+# Print the version and exit
+hangarfit --version
+
 # Check a hand-authored layout
 hangarfit check layouts/example.yaml
 ```

--- a/data/fleet.yaml
+++ b/data/fleet.yaml
@@ -32,7 +32,7 @@
 #   loader does not split; an aircraft with a `fuselage` part needs a `wing`
 #   part to derive the break.)
 # - turn_radius_m: own-gear minimum taxi turn radius (m). LOAD-BEARING since
-#   Phase 3a — consumed by the `towplanner` module's Dubins / Hybrid-A*
+#   Phase 3a — consumed by the `towplanner` module's Reeds–Shepp / Hybrid-A*
 #   path planning (it was an unused placeholder through Phase 1/2a). `null`
 #   on always_cart planes: they have no own-gear taxi radius, so the
 #   towplanner substitutes 0 (pivot-in-place on the cart) via

--- a/docs/adr/0007-tow-path-planner-v1-scope.md
+++ b/docs/adr/0007-tow-path-planner-v1-scope.md
@@ -267,6 +267,36 @@ per-layout *count* is exactly the right invariant. The alternative *tug* reading
 and is explicitly **not** adopted here; it would warrant its own ADR. Full
 reasoning: the [cart-inventory design doc](../superpowers/specs/2026-05-27-cart-inventory-design.md).
 
+### 2026-06-01 — grid heuristic default + global fill-budget cap (#336)
+
+The planner originally defaulted to a straight-line (euclidean) Hybrid-A\*
+heuristic with a per-plane expansion budget (`_MAX_EXPANSIONS`); the #332 spike
+exposed `grid` (obstacle-aware) as an opt-in seam. A spike-first go/no-go on the
+deferred RRT-Connect fallback (also #336) found the standard fixtures are all
+*feasible* — Hybrid-A\* routes them given budget — so **RRT-Connect was retired as
+unjustified**, and the cheap planner levers that dig surfaced were adopted:
+
+- **`grid` is now the default heuristic** for `plan_fill` / `solve` / the CLI
+  (`plan_path`'s primitive default stays `euclidean`; callers choose). Euclidean
+  ignores walls and floods the frontier in tight quarters (`aviat_husky`: ~13.5k
+  expansions); the obstacle-aware grid geodesic threads the same maneuver in
+  ~6062. Pass `--tow-heuristic euclidean` to opt out.
+- **Per-plane `_MAX_EXPANSIONS` raised 2000 → 8000** — the budget grid needs to
+  route the tight-but-feasible cases (the earlier "infeasible even at 4000" note
+  was a euclidean-heuristic artifact, not geometry).
+- **New deterministic global fill cap `_MAX_FILL_EXPANSIONS` (16000)** on the sum
+  of expansions across every `plan_path` call in a fill. A high per-plane budget
+  is needed to *route* tight planes but makes an un-routable fill expensive to
+  *disprove* (~per-plane × greedy-scan-retries); the cap bounds that worst case
+  (the default `spread=True` six-plane fill: ~997 s uncapped → ~334 s capped,
+  under the 400 s perf gate). Overridable via `plan_fill(max_total_expansions=)`.
+
+All RNG-free, so the ADR-0003 determinism contract is preserved (same scenario +
+seed → bit-identical `MovesPlan`). Multi-plane *fill* routability is dominated by
+placement, not the planner — the spread-vs-towability tension is tracked
+separately under [#280](https://github.com/DocGerd/hangarfit/issues/280)
+(back-fill [#320](https://github.com/DocGerd/hangarfit/issues/320)).
+
 ## More Information
 
 - Related spike: [Tow-path planning (#180)](../spikes/tow-path-planning.md) — the

--- a/docs/adr/0008-inter-plane-spread-soft-preference.md
+++ b/docs/adr/0008-inter-plane-spread-soft-preference.md
@@ -189,3 +189,53 @@ separation.
 **Determinism.** See the ADR-0003 amendment dated 2026-05-27 for the precise
 scoping: reproducible under a `max_restarts` bound; timing-dependent under a
 pure wall-clock `budget_s` bound.
+
+### 2026-06-01 — back-of-hangar fill bias (issue #320)
+
+**Background.** The repulsion energy is *position-symmetric*: it rewards
+inter-plane separation but is indifferent to *where* in the hangar that
+separation sits. So a lone plane settles mid-hangar, and multi-plane fills can
+leave free space wasted in the *middle* (between two filled bands) rather than
+at the door, where it is operationally useful — for the next exit, or for an
+out-of-band plane that needs to enter. This is also the lead lever of the
+tow-friendly-placement work ([#280](https://github.com/DocGerd/hangarfit/issues/280),
+Direction A): keeping the door-side approach corridors clear is what lets the
+bounded tow planner thread a path to each slot.
+
+**Change.** A secondary **back-bias** term is folded into the `_spread`
+hill-climb energy:
+
+```
+E_total = Σ_{i<j} exp(−gap_ij / scale)  +  back_bias_weight · Σ_p (length_m − y_p) / length_m
+          └─────────── spread (unchanged) ──────────┘     └──────── back bias B (#320) ───────┘
+```
+
+`B` is minimized when planes park deep (large `y`, toward the back wall at
+`y = hangar.length_m`), normalized by `length_m` so a single weight reads
+consistently across hangar sizes. It is a **secondary** term, not a hard
+back-wall snap: the smooth gradient and the "only valid moves accepted"
+invariant of the original `_spread` are preserved, and `min_pairwise_gap_m`
+remains the **primary** basin-selection key (#267) — the back-bias only
+re-ranks candidates *within* a basin's hill-climb. The `<2 planes` no-op guard
+is relaxed when back-bias is active so a lone plane is still pulled to the back
+wall (with `<2` planes the inter-plane energy is identically 0, so only the
+back-bias drives the climb).
+
+Because the back-bias scales ~linearly with plane count while the repulsion sum
+scales ~quadratically, a single weight is gentler on crowded hangars (where
+spread genuinely matters) and stronger on sparse ones — the intended behavior.
+
+**Default & toggle.** `SearchConfig.back_bias_weight` defaults to **0.0**
+(neutral — the raw spread mechanism and the `spread=False` determinism canaries
+stay byte-unchanged). The **CLI enables it by default** at weight `1.0`
+(`--no-back-fill` sets it to 0.0; no effect under `--no-spread`, since the bias
+rides the spread post-pass). `1.0` was chosen from a sweep over the acceptance
+fixtures as the smallest weight that breaks the mid-hangar symmetry (a lone
+plane reaches the back wall; the 2-plane `scenario_minimal` fill clears the
+door) while staying a secondary term that does not collapse the inter-plane gap.
+
+**Determinism.** The back-bias is RNG-free re-ranking: it adds no random draws
+and does not change the draw count or order (candidate generation is unchanged),
+so same-seed output stays byte-identical (`tests/test_solver_search.py::
+test_spread_back_fill_is_deterministic_for_same_seed`). No `determinism-guard`
+amendment is required.

--- a/docs/adr/0011-linear-history-strategy-under-gitflow.md
+++ b/docs/adr/0011-linear-history-strategy-under-gitflow.md
@@ -1,8 +1,19 @@
 # ADR-0011: Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline
 
-- **Status:** Proposed
+- **Status:** Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md)
 - **Date:** 2026-05-27
 - **Deciders:** Patrick Kuhn (DocGerd)
+
+> **Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md) (2026-05-29) — never adopted.**
+> This ADR's chosen Option 1 (*feature PRs land as squash merges*) was never put
+> into effect: squash and rebase merging were disabled repo-wide as a
+> release-safety guardrail after the v0.7.0 cascade, so feature PRs land as **merge
+> commits**. ADR-0014 records the in-effect **merge-commit-only** strategy. The
+> Q1–Q4 research below — why `required_linear_history` is incompatible with
+> GitFlow, the rulesets community-#80952 historical-commits bug, and the
+> merge-base cost of squashed back-merges — **remains valid** and is the analysis
+> ADR-0014 builds on. Read the Decision Outcome below as the *proposal that was not
+> taken*, not current policy.
 
 ## Context & Problem Statement
 

--- a/docs/adr/0011-linear-history-strategy-under-gitflow.md
+++ b/docs/adr/0011-linear-history-strategy-under-gitflow.md
@@ -4,16 +4,24 @@
 - **Date:** 2026-05-27
 - **Deciders:** Patrick Kuhn (DocGerd)
 
-> **Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md) (2026-05-29) — never adopted.**
-> This ADR's chosen Option 1 (*feature PRs land as squash merges*) was never put
-> into effect: squash and rebase merging were disabled repo-wide as a
-> release-safety guardrail after the v0.7.0 cascade, so feature PRs land as **merge
-> commits**. ADR-0014 records the in-effect **merge-commit-only** strategy. The
-> Q1–Q4 research below — why `required_linear_history` is incompatible with
-> GitFlow, the rulesets community-#80952 historical-commits bug, and the
-> merge-base cost of squashed back-merges — **remains valid** and is the analysis
-> ADR-0014 builds on. Read the Decision Outcome below as the *proposal that was not
-> taken*, not current policy.
+> **Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md) (2026-05-29) — never adopted as policy.**
+> ADR-0011 stayed `Proposed` and was never ratified. Its central decision
+> (*feature PRs land as squash merges*) no longer matches reality: after it was
+> drafted, squash and rebase merging were disabled repo-wide as a release-safety
+> guardrail, so feature PRs land as **merge commits**. ADR-0014 records the
+> in-effect **merge-commit-only** strategy.
+>
+> Read the **Decision Drivers and Decision Outcome** below as the *proposal that
+> was not taken*, not current policy. In particular, the Decision Driver claiming
+> the squash/rebase-disable *"was already tried and reverted … [it] broke the
+> release flow"* is **not** carried forward — that early, narrowly-scoped attempt
+> was later re-applied repo-wide and **kept** as the standing guardrail ADR-0014
+> records.
+>
+> The **Q1–Q4 research** (why `required_linear_history` is incompatible with
+> GitFlow, the rulesets community-#80952 historical-commits bug, and the merge-base
+> cost of squashed back-merges) **remains valid** and is the analysis ADR-0014
+> builds on.
 
 ## Context & Problem Statement
 

--- a/docs/adr/0014-merge-commit-only-history-strategy.md
+++ b/docs/adr/0014-merge-commit-only-history-strategy.md
@@ -1,0 +1,150 @@
+# ADR-0014: Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail
+
+- **Status:** Proposed
+
+- **Date:** 2026-05-29
+- **Deciders:** Patrick Kuhn (DocGerd)
+
+## Context & Problem Statement
+
+[ADR-0011](0011-linear-history-strategy-under-gitflow.md) (Proposed, 2026-05-27)
+chose **Option 1** — *feature PRs land as squash merges (single parent),
+release/back-merge PRs land as merge commits* — and named a follow-up
+(**Option 5**) to enforce squash-only on `feature/*`→`develop` via a GitHub
+merge-method ruleset. Its whole "clean first-parent mainline" rationale rests on
+*one squash commit per feature PR*.
+
+After ADR-0011 was drafted, **squash and rebase merging were disabled repo-wide**
+as a guardrail. The trigger was the v0.7.0 release cascade, where a squash-merge
+on #283 contributed to the burned-tag mess (see the v0.7.0 / v0.7.1 release
+history). The repo's current merge-button settings are:
+
+```
+allow_merge_commit:  true
+allow_squash_merge:  false   ← squash DISABLED
+allow_rebase_merge:  false   ← rebase DISABLED
+```
+
+So ADR-0011's central premise is now **false**: feature PRs land as **merge
+commits**, not squash merges, and the Option-5 squash-only ruleset is impossible
+to configure (squash is off). This ADR reconciles the documented strategy with
+the in-effect reality (#344). It supersedes ADR-0011's *decision*; ADR-0011's
+Q1–Q4 research — why `required_linear_history` is incompatible with GitFlow, the
+rulesets community-#80952 historical-commits bug, and the merge-base cost of
+squashed back-merges — **remains valid and is the analysis this ADR builds on**.
+
+## Decision Drivers
+
+- **Release-flow safety.** The squash-disable guardrail closed a concrete failure
+  mode: a wrong merge method chosen during a release cut corrupting the release
+  DAG (the #283 / v0.7.0 cascade). The guardrail must not be reopened casually.
+- **One merge method = no foot-gun.** With only "Create a merge commit" enabled,
+  no contributor or release operator can accidentally pick squash/rebase at a
+  moment it would damage the release topology. The safe path is the *only* path.
+- **Machine-enforcement over convention.** ADR-0011's squash-only goal was a
+  social convention with no automated check (its own Compliance section says so).
+  The merge-commit-only reality is enforced by the repo merge-button settings —
+  strictly stronger than a convention.
+- **`required_linear_history` is still incompatible with GitFlow.** Unchanged from
+  ADR-0011 Q1–Q4: the release flow PRs each `release/*` into **both** `main` and
+  `develop`, producing merge commits that `required_linear_history` forbids; the
+  rulesets variant additionally trips community-#80952. It stays **off**.
+
+## Considered Options
+
+1. **Merge-commit-only (squash + rebase disabled) — the chosen option.** Every PR
+   — feature and release alike — lands as a merge commit. The guardrail stays as
+   the machine-enforced policy.
+2. **Re-enable squash for feature merges** (revert to ADR-0011 Option 1 and pursue
+   the Option-5 squash-only ruleset).
+3. **Squash all merges, including releases** (ADR-0011 Option 4).
+4. **Enable `required_linear_history`** (classic branch protection or the rulesets
+   rule) (ADR-0011 Options 2/3).
+
+## Decision Outcome
+
+**Chosen option: Option 1 (merge-commit-only),** because the squash-disable
+guardrail is a deliberate, machine-enforced safety measure born of a real
+release-cascade incident, and the readability benefit of squashed feature commits
+does not outweigh reopening that risk. `required_linear_history` stays off for the
+reasons ADR-0011 established.
+
+We accept that `git log --first-parent develop` now carries a two-parent merge
+commit per feature PR rather than ADR-0011's hoped-for single squashed commit.
+That is the readability cost of the guardrail, and it is small: each feature merge
+commit still names its PR number and feature branch, so the first-parent log
+remains a usable high-level changelog with release merges as landmarks.
+
+### Why not Option 2 (re-enable squash for features)?
+
+It reopens exactly the foot-gun the guardrail closed — a squash/rebase chosen at
+the wrong moment during a release cut. ADR-0011's clean-single-parent-per-feature
+log is a readability nicety, not a correctness requirement, and the pre-v0.7.0
+two-parent feature merges already make the non-`--first-parent` log noisy
+regardless. The cost (reintroduced release risk) exceeds the benefit (slightly
+tidier first-parent log). If the release process is ever hardened so the
+wrong-method foot-gun is closed another way, this is the option a future ADR would
+revisit.
+
+### Why not Option 3 (squash all merges) or Option 4 (`required_linear_history`)?
+
+Both were already rejected by ADR-0011 and nothing has changed. Squashing the
+`release/*`→`develop` back-merge destroys `git merge-base` semantics between `main`
+and `develop` (ADR-0011 Q3). `required_linear_history` forbids the GitFlow release
+double-merge entirely, and its rulesets form trips the unresolved historical-commits
+bug community-#80952 on a repo that already has merge commits (ADR-0011 Q1/Q2).
+This ADR carries those rejections forward unchanged.
+
+## Consequences
+
+### Positive
+
+- Eliminates the wrong-merge-method-during-release foot-gun, **machine-enforced**
+  by the repo merge-button settings (not a convention that can silently lapse).
+- The GitFlow release flow and its back-merge topology are preserved exactly as
+  ADR-0011 Q3 requires — `git merge-base`, `git log main..develop`, and
+  `git branch --merged` stay semantically meaningful.
+- The rationale for `required_linear_history` being off is preserved and still
+  cross-referenced from `docs/security-posture.md`, so a future maintainer won't
+  re-enable it chasing a Scorecard point.
+
+### Negative
+
+- `git log --first-parent develop` shows a two-parent merge commit per feature PR,
+  noisier than ADR-0011's single squashed commit. The clean-single-parent-per-feature
+  goal is given up.
+- ADR-0011's Option-5 squash-only ruleset is moot/shelved while squash is disabled.
+
+### Neutral
+
+- If the release process is ever hardened enough to close the wrong-method foot-gun
+  independently, re-enabling squash for `feature/*` (and revisiting ADR-0011's
+  Option 5) could be reconsidered in a future ADR that would supersede this one.
+
+## Compliance
+
+Machine-enforced by the repo merge-button settings. Verify:
+
+```
+gh api repos/:owner/:repo --jq '{merge: .allow_merge_commit, squash: .allow_squash_merge, rebase: .allow_rebase_merge}'
+# expected: {"merge": true, "squash": false, "rebase": false}
+```
+
+Any feature PR that lands as a squash or rebase commit means the guardrail was
+changed — investigate before assuming it was intentional. The human-facing rule is
+documented in [`CLAUDE.md`](../../CLAUDE.md#development-workflow) (Branching).
+
+## More Information
+
+- Supersedes [ADR-0011](0011-linear-history-strategy-under-gitflow.md). ADR-0011's
+  Q1–Q4 research (the `required_linear_history` / rulesets / merge-base analysis)
+  remains the authoritative technical background and is incorporated here by
+  reference.
+- Reconciliation issue: [#344](https://github.com/DocGerd/hangarfit/issues/344)
+- Guardrail origin: the v0.7.0 release cascade (#283 squash-merge; #285 / #286
+  immutable-release tombstone) that prompted disabling squash + rebase repo-wide.
+- Related issues: [#141](https://github.com/DocGerd/hangarfit/issues/141) (branch
+  protection applied), [#202](https://github.com/DocGerd/hangarfit/issues/202)
+  (the spike that produced ADR-0011).
+- Related docs: [`docs/security-posture.md`](../security-posture.md) — the
+  "A note on linear history" section.

--- a/docs/adr/0014-merge-commit-only-history-strategy.md
+++ b/docs/adr/0014-merge-commit-only-history-strategy.md
@@ -1,6 +1,6 @@
 # ADR-0014: Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-29
 - **Deciders:** Patrick Kuhn (DocGerd)
 

--- a/docs/adr/0014-merge-commit-only-history-strategy.md
+++ b/docs/adr/0014-merge-commit-only-history-strategy.md
@@ -1,7 +1,6 @@
 # ADR-0014: Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail
 
 - **Status:** Proposed
-
 - **Date:** 2026-05-29
 - **Deciders:** Patrick Kuhn (DocGerd)
 
@@ -15,9 +14,11 @@ merge-method ruleset. Its whole "clean first-parent mainline" rationale rests on
 *one squash commit per feature PR*.
 
 After ADR-0011 was drafted, **squash and rebase merging were disabled repo-wide**
-as a guardrail. The trigger was the v0.7.0 release cascade, where a squash-merge
-on #283 contributed to the burned-tag mess (see the v0.7.0 / v0.7.1 release
-history). The repo's current merge-button settings are:
+as a guardrail. The trigger was the v0.7.0 release cascade: a squash-merge was
+mistakenly applied to the #283 release PR and had to be reset and re-merged as a
+proper merge commit, contributing to the burned-tag mess (the squash artifact was
+caught before it reached tagged history; the mechanism is documented in ADR-0011
+Q3's release-table footnote). The repo's current merge-button settings are:
 
 ```
 allow_merge_commit:  true
@@ -25,9 +26,9 @@ allow_squash_merge:  false   ← squash DISABLED
 allow_rebase_merge:  false   ← rebase DISABLED
 ```
 
-So ADR-0011's central premise is now **false**: feature PRs land as **merge
-commits**, not squash merges, and the Option-5 squash-only ruleset is impossible
-to configure (squash is off). This ADR reconciles the documented strategy with
+So ADR-0011's central premise no longer matches reality: feature PRs land as
+**merge commits**, not squash merges, and its Option-5 squash-only ruleset is
+impossible to configure (squash is off). This ADR reconciles the documented strategy with
 the in-effect reality (#344). It supersedes ADR-0011's *decision*; ADR-0011's
 Q1–Q4 research — why `required_linear_history` is incompatible with GitFlow, the
 rulesets community-#80952 historical-commits bug, and the merge-base cost of
@@ -132,7 +133,7 @@ gh api repos/:owner/:repo --jq '{merge: .allow_merge_commit, squash: .allow_squa
 
 Any feature PR that lands as a squash or rebase commit means the guardrail was
 changed — investigate before assuming it was intentional. The human-facing rule is
-documented in [`CLAUDE.md`](../../CLAUDE.md#development-workflow) (Branching).
+documented in [`CLAUDE.md`](../../CLAUDE.md#branching) (Branching).
 
 ## More Information
 

--- a/docs/adr/0014-merge-commit-only-history-strategy.md
+++ b/docs/adr/0014-merge-commit-only-history-strategy.md
@@ -17,8 +17,9 @@ After ADR-0011 was drafted, **squash and rebase merging were disabled repo-wide*
 as a guardrail. The trigger was the v0.7.0 release cascade: a squash-merge was
 mistakenly applied to the #283 release PR and had to be reset and re-merged as a
 proper merge commit, contributing to the burned-tag mess (the squash artifact was
-caught before it reached tagged history; the mechanism is documented in ADR-0011
-Q3's release-table footnote). The repo's current merge-button settings are:
+caught before it reached tagged history; the resulting tombstoned v0.7.0 release is
+recorded in ADR-0011 Q3's release-table footnote). The repo's current merge-button
+settings are:
 
 ```
 allow_merge_commit:  true

--- a/docs/adr/0015-wheels-not-in-collision-model.md
+++ b/docs/adr/0015-wheels-not-in-collision-model.md
@@ -7,7 +7,7 @@
 ## Context & Problem Statement
 
 Wheel positions became canonical per-aircraft data in [ADR-0013](0013-wheels-canonical-data.md):
-`data/fleet.yaml` now carries, per aircraft, a `Wheels` block — main gear at
+`data/fleet.yaml` now carries, per aircraft, a `wheels:` block — main gear at
 plane-local `(main_offset_x_m, ±track_m/2)` and an optional third (nose/tail)
 wheel at `(third_wheel_offset_x_m, 0)`. The visualizer draws gear glyphs from
 these, and `turn_radius_m` is cross-checked against the implied wheelbase at
@@ -21,15 +21,18 @@ of `Part` rectangles — `fuselage_front`, `fuselage_aft`, `wing`, `strut`,
 iterates only over those. `src/hangarfit/geometry.py` and
 `src/hangarfit/collisions.py` contain **zero** references to wheels.
 
-ADR-0013 explicitly deferred the question (its "Knock-on effects" note, echoed
-in issue [#322](https://github.com/DocGerd/hangarfit/issues/322)):
+The question was raised in issue
+[#322](https://github.com/DocGerd/hangarfit/issues/322)'s "Knock-on effects"
+note:
 
 > The parts model (ADR-0001, ADR-0012) doesn't currently include wheels.
 > Whether wheels participate in collision (they probably should: a wheel pad is
 > part of the plane's footprint) is a separate decision worth recording in an
 > ADR.
 
-This ADR settles that question so the omission is an intentional, citable
+[ADR-0013](0013-wheels-canonical-data.md) flagged the same open question — its
+D1.3 option, left as "a future decision; if revisited, this ADR is the starting
+point". This ADR settles that question so the omission is an intentional, citable
 decision rather than an apparent gap. **The question:** should a wheel /
 wheel-pad contribute to an aircraft's footprint for static collision purposes?
 
@@ -58,7 +61,7 @@ wheel-pad contribute to an aircraft's footprint for static collision purposes?
    documented). Wheels remain render + motion-model data; static validity stays
    "wing / fuselage / strut footprints, with z-nesting."
 2. **Add wheel pads as collision-bearing parts.** Derive a pad rectangle (or
-   disc) per wheel from the `Wheels` coordinates plus a **new** per-aircraft
+   disc) per wheel from the `wheels:` coordinates plus a **new** per-aircraft
    pad-size datum, give it a ground-anchored z-range (`0 .. axle height`), and
    feed it through `aircraft_parts_world` / `check` like any other `Part`.
 3. **Wheels participate only in a future tow-clearance check, never in static

--- a/docs/adr/0015-wheels-not-in-collision-model.md
+++ b/docs/adr/0015-wheels-not-in-collision-model.md
@@ -1,6 +1,6 @@
 # ADR-0015: Wheels do not participate in the static collision model (gear stays render/motion data)
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-31
 - **Deciders:** [@DocGerd](https://github.com/DocGerd)
 

--- a/docs/adr/0015-wheels-not-in-collision-model.md
+++ b/docs/adr/0015-wheels-not-in-collision-model.md
@@ -1,0 +1,143 @@
+# ADR-0015: Wheels do not participate in the static collision model (gear stays render/motion data)
+
+- **Status:** Proposed
+- **Date:** 2026-05-31
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+Wheel positions became canonical per-aircraft data in [ADR-0013](0013-wheels-canonical-data.md):
+`data/fleet.yaml` now carries, per aircraft, a `Wheels` block — main gear at
+plane-local `(main_offset_x_m, ±track_m/2)` and an optional third (nose/tail)
+wheel at `(third_wheel_offset_x_m, 0)`. The visualizer draws gear glyphs from
+these, and `turn_radius_m` is cross-checked against the implied wheelbase at
+load.
+
+But the collision checker has **never** known about wheels. The parts model
+([ADR-0001](0001-aircraft-parts-model.md), refined by
+[ADR-0012](0012-fuselage-front-aft-split.md)) represents an aircraft as a list
+of `Part` rectangles — `fuselage_front`, `fuselage_aft`, `wing`, `strut`,
+`tail` — each with a plan-view footprint and a z-range; `collisions.check`
+iterates only over those. `src/hangarfit/geometry.py` and
+`src/hangarfit/collisions.py` contain **zero** references to wheels.
+
+ADR-0013 explicitly deferred the question (its "Knock-on effects" note, echoed
+in issue [#322](https://github.com/DocGerd/hangarfit/issues/322)):
+
+> The parts model (ADR-0001, ADR-0012) doesn't currently include wheels.
+> Whether wheels participate in collision (they probably should: a wheel pad is
+> part of the plane's footprint) is a separate decision worth recording in an
+> ADR.
+
+This ADR settles that question so the omission is an intentional, citable
+decision rather than an apparent gap. **The question:** should a wheel /
+wheel-pad contribute to an aircraft's footprint for static collision purposes?
+
+## Decision Drivers
+
+- **Fidelity vs. over-constraint.** The checker exists to reject *physically
+  invalid* parking. It should catch real conflicts without rejecting layouts a
+  human would happily park (real aircraft sit with wheels close together).
+- **The hangar's actual geometry.** It is a deep, **stack-style** hangar with a
+  single front door: planes are parked nose-in, towed one at a time into a
+  fore/aft stack — not parked side-by-side, fuselage-to-fuselage.
+- **The data we actually have.** ADR-0013 models wheels as **points**, not
+  areas. There is no wheel-pad width/radius datum anywhere in `fleet.yaml`, and
+  every existing dimension is already an unmeasured placeholder
+  (`measured: false`).
+- **Where wheel geometry actually bites.** The load-bearing consumer of wheel
+  positions is the **tow-path planner** (turn radius, the swept motion fan) —
+  a *dynamic* clearance concern — not the *static* parking-validity check.
+- **The determinism / canary cost.** Any new collision-bearing part changes
+  what the checker reports, which forces regeneration of the solver determinism
+  canaries and re-validation of every routability fixture (ADR-0003 contract).
+
+## Considered Options
+
+1. **Keep wheels out of the static collision model** (status quo, now
+   documented). Wheels remain render + motion-model data; static validity stays
+   "wing / fuselage / strut footprints, with z-nesting."
+2. **Add wheel pads as collision-bearing parts.** Derive a pad rectangle (or
+   disc) per wheel from the `Wheels` coordinates plus a **new** per-aircraft
+   pad-size datum, give it a ground-anchored z-range (`0 .. axle height`), and
+   feed it through `aircraft_parts_world` / `check` like any other `Part`.
+3. **Wheels participate only in a future tow-clearance check, never in static
+   collision.** Static parking validity stays as Option 1; wheel footprint
+   enters the model later, scoped to the planner's swept-path clearance.
+
+## Decision Outcome
+
+Chosen option: **Option 1 — keep wheels out of the static collision model**,
+recorded deliberately, with **Option 3 named as the likely future home** for
+wheel geometry if and when it is needed. Reasoning:
+
+- **The modelled footprint already subsumes the wheels in this hangar's
+  geometry.** In a nose-in fore/aft stack, the parts that come close between
+  two aircraft are wings (laterally wide, often z-nested) and fuselages
+  (caught by the cockpit/tail rules). The main-gear *track* can be wider than
+  the fuselage, so the one case wheels could add is two fuselages parked
+  **side-by-side, laterally close, and longitudinally aligned** — but that
+  arrangement also aligns their wide wings (caught by the wing rules) and is
+  not how this stack-style hangar is loaded. The marginal conflict wheels would
+  catch is near-empty in practice.
+- **We would have to invent data to do it.** Option 2 needs a pad-size field
+  that does not exist; ADR-0013 deliberately kept wheels as points. Adding
+  collision pads on top of placeholder point data would manufacture
+  high-confidence-looking constraints from numbers nobody has measured —
+  exactly the "two surface representations disagree" trap ADR-0013 closed,
+  re-opened in a new place.
+- **The natural consumer is the planner, not the checker.** Wheel geometry
+  earns its keep in *swept-path* clearance (does the gear clear a neighbour
+  while being towed past?), which is dynamic. Folding it into static validity
+  conflates "can it be parked here" with "can it be moved to here" — a
+  distinction the project already draws (exit-3 tow-routability is separate
+  from exit-1 static invalidity).
+- **It is the reversible choice.** Option 1 keeps the door open for Option 3
+  without paying the canary-regeneration / fixture-re-validation cost now, for a
+  conflict class the current hangar geometry rarely produces.
+
+This is a genuine modelling decision, not a doc edit: **merging this ADR
+ratifies "wheels are not a collision part."** If you would rather adopt Option
+2 (wheels collide now), say so and this ADR is reworked to record that instead
+— the Option-2 mechanism is sketched above and in *Negative Consequences*.
+
+### Positive Consequences
+
+- The wheels-in-collision question is **settled and citable**; the absence of
+  wheels from `collisions.py` is intentional, not an oversight.
+- No new unmeasured data, no change to `check` output, no canary regeneration,
+  no fixture re-validation — zero risk to the ADR-0003 determinism contract.
+- Keeps the static checker's footprint = "structure the aircraft *is*" (wing,
+  fuselage, strut), cleanly separated from "how it *moves*" (gear/turn radius).
+
+### Negative Consequences
+
+- **A real (if narrow) conflict class is unmodelled:** two aircraft whose gear
+  tracks overlap while their wings/fuselages clear (laterally-close,
+  longitudinally-aligned side-by-side parking). Mitigation: this is not the
+  stack-style hangar's normal arrangement; revisit via Option 3 if real
+  measurements or a non-stack layout make it bite.
+- If Option 3 is later adopted, wheel footprint must be derived **consistently**
+  with the ADR-0013 point coordinates (a pad expanded around each canonical
+  point), and a pad-size datum added per aircraft — tracked as future work, not
+  done here.
+
+## Compliance
+
+- `grep -r wheel src/hangarfit/collisions.py src/hangarfit/geometry.py` returns
+  nothing — the checker and the transform remain wheel-free by design. This ADR
+  is the rationale a reader finds when they notice that and ask "why?".
+- No test or behavioural change accompanies this ADR; it documents the existing
+  boundary. A future Option-3 PR would add the tests.
+
+## More Information
+
+- [ADR-0001](0001-aircraft-parts-model.md) — the parts model (collision unit).
+- [ADR-0012](0012-fuselage-front-aft-split.md) — fuselage front/aft split.
+- [ADR-0013](0013-wheels-canonical-data.md) — wheels as canonical point data
+  (which deferred this question).
+- [ADR-0003](0003-rr-mc-solver-algorithm.md) — the determinism contract a
+  collision-rule change would disturb.
+- Issue [#353](https://github.com/DocGerd/hangarfit/issues/353) — this decision.
+- Issue [#322](https://github.com/DocGerd/hangarfit/issues/322) — where the
+  question was raised.

--- a/docs/adr/0016-spread-towability-fallback.md
+++ b/docs/adr/0016-spread-towability-fallback.md
@@ -36,8 +36,11 @@ placement is *not* enough.
   demonstrably exists.
 - **Never silently swap.** If the rendered arrangement is not the one a plain
   `solve` would emit, the user (and any machine consumer) must be told.
-- **Preserve the ADR-0003 determinism contract.** A given `--seed` must yield
-  the same result, including across the two-pass fallback.
+- **Preserve the ADR-0003 determinism contract.** The shared resolved seed must
+  drive both passes, so the fallback adds no nondeterminism beyond ADR-0003's
+  existing scoping — bit-identical under a `max_restarts` bound,
+  same-machine-reproducible under the wall-clock `budget_s` the CLI uses (the
+  #267 amendment).
 - **Do not couple the planner into the solver's hot loop.** The static solver
   stays collision-only; tow-routability must not become a term in the seeded
   candidate scoring (the ADR-0008 "isolate the soft logic" driver).
@@ -85,9 +88,12 @@ keeps the solver and planner decoupled — the fallback lives entirely in the CL
 
 The determinism contract holds because the seed is resolved **once**, up front
 (`resolved_seed = args.seed if args.seed is not None else secrets.randbits(32)`),
-and shared by both passes; each `solve()` call is individually deterministic for
-that seed (ADR-0003), and the fallback is a deterministic function of the first
-pass's outcome.
+and shared by both passes; each `solve()` call is as deterministic as ADR-0003
+specifies for its bound — bit-identical under a `max_restarts` bound,
+same-machine-reproducible under the wall-clock `budget_s` the CLI passes (the
+spread-OFF second pass is unconditionally reproducible per ADR-0003). The
+fallback adds no new entropy: it reuses the resolved seed and is a pure function
+of the first pass's outcome.
 
 Empirically (issue #280 acceptance probe, develop @ this ADR, seed 1, default
 grid heuristic + back-fill on): the 3-plane and 6-plane fills that were exit 3
@@ -117,9 +123,11 @@ automatic re-solve, so the path appears without a second manual invocation.
 A bigger budget is a band-aid: it does not address the geometry tension, costs
 deterministic worst-case search time on every routable plane, and the
 false-negatives persist for tight-enough corridors. (Separately, #336 *did* make
-`grid` the default heuristic and set a global fill-budget cap of 8000 — see the
-2026-06-01 amendment to [ADR-0007](0007-tow-path-planner-v1-scope.md) — but as an
-efficiency/never-hang measure, **not** as the spread-vs-towability fix.)
+`grid` the default heuristic, raise the per-plane `_MAX_EXPANSIONS` to 8000, and
+add a *separate* global fill cap `_MAX_FILL_EXPANSIONS` (16000) on the sum of
+expansions across one fill — see the 2026-06-01 amendment to
+[ADR-0007](0007-tow-path-planner-v1-scope.md) — but as efficiency/never-hang
+measures, **not** as the spread-vs-towability fix.)
 
 ### Why not a tow-aware spread axis (option 5)?
 

--- a/docs/adr/0016-spread-towability-fallback.md
+++ b/docs/adr/0016-spread-towability-fallback.md
@@ -1,0 +1,185 @@
+# ADR-0016: Spread-vs-towability — CLI re-solves spread-off as a backstop when a default-spread layout is un-routable
+
+- **Status:** Proposed
+
+- **Date:** 2026-06-02
+- **Deciders:** Patrick Kuhn (DocGerd)
+
+## Context & Problem Statement
+
+`hangarfit solve --render-paths` should produce "a valid layout **plus** a valid
+tow path for every plane". Two individually-correct, default-on features compose
+into a globally-worse default (issue [#280](https://github.com/DocGerd/hangarfit/issues/280)):
+the ADR-0008 spread post-pass *maximizes* inter-plane gaps (pushing planes toward
+walls/corners), while the bounded tow planner (ADR-0007 / ADR-0010, per-plane
+Hybrid-A\* with `towplanner._MAX_EXPANSIONS`) needs clear approach corridors from
+the door cone to each slot. Spread could push a plane into a slot whose approach
+lane the bounded search can no longer thread, so `plan_fill` returns
+`plans[i] = None`; with every candidate un-routable the CLI returns a bare exit 3
+("nothing is towable") — even though the *same* fleet and hangar route cleanly
+with `--no-spread`. The tool silently picked the *less* useful of two valid
+arrangements. This ADR records how `--render-paths` recovers a tow plan without
+making the user know to retry with `--no-spread`.
+
+This is the *backstop* half of the v0.9.0 "tow-friendly placement" work
+(Direction A). The *primary* lever is placement — the back-of-hangar fill bias
+([#320](https://github.com/DocGerd/hangarfit/issues/320), recorded as the
+2026-06-01 amendment to [ADR-0008](0008-inter-plane-spread-soft-preference.md))
+keeps the door-side approach corridors clear so the default-spread layout is
+tow-routable in the first place. This ADR covers what `--render-paths` does when
+placement is *not* enough.
+
+## Decision Drivers
+
+- **"Valid layout + valid path" is the headline UX.** A bare exit 3 reads as
+  "these planes can't be towed" when a towable arrangement of the same planes
+  demonstrably exists.
+- **Never silently swap.** If the rendered arrangement is not the one a plain
+  `solve` would emit, the user (and any machine consumer) must be told.
+- **Preserve the ADR-0003 determinism contract.** A given `--seed` must yield
+  the same result, including across the two-pass fallback.
+- **Do not couple the planner into the solver's hot loop.** The static solver
+  stays collision-only; tow-routability must not become a term in the seeded
+  candidate scoring (the ADR-0008 "isolate the soft logic" driver).
+- **Cheap in the common case.** With placement (#320) doing the heavy lifting,
+  the backstop should cost nothing when the first pass already routes.
+
+## Considered Options
+
+1. **Automatic spread-off fallback in `--render-paths` (chosen).** When a
+   default-spread layout is fully un-routable, re-solve once with `spread=False`,
+   tow-plan that, and render it instead — reporting the swap on every channel.
+2. **Towability as a soft factor in spread basin-selection.** Fold "is this
+   basin tow-routable?" into the ADR-0008 / #267 collect-then-select scoring so a
+   routable-but-tighter basin outranks an un-routable maximally-spread one.
+3. **Advisory hint only.** Keep exit 3, but emit a stderr hint telling the user
+   to retry with `--no-spread`.
+4. **Raise `_MAX_EXPANSIONS`.** Give the bounded planner more budget so it
+   threads the spread-widened corridors.
+5. **Tow-aware spread axis.** Spread only along axes that do not block the
+   door-approach corridors, so spread and towability never fight.
+
+## Decision Outcome
+
+**Chosen option: automatic spread-off fallback (option 1)**, because it restores
+the "+ valid path" guarantee fully automatically, preserves spread whenever spread
+*is* routable (the fallback only triggers on a fully un-routable first pass), and
+keeps the solver and planner decoupled — the fallback lives entirely in the CLI
+(`cmd_solve`), not the solver. Concretely:
+
+- **Trigger.** Only when `--render-paths` is set, spread was *not* explicitly
+  disabled (`args.spread` is true), the first solve returned at least one valid
+  layout, and **every** returned plan is `None`
+  (`all(plan is None for plan in result.plans)`).
+- **Action.** Re-solve once with `SearchConfig(spread=False)` and
+  `plan_paths=True`, reusing the **same resolved seed** as the spread pass.
+- **Guard.** Accept the swap **only if** the no-spread re-solve actually routes
+  at least one candidate (`any(plan is not None …)`). If it routes nothing
+  (genuinely too tight — e.g. the placeholder hangar), keep the original spread
+  result so exit 3 stands unchanged and no misleading note is printed.
+- **Report (never silent).** On a successful swap: a stderr note ("layout
+  un-routable with inter-plane spread; re-solved with spread disabled to produce
+  tow paths"), a structured `diagnostics.spread_fallback_applied: true` in
+  `--json`, and a provenance comment in any `--write-yaml` output. The rendered
+  layout is the tighter no-spread arrangement, and the user is told so.
+
+The determinism contract holds because the seed is resolved **once**, up front
+(`resolved_seed = args.seed if args.seed is not None else secrets.randbits(32)`),
+and shared by both passes; each `solve()` call is individually deterministic for
+that seed (ADR-0003), and the fallback is a deterministic function of the first
+pass's outcome.
+
+Empirically (issue #280 acceptance probe, develop @ this ADR, seed 1, default
+grid heuristic + back-fill on): the 3-plane and 6-plane fills that were exit 3
+*before* the #320 placement lever now route at **exit 0 with the fallback never
+firing** (`spread_fallback_applied=false`). So placement (#320) is what fixes the
+common case; this fallback is the backstop that keeps a stray un-routable
+spread-basin from ever reaching the user as a bare exit 3.
+
+### Why not towability as a soft factor in spread selection (option 2)?
+
+It would run `plan_fill` (a full Hybrid-A\* search) for *every* candidate basin
+inside the solver's selection loop — expensive, and it couples the tow planner
+into the static solver, violating the ADR-0008 driver that keeps the hard
+conflict loop collision-only and soft preferences isolated. The chosen fallback
+runs `plan_fill` at most twice total (once per pass), only on a fully un-routable
+first pass.
+
+### Why not an advisory hint only (option 3)?
+
+A pure hint keeps the bare exit 3 and puts the work on the user — they must know
+to retry with `--no-spread`, defeating the "valid layout + valid path" headline.
+The chosen option *adopts the hint* (the stderr note) but pairs it with the
+automatic re-solve, so the path appears without a second manual invocation.
+
+### Why not raise `_MAX_EXPANSIONS` (option 4)?
+
+A bigger budget is a band-aid: it does not address the geometry tension, costs
+deterministic worst-case search time on every routable plane, and the
+false-negatives persist for tight-enough corridors. (Separately, #336 *did* make
+`grid` the default heuristic and set a global fill-budget cap of 8000 — see the
+2026-06-01 amendment to [ADR-0007](0007-tow-path-planner-v1-scope.md) — but as an
+efficiency/never-hang measure, **not** as the spread-vs-towability fix.)
+
+### Why not a tow-aware spread axis (option 5)?
+
+It is the most principled long-term answer but the most complex: it requires the
+spread post-pass to know the door-approach geometry and constrain its descent
+directions accordingly, re-coupling the two modules. The back-fill bias (#320)
+captures most of the same benefit far more cheaply (bias planes toward the back
+wall, clearing the door side) without the spread pass needing planner knowledge.
+Left as possible future work if placement + fallback ever prove insufficient.
+
+## Consequences
+
+### Positive
+
+- `solve --render-paths` no longer emits a bare exit 3 for a fleet+hangar that is
+  towable under `--no-spread`; it routes (placement, the common case) or
+  transparently re-solves spread-off (the backstop).
+- The swap is reported on every channel (human stderr, `--json`, `--write-yaml`),
+  so neither a person nor a machine consumer is misled about which arrangement was
+  rendered.
+- Solver and planner stay decoupled; the static solver remains collision-only and
+  the ADR-0008 spread post-pass is unchanged.
+
+### Negative
+
+- Worst-case up to ~2× solve time — but **only** when the first (spread) pass is
+  fully un-routable, which the #320 placement lever makes rare.
+- The rendered layout after a swap is the *tighter* no-spread arrangement, not the
+  roomy spread one a plain `solve` (without `--render-paths`) would emit. This is
+  reported, not silent, but it does mean `--render-paths` and a plain `solve` can
+  return different layouts for the same scenario+seed.
+
+### Neutral
+
+- The fallback is CLI-only behavior; `solve()` as a library call is unchanged
+  (callers choose `spread` and `plan_paths` themselves).
+- When the no-spread re-solve also routes nothing (placeholder hangar, genuinely
+  too tight), behavior is identical to before this ADR: exit 3, original spread
+  layout kept, no note.
+
+## Compliance
+
+- **`tests/test_cli_solve.py`** — the spread-fallback test class pins: the
+  re-solve fires only on a fully un-routable spread pass; the swap is reported on
+  stderr; `--json` surfaces `spread_fallback_applied` true after a swap and false
+  otherwise; `--write-yaml` carries the provenance comment; a fallback that *also*
+  routes nothing keeps exit 3 with no misleading note; and the fallback reuses the
+  resolved seed (determinism across the two passes).
+
+## More Information
+
+- Related ADRs:
+  [ADR-0003 — RR-MC solver algorithm and determinism contract](0003-rr-mc-solver-algorithm.md);
+  [ADR-0007 — tow-path planner v1 scope](0007-tow-path-planner-v1-scope.md)
+  (2026-06-01 #336 amendment: grid default + fill-budget cap);
+  [ADR-0008 — inter-plane spread](0008-inter-plane-spread-soft-preference.md)
+  (2026-06-01 #320 amendment: back-of-hangar fill bias — the *primary* placement
+  lever this fallback backstops);
+  [ADR-0010 — Reeds–Shepp motion model](0010-reeds-shepp-motion-model.md).
+- Related issues / PRs:
+  [#280](https://github.com/DocGerd/hangarfit/issues/280) (umbrella),
+  [#320](https://github.com/DocGerd/hangarfit/issues/320) (placement lever),
+  [#336](https://github.com/DocGerd/hangarfit/issues/336) (planner efficiency).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,3 +91,4 @@ manual workflow above is canonical.
 | 0011 | [Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline](0011-linear-history-strategy-under-gitflow.md) | Proposed |
 | 0012 | [Split the fuselage into front/aft so a wing may overhang a tail but not a cockpit](0012-fuselage-front-aft-split.md) | Accepted |
 | 0013 | [Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load](0013-wheels-canonical-data.md) | Accepted |
+| 0015 | [Wheels do not participate in the static collision model (gear stays render/motion data)](0015-wheels-not-in-collision-model.md) | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -93,3 +93,4 @@ manual workflow above is canonical.
 | 0013 | [Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load](0013-wheels-canonical-data.md) | Accepted |
 | 0014 | [Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail](0014-merge-commit-only-history-strategy.md) | Accepted |
 | 0015 | [Wheels do not participate in the static collision model (gear stays render/motion data)](0015-wheels-not-in-collision-model.md) | Accepted |
+| 0016 | [Spread-vs-towability — CLI re-solves spread-off as a backstop when a default-spread layout is un-routable](0016-spread-towability-fallback.md) | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,5 +91,5 @@ manual workflow above is canonical.
 | 0011 | [Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline](0011-linear-history-strategy-under-gitflow.md) | Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md) |
 | 0012 | [Split the fuselage into front/aft so a wing may overhang a tail but not a cockpit](0012-fuselage-front-aft-split.md) | Accepted |
 | 0013 | [Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load](0013-wheels-canonical-data.md) | Accepted |
-| 0014 | [Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail](0014-merge-commit-only-history-strategy.md) | Proposed |
-| 0015 | [Wheels do not participate in the static collision model (gear stays render/motion data)](0015-wheels-not-in-collision-model.md) | Proposed |
+| 0014 | [Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail](0014-merge-commit-only-history-strategy.md) | Accepted |
+| 0015 | [Wheels do not participate in the static collision model (gear stays render/motion data)](0015-wheels-not-in-collision-model.md) | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -90,4 +90,4 @@ manual workflow above is canonical.
 | 0010 | [Reeds–Shepp motion model — towplanner v2](0010-reeds-shepp-motion-model.md) | Accepted |
 | 0011 | [Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline](0011-linear-history-strategy-under-gitflow.md) | Proposed |
 | 0012 | [Split the fuselage into front/aft so a wing may overhang a tail but not a cockpit](0012-fuselage-front-aft-split.md) | Accepted |
-| 0013 | [Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load](0013-wheels-canonical-data.md) | Proposed |
+| 0013 | [Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load](0013-wheels-canonical-data.md) | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -88,6 +88,7 @@ manual workflow above is canonical.
 | 0008 | [Inter-plane spread soft preference (repulsion-energy surrogate for maximin)](0008-inter-plane-spread-soft-preference.md) | Accepted |
 | 0009 | [Single supported Python — 3.12, anchored to the distro LTS](0009-single-supported-python-version.md) | Accepted |
 | 0010 | [Reeds–Shepp motion model — towplanner v2](0010-reeds-shepp-motion-model.md) | Accepted |
-| 0011 | [Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline](0011-linear-history-strategy-under-gitflow.md) | Proposed |
+| 0011 | [Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline](0011-linear-history-strategy-under-gitflow.md) | Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md) |
 | 0012 | [Split the fuselage into front/aft so a wing may overhang a tail but not a cockpit](0012-fuselage-front-aft-split.md) | Accepted |
 | 0013 | [Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load](0013-wheels-canonical-data.md) | Proposed |
+| 0014 | [Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail](0014-merge-commit-only-history-strategy.md) | Proposed |

--- a/docs/architecture/01-introduction-and-goals.md
+++ b/docs/architecture/01-introduction-and-goals.md
@@ -15,6 +15,30 @@ asked, searches for a valid arrangement itself.
 It is a CLI tool. It reads YAML, writes JSON and optional top-down PNG
 renders, and persists nothing between invocations.
 
+## Shipped phases
+
+Shipped capability by phase, tied to the release it landed in
+(authoritative version-to-date mapping in [`CHANGELOG.md`](../../CHANGELOG.md)):
+
+```mermaid
+timeline
+    title hangarfit phases (phase to shipped capability to release)
+    section Phase 1 substrate
+        v0.1.0 : hangarfit check : parts collision rule, hangar bounds, maintenance bay : top-down PNG render
+    section Phase 2a static solver
+        v0.6.0 : hangarfit solve : Random-Restart Monte-Carlo layout search : diversity metric (--alternatives)
+    section Phase 2b/2c solver polish
+        v0.7.0 : Phase 2b spread post-pass, maximise min inter-plane gap : Phase 2c collect-then-select pool, maximin selection
+    section Phase 3a/3b tow-path planning
+        v0.7.0 : Phase 3a solve --render-paths tow-path fill (Dubins arcs) : Phase 3b Reeds-Shepp reverse-capable tow, door entry-cone
+```
+
+*Phases map to the CLI surface: Phase 1 = `hangarfit check`; Phase 2a/2b/2c
+= `hangarfit solve`; Phase 3a/3b = `hangarfit solve --render-paths`. There
+were no v0.2.0–v0.5.0 tags — the Phase 2a solver shipped in v0.6.0; the
+spread-aware solver (2b/2c) and the full tow-path planner (3a/3b) all shipped
+in v0.7.0.*
+
 ## Quality goals
 
 In rough order of priority — earlier goals trump later ones when they

--- a/docs/architecture/03-context-and-scope.md
+++ b/docs/architecture/03-context-and-scope.md
@@ -75,11 +75,11 @@ The tool runs entirely on the user's local machine:
 
 | Out of scope | Why |
 |--------------|-----|
-| **Movement-sequence planning** — "in what order do I roll planes out and back in to reach this layout?" | The "Tower of Hanoi" reshuffling problem is harder than the static layout problem and was not the original need. The current tool finds *a* valid target; getting there is a human's job. |
+| **Movement-sequence planning** — "in what order do I roll planes out and back in to *re-sequence an already-parked* hangar?" | The "Tower of Hanoi" reshuffling of an already-occupied hangar is harder than the static layout problem and was not the original need; re-sequencing parked planes remains a human's job. This is **distinct from the empty-hangar tow-path fill** that *did* ship in Phase 3a/3b — `solve --render-paths` plans how each plane is towed into its slot from the door, one entry per plane ([ADR-0007](../adr/0007-tow-path-planner-v1-scope.md) / [ADR-0010](../adr/0010-reeds-shepp-motion-model.md)). |
 | **Tracking hangar state across runs.** | Each invocation is stateless. The scenario YAML carries everything. This is a deliberate constraint from §2; tracking state would invite an entire class of "what was true yesterday?" bugs. |
 | **GUI or web frontend.** | A CLI plus a PNG is the right shape for the actual usage (one operator, one decision, no audit trail needed yet). Anything browser-shaped is a separate project. |
 | **Live event stream** (late-arrival notifications, departure tracking). | The tool is invoked on demand against a hand-authored scenario. The club uses other tooling (radio, paper, eyeballs) to know who is back; `hangarfit` only checks whether a *proposed* layout is valid. |
-| **Soft constraints / preferences** ("prefer this region", "minimise total movement vs baseline"). | All constraints in v1 are HARD: pin, `force_on_carts`, maintenance plane. Soft-constraint optimization is a different problem; it would have its own ADR before being added. |
+| **Soft preferences *inside* the hard conflict-resolution loop** (a weighted "prefer this region" objective competing with collision penalties). | The conflict-resolution loop stays HARD-only (pin, `force_on_carts`, maintenance plane). Soft preferences are not banned outright — they ship as **isolated post-passes** that run only after a layout is already valid (the inter-plane spread post-pass, [ADR-0008](../adr/0008-inter-plane-spread-soft-preference.md)), each with its own ADR, never as a new key in the hard score tuple. |
 
 These boundaries are not "phase 1 limitations to be removed later." They
 are deliberate design choices that keep the tool small, correct, and

--- a/docs/architecture/04-solution-strategy.md
+++ b/docs/architecture/04-solution-strategy.md
@@ -8,10 +8,11 @@ to which ADR, not a re-derivation.
 
 ## Headline decisions
 
-Ordered roughly Phase 1 → Phase 2a → cross-cutting scope and operations
-choices: the geometric substrate first (parts model, transform), then
-the solver layered on top of it (algorithm, constraint posture), then
-the surrounding shape of the tool (delivery, documentation).
+Ordered roughly Phase 1 → Phase 2 → Phase 3 → cross-cutting scope and
+operations choices: the geometric substrate first (parts model,
+transform), then the solver layered on top of it (algorithm, constraint
+posture), then the tow-path planner layered on the solver, then the
+surrounding shape of the tool (delivery, documentation).
 
 ### Aircraft geometry as a list of parts, not a single bounding box
 
@@ -85,6 +86,26 @@ If further soft-constraint optimisation use cases materialise, each
 gets its own ADR and, if possible, its own isolated post-pass rather
 than a new key in the hard score tuple.
 
+### Tow-path planning as a bound-aware search over Reeds–Shepp motion
+
+`hangarfit solve --render-paths` does not just validate a static
+layout — it plans how each aircraft is towed into its slot from the
+door. The `towplanner` module fills the hangar back-to-front and routes
+each plane with a bound-aware Hybrid-A* search whose steering primitive
+is a closed-form **Reeds–Shepp** path (forward *and* reverse arcs),
+re-validated against the already-placed aircraft by the collision
+checker as it moves. Routing is best-effort: a plane the planner cannot
+route comes back as `plans[i] = None` rather than failing the whole
+layout, and the CLI exits 3 only when *no* candidate layout is fully
+tow-routable.
+
+A sampling-based planner (RRT / PRM) was rejected in favour of this
+closed-form motion vocabulary, which keeps the planner deterministic
+without an RNG. See [ADR-0007](../adr/0007-tow-path-planner-v1-scope.md)
+for the v1 scope and
+[ADR-0010](../adr/0010-reeds-shepp-motion-model.md) for the v2
+Reeds–Shepp motion model.
+
 ### CLI + JSON + optional PNG; nothing else
 
 `hangarfit` is a single-binary CLI invoked from a terminal. It reads
@@ -110,8 +131,11 @@ no MkDocs / Sphinx / Docusaurus build step. Mermaid diagrams render
 natively in GitHub Markdown.
 
 Choosing a documentation site generator is itself an architectural
-decision that would deserve its own ADR. Until that decision is made,
-GitHub's built-in rendering is enough — and the absence of a build step
+decision. It was evaluated in #372 and the decision recorded: stay with
+in-repo Markdown and treat GitHub Pages as deferred-not-rejected — the
+docs deliberately cross-link into source and config files outside
+`docs/`, which a static-site generator rooted at `docs/` cannot resolve.
+GitHub's built-in rendering is enough, and the absence of a build step
 removes one whole class of "did the docs publish?" failure modes.
 
 ## What the headline decisions do *not* cover

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -180,10 +180,12 @@ Internally:
   rectangle is enforced as a hard obstacle by the `bay_intrusion`
   collision rule, so no surrogate sample is needed.
 - **Initial placement** — random valid placements respecting pins.
-- **Descent step** — min-conflicts perturbation: identify the plane
-  with the largest conflict contribution (by `total_penetration_m2`),
-  perturb it to reduce its contribution, repeat until zero conflicts
-  or local minimum.
+- **Descent step** — min-conflicts perturbation: pick one conflicting
+  non-pinned plane *uniformly at random* (over a `sorted()` set, so the
+  RNG draw stays deterministic), generate `N` candidate moves for it
+  (small nudges + one large jump + one 180° flip) and greedily accept
+  the best-scoring one (ties broken by smallest displacement), repeat
+  until zero conflicts or a local minimum.
 - **Restart cycle** — when descent plateaus, restart with a new random
   placement.
 - **Acceptance gate** — every candidate runs through `collisions.check()`
@@ -204,6 +206,64 @@ across runs (compliance check:
 `tests/test_solver_canaries.py`). Tow-planning is RNG-free, so the
 bundled `(Layout, MovesPlan)` output preserves the same determinism
 contract.
+
+The `solve()` lifecycle as a state machine — the pre-search gate, the
+restart/descent inner loop, the post-acceptance spread + basin pool, and
+the four terminal `SolveStatus` outcomes:
+
+```mermaid
+stateDiagram-v2
+    direction TB
+    [*] --> PreSearchGate : solve(scenario, seed)
+
+    PreSearchGate : Pre-search infeasibility gate
+    PreSearchGate : (1) a plane bbox exceeds the hangar max dimension
+    PreSearchGate : (2) sum of bbox areas exceeds the hangar floor
+    PreSearchGate : (3) pin-only layout fails check()
+
+    PreSearchGate --> trivially_infeasible : a gate trips
+    PreSearchGate --> RestartLoop : all gates pass
+
+    state RestartLoop {
+        direction TB
+        [*] --> InitialPlacement
+        InitialPlacement : Initial placement
+        InitialPlacement : random (x, y, heading); pins verbatim
+        InitialPlacement : cart-bucket round-robin; maintenance plane excluded
+        InitialPlacement --> Descent
+        Descent : Min-conflicts descent
+        Descent : pick a conflicting non-pinned plane at random
+        Descent : try N moves (nudges + jump + 180 deg flip)
+        Descent : score = (conflict_count, penetration_m2)
+        Descent --> Descent : improved, greedy accept
+        Descent --> Spread : score reaches (0, 0.0)
+        Descent --> Restart : plateau or all conflicts pinned
+        Spread : Spread post-pass (ADR-0008)
+        Spread : minimise repulsion energy, valid moves only
+        Spread --> PoolAppend : append basin candidate
+        PoolAppend --> Restart : seek another basin
+        Restart --> InitialPlacement : restart_index under max_restarts, within budget_s
+    }
+
+    RestartLoop --> Select : budget_s or max_restarts reached
+    Select : Selection (ADR-0004, collect-then-select #267)
+    Select : sort by (-min_gap, energy, restart_index)
+    Select : diversity gate
+    Select --> found : selected count equals alternatives
+    Select --> found_partial : some but fewer than alternatives
+    Select --> exhausted_budget : pool empty
+
+    found --> [*]
+    found_partial --> [*]
+    exhausted_budget --> [*]
+    trivially_infeasible --> [*]
+```
+
+*RR-MC `solve()` state machine: pre-search gate → bounded random-restart
+loop (min-conflicts descent, spread post-pass once a layout reaches
+`(0, 0.0)`, basin pool) → collect-then-select maximin-gap + diversity
+selection → one of four `SolveStatus` outcomes. Sources:
+`src/hangarfit/solver.py`, ADR-0003, ADR-0004, ADR-0008.*
 
 ### `towplanner.py` — tow-path planning
 

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -228,8 +228,8 @@ stateDiagram-v2
         direction TB
         [*] --> InitialPlacement
         InitialPlacement : Initial placement
-        InitialPlacement : random (x, y, heading); pins verbatim
-        InitialPlacement : cart-bucket round-robin; maintenance plane excluded
+        InitialPlacement : random (x, y, heading), pins verbatim
+        InitialPlacement : cart-bucket round-robin, maintenance plane excluded
         InitialPlacement --> Descent
         Descent : Min-conflicts descent
         Descent : pick a conflicting non-pinned plane at random

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -299,7 +299,8 @@ the **empty-hangar fill** case — every plane enters once (ADR-0007).
 - **Failure is honest** — a layout it cannot route raises
   `NoFeasiblePlanError` naming the offending plane; `solve` records it
   best-effort (see the bundling bullet above), and the CLI's
-  `--render-paths` surfaces it (warning + exit code 3, [§6](06-runtime-view.md)).
+  `--render-paths` surfaces it (warning + exit code 3, [§6](06-runtime-view.md)) —
+  after first attempting the spread-off backstop ([ADR-0016](../adr/0016-spread-towability-fallback.md)).
 - **Deterministic** (no RNG): a given `Layout` always yields the same
   `MovesPlan`, preserving [ADR-0003](../adr/0003-rr-mc-solver-algorithm.md)'s
   contract through the bundle.

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -234,7 +234,7 @@ stateDiagram-v2
         Descent : Min-conflicts descent
         Descent : pick a conflicting non-pinned plane at random
         Descent : try N moves (nudges + jump + 180 deg flip)
-        Descent : score = (conflict_count, penetration_m2)
+        Descent : score = (conflict_count, total_penetration_m2)
         Descent --> Descent : improved, greedy accept
         Descent --> Spread : score reaches (0, 0.0)
         Descent --> Restart : plateau or all conflicts pinned

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -212,19 +212,17 @@ sequenceDiagram
     end
     Solver-->>CLI: SolveResult(layouts, plans, diagnostics, status, seed)
 
+    opt all plans None and spread was on (#280 backstop, ADR-0016)
+        Note over CLI: re-solve spread=False (same seed) and tow-plan<br/>swap in the tighter no-spread result iff it routes a candidate<br/>(swap reported via stderr, --json, --write-yaml)
+    end
+    Note over CLI: _warn_unroutable: stderr names each blocked plane
     loop per returned layout
         CLI->>Viz: render_layout(layout, moves_plan=plans[i])
         Note over Viz: _draw_tow_paths samples each arc<br/>(un-routable → no overlay)
         Viz->>FS: write out_i.png
     end
-    Note over CLI: _warn_unroutable: stderr names each blocked plane
-    alt no candidate routable (all plans None)
-        Note over CLI: spread backstop (#280, ADR-0016):<br/>if spread was on, re-solve spread=False (same seed) and tow-plan
-        alt re-solve routes a candidate
-            CLI->>Op: render tighter no-spread layout, exit 0<br/>(swap reported via stderr, --json, --write-yaml)
-        else still nothing routable
-            CLI->>Op: exit 3
-        end
+    alt no candidate routable (all plans None, after backstop)
+        CLI->>Op: exit 3
     else at least 1 routable
         CLI->>Op: exit 0 (or status-driven)
     end

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -153,6 +153,21 @@ Exit 3 is checked before the `--strict-k` exit-1 rule. Without
 `--render-paths` the CLI does not tow-plan, so tow-routability never
 affects the exit code.
 
+**Spread-vs-towability fallback (#280, [ADR-0016](../adr/0016-spread-towability-fallback.md)).**
+Before that exit 3 is returned, one backstop runs: if spread was *not*
+explicitly disabled and **every** plan came back un-routable, the CLI
+re-solves once with `spread=False` (reusing the same resolved seed) and,
+*only if that re-solve actually routes a candidate*, renders the tighter
+no-spread arrangement instead — reporting the swap on stderr, in
+`--json` (`diagnostics.spread_fallback_applied`), and as a `--write-yaml`
+provenance comment. If the no-spread re-solve also routes nothing
+(genuinely too tight — e.g. the placeholder hangar), the original spread
+result is kept and exit 3 stands. The *primary* reason default layouts
+are routable in the first place is the back-of-hangar fill bias
+([#320](https://github.com/DocGerd/hangarfit/issues/320), the 2026-06-01
+amendment to [ADR-0008](../adr/0008-inter-plane-spread-soft-preference.md));
+this fallback is the backstop for when placement is not enough.
+
 **No retries inside solve().** The solver does not retry on a single
 candidate's failure — it just restarts. There is no exception path
 from `check()` into the solver other than structural failure (which
@@ -204,7 +219,12 @@ sequenceDiagram
     end
     Note over CLI: _warn_unroutable: stderr names each blocked plane
     alt no candidate routable (all plans None)
-        CLI->>Op: exit 3
+        Note over CLI: spread backstop (#280, ADR-0016):<br/>if spread was on, re-solve spread=False (same seed) and tow-plan
+        alt re-solve routes a candidate
+            CLI->>Op: render tighter no-spread layout, exit 0<br/>(swap reported via stderr, --json, --write-yaml)
+        else still nothing routable
+            CLI->>Op: exit 3
+        end
     else at least 1 routable
         CLI->>Op: exit 0 (or status-driven)
     end

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -192,7 +192,7 @@ sequenceDiagram
             Tow-->>Solver: MovesPlan
         else greedy stuck
             Tow-->>Solver: raise NoFeasiblePlanError(plane_id)
-            Note over Solver: plans[i] = None;<br/>plane → diagnostics.unroutable_planes
+            Note over Solver: plans[i] = None,<br/>plane named in diagnostics.unroutable_planes
         end
     end
     Solver-->>CLI: SolveResult(layouts, plans, diagnostics, status, seed)
@@ -205,7 +205,7 @@ sequenceDiagram
     Note over CLI: _warn_unroutable: stderr names each blocked plane
     alt no candidate routable (all plans None)
         CLI->>Op: exit 3
-    else ≥1 routable
+    else at least 1 routable
         CLI->>Op: exit 0 (or status-driven)
     end
 ```

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -89,7 +89,7 @@ sequenceDiagram
                     Note over Solver: Spread (if SearchConfig.spread, default on):<br/>_spread maximizes inter-plane separation, only valid moves
                     Note over Solver: append valid (spread-polished) basin to pool
                 else conflicts > 0
-                    Note over Solver: perturb plane with max<br/>penetration contribution
+                    Note over Solver: perturb a conflicting non-pinned<br/>plane (chosen uniformly at random)
                 end
             end
         end

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -159,6 +159,59 @@ from `check()` into the solver other than structural failure (which
 would indicate a bug in the random-placement generator), and that
 bubbles up as exit code 2.
 
+## Scenario 3: `hangarfit solve scenario.yaml --render out_{i}.png --render-paths`
+
+The Phase 3a/3b path — a zoom-in on the `opt plan_paths` step that
+Scenario 2 abstracts as a single call. The operator wants the solver's
+layouts *plus* a per-plane tow path overlaid on each PNG; `--render-paths`
+turns on the best-effort tow bundle and the exit-3 routability check.
+
+```mermaid
+sequenceDiagram
+    participant Op as Operator
+    participant CLI as cli.py
+    participant Solver as solver.py
+    participant Tow as towplanner.py
+    participant Coll as collisions.py
+    participant Viz as visualize.py
+    participant FS as Filesystem
+
+    Op->>CLI: hangarfit solve scenario.yaml --render out_{i}.png --render-paths
+    Note over CLI: --render-paths requires a --render PATTERN<br/>(else: CLI usage error)
+    CLI->>Solver: solve(scenario, ..., plan_paths=True)
+    Note over Solver: search + spread + diversity select<br/>(Scenario 2) → accepted layouts
+    loop per accepted layout (best-effort, #197)
+        Solver->>Tow: plan_fill(layout)
+        Note over Tow: back_first_order: deepest slot first<br/>(y desc, x asc, plane_id asc)
+        loop per plane, deepest first
+            Tow->>Tow: plan_path (Hybrid-A* over Reeds–Shepp arcs)
+            Tow->>Coll: re-validate final arc (path_first_conflict → check)
+            Coll-->>Tow: per-pose clear / Conflict
+        end
+        alt all planes routed
+            Tow-->>Solver: MovesPlan
+        else greedy stuck
+            Tow-->>Solver: raise NoFeasiblePlanError(plane_id)
+            Note over Solver: plans[i] = None;<br/>plane → diagnostics.unroutable_planes
+        end
+    end
+    Solver-->>CLI: SolveResult(layouts, plans, diagnostics, status, seed)
+
+    loop per returned layout
+        CLI->>Viz: render_layout(layout, moves_plan=plans[i])
+        Note over Viz: _draw_tow_paths samples each arc<br/>(un-routable → no overlay)
+        Viz->>FS: write out_i.png
+    end
+    Note over CLI: _warn_unroutable: stderr names each blocked plane
+    alt no candidate routable (all plans None)
+        CLI->>Op: exit 3
+    else ≥1 routable
+        CLI->>Op: exit 0 (or status-driven)
+    end
+```
+
+*Scenario 3 — `solve --render-paths`: `solve(plan_paths=True)` tow-plans each accepted layout via `plan_fill` (back-first order; per-plane Hybrid-A\* over Reeds–Shepp arcs, the final arc re-validated by `collisions.check`). Routing is best-effort — a layout the bounded planner can't route keeps `plans[i]=None` and the blocked plane is recorded in `diagnostics.unroutable_planes` rather than dropping the valid static layout. The CLI overlays each routable path and exits 3 only when no returned candidate is tow-routable (#193/#197, ADR-0007/ADR-0010).*
+
 ## What is *not* a runtime concern
 
 - **Long-running state.** Each invocation is stateless. There is no

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -36,6 +36,41 @@ the uniform two-clause predicate. See
 [ADR-0012](../adr/0012-fuselage-front-aft-split.md) for the rationale
 and rejected alternatives.
 
+The wing-over-tail-but-not-cockpit rule in plan view, with the height
+band that makes the aft case a pass-through:
+
+```text
+PLAN VIEW (top-down).  World frame: +x along the door, +y INTO the hangar.
+Plane B parked nose-in (heading_deg = 0 -> nose toward +y).  Plane-local +x = nose.
+Split station x_break = wing.offset_x_m - wing.length_m/2  (the wing TRAILING edge):
+  fuselage_front = nose side [x_break .. nose]   |   fuselage_aft = tail side [tail .. x_break]
+
+           nose (+y, deeper in)                         nose (+y, deeper in)
+              ^   Plane B fuselage                          ^   Plane B fuselage
+              |                                             |
+        +-----------+  ... fuselage_front (COCKPIT)   +-----------+
+        |::::: A :::|                                 |           |
+   - - -|:::::::::::|- - - x_break (wing TE) - - - - - |           |- - - x_break - - -
+        |           |  ... fuselage_aft (TAIL)        |::::: A :::|
+        |           |                                 |:::::::::::|
+        +-----------+                                 +-----------+
+              |   tail (-y)                                 |   tail (-y)
+   [::: A :::] = Plane A's WING footprint overhanging Plane B in plan view
+
+      CASE B:  wing over fuselage_front          CASE A:  wing over fuselage_aft
+      => HARD CONFLICT, z-gap IGNORED            => LEGAL iff heights disjoint
+         (fuselage_front_wing_overlap)              (height-disjoint pass-through)
+
+HEIGHT BAND (side view, both cases): A's wing sits ABOVE B's fuselage with a
+z-gap >= wing_layer_clearance_m.   Case A: the gap makes it pass.  Case B: the
+gap is irrelevant -- the cockpit rule drops clause (2) entirely (ADR-0012, D1).
+
+         A wing  ----========----    (z_bottom_m .. z_top_m, the upper layer)
+                        | z-gap >= wing_layer_clearance_m
+         B fuselage  [############]   (lower layer)
+```
+*A wingtip may overhang a parked plane's aft fuselage / tail (Case A: legal when heights are disjoint, the two-clause `wing × fuselage_aft` rule) but never its cockpit / front fuselage (Case B: a hard `fuselage_front_wing_overlap` conflict at any nesting height). The loader auto-splits a `fuselage` part at the wing trailing edge `x_break`; front is the nose side, aft the tail side.*
+
 The closed set of `PartKind` values is `{"fuselage_front",
 "fuselage_aft", "wing", "strut", "tail"}`. The legacy `"fuselage"` is
 **not** a constructed kind — it survives only as a transient YAML keyword
@@ -81,6 +116,37 @@ that the back-`y` edge is *inherited* from the hangar boundary
 re-tested here. Any vertex of a non-occupant part that lies strictly
 inside that rectangle fires a `bay_intrusion` conflict on the owning
 plane — one conflict per offending part.
+
+Top-down, with the placeholder `data/hangar.yaml` values made concrete
+(the bay is the back-right 9 m × 9 m corner):
+
+```text
+ back wall  y = length_m = 25.0   (bay back edge: INHERITED, INCLUSIVE -> y = 25 is INSIDE)
+ x=0                                          x=9            x=13.5          x=18
+  +==========================================+=============================+   y = 25.0  [INSIDE]
+  |                                          |#############################|
+  |                                          |#  MAINTENANCE BAY (closed)  #|   right edge x=18
+  |          normal hangar floor             |#  back-anchored, partial-w  #|   == hangar wall
+  |                                          |#  x in (9.0, 18.0)          #|
+  |                                          |#  y in (16.0, 25.0]         #|
+  |                                          |#  any non-occupant vertex   #|
+  |                                          |#  STRICTLY inside  =>  one   #|
+  |                                          |#  bay_intrusion per part    #|
+  +------------------------------------------+#############################+   y = 16.0  (= 25 - 9)
+  |              side aisle                   ^ left edge x=9   front edge y=16  (both STRICT:
+  |        (a vertex ON x=9 or y=16                                              a vertex ON the
+  |         counts as OUTSIDE the bay)                                           edge is OUTSIDE)
+  |                                                                          |
+  |        +x runs right along the door --->        +y runs into hangar      |
+  +=========================[  door  ]=======================================+   y = 0.0
+ x=0          door center_x=9.0, width=12.0  (x in [3, 15])               x=18
+ front wall   heading_deg = 0 points toward +y (into the hangar)
+
+ In-bay predicate:  (9.0 < x < 18.0)  AND  (16.0 < y <= 25.0)
+   strict < on the left / right / front edges; inclusive <= on the back edge
+   (inherited from _hangar_bounds_conflicts, so y = 25 is not re-tested here)
+```
+*Maintenance-bay geometry on the placeholder hangar (`length_m`=25, `width_m`=18; bay `center_x_m`=13.5, `width_m`=9, `depth_m`=9): the back-right 9×9 m corner, `x ∈ (9.0, 18.0)`, `y ∈ (16.0, 25.0]`. The left/right/front edges are strict `<` (a vertex on the edge is in the aisle, not the bay); the back-`y` edge is inclusive because it coincides with the hangar back wall and is inherited from `_hangar_bounds_conflicts`. When a maintenance occupant is set, any non-occupant part vertex strictly inside fires one `bay_intrusion` conflict per offending part.*
 
 This rule replaced the earlier "fuselage centroid in the back strip"
 rule during the bay-walling work that completed in
@@ -153,6 +219,60 @@ headings (near 180°) are out of scope here; they belong to the Reeds–Shepp
 motion issue (#261). This replaces the earlier v1 single-ray reduction (one
 clamped target-x, heading 0°) described in ADR-0007 Q6.
 
+The motion vocabulary and the door entry-cone the planner searches over:
+
+```text
+REEDS-SHEPP MOTION MODEL (towplanner._primitives, ADR-0010)
+World frame: +x runs ALONG the door, +y runs INTO the hangar.
+A pose heading_deg=0 points nose-first toward +y (straight in).
+
+(1) REVERSE-CAPABLE REORIENT vs CART PIVOT-IN-PLACE
+---------------------------------------------------------------------
+ OWN GEAR (turn_radius_m = r > 0): 6 primitives, fixed order
+   forward:  Lf   Sf   Rf      reverse:  Lr   Sr   Rr   (gear = -1)
+   reverse legs cost _REVERSE_COST_FACTOR = 1.5 x  -> forward preferred
+
+   A turned goal a forward-only Dubins car can't reach in-bounds:
+
+      forward-only Dubins          Reeds-Shepp (fwd arc-line-arc + reverse)
+      must drive a full            backs up to reorient, then pulls in
+      turning-circle loop          (measured: an 18 m reverse beats a 32 m
+        .--->--.                    loop; even at the 1.5x weight it wins)
+       /        \                       Sf      Lr (reverse arc)
+      |  ~32 m   |  goal             >------>  .<......
+       \        /   X (turned)              \ '-.    : reverse retreats
+        '--<---'                       Lf arc   '--> X   around the steer centre
+
+ CART (turn_radius_m = 0): 4 primitives  ->  Lf  Sf  Rf  Sr
+   pivot-in-place (r = 0, zero translation) + reverse-straight (Sr).
+   Reverse PIVOTS (Lr/Rr) are omitted: a reverse pivot rotates heading the
+   same way as the OPPOSITE forward pivot -> exact duplicate, always loses
+   the best_g race. Only the reverse *straight* (Sr) is a genuinely new move.
+
+        ^ pivot CCW (Lf)    pivot CW (Rf)        Sr: back straight
+        |  .-.                .-.                 out of a slot
+        | (   ) spin in place (   )            <===== [plane] ======
+
+(2) DOOR ENTRY-CONE  (entry_poses, #262)  -- 3 x-samples x 5 headings
+---------------------------------------------------------------------
+ All surviving cone poses are seeded into the Hybrid-A* frontier at g=0
+ simultaneously; A* then returns the shortest path across the whole cone.
+
+  x-samples (within door interval): door-centre | clamped-target-x | midpoint
+  headings (forward-admissible, straight-in +/-30 deg in 15 deg steps):
+        330   345    0    15    30        (0 = straight into +y)
+
+  front wall (y=0) ===door-gap=== along +x ============================
+        x0          x1(target)         x2(mid)
+      \ | /        \ | /              \ | /        each fan = 5 headings
+       \|/          \|/                \|/         {330,345,0,15,30}
+        *            *                  *          = up to 15 seed poses
+                     |                              (duplicates removed;
+                     v  +y into hangar               poses clipping the
+                                                      side/back walls dropped)
+```
+*Reeds–Shepp gives every plane reverse legs (6 own-gear primitives `Lf Sf Rf Lr Sr Rr`, reverse weighted 1.5×; carts get 4: `Lf Sf Rf` + reverse-straight `Sr`), and the planner seeds the Hybrid-A\* search from a 3×5 door-cone fan instead of a single straight-in ray.*
+
 ## The coordinate convention
 
 The single most contributor-confusing concept in the project. Read
@@ -202,6 +322,44 @@ review-time subagent are the project's combined defense against a
 well-meaning contributor "fixing" it.
 
 If you're tempted to simplify the matrix, read ADR-0002 first.
+
+The picture below makes the handedness flip concrete: at the 45° canary
+heading the plane-local axes are overlaid on the world frame. The nose
+*and* the right wingtip both land in `+x` (to the right), but the wingtip
+lands *clockwise* of the nose, in `−y` (toward the door) — the opposite
+of where a pure (det = +1) rotation would send it.
+
+```text
+heading_deg = 45   (compass heading, CW from world +y; plane at the origin)
+plane-local axes:  +u = nose (forward),   +v = right wingtip (starboard)
+
+det = -1 map (local -> world), ADR-0002 / geometry.py:
+    world_x = x + u*sin(h) + v*cos(h)
+    world_y = y + u*cos(h) - v*sin(h)        at h = 45deg, sin h = cos h = 0.71
+
+                        +y  (deeper into hangar)
+                        ^
+                        |        N      nose:    (u=1, v=0) -> (+0.71, +0.71)
+                        |       /              ...lands in the (+x, +y) quadrant
+                        |      /
+                        |     /         sweeping nose -> right wingtip is +90deg
+                        |    /          IN THE PLANE, but in the WORLD the
+   -x ------------------+--------------> +x   (right, along the door wall)
+                        |    \          wingtip lands CLOCKWISE of the nose
+                        |     \
+                        |      \
+                        |       \
+                        |        R      wingtip: (u=0, v=1) -> (+0.71, -0.71)
+                        v              ...lands in the (+x, -y) quadrant
+                       -y  (front of door)         (right AND toward the door)
+
+THE FLIP:  a right-handed (det = +1) CCW rotation would instead send the
+           wingtip to (-0.71, +0.71) = the (-x, +y) quadrant -- mirrored,
+           WRONG. The nose probe alone cannot catch this (sin45 = cos45, so
+           the row swap is invisible at 45deg for u=1,v=0); only the wingtip
+           sign-flip reveals it. That is what the 45deg canary test pins.
+```
+*Plane-local frame (+u = nose, +v = right wingtip) overlaid on the world frame at the 45° canary heading. Both probes land in `+x`; the nose at (+0.71, +0.71) and the right wingtip at (+0.71, −0.71). A pure rotation would mirror the wingtip to (−0.71, +0.71). That reflected handedness is the determinant −1 (ADR-0002).*
 
 ### Fuselage offset signs
 

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -40,21 +40,21 @@ The wing-over-tail-but-not-cockpit rule in plan view, with the height
 band that makes the aft case a pass-through:
 
 ```text
-PLAN VIEW (top-down).  World frame: +x along the door, +y INTO the hangar.
-Plane B parked nose-in (heading_deg = 0 -> nose toward +y).  Plane-local +x = nose.
+PLAN VIEW (top-down).  +x along the door; +y runs deeper into the hangar,
+drawn DOWNWARD (door at top) to match the §8 convention box and the renderer.
+Plane B parked nose-in (heading_deg = 0 -> nose points DOWN, deeper in).  Plane-local +x = nose.
 Split station x_break = wing.offset_x_m - wing.length_m/2  (the wing TRAILING edge):
   fuselage_front = nose side [x_break .. nose]   |   fuselage_aft = tail side [tail .. x_break]
 
-           nose (+y, deeper in)                         nose (+y, deeper in)
-              ^   Plane B fuselage                          ^   Plane B fuselage
-              |                                             |
-        +-----------+  ... fuselage_front (COCKPIT)   +-----------+
-        |::::: A :::|                                 |           |
-   - - -|:::::::::::|- - - x_break (wing TE) - - - - - |           |- - - x_break - - -
-        |           |  ... fuselage_aft (TAIL)        |::::: A :::|
-        |           |                                 |:::::::::::|
+              |   tail (-y, near door)                      |   tail (-y, near door)
         +-----------+                                 +-----------+
-              |   tail (-y)                                 |   tail (-y)
+        |           |                                 |:::::::::::|
+        |           |  ... fuselage_aft (TAIL)        |::::: A :::|
+   - - -|:::::::::::|- - - x_break (wing TE) - - - - - |           |- - - x_break - - -
+        |::::: A :::|                                 |           |
+        +-----------+  ... fuselage_front (COCKPIT)   +-----------+
+              |   Plane B fuselage                          |   Plane B fuselage
+              v   nose (+y, deeper in)                      v   nose (+y, deeper in)
    [::: A :::] = Plane A's WING footprint overhanging Plane B in plan view
 
       CASE B:  wing over fuselage_front          CASE A:  wing over fuselage_aft
@@ -121,26 +121,27 @@ Top-down, with the placeholder `data/hangar.yaml` values made concrete
 (the bay is the back-right 9 m × 9 m corner):
 
 ```text
- back wall  y = length_m = 25.0   (bay back edge: INHERITED, INCLUSIVE -> y = 25 is INSIDE)
- x=0                                          x=9            x=13.5          x=18
-  +==========================================+=============================+   y = 25.0  [INSIDE]
-  |                                          |#############################|
-  |                                          |#  MAINTENANCE BAY (closed)  #|   right edge x=18
-  |          normal hangar floor             |#  back-anchored, partial-w  #|   == hangar wall
+ TOP-DOWN.  +x along the door; +y runs deeper into the hangar, drawn DOWNWARD
+ (door at top) to match the §8 convention box and the renderer.  Placeholder
+ data/hangar.yaml: length_m=25, width_m=18; bay center_x_m=13.5, width_m=9,
+ depth_m=9  ->  x in (9.0, 18.0),  y in (16.0, 25.0].
+ x=0          door center_x=9.0, width=12.0  (x in [3, 15])               x=18
+  +=========================[  door  ]=======================================+   y = 0.0   front wall
+  |        +x runs right along the door --->        +y runs into hangar      |
+  |                                                                          |
+  |                                                                          |
+  +------------------------------------------+#############################+   y = 16.0  bay FRONT edge
+  |                                          |#############################|   (= 25 - depth; STRICT:
+  |                                          |#  MAINTENANCE BAY (closed)  #|   a vertex ON x=9 or
+  |          normal hangar floor             |#  back-anchored, partial-w  #|   y=16 is OUTSIDE the bay)
   |                                          |#  x in (9.0, 18.0)          #|
-  |                                          |#  y in (16.0, 25.0]         #|
-  |                                          |#  any non-occupant vertex   #|
+  |                                          |#  y in (16.0, 25.0]         #|   right edge x=18
+  |                                          |#  any non-occupant vertex   #|   == hangar wall
   |                                          |#  STRICTLY inside  =>  one   #|
   |                                          |#  bay_intrusion per part    #|
-  +------------------------------------------+#############################+   y = 16.0  (= 25 - 9)
-  |              side aisle                   ^ left edge x=9   front edge y=16  (both STRICT:
-  |        (a vertex ON x=9 or y=16                                              a vertex ON the
-  |         counts as OUTSIDE the bay)                                           edge is OUTSIDE)
-  |                                                                          |
-  |        +x runs right along the door --->        +y runs into hangar      |
-  +=========================[  door  ]=======================================+   y = 0.0
- x=0          door center_x=9.0, width=12.0  (x in [3, 15])               x=18
- front wall   heading_deg = 0 points toward +y (into the hangar)
+  +==========================================+#############################+   y = 25.0  [INSIDE]
+ x=0                                          x=9            x=13.5          x=18
+ back wall  y = length_m = 25.0   (bay back edge: INHERITED, INCLUSIVE -> y = 25 is INSIDE)
 
  In-bay predicate:  (9.0 < x < 18.0)  AND  (16.0 < y <= 25.0)
    strict < on the left / right / front edges; inclusive <= on the back edge
@@ -298,6 +299,12 @@ looking down on the layout:
 - `+y` runs deeper into the hangar.
 - `heading_deg = 0` means the plane's nose points toward `+y`
   (deeper into hangar).
+
+Throughout §8, the top-down diagrams draw `+y` **downward** (door at the
+top), matching this box and the PNG renderer (`visualize.py` inverts the
+y-axis so the door renders at the top). The one exception is the det = −1
+sketch below, which uses standard math axes (`+y` up) because it is a
+coordinate-algebra diagram, not a hangar floor plan.
 
 **Plane-local coordinates** — origin at the plane reference point
 (main-gear / cart centroid):

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -50,7 +50,7 @@ Split station x_break = wing.offset_x_m - wing.length_m/2  (the wing TRAILING ed
         +-----------+                                 +-----------+
         |           |                                 |:::::::::::|
         |           |  ... fuselage_aft (TAIL)        |::::: A :::|
-   - - -|:::::::::::|- - - x_break (wing TE) - - - - - |           |- - - x_break - - -
+   - - -|:::::::::::|- - - x_break (wing TE) - - - - -|           |- - - x_break - - -
         |::::: A :::|                                 |           |
         +-----------+  ... fuselage_front (COCKPIT)   +-----------+
               |   Plane B fuselage                          |   Plane B fuselage

--- a/docs/assets/avatar.svg
+++ b/docs/assets/avatar.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="hangarfit">
+  <!-- White delta on the hangarfit Horizon accent circle, mark at ~52%.
+       Circle fill swapped from the shared #0D0E10 to #0079B5; mark kept white
+       at translate(24,24) scale(0.52). GitHub/package avatar source. -->
+  <circle cx="50" cy="50" r="50" fill="#0079B5"/>
+  <g transform="translate(24,24) scale(0.52)" fill="#FFFFFF">
+    <path d="M50 17.09 L69.87 51.5 L30.13 51.5 Z"/>
+    <path d="M26.96 57 L73.04 57 L88 82.91 L12 82.91 Z"/>
+  </g>
+</svg>

--- a/docs/assets/banner.svg
+++ b/docs/assets/banner.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 400" width="1280" height="400" role="img" aria-label="hangarfit — validate, solve, and render a flying club's hangar-parking layouts, from above">
+  <!--
+    hangarfit README banner — ON-BRAND VECTOR STOPGAP (DocGerdSoft brand handoff,
+    Deliverable 2, Composition A "Split"). The pixel-accurate PNG is the canonical
+    deliverable and is deferred to a Claude Design export; this SVG is a faithful
+    vector approximation. The wordmark falls back to system-ui because Geist is not
+    installed locally, so this is NOT pixel-identical to the design comp.
+    Canvas 1280x400. No (R)/(TM); DocGerdSoft is a personal brand, not a company.
+  -->
+  <defs>
+    <linearGradient id="horizonRule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#0079B5"/>
+      <stop offset="1" stop-color="#0079B5" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="gridMask" cx="78%" cy="30%" r="72%">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="1"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid40" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0 L0 0 L0 40" fill="none" stroke="#E6E9EC" stroke-width="1"/>
+    </pattern>
+    <mask id="gridFade">
+      <rect width="1280" height="400" fill="url(#gridMask)"/>
+    </mask>
+  </defs>
+
+  <!-- Background: Paper + faint 40px grid masked by a radial fade toward the right. -->
+  <rect width="1280" height="400" fill="#FBFBFC"/>
+  <rect width="1280" height="400" fill="url(#grid40)" mask="url(#gridFade)"/>
+
+  <!-- Right column: abstract top-down hangar schematic, bleeding off the right edge.
+       Three solid walls + a front wall with a central door gap, plus a faint
+       back-strip maintenance bay. Schematic only — never the brand mark. -->
+  <g transform="translate(760,60)" opacity="0.9">
+    <!-- floor -->
+    <rect x="0" y="0" width="560" height="280" fill="#FFFFFF" stroke="none"/>
+    <!-- back-strip maintenance bay (~13% opacity maint colour) -->
+    <rect x="0" y="0" width="560" height="46" fill="#7B63A3" opacity="0.13"/>
+    <!-- back wall -->
+    <line x1="0" y1="0" x2="560" y2="0" stroke="#3B4046" stroke-width="3"/>
+    <!-- left + right walls -->
+    <line x1="0" y1="0" x2="0" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="560" y1="0" x2="560" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <!-- front wall split around a central door gap -->
+    <line x1="0" y1="280" x2="210" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="350" y1="280" x2="560" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="210" y1="280" x2="350" y2="280" stroke="#bdc3c7" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <!-- a few abstract plane-slot tiles, brand palette, ink outline (never hue alone) -->
+    <rect x="60"  y="70"  width="120" height="40" rx="6" fill="#0079B5" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="220" y="120" width="120" height="40" rx="6" fill="#D55E00" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="380" y="80"  width="120" height="40" rx="6" fill="#009E73" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="110" y="180" width="120" height="40" rx="6" fill="#B45CA6" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="330" y="200" width="120" height="40" rx="6" fill="#4C4C9E" stroke="#14161A" stroke-width="1.5"/>
+  </g>
+
+  <!-- Left column (fixed 560px), padding 56 48, vertically centered. -->
+  <g transform="translate(48,118)">
+    <!-- Lockup: delta mark 54x54 (#0079B5) + wordmark. -->
+    <g transform="translate(0,0)">
+      <g transform="scale(0.54)" fill="#0079B5">
+        <path d="M50 17.09 L69.87 51.5 L30.13 51.5 Z"/>
+        <path d="M26.96 57 L73.04 57 L88 82.91 L12 82.91 Z"/>
+      </g>
+      <text x="70" y="48" font-family="Geist, system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
+            font-size="52" font-weight="600" letter-spacing="-1.5">
+        <tspan fill="#14161A">hangar</tspan><tspan fill="#0079B5">fit</tspan>
+      </text>
+    </g>
+
+    <!-- Horizon rule: 120x2 gradient. -->
+    <rect x="2" y="78" width="120" height="2" fill="url(#horizonRule)"/>
+
+    <!-- Tagline, ~23px, graphite-strong. -->
+    <text x="0" y="120" font-family="Geist, system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
+          font-size="23" font-weight="400" fill="#3B4046">
+      <tspan x="0" dy="0">Validate, solve, and render a flying club's</tspan>
+      <tspan x="0" dy="32">hangar-parking layouts — from above.</tspan>
+    </text>
+
+    <!-- Mono command block, ~16px, graphite. $ in accent, check + verdict in valid green. -->
+    <text x="0" y="206" font-family="'Geist Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace"
+          font-size="16" fill="#5E646B">
+      <tspan fill="#0079B5">$</tspan><tspan> hangarfit check layouts/example.yaml</tspan>
+    </text>
+    <text x="0" y="232" font-family="'Geist Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace"
+          font-size="16" fill="#5E646B">
+      <tspan fill="#0F7C72">-</tspan><tspan> valid  // 9 planes . 0 conflicts</tspan>
+    </text>
+  </g>
+</svg>

--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="hangarfit">
+  <!-- White delta on the hangarfit Horizon accent tile, container radius 22%
+       (tokens.radius.faviconContainer). Tile fill swapped from the shared
+       #0D0E10 to #0079B5; mark kept white at translate(19,19) scale(0.62).
+       Generate 48/32 PNG + ICO from this; use mark-line below 24px. -->
+  <rect width="100" height="100" rx="22" fill="#0079B5"/>
+  <g transform="translate(19,19) scale(0.62)" fill="#FFFFFF">
+    <path d="M50 17.09 L69.87 51.5 L30.13 51.5 Z"/>
+    <path d="M26.96 57 L73.04 57 L88 82.91 L12 82.91 Z"/>
+  </g>
+</svg>

--- a/docs/assets/mark.svg
+++ b/docs/assets/mark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="#0079B5" role="img" aria-label="hangarfit">
+  <!-- DocGerdSoft delta mark, recoloured to the hangarfit Horizon accent #0079B5.
+       Geometry reused verbatim from /home/pkuhn/brand/logo/mark-solid.svg:
+       an abstract equilateral delta split by a horizontal datum line. -->
+  <path d="M50 17.09 L69.87 51.5 L30.13 51.5 Z"/>
+  <path d="M26.96 57 L73.04 57 L88 82.91 L12 82.91 Z"/>
+</svg>

--- a/docs/assets/monogram.svg
+++ b/docs/assets/monogram.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88 88" width="88" height="88" role="img" aria-label="hangarfit">
+  <!-- "hf" monogram: white on the hangarfit Horizon accent tile, radius 10px
+       (tokens.radius.md). Geist Mono 600 per the handoff; system monospace
+       fallback since Geist Mono may be absent locally. For tight horizontal
+       lockups / package avatars (handoff Deliverable 1, concept B). -->
+  <rect width="88" height="88" rx="10" fill="#0079B5"/>
+  <text x="44" y="44" fill="#FFFFFF"
+        font-family="'Geist Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace"
+        font-size="42" font-weight="600" letter-spacing="-1"
+        text-anchor="middle" dominant-baseline="central">hf</text>
+</svg>

--- a/docs/openssf-best-practices-badge-silver.md
+++ b/docs/openssf-best-practices-badge-silver.md
@@ -120,7 +120,7 @@ also [`SECURITY.md`](../SECURITY.md) and [`security-posture.md`](security-postur
 
 | Criterion | Status | Justification + evidence |
 |---|---|---|
-| `documentation_roadmap` (MUST) | **Met** | README "Scope" (Phase 1/2a shipped + explicit out-of-scope list) + public [milestones](https://github.com/DocGerd/hangarfit/milestones). |
+| `documentation_roadmap` (MUST) | **Met** | README "Scope" + the phase timeline in [arc42 §1](architecture/01-introduction-and-goals.md) (Phases 1 → 3b shipped, v0.1.0 → v0.8.0) + the explicit out-of-scope list + public [milestones](https://github.com/DocGerd/hangarfit/milestones). |
 | `documentation_architecture` (MUST) | **Met** | [`docs/architecture/`](architecture/) (arc42) + [`docs/adr/`](adr/). |
 | `documentation_security` (MUST) | **Met** | [`SECURITY.md`](../SECURITY.md) + [`security-posture.md`](security-posture.md) + the assurance case above. |
 | `documentation_quick_start` (MUST) | **Met** | README "Install" + "Usage" (`pip install -e .`; `hangarfit check …`). |
@@ -139,7 +139,7 @@ also [`SECURITY.md`](../SECURITY.md) and [`security-posture.md`](security-postur
 
 | Criterion | Status | Justification + evidence |
 |---|---|---|
-| `maintenance_or_update` (MUST) | **Met** | Actively maintained: tagged releases (v0.1.0, v0.6.0, v0.6.1), recent commits, `[Unreleased]` section in [`CHANGELOG.md`](../CHANGELOG.md). |
+| `maintenance_or_update` (MUST) | **Met** | Actively maintained: regular tagged releases from v0.1.0 to the current **v0.8.0** (2026-05-29), recent commits, `[Unreleased]` section in [`CHANGELOG.md`](../CHANGELOG.md). |
 
 ## 5. Reporting
 

--- a/docs/openssf-best-practices-badge.md
+++ b/docs/openssf-best-practices-badge.md
@@ -27,7 +27,7 @@ alert #4) once the entry reaches Passing — see
 
 ## 0. Items that need *your* decision in the live form
 
-Everything else is mechanical. These three need a human:
+Everything else is mechanical. These need a human:
 
 1. **`know_secure_design` / `know_common_errors`** (Security) — self-attestation
    that the maintainer understands secure-design principles and common
@@ -35,9 +35,10 @@ Everything else is mechanical. These three need a human:
    threat-surface reasoning in [`SECURITY.md`](../SECURITY.md) and the
    determinant-trap / input-validation handling in the ADRs. (Only you can
    truthfully assert this — it's true.)
-2. **`dynamic_analysis`** (Analysis, *SUGGESTED*) — currently **Unmet**; fuzzing
-   the YAML loader is tracked in **#143** (parked). SUGGESTED does not block
-   Passing — mark Unmet with the #143 reference, or N/A.
+2. **`dynamic_analysis`** (Analysis, *SUGGESTED*) — **now Met** (no longer a
+   pending decision): nightly Atheris + Hypothesis fuzzing of the YAML loader
+   runs in `fuzz.yml` (#143, closed; the geometry/collisions harness was added
+   in #363). Mark **Met** with the `fuzz.yml` reference.
 3. **Contact email** — the form asks for a project contact. Use whatever address
    you want public; SECURITY.md routes vulnerabilities through GitHub private
    advisories rather than email.
@@ -72,7 +73,7 @@ Everything else is mechanical. These three need a human:
 | `repo_distributed` | **Met** | Git (a distributed VCS). |
 | `version_unique` | **Met** | Unique version per release. |
 | `version_semver` | **Met** | Semantic Versioning; declared in CHANGELOG. <https://github.com/DocGerd/hangarfit/blob/develop/CHANGELOG.md> |
-| `version_tags` | **Met** | Git tags `v0.1.0`, `v0.6.0`, `v0.6.1`. <https://github.com/DocGerd/hangarfit/tags> |
+| `version_tags` | **Met** | Git tags `v0.1.0`, `v0.6.0`, `v0.6.1`, `v0.7.0`, `v0.7.1`, `v0.7.2`, `v0.8.0`. <https://github.com/DocGerd/hangarfit/tags> |
 | `release_notes` | **Met** | CHANGELOG.md (Keep a Changelog format) + GitHub Releases. <https://github.com/DocGerd/hangarfit/releases> |
 | `release_notes_vulns` | **Met** | No vulnerabilities to date; release notes would call out any security fix per the CHANGELOG's "Fixed" section convention. |
 
@@ -136,9 +137,9 @@ Everything else is mechanical. These three need a human:
 | `static_analysis_common_vulnerabilities` | **Met** | CodeQL's default Python query suite covers common vulnerability classes. |
 | `static_analysis_fixed` | **Met** | CodeQL/ruff/mypy findings are fixed before merge (CI-gated). |
 | `static_analysis_often` | **Met** | Runs on every PR into `develop`/`main`. |
-| `dynamic_analysis` | **Unmet** (SUGGESTED) | No fuzzing yet; tracked in **#143** (fuzz the YAML loader). Does not block Passing. <https://github.com/DocGerd/hangarfit/issues/143> |
+| `dynamic_analysis` | **Met** (SUGGESTED) | Nightly Atheris + Hypothesis fuzzing of the YAML loader, extended to a geometry/collisions harness (#363), via [`fuzz.yml`](../.github/workflows/fuzz.yml); #143 closed. <https://github.com/DocGerd/hangarfit/blob/develop/.github/workflows/fuzz.yml> |
 | `dynamic_analysis_unsafe` | **N/A** | No unsafe-language memory bugs (pure Python). |
-| `dynamic_analysis_enable_assertions` | **N/A** | Follows from `dynamic_analysis` being deferred. |
+| `dynamic_analysis_enable_assertions` | **N/A** | The Atheris/Hypothesis harness runs under standard CPython with assertions active; there is no separate instrumented build to toggle. |
 
 ---
 

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -123,6 +123,8 @@ second-person-gated — the cap this section describes.
 **off**. Enabling it would forbid the merge commits the GitFlow release
 flow depends on (`release/*` → `main`, and the back-merge to `develop`).
 The trade-off was explored in spike [#202] and the decision is recorded in
+[ADR-0014](adr/0014-merge-commit-only-history-strategy.md) — with the detailed
+`required_linear_history` analysis preserved in the superseded
 [ADR-0011](adr/0011-linear-history-strategy-under-gitflow.md); do not "fix"
 this to chase a Scorecard point.
 

--- a/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
+++ b/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
@@ -1,0 +1,229 @@
+# Free-castering tow-pivot capability — design
+
+- **Date:** 2026-05-29
+- **Status:** Proposed (awaiting user spec review → implementation plan)
+- **Target milestone:** #28 (v0.9.0)
+- **Subsystem:** `towplanner` motion model (via `models.py` accessor + fleet data)
+- **Related:** [ADR-0010](../../adr/0010-reeds-shepp-motion-model.md) (Reeds–Shepp motion),
+  [ADR-0007](../../adr/0007-tow-path-planner-v1-scope.md) (cart = own-gear with `turn_radius_m = 0`),
+  [ADR-0013](../../adr/0013-wheels-canonical-data.md) (canonical per-aircraft data),
+  issue **#263** (nose-out — enabled by this), issue **#320** (back-bias — complemented by this).
+
+---
+
+## 1. Problem
+
+The tow-path planner models every own-gear plane as a car-like Reeds–Shepp vehicle with a
+fixed minimum turning radius (`Aircraft.turn_radius_m`). For the Aviat Husky that radius is
+`5.0 m`. But the Husky is a **free-castering taildragger**: when towed by hand or a tail-tug,
+its tailwheel swivels freely and the airframe rotates essentially *within its own length*
+about the main-gear axle. The `5.0 m` figure models **powered self-taxi**, not **towing** —
+and the planner's job is to plan *tows*.
+
+The consequence is observable. In the six-plane fill (`tests/fixtures/solve_fresh_six_planes.yaml`,
+`--no-spread --seed 1`) the planner returns **exit 3**, and the blocking plane is *literally the
+Husky*:
+
+```
+layout not tow-routable by the tow-path planner: plane 'aviat_husky' blocked
+(no_feasible_path: no in-bounds tow path found within 2000 expansions)
+```
+
+The static layout is valid; the planner just can't thread a 5.0 m-radius car through the gap a
+real handler would pivot the Husky into. The model is **conservative to the point of being wrong
+for the towing use case.**
+
+## 2. Goal & non-goals
+
+**Goal.** Let a plane declared free-castering be planned with the realistic *towing* motion —
+pivot in place, push straight, pivot — which is both physically faithful for a hand/tail-tug
+tow and the thing that makes tight fills routable.
+
+**Non-goals.**
+- Not modelling powered taxi (the `turn_radius_m` arc stays as the documented powered figure).
+- Not adding a probabilistic planner (RRT-Connect remains deferred per ADR-0010).
+- Not re-centering the pivot on an arbitrary main-gear offset (see §4.3 alternative (b), deferred).
+- Not changing which planes ride carts or the cart-eligibility rules.
+
+## 3. Decision summary
+
+| Axis | Decision | Why |
+|---|---|---|
+| Objective | Model realistic towing (pivot + push), which also maximizes routability | A tow planner should model towing; pivot+push is how a free-caster is actually towed |
+| Declaration | Explicit per-plane `free_castering: bool` flag in `fleet.yaml`, default `false` | ADR-0013 ethos: declare canonical capability, don't infer from `gear` (steerable/lockable tailwheels don't fully caster) |
+| Data-model shape | **Orthogonal boolean, NOT a new `MovementMode`** | Keeps `on_carts`/`movement_mode` invariants and cart-pool accounting untouched (§4.1) |
+| Motion realization | Reuse the existing `turn_radius_m == 0` cart-pivot machinery | No new primitive / word / cost constant / geometry math → determinism surface unchanged |
+| Pivot center | About the plane **datum** (existing behavior); main-gear-offset pivot deferred | 0.20 m error for the Husky (main gear ≈ datum); offsetting would touch motion math + trigger geometry-guard |
+
+## 4. Design
+
+### 4.1 Data model — orthogonal boolean, not a movement mode (load-bearing)
+
+`free_castering` is a capability **orthogonal to `movement_mode`**, added as a new boolean field
+on `Aircraft` (default `False`). It is deliberately **not** a new `MovementMode` value:
+
+- A free-castering Husky is **still on its own gear** — `on_carts = False`. The `Layout`
+  consistency invariant (`always_cart ↔ on_carts`, `models.py:488`) and the solver's cart-pool
+  accounting key off `movement_mode`. A new movement mode would tangle with both; an orthogonal
+  boolean touches neither.
+- It composes: `always_own_gear + free_castering` (the Husky today) and
+  `cart_eligible + free_castering` (a tailwheel that pivots on its own gear *and* can ride a
+  cart) both fall out correctly with no special-casing. `always_cart + free_castering` is
+  redundant but harmless (already `0.0`); the loader stays permissive (the flag is gear- and
+  mode-agnostic, since free-castering nosewheels also exist).
+
+### 4.2 The accessor — the single behavioral change
+
+`Aircraft.effective_turn_radius_m()` (`models.py:299`) is the *one* place the planner resolves a
+plane's planning radius. Today:
+
+```python
+if self.movement_mode == "always_cart":
+    return 0.0
+return self.required_turn_radius_m()
+```
+
+becomes:
+
+```python
+if self.movement_mode == "always_cart" or self.free_castering:
+    return 0.0
+return self.required_turn_radius_m()
+```
+
+A flagged plane returns `0.0`, and from `plan_path:1679` (`r = mover.effective_turn_radius_m()`)
+that `0.0` flows through the **existing** cart-pivot path with no further branching:
+
+- `_primitives(0.0)` → the 4-primitive fan (pivot-L, straight-fwd, pivot-R, straight-rev)
+- `DubinsArc.pose_at` r==0 branch → pivot-in-place integration (position fixed, heading steps)
+- `DubinsArc.sample` r==0 branch → angular density for collision sampling of the pivot
+- `_seg_cost` r==0 branch → pivot cost in radians × `_TURN_PENALTY`
+- `plan_reeds_shepp(turn_radius_m=0.0)` → delegates to `_plan_cart` (pivot → push → pivot,
+  reverse-enabled)
+
+`required_turn_radius_m()` and the `__post_init__` validation are unchanged: a free-castering
+own-gear plane still carries a positive `turn_radius_m` (the documented powered-taxi figure); the
+planner simply stops consulting it.
+
+### 4.3 Pivot center
+
+The r==0 pivot rotates about the plane's **datum** (local origin, `local_to_world`,
+`geometry.py:119`). The physically-true center is the **main-gear axle** (`main_offset_x_m`).
+
+- **(a) Pivot about the datum — CHOSEN.** Reuse the machinery verbatim; `towplanner.py` and
+  `geometry.py` are untouched, so **no geometry-invariant-guard review is required**. Faithful
+  for the Husky: its main gear sits at `main_offset_x_m = 0.20 m`, i.e. 20 cm (sub-wheel-width)
+  from the datum. Documented assumption: *accurate when datum ≈ main gear; the flag is opt-in, so
+  only flag planes where this holds.*
+- **(b) Pivot about `main_offset_x_m` — DEFERRED.** Physically general, but requires offsetting
+  the pivot center inside `pose_at` → touches motion math → triggers the geometry-invariant-guard
+  sign-flip review and a new heading canary, and breaks the "planner untouched" property — for a
+  0.20 m gain on the only currently-flagged plane. Recorded in the ADR as the future refinement if
+  a plane with a far-offset datum is ever flagged.
+
+### 4.4 Change surface
+
+| File | Change | Notes |
+|---|---|---|
+| `src/hangarfit/models.py` | Add `free_castering: bool = False` to `Aircraft`; add `or self.free_castering` to the `0.0` branch of `effective_turn_radius_m()` | `MovementMode` and `__post_init__` unchanged |
+| `src/hangarfit/loader.py` | Parse `free_castering` (default `False`) | Boolean; no coupling to `gear` |
+| `data/fleet.yaml` | `aviat_husky: free_castering: true` + comment; update header doc block | Other planes default `false`; club fills in as known |
+| `src/hangarfit/towplanner.py` | **None** | The headline property — flagged planes reuse the existing deterministic r==0 path |
+| `src/hangarfit/geometry.py`, `collisions.py` | **None** | No motion math change under decision (a) |
+
+## 5. Determinism
+
+The tow planner is **RNG-free**; determinism is structural (fixed primitive-fan order, fixed
+Reeds–Shepp word order with strict-`<` tie-break, a monotonic `(f, counter, node)` heap
+tie-break, total-order sorts). Because flagged planes reuse the **existing** r==0 path, this
+change adds **no new primitive, word, cost constant, ordering surface, or RNG**. The determinism
+contract (ADR-0003, `max_restarts`-scoped per the #267 amendment) holds by construction.
+
+A determinism canary (§7) proves it empirically: a free-castering-Husky scenario must produce a
+**byte-identical `MovesPlan`** across two runs of the same scenario + seed.
+
+## 6. Real-world basis
+
+A free-castering tailwheel has no rudder linkage; the aircraft is steered by differential braking
+and, with the tailwheel free-swivelling, can be rotated about a main wheel **within its own
+length** (FAA *Airplane Flying Handbook* ch. 14; EAA; AOPA). A tail-tug makes the tailwheel a
+steered, pushed rear point (trailer kinematics); the handler swings the tail and the body rotates
+about the main-gear line. The faithful planner abstraction is therefore **rotation about the
+main-gear axle with near-zero translation**, with the **wingtips** sweeping the binding circle.
+
+Key numbers (Aviat Husky): wingspan **10.82 m** (the value already in `fleet.yaml`'s wing
+`width_m`), so the swept circle has radius ≈ **5.4 m** — *wingtips*, not the tail, dominate the
+footprint. The existing pivot already samples the full angular sweep for collision checking
+(`DubinsArc.sample` r==0 branch), so the wingtip sweep is collision-checked. Because the Husky's
+main gear is ~0 m from its datum, the datum pivot (§4.3a) is a faithful main-gear pivot for it.
+
+## 7. Testing
+
+- **Unit (`models`):** `effective_turn_radius_m()` returns `0.0` for a free-castering own-gear
+  plane; field defaults `False`; `cart_eligible + free_castering → 0.0`.
+- **Loader:** `free_castering` parsed; defaults `False`; round-trips.
+- **Planner integration:** a flagged own-gear plane yields a pivot-style path (a `turn_radius_m == 0`
+  `DubinsArc` containing pivot segments).
+- **🎯 Payoff test:** with `aviat_husky.free_castering = true`, the six-plane fill
+  (`solve_fresh_six_planes`, `--no-spread --seed 1`) routes the Husky — turning the observed
+  exit-3 into a fully-routed fill. Directly measurable against the motivating failure.
+- **Determinism canary:** a free-castering-Husky scenario produces a byte-identical `MovesPlan`
+  across two runs (extends the canary suite); passes by construction, proven by the test.
+
+## 8. ADR & docs
+
+A new ADR — *"Free-castering tow-pivot capability"* — records the orthogonal-flag decision, the
+datum-pivot approximation with (b) as the deferred alternative, and the towing-vs-powered-taxi
+rationale. It cross-references ADR-0010 (motion), ADR-0007 (cart = r=0), and ADR-0013 (canonical
+per-aircraft data — same ethos). **Number allocated via `/new-adr` at implementation time**
+(committed ADRs stop at 0013; 0014 is earmarked for #263 in an issue comment, so this will likely
+be 0015 or later). The ADR lands **with** the implementation PR, per the project's #320/#263
+convention. Also: `fleet.yaml` header note + a one-line CLAUDE.md/arc42 pointer.
+
+*Alternative considered:* amend ADR-0010 instead. Rejected — this adds a fleet-schema field and a
+capability concept (ADR-0013-shaped), so a new ADR reads cleaner than bolting it onto the
+motion-vocabulary ADR.
+
+## 9. Interactions with deferred milestone-#28 work
+
+- **#320 (back-bias):** complementary, no conflict. Back-packing leaves the door cone clear;
+  tighter turns only raise its towability floor. Neither reasons about turn geometry. Any order.
+- **#263 (nose-out):** this is a direct **enabler**. #263 names the tailwheel gear class and
+  depends on the planner cheaply realizing nose-out exits; the free-castering pivot makes that
+  cheaper still. Sequence tow-pivot first for maximal nose-out payoff; #263 ships correctly
+  without it. No #263 assumption changes.
+
+## 10. Review plan
+
+- `pr-review-toolkit:code-reviewer` — main pass.
+- `pr-review-toolkit:type-design-analyzer` — `models.py` changes (new field + accessor).
+- `determinism-guard` — planner *behavior* changes via the accessor (even though `towplanner.py`
+  is untouched), so the byte-identical-plan contract is re-verified.
+- **No `geometry-invariant-guard`** — decision (a) touches no geometry math. *(Decision (b) would
+  require it.)*
+
+## 11. Caveats & known limitations
+
+- **`DubinsArc.length_m` mixes radians (pivot segments) and metres (straights)** — a pre-existing
+  quirk that, with this change, appears in an *own-gear* plane's path for the first time. The
+  renderer consumes paths via `sample()` (pose-based), not `length_m`, so visuals are unaffected.
+  A code comment will warn against treating a flagged plane's `length_m` as a physical distance.
+- **Datum-pivot approximation** (§4.3a): faithful only where the datum ≈ main gear. True for the
+  Husky; the opt-in flag keeps it from being applied where it isn't.
+- **`cart_eligible`-on-a-cart pre-existing gap:** `effective_turn_radius_m()` keys on the
+  `always_cart` movement mode, not a placement's `on_carts` state, so a `cart_eligible` plane
+  placed on a cart is *not* given pivot motion today. Out of scope here; noted for completeness.
+
+## 12. Out of scope / future
+
+- Main-gear-offset pivot (§4.3b) — a fidelity ADR if a far-offset-datum plane is ever flagged.
+- Flagging planes beyond the Husky — a club data call as real measurements arrive.
+- Modelling powered self-taxi distinctly from towing.
+
+## 13. Process
+
+- Branch: `feature/free-castering-tow-pivot` off `develop`.
+- Tracking issue: file in milestone #28 at implementation time (`Closes #N` in the PR body), per
+  "no code without an issue".
+- Supervised work only (touches determinism-guarded planner behavior); no unattended worktree
+  dispatch.

--- a/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
+++ b/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
@@ -107,11 +107,15 @@ documented powered-taxi figure); the planner just stops consulting it.
 
 ### 4.3 Pivot center
 
-The r==0 pivot rotates about the plane's **datum** (local origin, `geometry.py:119`).
+The r==0 pivot rotates about the plane's **datum** (the `Pose` `x_m`/`y_m`, which is the
+plane-local origin). The mechanism is `DubinsArc.pose_at` (`towplanner.py:140-145`): for an `L`/`R`
+segment at `r==0`, position is held fixed and only the heading `theta` advances. (Note:
+`geometry.local_to_world`, `geometry.py:119`, is *unrelated* — it maps part vertices for the
+collision/visualize code, not for path integration.)
 
-- **(a) Pivot about the datum — CHOSEN.** Reuse the machinery verbatim; `towplanner.py` and
-  `geometry.py` untouched → **no geometry-invariant-guard review required**. Faithful here (all
-  flagged planes' main gear is ≤0.5 m from the datum).
+- **(a) Pivot about the datum — CHOSEN.** Reuse the machinery verbatim; the `pose_at` integrator
+  and `geometry.py` are untouched → **no geometry-invariant-guard review required**. Faithful here
+  (all flagged planes' main gear is ≤0.5 m from the datum).
 - **(b) Pivot about `main_offset_x_m` — DEFERRED.** General, but offsetting the pivot inside
   `pose_at` touches motion math → triggers the geometry sign-flip guard + a new canary, for a
   sub-metre gain on the current fleet. ADR records it as the future refinement.

--- a/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
+++ b/docs/superpowers/specs/2026-05-29-free-castering-tow-pivot-design.md
@@ -1,229 +1,220 @@
-# Free-castering tow-pivot capability — design
+# Tow-pivot capability (`tow_pivotable`) — design
 
 - **Date:** 2026-05-29
-- **Status:** Proposed (awaiting user spec review → implementation plan)
-- **Target milestone:** #28 (v0.9.0)
-- **Subsystem:** `towplanner` motion model (via `models.py` accessor + fleet data)
+- **Status:** **Shelved as a standalone change — to be implemented *together with* [#263](https://github.com/DocGerd/hangarfit/issues/263) (nose-out parked heading).** Design + characterization complete; coupled to #263 because the pivot's functional payoff is the nose-out motion.
+- **Target milestone:** #28 (v0.9.0), folded into #263.
+- **Subsystem:** `towplanner` motion model (via a `models.py` accessor + a fleet-data flag).
 - **Related:** [ADR-0010](../../adr/0010-reeds-shepp-motion-model.md) (Reeds–Shepp motion),
   [ADR-0007](../../adr/0007-tow-path-planner-v1-scope.md) (cart = own-gear with `turn_radius_m = 0`),
   [ADR-0013](../../adr/0013-wheels-canonical-data.md) (canonical per-aircraft data),
-  issue **#263** (nose-out — enabled by this), issue **#320** (back-bias — complemented by this).
+  **#263** (nose-out — the motion this enables), #320 (back-bias — complemented).
+
+> **Naming note.** An earlier draft called the flag `free_castering`. It is renamed
+> **`tow_pivotable`** because the capability is reached by *two* mechanisms (see §3): a
+> free-castering tailwheel, **or** pressing the tail down to lift a nosewheel off the ground.
+> The planner-relevant fact is "can be pivoted about the main gear when towed," not the gear type.
 
 ---
 
-## 1. Problem
+## 1. Origin & honest problem statement
 
-The tow-path planner models every own-gear plane as a car-like Reeds–Shepp vehicle with a
-fixed minimum turning radius (`Aircraft.turn_radius_m`). For the Aviat Husky that radius is
-`5.0 m`. But the Husky is a **free-castering taildragger**: when towed by hand or a tail-tug,
-its tailwheel swivels freely and the airframe rotates essentially *within its own length*
-about the main-gear axle. The `5.0 m` figure models **powered self-taxi**, not **towing** —
-and the planner's job is to plan *tows*.
+This started from an observation that the planner models every own-gear plane as a car-like
+Reeds–Shepp vehicle with a fixed `turn_radius_m` (5.0 m for the Husky), which models *powered
+self-taxi* — not *towing*. The hypothesis was that this conservatism is **why dense fills are
+un-towable**.
 
-The consequence is observable. In the six-plane fill (`tests/fixtures/solve_fresh_six_planes.yaml`,
-`--no-spread --seed 1`) the planner returns **exit 3**, and the blocking plane is *literally the
-Husky*:
+**That hypothesis was tested and falsified** (see §6 Characterization). Modelling the Husky as a
+zero-radius pivot does **not** make the six-plane fill routable: the binding constraint there is
+**wing-transit geometry** (a 10.82 m wingspan cannot thread the corridor between already-placed
+planes), which no turn-radius change addresses. A valid static layout does not guarantee an
+evacuation path — which is exactly why the tow planner is a separate stage.
 
-```
-layout not tow-routable by the tow-path planner: plane 'aviat_husky' blocked
-(no_feasible_path: no in-bounds tow path found within 2000 expansions)
-```
-
-The static layout is valid; the planner just can't thread a 5.0 m-radius car through the gap a
-real handler would pivot the Husky into. The model is **conservative to the point of being wrong
-for the towing use case.**
+**What the capability *is* good for** (also measured, §6): physical **fidelity** of the towing
+motion, **shorter/cleaner reorientation paths** (a 180° nose-out flip plans ~15% shorter as a
+pivot than as an arc loop), and being the **enabler for #263 nose-out** — facing-the-door parking
+becomes a cheap in-place pivot instead of a wide loop. Because that payoff is realized *through*
+#263, this design is shelved as a standalone PR and folded into #263.
 
 ## 2. Goal & non-goals
 
-**Goal.** Let a plane declared free-castering be planned with the realistic *towing* motion —
-pivot in place, push straight, pivot — which is both physically faithful for a hand/tail-tug
-tow and the thing that makes tight fills routable.
+**Goal.** Let a plane *declared* tow-pivotable be planned with the realistic towing motion —
+pivot in place, push straight, pivot — modelling how it is actually hand/tail-tug manoeuvred.
 
 **Non-goals.**
-- Not modelling powered taxi (the `turn_radius_m` arc stays as the documented powered figure).
-- Not adding a probabilistic planner (RRT-Connect remains deferred per ADR-0010).
-- Not re-centering the pivot on an arbitrary main-gear offset (see §4.3 alternative (b), deferred).
-- Not changing which planes ride carts or the cart-eligibility rules.
+- **Not** a dense-fill towability fix (falsified — §6). That needs corridor-aware packing or the
+  deferred #336 RRT-Connect, not this.
+- Not modelling powered taxi (`turn_radius_m` stays as the documented powered figure).
+- Not re-centering the pivot on an arbitrary main-gear offset (§4.3 alternative (b), deferred).
+- Not changing cart-eligibility or which planes ride carts.
 
-## 3. Decision summary
+## 3. The capability and its two mechanisms
 
-| Axis | Decision | Why |
-|---|---|---|
-| Objective | Model realistic towing (pivot + push), which also maximizes routability | A tow planner should model towing; pivot+push is how a free-caster is actually towed |
-| Declaration | Explicit per-plane `free_castering: bool` flag in `fleet.yaml`, default `false` | ADR-0013 ethos: declare canonical capability, don't infer from `gear` (steerable/lockable tailwheels don't fully caster) |
-| Data-model shape | **Orthogonal boolean, NOT a new `MovementMode`** | Keeps `on_carts`/`movement_mode` invariants and cart-pool accounting untouched (§4.1) |
-| Motion realization | Reuse the existing `turn_radius_m == 0` cart-pivot machinery | No new primitive / word / cost constant / geometry math → determinism surface unchanged |
-| Pivot center | About the plane **datum** (existing behavior); main-gear-offset pivot deferred | 0.20 m error for the Husky (main gear ≈ datum); offsetting would touch motion math + trigger geometry-guard |
+`tow_pivotable` means **the airframe can be rotated about its main-gear axle in place when
+towed**, reached by either:
+
+1. **Free-castering tailwheel** — the tailwheel swivels freely; lock/load one main and swing the
+   tail, the airframe rotates within its own length (Aviat Husky).
+2. **Nose-lift** — press the tail down so the nosewheel leaves the ground; the plane then pivots
+   on its mains exactly like (1) (light nosewheel types — **FK9, CTSL** per the club operator).
+
+Both are operational facts about ground handling, not gear-type inferences — hence an explicit,
+declared flag (ADR-0013 ethos), not a `gear == "tailwheel"` heuristic.
+
+### Scope (initial flag values)
+
+| Plane | Gear | Wingspan | Main gear vs datum | `tow_pivotable` | Mechanism |
+|---|---|---|---|---|---|
+| aviat_husky | tailwheel | 10.82 m | +0.20 m | **true** | free-castering tailwheel |
+| fk9_mkii | nosewheel | 9.85 m | −0.10 m | **true** | tail-down nose-lift |
+| ctsl | nosewheel | 8.59 m | −0.10 m | **true** | tail-down nose-lift |
+| cessna_140 | tailwheel | 10.16 m | +0.50 m | *club data call* | (tailwheel — likely, unconfirmed) |
+| *(all others)* | — | — | — | false (default) | — |
+
+The datum-pivot approximation (§4.3) holds for all of these — main gear within 0.5 m of the datum.
 
 ## 4. Design
 
 ### 4.1 Data model — orthogonal boolean, not a movement mode (load-bearing)
 
-`free_castering` is a capability **orthogonal to `movement_mode`**, added as a new boolean field
-on `Aircraft` (default `False`). It is deliberately **not** a new `MovementMode` value:
+`tow_pivotable` is a capability **orthogonal to `movement_mode`**, added as a `bool` field on
+`Aircraft` (default `False`). It is deliberately **not** a new `MovementMode` value:
 
-- A free-castering Husky is **still on its own gear** — `on_carts = False`. The `Layout`
+- A tow-pivotable Husky is **still on its own gear** — `on_carts = False`. The `Layout`
   consistency invariant (`always_cart ↔ on_carts`, `models.py:488`) and the solver's cart-pool
   accounting key off `movement_mode`. A new movement mode would tangle with both; an orthogonal
   boolean touches neither.
-- It composes: `always_own_gear + free_castering` (the Husky today) and
-  `cart_eligible + free_castering` (a tailwheel that pivots on its own gear *and* can ride a
-  cart) both fall out correctly with no special-casing. `always_cart + free_castering` is
-  redundant but harmless (already `0.0`); the loader stays permissive (the flag is gear- and
-  mode-agnostic, since free-castering nosewheels also exist).
+- It composes: `always_own_gear + tow_pivotable` (the Husky) and `cart_eligible + tow_pivotable`
+  (FK9, CTSL — pivot on own gear *and* can ride a cart) both fall out with no special-casing.
+  `always_cart + tow_pivotable` is redundant-but-harmless (already `0.0`); the loader stays
+  permissive (the flag is gear- and mode-agnostic).
 
 ### 4.2 The accessor — the single behavioral change
 
 `Aircraft.effective_turn_radius_m()` (`models.py:299`) is the *one* place the planner resolves a
-plane's planning radius. Today:
+plane's planning radius:
 
 ```python
-if self.movement_mode == "always_cart":
+if self.movement_mode == "always_cart" or self.tow_pivotable:
     return 0.0
 return self.required_turn_radius_m()
 ```
 
-becomes:
-
-```python
-if self.movement_mode == "always_cart" or self.free_castering:
-    return 0.0
-return self.required_turn_radius_m()
-```
-
-A flagged plane returns `0.0`, and from `plan_path:1679` (`r = mover.effective_turn_radius_m()`)
-that `0.0` flows through the **existing** cart-pivot path with no further branching:
-
-- `_primitives(0.0)` → the 4-primitive fan (pivot-L, straight-fwd, pivot-R, straight-rev)
-- `DubinsArc.pose_at` r==0 branch → pivot-in-place integration (position fixed, heading steps)
-- `DubinsArc.sample` r==0 branch → angular density for collision sampling of the pivot
-- `_seg_cost` r==0 branch → pivot cost in radians × `_TURN_PENALTY`
-- `plan_reeds_shepp(turn_radius_m=0.0)` → delegates to `_plan_cart` (pivot → push → pivot,
-  reverse-enabled)
-
-`required_turn_radius_m()` and the `__post_init__` validation are unchanged: a free-castering
-own-gear plane still carries a positive `turn_radius_m` (the documented powered-taxi figure); the
-planner simply stops consulting it.
+A flagged plane returns `0.0`, and from `plan_path:1679` that flows through the **existing**
+cart-pivot path with no further branching (`_primitives(0.0)`, the `pose_at`/`sample`/`_seg_cost`
+r==0 branches, `plan_reeds_shepp → _plan_cart`). `required_turn_radius_m()` and `__post_init__`
+are unchanged — a tow-pivotable own-gear plane still carries its positive `turn_radius_m` (the
+documented powered-taxi figure); the planner just stops consulting it.
 
 ### 4.3 Pivot center
 
-The r==0 pivot rotates about the plane's **datum** (local origin, `local_to_world`,
-`geometry.py:119`). The physically-true center is the **main-gear axle** (`main_offset_x_m`).
+The r==0 pivot rotates about the plane's **datum** (local origin, `geometry.py:119`).
 
 - **(a) Pivot about the datum — CHOSEN.** Reuse the machinery verbatim; `towplanner.py` and
-  `geometry.py` are untouched, so **no geometry-invariant-guard review is required**. Faithful
-  for the Husky: its main gear sits at `main_offset_x_m = 0.20 m`, i.e. 20 cm (sub-wheel-width)
-  from the datum. Documented assumption: *accurate when datum ≈ main gear; the flag is opt-in, so
-  only flag planes where this holds.*
-- **(b) Pivot about `main_offset_x_m` — DEFERRED.** Physically general, but requires offsetting
-  the pivot center inside `pose_at` → touches motion math → triggers the geometry-invariant-guard
-  sign-flip review and a new heading canary, and breaks the "planner untouched" property — for a
-  0.20 m gain on the only currently-flagged plane. Recorded in the ADR as the future refinement if
-  a plane with a far-offset datum is ever flagged.
+  `geometry.py` untouched → **no geometry-invariant-guard review required**. Faithful here (all
+  flagged planes' main gear is ≤0.5 m from the datum).
+- **(b) Pivot about `main_offset_x_m` — DEFERRED.** General, but offsetting the pivot inside
+  `pose_at` touches motion math → triggers the geometry sign-flip guard + a new canary, for a
+  sub-metre gain on the current fleet. ADR records it as the future refinement.
 
 ### 4.4 Change surface
 
 | File | Change | Notes |
 |---|---|---|
-| `src/hangarfit/models.py` | Add `free_castering: bool = False` to `Aircraft`; add `or self.free_castering` to the `0.0` branch of `effective_turn_radius_m()` | `MovementMode` and `__post_init__` unchanged |
-| `src/hangarfit/loader.py` | Parse `free_castering` (default `False`) | Boolean; no coupling to `gear` |
-| `data/fleet.yaml` | `aviat_husky: free_castering: true` + comment; update header doc block | Other planes default `false`; club fills in as known |
-| `src/hangarfit/towplanner.py` | **None** | The headline property — flagged planes reuse the existing deterministic r==0 path |
-| `src/hangarfit/geometry.py`, `collisions.py` | **None** | No motion math change under decision (a) |
+| `src/hangarfit/models.py` | Add `tow_pivotable: bool = False` to `Aircraft`; add `or self.tow_pivotable` to the `0.0` branch of `effective_turn_radius_m()` | `MovementMode`, `__post_init__` unchanged |
+| `src/hangarfit/loader.py` | Parse `tow_pivotable` (default `False`) | Boolean; no coupling to `gear` |
+| `data/fleet.yaml` | `tow_pivotable: true` on `aviat_husky`, `fk9_mkii`, `ctsl` + comments; header doc | Others default `false` |
+| `src/hangarfit/towplanner.py` | **None** | Flagged planes reuse the existing deterministic r==0 path |
+| `geometry.py`, `collisions.py` | **None** | No motion math change under decision (a) |
 
 ## 5. Determinism
 
 The tow planner is **RNG-free**; determinism is structural (fixed primitive-fan order, fixed
 Reeds–Shepp word order with strict-`<` tie-break, a monotonic `(f, counter, node)` heap
-tie-break, total-order sorts). Because flagged planes reuse the **existing** r==0 path, this
-change adds **no new primitive, word, cost constant, ordering surface, or RNG**. The determinism
-contract (ADR-0003, `max_restarts`-scoped per the #267 amendment) holds by construction.
+tie-break). Reusing the **existing** r==0 path adds **no new primitive, word, cost constant,
+ordering surface, or RNG** — the determinism contract (ADR-0003, `max_restarts`-scoped per #267)
+holds by construction. A canary (§7) proves byte-identical `MovesPlan` across two runs.
 
-A determinism canary (§7) proves it empirically: a free-castering-Husky scenario must produce a
-**byte-identical `MovesPlan`** across two runs of the same scenario + seed.
+## 6. Characterization (the evidence; 2026-05-29)
 
-## 6. Real-world basis
+Method: monkeypatch `effective_turn_radius_m → 0.0` for the flagged set and compare against
+baseline, on real fixtures and constructed goals.
 
-A free-castering tailwheel has no rudder linkage; the aircraft is steered by differential braking
-and, with the tailwheel free-swivelling, can be rotated about a main wheel **within its own
-length** (FAA *Airplane Flying Handbook* ch. 14; EAA; AOPA). A tail-tug makes the tailwheel a
-steered, pushed rear point (trailer kinematics); the handler swings the tail and the body rotates
-about the main-gear line. The faithful planner abstraction is therefore **rotation about the
-main-gear axle with near-zero translation**, with the **wingtips** sweeping the binding circle.
+**(a) Routability — pivot converts ZERO cases, regresses none.**
 
-Key numbers (Aviat Husky): wingspan **10.82 m** (the value already in `fleet.yaml`'s wing
-`width_m`), so the swept circle has radius ≈ **5.4 m** — *wingtips*, not the tail, dominate the
-footprint. The existing pivot already samples the full angular sweep for collision checking
-(`DubinsArc.sample` r==0 branch), so the wingtip sweep is collision-checked. Because the Husky's
-main gear is ~0 m from its datum, the datum pivot (§4.3a) is a faithful main-gear pivot for it.
+| Fixture | baseline un-routable | pivot un-routable | converted |
+|---|---|---|---|
+| 3-plane | none | none | — |
+| bay-3 | none | none | — |
+| 6-plane | `aviat_husky` | `aviat_husky` | **none** |
 
-## 7. Testing
+**(b) Geometry — why.** At the 6-plane parked slots, rotational headroom is tight for the
+big-wing planes (`aviat_husky 11/72`, `ctsl 15/72`, `cessna_140 17/72` clear headings;
+`fk9 37/72`, `fuji 49/72`). And the Husky can translate only 2.0 m toward the door before a wing
+hits `fuji`. The block is **wing transit through the inter-plane corridor**, not turn radius. The
+pivot's swept disc = wingspan (~10.8 m), so the window where a pivot fits but an arc-loop doesn't
+is narrow for these aircraft.
 
-- **Unit (`models`):** `effective_turn_radius_m()` returns `0.0` for a free-castering own-gear
-  plane; field defaults `False`; `cart_eligible + free_castering → 0.0`.
-- **Loader:** `free_castering` parsed; defaults `False`; round-trips.
-- **Planner integration:** a flagged own-gear plane yields a pivot-style path (a `turn_radius_m == 0`
-  `DubinsArc` containing pivot segments).
-- **🎯 Payoff test:** with `aviat_husky.free_castering = true`, the six-plane fill
-  (`solve_fresh_six_planes`, `--no-spread --seed 1`) routes the Husky — turning the observed
-  exit-3 into a fully-routed fill. Directly measurable against the motivating failure.
-- **Determinism canary:** a free-castering-Husky scenario produces a byte-identical `MovesPlan`
-  across two runs (extends the canary suite); passes by construction, proven by the test.
+**(c) Path quality / nose-out — the real win.** In open space, a 180° nose-out flip plans as
+**23.7 m (pivot)** vs **27.8 m (arc loop)** — ~15% shorter and cleaner. Straight-in is equivalent
+(~12 m). This is the #263 motion; the pivot is what makes nose-out cheap.
+
+**Conclusion:** `tow_pivotable` is a **fidelity + path-quality + #263-enabler** change, **not** a
+towability unlock. Hence: fold into #263.
+
+## 7. Testing (when implemented with #263)
+
+- **Unit (`models`):** `effective_turn_radius_m()` returns `0.0` for a tow-pivotable own-gear
+  plane; field defaults `False`; `cart_eligible + tow_pivotable → 0.0`.
+- **Loader:** `tow_pivotable` parsed; defaults `False`; round-trips.
+- **Planner integration:** a flagged own-gear plane yields a pivot-style path (a `turn_radius_m ==
+  0` `DubinsArc` with pivot segments).
+- **Path-quality (the honest payoff test):** a nose-out 180° goal plans **shorter** as a pivot
+  than as an arc (the 23.7 vs 27.8 m result), in an empty hangar with a feasible (in-bounds-wing)
+  goal.
+- **No-regression:** the 3-plane and bay-3 fills route identically with the flag on (converted/
+  regressed both empty).
+- **Determinism canary:** a tow-pivotable scenario produces a byte-identical `MovesPlan` across
+  two runs.
+- **NOT a test:** "the six-plane fill becomes routable" — falsified (§6); do not assert it.
 
 ## 8. ADR & docs
 
-A new ADR — *"Free-castering tow-pivot capability"* — records the orthogonal-flag decision, the
-datum-pivot approximation with (b) as the deferred alternative, and the towing-vs-powered-taxi
-rationale. It cross-references ADR-0010 (motion), ADR-0007 (cart = r=0), and ADR-0013 (canonical
-per-aircraft data — same ethos). **Number allocated via `/new-adr` at implementation time**
-(committed ADRs stop at 0013; 0014 is earmarked for #263 in an issue comment, so this will likely
-be 0015 or later). The ADR lands **with** the implementation PR, per the project's #320/#263
-convention. Also: `fleet.yaml` header note + a one-line CLAUDE.md/arc42 pointer.
+The tow-pivot decision is recorded **in #263's ADR** (the nose-out ADR, earmarked ADR-0014) as a
+sub-section — the orthogonal-flag decision, the datum-pivot approximation with (b) deferred, and
+the towing-vs-powered-taxi rationale — rather than a separate ADR, since the two ship together.
+Cross-references ADR-0010 / ADR-0007 / ADR-0013. Plus a `fleet.yaml` header note and a one-line
+CLAUDE.md/arc42 pointer.
 
-*Alternative considered:* amend ADR-0010 instead. Rejected — this adds a fleet-schema field and a
-capability concept (ADR-0013-shaped), so a new ADR reads cleaner than bolting it onto the
-motion-vocabulary ADR.
+## 9. Interactions
 
-## 9. Interactions with deferred milestone-#28 work
+- **#263 (nose-out):** the pivot is the **enabler** — nose-out flips become ~15% cheaper in-place
+  pivots. Implement together. The pivot has no standalone consumer until #263 exists.
+- **#320 (back-bias):** complementary, no conflict; neither reasons about turn geometry.
 
-- **#320 (back-bias):** complementary, no conflict. Back-packing leaves the door cone clear;
-  tighter turns only raise its towability floor. Neither reasons about turn geometry. Any order.
-- **#263 (nose-out):** this is a direct **enabler**. #263 names the tailwheel gear class and
-  depends on the planner cheaply realizing nose-out exits; the free-castering pivot makes that
-  cheaper still. Sequence tow-pivot first for maximal nose-out payoff; #263 ships correctly
-  without it. No #263 assumption changes.
+## 10. Review plan (when built)
 
-## 10. Review plan
-
-- `pr-review-toolkit:code-reviewer` — main pass.
-- `pr-review-toolkit:type-design-analyzer` — `models.py` changes (new field + accessor).
-- `determinism-guard` — planner *behavior* changes via the accessor (even though `towplanner.py`
-  is untouched), so the byte-identical-plan contract is re-verified.
-- **No `geometry-invariant-guard`** — decision (a) touches no geometry math. *(Decision (b) would
-  require it.)*
+`code-reviewer` (main) + `type-design-analyzer` (`models.py`) + `determinism-guard` (planner
+behavior changes via the accessor). **No `geometry-invariant-guard`** under decision (a).
 
 ## 11. Caveats & known limitations
 
-- **`DubinsArc.length_m` mixes radians (pivot segments) and metres (straights)** — a pre-existing
-  quirk that, with this change, appears in an *own-gear* plane's path for the first time. The
-  renderer consumes paths via `sample()` (pose-based), not `length_m`, so visuals are unaffected.
-  A code comment will warn against treating a flagged plane's `length_m` as a physical distance.
-- **Datum-pivot approximation** (§4.3a): faithful only where the datum ≈ main gear. True for the
-  Husky; the opt-in flag keeps it from being applied where it isn't.
+- **`DubinsArc.length_m` mixes radians (pivots) and metres (straights)** — pre-existing; appears
+  in an own-gear path for the first time with this change. The renderer uses `sample()` (poses),
+  not `length_m`, so visuals are fine; a comment will warn consumers.
+- **Datum-pivot approximation** (§4.3a): faithful where datum ≈ main gear (true for all flagged
+  planes); the opt-in flag keeps it from misapplying.
 - **`cart_eligible`-on-a-cart pre-existing gap:** `effective_turn_radius_m()` keys on the
-  `always_cart` movement mode, not a placement's `on_carts` state, so a `cart_eligible` plane
-  placed on a cart is *not* given pivot motion today. Out of scope here; noted for completeness.
+  `always_cart` mode, not a placement's `on_carts`, so a `cart_eligible` plane *placed on a cart*
+  is not given pivot motion today. Out of scope; noted.
 
 ## 12. Out of scope / future
 
-- Main-gear-offset pivot (§4.3b) — a fidelity ADR if a far-offset-datum plane is ever flagged.
-- Flagging planes beyond the Husky — a club data call as real measurements arrive.
-- Modelling powered self-taxi distinctly from towing.
+- Main-gear-offset pivot (§4.3b) — fidelity refinement if a far-offset-datum plane is flagged.
+- The actual dense-fill towability lever: corridor/wingspan-aware packing in the solver, or #336
+  RRT-Connect. This spec explicitly does **not** address that.
 
 ## 13. Process
 
-- Branch: `feature/free-castering-tow-pivot` off `develop`.
-- Tracking issue: file in milestone #28 at implementation time (`Closes #N` in the PR body), per
-  "no code without an issue".
-- Supervised work only (touches determinism-guarded planner behavior); no unattended worktree
-  dispatch.
+- Design committed on `feature/free-castering-tow-pivot` (this spec).
+- Durable design + characterization summary posted as a comment on **#263**.
+- Implementation happens with #263 (supervised; determinism-guarded planner behavior).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hangarfit"
-version = "0.8.0"
+version = "0.9.0"
 description = "Helper tool for arranging a flying club's fleet in a stack-style hangar — collision checker, layout solver, tow-path planner, and top-down visualizer."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "hangarfit"
 version = "0.8.0"
-description = "Helper tool for arranging the flying club fleet in a stack-style hangar — collision checker + visualizer (Phase 1)."
+description = "Helper tool for arranging a flying club's fleet in a stack-style hangar — collision checker, layout solver, tow-path planner, and top-down visualizer."
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [{ name = "Patrick Kuhn" }]

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -206,13 +206,14 @@ def build_parser() -> argparse.ArgumentParser:
     solve.add_argument(
         "--tow-heuristic",
         choices=("euclidean", "grid"),
-        default="euclidean",
+        default="grid",
         dest="tow_heuristic",
         help=(
-            "EXPERIMENTAL (#332): A* tow-path heuristic. 'euclidean' (default) is "
-            "the shipped straight-line heuristic; 'grid' is the obstacle-aware "
-            "free-space geodesic that routes around placed planes (only affects "
-            "--render-paths runs). Deterministic; the path is exact-oracle-validated."
+            "A* tow-path heuristic. 'grid' (default since #336) is the "
+            "obstacle-aware free-space geodesic that threads tight maneuvers in "
+            "far fewer expansions; 'euclidean' is the older straight-line "
+            "heuristic (opt out). Only affects --render-paths runs; deterministic, "
+            "and the path is exact-oracle-validated."
         ),
     )
     solve.add_argument(
@@ -222,9 +223,9 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         dest="tow_max_expansions",
         help=(
-            "EXPERIMENTAL (#332): per-plane Hybrid-A* expansion budget for tow "
-            "planning (default: the module _MAX_EXPANSIONS=700). Raise to trade "
-            "time for routability on hard fills."
+            "Per-plane Hybrid-A* expansion budget for tow planning (default: the "
+            "module _MAX_EXPANSIONS=8000). Raise to trade time for routability on "
+            "hard fills; a global per-fill cap bounds the worst case (#336)."
         ),
     )
 

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -34,6 +34,14 @@ if TYPE_CHECKING:
 _JSON_SCHEMA = "hangarfit.check/v1"
 _SOLVE_JSON_SCHEMA = "hangarfit.solve/v1"
 
+# #320 back-of-hangar fill bias: the SearchConfig.back_bias_weight the CLI passes
+# when back-fill is enabled (the default; --no-back-fill sets it to 0.0). Chosen
+# from a sweep over the acceptance fixtures (single plane → back wall; the
+# scenario_minimal 2-plane fill clears the door) as the smallest weight that
+# breaks the mid-hangar symmetry while staying a secondary term below the spread
+# objective — it does not collapse the inter-plane gap. See ADR-0008 (amended).
+_BACK_FILL_DEFAULT_WEIGHT = 1.0
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the argparse parser with the ``check`` and ``solve`` subcommands."""
@@ -180,6 +188,18 @@ def build_parser() -> argparse.ArgumentParser:
         dest="spread",
         default=True,
         help="Disable the inter-plane spread post-pass (default: spread enabled).",
+    )
+    solve.add_argument(
+        "--no-back-fill",
+        action="store_false",
+        dest="back_fill",
+        default=True,
+        help=(
+            "Disable the back-of-hangar fill bias (#320). By default the spread "
+            "post-pass also biases planes toward the back wall, leaving free space "
+            "at the door; pass this to keep the symmetric spread only. (No effect "
+            "with --no-spread, since the bias rides on the spread post-pass.)"
+        ),
     )
     # ── Experimental tow-planner knobs (towplanner-v2 routability spike, #332) ──
     # Behind opt-in flags; defaults reproduce the shipped planner byte-for-byte.
@@ -429,7 +449,10 @@ def cmd_solve(args: argparse.Namespace) -> int:
         budget_s=args.budget,
         alternatives=args.alternatives,
         seed=resolved_seed,
-        search=SearchConfig(spread=args.spread),
+        search=SearchConfig(
+            spread=args.spread,
+            back_bias_weight=_BACK_FILL_DEFAULT_WEIGHT if args.back_fill else 0.0,
+        ),
         plan_paths=args.render_paths,
         tow_heuristic=args.tow_heuristic,
         tow_max_expansions=args.tow_max_expansions,

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -201,8 +201,9 @@ def build_parser() -> argparse.ArgumentParser:
             "with --no-spread, since the bias rides on the spread post-pass.)"
         ),
     )
-    # ── Experimental tow-planner knobs (towplanner-v2 routability spike, #332) ──
-    # Behind opt-in flags; defaults reproduce the shipped planner byte-for-byte.
+    # ── Tow-planner knobs (grid heuristic default + global fill cap since #336;
+    # spike #332). --tow-heuristic defaults to the shipped grid planner and
+    # --tow-max-expansions widens the per-plane budget; both RNG-free (ADR-0003).
     solve.add_argument(
         "--tow-heuristic",
         choices=("euclidean", "grid"),

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -20,7 +20,7 @@ import secrets
 import sys
 from typing import TYPE_CHECKING
 
-from hangarfit import collisions, visualize
+from hangarfit import __version__, collisions, visualize
 from hangarfit.loader import LoaderError, load_fleet, load_hangar, load_layout
 from hangarfit.models import CheckResult, Conflict, DiversityConfig, Layout, SolveResult
 
@@ -39,6 +39,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="hangarfit",
         description="Check a hand-authored hangar layout for validity.",
+    )
+    # Top-level so `hangarfit --version` works before any subcommand. The
+    # version action fires (and exits 0) during parse, ahead of the
+    # required-subparser check below, so no `cmd` is needed. The string is
+    # sourced from the installed package metadata (hangarfit.__version__) so
+    # it can never drift from pyproject.toml's [project] version.
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
 

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface for hangarfit.
 
 Implements:
+    hangarfit [--version]
     hangarfit check LAYOUT [--render OUT.png] [--fleet PATH] [--hangar PATH] [--json]
 
 See ``docs/superpowers/specs/2026-05-21-cli-design.md`` for the design.

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -996,7 +996,20 @@ class SearchConfig:
     mid-hangar; the ``<2 planes`` no-op guard is also relaxed so a lone plane is
     still pulled to the back wall. ``min_pairwise_gap_m`` remains the primary
     basin-selection key — this only re-ranks candidates *within* a basin's
-    hill-climb. The CLI enables it by default (``--no-back-fill`` opts out)."""
+    hill-climb. The CLI enables it by default (``--no-back-fill`` opts out).
+
+    This is a **dimensionless relative weight** balancing the back-bias term
+    (normalized to ``[0, 1]`` per plane) against the inter-plane spread energy
+    (a sum of ``O(1)`` ``exp`` terms); ``~1.0`` is the tuned operating point, and
+    large values subordinate spread to back-fill (collapsing gaps), so keep it a
+    *secondary* term. **No effect when ``spread=False``** — the bias is folded
+    into the spread post-pass, which only runs under ``spread=True`` (a
+    ``spread=False, back_bias_weight>0`` config is a silent no-op by design; the
+    CLI never builds one). Modeled as ``float = 0.0`` rather than ``float |
+    None`` deliberately: ``0.0`` is the exact identity of ``weight · B``
+    (contributes nothing), not a degenerate value, so no distinct opt-out
+    sentinel is warranted — ``None`` stays the *only* sentinel in this dataclass
+    (on ``max_restarts``)."""
 
     def __post_init__(self) -> None:
         if self.candidates_per_iter < 1:

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -985,6 +985,19 @@ class SearchConfig:
     keeping the kernel sensitive across hangar sizes. When set explicitly,
     must be ``> 0``."""
 
+    back_bias_weight: float = 0.0
+    """Strength of the back-of-hangar fill bias folded into the spread post-pass
+    (#320, ADR-0008 amendment). ``0.0`` (default) ⇒ pure inter-plane spread — the
+    pre-#320 behaviour, so the raw spread mechanism and the determinism canaries
+    (which run ``spread=False``) stay byte-unchanged. When ``> 0`` the spread
+    hill-climb additionally minimizes a secondary term
+    ``B = Σ (hangar.length_m − y_p) / hangar.length_m`` that rewards parking deep
+    (large ``y``), so free space accumulates at the door end rather than
+    mid-hangar; the ``<2 planes`` no-op guard is also relaxed so a lone plane is
+    still pulled to the back wall. ``min_pairwise_gap_m`` remains the primary
+    basin-selection key — this only re-ranks candidates *within* a basin's
+    hill-climb. The CLI enables it by default (``--no-back-fill`` opts out)."""
+
     def __post_init__(self) -> None:
         if self.candidates_per_iter < 1:
             raise ValueError(
@@ -1015,4 +1028,9 @@ class SearchConfig:
             raise ValueError(
                 f"SearchConfig.spread_scale_m must be positive when set "
                 f"(pass None for the adaptive default), got {self.spread_scale_m}"
+            )
+        if self.back_bias_weight < 0.0:
+            raise ValueError(
+                f"SearchConfig.back_bias_weight must be >= 0 "
+                f"(0 disables the back-of-hangar fill bias), got {self.back_bias_weight}"
             )

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -9,6 +9,12 @@ the current implementation supports:
 - K-diverse alternatives + termination (§4.5-§4.7)  [Chunk E]
 - inter-plane spread post-pass (``_spread`` / ``_inter_plane_energy``; ADR-0008,
   default on via ``SearchConfig.spread``)
+- collect-then-select pool with maximin-gap selection across restarts, surfacing
+  ``min_pairwise_gap_m`` / ``valid_basins_found`` (Phase 2c, #267; determinism is
+  now ``max_restarts``-scoped per the ADR-0003 amendment)
+- best-effort tow-path bundling: with ``plan_paths=True`` each returned layout is
+  paired with a per-plane tow plan from ``hangarfit.towplanner``; an un-routable
+  plane is kept as ``plans[i] = None`` (Phase 3a, ADR-0007 / ADR-0010)
 """
 
 from __future__ import annotations

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -107,48 +107,21 @@ def solve(
     resolved_seed = seed if seed is not None else secrets.randbits(32)
     rng = _random_module.Random(resolved_seed)
 
-    # ── Diversity-impossible heuristic (spec §4.6) ──────────────────────
-    # When the number of free (non-pinned) planes is strictly less than
-    # diversity.min_planes_moved AND the caller asked for >1 alternative,
-    # they cannot mathematically get more than one accepted layout: every
-    # candidate L' after the first will share too many pinned planes with
-    # L to ever pass `n_moved ≥ min_planes_moved`. Logged as a warning
-    # so CLI / library users see it; we do NOT mutate `alternatives` —
-    # search runs normally and the natural outcome is found_partial with
-    # one accepted layout (spec deliberately avoids downgrading the API
-    # contract). Pin-detection mirrors `_check_trivially_infeasible`.
-    free_planes = sum(
-        1
-        for pid in scenario.fleet_in
-        if scenario.constraints.get(pid) is None or scenario.constraints[pid].pin is None
-    )
-    diversity_impossible = alternatives > 1 and free_planes < diversity.min_planes_moved
-    if diversity_impossible:
-        _logger.warning(
-            "requested %d alternatives but only 1 is achievable "
-            "(%d of %d planes are pinned). Expect status=found_partial.",
-            alternatives,
-            len(scenario.fleet_in) - free_planes,
-            len(scenario.fleet_in),
-        )
+    # Diversity-impossible heuristic (spec §4.6): warn (without mutating
+    # `alternatives`) when too many planes are pinned to ever yield >1
+    # diverse layout. See `_diversity_is_impossible`.
+    diversity_impossible = _diversity_is_impossible(scenario, alternatives, diversity)
 
     # ── Pre-search infeasibility checks (§4.1) ──────────────────────────
     start = time.monotonic()
 
     infeasible = _check_trivially_infeasible(scenario)
     if infeasible is not None:
-        bad_check, bad_layout = infeasible
-        return SolveResult(
-            status="trivially_infeasible",
-            layouts=(),
-            diagnostics=SolverDiagnostics(
-                restarts_attempted=0,
-                wall_time_s=time.monotonic() - start,
-                best_partial=bad_check,
-                best_partial_layout=bad_layout,
-                seed=resolved_seed,
-                diversity_impossible=diversity_impossible,
-            ),
+        return _build_trivially_infeasible_result(
+            infeasible,
+            start=start,
+            resolved_seed=resolved_seed,
+            diversity_impossible=diversity_impossible,
         )
 
     # ── Real search (RR-MC, spec §4.2-§4.5) ─────────────────────────────
@@ -294,71 +267,213 @@ def solve(
     selected, diversity_rejected_count = _select_spread_diverse(pool, alternatives, diversity)
 
     if selected:
-        accepted_layouts = [c.layout for c in selected]
-        min_gaps = tuple(c.min_gap for c in selected)
-        status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
-        # Tow-plan every returned layout (best-effort enrichment, #197). The
-        # v2 planner (Reeds–Shepp arcs + bounded Hybrid-A* — #222/#261 under
-        # ADR-0007 + ADR-0010) cannot route dense multi-plane fills and has
-        # documented false-negatives, so an un-routable layout is recorded as
-        # plans[i]=None rather than discarding the otherwise-valid static
-        # arrangement — the layout is the headline answer; the tow plan is
-        # advisory (spike Risk #8). The `status` stays search-driven:
-        # tow-planning never changes found/found_partial.
-        plans: tuple[MovesPlan | None, ...]
-        unroutable: list[str] = []
-        if plan_paths:
-            built: list[MovesPlan | None] = []
-            for layout in accepted_layouts:
-                try:
-                    # Default path calls ``plan_fill(layout)`` EXACTLY as before
-                    # (byte-identical; #332 spike params are opt-in), so the
-                    # ADR-0003 determinism canaries — and any test that stubs
-                    # ``plan_fill`` with a target-only signature — are untouched.
-                    if tow_heuristic == "euclidean" and tow_max_expansions is None:
-                        built.append(plan_fill(layout))
-                    else:
-                        built.append(
-                            plan_fill(
-                                layout,
-                                heuristic=tow_heuristic,
-                                max_expansions=tow_max_expansions,
-                            )
-                        )
-                except NoFeasiblePlanError as e:
-                    built.append(None)
-                    unroutable.append(e.plane_id)
-                    # Log the conflict kind/detail too, not just the plane: it
-                    # distinguishes a genuinely-boxed-in plane from a Hybrid-A*
-                    # budget exhaustion (a known false-negative class), which
-                    # call for different operator responses.
-                    _logger.warning(
-                        "layout not tow-routable by the tow-path planner: plane %r blocked "
-                        "(%s: %s); returning the valid static layout without a tow plan",
-                        e.plane_id,
-                        e.conflict.kind,
-                        e.conflict.detail,
-                    )
-            plans = tuple(built)
-        else:
-            plans = (None,) * len(accepted_layouts)
-        return SolveResult(
-            status=status,
-            layouts=tuple(accepted_layouts),
-            plans=plans,
-            diagnostics=SolverDiagnostics(
-                restarts_attempted=restart_index,
-                wall_time_s=elapsed,
-                best_partial=None,
-                best_partial_layout=None,
-                seed=resolved_seed,
-                diversity_impossible=diversity_impossible,
-                diversity_rejected_count=diversity_rejected_count,
-                unroutable_planes=tuple(unroutable),
-                min_pairwise_gap_m=min_gaps,
-                valid_basins_found=len(pool),
-            ),
+        return _build_found_result(
+            selected,
+            alternatives=alternatives,
+            plan_paths=plan_paths,
+            tow_heuristic=tow_heuristic,
+            tow_max_expansions=tow_max_expansions,
+            restart_index=restart_index,
+            elapsed=elapsed,
+            resolved_seed=resolved_seed,
+            diversity_impossible=diversity_impossible,
+            diversity_rejected_count=diversity_rejected_count,
+            valid_basins_found=len(pool),
         )
+    return _build_exhausted_result(
+        best_partial_layout,
+        restart_index=restart_index,
+        elapsed=elapsed,
+        resolved_seed=resolved_seed,
+        diversity_impossible=diversity_impossible,
+        diversity_rejected_count=diversity_rejected_count,
+        valid_basins_found=len(pool),
+    )
+
+
+def _diversity_is_impossible(
+    scenario: Scenario,
+    alternatives: int,
+    diversity: DiversityConfig,
+) -> bool:
+    """Detect (and warn about) a structurally diversity-impossible request (spec §4.6).
+
+    When the number of free (non-pinned) planes is strictly less than
+    ``diversity.min_planes_moved`` AND the caller asked for >1 alternative, they
+    cannot mathematically get more than one accepted layout: every candidate L'
+    after the first will share too many pinned planes with L to ever pass
+    ``n_moved ≥ min_planes_moved``. Logged as a warning so CLI / library users
+    see it; ``alternatives`` is deliberately NOT mutated — search runs normally
+    and the natural outcome is found_partial with one accepted layout (the spec
+    avoids downgrading the API contract). Pin-detection mirrors
+    ``_check_trivially_infeasible``. RNG-free.
+    """
+    free_planes = sum(
+        1
+        for pid in scenario.fleet_in
+        if scenario.constraints.get(pid) is None or scenario.constraints[pid].pin is None
+    )
+    diversity_impossible = alternatives > 1 and free_planes < diversity.min_planes_moved
+    if diversity_impossible:
+        _logger.warning(
+            "requested %d alternatives but only 1 is achievable "
+            "(%d of %d planes are pinned). Expect status=found_partial.",
+            alternatives,
+            len(scenario.fleet_in) - free_planes,
+            len(scenario.fleet_in),
+        )
+    return diversity_impossible
+
+
+def _build_trivially_infeasible_result(
+    infeasible: tuple[CheckResult, Layout],
+    *,
+    start: float,
+    resolved_seed: int,
+    diversity_impossible: bool,
+) -> SolveResult:
+    """Build the ``trivially_infeasible`` :class:`SolveResult` (spec §4.1).
+
+    RNG-free. ``wall_time_s`` is measured at the same point in execution as the
+    inline code this replaces; the determinism canaries do not assert on it.
+    """
+    bad_check, bad_layout = infeasible
+    return SolveResult(
+        status="trivially_infeasible",
+        layouts=(),
+        diagnostics=SolverDiagnostics(
+            restarts_attempted=0,
+            wall_time_s=time.monotonic() - start,
+            best_partial=bad_check,
+            best_partial_layout=bad_layout,
+            seed=resolved_seed,
+            diversity_impossible=diversity_impossible,
+        ),
+    )
+
+
+def _tow_plan_layouts(
+    accepted_layouts: list[Layout],
+    *,
+    plan_paths: bool,
+    tow_heuristic: Literal["euclidean", "grid"],
+    tow_max_expansions: int | None,
+) -> tuple[tuple[MovesPlan | None, ...], tuple[str, ...]]:
+    """Tow-plan every returned layout (best-effort enrichment, #197).
+
+    Returns ``(plans, unroutable)`` index-aligned with ``accepted_layouts``.
+    The v2 planner (Reeds–Shepp arcs + bounded Hybrid-A* — #222/#261 under
+    ADR-0007 + ADR-0010) cannot route dense multi-plane fills and has documented
+    false-negatives, so an un-routable layout is recorded as ``plans[i]=None``
+    rather than discarding the otherwise-valid static arrangement — the layout is
+    the headline answer; the tow plan is advisory (spike Risk #8). RNG-free, so
+    it preserves the ADR-0003 determinism contract.
+
+    With ``plan_paths=False`` no planning runs and ``plans`` is all-``None``
+    (still index-aligned), with no ``unroutable`` planes.
+    """
+    if not plan_paths:
+        return (None,) * len(accepted_layouts), ()
+
+    built: list[MovesPlan | None] = []
+    unroutable: list[str] = []
+    for layout in accepted_layouts:
+        try:
+            # Default path calls ``plan_fill(layout)`` EXACTLY as before
+            # (byte-identical; #332 spike params are opt-in), so the ADR-0003
+            # determinism canaries — and any test that stubs ``plan_fill`` with a
+            # target-only signature — are untouched.
+            if tow_heuristic == "euclidean" and tow_max_expansions is None:
+                built.append(plan_fill(layout))
+            else:
+                built.append(
+                    plan_fill(
+                        layout,
+                        heuristic=tow_heuristic,
+                        max_expansions=tow_max_expansions,
+                    )
+                )
+        except NoFeasiblePlanError as e:
+            built.append(None)
+            unroutable.append(e.plane_id)
+            # Log the conflict kind/detail too, not just the plane: it
+            # distinguishes a genuinely-boxed-in plane from a Hybrid-A* budget
+            # exhaustion (a known false-negative class), which call for different
+            # operator responses.
+            _logger.warning(
+                "layout not tow-routable by the tow-path planner: plane %r blocked "
+                "(%s: %s); returning the valid static layout without a tow plan",
+                e.plane_id,
+                e.conflict.kind,
+                e.conflict.detail,
+            )
+    return tuple(built), tuple(unroutable)
+
+
+def _build_found_result(
+    selected: list[_SpreadCandidate],
+    *,
+    alternatives: int,
+    plan_paths: bool,
+    tow_heuristic: Literal["euclidean", "grid"],
+    tow_max_expansions: int | None,
+    restart_index: int,
+    elapsed: float,
+    resolved_seed: int,
+    diversity_impossible: bool,
+    diversity_rejected_count: int,
+    valid_basins_found: int,
+) -> SolveResult:
+    """Build the ``found`` / ``found_partial`` :class:`SolveResult`.
+
+    Derives the accepted layouts and per-layout maximin gaps from the selected
+    basins, tow-plans them (best-effort, see :func:`_tow_plan_layouts`), and
+    assembles the diagnostics. The ``status`` stays search-driven — tow-planning
+    never flips found ↔ found_partial. RNG-free.
+    """
+    accepted_layouts = [c.layout for c in selected]
+    min_gaps = tuple(c.min_gap for c in selected)
+    status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
+    plans, unroutable = _tow_plan_layouts(
+        accepted_layouts,
+        plan_paths=plan_paths,
+        tow_heuristic=tow_heuristic,
+        tow_max_expansions=tow_max_expansions,
+    )
+    return SolveResult(
+        status=status,
+        layouts=tuple(accepted_layouts),
+        plans=plans,
+        diagnostics=SolverDiagnostics(
+            restarts_attempted=restart_index,
+            wall_time_s=elapsed,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=resolved_seed,
+            diversity_impossible=diversity_impossible,
+            diversity_rejected_count=diversity_rejected_count,
+            unroutable_planes=unroutable,
+            min_pairwise_gap_m=min_gaps,
+            valid_basins_found=valid_basins_found,
+        ),
+    )
+
+
+def _build_exhausted_result(
+    best_partial_layout: Layout | None,
+    *,
+    restart_index: int,
+    elapsed: float,
+    resolved_seed: int,
+    diversity_impossible: bool,
+    diversity_rejected_count: int,
+    valid_basins_found: int,
+) -> SolveResult:
+    """Build the ``exhausted_budget`` :class:`SolveResult`.
+
+    Re-checks ``best_partial_layout`` (if any) for the fused best-partial pair.
+    RNG-free.
+    """
     bp = check_layout(best_partial_layout) if best_partial_layout is not None else None
     return SolveResult(
         status="exhausted_budget",
@@ -371,7 +486,7 @@ def solve(
             seed=resolved_seed,
             diversity_impossible=diversity_impossible,
             diversity_rejected_count=diversity_rejected_count,
-            valid_basins_found=len(pool),
+            valid_basins_found=valid_basins_found,
         ),
     )
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -838,6 +838,20 @@ def _inter_plane_energy(
     return energy
 
 
+def _back_bias_energy(placements: dict[str, Placement], scenario: Scenario) -> float:
+    """Back-of-hangar fill bias ``B = Σ (length_m − y_p) / length_m`` (#320).
+
+    Minimized when planes park deep (large ``y``, toward the back wall at
+    ``y = hangar.length_m``), so the spread hill-climb leaves free space at the
+    door end (``y ≈ 0``) instead of mid-hangar. Normalized by ``length_m`` so a
+    single ``back_bias_weight`` reads consistently across hangar sizes. Summed
+    over ALL placements — pinned planes add a constant offset that cannot change
+    the per-target argmin. RNG-free. See ADR-0008 (amended) and #320.
+    """
+    length = scenario.hangar.length_m
+    return sum((length - p.y_m) / length for p in placements.values())
+
+
 def _resolve_spread_scale(scenario: Scenario, search: SearchConfig) -> float:
     """Repulsion length-scale for spread (spec §4): explicit override or
     20% of the smaller hangar dimension. Single source so ``_spread`` and
@@ -904,12 +918,23 @@ def _spread(
     scale = _resolve_spread_scale(scenario, search)
 
     movable = sorted(pid for pid in placements if pid not in pinned_planes)
-    if not movable or len(placements) < 2:
-        # Nothing to optimize: all planes pinned (no movable target) or
-        # <2 planes (energy is identically 0.0).
+    back_fill = search.back_bias_weight > 0.0
+    if not movable or (len(placements) < 2 and not back_fill):
+        # Nothing to optimize: no movable target, or <2 planes with no back-fill
+        # bias (inter-plane energy is identically 0.0). With back-fill active a
+        # lone plane is still pulled to the back wall, so we do NOT bail there.
         return placements
 
-    current_energy = _inter_plane_energy(placements, scenario, scale)
+    def _energy(trial: dict[str, Placement]) -> float:
+        # Spread repulsion, plus the #320 back-of-hangar bias when active. The
+        # back-bias re-ranks candidates *within* this hill-climb; basin selection
+        # stays min-gap-primary (ADR-0008 amended).
+        e = _inter_plane_energy(trial, scenario, scale)
+        if back_fill:
+            e += search.back_bias_weight * _back_bias_energy(trial, scenario)
+        return e
+
+    current_energy = _energy(placements)
     last_improved = 0
 
     for iter_count in range(10000):  # large cap; real exit via stall/budget
@@ -954,7 +979,7 @@ def _spread(
                 continue
             if _score(trial_layout) != (0, 0.0):
                 continue  # must STAY valid
-            e = _inter_plane_energy(trial, scenario, scale)
+            e = _energy(trial)
             disp = (
                 (cand.x_m - placements[target].x_m) ** 2 + (cand.y_m - placements[target].y_m) ** 2
             ) ** 0.5

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -757,35 +757,12 @@ def _spread(
         target = rng.choice(movable)
 
         # Same candidate mix as _descent_step: (N-2) small nudges + 1 large + 1 flip.
-        candidates: list[Placement] = []
-        n_small = max(0, search.candidates_per_iter - 2)
-        for _ in range(n_small):
-            candidates.append(
-                _perturb_plane(
-                    current=placements[target],
-                    scenario=scenario,
-                    rng=rng,
-                    search=search,
-                    large_jump=False,
-                )
-            )
-        candidates.append(
-            _perturb_plane(
-                current=placements[target],
-                scenario=scenario,
-                rng=rng,
-                search=search,
-                large_jump=True,
-            )
-        )
-        candidates.append(
-            Placement(
-                plane_id=target,
-                x_m=placements[target].x_m,
-                y_m=placements[target].y_m,
-                heading_deg=(placements[target].heading_deg + 180.0) % 360.0,
-                on_carts=placements[target].on_carts,
-            )
+        candidates = _generate_candidates(
+            current=placements[target],
+            target=target,
+            scenario=scenario,
+            rng=rng,
+            search=search,
         )
 
         # Pick the lowest-(energy, displacement) VALID candidate. Adopt it
@@ -1036,6 +1013,61 @@ def _perturb_plane(
     )
 
 
+def _generate_candidates(
+    *,
+    current: Placement,
+    target: str,
+    scenario: Scenario,
+    rng: _random_module.Random,
+    search: SearchConfig,
+) -> list[Placement]:
+    """Build the standard candidate mix for one plane (spec §4.3 step 4).
+
+    ``N = candidates_per_iter`` candidates, generated in a fixed order that
+    pins the RNG draw sequence: ``N - 2`` small Gaussian nudges, then 1 large
+    global jump, then 1 deterministic 180° heading flip. The two RNG-driven
+    variants (small nudges, large jump) consume entropy in exactly this order;
+    the flip draws nothing.
+
+    Shared verbatim by :func:`_descent_step` (min-conflicts descent) and
+    :func:`_spread` (the inter-plane spread post-pass) — both need the identical
+    mix. The extraction is byte-for-byte behaviour-preserving: keeping the draw
+    order (small × ``n_small`` → large → flip) is what preserves the ADR-0003
+    determinism contract, so do not reorder the appends.
+    """
+    candidates: list[Placement] = []
+    n_small = max(0, search.candidates_per_iter - 2)
+    for _ in range(n_small):
+        candidates.append(
+            _perturb_plane(
+                current=current,
+                scenario=scenario,
+                rng=rng,
+                search=search,
+                large_jump=False,
+            )
+        )
+    candidates.append(
+        _perturb_plane(
+            current=current,
+            scenario=scenario,
+            rng=rng,
+            search=search,
+            large_jump=True,
+        )
+    )
+    candidates.append(
+        Placement(
+            plane_id=target,
+            x_m=current.x_m,
+            y_m=current.y_m,
+            heading_deg=(current.heading_deg + 180.0) % 360.0,
+            on_carts=current.on_carts,
+        )
+    )
+    return candidates
+
+
 def _descent_step(
     *,
     placements: dict[str, Placement],
@@ -1101,35 +1133,14 @@ def _descent_step(
     target = rng.choice(sorted(conflicting))
 
     # Generate N candidate perturbations: (N-2) small + 1 large + 1 flip
-    candidates: list[Placement] = []
-    n_small = max(0, search.candidates_per_iter - 2)
-    for _ in range(n_small):
-        candidates.append(
-            _perturb_plane(
-                current=placements[target],
-                scenario=scenario,
-                rng=rng,
-                search=search,
-                large_jump=False,
-            )
-        )
-    candidates.append(
-        _perturb_plane(
-            current=placements[target],
-            scenario=scenario,
-            rng=rng,
-            search=search,
-            large_jump=True,
-        )
+    # (shared with _spread; see _generate_candidates for the draw-order contract).
+    candidates = _generate_candidates(
+        current=placements[target],
+        target=target,
+        scenario=scenario,
+        rng=rng,
+        search=search,
     )
-    flipped = Placement(
-        plane_id=target,
-        x_m=placements[target].x_m,
-        y_m=placements[target].y_m,
-        heading_deg=(placements[target].heading_deg + 180.0) % 360.0,
-        on_carts=placements[target].on_carts,
-    )
-    candidates.append(flipped)
 
     # Score each candidate. Tie-break by displacement from the current
     # state (encourages smooth trajectories — spec §4.3 step 4).

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -849,7 +849,11 @@ def _back_bias_energy(placements: dict[str, Placement], scenario: Scenario) -> f
     the per-target argmin. RNG-free. See ADR-0008 (amended) and #320.
     """
     length = scenario.hangar.length_m
-    return sum((length - p.y_m) / length for p in placements.values())
+    # Iterate in sorted plane-id order (mirrors _inter_plane_energy /
+    # _spread_quality) so this float sum is order-stable even if a future
+    # refactor ever builds the placements dict from an unordered source — an
+    # ADR-0003 hardening; the dict is currently fleet_in-ordered already.
+    return sum((length - placements[pid].y_m) / length for pid in sorted(placements))
 
 
 def _resolve_spread_scale(scenario: Scenario, search: SearchConfig) -> float:

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -57,7 +57,7 @@ def solve(
     diversity: DiversityConfig | None = None,
     search: SearchConfig | None = None,
     plan_paths: bool = True,
-    tow_heuristic: Literal["euclidean", "grid"] = "euclidean",
+    tow_heuristic: Literal["euclidean", "grid"] = "grid",
     tow_max_expansions: int | None = None,
 ) -> SolveResult:
     """Solve a Scenario into up to ``alternatives`` diverse valid Layouts.
@@ -93,11 +93,11 @@ def solve(
     contract (ADR-0003) end-to-end through the bundle.
 
     ``tow_heuristic`` and ``tow_max_expansions`` are forwarded verbatim to
-    :func:`~hangarfit.towplanner.plan_fill` (towplanner-v2 routability spike,
-    #332). The defaults (``"euclidean"`` / module ``_MAX_EXPANSIONS``) reproduce
-    the shipped planner byte-for-byte; ``tow_heuristic="grid"`` opts into the
-    obstacle-aware free-space heuristic and a larger ``tow_max_expansions`` opts
-    into a bigger per-plane search budget — both RNG-free, so determinism holds.
+    :func:`~hangarfit.towplanner.plan_fill` (#332/#336). Since #336 the shipped
+    default is ``tow_heuristic="grid"`` (the obstacle-aware free-space heuristic)
+    with the module per-plane and global fill budgets; pass
+    ``tow_heuristic="euclidean"`` to opt out, or a larger ``tow_max_expansions``
+    to widen the per-plane budget. All RNG-free, so determinism holds (ADR-0003).
     """
     if diversity is None:
         diversity = DiversityConfig()
@@ -385,11 +385,13 @@ def _tow_plan_layouts(
     unroutable: list[str] = []
     for layout in accepted_layouts:
         try:
-            # Default path calls ``plan_fill(layout)`` EXACTLY as before
-            # (byte-identical; #332 spike params are opt-in), so the ADR-0003
-            # determinism canaries — and any test that stubs ``plan_fill`` with a
-            # target-only signature — are untouched.
-            if tow_heuristic == "euclidean" and tow_max_expansions is None:
+            # Default path calls ``plan_fill(layout)`` with NO kwargs, so the
+            # ADR-0003 determinism canaries — and any test that stubs
+            # ``plan_fill`` with a target-only signature — stay untouched. Since
+            # #336 the shipped default is grid + the module budgets, which is
+            # exactly what a bare ``plan_fill(layout)`` applies; an explicit
+            # euclidean / custom budget takes the kwargs path below.
+            if tow_heuristic == "grid" and tow_max_expansions is None:
                 built.append(plan_fill(layout))
             else:
                 built.append(

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -385,6 +385,13 @@ def _check_trivially_infeasible(
     infeasible (the caller plugs both into
     :class:`SolverDiagnostics`); else ``None``.
 
+    The three checks run in a **fixed order** — per-plane bbox (#1), summed
+    footprint area (#2), pin self-collision (#3) — and the first to trip is
+    returned. The order is part of the observed behaviour (it determines which
+    conflict ``kind`` a multiply-infeasible scenario reports), so it must not
+    change; each sub-check is a pure predicate over ``scenario`` returning the
+    same ``(CheckResult, Layout)`` pair or ``None``.
+
     The Layout is paired with the CheckResult because
     :class:`SolverDiagnostics` requires ``best_partial`` and
     ``best_partial_layout`` to both be set or both be ``None``. For
@@ -393,7 +400,24 @@ def _check_trivially_infeasible(
     scenario, with no placements and no maintenance plane. For check #3
     it is the pin-only Layout that was used to detect the conflict.
     """
-    # Check 1: per-plane bbox vs hangar
+    for check in (
+        _check_plane_too_big,
+        _check_sum_areas,
+        _check_pin_feasibility,
+    ):
+        result = check(scenario)
+        if result is not None:
+            return result
+    return None
+
+
+def _check_plane_too_big(scenario: Scenario) -> tuple[CheckResult, Layout] | None:
+    """Check 1: any single plane's bbox exceeds the hangar's larger dimension.
+
+    A plane whose max part extent is larger than ``max(length, width)`` cannot
+    fit at any heading. Returns the conflict paired with the empty Layout, or
+    ``None`` if every plane fits.
+    """
     for pid in scenario.fleet_in:
         plane = scenario.fleet[pid]
         length, width = _plane_max_extent(plane)
@@ -413,11 +437,17 @@ def _check_trivially_infeasible(
                 total_penetration_m2=0.0,
             )
             return check, _empty_layout(scenario)
+    return None
 
-    # Check 2: Σ bbox areas vs hangar floor area. Uses the full-fuselage
-    # footprint (not _plane_max_extent) so the fuselage front/aft split
-    # (#50/ADR-0012) doesn't shrink the estimate and let an infeasible fleet
-    # slip the gate.
+
+def _check_sum_areas(scenario: Scenario) -> tuple[CheckResult, Layout] | None:
+    """Check 2: Σ bbox areas vs hangar floor area.
+
+    Uses the full-fuselage footprint (not _plane_max_extent) so the fuselage
+    front/aft split (#50/ADR-0012) doesn't shrink the estimate and let an
+    infeasible fleet slip the gate. Returns the conflict paired with the empty
+    Layout, or ``None`` if the summed footprint fits the floor.
+    """
     total_area = 0.0
     for pid in scenario.fleet_in:
         plane = scenario.fleet[pid]
@@ -442,75 +472,86 @@ def _check_trivially_infeasible(
             total_penetration_m2=0.0,
         )
         return check, _empty_layout(scenario)
+    return None
 
-    # Check 3: pin self-collision (build a pin-only Layout and run check())
+
+def _check_pin_feasibility(scenario: Scenario) -> tuple[CheckResult, Layout] | None:
+    """Check 3: pinned placements must satisfy the cart rule and not collide.
+
+    Builds a Layout containing only the pinned planes and runs ``check()`` on
+    it (after a sharp cart-rule pre-check). Returns the conflict paired with the
+    pin-only Layout, or ``None`` if there are no pins or the pin-only layout is
+    valid.
+    """
     pinned_placements = []
     for pid in scenario.fleet_in:
         constraint = scenario.constraints.get(pid)
         if constraint is not None and constraint.pin is not None:
             pinned_placements.append(constraint.pin)
 
-    if pinned_placements:
-        # The cart rule (at most hangar.max_carts cart_eligible planes on
-        # carts at a time) is enforced by Layout.__post_init__ but NOT by
-        # Scenario.__post_init__ — that's a cross-pin invariant Scenario
-        # currently doesn't check. Guard explicitly here so we can return
-        # a sharp `pin_cart_rule` conflict instead of silently absorbing
-        # a generic Layout `ValueError`. Morally this check belongs in
-        # Scenario; a follow-up could migrate it to Scenario.__post_init__
-        # so every caller (not just solve()) benefits. The limit tracks
-        # scenario.hangar.max_carts so it agrees with the Layout invariant
-        # (and with any --max-carts override already applied to the hangar).
-        max_carts = scenario.hangar.max_carts
-        cart_eligible_on_carts = sum(
-            1
-            for p in pinned_placements
-            if p.on_carts and scenario.fleet[p.plane_id].movement_mode == "cart_eligible"
-        )
-        if cart_eligible_on_carts > max_carts:
-            check = CheckResult(
-                conflicts=(
-                    Conflict.single(
-                        kind="trivially_infeasible_pin_cart_rule",
-                        plane=pinned_placements[0].plane_id,
-                        detail=(
-                            f"{cart_eligible_on_carts} cart_eligible pins on "
-                            f"carts (cart rule allows at most {max_carts})"
-                        ),
+    if not pinned_placements:
+        return None
+
+    # The cart rule (at most hangar.max_carts cart_eligible planes on
+    # carts at a time) is enforced by Layout.__post_init__ but NOT by
+    # Scenario.__post_init__ — that's a cross-pin invariant Scenario
+    # currently doesn't check. Guard explicitly here so we can return
+    # a sharp `pin_cart_rule` conflict instead of silently absorbing
+    # a generic Layout `ValueError`. Morally this check belongs in
+    # Scenario; a follow-up could migrate it to Scenario.__post_init__
+    # so every caller (not just solve()) benefits. The limit tracks
+    # scenario.hangar.max_carts so it agrees with the Layout invariant
+    # (and with any --max-carts override already applied to the hangar).
+    max_carts = scenario.hangar.max_carts
+    cart_eligible_on_carts = sum(
+        1
+        for p in pinned_placements
+        if p.on_carts and scenario.fleet[p.plane_id].movement_mode == "cart_eligible"
+    )
+    if cart_eligible_on_carts > max_carts:
+        check = CheckResult(
+            conflicts=(
+                Conflict.single(
+                    kind="trivially_infeasible_pin_cart_rule",
+                    plane=pinned_placements[0].plane_id,
+                    detail=(
+                        f"{cart_eligible_on_carts} cart_eligible pins on "
+                        f"carts (cart rule allows at most {max_carts})"
                     ),
                 ),
-                total_penetration_m2=0.0,
-            )
-            return check, _empty_layout(scenario)
-
-        # Build a Layout containing ONLY the pinned planes.
-        #
-        # ``maintenance_plane`` is forwarded to the pin-only Layout so that
-        # ``collisions.check()`` can fire the maintenance_position rule if the
-        # pins collectively leave the maintenance area occupied by another plane
-        # or violated (detected early, before burning the full solve() budget
-        # on a restart loop that can never escape a pinned conflict).
-        #
-        # Scenario.__post_init__ guarantees that the maintenance_plane cannot
-        # carry a pin (raises ValueError if it does), so ``pinned_placements``
-        # is provably free of the maintenance occupant — no filter is needed.
-        #
-        # No try/except: every remaining Layout invariant that could fire
-        # here is either structurally impossible given pin-only construction
-        # or already caught by Scenario.__post_init__ (pin.plane_id mismatch,
-        # pin.on_carts vs movement_mode). A genuinely unexpected ValueError
-        # should propagate as a bug, not get silently re-wrapped as a pin
-        # infeasibility.
-        pin_only_layout = Layout(
-            fleet=scenario.fleet,
-            hangar=scenario.hangar,
-            placements=tuple(pinned_placements),
-            maintenance_plane=scenario.maintenance_plane,
+            ),
+            total_penetration_m2=0.0,
         )
+        return check, _empty_layout(scenario)
 
-        pin_check = check_layout(pin_only_layout)
-        if not pin_check.valid:
-            return pin_check, pin_only_layout
+    # Build a Layout containing ONLY the pinned planes.
+    #
+    # ``maintenance_plane`` is forwarded to the pin-only Layout so that
+    # ``collisions.check()`` can fire the maintenance_position rule if the
+    # pins collectively leave the maintenance area occupied by another plane
+    # or violated (detected early, before burning the full solve() budget
+    # on a restart loop that can never escape a pinned conflict).
+    #
+    # Scenario.__post_init__ guarantees that the maintenance_plane cannot
+    # carry a pin (raises ValueError if it does), so ``pinned_placements``
+    # is provably free of the maintenance occupant — no filter is needed.
+    #
+    # No try/except: every remaining Layout invariant that could fire
+    # here is either structurally impossible given pin-only construction
+    # or already caught by Scenario.__post_init__ (pin.plane_id mismatch,
+    # pin.on_carts vs movement_mode). A genuinely unexpected ValueError
+    # should propagate as a bug, not get silently re-wrapped as a pin
+    # infeasibility.
+    pin_only_layout = Layout(
+        fleet=scenario.fleet,
+        hangar=scenario.hangar,
+        placements=tuple(pinned_placements),
+        maintenance_plane=scenario.maintenance_plane,
+    )
+
+    pin_check = check_layout(pin_only_layout)
+    if not pin_check.valid:
+        return pin_check, pin_only_layout
 
     return None
 

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1068,16 +1068,27 @@ class NoFeasiblePlanError(Exception):
 def plan_fill(
     target: Layout,
     *,
-    heuristic: Literal["euclidean", "grid"] = "euclidean",
+    heuristic: Literal["euclidean", "grid"] = "grid",
     max_expansions: int | None = None,
+    max_total_expansions: int | None = None,
 ) -> MovesPlan:
     """Plan a collision-free entry order + per-plane path for an empty fill.
 
-    ``heuristic`` and ``max_expansions`` are forwarded to :func:`plan_path` for
-    every plane (towplanner-v2 routability spike, #332). The defaults reproduce
-    the shipped planner byte-for-byte (``max_expansions=None`` ⇒ the module
-    ``_MAX_EXPANSIONS`` budget); ``heuristic="grid"`` and/or a raised
-    ``max_expansions`` are the opt-in routability experiments.
+    ``heuristic`` selects the per-plane :func:`plan_path` heuristic. ``"grid"``
+    (the default since #336) is the obstacle-aware free-space geodesic, which
+    threads tight-clearance maneuvers in far fewer expansions than the
+    straight-line ``"euclidean"`` (which ignores walls and floods the frontier);
+    pass ``heuristic="euclidean"`` to opt out. ``max_expansions`` (``None`` ⇒ the
+    module ``_MAX_EXPANSIONS`` per-plane budget) caps each plane's search.
+
+    ``max_total_expansions`` (``None`` ⇒ the module ``_MAX_FILL_EXPANSIONS``) is
+    a deterministic GLOBAL cap on the expansions summed across *every*
+    :func:`plan_path` call in the whole fill — including the failed candidates of
+    the greedy scan. A high per-plane budget is needed to *route* tight-feasible
+    planes, but it makes an un-routable fill expensive to *disprove*
+    (~per-plane × scan-retries); the global cap bounds that worst case so the
+    planner bails in bounded time instead of running away, while a routable fill
+    finishes well under it. RNG-free, so the cap is seed-deterministic (#336).
 
     Walks :func:`back_first_order` (deepest slot first); for each plane searches
     for an in-bounds path from the door-cone entry poses (:func:`entry_poses`) to
@@ -1102,6 +1113,8 @@ def plan_fill(
     :class:`MovesPlan`.
     """
     budget = _MAX_EXPANSIONS if max_expansions is None else max_expansions
+    total_budget = _MAX_FILL_EXPANSIONS if max_total_expansions is None else max_total_expansions
+    total_used = 0
     ordered = list(back_first_order(target.placements))
     fleet = target.fleet
     hangar = target.hangar
@@ -1126,13 +1139,29 @@ def plan_fill(
             maintenance_plane=target.maintenance_plane,
         )
         for idx, slot in enumerate(ordered):
+            remaining = total_budget - total_used
+            if remaining <= 0:
+                # Global fill-expansion budget exhausted (#336): bail in bounded
+                # time rather than paying per-plane budget × scan-retries on an
+                # un-routable fill. Name the deepest still-unplaced plane.
+                raise NoFeasiblePlanError(
+                    ordered[0].plane_id,
+                    Conflict.single(
+                        kind="no_feasible_path",
+                        plane=ordered[0].plane_id,
+                        detail=f"global fill expansion budget ({total_budget}) exhausted",
+                    ),
+                )
             plane = fleet[slot.plane_id]
+            stats: dict[str, object] = {}
             try:
                 # The full door cone drives the multi-start search (#262). Compute
                 # it once and pass it as `entries=`; the positional `entry` arg is
                 # ignored by plan_path whenever `entries` is set, so reuse cone[0]
                 # for it rather than recomputing entry_pose() (which plan_path would
-                # never read here).
+                # never read here). Each call is capped at the smaller of the
+                # per-plane budget and the global remainder, and its expansions are
+                # charged to the global total whether it succeeds or fails (#336).
                 cone = entry_poses(slot, hangar)
                 arc = plan_path(
                     plane,
@@ -1143,14 +1172,19 @@ def plan_fill(
                     mover_on_carts=slot.on_carts,
                     entries=cone,
                     heuristic=heuristic,
-                    max_expansions=budget,
+                    max_expansions=min(budget, remaining),
+                    stats=stats,
                 )
             except NoFeasiblePlanError as exc:
                 # This plane cannot be routed against the current obstacles; try
                 # the next candidate. Remember its conflict for the bail message.
+                exp = stats.get("expansions", 0)
+                total_used += exp if isinstance(exp, int) else 0
                 if deepest_conflict is None:
                     deepest_conflict = exc.conflict
                 continue
+            exp = stats.get("expansions", 0)
+            total_used += exp if isinstance(exp, int) else 0
             chosen, chosen_arc = idx, arc
             break
         if chosen is None:
@@ -1174,31 +1208,34 @@ _GRID_XY_M = 0.5  # (x, y) cell size for state binning
 _GRID_DEG = 15.0  # heading cell size; 360 / 15 = 24 heading bins
 _HEADING_BINS = round(360.0 / _GRID_DEG)
 _TURN_PENALTY = 0.1  # per-radian g-cost penalty to prefer straighter paths
-_MAX_EXPANSIONS = 2000  # node-expansion budget per plane before bailing (#335).
-# Raised 700 → 2000 based on a budget sweep over the standard fixtures
-# (placeholder 25×18 hangar, solve_fresh_six_planes seed=1, 5 floor planes):
+_MAX_EXPANSIONS = 8000  # node-expansion budget per plane before bailing (#336).
+# Raised 2000 → 8000 when the GRID heuristic became the plan_fill default (#336).
+# The earlier euclidean sweep concluded aviat_husky (first in back-first order at
+# seed=1) was "un-routable even at 4000 — genuine tight-geometry exhaustion."
+# That was a HEURISTIC artifact, NOT infeasibility: euclidean ignores walls and
+# floods the frontier, needing ~13.5k expansions, whereas the obstacle-aware grid
+# heuristic threads the same maneuver in ~6062. So with grid the routability knee
+# moves to ~6100, and 8000 gives headroom to route it (the seed=1 fill reaches
+# 5/5, ~8.4k total expansions).
 #
-#   Budget | Routed (seed=1) | plan_fill wall-clock (seed=7)
-#   -------|-----------------|-----------------------------
-#      700 |  3/5            |  ~108 s
-#     1000 |  3/5 (no gain)  |  ~137 s
-#     1500 |  3/5 (no gain)  |  ~215 s
-#     2000 |  4/5 (+1, KNEE) |  ~271 s
-#     3000 |  4/5 (no gain)  |  ~441 s
-#     4000 |  4/5 (no gain)  |  ~540 s+ (extrapolated)
-#
-# The knee is at 2000: routed count improves from 3→4 and does not improve
-# further at 3000 or 4000.  The aviat_husky (first in back-first order at
-# seed=1) remains un-routable even at budget 4000 — genuine tight-geometry
-# budget exhaustion that a larger budget alone cannot fix, not a false negative.
-#
-# Deterministic (machine-independent) bound on worst-case search cost. The flip
-# side: budget exhaustion can also report a genuinely-feasible-but-hard layout
-# as NoFeasiblePlanError (a false negative). Accepted v2 tradeoff — see the
-# design spec's failure semantics; retune once real (measured) hangar geometry
-# is available, or once issue #336 (RRT-Connect v2) extends the motion model.
-# Overridable per-invocation via the ``--tow-max-expansions`` CLI flag and the
-# ``tow_max_expansions`` param on ``solve()``/``plan_fill()`` (#332).
+# Deterministic (machine-independent) bound on worst-case per-plane search cost.
+# Budget exhaustion can still report a genuinely-feasible-but-hard layout as
+# NoFeasiblePlanError (a false negative) — accepted v2 tradeoff; retune once real
+# (measured) hangar geometry lands. Overridable per-invocation via the
+# ``--tow-max-expansions`` CLI flag and the ``tow_max_expansions`` param on
+# ``solve()`` / ``plan_fill()`` (#332).
+
+_MAX_FILL_EXPANSIONS = 16000  # GLOBAL expansion budget across one whole fill (#336).
+# Bounds the worst-case wall-clock of an UN-routable fill. The higher per-plane
+# budget above is needed to ROUTE tight-but-feasible planes, but it makes an
+# un-routable fill expensive to disprove: the greedy back-first scan retries the
+# remaining planes, each burning up to the per-plane budget, so cost is
+# ~per-plane × scan-retries (the default spread=True six-plane fill measured
+# ~997 s at per-plane 8000 with NO global cap). Capping the SUM of expansions
+# across every plan_path call — failed candidates included — bounds that: the
+# same fill bails at the cap in ~334 s (< the 400 s perf gate), while a routable
+# fill (seed=1: ~8.4k total) finishes well under it. Deterministic / RNG-free.
+# Overridable via the ``max_total_expansions`` param on ``plan_fill()``.
 # Sampling resolution for the FAST in-search `_motion_clear` validity checks
 # (edges + the analytic-shot screen). Coarser than the exact oracle's default
 # (0.05 m / 1°) to keep the search tractable: the worst case is a plane that can

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -8,10 +8,12 @@ maintenance bay rendered conditionally on ``layout.maintenance_plane``
 placed aircraft drawn as its world :class:`Part` polygons (fuselage
 near-opaque — ``fuselage_front``/cockpit a darker tint than
 ``fuselage_aft``/tail — wing translucent so overlapping wings show their
-stack, struts as thin lines). Aircraft are color-keyed by ``wing_position``.
-If a
+stack, struts as thin lines). Each plane gets one colour from the
+DocGerdSoft CVD-safe ``PLANES`` brand palette, keyed per plane by sorted
+``plane_id``; every part also carries an ink outline so identity never rests
+on hue alone. If a
 :class:`CheckResult` is supplied, the parts of conflicting planes are
-overdrawn in red.
+overdrawn in the conflict colour with a hatch + dashed edge.
 
 The renderer's job is to give a human something to eyeball — visual
 quality is intentionally not asserted in tests. The smoke tests verify
@@ -39,7 +41,7 @@ from matplotlib.patches import Circle as MplCircle  # noqa: E402
 from matplotlib.patches import Polygon as MplPolygon  # noqa: E402
 
 from .geometry import WorldPart, aircraft_parts_world, local_to_world  # noqa: E402
-from .models import Aircraft, CheckResult, Layout, Placement, WingPosition  # noqa: E402
+from .models import Aircraft, CheckResult, Layout, Placement  # noqa: E402
 
 if TYPE_CHECKING:
     # Annotation-only import: the runtime code in _draw_tow_paths is duck-typed
@@ -48,32 +50,86 @@ if TYPE_CHECKING:
     # visualize, so this is safe under TYPE_CHECKING either way.
     from .towplanner import MovesPlan
 
-_WING_COLORS: dict[WingPosition, str] = {
-    "high": "#3498db",  # blue (retained — good contrast at all positions)
-    "mid": "#d55e00",  # Okabe–Ito vermillion — replaces #e67e22 (orange) for
-    # better luminance separation from the low-wing yellow #f4d03f under
-    # protanopia; #e67e22 and #f4d03f can merge for red-blind viewers.
-    "low": "#f4d03f",  # yellow
+# ── DocGerdSoft brand palette (Horizon-blue expression) ─────────────────────
+# Lifted verbatim from the authoritative DocGerdSoft brand handoff for
+# hangarfit ("Deliverable 4 — matplotlib Diagram Palette", README "Drop-in"
+# block). The categorical set is derived from the Okabe–Ito CVD-safe palette
+# (https://jfly.uni-koeln.de/color/) and tuned so every fill also clears
+# ≥3:1 contrast on white (WCAG non-text threshold). Identity must never rest
+# on hue alone: every plane also carries an ink outline (``_INK_EDGE``) and a
+# mono id label, and conflicts always add a hatch + ink edge (see
+# :func:`_draw_conflict_overlay`).
+#
+# PLANES — one colour per aircraft, ordered for max pairwise CVD separation.
+PLANES = [
+    "#0079B5",  # 01 Horizon (the hangarfit accent)
+    "#D55E00",  # 02 Vermillion
+    "#009E73",  # 03 Sea green
+    "#B45CA6",  # 04 Orchid
+    "#B37903",  # 05 Amber
+    "#108FAA",  # 06 Cyan
+    "#4C4C9E",  # 07 Indigo
+    "#8A542D",  # 08 Sienna
+    "#5E646B",  # 09 Graphite
+]
+# STATUS — status & structure inks. Key is "wall" per the authoritative README
+# drop-in (NOT "datum" as in the page's hangarfit.js): wall/door/datum all map
+# to the one graphite-strong ink #3B4046.
+STATUS = {
+    "valid": "#0F7C72",  # 5.06:1 on white
+    "conflict": "#C8442C",  # 4.86:1 — always pair with a hatch + ink edge
+    "maint": "#7B63A3",  # 5.05:1 — maintenance-bay fill
+    "wall": "#3B4046",  # 10.5:1 — wall · door · datum ink
 }
-# Defensive: ``WingPosition`` is closed at ``Literal["high", "mid", "low"]``
-# and ``_WING_COLORS`` covers all three, so this fallback is unreachable
-# today. It exists so that adding a new wing_position literal to the model
-# doesn't blow up the renderer with KeyError before someone updates the map.
+# PLANES_DARK — lifted fills for the dark-figure variant (drawn at ~92%
+# opacity on #0D0E10). Same ordering as PLANES.
+PLANES_DARK = [
+    "#3FA3D6",
+    "#E8794A",
+    "#33B894",
+    "#CE7EC0",
+    "#D29A2E",
+    "#3FB6CE",
+    "#8585C9",
+    "#BC8154",
+    "#9AA0A8",
+]
+
+# Plane / part outline ink (#14161A) — the "never hue alone" guarantee: every
+# plane part is stroked in this ink so the silhouette reads without colour.
+# Distinct from the wall ink (STATUS["wall"] = #3B4046), which is the
+# hangar/door/datum structure colour.
+_INK_EDGE = "#14161A"
+
+# Retained for back-compat with the wing-position concept and as the
+# unreachable-by-default fallback when a placement cannot be mapped to a
+# PLANES index (see :func:`_draw_aircraft`). Kept gray so a stray placement is
+# visibly "uncoloured" rather than masquerading as a real plane hue.
 _FALLBACK_COLOR = "#95a5a6"  # gray
 
-_CONFLICT_COLOR = "#e74c3c"  # red
+# Conflict ink, sourced from the brand STATUS map. Was #e74c3c pre-brand; the
+# constant NAME is preserved so importers (tests read to_rgba(_CONFLICT_COLOR))
+# keep resolving. The conflict overlay pairs this edge with a hatch + dashed
+# stroke (non-colour redundancy) — see :func:`_draw_conflict_overlay`.
+_CONFLICT_COLOR = STATUS["conflict"]  # "#C8442C"
 
 # Tow-path overlay palette (#192). One colour per plane, cycled by sorted
-# plane_id. Deliberately excludes the conflict red (#e74c3c) and the gray
-# fallback so a path never blurs into a conflict highlight or a placeholder
-# part. Eight entries cover the fleet (<=9 planes); a 9th plane reuses the
-# first colour — acceptable since each path terminates at its annotated slot.
+# plane_id. Deliberately excludes the conflict colour and the gray fallback so
+# a path never blurs into a conflict highlight or a placeholder part. Eight
+# entries cover the fleet (<=9 planes); a 9th plane reuses the first colour —
+# acceptable since each path terminates at its annotated slot.
+#
+# TODO(brand): the DocGerdSoft handoff specifies tow paths coloured by the
+# plane's index in the 9-colour ``PLANES`` set. Repointing here is deferred:
+# ``test_colour_cycle_wraps_beyond_palette`` pins ``len(set) == len(
+# _TOW_PATH_COLORS)`` (exactly 8 distinct on a 9-plane fleet), which a 9-entry
+# palette would break. Aligning to PLANES needs that test updated deliberately.
 #
 # Palette: Okabe–Ito 8-colour CVD-safe set (https://jfly.uni-koeln.de/color/).
 # This palette is distinguishable under deuteranopia, protanopia, and
-# tritanopia simultaneously, and reads in grey-scale. The conflict red
-# (#e74c3c) is excluded from this cycle as noted above; it is not part of
-# the Okabe–Ito set either.
+# tritanopia simultaneously, and reads in grey-scale. The conflict colour is
+# excluded from this cycle as noted above; it is not part of the Okabe–Ito set
+# either.
 _TOW_PATH_COLORS = (
     "#000000",  # black
     "#e69f00",  # orange
@@ -118,7 +174,11 @@ _BAY_WALL_EDGE = "#641e16"
 _BAY_WALL_ALPHA = 0.55
 _BAY_WALL_HATCH = "///"
 _BAY_LABEL_COLOR = "#ffffff"
-_HANGAR_EDGE = "#2c3e50"  # near-black
+# Wall / door / datum ink, sourced from the brand STATUS map (#3B4046,
+# 10.5:1 on white). The handoff folds wall, door, and datum onto this one
+# graphite-strong ink. The door is then *lightened* (``_DOOR_EDGE``) so the
+# opening reads as "open" rather than a wall.
+_HANGAR_EDGE = STATUS["wall"]  # "#3B4046" — wall · door · datum ink
 _DOOR_EDGE = "#bdc3c7"  # light gray — visually "open"
 
 # ── Wheel / cart glyph constants ────────────────────────────────────────────
@@ -327,10 +387,22 @@ def _draw_maintenance_bay(ax: Any, layout: Layout) -> None:
 
 
 def _draw_aircraft(ax: Any, layout: Layout) -> None:
-    """Draw each placed plane as its world parts, color-keyed by wing position."""
+    """Draw each placed plane as its world parts, one brand colour per plane.
+
+    Colour is keyed *per plane* from the DocGerdSoft ``PLANES`` categorical set
+    (handoff Deliverable 4) — a shift from the pre-brand scheme, which keyed
+    three colours off ``wing_position``. Each placement gets a stable index by
+    enumerating ``layout.placements`` sorted by ``plane_id`` (the same
+    deterministic sorted-id approach :func:`_draw_tow_paths` uses), so a given
+    layout always renders the same plane in the same colour regardless of
+    placement order. The 9-colour palette wraps with ``idx % len(PLANES)`` for
+    fleets beyond nine. Identity never rests on hue alone: every part also
+    carries the ``_INK_EDGE`` outline and a mono id label.
+    """
+    colour_for = _plane_colour_map(layout)
     for placement in layout.placements:
         aircraft = layout.fleet[placement.plane_id]
-        color = _WING_COLORS.get(aircraft.wing_position, _FALLBACK_COLOR)
+        color = colour_for.get(placement.plane_id, _FALLBACK_COLOR)
         world_parts = aircraft_parts_world(aircraft, placement)
         # Gear/cart glyph drawn before parts so the fuselage patch (zorder=2)
         # sits on top — wheels peek out at nose/tail/sides.
@@ -340,10 +412,22 @@ def _draw_aircraft(ax: Any, layout: Layout) -> None:
         _annotate_plane(ax, placement, aircraft.id)
 
 
+def _plane_colour_map(layout: Layout) -> dict[str, str]:
+    """Map each placed ``plane_id`` to a stable colour from ``PLANES``.
+
+    Indices are assigned by *sorted* ``plane_id`` so the mapping is independent
+    of placement order (ADR-0003 determinism spirit), mirroring
+    :func:`_draw_tow_paths`. Wraps with ``idx % len(PLANES)`` so fleets larger
+    than the nine-colour palette never raise.
+    """
+    plane_ids = sorted({p.plane_id for p in layout.placements})
+    return {pid: PLANES[i % len(PLANES)] for i, pid in enumerate(plane_ids)}
+
+
 def _darken(color: str, factor: float = _FUSELAGE_FRONT_DARKEN) -> tuple[float, float, float]:
     """Return ``color`` with each RGB channel multiplied by ``factor`` (toward
     black). Used to tint ``fuselage_front`` a darker shade of the plane's
-    wing-position fill so the cockpit boundary is legible (ADR-0012)."""
+    brand fill so the cockpit boundary is legible (ADR-0012)."""
     from matplotlib.colors import to_rgb
 
     r, g, b = to_rgb(color)
@@ -353,11 +437,15 @@ def _darken(color: str, factor: float = _FUSELAGE_FRONT_DARKEN) -> tuple[float, 
 def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
     """Render a single world part. Fuselage segments are near-opaque (two
     fuselages overlapping is always a conflict; no value in seeing through) —
-    ``fuselage_front`` (cockpit) a darker tint of the wing-position fill,
+    ``fuselage_front`` (cockpit) a darker tint of the plane's brand fill,
     ``fuselage_aft`` (tail) the plain fill — wing translucent (so stacked
     wings show their plan-view overlap visually), strut as a thin outlined
     polygon (struts are physically thin, a fill would be near-invisible), tail
     rendered like a small fuselage (same z-tier, same conflict semantics).
+
+    Solid parts are stroked in ``_INK_EDGE`` (#14161A), the brand "never hue
+    alone" outline — so a plane's silhouette reads even in greyscale or under
+    colour-vision deficiency, independent of its fill hue.
 
     Any other ``PartKind`` value raises ``ValueError`` rather than falling
     through to a generic style. ``PartKind`` is closed at the type level,
@@ -370,7 +458,7 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
             coords,
             closed=True,
             facecolor=_darken(color),
-            edgecolor=_HANGAR_EDGE,
+            edgecolor=_INK_EDGE,
             alpha=_FUSELAGE_ALPHA,
             lw=0.5,
             zorder=2,
@@ -380,7 +468,7 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
             coords,
             closed=True,
             facecolor=color,
-            edgecolor=_HANGAR_EDGE,
+            edgecolor=_INK_EDGE,
             alpha=_FUSELAGE_ALPHA,
             lw=0.5,
             zorder=2,
@@ -400,7 +488,7 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
             coords,
             closed=True,
             facecolor="none",
-            edgecolor=_HANGAR_EDGE,
+            edgecolor=_INK_EDGE,
             lw=_STRUT_LINEWIDTH,
             zorder=3,
         )
@@ -503,7 +591,7 @@ def _annotate_plane(ax: Any, placement: Placement, plane_id: str) -> None:
             placement.y_m + dy * _NOSE_ARROW_LENGTH_M,
         ),
         xytext=(placement.x_m, placement.y_m),
-        arrowprops=dict(arrowstyle="->", color=_HANGAR_EDGE, lw=1),
+        arrowprops=dict(arrowstyle="->", color=_INK_EDGE, lw=1),
         zorder=4,
     )
     ax.text(
@@ -513,7 +601,7 @@ def _annotate_plane(ax: Any, placement: Placement, plane_id: str) -> None:
         ha="center",
         va="top",
         fontsize=7,
-        color=_HANGAR_EDGE,
+        color=_INK_EDGE,
         zorder=4,
     )
 
@@ -525,9 +613,18 @@ def _draw_conflict_overlay(ax: Any, layout: Layout, check_result: CheckResult) -
 
     Non-colour redundancy: ``hatch="xxx"`` (dense cross pattern) plus
     ``linestyle="--"`` (dashed stroke) ensure "this part is in conflict" is
-    legible without relying on the red edge colour alone.  The red edge is
-    *kept* as a fast visual signal for colour-normal viewers — the non-colour
-    signals are additive, not replacements.
+    legible without relying on the conflict colour alone.  The conflict edge
+    (``_CONFLICT_COLOR`` = ``STATUS["conflict"]``) is *kept* as a fast visual
+    signal for colour-normal viewers — the non-colour signals are additive,
+    not replacements.
+
+    TODO(brand): the DocGerdSoft handoff calls for a 45° hatch (``"////"``)
+    paired with the conflict fill + ink edge. The current overlay uses
+    ``hatch="xxx"`` on a ``facecolor="none"`` overdraw, which satisfies the
+    "never colour alone" rule and the existing accessibility regression test
+    (``test_conflict_overlay_carries_non_colour_redundancy`` asserts a truthy
+    hatch, not a specific pattern). Switching to the 45° fill+hatch form is a
+    deliberate visual change deferred to avoid any subtle test interaction.
     """
     conflicting_planes: set[str] = set()
     for conflict in check_result.conflicts:

--- a/tests/fuzz/atheris_geometry_harness.py
+++ b/tests/fuzz/atheris_geometry_harness.py
@@ -1,0 +1,29 @@
+"""Atheris bridge harness for the geometry transform & collision checker (#355 Part B).
+
+Like ``atheris_loader_harness.py``, the ``import atheris`` below is what OpenSSF
+Scorecard's Python fuzzing probe greps for. Running it (nightly) drives
+libFuzzer through the SAME Hypothesis strategies the pytest property suite
+(``test_geometry_fuzz.py``) uses, via ``fuzz_one_input``.
+
+Run (from repo root, with atheris installed):
+    python -m tests.fuzz.atheris_geometry_harness -max_total_time=300
+"""
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from hypothesis import given
+
+    from tests.fuzz import geometry_strategies
+
+
+@given(geometry_strategies.geometry_tagged_documents())
+def _fuzz_geometry(tagged):
+    geometry_strategies.run_geometry_tagged(tagged)
+
+
+if __name__ == "__main__":
+    atheris.Setup(sys.argv, _fuzz_geometry.hypothesis.fuzz_one_input)
+    atheris.Fuzz()

--- a/tests/fuzz/geometry_strategies.py
+++ b/tests/fuzz/geometry_strategies.py
@@ -1,0 +1,261 @@
+"""Hypothesis strategies + run-helpers for fuzzing the geometry transform and
+the collision checker (#355 Part B).
+
+Companion to ``strategies.py`` (which fuzzes the YAML *loader*). That module
+feeds malformed *documents* and asserts the loader either returns a model or
+raises ``LoaderError``. This one is different in kind: it builds **valid** model
+objects (via the constructors, which enforce every invariant) and drives the
+pure geometry/collision functions, asserting they never crash **and** that their
+structural invariants hold. There is no "expected exception" here — the inputs
+are valid by construction, so any exception is a finding, as is any invariant
+violation.
+
+Shared by the pytest property suite (``test_geometry_fuzz.py``) and the Atheris
+bridge harness (``atheris_geometry_harness.py``) so input construction lives in
+exactly one place — mirroring the loader-fuzz split.
+
+The oracles, per target:
+
+- :func:`hangarfit.geometry.local_to_world` — finite in ⇒ finite out;
+  deterministic; the linear part is an isometry with determinant −1 (ADR-0002).
+- :func:`hangarfit.geometry.aircraft_parts_world` — one ``WorldPart`` per source
+  part, in order; area preserved (|det| = 1); z-range / kind / plane_id
+  preserved; deterministic.
+- :func:`hangarfit.collisions.check` — returns a ``CheckResult`` with
+  ``total_penetration_m2 >= 0``; deterministic; **order-independent** (the
+  conflict multiset and penetration do not depend on placement iteration order).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from hypothesis import strategies as st
+
+from hangarfit.collisions import check as check_layout
+from hangarfit.geometry import aircraft_parts_world, local_to_world
+from hangarfit.models import (
+    Aircraft,
+    Door,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    Placement,
+    Wheels,
+)
+
+# --- primitive strategies -------------------------------------------------
+# Finite and reasonably bounded: the goal is coverage-guided search over OUR
+# transform/checker logic, not probing how GEOS handles ±inf coordinates (a
+# shapely concern, not ours — and a source of false findings). Headings range
+# well outside [0, 360) to exercise the sin/cos wrap.
+_PART_KINDS = ["fuselage_front", "fuselage_aft", "wing", "strut", "tail"]
+_coord = st.floats(min_value=-60.0, max_value=60.0, allow_nan=False, allow_infinity=False)
+_dim = st.floats(min_value=0.05, max_value=25.0, allow_nan=False, allow_infinity=False)
+_heading = st.floats(min_value=-1080.0, max_value=1080.0, allow_nan=False, allow_infinity=False)
+_angle = st.floats(min_value=-360.0, max_value=360.0, allow_nan=False, allow_infinity=False)
+_local = st.floats(min_value=-40.0, max_value=40.0, allow_nan=False, allow_infinity=False)
+
+
+@st.composite
+def _part(draw: Any) -> Part:
+    """A valid :class:`Part`: positive dims, ``0 <= z_bottom < z_top``."""
+    z_bottom = draw(st.floats(min_value=0.0, max_value=8.0, allow_nan=False, allow_infinity=False))
+    z_top = z_bottom + draw(
+        st.floats(min_value=0.01, max_value=4.0, allow_nan=False, allow_infinity=False)
+    )
+    return Part(
+        kind=draw(st.sampled_from(_PART_KINDS)),
+        length_m=draw(_dim),
+        width_m=draw(_dim),
+        offset_x_m=draw(_coord),
+        offset_y_m=draw(_coord),
+        angle_deg=draw(_angle),
+        z_bottom_m=z_bottom,
+        z_top_m=z_top,
+    )
+
+
+@st.composite
+def _wheels(draw: Any) -> Wheels:
+    """A valid :class:`Wheels`: tricycle/tailwheel (both set) or monowheel (both None)."""
+    if draw(st.booleans()):
+        return Wheels(
+            main_offset_x_m=draw(_coord),
+            track_m=draw(st.floats(min_value=0.5, max_value=4.0, allow_nan=False)),
+            third_wheel_offset_x_m=draw(_coord),
+        )
+    return Wheels(main_offset_x_m=draw(_coord), track_m=None, third_wheel_offset_x_m=None)
+
+
+@st.composite
+def _aircraft(draw: Any, plane_id: str) -> Aircraft:
+    """A valid :class:`Aircraft` with 1–4 parts. ``always_own_gear`` so the
+    Layout cart-rule never rejects it — this fuzzer targets geometry, not the
+    cart invariants (those are covered by the loader fuzz suite)."""
+    parts = tuple(draw(st.lists(_part(), min_size=1, max_size=4)))
+    return Aircraft(
+        id=plane_id,
+        name=plane_id.upper(),
+        wing_position=draw(st.sampled_from(["high", "mid", "low"])),
+        gear=draw(st.sampled_from(["tailwheel", "nosewheel", "monowheel"])),
+        movement_mode="always_own_gear",
+        turn_radius_m=draw(st.floats(min_value=1.0, max_value=20.0, allow_nan=False)),
+        measured=False,
+        parts=parts,
+        wheels=draw(_wheels()),
+    )
+
+
+@st.composite
+def _placement(draw: Any, plane_id: str) -> Placement:
+    return Placement(
+        plane_id=plane_id,
+        x_m=draw(_coord),
+        y_m=draw(_coord),
+        heading_deg=draw(_heading),
+        on_carts=False,
+    )
+
+
+# A roomy hangar so bounds conflicts are possible but not the only outcome; the
+# checker is exercised regardless of how many parts fall outside it.
+_FUZZ_HANGAR = Hangar(
+    length_m=60.0,
+    width_m=60.0,
+    door=Door(center_x_m=30.0, width_m=10.0),
+    maintenance_bay=MaintenanceBay(center_x_m=30.0, width_m=8.0, depth_m=6.0),
+    clearance_m=0.3,
+    wing_layer_clearance_m=0.2,
+)
+
+
+# --- top-level strategies -------------------------------------------------
+
+
+@st.composite
+def local_to_world_inputs(draw: Any) -> tuple[float, float, Placement]:
+    return (draw(_local), draw(_local), draw(_placement("probe")))
+
+
+@st.composite
+def aircraft_world_inputs(draw: Any) -> tuple[Aircraft, Placement]:
+    return (draw(_aircraft("probe")), draw(_placement("probe")))
+
+
+@st.composite
+def layout_inputs(draw: Any) -> Layout:
+    """A valid multi-aircraft :class:`Layout` (1–4 planes), optionally with a
+    maintenance occupant (which is in the fleet but absent from placements, per
+    the Layout invariant)."""
+    n = draw(st.integers(min_value=1, max_value=4))
+    ids = [f"p{i}" for i in range(n)]
+    fleet = {pid: draw(_aircraft(pid)) for pid in ids}
+    # Optionally close the bay: pick an occupant that is NOT placed.
+    maintenance_plane = None
+    placeable = list(ids)
+    if n >= 2 and draw(st.booleans()):
+        maintenance_plane = draw(st.sampled_from(ids))
+        placeable = [pid for pid in ids if pid != maintenance_plane]
+    placements = tuple(draw(_placement(pid)) for pid in placeable)
+    return Layout(
+        fleet=fleet,
+        hangar=_FUZZ_HANGAR,
+        placements=placements,
+        maintenance_plane=maintenance_plane,
+    )
+
+
+# --- run-helpers (the oracles) --------------------------------------------
+
+
+def run_local_to_world(inputs: tuple[float, float, Placement]) -> None:
+    u, v, placement = inputs
+    wx, wy = local_to_world(u, v, placement)
+    assert math.isfinite(wx) and math.isfinite(wy), f"non-finite world point ({wx}, {wy})"
+    # Determinism.
+    assert local_to_world(u, v, placement) == (wx, wy)
+    # The linear part is an isometry with determinant −1 (ADR-0002): the images
+    # of the plane-local basis vectors, relative to the placement origin, form a
+    # det=−1 matrix. Use a probe placement at the same heading but at the origin
+    # to isolate the linear part.
+    origin = Placement(
+        plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=placement.heading_deg, on_carts=False
+    )
+    ax, ay = local_to_world(1.0, 0.0, origin)
+    bx, by = local_to_world(0.0, 1.0, origin)
+    det = ax * by - ay * bx
+    assert math.isclose(det, -1.0, rel_tol=1e-9, abs_tol=1e-9), f"determinant {det} != -1"
+
+
+def run_aircraft_parts_world(inputs: tuple[Aircraft, Placement]) -> None:
+    aircraft, placement = inputs
+    world = aircraft_parts_world(aircraft, placement)
+    assert len(world) == len(aircraft.parts), "part count not preserved"
+    for src, dst in zip(aircraft.parts, world, strict=True):
+        # Area is preserved by a |det|=1 map (ADR-0002). A tiny part can have a
+        # tiny area, so use a relative tolerance with an absolute floor.
+        expected = src.length_m * src.width_m
+        assert math.isclose(dst.polygon.area, expected, rel_tol=1e-7, abs_tol=1e-9), (
+            f"area {dst.polygon.area} != {expected} for {src.kind}"
+        )
+        assert dst.polygon.is_valid, f"invalid polygon for {src.kind}"
+        # Metadata carried through untouched.
+        assert dst.kind == src.kind
+        assert dst.z_bottom_m == src.z_bottom_m
+        assert dst.z_top_m == src.z_top_m
+        assert dst.plane_id == placement.plane_id
+    # Determinism: same inputs ⇒ identical world coordinates.
+    again = aircraft_parts_world(aircraft, placement)
+    assert [w.polygon.bounds for w in again] == [w.polygon.bounds for w in world]
+
+
+def run_collisions_check(layout: Layout) -> None:
+    result = check_layout(layout)
+    assert result.total_penetration_m2 >= 0.0, "negative penetration"
+    assert all(1 <= len(c.planes) <= 2 for c in result.conflicts), "conflict has bad plane count"
+    # Determinism.
+    again = check_layout(layout)
+    assert sorted(c.kind for c in result.conflicts) == sorted(c.kind for c in again.conflicts)
+    assert result.total_penetration_m2 == again.total_penetration_m2
+    # Order independence: reversing the placement order must not change the
+    # conflict multiset or the accumulated penetration (the alphabetised kind
+    # taxonomy in _pairwise_conflicts exists to guarantee this).
+    if len(layout.placements) >= 2:
+        reversed_layout = Layout(
+            fleet=layout.fleet,
+            hangar=layout.hangar,
+            placements=tuple(reversed(layout.placements)),
+            maintenance_plane=layout.maintenance_plane,
+        )
+        rev = check_layout(reversed_layout)
+        assert sorted(c.kind for c in result.conflicts) == sorted(c.kind for c in rev.conflicts), (
+            "conflict multiset depends on placement order"
+        )
+        assert math.isclose(
+            result.total_penetration_m2, rev.total_penetration_m2, rel_tol=1e-9, abs_tol=1e-9
+        ), "penetration depends on placement order"
+
+
+# --- tagged union (mirrors strategies.tagged_documents / run_tagged) ------
+
+_RUNNERS = {
+    "local_to_world": run_local_to_world,
+    "aircraft_parts_world": run_aircraft_parts_world,
+    "collisions_check": run_collisions_check,
+}
+
+
+def geometry_tagged_documents() -> st.SearchStrategy[tuple[str, Any]]:
+    return st.one_of(
+        st.tuples(st.just("local_to_world"), local_to_world_inputs()),
+        st.tuples(st.just("aircraft_parts_world"), aircraft_world_inputs()),
+        st.tuples(st.just("collisions_check"), layout_inputs()),
+    )
+
+
+def run_geometry_tagged(tagged: tuple[str, Any]) -> None:
+    tag, payload = tagged
+    _RUNNERS[tag](payload)

--- a/tests/fuzz/test_geometry_fuzz.py
+++ b/tests/fuzz/test_geometry_fuzz.py
@@ -1,0 +1,36 @@
+"""Property tests for the geometry transform and the collision checker (#355 Part B).
+
+Invariant under test for every target: given any **valid** model input (built by
+the constructors, which enforce every invariant), the pure geometry/collision
+functions must not crash and must hold their structural invariants — see the
+per-target oracles in ``geometry_strategies`` (finiteness, determinism,
+determinant −1, area preservation, metadata preservation, non-negative
+penetration, and placement-order independence).
+
+This is the Hypothesis side of #355 Part B; the SAME strategies drive the
+nightly Atheris coverage-guided run via ``atheris_geometry_harness``. Companion
+to ``test_loader_fuzz.py`` (which fuzzes the YAML loader). Runs under the ``ci``
+profile by default (fast, every PR); the nightly workflow sets
+HYPOTHESIS_PROFILE=nightly for a deep run.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+
+from tests.fuzz import geometry_strategies as g
+
+
+@given(g.local_to_world_inputs())
+def test_local_to_world_never_crashes(inputs):
+    g.run_local_to_world(inputs)
+
+
+@given(g.aircraft_world_inputs())
+def test_aircraft_parts_world_never_crashes(inputs):
+    g.run_aircraft_parts_world(inputs)
+
+
+@given(g.layout_inputs())
+def test_collisions_check_never_crashes(layout):
+    g.run_collisions_check(layout)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from hangarfit import __version__
 from hangarfit.cli import main
 
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
@@ -28,6 +29,17 @@ class TestArgparseUsageErrors:
         with pytest.raises(SystemExit) as exc_info:
             main(["nope"])
         assert exc_info.value.code == 2
+
+    def test_version_flag_exits_0_and_prints_version(self, capsys):
+        """`hangarfit --version` exits 0 (the version action fires before the
+        required-subparser check) and prints `hangarfit <version>` to stdout,
+        sourced from the packaged metadata so it tracks pyproject.toml."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--version"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == f"hangarfit {__version__}"
+        assert captured.err == ""
 
 
 class TestCheckHappyPath:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,7 +38,9 @@ class TestArgparseUsageErrors:
             main(["--version"])
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
-        assert captured.out.strip() == f"hangarfit {__version__}"
+        # Exact, un-stripped match pins the `%(prog)s {__version__}` template,
+        # the single trailing newline, and the absence of any extra output.
+        assert captured.out == f"hangarfit {__version__}\n"
         assert captured.err == ""
 
 

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -585,6 +585,37 @@ def test_solve_no_spread_flag_accepted_and_runs(tmp_path):
     assert out.exists()
 
 
+def test_solve_back_fill_defaults_on_and_no_back_fill_opts_out():
+    """`--no-back-fill` flips the ``back_fill`` namespace default (#320); absent,
+    it defaults ON (the back-of-hangar bias rides the spread post-pass)."""
+    from hangarfit.cli import build_parser
+
+    assert build_parser().parse_args(["solve", "s.yaml"]).back_fill is True
+    assert build_parser().parse_args(["solve", "s.yaml", "--no-back-fill"]).back_fill is False
+
+
+def test_solve_no_back_fill_flag_accepted_and_runs(tmp_path):
+    """`--no-back-fill` is accepted on `solve` and drives a successful run."""
+    from hangarfit.cli import main
+
+    out = tmp_path / "layout.yaml"
+    rc = main(
+        [
+            "solve",
+            "tests/fixtures/solve_all_nine_large_hangar.yaml",
+            "--seed",
+            "42",
+            "--budget",
+            "10",
+            "--no-back-fill",
+            "--write-yaml",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    assert out.exists()
+
+
 class TestSolveRenderPaths:
     """`--render-paths` flag: tow-path overlay rendering + exit-3 semantics (#193).
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1103,6 +1103,18 @@ class TestSearchConfig:
         assert SearchConfig(spread_scale_m=None).spread_scale_m is None
         assert SearchConfig(spread_scale_m=3.5).spread_scale_m == 3.5
 
+    def test_search_config_back_bias_weight_defaults_zero(self) -> None:
+        # Neutral library default (#320): pure spread, pre-back-fill behaviour.
+        # The CLI enables back-fill by default; --no-back-fill opts out.
+        assert SearchConfig().back_bias_weight == 0.0
+
+    def test_search_config_back_bias_weight_rejects_negative(self) -> None:
+        with pytest.raises(ValueError, match="back_bias_weight"):
+            SearchConfig(back_bias_weight=-0.1)
+        # zero (disabled) and positive are accepted
+        assert SearchConfig(back_bias_weight=0.0).back_bias_weight == 0.0
+        assert SearchConfig(back_bias_weight=2.5).back_bias_weight == 2.5
+
 
 # ---------------------------------------------------------------------------
 # SolveResult.plans — best-effort tow-plan bundle (#197)

--- a/tests/test_property_invariants.py
+++ b/tests/test_property_invariants.py
@@ -1,0 +1,296 @@
+"""Property-based (Hypothesis) invariants for the geometry transform, the
+collision checker, and the heading short-arc helper (#355, Part A).
+
+The example-based suite (``tests/test_geometry.py``) pins specific hand-picked
+headings — the off-by-90°/determinant-−1 trap is caught there at 45°/135°.
+*These* tests pin the **structural** invariants over randomized inputs, so a
+regression is caught at headings nobody thought to enumerate:
+
+- the plane-local→world map (``local_to_world`` / ``aircraft_parts_world``,
+  ADR-0002) is an **area-preserving isometry whose linear part has
+  determinant −1** at *every* heading, and is translation-equivariant;
+- :func:`hangarfit.collisions.check` is **order-independent** — the conflict
+  multiset and ``total_penetration_m2`` do not depend on placement iteration
+  order (the ``kind`` taxonomy is alphabetised precisely to guarantee this);
+- :func:`hangarfit.solver._heading_delta_short_arc` obeys its documented
+  algebra (range ``[0, 180]``, symmetry, 360°-periodicity).
+
+They complement — not replace — the worked-example tests. Hypothesis is
+already a dev dependency (used today only by the loader fuzz suite); these put
+it to work on the highest-consequence math in the project. ``deadline=None``
+is set explicitly so the suite never depends on the ``tests/fuzz`` conftest
+profiles being loaded, and a per-example deadline can't flake on a cold CI
+runner doing shapely work.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from hangarfit.collisions import check as check_layout
+from hangarfit.geometry import aircraft_parts_world, local_to_world
+from hangarfit.loader import load_layout
+from hangarfit.models import Aircraft, Layout, Part, Placement, Wheels
+from hangarfit.solver import _heading_delta_short_arc
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Bounded, well-conditioned float strategies. Headings deliberately range well
+# outside [0, 360) to exercise the sin/cos wrap and the helper's ``% 360``.
+headings = st.floats(min_value=-1080.0, max_value=1080.0, allow_nan=False, allow_infinity=False)
+coords = st.floats(min_value=-50.0, max_value=50.0, allow_nan=False, allow_infinity=False)
+local_coords = st.floats(min_value=-30.0, max_value=30.0, allow_nan=False, allow_infinity=False)
+dims = st.floats(min_value=0.1, max_value=20.0, allow_nan=False, allow_infinity=False)
+part_angles = st.floats(min_value=-360.0, max_value=360.0, allow_nan=False, allow_infinity=False)
+
+
+def _placement(x: float, y: float, h: float) -> Placement:
+    return Placement(plane_id="probe", x_m=x, y_m=y, heading_deg=h, on_carts=False)
+
+
+def _probe_aircraft(part: Part) -> Aircraft:
+    return Aircraft(
+        id="probe",
+        name="Probe",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=5.0,
+        measured=False,
+        parts=(part,),
+        wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
+    )
+
+
+# ----------------------------------------------------------------------------
+# local_to_world — the single canonical per-point transform (#293, ADR-0002).
+# ----------------------------------------------------------------------------
+
+
+class TestLocalToWorldInvariants:
+    @settings(max_examples=200, deadline=None)
+    @given(u=local_coords, v=local_coords, x=coords, y=coords, h=headings, dx=coords, dy=coords)
+    def test_translation_equivariant(
+        self, u: float, v: float, x: float, y: float, h: float, dx: float, dy: float
+    ) -> None:
+        """Shifting the placement origin by ``(dx, dy)`` shifts the world image
+        by exactly ``(dx, dy)`` — the translation is applied after the linear
+        part, independent of heading."""
+        wx0, wy0 = local_to_world(u, v, _placement(x, y, h))
+        wx1, wy1 = local_to_world(u, v, _placement(x + dx, y + dy, h))
+        assert math.isclose(wx1, wx0 + dx, rel_tol=1e-9, abs_tol=1e-9)
+        assert math.isclose(wy1, wy0 + dy, rel_tol=1e-9, abs_tol=1e-9)
+
+    @settings(max_examples=200, deadline=None)
+    @given(u1=local_coords, v1=local_coords, u2=local_coords, v2=local_coords, h=headings)
+    def test_linear_part_is_an_isometry(
+        self, u1: float, v1: float, u2: float, v2: float, h: float
+    ) -> None:
+        """A rotation-composed-with-reflection preserves distances: the world
+        distance between two points equals their plane-local distance, at any
+        heading. (Placement at the origin isolates the linear part.)"""
+        p = _placement(0.0, 0.0, h)
+        wx1, wy1 = local_to_world(u1, v1, p)
+        wx2, wy2 = local_to_world(u2, v2, p)
+        d_local = math.hypot(u1 - u2, v1 - v2)
+        d_world = math.hypot(wx1 - wx2, wy1 - wy2)
+        assert math.isclose(d_world, d_local, rel_tol=1e-9, abs_tol=1e-9)
+
+    @settings(max_examples=200, deadline=None)
+    @given(h=headings)
+    def test_linear_part_determinant_is_minus_one(self, h: float) -> None:
+        """🔬 The determinant-−1 guard, pinned over *all* headings rather than
+        the hand-picked ones in test_geometry.py.
+
+        With the placement at the origin, the world images of the plane-local
+        basis vectors ``(1, 0)`` and ``(0, 1)`` are the columns of the linear
+        map. Its determinant must be exactly −1 (a pure rotation would give
+        +1) — the algebraic statement of the "do not 'fix' it to a det=+1
+        rotation" warning in ADR-0002.
+        """
+        p = _placement(0.0, 0.0, h)
+        ax, ay = local_to_world(1.0, 0.0, p)  # image of plane-local +forward
+        bx, by = local_to_world(0.0, 1.0, p)  # image of plane-local +right
+        det = ax * by - ay * bx
+        assert math.isclose(det, -1.0, rel_tol=1e-9, abs_tol=1e-9)
+
+
+# ----------------------------------------------------------------------------
+# aircraft_parts_world — the part-level transform built on local_to_world.
+# ----------------------------------------------------------------------------
+
+
+class TestAircraftPartsWorldInvariants:
+    @settings(max_examples=150, deadline=None)
+    @given(
+        length=dims,
+        width=dims,
+        angle=part_angles,
+        ox=local_coords,
+        oy=local_coords,
+        x=coords,
+        y=coords,
+        h=headings,
+    )
+    def test_area_preserved_at_any_heading(
+        self,
+        length: float,
+        width: float,
+        angle: float,
+        ox: float,
+        oy: float,
+        x: float,
+        y: float,
+        h: float,
+    ) -> None:
+        """A det-magnitude-1 map preserves area: the transformed part polygon
+        has area ``length × width`` regardless of placement heading, the
+        part's own in-plane ``angle_deg``, or its offset."""
+        part = Part(
+            kind="wing",
+            length_m=length,
+            width_m=width,
+            offset_x_m=ox,
+            offset_y_m=oy,
+            angle_deg=angle,
+            z_bottom_m=1.0,
+            z_top_m=2.0,
+        )
+        [world] = aircraft_parts_world(_probe_aircraft(part), _placement(x, y, h))
+        assert math.isclose(world.polygon.area, length * width, rel_tol=1e-9, abs_tol=1e-9)
+
+    @settings(max_examples=150, deadline=None)
+    @given(
+        length=dims,
+        width=dims,
+        angle=part_angles,
+        x=coords,
+        y=coords,
+        h=headings,
+        dx=coords,
+        dy=coords,
+    )
+    def test_polygon_translation_equivariant(
+        self,
+        length: float,
+        width: float,
+        angle: float,
+        x: float,
+        y: float,
+        h: float,
+        dx: float,
+        dy: float,
+    ) -> None:
+        """Translating the placement translates every world vertex by the same
+        vector (centroid is a faithful proxy, being affine-equivariant)."""
+        part = Part(
+            kind="fuselage_aft",
+            length_m=length,
+            width_m=width,
+            offset_x_m=0.0,
+            offset_y_m=0.0,
+            angle_deg=angle,
+            z_bottom_m=0.0,
+            z_top_m=1.0,
+        )
+        ac = _probe_aircraft(part)
+        [w0] = aircraft_parts_world(ac, _placement(x, y, h))
+        [w1] = aircraft_parts_world(ac, _placement(x + dx, y + dy, h))
+        assert math.isclose(w1.polygon.centroid.x, w0.polygon.centroid.x + dx, abs_tol=1e-6)
+        assert math.isclose(w1.polygon.centroid.y, w0.polygon.centroid.y + dy, abs_tol=1e-6)
+
+
+# ----------------------------------------------------------------------------
+# _heading_delta_short_arc — pure angular helper (solver spec §4.6).
+# ----------------------------------------------------------------------------
+
+
+class TestHeadingDeltaShortArc:
+    @settings(max_examples=300, deadline=None)
+    @given(a=headings, b=headings)
+    def test_range_and_symmetry(self, a: float, b: float) -> None:
+        """Result is always in [0, 180] and symmetric in its arguments."""
+        d = _heading_delta_short_arc(a, b)
+        assert 0.0 <= d <= 180.0 + 1e-9
+        assert math.isclose(d, _heading_delta_short_arc(b, a), rel_tol=1e-9, abs_tol=1e-9)
+
+    @settings(max_examples=300, deadline=None)
+    @given(a=headings, b=headings, ka=st.integers(-5, 5), kb=st.integers(-5, 5))
+    def test_360_periodic_in_each_argument(self, a: float, b: float, ka: int, kb: int) -> None:
+        """Adding a whole turn to either argument leaves the short arc
+        unchanged — the contract that keeps the diversity filter from
+        mis-reading 1° vs 359° as a 358° move."""
+        base = _heading_delta_short_arc(a, b)
+        shifted = _heading_delta_short_arc(a + 360.0 * ka, b + 360.0 * kb)
+        assert math.isclose(base, shifted, rel_tol=1e-9, abs_tol=1e-7)
+
+    @settings(max_examples=200, deadline=None)
+    @given(a=headings)
+    def test_self_is_zero_and_antipode_is_180(self, a: float) -> None:
+        assert math.isclose(_heading_delta_short_arc(a, a), 0.0, abs_tol=1e-9)
+        assert math.isclose(_heading_delta_short_arc(a, a + 180.0), 180.0, abs_tol=1e-7)
+
+
+# ----------------------------------------------------------------------------
+# collisions.check — order independence.
+# ----------------------------------------------------------------------------
+
+_BASE_LAYOUT = load_layout(REPO_ROOT / "tests" / "fixtures" / "valid_all_nine_planes.yaml")
+_N = len(_BASE_LAYOUT.placements)
+_perturb = st.floats(min_value=-4.0, max_value=4.0, allow_nan=False, allow_infinity=False)
+
+
+class TestCheckOrderIndependence:
+    @settings(max_examples=75, deadline=None)
+    @given(
+        perturb=st.lists(st.tuples(_perturb, _perturb, headings), min_size=_N, max_size=_N),
+        perm=st.permutations(list(range(_N))),
+    )
+    def test_check_invariant_under_placement_reordering(
+        self, perturb: list[tuple[float, float, float]], perm: list[int]
+    ) -> None:
+        """🔬 The conflict multiset and total penetration are independent of the
+        order placements are listed in. The ``kind`` taxonomy is alphabetised
+        in ``_pairwise_conflicts`` specifically so that swapping plane_a/plane_b
+        cannot change a conflict's kind — this pins that guarantee end-to-end.
+
+        Planes are nudged by Hypothesis-drawn offsets so examples span the full
+        range from fully-disjoint (zero conflicts) to heavily-overlapping; the
+        invariant must hold across all of them. Reordering preserves on_carts
+        and the maintenance plane, so every constructed Layout stays valid.
+        """
+        moved = tuple(
+            Placement(
+                plane_id=p.plane_id,
+                x_m=p.x_m + dx,
+                y_m=p.y_m + dy,
+                heading_deg=p.heading_deg + dh,
+                on_carts=p.on_carts,
+            )
+            for p, (dx, dy, dh) in zip(_BASE_LAYOUT.placements, perturb, strict=True)
+        )
+        reordered = tuple(moved[i] for i in perm)
+
+        def _result(placements: tuple[Placement, ...]) -> tuple[int, list[str], float]:
+            layout = Layout(
+                fleet=_BASE_LAYOUT.fleet,
+                hangar=_BASE_LAYOUT.hangar,
+                placements=placements,
+                maintenance_plane=_BASE_LAYOUT.maintenance_plane,
+            )
+            res = check_layout(layout)
+            return (
+                len(res.conflicts),
+                sorted(c.kind for c in res.conflicts),
+                res.total_penetration_m2,
+            )
+
+        n0, kinds0, pen0 = _result(moved)
+        n1, kinds1, pen1 = _result(reordered)
+        assert n0 == n1
+        assert kinds0 == kinds1
+        assert math.isclose(pen0, pen1, rel_tol=1e-9, abs_tol=1e-9)

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -1216,6 +1216,116 @@ def test_spread_runs_with_single_movable_among_pinned():
     assert _inter_plane_energy(out, s, scale) <= e_before
 
 
+def test_spread_back_fills_single_movable_plane_toward_the_back_wall():
+    """#320: with ``back_bias_weight > 0`` the ``<2 planes`` no-op guard is
+    relaxed and a lone movable plane is pulled DEEP toward the back wall (large
+    ``y``), where the back-bias term ``B = Σ (length_m − y) / length_m`` is
+    minimized. With the default ``back_bias_weight = 0.0`` the same call is a
+    no-op (see ``test_spread_noop_when_single_movable_plane``)."""
+    import random
+    import time
+
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import Placement, SearchConfig
+    from hangarfit.solver import _spread
+
+    s = load_scenario(REPO_ROOT / "tests" / "fixtures" / "solve_all_nine_large_hangar.yaml")
+    pid = next(p for p in s.fleet_in if p != s.maintenance_plane)
+    start = Placement(plane_id=pid, x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False)
+
+    out = _spread(
+        {pid: start},
+        s,
+        random.Random(1),
+        SearchConfig(back_bias_weight=1.0),
+        start=time.monotonic(),
+        budget_s=10.0,
+        pinned_planes=frozenset(),
+    )
+    # Pulled deeper than it started, and into the back half of the hangar.
+    assert out[pid].y_m > start.y_m
+    assert out[pid].y_m > s.hangar.length_m / 2
+
+
+def test_spread_back_fill_is_deterministic_for_same_seed():
+    """#320: the back-bias is RNG-free re-ranking (it does not change the draw
+    count or order), so back-fill stays byte-identical across runs on a fixed
+    seed — the ADR-0003 belt-and-suspenders canary for the new term."""
+    import random
+    import time
+
+    from hangarfit.models import SearchConfig
+    from hangarfit.solver import _spread
+
+    s, placements = _valid_placements(seed=11)
+    cfg = SearchConfig(back_bias_weight=2.0)
+
+    a = _spread(
+        placements,
+        s,
+        random.Random(99),
+        cfg,
+        start=time.monotonic(),
+        budget_s=60.0,
+        pinned_planes=frozenset(),
+    )
+    b = _spread(
+        placements,
+        s,
+        random.Random(99),
+        cfg,
+        start=time.monotonic(),
+        budget_s=60.0,
+        pinned_planes=frozenset(),
+    )
+    assert {k: (v.x_m, v.y_m, v.heading_deg) for k, v in a.items()} == {
+        k: (v.x_m, v.y_m, v.heading_deg) for k, v in b.items()
+    }
+
+
+def test_spread_back_fill_packs_planes_deeper_than_spread_only():
+    """#320: with ``back_bias_weight > 0`` the spread hill-climb settles a
+    multi-plane layout DEEPER (larger mean ``y``) than pure spread, while
+    remaining a valid layout (the back-bias never overrides collision validity)."""
+    import random
+    import time
+    from statistics import mean
+
+    from hangarfit.models import Layout, SearchConfig
+    from hangarfit.solver import _score, _spread
+
+    s, placements = _valid_placements(seed=11)
+    assert len(placements) >= 2, "fixture sanity"
+
+    spread_only = _spread(
+        placements,
+        s,
+        random.Random(7),
+        SearchConfig(),
+        start=time.monotonic(),
+        budget_s=60.0,
+        pinned_planes=frozenset(),
+    )
+    back_filled = _spread(
+        placements,
+        s,
+        random.Random(7),
+        SearchConfig(back_bias_weight=3.0),
+        start=time.monotonic(),
+        budget_s=60.0,
+        pinned_planes=frozenset(),
+    )
+
+    assert mean(p.y_m for p in back_filled.values()) > mean(p.y_m for p in spread_only.values())
+    layout = Layout(
+        fleet=s.fleet,
+        hangar=s.hangar,
+        placements=tuple(back_filled.values()),
+        maintenance_plane=s.maintenance_plane,
+    )
+    assert _score(layout) == (0, 0.0)
+
+
 def test_plane_footprint_area_does_not_double_count_tail():
     """Regression guard for #317: a plane with a standalone ``tail`` part
     must not have its tail length both folded into the reconstructed

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -99,6 +99,42 @@ def test_solve_default_enables_spread():
     ]
 
 
+def test_solve_back_fill_parks_single_plane_at_back_wall():
+    """#320 acceptance: with back-fill a lone plane parks deep against the back
+    wall — and strictly deeper than with back-fill off, same seed. Bounded by
+    ``max_restarts`` so the basin pool (and selection) is seed-deterministic."""
+    s = load_scenario("tests/fixtures/solve_trivial_single_plane.yaml")
+    off = solve(
+        s, seed=42, search=SearchConfig(max_restarts=5, back_bias_weight=0.0), plan_paths=False
+    )
+    on = solve(
+        s, seed=42, search=SearchConfig(max_restarts=5, back_bias_weight=1.0), plan_paths=False
+    )
+    assert off.layouts and on.layouts
+    (p_off,) = off.layouts[0].placements
+    (p_on,) = on.layouts[0].placements
+    assert p_on.y_m > p_off.y_m  # back-fill pulls the lone plane deeper
+    assert p_on.y_m > 0.7 * s.hangar.length_m  # and up against the back wall
+
+
+def test_solve_back_fill_clears_the_door_on_two_plane_fill():
+    """#320 acceptance: on the 2-plane minimal fill, back-fill leaves free space
+    at the door — the front-most plane sits deeper than with back-fill off, and
+    no plane is parked in the front third of the hangar."""
+    s = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    off = solve(
+        s, seed=1, search=SearchConfig(max_restarts=5, back_bias_weight=0.0), plan_paths=False
+    )
+    on = solve(
+        s, seed=1, search=SearchConfig(max_restarts=5, back_bias_weight=1.0), plan_paths=False
+    )
+    assert off.layouts and on.layouts
+    front_off = min(p.y_m for p in off.layouts[0].placements)
+    front_on = min(p.y_m for p in on.layouts[0].placements)
+    assert front_on > front_off  # door-side cleared relative to the spread-only baseline
+    assert front_on > s.hangar.length_m / 3  # no plane left in the front (door) third
+
+
 def test_solve_k2_with_spread_never_invalid_and_diverse_if_found():
     """The spread/diversity interaction (spec known-interaction): with K=2 and
     spread on, every returned layout must be valid, and if status==found the

--- a/tests/test_solver_towplanner.py
+++ b/tests/test_solver_towplanner.py
@@ -124,6 +124,35 @@ def test_solve_best_effort_real_planner_on_untowable_fill():
     assert result.diagnostics.unroutable_planes  # non-empty
 
 
+@pytest.mark.slow
+def test_six_plane_fresh_fill_fully_routes_at_shipped_defaults():
+    """#336: a tow-friendly (spread=False) fill of ``solve_fresh_six_planes``
+    (seed=1) is **fully** tow-routable under the SHIPPED default planner — the
+    obstacle-aware grid heuristic + the raised per-plane budget. Previously
+    un-routable: euclidean@2000 capped out on ``aviat_husky`` (which needs
+    ~6062 grid expansions to thread its 10.82 m wing into the back corner).
+
+    Scope: this asserts the *planner* improvement on a tow-friendly layout. The
+    default ``spread=True`` fill remaining hard is the separate #280 placement
+    tension (back-fill #320), not this issue. Slow (real per-plane search).
+    """
+    from hangarfit.loader import load_scenario
+    from hangarfit.models import SearchConfig
+    from hangarfit.solver import solve
+
+    scenario = load_scenario("tests/fixtures/solve_fresh_six_planes.yaml")
+    result = solve(
+        scenario, budget_s=15.0, alternatives=1, seed=1, search=SearchConfig(spread=False)
+    )
+    assert result.status in ("found", "found_partial")
+    assert len(result.layouts) == 1
+    assert all(p is not None for p in result.plans), (
+        f"fill not fully routed at shipped defaults: "
+        f"unroutable={result.diagnostics.unroutable_planes}"
+    )
+    assert result.diagnostics.unroutable_planes == ()
+
+
 def test_solve_k_gt_1_bundle_alignment_with_mixed_routability(monkeypatch):
     """K>1: the per-layout loop builds an aligned plans tuple with a mix of
     real plans and None, and unroutable_planes records exactly the failed

--- a/tests/test_towplanner_grid_heuristic.py
+++ b/tests/test_towplanner_grid_heuristic.py
@@ -15,16 +15,17 @@ towplanner-v2 routability spike:
 * the geodesic field is well-formed (0 at the goal, increasing with distance,
   finite where free, and absent — i.e. ``+inf``/fallback — where walled off).
 
-These pin the *correctness* and *determinism* of the seam — NOT a routability
-win. Whether the grid heuristic buys routability is an empirical question the
-spike benchmark (``docs/spikes/towplanner_v2_routability_bench.py``) and the spike
-doc answer, and the honest answer is "no, not on these fixtures": their failures
-are budget-exhausted *finite-width maneuvering*, not interior-obstacle clutter, so
-a 2-D cost-to-go heuristic (this one, or a learned one) is inert. There is
-therefore deliberately **no** "grid routes what euclidean cannot" test — it would
-not hold, on the fixtures *or* on constructed bug-traps (once a detour is forced,
-the tight-maneuver bottleneck defeats both heuristics within budget). The seam is
-kept as a tested, opt-in PoC and the home for a future clutter/learned heuristic.
+These pin the *correctness* and *determinism* of the grid seam. **Since #336 grid
+is the shipped default** for ``plan_fill`` / ``solve`` (``plan_path``'s own
+primitive default stays ``euclidean`` — callers choose). The earlier "grid is
+inert, so no 'grid beats euclidean' test can exist" conclusion was a budget-700/
+2000 artifact: at those budgets BOTH heuristics cap out on the tight cases, so
+grid bought no extra *routed count*. But grid roughly halves the *expansions*
+(aviat_husky ~13.5k euclidean → ~6062 grid), which converts to a routed plane once
+the per-plane budget clears ~6100 (#336 raised it to 8000). The end-to-end "grid
+routes a tight fill euclidean cannot, at the shipped default budget" proof now
+lives in ``tests/test_solver_towplanner.py::
+test_six_plane_fresh_fill_fully_routes_at_shipped_defaults``.
 """
 
 from __future__ import annotations
@@ -340,6 +341,18 @@ def test_plan_fill_accepts_grid_heuristic_and_explicit_budget() -> None:
     assert [m.plane_id for m in plan.moves] == ["B", "A"]  # deepest first
 
 
+def test_plan_fill_global_cap_bails_in_bounded_total_expansions() -> None:
+    """``max_total_expansions`` caps the SUM of expansions across the whole fill
+    (#336). A tiny global cap forces a fast, bounded bail with the cap-exhausted
+    conflict — instead of paying per-plane-budget × scan-retries on a fill the
+    bounded planner cannot route. ``valid_two_separated`` leads with the 18 m-wing
+    scheibe_falke, which cannot route in 10 expansions, so the global cap trips."""
+    layout = load_layout("tests/fixtures/valid_two_separated.yaml")
+    with pytest.raises(NoFeasiblePlanError) as ei:
+        plan_fill(layout, max_total_expansions=10)
+    assert "global fill expansion budget" in ei.value.conflict.detail
+
+
 def test_solve_accepts_grid_tow_heuristic() -> None:
     """``solve(..., tow_heuristic="grid", tow_max_expansions=N)`` runs the opt-in
     grid branch in the solver. The plane may or may not route (best-effort); the
@@ -439,11 +452,12 @@ def test_grid_field_blocks_cells_past_non_aligned_walls() -> None:
 # ── CLI flag wiring (the #332 experimental knobs) ────────────────────────────
 
 
-def test_cli_tow_flags_default_to_the_byte_identical_shipped_planner() -> None:
-    """No ``--tow-*`` flags ⇒ the namespace defaults that route ``solve()`` down
-    the unchanged ``plan_fill(layout)`` path (the byte-identical-default guard)."""
+def test_cli_tow_flags_default_to_grid_with_no_explicit_budget() -> None:
+    """No ``--tow-*`` flags ⇒ the shipped default is ``grid`` (since #336) with no
+    explicit per-plane budget, so ``solve()`` takes the bare ``plan_fill(layout)``
+    no-kwargs path (the stub-compatible default)."""
     args = build_parser().parse_args(["solve", "scenario.yaml"])
-    assert args.tow_heuristic == "euclidean"
+    assert args.tow_heuristic == "grid"
     assert args.tow_max_expansions is None
 
 

--- a/tests/test_towplanner_perf.py
+++ b/tests/test_towplanner_perf.py
@@ -40,8 +40,14 @@ from hangarfit.towplanner import NoFeasiblePlanError, path_first_conflict, plan_
 # exhausting the full budget, tried multiple times by the greedy scan) measured
 # ~271 s on the development machine.  400 s = ~271 s × 1.5 + rounding — keeps
 # the runaway guard meaningful while allowing for slower CI machines.  Tighten
-# once real (measured) hangar geometry is available or issue #336 (RRT-Connect
-# v2) extends the motion model.
+# once real (measured) hangar geometry is available.
+#
+# #336: the per-plane budget rose 2000 → 8000 (grid heuristic became the
+# plan_fill default) AND a GLOBAL per-fill expansion cap
+# (_MAX_FILL_EXPANSIONS = 16000) was added. The cap is what keeps this gate
+# green: grid@8000 with NO global cap measured ~997 s on the seed=7 fill
+# (blowing 400 s), but the cap bails it at ~334 s. So 400 s still holds — now
+# bounded by the global fill cap, not per-plane budget × scan-retries.
 _PLAN_FILL_CEILING_S = 400.0
 
 
@@ -55,7 +61,10 @@ _PLAN_FILL_CEILING_S = 400.0
 )
 def test_plan_fill_on_solved_layouts_completes_within_budget(scenario_path: str) -> None:
     scenario = load_scenario(scenario_path)
-    result = solve(scenario, budget_s=10.0, alternatives=1, seed=7)
+    # plan_paths=False: this gate times its OWN plan_fill calls below, so the
+    # layout search must NOT also tow-plan internally (wasted work that, since
+    # #336's grid default + larger budget, costs as much as the timed section).
+    result = solve(scenario, budget_s=10.0, alternatives=1, seed=7, plan_paths=False)
     if not result.layouts:
         pytest.skip(f"{scenario_path}: solve produced no layout (status={result.status})")
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1042,3 +1042,85 @@ class TestGearGlyph:
 
         # Three wheels (two mains + nose) drawn from wheels.positions.
         assert ax.add_patch.call_count == 3
+
+
+class TestBrandPalette:
+    """Pin the DocGerdSoft brand palette lifted into ``visualize`` (handoff
+    Deliverable 4). Guards a regression that silently drifts a hex away from
+    the authoritative handoff "Drop-in" block, and that the per-plane colour
+    keying still draws every part of every placed plane.
+    """
+
+    def test_planes_palette_is_the_handoff_nine(self) -> None:
+        from hangarfit.visualize import PLANES
+
+        assert PLANES == [
+            "#0079B5",
+            "#D55E00",
+            "#009E73",
+            "#B45CA6",
+            "#B37903",
+            "#108FAA",
+            "#4C4C9E",
+            "#8A542D",
+            "#5E646B",
+        ]
+
+    def test_planes_dark_palette_is_the_handoff_nine(self) -> None:
+        from hangarfit.visualize import PLANES_DARK
+
+        assert PLANES_DARK == [
+            "#3FA3D6",
+            "#E8794A",
+            "#33B894",
+            "#CE7EC0",
+            "#D29A2E",
+            "#3FB6CE",
+            "#8585C9",
+            "#BC8154",
+            "#9AA0A8",
+        ]
+
+    def test_status_map_matches_handoff_drop_in(self) -> None:
+        # Key is "wall" per the authoritative README drop-in (NOT "datum").
+        from hangarfit.visualize import STATUS
+
+        assert STATUS == {
+            "valid": "#0F7C72",
+            "conflict": "#C8442C",
+            "maint": "#7B63A3",
+            "wall": "#3B4046",
+        }
+
+    def test_conflict_colour_is_sourced_from_status(self) -> None:
+        from hangarfit.visualize import _CONFLICT_COLOR, STATUS
+
+        assert _CONFLICT_COLOR == STATUS["conflict"] == "#C8442C"
+
+    def test_plane_parts_drawn_per_part_with_ink_outline(self) -> None:
+        """Each placed plane's parts are still drawn one ``_draw_part`` call
+        per part, and solid parts carry the brand ink outline (#14161A) so
+        identity never rests on hue alone.
+        """
+        import matplotlib.colors
+
+        from hangarfit.geometry import aircraft_parts_world
+        from hangarfit.visualize import _INK_EDGE, _draw_aircraft
+
+        layout = _load("valid_two_separated")
+        expected_parts = sum(
+            len(aircraft_parts_world(layout.fleet[p.plane_id], p)) for p in layout.placements
+        )
+        ax = MagicMock()
+
+        _draw_aircraft(ax, layout)
+
+        # One add_patch per part, plus the per-wheel gear glyphs. At minimum,
+        # every part must have produced a patch.
+        assert ax.add_patch.call_count >= expected_parts
+        ink = matplotlib.colors.to_rgba(_INK_EDGE)
+        # At least one solid (fuselage/strut) part must be stroked in the ink.
+        edges = [c.args[0].get_edgecolor() for c in ax.add_patch.call_args_list]
+        assert any(e[:3] == ink[:3] for e in edges), (
+            "at least one plane part must carry the _INK_EDGE outline"
+        )


### PR DESCRIPTION
## Release v0.9.0

This PR merges the `release/0.9.0` branch into `main`, tagging the
v0.9.0 release of hangarfit.

**Tow-friendly placement.** v0.9.0 makes the static solver emit layouts that the
bounded tow planner can actually route under default settings: a back-of-hangar
fill bias (#320) clears the door-side approach corridors, the `grid` heuristic
becomes the default with a global fill-budget cap so planning never hangs (#336),
and `solve --render-paths` gains a spread-off backstop that recovers a tow plan
when a spread layout is un-routable (#280, ADR-0016). Also lands `--version`
(#360), the DocGerdSoft "Horizon" brand identity (#380), and nightly fuzzing of
the geometry/collision layers (#362/#369).

See `CHANGELOG.md` `[0.9.0]` for the full list.

**Do not merge until all checks pass and the release is confirmed ready.**

After merging, tag the release:
  git fetch origin main
  git tag -a v0.9.0 -m "Release v0.9.0" <merge-commit-sha-on-main>
  git push origin v0.9.0