### PR TITLE
feat(viewer): render landing gear + tow carts in 3D (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 - **3D viewer renders landing gear + tow carts (#399).** `scene/v1` now emits
   per-plane `wheels[]` (canonical plane-local positions, ADR-0013) and an
-  `on_carts` flag, plus a `gear_anchors` oracle. The viewer draws a wheel and a
-  short leg up to the belly at each wheel — and a pallet deck under each wheel for
-  carted planes — all parented to the existing per-plane affine Group, so the gear
+  `on_carts` flag, plus a `gear_anchors` oracle. The viewer draws a wheel at each
+  wheel point (+ a short leg up to the belly where it clears) — and a pallet deck
+  under each wheel for carted planes — all parented to the existing per-plane
+  affine Group, so the gear
   inherits the determinant-−1 transform and animates along the tow path for free.
   The load-time anchor self-check now also oracles gear world positions (the only
   cross-language backstop, since `viewer.js` is not pytest-covered). Wheels/carts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **3D viewer renders landing gear + tow carts (#399).** `scene/v1` now emits
+  per-plane `wheels[]` (canonical plane-local positions, ADR-0013) and an
+  `on_carts` flag, plus a `gear_anchors` oracle. The viewer draws a wheel and a
+  short leg up to the belly at each wheel — and a pallet deck under each wheel for
+  carted planes — all parented to the existing per-plane affine Group, so the gear
+  inherits the determinant-−1 transform and animates along the tow path for free.
+  The load-time anchor self-check now also oracles gear world positions (the only
+  cross-language backstop, since `viewer.js` is not pytest-covered). Wheels/carts
+  are render-only and never enter the collision model (ADR-0015); `build_scene`
+  stays byte-deterministic and `collisions.py` is untouched.
+
 ### Changed
 
 ### Fixed

--- a/docs/architecture/scene-v1-schema.md
+++ b/docs/architecture/scene-v1-schema.md
@@ -96,10 +96,10 @@ renders `wing` boxes translucent so vertical stacking is visible.
 `wheels` is the aircraft's canonical plane-local wheel positions
 ([ADR-0013](../adr/0013-wheels-canonical-data.md)) — one `(u, v)` per wheel (1 for
 a monowheel, 3 for tricycle/tailwheel). `on_carts` is the per-placement dolly flag.
-The viewer draws a wheel (+ a short leg up to the belly) at each point inside the
-same affine Group as the boxes — so the gear inherits the plane-local→world
-transform and animates along the tow path — plus a pallet deck under each wheel
-when `on_carts`. Render *sizes* (wheel radius, pallet extent) are viewer-layer
+The viewer draws a wheel at each point (+ a short leg up to the belly where the
+belly clears the wheel) inside the same affine Group as the boxes — so the gear
+inherits the plane-local→world transform and animates along the tow path — plus a
+pallet deck under each wheel when `on_carts`. Render *sizes* (wheel radius, pallet extent) are viewer-layer
 constants mirroring `visualize.py`, never data: the schema carries only positions.
 
 ## `timeline`

--- a/docs/architecture/scene-v1-schema.md
+++ b/docs/architecture/scene-v1-schema.md
@@ -32,6 +32,7 @@ metres.
 | `final_poses` | object | `plane_id → affine`: each plane at its parked slot. |
 | `conflicts` | array of string | Plane ids to tint red (flattened from a `CheckResult`); `[]` if none / not checked. |
 | `anchors` | object | `plane_id → [box → [corner → [x, y]]]`: oracle world corners at the final placement, for the viewer's load-time self-check. |
+| `gear_anchors` | object | `plane_id → [wheel → [x, y]]`: oracle world wheel positions at the final placement (same `local_to_world` as `anchors`), so the viewer self-check also covers the gear render. |
 
 ## The affine
 
@@ -82,13 +83,24 @@ draws it as a translucent red box only when `closed`.
       "angle_deg": 0.0                   // CCW rotation within plane-local (oriented_rect)
     }
     // … one box per Part
-  ]
+  ],
+  "wheels": [[0.0, 1.0], [0.0, -1.0], [-3.0, 0.0]],  // plane-local (u, v) per wheel (ADR-0013)
+  "on_carts": false                                  // true ⇒ plane rides a dolly
 }
 ```
 
 Boxes are static plane-local geometry, built once. Each is the 3D box of one
 `Part` (`offset_x/y` → `cx/cy`, `z_bottom/z_top` → `cz`/`height_m`). The viewer
 renders `wing` boxes translucent so vertical stacking is visible.
+
+`wheels` is the aircraft's canonical plane-local wheel positions
+([ADR-0013](../adr/0013-wheels-canonical-data.md)) — one `(u, v)` per wheel (1 for
+a monowheel, 3 for tricycle/tailwheel). `on_carts` is the per-placement dolly flag.
+The viewer draws a wheel (+ a short leg up to the belly) at each point inside the
+same affine Group as the boxes — so the gear inherits the plane-local→world
+transform and animates along the tow path — plus a pallet deck under each wheel
+when `on_carts`. Render *sizes* (wheel radius, pallet extent) are viewer-layer
+constants mirroring `visualize.py`, never data: the schema carries only positions.
 
 ## `timeline`
 

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -119,6 +119,66 @@ document.getElementById('walls').addEventListener('change', (e) => {
   wallMeshes.forEach((m) => { m.visible = e.target.checked; });
 });
 
+// ── gear / cart render constants (#399) ──────────────────────────────────────
+// Render *sizes* live here in the viewer layer, never in fleet.yaml (the canonical
+// data carries only plane-local wheel POSITIONS, ADR-0013). Values mirror the 2D
+// path's constants in visualize.py so 2D and 3D read alike; the two that have no
+// 2D analogue (the top-down PNG has no z) are glyph depths chosen to read at
+// fuselage scale.
+const WHEEL_RADIUS_M = 0.18; // visualize._WHEEL_RADIUS_M
+const WHEEL_WIDTH_M = 0.12; // tyre width — 3D-only glyph depth
+const LEG_WIDTH_M = 0.06; // thin gear-leg strut up to the belly — 3D-only glyph
+const CART_PALLET_HALF_EXTENT_M = 0.4; // visualize._CART_PALLET_HALF_EXTENT_M
+const CART_PALLET_HEIGHT_M = 0.12; // dolly deck thickness — 3D-only glyph depth
+const WHEEL_COLOR = 0x566573; // visualize._WHEEL_COLOR
+const CART_DECK_COLOR = 0xaab7b8; // visualize._CART_DECK_COLOR
+// Shared materials (DoubleSide: the plane Group matrix may be det −1).
+const gearMat = new THREE.MeshStandardMaterial({
+  color: WHEEL_COLOR, side: THREE.DoubleSide, roughness: 0.6, metalness: 0.1,
+});
+const palletMat = new THREE.MeshStandardMaterial({
+  color: CART_DECK_COLOR, side: THREE.DoubleSide, roughness: 0.9, metalness: 0.0,
+});
+
+// Draw gear (wheels + short legs up to the belly) and, when carted, a pallet deck
+// under each wheel, all parented to the plane's affine Group `g` so they inherit
+// the verified plane-local→world transform and animate along the tow path for
+// free. Wheel/leg/pallet world positions are oracle-checked in checkAnchors().
+function addGear(g, p) {
+  // Belly = lowest box bottom; the leg rises from the wheel top to it.
+  let belly = Infinity;
+  for (const b of p.boxes) belly = Math.min(belly, b.cz - b.height_m / 2);
+  if (!isFinite(belly)) belly = 2 * WHEEL_RADIUS_M;
+  const deck = p.on_carts ? CART_PALLET_HEIGHT_M : 0;
+  for (const [u, v] of p.wheels) {
+    // Cylinder's default axis is +Y = local v (lateral), so the disc lies in the
+    // forward/up (u,w) plane — a wheel that rolls forward. No rotation needed.
+    const wheelZ = deck + WHEEL_RADIUS_M;
+    const wheel = new THREE.Mesh(
+      new THREE.CylinderGeometry(WHEEL_RADIUS_M, WHEEL_RADIUS_M, WHEEL_WIDTH_M, 16),
+      gearMat,
+    );
+    wheel.position.set(u, v, wheelZ);
+    g.add(wheel);
+
+    const wheelTop = wheelZ + WHEEL_RADIUS_M;
+    const legH = belly - wheelTop;
+    if (legH > 0.01) {
+      const leg = new THREE.Mesh(new THREE.BoxGeometry(LEG_WIDTH_M, LEG_WIDTH_M, legH), gearMat);
+      leg.position.set(u, v, wheelTop + legH / 2);
+      g.add(leg);
+    }
+    if (p.on_carts) {
+      const pallet = new THREE.Mesh(
+        new THREE.BoxGeometry(2 * CART_PALLET_HALF_EXTENT_M, 2 * CART_PALLET_HALF_EXTENT_M, deck),
+        palletMat,
+      );
+      pallet.position.set(u, v, deck / 2);
+      g.add(pallet);
+    }
+  }
+}
+
 // ── planes: one Group of boxes each, built ONCE in plane-local coords ────────
 const CONFLICT = 0xc8442c;
 const groups = {};
@@ -144,6 +204,7 @@ for (const p of SCENE.planes) {
     mesh.rotation.z = THREE.MathUtils.degToRad(b.angle_deg); // CCW about local up, as oriented_rect
     g.add(mesh);
   }
+  addGear(g, p); // wheels + legs (+ pallets when carted), same affine Group
   groups[p.id] = g;
   scene.add(g);
 
@@ -197,6 +258,22 @@ function applyAffine(aff, u, v) {
           const [wx, wy] = applyAffine(aff, u, v);
           maxErr = Math.max(maxErr, Math.abs(wx - want[bi][ci][0]), Math.abs(wy - want[bi][ci][1]));
         });
+      });
+      // Gear oracle (#399): the wheels[] ride the same affine Group as the boxes,
+      // so a wrong transform corrupts both — but viewer.js is not pytest-covered,
+      // so we cross-check the wheel world positions against the Python oracle too.
+      const gw = SCENE.gear_anchors[p.id];
+      if (!gw || !p.wheels) {
+        structural = 'missing gear anchors/wheels for ' + p.id;
+        break;
+      }
+      if (gw.length !== p.wheels.length) {
+        structural = 'gear anchor/wheel count mismatch for ' + p.id;
+        break;
+      }
+      p.wheels.forEach(([u, v], wi) => {
+        const [wx, wy] = applyAffine(aff, u, v);
+        maxErr = Math.max(maxErr, Math.abs(wx - gw[wi][0]), Math.abs(wy - gw[wi][1]));
       });
     }
     if (structural) {

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -122,9 +122,10 @@ document.getElementById('walls').addEventListener('change', (e) => {
 // ── gear / cart render constants (#399) ──────────────────────────────────────
 // Render *sizes* live here in the viewer layer, never in fleet.yaml (the canonical
 // data carries only plane-local wheel POSITIONS, ADR-0013). Values mirror the 2D
-// path's constants in visualize.py so 2D and 3D read alike; the two that have no
-// 2D analogue (the top-down PNG has no z) are glyph depths chosen to read at
-// fuselage scale.
+// path's constants in visualize.py so 2D and 3D read alike; the remaining three
+// (WHEEL_WIDTH_M, LEG_WIDTH_M, CART_PALLET_HEIGHT_M) have no 2D analogue — the
+// top-down PNG has no z and draws no gear leg — and are glyph extents chosen to
+// read at fuselage scale.
 const WHEEL_RADIUS_M = 0.18; // visualize._WHEEL_RADIUS_M
 const WHEEL_WIDTH_M = 0.12; // tyre width — 3D-only glyph depth
 const LEG_WIDTH_M = 0.06; // thin gear-leg strut up to the belly — 3D-only glyph
@@ -140,12 +141,14 @@ const palletMat = new THREE.MeshStandardMaterial({
   color: CART_DECK_COLOR, side: THREE.DoubleSide, roughness: 0.9, metalness: 0.0,
 });
 
-// Draw gear (wheels + short legs up to the belly) and, when carted, a pallet deck
-// under each wheel, all parented to the plane's affine Group `g` so they inherit
-// the verified plane-local→world transform and animate along the tow path for
-// free. Wheel/leg/pallet world positions are oracle-checked in checkAnchors().
+// Draw gear (a wheel at each point + a short leg up to the belly where there is
+// clearance) and, when carted, a pallet deck under each wheel, all parented to the
+// plane's affine Group `g` so they inherit the verified plane-local→world transform
+// and animate along the tow path for free. Wheel world positions are oracle-checked
+// in checkAnchors().
 function addGear(g, p) {
-  // Belly = lowest box bottom; the leg rises from the wheel top to it.
+  // Belly = lowest box bottom; the leg rises from the wheel top to it. A plane
+  // with no boxes falls back to a wheel-diameter belly so a stub leg still renders.
   let belly = Infinity;
   for (const b of p.boxes) belly = Math.min(belly, b.cz - b.height_m / 2);
   if (!isFinite(belly)) belly = 2 * WHEEL_RADIUS_M;

--- a/src/hangarfit/scene.py
+++ b/src/hangarfit/scene.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
-from hangarfit.geometry import aircraft_parts_world
+from hangarfit.geometry import aircraft_parts_world, local_to_world
 from hangarfit.models import CheckResult, Layout, Placement
 from hangarfit.towplanner import back_first_order
 from hangarfit.visualize import PLANES
@@ -86,7 +86,17 @@ def _plane_blocks(layout: Layout) -> list[dict]:
             for part in ac.parts
         ]
         blocks.append(
-            {"id": placement.plane_id, "color": colour[placement.plane_id], "boxes": boxes}
+            {
+                "id": placement.plane_id,
+                "color": colour[placement.plane_id],
+                "boxes": boxes,
+                # Canonical plane-local wheel points (ADR-0013) + the per-placement
+                # cart flag, so the viewer draws gear (and, when carted, pallets)
+                # parented to the same affine Group as the boxes (#399). Render
+                # sizes (wheel radius, pallet extent) stay viewer-layer constants.
+                "wheels": [[u, v] for u, v in ac.wheels.positions],
+                "on_carts": placement.on_carts,
+            }
         )
     return blocks
 
@@ -117,6 +127,23 @@ def _anchors(layout: Layout) -> dict[str, list[list[list[float]]]]:
         out[placement.plane_id] = [
             [[x, y] for x, y in list(wp.polygon.exterior.coords)[:-1]]
             for wp in aircraft_parts_world(ac, placement)
+        ]
+    return out
+
+
+def _gear_anchors(layout: Layout) -> dict[str, list[list[float]]]:
+    """Per-plane world wheel positions at the FINAL placement, via the production
+    :func:`hangarfit.geometry.local_to_world` transform. Sibling to
+    :func:`_anchors` (which oracles box corners): the viewer recomputes each wheel
+    from the plane-local ``wheels[]`` + the final affine and asserts agreement on
+    load. ``viewer.js`` is not pytest-covered, so this is the only cross-language
+    backstop for the gear render (#399), and it shares the same det-−1 transform
+    as the box anchors — so a sign-flip regression fails both at once."""
+    out: dict[str, list[list[float]]] = {}
+    for placement in sorted(layout.placements, key=lambda p: p.plane_id):
+        ac = layout.fleet[placement.plane_id]
+        out[placement.plane_id] = [
+            list(local_to_world(u, v, placement)) for u, v in ac.wheels.positions
         ]
     return out
 
@@ -229,4 +256,5 @@ def build_scene(
         "final_poses": dict(finals),
         "conflicts": _conflict_ids(check_result),
         "anchors": _anchors(layout),
+        "gear_anchors": _gear_anchors(layout),
     }

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -251,3 +251,47 @@ def test_build_scene_is_byte_deterministic():
     a = json.dumps(scene.build_scene(lay, moves_plan=plan))
     b = json.dumps(scene.build_scene(lay, moves_plan=plan))
     assert a == b
+
+
+# ── Task 6 (#399): gear + carts — plane-local wheels + world gear anchors ─────
+
+
+def test_plane_blocks_carry_wheels_and_on_carts():
+    # #399: each plane block emits its canonical plane-local wheel positions
+    # (ADR-0013) and the per-placement on_carts flag, so the viewer can draw gear
+    # and (when carted) pallets parented to the same affine Group.
+    lay = load_layout(LAYOUT)
+    planes = scene._plane_blocks(lay)
+    for placement in lay.placements:
+        ac = lay.fleet[placement.plane_id]
+        p = next(b for b in planes if b["id"] == placement.plane_id)
+        assert p["wheels"] == [[u, v] for u, v in ac.wheels.positions]
+        assert p["on_carts"] == placement.on_carts
+
+
+def test_gear_anchors_are_world_wheel_positions():
+    # The cross-language gear oracle: world wheel positions at the FINAL pose,
+    # via the production local_to_world transform (the viewer recomputes them from
+    # the plane-local wheels[] + the final affine and asserts agreement on load).
+    from hangarfit.geometry import local_to_world
+
+    lay = load_layout(LAYOUT)
+    ga = scene._gear_anchors(lay)
+    for placement in lay.placements:
+        ac = lay.fleet[placement.plane_id]
+        got = ga[placement.plane_id]
+        want = [local_to_world(u, v, placement) for u, v in ac.wheels.positions]
+        assert len(got) == len(want)
+        for (gx, gy), (wx, wy) in zip(got, want, strict=True):
+            assert math.isclose(gx, wx, abs_tol=1e-9) and math.isclose(gy, wy, abs_tol=1e-9)
+
+
+def test_build_scene_includes_gear_anchors_and_wheels():
+    lay = load_layout(LAYOUT)
+    plan = plan_fill(lay)
+    sc = scene.build_scene(lay, moves_plan=plan)
+    assert "gear_anchors" in sc
+    assert set(sc["gear_anchors"]) == {pl.plane_id for pl in lay.placements}
+    for p in sc["planes"]:
+        assert "wheels" in p and "on_carts" in p
+    json.dumps(sc)  # the new fields stay JSON-serializable


### PR DESCRIPTION
## F2 — 3D landing gear + tow carts (#399)

Closes #399.

⚠️ **Stacked PR** — based on `feature/398-view-tow-cap` (#405), not `develop` directly, so this diff shows only F2's changes. GitHub will auto-retarget this PR to `develop` once #405 merges and its branch is deleted. **Merge order: #405 → this (#399) → #400 → #401.**

### What
3D planes were plain floating boxes — no gear, no dolly, while the 2D PNG already draws both. This brings 3D to parity.

- **`scene.py`** emits, per plane, additive `wheels[]` (canonical plane-local positions, ADR-0013) + an `on_carts` flag, and a top-level `gear_anchors` oracle (world wheel positions via the *same* `local_to_world` as the box anchors).
- **`viewer.js`** draws a wheel (`CylinderGeometry`, default +Y axis = local lateral, so it rolls forward) + a short leg up to the belly at each wheel, and a pallet deck under each wheel when `on_carts` — all parented to the existing per-plane affine Group, so the gear inherits the det-−1 transform and **animates along the tow path for free**.
- **Load-time self-check extended** to oracle gear world positions. `viewer.js` is not pytest-covered, so this is the only cross-language backstop — and because wheels share the box Group, a sign-flip corrupts both.

### Guardrails held
- Render *sizes* (wheel radius 0.18 m, pallet half-extent 0.4 m) stay viewer-layer constants mirroring `visualize.py`; the schema carries only positions (per the issue decision — never in `fleet.yaml`).
- Wheels/carts are **not** Parts (ADR-0015) → `collisions.py` untouched, `build_scene` byte-deterministic (pinned by `test_build_scene_is_byte_deterministic`).
- Viewer does **zero** transform math (ADR-0017 intact).

### Verification
- New scene tests: `wheels[]`/`on_carts` per plane, `gear_anchors` match the `local_to_world` oracle, `gear_anchors` present in `build_scene`.
- Headless swiftshader screenshots (own-gear `valid_left_side_nesting`; carted `valid_gear_glyph_smoke`) render with **no transform-mismatch banner** — the gear oracle passes. (Screenshots captured locally; can attach on request.)
- Full non-slow suite: **1179 passed**; ruff / ruff format / mypy clean.

### Acceptance criteria
- [x] `scene/v1` gains additive `wheels[]` + `on_carts` per plane; schema doc updated.
- [x] Viewer draws wheels (+ legs) and, when `on_carts`, a pallet under each wheel; both ride the affine Group and animate along the tow path.
- [x] Load-time anchor self-check extended to oracle gear world positions; on-page banner on mismatch.
- [x] `build_scene` output byte-deterministic; `collisions.py` untouched.
- [x] Headless swiftshader verification done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)