### PR TITLE
fix(#411): door-aware front-gap exemption — tow can't clip the wall beside the door

### DIFF
--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -954,22 +954,30 @@ def entry_pose(target: Placement, hangar: Hangar) -> Pose:
 def _mover_motion_bounds_conflict(
     mover: Aircraft, placement: Placement, hangar: Hangar
 ) -> Conflict | None:
-    """First side/back-wall bounds violation for a plane *in transit*, else ``None``.
+    """First wall violation for a plane *in transit*, else ``None``.
 
-    **Front-gap exemption (#222):** a plane being towed through the door
-    legitimately protrudes in front of it (``y < 0`` — the conceptual apron,
-    spike Q6). So — unlike the static :func:`hangarfit.collisions.check` oracle,
-    which forbids ``y < 0`` — the front wall is NOT enforced on the mover
-    mid-motion. The side walls (``0 ≤ x ≤ width``) and the back wall
-    (``y ≤ length``) still are; the mover's final slot is itself a valid static
-    placement, so full bounds hold at rest. Reuses the canonical
+    **Door-aware front-gap exemption (#222, refined in #411):** a plane being
+    towed through the door legitimately protrudes in front of it (``y < 0`` — the
+    conceptual apron, spike Q6) — but *only through the door opening*. The front
+    wall is solid except for the door gap, so a ``y < 0`` vertex is allowed only
+    when ``door_lo ≤ x ≤ door_hi``; a ``y < 0`` vertex *beside* the door clips the
+    solid front wall / jamb (an off-centre entry, or a plane wider than the door)
+    and is a conflict — making the door a true motion gate and matching what the
+    renderer draws. Unlike the static :func:`hangarfit.collisions.check` oracle
+    (which forbids ``y < 0`` entirely), only the door-gap protrusion is exempt.
+    The side walls (``0 ≤ x ≤ width``) and the back wall (``y ≤ length``) are
+    enforced unchanged; the mover's final slot is itself a valid static placement,
+    so full bounds hold at rest. Reuses the canonical
     :func:`~hangarfit.geometry.aircraft_parts_world` transform rather than
     re-deriving geometry — the determinant-(-1) trap lives there (ADR-0002).
     """
+    door_half = hangar.door.width_m / 2.0
+    door_lo = hangar.door.center_x_m - door_half
+    door_hi = hangar.door.center_x_m + door_half
     for world_part in aircraft_parts_world(mover, placement):
         for x, y in list(world_part.polygon.exterior.coords)[:-1]:
-            # The static rule is `0 <= x <= width and 0 <= y <= length`; the
-            # only relaxation is dropping the `0 <= y` front-wall lower bound.
+            # Side walls + back wall (unchanged): the static rule is
+            # `0 <= x <= width and 0 <= y <= length`.
             if x < 0.0 or x > hangar.width_m or y > hangar.length_m:
                 return Conflict.single(
                     kind="hangar_bounds",
@@ -978,6 +986,19 @@ def _mover_motion_bounds_conflict(
                         f"part {world_part.kind!r} vertex ({x:.3f}, {y:.3f}) "
                         f"outside hangar side/back walls during tow "
                         f"(0..{hangar.width_m:g} x ..{hangar.length_m:g})"
+                    ),
+                )
+            # Front wall is solid except the door gap (#411): a vertex in front of
+            # the hangar (y < 0) is legal only when it passes *through* the door
+            # opening; beside the door it clips the solid front wall / jamb.
+            if y < 0.0 and not (door_lo <= x <= door_hi):
+                return Conflict.single(
+                    kind="hangar_bounds",
+                    plane=mover.id,
+                    detail=(
+                        f"part {world_part.kind!r} vertex ({x:.3f}, {y:.3f}) "
+                        f"clips the solid front wall beside the door during tow "
+                        f"(door opening x in {door_lo:g}..{door_hi:g})"
                     ),
                 )
     return None

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -892,9 +892,11 @@ def entry_poses(target: Placement, hangar: Hangar) -> tuple[Pose, ...]:
       second occurrence.
 
     The caller (:func:`plan_path` via ``entries=`` and :func:`plan_fill`) filters
-    candidates that clip the side/back walls at the entry pose before seeding the
-    search; a straight-in centre pose is always the final fallback so the search
-    has at least one start.
+    candidates that clip the side/back walls, or protrude in front of the solid
+    wall beside the door (the door-gated front-gap exemption, #411), before
+    seeding the search; a straight-in centre pose is always the final fallback so
+    the search has at least one start (which may itself be infeasible — e.g. a
+    plane wider than the door — leaving the plane un-towable).
 
     Returns a non-empty :class:`tuple` of :class:`Pose` objects, each with
     ``y_m = 0.0`` and ``heading_deg`` from ``_CONE_HEADINGS``.
@@ -1687,10 +1689,13 @@ def plan_path(
     **Multi-start / door-cone mode** (``entries`` provided, #262): seeds the
     search frontier with every *surviving* start pose from the cone — a pose
     survives iff its footprint at the front boundary does not clip the side or
-    back walls (:func:`_mover_motion_bounds_conflict`; the front-wall ``y < 0``
-    exemption still applies).  If ALL candidates are filtered out, the fallback
-    is the door-centre straight-in pose (always safe) so the search always has
-    at least one start.  Each surviving start is enqueued at ``g = 0`` with its
+    back walls AND any ``y < 0`` protrusion stays within the door opening
+    (:func:`_mover_motion_bounds_conflict`; the front-gap exemption is now
+    door-gated, #411).  If ALL candidates are filtered out, the fallback is the
+    door-centre straight-in pose so the search always has at least one start —
+    which may itself be infeasible (e.g. a plane wider than the door), in which
+    case no valid path is found and the caller raises
+    :class:`NoFeasiblePlanError`.  Each surviving start is enqueued at ``g = 0`` with its
     own Euclidean heuristic; A* then naturally expands the most-promising start
     first and returns the best total path across the whole cone.  The
     ``DubinsArc.start`` of the returned arc is the cone pose that *won* (from
@@ -1762,14 +1767,17 @@ def plan_path(
 
     # ── Build the effective start set ────────────────────────────────────────
     # Single-start (no cone): use the bare ``entry`` unchanged.
-    # Multi-start (cone provided): filter cone candidates that clip side/back walls
-    # at the entry pose; fall back to the door-centre straight-in pose if all are
-    # filtered so the search always has at least one start.
+    # Multi-start (cone provided): filter cone candidates that clip the side/back
+    # walls OR protrude in front of the solid wall beside the door; fall back to
+    # the door-centre straight-in pose if all are filtered so the search always
+    # has at least one start.
     if entries is None:
         start_poses: tuple[Pose, ...] = (entry,)
     else:
         # Filter: keep only poses whose footprint at the door boundary is clear of
-        # side/back walls (front-wall y<0 exemption already built into the predicate).
+        # the side/back walls AND whose y<0 protrusion (if any) stays within the
+        # door opening (the door-gated front-gap exemption is built into the
+        # predicate, #411).
         surviving: list[Pose] = []
         for candidate_pose in entries:
             candidate_placement = Placement(
@@ -1784,7 +1792,9 @@ def plan_path(
         if surviving:
             start_poses = tuple(surviving)
         else:
-            # Fallback: straight-in door-centre pose (always fits through the door).
+            # Fallback: door-centre straight-in pose, so the search always has a
+            # start. It is NOT guaranteed feasible — a plane wider than the door
+            # clips even here, and the search then finds no valid path (#411).
             start_poses = (Pose(x_m=hangar.door.center_x_m, y_m=0.0, heading_deg=0.0),)
 
     # ── Seed the open heap with all surviving start poses ───────────────────

--- a/tests/test_towplanner_entry_cone.py
+++ b/tests/test_towplanner_entry_cone.py
@@ -6,8 +6,9 @@ Tests are grouped into four blocks:
 2. Candidate filtering: poses that clip side/back walls are dropped before the search;
    if all are filtered the fallback straight-in centre pose is returned.
 3. Multi-start plan_path: the search accepts the cone and seeds all surviving entries.
-4. Path-length regression: an off-to-the-side slot gets a shorter path than the v1
-   single-start baseline (straight-in only).
+4. Door-gate (#411): for an off-to-the-side slot the cone does NOT corner-cut
+   through the solid front wall beside the door — its best legal path equals the
+   v1 straight-in baseline (the prior sub-cm "win" was a jamb wall-clip).
 """
 
 from __future__ import annotations
@@ -393,14 +394,21 @@ def test_plan_path_single_entry_tuple_same_as_no_entries() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cone_produces_shorter_path_for_off_side_slot() -> None:
-    """An angled slot off to the side of the door yields a shorter path with the
-    full cone search than the v1 single straight-in entry pose.
+def test_off_side_slot_cone_does_not_corner_cut_through_jamb() -> None:
+    """Door-gate regression (#411): for an off-side slot, the only route shorter
+    than the straight-in v1 entry would cut the corner THROUGH the solid front
+    wall beside the door (the box dipping to ``y < 0`` just left of the door
+    edge). The door-aware front-gap exemption forbids that, so the cone must NOT
+    take the shortcut — its best legal path EQUALS the v1 path, and neither clips
+    the front wall.
 
-    This is the core regression check: the cone win demonstrates the feature
-    actually helps. We use a slot at heading=30° near the left side of a wide hangar
-    so the straight-in entry at x=door_center forces a large heading correction,
-    while a 30°-heading cone entry from further left can close nearly straight.
+    Pre-#411 the cone was ~6 mm shorter here (10.422 vs 10.428 m) via exactly
+    that jamb corner-cut — a path that clipped the wall. This now guards that the
+    planner does not corner-cut through the jamb even when shorter; reverting the
+    door-gate would make the cone beat v1 again and fail this test. (The #262
+    cone still provides valid multi-start search + determinism, guarded by the
+    other tests in this module; whether it yields a *legal* strict path win on any
+    fixture is tracked as a follow-up.)
     """
     from hangarfit.towplanner import path_first_conflict
 
@@ -440,14 +448,15 @@ def test_cone_produces_shorter_path_for_off_side_slot() -> None:
     )
     len_cone = arc_cone.length_m
 
-    # The cone must find a shorter or equal path.
-    assert len_cone <= len_v1 + 1e-9, (
-        f"Cone path ({len_cone:.3f} m) should be ≤ v1 path ({len_v1:.3f} m)"
+    # The cone must NOT beat v1 by corner-cutting through the door jamb: with the
+    # #411 door-gate the only shorter route is illegal, so the best legal cone
+    # path EQUALS the v1 path (a door-gate revert would make it shorter again and
+    # fail here).
+    assert len_cone == pytest.approx(len_v1, abs=1e-9), (
+        f"Cone path ({len_cone:.3f} m) should equal the v1 path ({len_v1:.3f} m) — "
+        "the only shorter route corner-cuts through the door jamb, which #411 forbids"
     )
-    # And for this particular geometry it should actually be strictly shorter.
-    assert len_cone < len_v1, (
-        f"Expected cone ({len_cone:.3f} m) < v1 ({len_v1:.3f} m) for off-side slot"
-    )
-    # Both must be exact-oracle clean.
+    # Both must be exact-oracle clean — which, post-#411, also means neither
+    # protrudes to y < 0 beside the door (the door-gate lives in path_first_conflict).
     assert path_first_conflict(arc_v1, plane, mover_on_carts=False, placed=placed) is None
     assert path_first_conflict(arc_cone, plane, mover_on_carts=False, placed=placed) is None

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -386,3 +386,49 @@ def test_plane_wider_than_door_is_untowable() -> None:
     with pytest.raises(NoFeasiblePlanError) as ei:
         plan_fill(target)
     assert ei.value.plane_id == "W"
+
+
+def test_off_centre_plane_within_door_still_routes() -> None:
+    """#411 (no over-fire): the door-gate must NOT block a plane whose y<0 entry
+    protrusion stays WITHIN the door opening. A narrow origin-spanning plane
+    parked off-centre — but inside a wide door — tows in cleanly. The gate only
+    rejects protrusions BESIDE the door, not through it; this is the positive
+    mirror of test_plane_wider_than_door_is_untowable.
+    """
+    from hangarfit.towplanner import path_first_conflict
+
+    def span_plane(pid: str) -> Aircraft:
+        return Aircraft(
+            id=pid,
+            name=pid,
+            wing_position="high",
+            gear="tailwheel",
+            movement_mode="always_own_gear",
+            turn_radius_m=4.0,
+            measured=False,
+            parts=(
+                Part(
+                    kind="fuselage_aft",
+                    length_m=3.0,
+                    width_m=0.6,
+                    offset_x_m=0.0,
+                    offset_y_m=0.0,
+                    angle_deg=0.0,
+                    z_bottom_m=0.0,
+                    z_top_m=1.0,
+                ),
+            ),
+            wheels=_TAIL_WHEELS,
+        )
+
+    # Wide door [4, 16]; the narrow plane parks off-centre at x = 6, well inside
+    # it, so its y<0 entry protrusion (x ~ [5.7, 6.3]) passes through the doorway.
+    h = _hangar(width_m=20.0, length_m=30.0, door_center=10.0, door_width=12.0)
+    fleet = {"P": span_plane("P")}
+    target = _layout(fleet, h, Placement("P", x_m=6.0, y_m=12.0, heading_deg=0.0, on_carts=False))
+    plan = plan_fill(target)
+    (move,) = plan.moves
+    assert move.plane_id == "P"
+    # The routed path is oracle-clean: no front-wall-beside-door clip anywhere.
+    empty = Layout(fleet=fleet, hangar=h, placements=())
+    assert path_first_conflict(move.path, fleet["P"], mover_on_carts=False, placed=empty) is None

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -324,3 +324,65 @@ def test_plan_fill_routes_origin_spanning_planes() -> None:
             is None
         )
         placed.append(slot)
+
+
+def test_plane_wider_than_door_is_untowable() -> None:
+    """#411: a plane whose wing span exceeds the door width cannot pass through
+    the door at any admissible entry orientation, so plan_fill reports it
+    un-towable (raises NoFeasiblePlanError naming it) rather than routing a path
+    that clips the solid front wall beside the door. This is the
+    "no orientation fits -> un-towable" half of the door-gate fix.
+    """
+
+    def wide_wing_plane(pid: str) -> Aircraft:
+        # 16 m wing span vs a 12 m door: no heading gets the wing through the gap.
+        return Aircraft(
+            id=pid,
+            name=pid,
+            wing_position="high",
+            gear="tailwheel",
+            movement_mode="always_own_gear",
+            turn_radius_m=5.0,
+            measured=False,
+            parts=(
+                Part(
+                    kind="wing",
+                    length_m=1.5,
+                    width_m=16.0,
+                    offset_x_m=0.0,
+                    offset_y_m=0.0,
+                    angle_deg=0.0,
+                    z_bottom_m=1.8,
+                    z_top_m=2.1,
+                ),
+                Part(
+                    kind="fuselage_aft",
+                    length_m=4.0,
+                    width_m=1.0,
+                    offset_x_m=0.0,
+                    offset_y_m=0.0,
+                    angle_deg=0.0,
+                    z_bottom_m=0.0,
+                    z_top_m=1.2,
+                ),
+            ),
+            wheels=_TAIL_WHEELS,
+        )
+
+    h = Hangar(
+        length_m=30.0,
+        width_m=30.0,
+        door=Door(center_x_m=15.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=15.0, width_m=2.0, depth_m=2.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.3,
+    )
+    fleet = {"W": wide_wing_plane("W")}
+    target = Layout(
+        fleet=fleet,
+        hangar=h,
+        placements=(Placement(plane_id="W", x_m=15.0, y_m=15.0, heading_deg=0.0, on_carts=False),),
+    )
+    with pytest.raises(NoFeasiblePlanError) as ei:
+        plan_fill(target)
+    assert ei.value.plane_id == "W"

--- a/tests/test_towplanner_motion.py
+++ b/tests/test_towplanner_motion.py
@@ -252,6 +252,25 @@ def test_reverse_through_door_is_front_gap_exempt(simple_hangar: Hangar) -> None
     assert path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed) is None
 
 
+def test_front_protrusion_through_solid_wall_beside_door_is_a_conflict(
+    simple_hangar: Hangar,
+) -> None:
+    """The front-gap exemption is door-AWARE (#411): a mover may straddle y < 0
+    only THROUGH the door opening, never the solid wall beside it. The spanning
+    plane towed up x = 4 protrudes to y = -2 at x ~= 4 — left of the door interval
+    [7, 13] — i.e. through the solid front wall / jamb. That must be a
+    hangar_bounds conflict, NOT exempt (contrast
+    test_front_door_protrusion_is_exempt_for_mover, which puts the same
+    protrusion at the door centre x = 10 and stays exempt)."""
+    fleet = {"B": _spanning_plane("B")}
+    placed = Layout(fleet=fleet, hangar=simple_hangar, placements=())
+    arc = plan_dubins(Pose(4.0, 0.0, 0.0), Pose(4.0, 10.0, 0.0), turn_radius_m=4.0)
+    conflict = path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed)
+    assert conflict is not None
+    assert conflict.kind == "hangar_bounds"
+    assert "B" in conflict.planes
+
+
 def test_reverse_into_side_wall_still_bounded(simple_hangar: Hangar) -> None:
     """The reverse front-gap exemption removes ONLY the y < 0 front wall. A
     plane backing into a SIDE wall (x < 0) while inside (y ≥ 0) still conflicts

--- a/tests/test_towplanner_motion.py
+++ b/tests/test_towplanner_motion.py
@@ -257,9 +257,9 @@ def test_front_protrusion_through_solid_wall_beside_door_is_a_conflict(
 ) -> None:
     """The front-gap exemption is door-AWARE (#411): a mover may straddle y < 0
     only THROUGH the door opening, never the solid wall beside it. The spanning
-    plane towed up x = 4 protrudes to y = -2 at x ~= 4 — left of the door interval
-    [7, 13] — i.e. through the solid front wall / jamb. That must be a
-    hangar_bounds conflict, NOT exempt (contrast
+    plane towed up x = 4 protrudes to y = -2 at x ~= 4 — left of the door opening
+    (door centre 10 +- 3 = [7, 13]) — i.e. through the solid front wall / jamb.
+    That must be a hangar_bounds conflict, NOT exempt (contrast
     test_front_door_protrusion_is_exempt_for_mover, which puts the same
     protrusion at the door centre x = 10 and stays exempt)."""
     fleet = {"B": _spanning_plane("B")}
@@ -269,6 +269,43 @@ def test_front_protrusion_through_solid_wall_beside_door_is_a_conflict(
     assert conflict is not None
     assert conflict.kind == "hangar_bounds"
     assert "B" in conflict.planes
+    # Specifically the front-wall-beside-door gate, not a side/back-wall hit
+    # (both are hangar_bounds) — pins which rule fired.
+    assert "front wall" in conflict.detail
+
+
+def test_front_protrusion_exactly_at_door_edge_is_exempt(simple_hangar: Hangar) -> None:
+    """#411 door-gate boundary: the door interval is INCLUSIVE. A y < 0 vertex
+    landing exactly on the jamb edge (x == door_lo) passes through the doorway,
+    not the solid wall, so it is exempt — guards the ``<=`` vs ``<`` off-by-one.
+    A 2 m-wide origin-spanning fuselage towed up x = 8 in the [7, 13] door puts a
+    y < 0 rear vertex at exactly x = 7.0 == door_lo (and x = 9.0, inside)."""
+    edge_plane = Aircraft(
+        id="B",
+        name="Edge B",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=4.0,
+        measured=False,
+        parts=(
+            Part(
+                kind="fuselage_aft",
+                length_m=4.0,
+                width_m=2.0,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.0,
+            ),
+        ),
+        wheels=_TAIL_WHEELS,
+    )
+    fleet = {"B": edge_plane}
+    placed = Layout(fleet=fleet, hangar=simple_hangar, placements=())
+    arc = plan_dubins(Pose(8.0, 0.0, 0.0), Pose(8.0, 10.0, 0.0), turn_radius_m=4.0)
+    assert path_first_conflict(arc, fleet["B"], mover_on_carts=False, placed=placed) is None
 
 
 def test_reverse_into_side_wall_still_bounded(simple_hangar: Hangar) -> None:


### PR DESCRIPTION
## What & why

Closes #411.

The v0.10.0 3D viewer showed a plane's wing clipping **through the solid wall beside the door** at tow t=0. Root cause: the tow planner's #222 front-gap exemption dropped the **entire** front wall for a mover in transit, so a plane straddling `y<0` *outside* the door opening (an off-centre or too-wide entry) was never rejected — and the viewer faithfully rendered that real entry pose.

## Fix

Make the front-gap exemption **door-aware** in `_mover_motion_bounds_conflict` — the shared oracle used by the entry-pose filter, the Hybrid-A\* `_motion_clear`, and `path_first_conflict`. A mover vertex at `y < 0` is a `hangar_bounds` conflict **unless** `door_lo ≤ x ≤ door_hi`. The door is now a true motion gate for the whole tow:

- **Off-centre entries that would clip are filtered** → the planner self-selects an angled/centred entry whose through-door footprint stays within the opening. Verified end-to-end: in `valid_left_side_nesting`, fuji now enters angled, every near-wall (`y<0`) vertex within the door `[3, 15]` (min x = 3.38 m), no wall clip.
- **A plane wider than the door at every admissible orientation is reported un-towable** (best-effort `plans[i]=None`, named in diagnostics) rather than drawn clipping — the ratified "no orientation fits → un-towable" behaviour.

Side/back walls unchanged; the legitimate through-the-door protrusion (the apron, spike Q6) is preserved.

## Determinism & safety

RNG-free / closed-form — the **ADR-0003 byte-identical planner contract holds** (determinism-guard **PASS**; canaries pass; `plan_fill` byte-identical across runs). No change to `solver.py` or `collisions.py`; the det-−1 transform is reused via `aircraft_parts_world`, not re-derived (ADR-0002).

## Tests

- NEW `test_front_protrusion_through_solid_wall_beside_door_is_a_conflict` — a `y<0` protrusion beside the door is a conflict.
- NEW `test_front_protrusion_exactly_at_door_edge_is_exempt` — the door interval is inclusive (`<=` boundary).
- NEW `test_plane_wider_than_door_is_untowable` — too-wide plane → `NoFeasiblePlanError`.
- NEW `test_off_centre_plane_within_door_still_routes` — the gate does not over-fire (positive mirror).
- REFRAMED `test_off_side_slot_cone_does_not_corner_cut_through_jamb` — see "entry-cone interaction" below.

The first three were confirmed **RED without the fix / GREEN with it**. Full suite 1200+ passed (the lone `test_solve_deterministic_given_seed` failure under the 280 s full run is the *documented* wall-clock-budget flake — passes in isolation, and runs `plan_paths=False` so this change isn't exercised). ruff + mypy clean.

## Heads-up: #262 entry-cone interaction

The reframed cone test previously asserted the entry-cone produced a strictly shorter path for an off-side slot. That ~6 mm "win" was itself a **jamb-clipping corner-cut** this fix correctly forbids, so the cone now equals v1 on that fixture. The cone still provides valid multi-start search + determinism (guarded by the other entry-cone tests). Whether the cone yields a *legal* strict path win on any fixture — or should be simplified/retired — is tracked in **#420**. Reframing (vs. hunting for a new strict-win geometry) was the maintainer's explicit choice.

## Review

determinism-guard (**PASS**) + `code-reviewer` + `pr-test-analyzer` + `comment-analyzer` — all clean on critical/important. The surfaced caller doc-staleness (the `plan_path`/`entry_poses` docs still called the exemption "unconditional" / the fallback "always fits") and 2 coverage gaps (door-edge boundary + over-fire) were fixed in the second commit.
