### PR TITLE
chore: back-merge v0.9.0 into develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hangarfit"
-version = "0.8.0"
+version = "0.9.0"
 description = "Helper tool for arranging a flying club's fleet in a stack-style hangar — collision checker, layout solver, tow-path planner, and top-down visualizer."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Back-merge v0.9.0 into develop

Merges the `release/0.9.0` branch back into `develop` to keep the
branches in sync after the release (the `pyproject.toml` version bump to
`0.9.0`).

This PR should be merged AFTER the main release PR (#384) is merged.