### PR TITLE
docs(CLAUDE.md): Phase 4 learnings — codecov/@slow gotcha + view verify recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,11 @@ pytest -m slow
 # Or run everything regardless of marker
 pytest -m ""
 
+# GOTCHA: CI runs `pytest -m 'not slow'` and derives coverage from THAT run, so
+# marking a test @slow drops it from coverage too. If a @slow test is the only
+# one covering a new code path, the `codecov/patch` PR check fails — keep >=1
+# non-slow test per new path.
+
 # Lint + format check (CI also runs these)
 ruff check src/ tests/
 ruff format --check src/ tests/
@@ -231,7 +236,9 @@ pip-compile --generate-hashes --no-strip-extras --allow-unsafe -o requirements-p
 # the build toolchain from `requirements-build.txt` likewise, then
 # installs the project itself in editable mode with `--no-deps
 # --no-build-isolation` (reusing the hash-verified host setuptools/wheel
-# instead of an unpinned isolated build env). No coverage gate yet.
+# instead of an unpinned isolated build env). No pytest coverage threshold
+# (no --cov-fail-under), but Codecov's `codecov/patch` status gates patch
+# coverage on each PR (see the @slow gotcha above).
 
 # Phase 1 acceptance smoke test
 hangarfit check layouts/example.yaml --render out.png
@@ -240,6 +247,15 @@ hangarfit check layouts/example.yaml --render out.png
 # can't fully route renders without paths (blocking plane named on stderr);
 # exit 3 only if NO candidate layout is tow-routable.
 hangarfit solve tests/fixtures/scenario_minimal.yaml --render out.png --render-paths
+
+# Phase 4: 3D viewer (self-contained offline HTML). layouts/example.yaml is NOT
+# tow-routable (renders static-only) → use the wing-over-nesting fixture for an
+# animated demo. Verify headlessly via swiftshader WebGL (dbus/UPower + WebGL
+# "ReadPixels stall" lines are noise; a transform mismatch shows an on-page banner).
+hangarfit view tests/fixtures/valid_left_side_nesting.yaml -o out.html
+google-chrome --headless=new --use-gl=angle --use-angle=swiftshader \
+  --enable-unsafe-swiftshader --virtual-time-budget=8000 \
+  --screenshot=out.png "file://$PWD/out.html"
 
 # GitFlow loops
 git switch develop && git pull

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,8 +237,10 @@ pip-compile --generate-hashes --no-strip-extras --allow-unsafe -o requirements-p
 # installs the project itself in editable mode with `--no-deps
 # --no-build-isolation` (reusing the hash-verified host setuptools/wheel
 # instead of an unpinned isolated build env). No pytest coverage threshold
-# (no --cov-fail-under), but Codecov's `codecov/patch` status gates patch
-# coverage on each PR (see the @slow gotcha above).
+# (no --cov-fail-under); Codecov posts a `codecov/patch` status flagging patch
+# coverage on each PR, but it is NOT a required check on `develop` (required =
+# test 3.12 + the three lockfile-drift jobs + Analyze), so a red patch status
+# reports but does not by itself block merge (see the @slow gotcha above).
 
 # Phase 1 acceptance smoke test
 hangarfit check layouts/example.yaml --render out.png
@@ -249,9 +251,12 @@ hangarfit check layouts/example.yaml --render out.png
 hangarfit solve tests/fixtures/scenario_minimal.yaml --render out.png --render-paths
 
 # Phase 4: 3D viewer (self-contained offline HTML). layouts/example.yaml is NOT
-# tow-routable (renders static-only) → use the wing-over-nesting fixture for an
-# animated demo. Verify headlessly via swiftshader WebGL (dbus/UPower + WebGL
-# "ReadPixels stall" lines are noise; a transform mismatch shows an on-page banner).
+# tow-routable → it renders static-only but grinds ~2 min first exhausting the
+# tow-planner's per-plane expansion budget (layout-mode view has no wall-clock
+# cap); pass --no-animate to skip straight to static, or use the wing-over-nesting
+# fixture for a fast animated demo. Verify headlessly via swiftshader WebGL
+# (dbus/UPower + WebGL "ReadPixels stall" lines are noise; a transform mismatch
+# shows an on-page banner).
 hangarfit view tests/fixtures/valid_left_side_nesting.yaml -o out.html
 google-chrome --headless=new --use-gl=angle --use-angle=swiftshader \
   --enable-unsafe-swiftshader --virtual-time-budget=8000 \


### PR DESCRIPTION
Records two durable operational learnings from the Phase 4 session in CLAUDE.md (no code change):

1. **codecov/@slow gotcha** — CI runs `pytest -m 'not slow'` and derives coverage from that same run, so marking a test `@slow` drops it from coverage. If it is the only test covering new code, `codecov/patch` fails (this happened on #393). Keep ≥1 non-slow test per new path. Also corrects the now-stale 'No coverage gate yet' note.
2. **`hangarfit view` verify recipe** — the headless-Chrome (swiftshader WebGL) screenshot command, plus the caveat that `layouts/example.yaml` is not tow-routable so the wing-over-nesting fixture is the canonical animated demo.

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)