### PR TITLE
docs(release): prep v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.10.0] — 2026-06-04
+
+### Added
+
 - **3D viewer renders landing gear + tow carts (#399).** `scene/v1` now emits
   per-plane `wheels[]` (canonical plane-local positions, ADR-0013) and an
   `on_carts` flag, plus a `gear_anchors` oracle. The viewer draws a wheel at each
@@ -234,7 +242,8 @@ First Phase 1 cut — substrate for arranging the flying club fleet in a stack-s
 - Apache-2.0 license, public-audience README, CI matrix (Python 3.11 + 3.12), branch protection on develop + main (#13, #14, #15, #16).
 - Strut-aware golden tests + all-9-planes fixture using larger test-only hangar to accommodate strut-bracing geometry on placeholder dimensions (#5).
 
-[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/DocGerd/hangarfit/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/DocGerd/hangarfit/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/DocGerd/hangarfit/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/DocGerd/hangarfit/compare/v0.7.1...v0.7.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,12 +269,15 @@ hangarfit check layouts/example.yaml --render out.png
 hangarfit solve tests/fixtures/scenario_minimal.yaml --render out.png --render-paths
 
 # Phase 4: 3D viewer (self-contained offline HTML). layouts/example.yaml is NOT
-# tow-routable → it renders static-only but grinds ~2 min first exhausting the
-# tow-planner's per-plane expansion budget (layout-mode view has no wall-clock
-# cap); pass --no-animate to skip straight to static, or use the wing-over-nesting
-# fixture for a fast animated demo. Verify headlessly via swiftshader WebGL
-# (dbus/UPower + WebGL "ReadPixels stall" lines are noise; a transform mismatch
-# shows an on-page banner).
+# tow-routable → it falls back to a static 3D render. Since #398 (F1), layout-mode
+# `view` passes a small deterministic GLOBAL tow-expansion cap
+# (_VIEW_TOW_MAX_TOTAL_EXPANSIONS=300) to the planner, so an un-routable layout
+# degrades to static in ~5 s instead of grinding ~2 min — a deterministic
+# expansion COUNT, not a wall-clock deadline (ADR-0003). Override with
+# --tow-max-expansions N; pass --no-animate to skip tow planning entirely, or use
+# the wing-over-nesting fixture for a fast animated demo. Verify headlessly via
+# swiftshader WebGL (dbus/UPower + WebGL "ReadPixels stall" lines are noise; a
+# transform mismatch shows an on-page banner).
 hangarfit view tests/fixtures/valid_left_side_nesting.yaml -o out.html
 google-chrome --headless=new --use-gl=angle --use-angle=swiftshader \
   --enable-unsafe-swiftshader --virtual-time-budget=8000 \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It also renders a top-down PNG so a human can sanity-check the result by eye.
 
 **Phase 3b — shipped.** Tow-path planner v2: a Reeds–Shepp motion model (reverse arcs eliminate the reorientation loops Dubins introduced) plus a door entry-cone search over heading × offset. See [ADR-0010](docs/adr/0010-reeds-shepp-motion-model.md).
 
-**Phase 4 — shipped.** Interactive 3D viewer: `hangarfit view` emits a self-contained, offline HTML file (vendored Three.js) showing the hangar and each aircraft as box models, with a scrubbable whole-fill tow timeline. Built from a documented `hangarfit.scene/v1` JSON seam; the determinant-−1 transform stays in Python (the viewer consumes per-frame affine matrices). See [ADR-0017](docs/adr/0017-3d-viewer-architecture.md).
+**Phase 4 — shipped.** Interactive 3D viewer: `hangarfit view` emits a self-contained, offline HTML file (vendored Three.js) showing the hangar and each aircraft as a stack of boxes — with landing gear, tow carts, soft contact shadows, kind-based materials, nose-cone arrows and id labels (both toggle from the on-page `labels` control) — plus a scrubbable whole-fill tow timeline. A "PLACEHOLDER DATA" honesty banner is shown (on both the 3D viewer and the 2D PNG) whenever any placed aircraft is on unmeasured data. Built from a documented `hangarfit.scene/v1` JSON seam; the determinant-−1 transform stays in Python (the viewer consumes per-frame affine matrices). See [ADR-0017](docs/adr/0017-3d-viewer-architecture.md).
 
 **Still explicitly out of scope:**
 
@@ -132,7 +132,7 @@ A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which
 
 ### Interactive 3D viewer (Phase 4)
 
-`hangarfit view` renders a **self-contained, offline** 3D HTML file — open it in any browser (no server, no internet, no Python), orbit the camera, and scrub a whole-fill tow timeline (planes enter back-first; play / pause / step per plane). Each aircraft is drawn as its stack of boxes, so the vertical clearances the collision checker reasons about (a high wing overhanging another plane's tail) are visible in a way the top-down PNG cannot show.
+`hangarfit view` renders a **self-contained, offline** 3D HTML file — open it in any browser (no server, no internet, no Python), orbit the camera, and scrub a whole-fill tow timeline (planes enter back-first; play / pause / step per plane). Each aircraft is drawn as its stack of boxes — with landing gear, tow carts, soft contact shadows, kind-based materials, nose-cone arrows and id labels (both toggle from the on-page `labels` control) — so the vertical clearances the collision checker reasons about (a high wing overhanging another plane's tail) are visible in a way the top-down PNG cannot show. When any placed aircraft is on placeholder (`measured: false`) data, a "PLACEHOLDER DATA" banner is overlaid (the same banner now appears on the 2D PNG), and a valid layout surfaces the tightest plan-view inter-plane gap and the smallest wing-over-tail clearance.
 
 ```bash
 # View a layout in 3D (best-effort tow animation; static if un-routable).
@@ -146,7 +146,7 @@ hangarfit view layouts/example.yaml -o static3d.html --no-animate
 hangarfit view some_invalid_layout.yaml -o conflicts3d.html --check --no-animate
 ```
 
-Layout mode best-effort tow-plans for the animation; a layout the planner can't route degrades to a static 3D scene with a stderr note (`--tow-max-expansions` bounds that search so it degrades fast). The viewer is built from a documented `hangarfit.scene/v1` JSON contract (the seam between the Python core and any renderer) and a pinned, vendored copy of Three.js; the transform stays in Python (per-frame affine matrices), so the viewer never re-derives the determinant-−1 map. See [ADR-0017](docs/adr/0017-3d-viewer-architecture.md) and the schema reference [`docs/architecture/scene-v1-schema.md`](docs/architecture/scene-v1-schema.md).
+Layout mode best-effort tow-plans for the animation; a layout the planner can't route degrades to a static 3D scene with a stderr note. By default the viewer applies a small deterministic global tow-expansion cap, so an un-routable layout (e.g. the default `layouts/example.yaml`) falls back to the static render in a few seconds rather than grinding through the full disprove budget — a fixed expansion count, **not** a wall-clock deadline ([ADR-0003](docs/adr/0003-rr-mc-solver-algorithm.md)); `--tow-max-expansions` overrides it. The viewer is built from a documented `hangarfit.scene/v1` JSON contract (the seam between the Python core and any renderer) and a pinned, vendored copy of Three.js; the transform stays in Python (per-frame affine matrices), so the viewer never re-derives the determinant-−1 map. See [ADR-0017](docs/adr/0017-3d-viewer-architecture.md) and the schema reference [`docs/architecture/scene-v1-schema.md`](docs/architecture/scene-v1-schema.md).
 
 ### JSON schemas
 
@@ -166,7 +166,7 @@ The test suite includes a strut-aware golden set for the collision checker cover
 ## Project layout
 
 ```
-src/hangarfit/      # models, loader, geometry, collisions, solver, towplanner, visualize, cli
+src/hangarfit/      # models, loader, geometry, collisions, solver, towplanner, visualize, scene, viewer, metrics, cli
 data/               # fleet.yaml, hangar.yaml — placeholder measurements
 layouts/            # hand-authored candidate layouts, one YAML per scenario
 tests/              # pytest suite, including strut-aware collision golden tests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,8 +25,9 @@ The following areas have non-zero attack surface and merit scrutiny:
 
 - **YAML loader** (`src/hangarfit/loader.py`): parses user-supplied layout and fleet files
 - **Visualizer** (`src/hangarfit/visualize.py`): renders user-supplied aircraft placements and conflict data
+- **3D viewer** (`src/hangarfit/scene.py`, `src/hangarfit/viewer.py`): builds a self-contained offline HTML file embedding user-supplied plane ids and a JSON scene. By design, ids reach the page only via safe text APIs — canvas `fillText`, `textContent`, and `createTextNode` — never `innerHTML`; the inlined scene JSON escapes every `<` (to its JSON unicode escape) so a value can never close the `<script>` block. Three.js is vendored (r160) and hash-recorded in its `_viewer_assets/three/VENDOR.md`.
 
-We welcome reports of resource exhaustion, parsing edge cases, or rendering defects that could affect the tool's reliability or the user's system.
+We welcome reports of resource exhaustion, parsing edge cases, rendering defects, or any way the generated viewer HTML could be coerced into executing injected markup — anything that could affect the tool's reliability or the user's system.
 
 ## Project security posture
 

--- a/docs/adr/0017-3d-viewer-architecture.md
+++ b/docs/adr/0017-3d-viewer-architecture.md
@@ -1,9 +1,24 @@
 # ADR-0017: 3D viewer — a `scene/v1` JSON seam fed to a self-contained offline Three.js HTML, with the transform owned by Python
 
-- **Status:** Proposed
+- **Status:** Accepted
 
 - **Date:** 2026-06-03
 - **Deciders:** Patrick Kuhn (DocGerd)
+
+> **v0.10.0 amendment (milestone #30, "viewer appeal").** The core decision —
+> the `scene/v1` seam and the Python-owned determinant-−1 transform — is
+> unchanged. Additive, render-only extensions shipped on top: gear + tow carts
+> (#399; `scene/v1` gains per-plane `wheels[]`/`on_carts` + a `gear_anchors`
+> oracle, still absent from the collision model per
+> [ADR-0015](0015-wheels-not-in-collision-model.md)); soft contact shadows,
+> kind-based materials, billboarded id labels (`CanvasTexture` via safe
+> `fillText`, never `innerHTML`) and nose-cone arrows behind a `labels` toggle
+> (#400); and a "PLACEHOLDER DATA" honesty banner + valid-layout readouts driven
+> by the new read-only `metrics` module (#401). Layout-mode `view` also gained a
+> small deterministic *global* tow-expansion cap so an un-routable layout
+> degrades to a static render in seconds (#398) — an expansion count, **not** a
+> wall-clock deadline ([ADR-0003](0003-rr-mc-solver-algorithm.md)). Schema-level
+> record of the new fields: [`scene-v1-schema.md`](../architecture/scene-v1-schema.md).
 
 ## Context & Problem Statement
 

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -349,6 +349,16 @@ conflicting parts in red. The two-layer rendering (base layout in
 neutral colors, conflicts in red on top) lets the operator see *what
 broke* at a glance.
 
+Two render-only annotations (#401) share the read-only `metrics` oracle with the
+3D viewer so the 2D and 3D outputs never drift: when any placed aircraft is on
+placeholder (`measured: false`) data the persistent "PLACEHOLDER DATA" honesty
+banner is drawn across the top (wording from `metrics.PLACEHOLDER_BANNER`), and for
+a valid layout the tightest plan-view inter-plane gap and smallest wing-over-tail
+clearance are drawn along the bottom. Landing-gear wheels are drawn from each
+plane's canonical `aircraft.wheels.positions`
+([ADR-0013](../adr/0013-wheels-canonical-data.md)), or a cart glyph when
+`placement.on_carts`. None of this enters the collision model.
+
 The render is the only project output that is not also JSON-encodable;
 it is the human's sanity-check.
 
@@ -375,10 +385,30 @@ Assembles **one** offline HTML file: it inlines the `scene/v1` JSON plus a
 as package data) and the hand-written `_viewer_assets/viewer.js`. The `data:`
 import-map sidesteps the ES-module `file://` CORS block so a double-clicked page
 loads with zero network. The embedded scene JSON escapes `<` to prevent a
-`</script>` breakout. The thin `viewer.js` consumer builds each plane as a
+`</script>` breakout. The thin `viewer.js` consumer (Three.js vendored at r160) builds each plane as a
 Three.js `Group` driven per-frame by the affine as a `Matrix4` (`DoubleSide` for
-the reflected matrix), with an orbit camera and a scrub/play/step timeline, and a
-load-time self-check of the affine path against the emitted `anchors`.
+the reflected det-−1 matrix), with an orbit camera and a scrub/play/step timeline, and a
+load-time self-check of the affine path against the emitted `anchors` **and `gear_anchors`**.
+
+The v0.10.0 "viewer appeal" work (milestone #30) is all client-side and render-only —
+it never touches the scene's geometry contract:
+
+- **Gear + carts (#399).** Each plane `Group` also gets a wheel at every
+  `planes[].wheels[]` position (canonical plane-local data,
+  [ADR-0013](../adr/0013-wheels-canonical-data.md)) plus a short leg to the belly,
+  and a pallet deck under each wheel when `on_carts` — so the gear inherits the same
+  affine and animates along the tow path. Render-only, never in collisions
+  ([ADR-0015](../adr/0015-wheels-not-in-collision-model.md)); the load-time
+  self-check validates it against `gear_anchors`.
+- **Polish (#400).** A `PCFSoftShadowMap` key sun casts soft contact shadows (so a
+  high wing's shadow on a neighbour's tail reads as vertical clearance); kind-based
+  materials (translucent wings, metallic struts, a tinted cockpit); billboarded id
+  labels built as a `CanvasTexture` via safe `fillText` (never `innerHTML` — ids are
+  user YAML) and a nose-cone arrow per plane, both behind a `labels` HUD toggle.
+- **Honesty banner + readouts (#401).** When `scene.placeholder` is set the viewer
+  unhides the "PLACEHOLDER DATA" banner (wording shared with the 2D PNG via
+  `metrics.PLACEHOLDER_BANNER`); when `scene.readouts` is present (valid layouts
+  only) it shows the tightest plan-view gap and smallest wing-over-tail clearance.
 
 ### `metrics.py` — read-only render annotations
 

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -1,9 +1,10 @@
 # §6 Runtime View
 
-Two scenarios cover the operational use of `hangarfit`: validating a
-candidate layout (`hangarfit check`) and searching for a valid layout
-(`hangarfit solve`). Both are short-lived CLI invocations — there is
-no daemon, no long-running process, no stateful session.
+Four scenarios cover the operational use of `hangarfit`: validating a
+candidate layout (`hangarfit check`), searching for a valid layout
+(`hangarfit solve`), the `--render-paths` tow-overlay zoom-in, and writing
+the interactive 3D viewer (`hangarfit view`). All are short-lived CLI
+invocations — there is no daemon, no long-running process, no stateful session.
 
 ## Scenario 1: `hangarfit check layouts/example.yaml --render out.png`
 
@@ -229,6 +230,30 @@ sequenceDiagram
 ```
 
 *Scenario 3 — `solve --render-paths`: `solve(plan_paths=True)` tow-plans each accepted layout via `plan_fill` (back-first order; per-plane Hybrid-A\* over Reeds–Shepp arcs, the final arc re-validated by `collisions.check`). Routing is best-effort — a layout the bounded planner can't route keeps `plans[i]=None` and the blocked plane is recorded in `diagnostics.unroutable_planes` rather than dropping the valid static layout. The CLI overlays each routable path and exits 3 only when no returned candidate is tow-routable (#193/#197, ADR-0007/ADR-0010).*
+
+## Scenario 4: `hangarfit view layout.yaml -o out.html`
+
+The Phase 4 / v0.10.0 path. The operator wants a self-contained, offline 3D
+HTML view of a candidate layout — with the whole-fill tow animation when the
+layout is tow-routable. In layout mode the CLI best-effort tow-plans the layout
+to drive the animation, but caps the **global** fill budget at a small
+deterministic expansion count (`_VIEW_TOW_MAX_TOTAL_EXPANSIONS = 300`, #398) so
+an un-routable layout (e.g. the default `layouts/example.yaml`) degrades to a
+**static** 3D render in a few seconds instead of grinding through the full
+disprove budget (~2 min). This is a deterministic expansion-count cap, **not** a
+wall-clock deadline ([ADR-0003](../adr/0003-rr-mc-solver-algorithm.md));
+`--tow-max-expansions` overrides it. On a `NoFeasiblePlanError` the CLI prints a
+`note:` to stderr and proceeds; `scene.build_scene` then emits empty `timeline`
+segments and the viewer disables transport. `cmd_view` calls
+`scene.build_scene` → `viewer.render_viewer` and writes the HTML; exit 0 even
+for an un-routable (static) layout, exit 2 on a load/write error, and — in
+`--solve` mode only — exit 1 when the solver finds no valid layout. `--no-animate`
+skips tow planning entirely; `view --solve` solves a scenario first and routes
+via `solve()`, unaffected by this global cap. In layout mode the render never
+touches the solver's seeded path — it goes through `metrics` only for the
+placeholder banner and readouts — so the scene is byte-identical for a given
+input layout; under `--solve`, reproducibility is the solver's usual same-seed
+contract.
 
 ## What is *not* a runtime concern
 

--- a/docs/architecture/scene-v1-schema.md
+++ b/docs/architecture/scene-v1-schema.md
@@ -32,7 +32,7 @@ metres.
 | `final_poses` | object | `plane_id → affine`: each plane at its parked slot. |
 | `conflicts` | array of string | Plane ids to tint red (flattened from a `CheckResult`); `[]` if none / not checked. |
 | `anchors` | object | `plane_id → [box → [corner → [x, y]]]`: oracle world corners at the final placement, for the viewer's load-time self-check. |
-| `gear_anchors` | object | `plane_id → [wheel → [x, y]]`: oracle world wheel positions at the final placement (same `local_to_world` as `anchors`), so the viewer self-check also covers the gear render. |
+| `gear_anchors` | object | `plane_id → [wheel → [x, y]]`: oracle world wheel positions at the final placement — each canonical plane-local wheel pushed through `geometry.local_to_world` (the same determinant-−1 map `anchors` applies via `aircraft_parts_world`), so the viewer self-check also covers the gear render and a sign-flip regression fails both at once. |
 | `placeholder` | bool | `true` iff any placed aircraft is on unmeasured (`measured: false`) data — drives the "PLACEHOLDER DATA" honesty banner on the 2D PNG and the 3D viewer (#401, #79). |
 | `readouts` | object \| null | Actionable quality numbers for a **valid** layout: `{ "min_gap_m", "min_wing_over_tail_clearance_m" }` (either may be `null` — single plane / no overhang). `null` when the layout is invalid — validity is taken from the supplied `CheckResult`, or collision-checked by `build_scene` itself when none was supplied, so readouts never imply an unverified validity. |
 


### PR DESCRIPTION
## Release prep for v0.10.0

Promotes the CHANGELOG `[Unreleased]` block to `## [0.10.0] — 2026-06-04` (fresh
empty `[Unreleased]` re-inserted; compare links retargeted) and refreshes the
docs ahead of the release cut, so the doc work gets a focused review surface
separate from the release-state PR.

After this PR merges into `develop`, run `/release-cut version=0.10.0` to create
the actual release branch and PRs.

### Doc refresh (v0.10.0 "viewer appeal", milestone #30 — F1–F4)

A 4-agent cross-layer audit (docs vs. actual code) found the `scene/v1` schema
already current; the gaps were elsewhere:

- **README.md** — module list now lists `scene`/`viewer`/`metrics`; Scope + viewer
  section reflect gear/carts, shadows/materials/labels/nose-arrows, the honesty
  banner + readouts, and the default fast-degrade tow cap.
- **CLAUDE.md** — `view` gotcha corrected from the pre-F1 "grinds ~2 min / no cap"
  to the 300-cap ~5 s static fallback.
- **SECURITY.md** — added the 3D-viewer/scene HTML-emission attack surface
  (`fillText`/`textContent`/`createTextNode`, never `innerHTML`; the inlined scene
  JSON escapes every `<` so a value can't close the `<script>` block; vendored
  Three.js r160 hash-recorded in `VENDOR.md`).
- **docs/adr/0017** — Status `Proposed` → `Accepted` + a v0.10.0 amendment note.
- **arc42 §5** — `viewer.py`/`visualize.py` entries gain the F2/F3/F4 render-only
  additions.
- **arc42 §6** — intro "Two scenarios" → "Four"; new **Scenario 4: `hangarfit
  view`** documenting the F1 deterministic global tow-expansion cap fallback.
- **scene-v1-schema.md** — `gear_anchors` row corrected (`anchors` →
  `aircraft_parts_world`, `gear_anchors` → `local_to_world`, both det-−1).

### Review evidence

Reviewed with **`pr-review-toolkit:code-reviewer`** (mandated main pass) and
**`pr-review-toolkit:comment-analyzer`** (mandated for doc PRs), each cross-checking
every claim against `src/hangarfit/` (`cli.py`, `scene.py`, `viewer.py`,
`_viewer_assets/viewer.js`, `metrics.py`, `visualize.py`, `towplanner.py`).

- **Critical: 0 · Important: 0** — both agents passed clean; every load-bearing
  claim verified against code.
- **6 accuracy refinements found and fixed** before this PR opened: SECURITY safe-sink
  list (`createTextNode`) + escaping wording; §6 Scenario 4 missing `--solve` exit-1
  (now matches the §5 exit-code table); §6 determinism clause scoped to layout mode;
  README `labels` toggle also covers nose arrows + a partial banner quote tightened.
- One audit suggestion linked a non-existent `0015-render-only-gear-carts.md`; the
  correct file `0015-wheels-not-in-collision-model.md` was used (all links verified
  to resolve).
