### PR TITLE
feat: PLACEHOLDER-DATA banner + actionable readouts + plain-language failures (#401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,23 @@ All notable changes to this project are documented here. Format follows [Keep a 
   `labels` HUD toggle. All client-side with the already-vendored Three.js r160 —
   still a single self-contained offline HTML, no new assets, no determinism or
   collision risk.
+- **Honesty banner + actionable readouts (#401).** A persistent "PLACEHOLDER
+  DATA — illustrative only, not for real parking" banner now appears on both the
+  2D PNG and the 3D viewer whenever any placed aircraft is on unmeasured
+  (`measured: false`) data — so a club member never mistakes an illustrative
+  render for a real parking plan (#79). It disappears once the data is measured.
+  Valid layouts also surface two actionable numbers — the tightest plan-view
+  inter-plane gap and the smallest wing-over-tail vertical clearance — computed by
+  a new read-only `hangarfit.metrics` module (never entering the collision model).
 
 ### Changed
+
+- **Plain-language conflict messages (#401).** `check` (exit 1) and the solver's
+  trivially-infeasible / exhausted-budget summaries now lead each conflict with a
+  readable sentence ("`fuji` overlaps `scheibe_falke`", "`x` intrudes into the
+  maintenance bay", "`x` extends outside the hangar") instead of the raw `kind`
+  enum, while keeping the precise `detail` (parts + z-gaps) verbatim. The exit-3
+  "no feasible tow path (plane …)" message already named the blocking plane.
 
 ### Fixed
 

--- a/docs/architecture/scene-v1-schema.md
+++ b/docs/architecture/scene-v1-schema.md
@@ -34,7 +34,7 @@ metres.
 | `anchors` | object | `plane_id → [box → [corner → [x, y]]]`: oracle world corners at the final placement, for the viewer's load-time self-check. |
 | `gear_anchors` | object | `plane_id → [wheel → [x, y]]`: oracle world wheel positions at the final placement (same `local_to_world` as `anchors`), so the viewer self-check also covers the gear render. |
 | `placeholder` | bool | `true` iff any placed aircraft is on unmeasured (`measured: false`) data — drives the "PLACEHOLDER DATA" honesty banner on the 2D PNG and the 3D viewer (#401, #79). |
-| `readouts` | object \| null | Actionable quality numbers for a **valid** layout: `{ "min_gap_m", "min_wing_over_tail_clearance_m" }` (either may be `null` — single plane / no overhang). `null` when the layout has conflicts. |
+| `readouts` | object \| null | Actionable quality numbers for a **valid** layout: `{ "min_gap_m", "min_wing_over_tail_clearance_m" }` (either may be `null` — single plane / no overhang). `null` when the layout is invalid — validity is taken from the supplied `CheckResult`, or collision-checked by `build_scene` itself when none was supplied, so readouts never imply an unverified validity. |
 
 ## The affine
 

--- a/docs/architecture/scene-v1-schema.md
+++ b/docs/architecture/scene-v1-schema.md
@@ -33,6 +33,8 @@ metres.
 | `conflicts` | array of string | Plane ids to tint red (flattened from a `CheckResult`); `[]` if none / not checked. |
 | `anchors` | object | `plane_id → [box → [corner → [x, y]]]`: oracle world corners at the final placement, for the viewer's load-time self-check. |
 | `gear_anchors` | object | `plane_id → [wheel → [x, y]]`: oracle world wheel positions at the final placement (same `local_to_world` as `anchors`), so the viewer self-check also covers the gear render. |
+| `placeholder` | bool | `true` iff any placed aircraft is on unmeasured (`measured: false`) data — drives the "PLACEHOLDER DATA" honesty banner on the 2D PNG and the 3D viewer (#401, #79). |
+| `readouts` | object \| null | Actionable quality numbers for a **valid** layout: `{ "min_gap_m", "min_wing_over_tail_clearance_m" }` (either may be `null` — single plane / no overhang). `null` when the layout has conflicts. |
 
 ## The affine
 

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -15,6 +15,17 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 const SCENE = JSON.parse(document.getElementById('scene').textContent);
 const H = SCENE.hangar;
 
+// #401 honesty banner + actionable readouts. The banner text is static (set in
+// the HTML); we only unhide it. Readouts are numbers from the scene — no user
+// HTML, set via textContent.
+if (SCENE.placeholder) document.getElementById('placeholder').hidden = false;
+if (SCENE.readouts) {
+  const fmtM = (v) => (v == null ? 'n/a' : v.toFixed(2) + ' m');
+  document.getElementById('readouts').textContent =
+    'gap ' + fmtM(SCENE.readouts.min_gap_m) +
+    ' · wing-over-tail ' + fmtM(SCENE.readouts.min_wing_over_tail_clearance_m);
+}
+
 function banner(msg) {
   const b = document.getElementById('banner');
   b.hidden = false;

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -356,9 +356,29 @@ def _emit_human(result: CheckResult) -> None:
         print(_format_conflict(c))
 
 
+# Plain-language lead-in per single-plane conflict kind (#401). Pairwise overlaps
+# are phrased "A overlaps B" generically — the authoritative ``detail`` already
+# names the exact parts and z-gaps, so we never re-parse it (which would be fragile).
+_SINGLE_CONFLICT_PHRASES = {
+    "bay_intrusion": "intrudes into the maintenance bay",
+    "hangar_bounds": "extends outside the hangar",
+}
+
+
 def _format_conflict(c: Conflict) -> str:
-    """One-line human render of a Conflict. No re-parsing of ``detail``."""
-    return f"  - {c.kind} [{', '.join(c.planes)}]: {c.detail}"
+    """One-line *plain-language* render of a Conflict, keeping the authoritative
+    ``detail`` verbatim (#401). No re-parsing of ``detail`` — the lead-in is built
+    from ``kind`` + ``planes`` only."""
+    planes = list(c.planes)
+    if c.kind.endswith("_overlap") and len(planes) == 2:
+        lead = f"{planes[0]} overlaps {planes[1]}"
+    elif c.kind in _SINGLE_CONFLICT_PHRASES and planes:
+        lead = f"{planes[0]} {_SINGLE_CONFLICT_PHRASES[c.kind]}"
+    else:
+        # Unknown / future kind: fall back to the raw kind + ids (still names the
+        # planes), never crash.
+        lead = f"{c.kind} [{', '.join(planes)}]"
+    return f"  - {lead}: {c.detail}"
 
 
 def _conflict_to_dict(c: Conflict) -> dict:
@@ -418,7 +438,7 @@ def _emit_solve_human(result: SolveResult, *, alternatives: int) -> None:
         print("Trivially infeasible:")
         if d.best_partial is not None:
             for c in d.best_partial.conflicts:
-                print(f"  - {c.kind} [{', '.join(c.planes)}]: {c.detail}")
+                print(_format_conflict(c))
         return
 
     if result.status == "exhausted_budget":
@@ -430,7 +450,7 @@ def _emit_solve_human(result: SolveResult, *, alternatives: int) -> None:
             n = len(d.best_partial.conflicts)
             print(f"Best partial had {n} conflict{'s' if n != 1 else ''}:")
             for c in d.best_partial.conflicts:
-                print(f"  - {c.kind} [{', '.join(c.planes)}]: {c.detail}")
+                print(_format_conflict(c))
         print("Hint: increase --budget, or relax pins.")
         return
 

--- a/src/hangarfit/metrics.py
+++ b/src/hangarfit/metrics.py
@@ -1,0 +1,93 @@
+"""Read-only layout metrics for honest, actionable render annotations (#401).
+
+Pure functions over a :class:`~hangarfit.models.Layout`: whether any *placed*
+aircraft is on placeholder (unmeasured) data, the tightest plan-view inter-plane
+gap, and the smallest vertical clearance where one plane's wing passes over
+another plane's tail / aft fuselage. None of this enters the collision model — it
+only annotates the 2D PNG and the 3D viewer so an operator can judge a tight
+arrangement and know when the data is illustrative. Leaf consumer of the core
+types, like :mod:`hangarfit.visualize` and :mod:`hangarfit.scene`.
+"""
+
+from __future__ import annotations
+
+import math
+
+from hangarfit.geometry import WorldPart, aircraft_parts_world
+from hangarfit.models import Layout
+
+# Parts a wing may legally overhang: a wingtip may overhang a low-winger's tail or
+# aft fuselage, never its cockpit (ADR-0012). The vertical clearance there is the
+# actionable "how close did that overhang come" number an operator should eyeball.
+_OVERHANGABLE = frozenset({"tail", "fuselage_aft"})
+
+# The single source of the honesty-banner wording, shared by the 2D PNG
+# (visualize) and the 3D viewer so they never drift (#401).
+PLACEHOLDER_BANNER = "PLACEHOLDER DATA — illustrative only, not for real parking"
+
+
+def has_placeholder_data(layout: Layout) -> bool:
+    """True iff any *placed* aircraft is unmeasured (``measured is False``).
+
+    Drives the "PLACEHOLDER DATA" honesty banner (#401, #79). There is no hangar
+    ``measured`` flag today, so the signal is fleet-driven; once every placed
+    aircraft is ``measured: true`` the banner disappears.
+    """
+    return any(not layout.fleet[p.plane_id].measured for p in layout.placements)
+
+
+def _world_by_plane(layout: Layout) -> tuple[list[str], dict[str, list[WorldPart]]]:
+    """Per-plane world parts, keyed by id (sorted) — the shared geometry both
+    metrics walk. Routed through the production ``aircraft_parts_world`` oracle."""
+    by_id = {p.plane_id: p for p in layout.placements}
+    ids = sorted(by_id)
+    world = {pid: aircraft_parts_world(layout.fleet[pid], by_id[pid]) for pid in ids}
+    return ids, world
+
+
+def min_pairwise_gap_m(layout: Layout) -> float | None:
+    """Tightest plan-view gap (m) between any two planes' parts; ``None`` for a
+    layout with fewer than two planes.
+
+    Mirrors the solver's ``_spread_quality`` min-gap (ADR-0008) but works on *any*
+    layout — the solver only records ``min_pairwise_gap_m`` for results it
+    produced, whereas ``check`` / ``view`` operate on hand-authored layouts.
+    """
+    ids, world = _world_by_plane(layout)
+    if len(ids) < 2:
+        return None
+    best = math.inf
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            for pa in world[ids[i]]:
+                for pb in world[ids[j]]:
+                    best = min(best, pa.polygon.distance(pb.polygon))
+    return best
+
+
+def min_wing_over_tail_clearance_m(layout: Layout) -> float | None:
+    """Smallest vertical clearance (m) where one plane's wing passes over another
+    plane's tail / aft fuselage, measured only where their plan-view footprints
+    overlap and the wing is above. ``None`` when no such overhang exists.
+
+    This is the tightest "is a wing about to clip a tail" margin — exactly the
+    vertical near-miss an operator cannot see in a top-down PNG and should eyeball
+    before parking. It is a clearance on a *valid* layout (an actual overlap with
+    insufficient z is a collision the checker already rejects).
+    """
+    ids, world = _world_by_plane(layout)
+    best = math.inf
+    for a in ids:
+        wings = [wp for wp in world[a] if wp.kind == "wing"]
+        if not wings:
+            continue
+        for b in ids:
+            if b == a:
+                continue
+            lowers = [wp for wp in world[b] if wp.kind in _OVERHANGABLE]
+            for wing in wings:
+                for low in lowers:
+                    gap = wing.z_bottom_m - low.z_top_m
+                    if gap >= 0.0 and wing.polygon.intersects(low.polygon):
+                        best = min(best, gap)
+    return best if math.isfinite(best) else None

--- a/src/hangarfit/metrics.py
+++ b/src/hangarfit/metrics.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 
 import math
 
+from hangarfit import collisions
 from hangarfit.geometry import WorldPart, aircraft_parts_world
-from hangarfit.models import Layout
+from hangarfit.models import CheckResult, Layout
 
 # Parts a wing may legally overhang: a wingtip may overhang a low-winger's tail or
 # aft fuselage, never its cockpit (ADR-0012). The vertical clearance there is the
@@ -31,9 +32,24 @@ def has_placeholder_data(layout: Layout) -> bool:
 
     Drives the "PLACEHOLDER DATA" honesty banner (#401, #79). There is no hangar
     ``measured`` flag today, so the signal is fleet-driven; once every placed
-    aircraft is ``measured: true`` the banner disappears.
+    aircraft is ``measured: true`` the banner disappears. A layout with no
+    placements is vacuously not-placeholder — nothing is drawn, so there is no
+    illustrative arrangement to caveat.
     """
     return any(not layout.fleet[p.plane_id].measured for p in layout.placements)
+
+
+def layout_is_valid(layout: Layout, check_result: CheckResult | None = None) -> bool:
+    """Whether the layout is collision-free, for gating render annotations (#401).
+
+    Trusts a supplied :class:`CheckResult`; otherwise runs :func:`collisions.check`
+    itself. Annotations (the quality readouts) must never imply a validity that was
+    never verified — ``check_result is None`` means "caller did not check", **not**
+    "valid", so we determine it here rather than assuming the layout is fine.
+    """
+    if check_result is not None:
+        return check_result.valid
+    return collisions.check(layout).valid
 
 
 def _world_by_plane(layout: Layout) -> tuple[list[str], dict[str, list[WorldPart]]]:
@@ -62,7 +78,11 @@ def min_pairwise_gap_m(layout: Layout) -> float | None:
             for pa in world[ids[i]]:
                 for pb in world[ids[j]]:
                     best = min(best, pa.polygon.distance(pb.polygon))
-    return best
+    # isfinite guard (symmetry with min_wing_over_tail_clearance_m): with ≥2
+    # planes and the non-empty-parts invariant best is always finite, but never
+    # let an inf leak into the scene JSON — json would emit a bare `Infinity` that
+    # breaks the viewer's JSON.parse.
+    return best if math.isfinite(best) else None
 
 
 def min_wing_over_tail_clearance_m(layout: Layout) -> float | None:

--- a/src/hangarfit/scene.py
+++ b/src/hangarfit/scene.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
+from hangarfit import metrics
 from hangarfit.geometry import aircraft_parts_world, local_to_world
 from hangarfit.models import CheckResult, Layout, Placement
 from hangarfit.towplanner import back_first_order
@@ -222,6 +223,19 @@ def _conflict_ids(check_result: CheckResult | None) -> list[str]:
     return sorted({pid for c in check_result.conflicts for pid in c.planes})
 
 
+def _readouts(layout: Layout, conflict_ids: list[str]) -> dict | None:
+    """Actionable quality numbers for a *valid* layout (#401): the tightest
+    plan-view inter-plane gap and the smallest wing-over-tail vertical clearance
+    (either may be ``null`` — single plane / no overhang). ``None`` when the
+    layout has conflicts: an invalid arrangement has no quality to report."""
+    if conflict_ids:
+        return None
+    return {
+        "min_gap_m": metrics.min_pairwise_gap_m(layout),
+        "min_wing_over_tail_clearance_m": metrics.min_wing_over_tail_clearance_m(layout),
+    }
+
+
 def build_scene(
     layout: Layout,
     *,
@@ -246,6 +260,7 @@ def build_scene(
         max_seg_s=max_seg_s,
         max_samples_per_path=max_samples_per_path,
     )
+    conflicts = _conflict_ids(check_result)
     return {
         "schema": SCHEMA,
         "units": "m",
@@ -254,7 +269,9 @@ def build_scene(
         "planes": _plane_blocks(layout),
         "timeline": timeline,
         "final_poses": dict(finals),
-        "conflicts": _conflict_ids(check_result),
+        "conflicts": conflicts,
         "anchors": _anchors(layout),
         "gear_anchors": _gear_anchors(layout),
+        "placeholder": metrics.has_placeholder_data(layout),
+        "readouts": _readouts(layout, conflicts),
     }

--- a/src/hangarfit/scene.py
+++ b/src/hangarfit/scene.py
@@ -223,13 +223,12 @@ def _conflict_ids(check_result: CheckResult | None) -> list[str]:
     return sorted({pid for c in check_result.conflicts for pid in c.planes})
 
 
-def _readouts(layout: Layout, conflict_ids: list[str]) -> dict | None:
-    """Actionable quality numbers for a *valid* layout (#401): the tightest
-    plan-view inter-plane gap and the smallest wing-over-tail vertical clearance
-    (either may be ``null`` — single plane / no overhang). ``None`` when the
-    layout has conflicts: an invalid arrangement has no quality to report."""
-    if conflict_ids:
-        return None
+def _readouts(layout: Layout) -> dict:
+    """Actionable quality numbers (#401): the tightest plan-view inter-plane gap
+    and the smallest wing-over-tail vertical clearance (either may be ``null`` —
+    single plane / no overhang). Only meaningful for a *valid* layout; the caller
+    (:func:`build_scene`) decides validity via :func:`metrics.layout_is_valid` and
+    emits ``null`` instead for an invalid one."""
     return {
         "min_gap_m": metrics.min_pairwise_gap_m(layout),
         "min_wing_over_tail_clearance_m": metrics.min_wing_over_tail_clearance_m(layout),
@@ -261,6 +260,11 @@ def build_scene(
         max_samples_per_path=max_samples_per_path,
     )
     conflicts = _conflict_ids(check_result)
+    # Readouts imply a *verified-valid* layout. Determine validity ourselves when
+    # the caller passed no CheckResult (e.g. `view` without --check) so we never
+    # present a misleading "gap 0.00 m" on an unchecked, actually-invalid layout
+    # (#401 review). collisions.check is pure/deterministic — determinism intact.
+    valid = metrics.layout_is_valid(layout, check_result)
     return {
         "schema": SCHEMA,
         "units": "m",
@@ -273,5 +277,5 @@ def build_scene(
         "anchors": _anchors(layout),
         "gear_anchors": _gear_anchors(layout),
         "placeholder": metrics.has_placeholder_data(layout),
-        "readouts": _readouts(layout, conflicts),
+        "readouts": _readouts(layout) if valid else None,
     }

--- a/src/hangarfit/viewer.py
+++ b/src/hangarfit/viewer.py
@@ -15,6 +15,8 @@ import json
 from importlib import resources
 from pathlib import Path
 
+from hangarfit import metrics
+
 _ASSETS = "hangarfit._viewer_assets"
 _THREE = "hangarfit._viewer_assets.three"
 
@@ -61,6 +63,9 @@ def render_viewer(scene: dict, output_path: Path | str) -> None:
         "</head><body>\n"
         '<div id="app"><canvas id="c"></canvas></div>\n'
         '<div id="banner" hidden></div>\n'
+        # #401 honesty banner: static text (not user data), shown by viewer.js
+        # when scene.placeholder is true. Same wording as the 2D PNG.
+        f'<div id="placeholder" hidden>{metrics.PLACEHOLDER_BANNER}</div>\n'
         f'<div id="hud">{_HUD}</div>\n'
         f'<script type="application/json" id="scene">{_embed_json(scene)}</script>\n'
         f'<script type="module">{viewer_js}</script>\n'
@@ -80,6 +85,9 @@ _CSS = (
     "#scrub{flex:1;min-width:160px}"
     "#banner{position:fixed;top:0;left:0;right:0;padding:10px;background:#7a1f1f;color:#fff;"
     "text-align:center;z-index:9;font-weight:600}"
+    "#placeholder{position:fixed;top:0;left:0;right:0;padding:7px;background:#b00020;"
+    "color:#fff;text-align:center;z-index:8;font-weight:700;letter-spacing:.02em}"
+    "#readouts{color:#aeb6c2;font-variant-numeric:tabular-nums}"
     "#legend{display:flex;gap:8px;flex-wrap:wrap}"
     ".sw{display:inline-flex;align-items:center;gap:4px}"
     ".sw i{width:11px;height:11px;border-radius:2px;display:inline-block}"
@@ -97,5 +105,6 @@ _HUD = (
     '<button id="reset">reset view</button>'
     '<label><input id="walls" type="checkbox" checked> walls</label>'
     '<label><input id="labels" type="checkbox" checked> labels</label>'
+    '<span id="readouts"></span>'
     '<span id="legend"></span>'
 )

--- a/src/hangarfit/viewer.py
+++ b/src/hangarfit/viewer.py
@@ -35,8 +35,12 @@ def _data_url(js_source: str) -> str:
 def _embed_json(obj: dict) -> str:
     """Compact JSON safe to inline inside a ``<script>`` element: ``<`` is
     escaped to ``\\u003c`` so a value can never produce a ``</script>``
-    breakout (the canonical safe-embedding technique)."""
-    return json.dumps(obj, separators=(",", ":")).replace("<", "\\u003c")
+    breakout (the canonical safe-embedding technique).
+
+    ``allow_nan=False`` makes a non-finite value (``inf``/``nan``) raise here at
+    the producer rather than serialize to a bare ``Infinity``/``NaN`` token that
+    the viewer's ``JSON.parse`` would choke on — fail loud, not a blank page."""
+    return json.dumps(obj, separators=(",", ":"), allow_nan=False).replace("<", "\\u003c")
 
 
 def render_viewer(scene: dict, output_path: Path | str) -> None:

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -40,8 +40,14 @@ import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.patches import Circle as MplCircle  # noqa: E402
 from matplotlib.patches import Polygon as MplPolygon  # noqa: E402
 
+from . import metrics  # noqa: E402
 from .geometry import WorldPart, aircraft_parts_world, local_to_world  # noqa: E402
 from .models import Aircraft, CheckResult, Layout, Placement  # noqa: E402
+
+# #401 honesty banner: shown whenever any placed aircraft is on placeholder
+# (unmeasured) data, so a club member never mistakes an illustrative render for a
+# real parking plan. Wording is shared 2D/3D via metrics.PLACEHOLDER_BANNER.
+_PLACEHOLDER_BANNER = metrics.PLACEHOLDER_BANNER
 
 if TYPE_CHECKING:
     # Annotation-only import: the runtime code in _draw_tow_paths is duck-typed
@@ -262,6 +268,13 @@ def render_layout(
         if moves_plan is not None:
             _draw_tow_paths(ax, moves_plan)
         _finalize_axes(ax, layout, title)
+        if metrics.has_placeholder_data(layout):
+            _draw_placeholder_banner(fig)
+        # Readouts only make sense for a valid arrangement (#401): an invalid one
+        # has overlaps, so a "tightest gap" of 0 would mislead. `check` passes a
+        # CheckResult; solve/None layouts are valid by construction.
+        if check_result is None or check_result.valid:
+            _draw_readouts(fig, layout)
         fig.savefig(str(output_path), dpi=dpi, bbox_inches="tight")
     finally:
         # Always close the figure, even if savefig raises (bad path,
@@ -681,6 +694,47 @@ def _draw_tow_paths(ax: Any, moves_plan: MovesPlan) -> None:
             zorder=5,
             label=move.plane_id,
         )
+
+
+def _draw_placeholder_banner(fig: Any) -> None:
+    """Draw the persistent "PLACEHOLDER DATA" honesty banner across the top of the
+    figure (#401). Caller decides whether to show it (unmeasured data loaded)."""
+    fig.text(
+        0.5,
+        0.995,
+        _PLACEHOLDER_BANNER,
+        ha="center",
+        va="top",
+        fontsize=12,
+        fontweight="bold",
+        color="white",
+        bbox={"facecolor": "#b00020", "edgecolor": "none", "boxstyle": "round,pad=0.45"},
+    )
+
+
+def _readout_text(layout: Layout) -> str:
+    """Human one-liner of the actionable readouts (#401): the tightest plan-view
+    inter-plane gap and the smallest wing-over-tail vertical clearance. Each reads
+    ``n/a`` when undefined (single plane / no overhang)."""
+    gap = metrics.min_pairwise_gap_m(layout)
+    clr = metrics.min_wing_over_tail_clearance_m(layout)
+    gap_s = f"{gap:.2f} m" if gap is not None else "n/a (single plane)"
+    clr_s = f"{clr:.2f} m" if clr is not None else "n/a"
+    return f"tightest inter-plane gap: {gap_s}    ·    smallest wing-over-tail clearance: {clr_s}"
+
+
+def _draw_readouts(fig: Any, layout: Layout) -> None:
+    """Draw the actionable quality readouts along the bottom of the figure (#401)."""
+    fig.text(
+        0.5,
+        0.005,
+        _readout_text(layout),
+        ha="center",
+        va="bottom",
+        fontsize=9,
+        color="#2c3e50",
+        bbox={"facecolor": "#ecf0f1", "edgecolor": "#bdc3c7", "boxstyle": "round,pad=0.4"},
+    )
 
 
 def _finalize_axes(ax: Any, layout: Layout, title: str | None) -> None:

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -270,10 +270,11 @@ def render_layout(
         _finalize_axes(ax, layout, title)
         if metrics.has_placeholder_data(layout):
             _draw_placeholder_banner(fig)
-        # Readouts only make sense for a valid arrangement (#401): an invalid one
-        # has overlaps, so a "tightest gap" of 0 would mislead. `check` passes a
-        # CheckResult; solve/None layouts are valid by construction.
-        if check_result is None or check_result.valid:
+        # Readouts only make sense for a *verified-valid* arrangement (#401): an
+        # invalid one has overlaps, so a "tightest gap" of 0 would mislead. Trust a
+        # supplied CheckResult, else verify (so a caller that renders an unchecked
+        # layout never gets misleading numbers).
+        if metrics.layout_is_valid(layout, check_result):
             _draw_readouts(fig, layout)
         fig.savefig(str(output_path), dpi=dpi, bbox_inches="tight")
     finally:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,10 +8,43 @@ from pathlib import Path
 import pytest
 
 from hangarfit import __version__
-from hangarfit.cli import main
+from hangarfit.cli import _format_conflict, main
+from hangarfit.models import Conflict
 
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestPlainLanguageConflicts:
+    """#401: conflict output reads as plain language, not just a kind enum,
+    while still keeping the authoritative detail string."""
+
+    def test_pairwise_overlap_says_overlaps_and_names_planes(self):
+        c = Conflict.pair(
+            kind="tail_wing_overlap",
+            plane_a="aviat_husky",
+            plane_b="falke",
+            detail="part 'tail' (z=0..1) and part 'wing' (z=0.5..0.7) ...",
+        )
+        s = _format_conflict(c)
+        assert "aviat_husky" in s and "falke" in s
+        assert "overlaps" in s
+        assert c.detail in s  # the precise detail is preserved
+
+    def test_bay_intrusion_is_plain(self):
+        c = Conflict.single(kind="bay_intrusion", plane="cessna_150", detail="...")
+        s = _format_conflict(c)
+        assert "cessna_150" in s and "maintenance bay" in s
+
+    def test_hangar_bounds_is_plain(self):
+        c = Conflict.single(kind="hangar_bounds", plane="fuji", detail="...")
+        s = _format_conflict(c)
+        assert "fuji" in s and "outside the hangar" in s
+
+    def test_unknown_kind_falls_back_without_crashing(self):
+        c = Conflict.single(kind="some_future_kind", plane="x", detail="d")
+        s = _format_conflict(c)
+        assert "x" in s and "d" in s
 
 
 class TestArgparseUsageErrors:
@@ -83,11 +116,12 @@ class TestCheckHappyPath:
         assert exit_code == 1
         captured = capsys.readouterr()
         assert captured.out.startswith("invalid:")
-        # Conflict line uses the spec's format: "  - <kind> [<plane>[, <plane>]]: <detail>"
-        # The fuselage front/aft split (#50/ADR-0012) replaced the single
-        # fuselage_wing_overlap kind with the segment-specific kinds; this
-        # fixture's wing crosses both of scheibe's fuselage segments.
-        assert "fuselage_front_wing_overlap" in captured.out
+        # Plain-language conflict lines (#401): "  - <A> overlaps <B>: <detail>".
+        # The lead-in says "overlaps" (not the raw kind), while the authoritative
+        # detail still names the parts — the fuselage front/aft split (#50/ADR-0012)
+        # means this fixture's wing crosses scheibe's fuselage_front segment.
+        assert "overlaps" in captured.out
+        assert "fuselage_front" in captured.out  # part named in the kept detail
         # Every conflict line starts with the two-space-dash prefix
         for line in captured.out.strip().split("\n")[1:]:
             assert line.startswith("  - ")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -52,3 +52,15 @@ def test_min_wing_over_tail_clearance_positive_when_overhang():
 def test_min_wing_over_tail_clearance_none_when_no_overhang():
     # Two well-separated planes: no wing footprint overlaps another's tail/aft.
     assert metrics.min_wing_over_tail_clearance_m(load_layout(SEPARATED)) is None
+
+
+def test_layout_is_valid_self_checks_when_no_check_result():
+    from hangarfit.collisions import check
+
+    valid_lay = load_layout(NESTING)
+    assert metrics.layout_is_valid(valid_lay) is True
+
+    invalid_lay = load_layout("tests/fixtures/invalid_fuselage_wing_overlap.yaml")
+    assert metrics.layout_is_valid(invalid_lay) is False  # determined by self-check
+    # And it trusts a supplied CheckResult rather than re-running.
+    assert metrics.layout_is_valid(invalid_lay, check(invalid_lay)) is False

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,54 @@
+"""Tests for the read-only render-annotation metrics (hangarfit.metrics, #401)."""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+
+from hangarfit import metrics
+from hangarfit.geometry import aircraft_parts_world
+from hangarfit.loader import load_layout
+
+NESTING = "tests/fixtures/valid_left_side_nesting.yaml"
+SEPARATED = "tests/fixtures/valid_two_separated.yaml"
+WING_OVER_AFT = "tests/fixtures/valid_high_over_low_aft_z_disjoint.yaml"
+
+
+def test_has_placeholder_data_true_for_unmeasured_fleet():
+    # The shipped fleet is all measured: false, so any loaded layout is placeholder.
+    assert metrics.has_placeholder_data(load_layout(NESTING)) is True
+
+
+def test_has_placeholder_data_false_when_all_measured():
+    lay = load_layout(NESTING)
+    measured_fleet = {pid: dataclasses.replace(ac, measured=True) for pid, ac in lay.fleet.items()}
+    lay2 = dataclasses.replace(lay, fleet=measured_fleet)
+    assert metrics.has_placeholder_data(lay2) is False
+
+
+def test_min_pairwise_gap_matches_direct_computation():
+    lay = load_layout(NESTING)
+    got = metrics.min_pairwise_gap_m(lay)
+    by_id = {p.plane_id: p for p in lay.placements}
+    ids = sorted(by_id)
+    world = {pid: aircraft_parts_world(lay.fleet[pid], by_id[pid]) for pid in ids}
+    want = min(pa.polygon.distance(pb.polygon) for pa in world[ids[0]] for pb in world[ids[1]])
+    assert got is not None and math.isclose(got, want, abs_tol=1e-12)
+
+
+def test_min_pairwise_gap_none_for_single_plane():
+    lay = load_layout(NESTING)
+    single = dataclasses.replace(lay, placements=(lay.placements[0],))
+    assert metrics.min_pairwise_gap_m(single) is None
+
+
+def test_min_wing_over_tail_clearance_positive_when_overhang():
+    # A high wing sitting (z-disjoint) over a low aft fuselage: there IS a positive
+    # vertical clearance where the wing footprint overlaps the aft footprint.
+    c = metrics.min_wing_over_tail_clearance_m(load_layout(WING_OVER_AFT))
+    assert c is not None and c >= 0.0
+
+
+def test_min_wing_over_tail_clearance_none_when_no_overhang():
+    # Two well-separated planes: no wing footprint overlaps another's tail/aft.
+    assert metrics.min_wing_over_tail_clearance_m(load_layout(SEPARATED)) is None

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -295,3 +295,25 @@ def test_build_scene_includes_gear_anchors_and_wheels():
     for p in sc["planes"]:
         assert "wheels" in p and "on_carts" in p
     json.dumps(sc)  # the new fields stay JSON-serializable
+
+
+# ── Task 7 (#401): honesty banner flag + actionable readouts ─────────────────
+
+
+def test_build_scene_emits_placeholder_and_readouts_when_valid():
+    lay = load_layout(LAYOUT)  # unmeasured fleet, valid (no conflicts)
+    sc = scene.build_scene(lay, moves_plan=plan_fill(lay))
+    assert sc["placeholder"] is True  # shipped fleet is measured: false
+    assert sc["readouts"] is not None
+    assert {"min_gap_m", "min_wing_over_tail_clearance_m"} <= set(sc["readouts"])
+    json.dumps(sc)
+
+
+def test_build_scene_readouts_none_when_conflicts():
+    from hangarfit import collisions
+    from hangarfit.loader import load_layout as _ll
+
+    lay = _ll("tests/fixtures/invalid_fuselage_wing_overlap.yaml")
+    sc = scene.build_scene(lay, check_result=collisions.check(lay))
+    assert sc["readouts"] is None  # an invalid layout shows no quality readouts
+    assert sc["placeholder"] is True

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -317,3 +317,14 @@ def test_build_scene_readouts_none_when_conflicts():
     sc = scene.build_scene(lay, check_result=collisions.check(lay))
     assert sc["readouts"] is None  # an invalid layout shows no quality readouts
     assert sc["placeholder"] is True
+
+
+def test_build_scene_readouts_none_for_unchecked_invalid_layout():
+    # #401 review (silent-failure): even with NO check_result (e.g. `view` without
+    # --check), an actually-invalid layout must not get readouts — build_scene
+    # verifies validity itself rather than conflating "not checked" with "valid".
+    from hangarfit.loader import load_layout as _ll
+
+    lay = _ll("tests/fixtures/invalid_fuselage_wing_overlap.yaml")
+    sc = scene.build_scene(lay)  # no check_result
+    assert sc["readouts"] is None

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -88,6 +88,20 @@ def test_html_embeds_polish_features(tmp_path):
     assert 'id="labels"' in html  # the HUD toggle for labels + nose arrows
 
 
+def test_html_embeds_honesty_banner_and_readouts(tmp_path):
+    # #401: the placeholder banner + readouts wiring must reach the artifact, and
+    # the scene JSON must carry the placeholder flag (shipped fleet is unmeasured).
+    html = _html(tmp_path)
+    assert "PLACEHOLDER DATA" in html
+    assert 'id="placeholder"' in html
+    assert 'id="readouts"' in html
+    m = re.search(r'id="scene">(.*?)</script>', html, re.S)
+    assert m is not None
+    scene_json = json.loads(m.group(1))
+    assert scene_json["placeholder"] is True
+    assert scene_json["readouts"] is not None
+
+
 def test_static_scene_renders(tmp_path):
     # A layout with no MovesPlan → static scene, still a valid HTML artifact.
     lay = load_layout(LAYOUT)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -34,10 +34,12 @@ from hangarfit.visualize import (
     _CART_PALLET_HALF_EXTENT_M,
     _CONFLICT_COLOR,
     _GLYPH_ZORDER,
+    _PLACEHOLDER_BANNER,
     _WHEEL_COLOR,
     _draw_conflict_overlay,
     _draw_gear_glyph,
     _draw_maintenance_bay,
+    _readout_text,
     nose_direction,
     render_layout,
 )
@@ -1124,3 +1126,23 @@ class TestBrandPalette:
         assert any(e[:3] == ink[:3] for e in edges), (
             "at least one plane part must carry the _INK_EDGE outline"
         )
+
+
+class TestHonestyAnnotations:
+    """#401: placeholder banner constant + actionable readouts."""
+
+    def test_readout_text_reports_gap_and_clearance(self):
+        s = _readout_text(_load("valid_left_side_nesting"))
+        assert "tightest inter-plane gap" in s
+        assert "smallest wing-over-tail clearance" in s
+
+    def test_banner_constant_is_explicit_about_placeholder(self):
+        assert "PLACEHOLDER DATA" in _PLACEHOLDER_BANNER
+        assert "not for real parking" in _PLACEHOLDER_BANNER
+
+    def test_render_with_placeholder_data_produces_png(self, tmp_path):
+        # The shipped fleet is measured: false, so this exercises the banner +
+        # readout draw paths end-to-end and must still produce a valid PNG.
+        out = tmp_path / "placeholder.png"
+        render_layout(_load("valid_left_side_nesting"), out)
+        _assert_valid_png(out)


### PR DESCRIPTION
## F4 — Honesty banner + actionable readouts + plain-language failures (#401)

Closes #401.

⚠️ **Stacked PR** — based on `feature/400-viewer-polish` (#407) → `#406` → `#405`. This diff shows only F4's changes; GitHub auto-retargets to `develop` as the parents merge. **Merge order: #405 → #406 → #407 → this (#401)** (also wired as GitHub issue `blocked_by` dependencies).

### What
1. **Honesty banner.** A persistent **"PLACEHOLDER DATA — illustrative only, not for real parking"** strip on *both* the 2D PNG (`visualize`) and the 3D viewer whenever any placed aircraft is on unmeasured (`measured: false`) data (#79) — so a club member never mistakes an illustrative render for a real parking plan. It disappears once data is `measured: true`. The wording is single-sourced in the new `hangarfit.metrics` module so 2D/3D never drift.
2. **Actionable readouts.** Valid layouts surface the **tightest plan-view inter-plane gap** and the **smallest wing-over-tail vertical clearance** (the vertical near-miss you can't see in a top-down PNG). New read-only `metrics` (`min_pairwise_gap_m` / `min_wing_over_tail_clearance_m`); `scene/v1` gains additive `placeholder` (bool) + `readouts` (object|null, null when the layout has conflicts).
3. **Plain-language failures.** `_format_conflict` now leads each conflict with a readable sentence — *"`fuji` overlaps `scheibe_falke`"*, *"`x` intrudes into the maintenance bay"*, *"`x` extends outside the hangar"* — instead of the raw `kind` enum, keeping the precise `detail` (parts + z-gaps) verbatim (no fragile re-parsing). Applied to `check` exit 1 and the solver's trivially-infeasible / exhausted-budget summaries. Exit 3 already named the blocking plane via `_warn_unroutable`.

### Guardrails held
- `metrics` is read-only and **never enters the collision model** → `collisions.py`/`geometry.py` untouched, `build_scene` byte-deterministic (no determinism/geometry guard needed). No solver change (`unroutable_planes` already existed in `SolverDiagnostics`).
- Label/banner text is static or numeric — no `innerHTML` surface.

### Verification
- Headless swiftshader 3D screenshot: red banner across the top + HUD readouts ("gap 0.00 m · wing-over-tail n/a"). 2D PNG: banner + bottom readout box. (Captured locally; can attach.)
- `hangarfit check invalid_fuselage_wing_overlap.yaml` → "`fuji` overlaps `scheibe_falke`: part 'wing' … and part 'fuselage_front' …".
- New tests: `test_metrics.py` (6), scene placeholder/readouts, cli humanizer (4), visualize readout/banner (3), viewer banner+readouts embed. Full non-slow suite **1197 passed**; ruff / format / mypy clean.

### Acceptance criteria
- [x] Banner on both 2D PNG and 3D viewer while `measured: false`; disappears once measured.
- [x] Valid-layout renders show tightest inter-plane gap + smallest wing-over-tail clearance.
- [x] Exit 1 / exit 3 emit plain-language reasons naming the offending parts/planes.
- [x] ≥1 non-slow test per new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)