### PR TITLE
Apply the DocGerdSoft brand to the 3D viewer (environment, chrome, materials, HUD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
   view` now uses the dark-lifted fleet palette (`PLANES_DARK`, keyed by the same
   sorted id so 2D/3D plane identity is preserved), a unified scene shell
   (floor/grid/walls on the STATUS `wall` ink), a `maint`-violet maintenance bay
-  (retiring the off-system red), an accent fill light, branded HUD chrome (dark
+  (retiring the viewer's off-system red), an accent fill light, branded HUD chrome (dark
   neutrals, accent focus ring, amber honesty banner, Geist/mono typography), and a
   non-colour `⚠ conflict` label cue (the 3D analogue of the 2D hatch — "never hue
   alone"). Render-only: the `scene/v1` contract, the Python-owned determinant-−1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Brand source of truth in-repo (#414).** `docs/assets/BRAND.md` captures the
+  hangarfit brand (DocGerdSoft lineage + the 2D tokens + the 3D dark-surface
+  section + the full token table), so the viewer's colours, banners, and
+  typography trace to one document.
+
 ### Changed
+
+- **3D viewer renders on the DocGerdSoft dark-surface brand (#415).** `hangarfit
+  view` now uses the dark-lifted fleet palette (`PLANES_DARK`, keyed by the same
+  sorted id so 2D/3D plane identity is preserved), a unified scene shell
+  (floor/grid/walls on the STATUS `wall` ink), a `maint`-violet maintenance bay
+  (retiring the off-system red), an accent fill light, branded HUD chrome (dark
+  neutrals, accent focus ring, amber honesty banner, Geist/mono typography), and a
+  non-colour `⚠ conflict` label cue (the 3D analogue of the 2D hatch — "never hue
+  alone"). Render-only: the `scene/v1` contract, the Python-owned determinant-−1
+  transform, `build_scene` byte-determinism, and the collision model are unchanged.
 
 ### Fixed
 

--- a/docs/assets/BRAND.md
+++ b/docs/assets/BRAND.md
@@ -184,8 +184,8 @@ JS uses.
 | Emissive policy | body **none**; nose cone `colour × 0.25` (cap 0.30) | `boxMaterial` (no emissive) / `addLabelAndNose` nose `emissive` | nose ×0.25 | Lit fills stay honest so CVD separation holds under the key light; reserve a faint self-emit for the nose wayfinding cone only. |
 | Wing | `PLANES_DARK` colour, opacity **0.5** *(keep)* | `boxMaterial` `kind==='wing'` | 0.5 | Translucent so vertical stacking reads — the 3D analogue of 2D `_WING_ALPHA` (0.4). Matte body `roughness 0.7`. |
 | Strut | `PLANES_DARK` colour, `roughness 0.35` / `metalness 0.85` *(keep)* | `boxMaterial` `kind==='strut'` | same | Metallic so struts read as gear, distinct from the matte body. |
-| Cockpit (`fuselage_front`) | `colour × 0.55` (linear) *(keep)* | `boxMaterial` `multiplyScalar(0.55)` | ×0.55 | Darker cockpit tint = the perceptual match to 2D `_FUSELAGE_FRONT_DARKEN` (0.62 sRGB). |
-| Wheels | `#566573` *(keep)* | `WHEEL_COLOR = 0x566573` (= `visualize._WHEEL_COLOR`) | same | Gear slate, deliberately offset from `PLANES[8]` graphite `#5E646B` so gear never reads as plane-09. Tokenise as **Gear slate**. |
+| Cockpit (`fuselage_front`) | `colour × 0.55` (linear) *(keep)* | `boxMaterial` `multiplyScalar(0.55)` | ×0.55 | Darker cockpit tint = the 3D analogue of 2D `_FUSELAGE_FRONT_DARKEN` (0.62 sRGB) — same *intent* (a darker cockpit), applied in **linear** space, **not** a perceptual sRGB match (see the `boxMaterial` note in `viewer.js`). |
+| Wheels | `#566573` *(keep)* | `WHEEL_COLOR = 0x566573` (= `visualize._WHEEL_COLOR`) | same | Gear slate, deliberately offset from the graphite fleet fill (`PLANES[8]` `#5E646B` in 2D / `PLANES_DARK[8]` `#9AA0A8` in the 3D scene) so gear never reads as plane-09. Tokenise as **Gear slate**. |
 | Cart decks | `#AAB7B8` *(keep)* | `CART_DECK_COLOR = 0xaab7b8` (= `visualize._CART_DECK_COLOR`) | same | Lighter neutral so the dolly pallet separates from the darker wheel disc. Tokenise as **Cart deck**. |
 | Conflict | `#C8442C` **+ label cue** | `CONFLICT = 0xc8442c`; add `⚠ conflict` in `makeLabel` / chip bg `#C8442C` | `0xc8442c` (colour only) | STATUS `conflict` ink. The label suffix supplies the non-colour redundancy 3D can't hatch — honours "never hue alone." |
 | Nose arrow | plane `PLANES_DARK` colour, `emissive ×0.25` *(keep)* | `addLabelAndNose` nose material | plane hue | The wayfinding tip carries the plane's own identity hue + a faint self-emit. |
@@ -232,7 +232,7 @@ machine output in Geist Mono.
 
 These keep the *single source of truth* honest but touch `visualize.py`, not the
 viewer. Render-only, no test/contract impact beyond a deliberate value change;
-recommend bundling with #415 or a sibling issue:
+tracked as the sibling issue #418 (deliberately **not** folded into #415, which is 3D-only):
 
 - **Maintenance bay → `maint` violet.** The 2D closed-bay currently draws
   `_BAY_WALL_FACE #922b21` / `_BAY_WALL_EDGE #641e16` (a second red that the code

--- a/docs/assets/BRAND.md
+++ b/docs/assets/BRAND.md
@@ -1,0 +1,267 @@
+# hangarfit — Brand
+
+The single source of truth for the **hangarfit** product brand. hangarfit is a
+product brand derived from the umbrella **DocGerdSoft** design system; it inherits
+that system's neutral core, delta mark, Geist type, 8-pt grid, status inks and
+CVD-safety guarantees unchanged, and expresses itself through **exactly one
+accent**: Horizon blue `#0079B5` (dark-lifted `#3FA3D6`).
+
+This file folds in the existing 2D expression (matplotlib top-down render, marks,
+banner) and adds the **3D / dark-surface expression** for the offline Three.js
+viewer (`hangarfit view`). Issue #414 (this document) defines the brand; issue
+#415 applies it to `viewer.js` / `viewer.py`. Everything here is **render-only** —
+no change to the `scene/v1` contract, the Python-owned determinant-−1 transform,
+determinism, or the collision model.
+
+- **Parent system:** `DocGerd/brand` → `color/tokens.css`, `type/typography.css`,
+  `docs/brand-guidelines.md`.
+- **2D tokens & code:** `src/hangarfit/visualize.py` (top brand-palette block).
+- **3D surface:** `src/hangarfit/_viewer_assets/viewer.js`,
+  `src/hangarfit/viewer.py` (`_CSS` / `_HUD`); schema `docs/architecture/scene-v1-schema.md`; rationale ADR-0017.
+- **Marks:** `docs/assets/{banner,mark,monogram,avatar,favicon}.svg`.
+
+---
+
+## 1 · Lineage — what hangarfit inherits from DocGerdSoft
+
+The governing rule of the parent system: **one neutral core (fixed) + one wordmark
++ one grid; each product expresses itself through exactly one accent.** hangarfit
+follows it — only the accent rotates. Inherited verbatim:
+
+- **Personality.** "An instrument, not a poster." Calm, exact, Swiss-restraint.
+  One accent of *weight*, not colour. Machine output is always mono. Text measure
+  ≤ 70ch. No ®/™, no mascot, never imply a company.
+- **Type.** Geist (UI & text) + Geist Mono (machine output: code, ids, paths,
+  metrics, timestamps, kickers). Geist has **no italics** — emphasise with weight
+  (500/600), never slant or colour. Mono data: `tnum` + slashed `zero`, no
+  ligatures.
+- **Neutral core (dark mode).** `--paper #0D0E10` · `--surface #15171A` ·
+  `--mist #1B1E22` · `--mist-2 #141619` · `--hairline #2A2E33` ·
+  `--hairline-2 #202428` · `--graphite #969CA4` · `--graphite-strong #C2C7CD` ·
+  `--ink #ECEEF1`.
+- **Spacing (8-pt):** 4 · 8 · 12 · 16 · 24 · 32 · 48 · 64 · 96 · 128.
+  **Radius:** 3 / 6 / 10 / 16 / pill. **Focus ring:** the product accent.
+- **The "never hue alone" guarantee.** Identity and status must never rest on
+  colour alone — always a second, non-colour signal (ink outline, label, hatch,
+  dashed stroke). This is load-bearing for CVD-safety and B&W printouts.
+- **Status-ink meanings (fixed across surfaces).** `valid #0F7C72` ·
+  `conflict #C8442C` · `maint #7B63A3` · `wall·door·datum #3B4046`.
+
+### Accent — "Horizon" blue (the only hangarfit-specific colour)
+
+The signature DocGerdSoft accent is steel azure `#2C6CB0`. hangarfit rotates the
+hue a few degrees cooler — toward a clean flight horizon — at the same family
+lightness/chroma.
+
+| Token | Light | Dark | Contrast | Role |
+|---|---|---|---|---|
+| `--accent` | `#0079B5` | `#3FA3D6` | 4.77:1 on white · 6.7:1 on `#0D0E10` | Links, focus, primary action, mark, `fit` |
+| `--accent-strong` | `#005E94` | `#6BBCE2` | 6.93:1 on white | Hover / pressed |
+| `--accent-tint` | `#E4F1FA` | `#10242F` | — | Wash, selected, badges |
+
+> Evaluated & rejected: Sky `#128BBC` (3.86:1 — fails AA text), Deep `#295CA5`
+> (pulls back toward the signature azure). **Pick = `#0079B5`** (dark `#3FA3D6`).
+
+---
+
+## 2 · 2D expression (matplotlib top-down) — folded in
+
+The authoritative 2D token block, lifted verbatim into
+`src/hangarfit/visualize.py`. The categorical set is **Okabe–Ito-derived** and
+tuned so every fill also clears **≥ 3:1 on white** (WCAG non-text). Every plane
+also carries the `_INK_EDGE` (`#14161A`) outline and a mono id; conflicts add a
+hatch + dashed edge — never colour alone.
+
+### `PLANES` — one colour per aircraft (light figures, on white)
+
+| # | Name | Hex | on white |
+|---|---|---|---|
+| 01 | Horizon | `#0079B5` | 4.77 |
+| 02 | Vermillion | `#D55E00` | 3.87 |
+| 03 | Sea green | `#009E73` | 3.42 |
+| 04 | Orchid | `#B45CA6` | 4.18 |
+| 05 | Amber | `#B37903` | 3.71 |
+| 06 | Cyan | `#108FAA` | 3.80 |
+| 07 | Indigo | `#4C4C9E` | 7.41 |
+| 08 | Sienna | `#8A542D` | 6.20 |
+| 09 | Graphite | `#5E646B` | 5.98 |
+
+### `STATUS` & structure
+
+| Role | Hex | Notes |
+|---|---|---|
+| valid | `#0F7C72` | 5.06:1 |
+| conflict | `#C8442C` | 4.86:1 — always pair with hatch + ink edge |
+| maint | `#7B63A3` | 5.05:1 — maintenance-bay identity fill |
+| wall · door · datum | `#3B4046` | 10.5:1 — structure ink (`_HANGAR_EDGE`) |
+| ink edge | `#14161A` | `_INK_EDGE` — the "never hue alone" outline |
+
+### `PLANES_DARK` — lifted fills (dark figures, on `#0D0E10`)
+
+Same ordering/identity as `PLANES`; each row is the dark-surface expression of the
+same hue. Contrast measured on `#0D0E10`:
+
+| # | Hex | on `#0D0E10` |
+|---|---|---|
+| 01 | `#3FA3D6` | 6.7 |
+| 02 | `#E8794A` | 6.6 |
+| 03 | `#33B894` | 7.7 |
+| 04 | `#CE7EC0` | 6.7 |
+| 05 | `#D29A2E` | 7.7 |
+| 06 | `#3FB6CE` | 8.0 |
+| 07 | `#8585C9` | 5.6 |
+| 08 | `#BC8154` | 5.8 |
+| 09 | `#9AA0A8` | 7.2 |
+
+All clear WCAG AA (≥ 4.5:1) on the dark paper.
+
+---
+
+## 3 · 3D / dark-surface expression (the `hangarfit view` viewer)
+
+The 3D viewer is a **dark interactive scene** that exists to show the *vertical*
+clearances the 2D plan view can't — a high wing's shadow falling across a
+neighbour's tail (ADR-0017). The brand job here is to put that scene fully on the
+DocGerdSoft system: a `#0D0E10` room, neutral honest light so the CVD palette
+renders true, the plane fleet in `PLANES_DARK`, status inks unchanged, and HUD
+chrome built from the dark neutral core.
+
+**Three principles for the dark surface:**
+
+1. **Honest light.** Sky, hemisphere and key lights stay neutral white so a
+   plane's brand hue is the hue you see — no warm/cool cast that would erode the
+   CVD separation the palette was tuned for. The *only* coloured light is a faint
+   fill tinted from the horizon accent.
+2. **One token per role, across surfaces.** A wall is `#3B4046` in the PNG *and*
+   in the scene. The maintenance bay is `maint` violet in both. Conflict is
+   `#C8442C` in both. The viewer stops inventing ad-hoc slates and reds.
+3. **Never hue alone — in 3D too.** A 3D box can't hatch, so the redundant
+   non-colour signal moves to the billboard **label**: a conflicted plane's id
+   chip turns to the conflict ink *and* gains a `⚠ conflict` suffix, so the state
+   reads without colour.
+
+### Conflict redundancy in 3D
+
+2D pairs the conflict fill with a hatch + dashed edge. 3D has no hatch, so the
+non-colour cue is text: append `⚠ conflict` to the plane's label (already a
+`CanvasTexture` drawn with safe `fillText`) and flip the chip background to
+`#C8442C`. The plane fill also goes to the conflict ink. This keeps the
+"never hue alone" guarantee on the dark surface.
+
+---
+
+## 4 · Token table — drop straight into `viewer.js` / `viewer.py`
+
+Every value below is render-only. "Constant" names the exact `viewer.js` /
+`viewer.py` symbol to change. Hex shown as both `#RRGGBB` and the `0xRRGGBB` the
+JS uses.
+
+### Scene shell — `viewer.js`
+
+| Element | Recommended | Constant (where) | Currently | Rationale |
+|---|---|---|---|---|
+| Background | `#0D0E10` *(keep)* | `scene.background = 0x0d0e10` | `0x0d0e10` | Brand `--paper` dark. Already correct. |
+| Floor | `#15171A` | `floor` material `color` `0x16181c` → `0x15171a` | `0x16181c` | Brand `--surface` dark — the raised plane the fleet sits on. Keep `roughness:1` (matte, catches shadow). |
+| Grid major | `#3B4046` *(keep)* | `GridHelper(…, 0x3b4046, …)` | `0x3b4046` | STATUS `wall` ink — structural majors match the 2D wall colour. |
+| Grid minor | `#202428` | `GridHelper(…, …, 0x23262b)` → `0x202428` | `0x23262b` | Brand `--hairline-2` dark — the faintest structural line. |
+| Walls (+opacity) | `#3B4046` @ **0.20** | `addWall` material `color 0x4b5560` → `0x3b4046`, `opacity 0.16` → `0.20` | `0x4b5560` @ 0.16 | Unify on STATUS `wall` so "wall = `#3B4046`" in 2D **and** 3D; opacity nudged up so the darker pane still catches the key light. |
+| Maintenance bay (+opacity) | `#7B63A3` @ **0.32** | bay material `color 0x922b21` → `0x7b63a3`, `opacity 0.34` → `0.32` | `0x922b21` @ 0.34 | Brand STATUS `maint` violet. Removes the off-system red that collided with the conflict red; CVD-safe; ties the bay to one token across surfaces. |
+| Datum / door edge | `#3B4046`; threshold marker `#969CA4` if drawn | (no mesh today) | — | STATUS `wall·door·datum` ink. If a door threshold line is added, lift to `--graphite` dark so the opening reads as "open," mirroring the 2D `_DOOR_EDGE`. |
+
+### Lights — `viewer.js`
+
+| Element | Recommended | Constant | Currently | Rationale |
+|---|---|---|---|---|
+| Hemisphere | sky `#FFFFFF` / ground `#202428` @ **0.85** *(keep)* | `HemisphereLight(0xffffff, 0x202428, 0.85)` | same | Neutral white sky keeps hues honest; ground bounce = `--hairline-2` dark (already on-brand). |
+| Sun (key) | `#FFFFFF` @ **1.0** *(keep)* | `DirectionalLight(0xffffff, 1.0)` | same | Neutral white key so the CVD palette renders true; casts the contact shadows the viewer exists for. |
+| Fill | `#CFE3F2` @ **0.3** | `DirectionalLight(0xcfe0ff, 0.3)` → `0xcfe3f2` | `0xcfe0ff` @ 0.3 | The scene's *only* coloured light = a pale tint of the horizon accent (`#3FA3D6`), so even the soft fill belongs to the brand hue. |
+
+### Plane materials — `viewer.js`
+
+| Element | Recommended | Constant | Currently | Rationale |
+|---|---|---|---|---|
+| Plane fill | **`PLANES_DARK`** (by sorted-id index) | `p.color` in the scene JSON — emit `PLANES_DARK[i]` from `scene.py` (`_color_map`) instead of `PLANES[i]` | `PLANES` (light) | Dark-lifted CVD-safe fills (5.6–8.0:1 on `#0D0E10`). Same index → same plane: **identity parity with 2D is preserved, no hue reassignment.** |
+| Emissive policy | body **none**; nose cone `colour × 0.25` (cap 0.30) | `boxMaterial` (no emissive) / `addLabelAndNose` nose `emissive` | nose ×0.25 | Lit fills stay honest so CVD separation holds under the key light; reserve a faint self-emit for the nose wayfinding cone only. |
+| Wing | `PLANES_DARK` colour, opacity **0.5** *(keep)* | `boxMaterial` `kind==='wing'` | 0.5 | Translucent so vertical stacking reads — the 3D analogue of 2D `_WING_ALPHA` (0.4). Matte body `roughness 0.7`. |
+| Strut | `PLANES_DARK` colour, `roughness 0.35` / `metalness 0.85` *(keep)* | `boxMaterial` `kind==='strut'` | same | Metallic so struts read as gear, distinct from the matte body. |
+| Cockpit (`fuselage_front`) | `colour × 0.55` (linear) *(keep)* | `boxMaterial` `multiplyScalar(0.55)` | ×0.55 | Darker cockpit tint = the perceptual match to 2D `_FUSELAGE_FRONT_DARKEN` (0.62 sRGB). |
+| Wheels | `#566573` *(keep)* | `WHEEL_COLOR = 0x566573` (= `visualize._WHEEL_COLOR`) | same | Gear slate, deliberately offset from `PLANES[8]` graphite `#5E646B` so gear never reads as plane-09. Tokenise as **Gear slate**. |
+| Cart decks | `#AAB7B8` *(keep)* | `CART_DECK_COLOR = 0xaab7b8` (= `visualize._CART_DECK_COLOR`) | same | Lighter neutral so the dolly pallet separates from the darker wheel disc. Tokenise as **Cart deck**. |
+| Conflict | `#C8442C` **+ label cue** | `CONFLICT = 0xc8442c`; add `⚠ conflict` in `makeLabel` / chip bg `#C8442C` | `0xc8442c` (colour only) | STATUS `conflict` ink. The label suffix supplies the non-colour redundancy 3D can't hatch — honours "never hue alone." |
+| Nose arrow | plane `PLANES_DARK` colour, `emissive ×0.25` *(keep)* | `addLabelAndNose` nose material | plane hue | The wayfinding tip carries the plane's own identity hue + a faint self-emit. |
+
+### Labels & HUD — `viewer.js` (`makeLabel`) and `viewer.py` (`_CSS`)
+
+| Element | Recommended | Constant | Currently | Rationale |
+|---|---|---|---|---|
+| Label text | `#ECEEF1` | `makeLabel` `fillStyle '#e8eaed'` → `'#ECEEF1'` | `#e8eaed` | Brand `--ink` dark. |
+| Label chip bg | `rgba(21,23,26,0.86)` | `makeLabel` `fillStyle 'rgba(18,20,24,0.82)'` | `rgba(18,20,24,.82)` | Brand `--surface` dark @ 0.86 — the one **HUD glass**, shared with the HUD bar. |
+| Label / id font | Geist Mono → `ui-monospace` offline | `makeLabel` `ctx.font … 'system-ui'` → mono stack | system-ui | Plane ids are machine output → mono per brand; a mono fallback stack keeps it offline. |
+| HUD bar | `rgba(21,23,26,0.86)` + 1px top `#2A2E33` | `_CSS` `#hud{background:rgba(18,20,24,.86)}` | `rgba(18,20,24,.86)` | Brand surface glass; hairline top edge = `--hairline` dark. |
+| HUD buttons | bg `#1B1E22` / border `#2A2E33` / text `#ECEEF1`; focus ring `#3FA3D6` | `_CSS` `#hud button` (`#2a2d33` / `#3b4046`) | `#2a2d33` / `#3b4046` | Brand `--mist` / `--hairline` / `--ink` dark; accent focus ring = brand focus. |
+| Honesty / placeholder banner | bg `#D6A23E`, text `#14161A`, **700** | `_CSS` `#placeholder{background:#b00020}` | `#b00020` | Brand `--warning` (amber): semantically *"illustrative data,"* not a failure — and visibly distinct from the red error & red conflict. Keep the 2D PNG banner in parity (see §6). |
+| Note / error banner | bg `#BC4438`, text `#FFFFFF`, **600** | `_CSS` `#banner{background:#7a1f1f}` | `#7a1f1f` | Brand `--danger`: a real *"do not trust this render"* failure (WebGL/transform-check). One on-system red, kept separate from the conflict ink. |
+| Readouts text | `#C2C7CD`, mono, tabular | `_CSS` `#readouts{color:#aeb6c2}` | `#aeb6c2` | Brand `--graphite-strong` dark — readable but clearly secondary to white ink; mono-data figures. |
+| Legend chip text / dot | text `#ECEEF1`; dot = plane `PLANES_DARK` colour | `legend` `.sw` / `.sw i` | inherits | Body ink; dot carries the plane's dark fill (matches the scene). |
+| Body / HUD text colour | `#ECEEF1` | `_CSS` `body{color:#e8eaed}` → `#ECEEF1` | `#e8eaed` | Brand `--ink` dark. |
+
+---
+
+## 5 · Typography treatment — banner / HUD / labels
+
+Consistent with the hangarfit marks (`docs/assets/banner.svg`): Geist 600 wordmark,
+tracking −0.03em, all-lowercase to match the CLI command, **`fit` in the accent**;
+machine output in Geist Mono.
+
+- **Viewer wordmark** (title bar / about): `hangar` in `--ink`, `fit` in
+  `#3FA3D6`, Geist 600, −0.03em. The mark is the system delta in `#3FA3D6`.
+- **HUD bar.** Geist (`--sans`), 13px / 500 for button labels; offline fallback is
+  `system-ui` (Geist isn't vendored into the offline file — adopt the brand
+  `--sans` *stack* so Geist is used wherever present, else falls back at no cost).
+- **Machine output** — the clock (`0.0s`), readouts (`gap … · wing-over-tail …`),
+  `towing: <id>`, plane ids in labels and the legend — is **Geist Mono**, tabular
+  figures, slashed zero. Offline fallback `ui-monospace, "SF Mono", Menlo, monospace`.
+- **Label sprites.** Plane id in mono, `#ECEEF1` on the `rgba(21,23,26,0.86)` glass
+  chip; conflicted state appends `⚠ conflict` and flips the chip to `#C8442C`.
+- **Kickers / section eyebrows** (in any branded chrome): mono, uppercase, 0.16em
+  tracking, `--graphite` dark.
+
+---
+
+## 6 · Cross-surface parity follow-ups (2D PNG — outside the 3D scope)
+
+These keep the *single source of truth* honest but touch `visualize.py`, not the
+viewer. Render-only, no test/contract impact beyond a deliberate value change;
+recommend bundling with #415 or a sibling issue:
+
+- **Maintenance bay → `maint` violet.** The 2D closed-bay currently draws
+  `_BAY_WALL_FACE #922b21` / `_BAY_WALL_EDGE #641e16` (a second red that the code
+  itself notes must be "kept distinct" from the conflict red). Align it to STATUS
+  `maint #7B63A3` (fill) with an ink edge + retained hatch, matching the 3D bay and
+  removing the two-reds problem.
+- **Placeholder banner → `warning` amber.** The 2D `_draw_placeholder_banner` uses
+  `#b00020`; move it to `--warning #D6A23E` with `#14161A` text so the
+  "illustrative data" caution matches the viewer and is distinct from true errors.
+- **Net effect:** the system's reds resolve to three *distinct, on-token* signals —
+  **conflict** `#C8442C` (a collision), **danger/error** `#BC4438` (a render
+  failure), **warning** `#D6A23E` (illustrative data) — plus **maint** violet
+  `#7B63A3` for the bay. No more ad-hoc `#922b21` / `#b00020` / `#7a1f1f` reds.
+
+---
+
+## 7 · Assets — new / changed
+
+| File | Status | Note |
+|---|---|---|
+| `docs/assets/BRAND.md` | **new** | This file — hangarfit's single brand source of truth (lineage + 2D + 3D). |
+| `src/hangarfit/_viewer_assets/viewer.js` | change (#415) | Apply the §4 scene/light/material/label values. Render-only. |
+| `src/hangarfit/viewer.py` | change (#415) | Apply the §4 `_CSS` HUD/banner/readout values. |
+| `src/hangarfit/scene.py` | change (#415) | `_color_map` emits `PLANES_DARK[i]` for `p.color` (same index → same plane). Does **not** alter `scene/v1` shape. |
+| `src/hangarfit/visualize.py` | follow-up (§6) | Optional 2D parity: bay → `maint` violet, placeholder banner → `warning` amber. |
+| `docs/assets/hero-3d.png` | optional (new) | Rendered dark-scene hero for the README, alongside `banner.svg`. |
+| `docs/assets/{banner,mark,monogram,avatar,favicon}.svg` | unchanged | Marks inherited as-is; the viewer wordmark uses the same delta + Geist treatment. |
+
+---
+
+*© 2026 Patrick Kuhn · Apache-2.0 · DocGerdSoft is a personal brand, not a company.
+No ®/™. Built on the DocGerdSoft design system.*

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -86,7 +86,7 @@ sc.near = 0.5;
 sc.far = span * 3.5;
 sc.updateProjectionMatrix();
 scene.add(sun);
-const fill = new THREE.DirectionalLight(0xcfe0ff, 0.3); // cool soft fill, no shadow
+const fill = new THREE.DirectionalLight(0xcfe3f2, 0.3); // soft fill: pale tint of the horizon accent #3FA3D6, no shadow
 fill.position.set(H.width_m * 0.7, H.length_m * 1.2, span * 0.6);
 scene.add(fill);
 
@@ -110,13 +110,13 @@ const wallMeshes = [];
 function addHangar() {
   const floor = new THREE.Mesh(
     new THREE.PlaneGeometry(H.width_m, H.length_m),
-    new THREE.MeshStandardMaterial({ color: 0x16181c, roughness: 1, side: THREE.DoubleSide }),
+    new THREE.MeshStandardMaterial({ color: 0x15171a, roughness: 1, side: THREE.DoubleSide }),
   );
   floor.position.set(H.width_m / 2, H.length_m / 2, 0); // PlaneGeometry lies in XY (normal +Z)
   floor.receiveShadow = true; // catches the planes' contact shadows (#400)
   scene.add(floor);
 
-  const grid = new THREE.GridHelper(span, Math.round(span), 0x3b4046, 0x23262b);
+  const grid = new THREE.GridHelper(span, Math.round(span), 0x3b4046, 0x202428);
   grid.rotation.x = Math.PI / 2; // GridHelper is in XZ by default → rotate into XY
   grid.position.set(H.width_m / 2, H.length_m / 2, 0.003);
   scene.add(grid);
@@ -124,7 +124,7 @@ function addHangar() {
   const t = 0.08;
   const addWall = (sx, sy, x, y) => {
     const m = new THREE.MeshStandardMaterial({
-      color: 0x4b5560, transparent: true, opacity: 0.16, side: THREE.DoubleSide,
+      color: 0x3b4046, transparent: true, opacity: 0.20, side: THREE.DoubleSide,
     });
     const mesh = new THREE.Mesh(new THREE.BoxGeometry(sx, sy, WALL_H), m);
     mesh.position.set(x, y, WALL_H / 2);
@@ -143,7 +143,7 @@ function addHangar() {
   if (bay && bay.closed) {
     const bm = new THREE.Mesh(
       new THREE.BoxGeometry(bay.width_m, bay.depth_m, WALL_H),
-      new THREE.MeshStandardMaterial({ color: 0x922b21, transparent: true, opacity: 0.34 }),
+      new THREE.MeshStandardMaterial({ color: 0x7b63a3, transparent: true, opacity: 0.32 }),
     );
     bm.position.set(bay.center_x_m, H.length_m - bay.depth_m / 2, WALL_H / 2);
     scene.add(bm);
@@ -248,21 +248,26 @@ function boxMaterial(b, colour) {
 // the plane-local +x tip show which plane is which and which way it faces.
 const labelMeshes = [];
 const noseMeshes = [];
-function makeLabel(text) {
+function makeLabel(text, conflicted = false) {
+  // Plane ids are machine output → mono (brand). A conflicted plane carries the
+  // non-colour "never hue alone" cue 3D can't hatch: a " ⚠ conflict" suffix and
+  // the conflict-ink chip instead of the surface glass (BRAND.md §3).
+  const shown = conflicted ? text + ' ⚠ conflict' : text;
   const fontPx = 64, padX = 14, padY = 8;
+  const fontStack = "px ui-monospace, 'SF Mono', Menlo, monospace";
   const measure = document.createElement('canvas').getContext('2d');
-  measure.font = fontPx + 'px system-ui, sans-serif';
-  const tw = Math.ceil(measure.measureText(text).width);
+  measure.font = fontPx + fontStack;
+  const tw = Math.ceil(measure.measureText(shown).width);
   const canvas = document.createElement('canvas');
   canvas.width = tw + padX * 2;
   canvas.height = fontPx + padY * 2;
   const ctx = canvas.getContext('2d');
-  ctx.font = fontPx + 'px system-ui, sans-serif';
+  ctx.font = fontPx + fontStack;
   ctx.textBaseline = 'middle';
-  ctx.fillStyle = 'rgba(18,20,24,0.82)';
+  ctx.fillStyle = conflicted ? '#C8442C' : 'rgba(21,23,26,0.86)';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
-  ctx.fillStyle = '#e8eaed';
-  ctx.fillText(text, padX, canvas.height / 2); // SAFE: canvas fillText, never innerHTML (ids are user YAML)
+  ctx.fillStyle = '#ECEEF1';
+  ctx.fillText(shown, padX, canvas.height / 2); // SAFE: canvas fillText, never innerHTML (ids are user YAML)
   const tex = new THREE.CanvasTexture(canvas);
   tex.anisotropy = 4;
   const sprite = new THREE.Sprite(
@@ -273,7 +278,7 @@ function makeLabel(text) {
   sprite.renderOrder = 999; // float above geometry (depthTest off)
   return sprite;
 }
-function addLabelAndNose(g, p, colour) {
+function addLabelAndNose(g, p, colour, conflicted) {
   let maxTop = 0, sx = 0, sy = 0, noseX = -Infinity, noseZ = 0;
   for (const b of p.boxes) {
     maxTop = Math.max(maxTop, b.cz + b.height_m / 2);
@@ -286,7 +291,7 @@ function addLabelAndNose(g, p, colour) {
   if (!isFinite(noseX)) noseX = 0;
   if (noseZ === 0) noseZ = maxTop * 0.5;
 
-  const label = makeLabel(p.id);
+  const label = makeLabel(p.id, conflicted);
   label.position.set(sx / n, sy / n, maxTop + 1.0); // above the plane, in plane-local
   g.add(label);
   labelMeshes.push(label);
@@ -324,7 +329,7 @@ for (const p of SCENE.planes) {
     g.add(mesh);
   }
   addGear(g, p); // wheels + legs (+ pallets when carted), same affine Group
-  addLabelAndNose(g, p, colour); // id label + nose arrow, HUD-toggleable
+  addLabelAndNose(g, p, colour, conflicted); // id label + nose arrow, HUD-toggleable
   groups[p.id] = g;
   scene.add(g);
 

--- a/src/hangarfit/scene.py
+++ b/src/hangarfit/scene.py
@@ -21,7 +21,7 @@ from hangarfit import metrics
 from hangarfit.geometry import aircraft_parts_world, local_to_world
 from hangarfit.models import CheckResult, Layout, Placement
 from hangarfit.towplanner import back_first_order
-from hangarfit.visualize import PLANES
+from hangarfit.visualize import PLANES_DARK
 
 if TYPE_CHECKING:
     from hangarfit.towplanner import DubinsArc, MovesPlan
@@ -40,10 +40,12 @@ _COORD_NOTE = (
 
 
 def _color_map(plane_ids: list[str]) -> dict[str, str]:
-    """Stable per-plane colour by sorted id — parity with
-    :func:`hangarfit.visualize._plane_colour_map` so 2D and 3D agree."""
+    """Stable per-plane fill by sorted id, dark-lifted for the ``#0D0E10`` 3D
+    surface (``PLANES_DARK``). Same sorted-id index as
+    :func:`hangarfit.visualize._plane_colour_map`, so 2D and 3D keep the same
+    plane->colour identity (ADR-0017 brand parity, #415)."""
     ordered = sorted(set(plane_ids))
-    return {pid: PLANES[i % len(PLANES)] for i, pid in enumerate(ordered)}
+    return {pid: PLANES_DARK[i % len(PLANES_DARK)] for i, pid in enumerate(ordered)}
 
 
 def _hangar_block(layout: Layout) -> dict:

--- a/src/hangarfit/viewer.py
+++ b/src/hangarfit/viewer.py
@@ -78,9 +78,10 @@ def render_viewer(scene: dict, output_path: Path | str) -> None:
     Path(output_path).write_text(html, encoding="utf-8")
 
 
-# DocGerdSoft dark-surface brand (BRAND.md §4). Form controls (button, select,
-# input) don't inherit font-family, so the Geist / Geist-Mono stacks are set
-# explicitly on them; machine output (clock, readouts, ids) is mono per brand.
+# DocGerdSoft dark-surface brand (BRAND.md §4). Form controls don't inherit
+# font-family, so the Geist stack is set explicitly on the text-bearing controls
+# (the HUD buttons + the speed select); machine output (clock, readouts, ids) is
+# mono per brand.
 _CSS = (
     "html,body{margin:0;height:100%;background:#0d0e10;color:#ECEEF1;"
     'font:13px "Geist",system-ui,sans-serif;overflow:hidden}'
@@ -91,6 +92,7 @@ _CSS = (
     "#hud button{cursor:pointer;background:#1B1E22;color:#ECEEF1;border:1px solid #2A2E33;"
     'font:500 13px "Geist",system-ui,sans-serif;'
     "border-radius:6px;padding:5px 10px}#hud button:disabled{opacity:.4;cursor:default}"
+    '#hud select{font:500 13px "Geist",system-ui,sans-serif}'
     "#hud button:focus,#scrub:focus{outline:2px solid #3FA3D6;outline-offset:2px}"
     "#scrub{flex:1;min-width:160px;accent-color:#3FA3D6}"
     "#banner{position:fixed;top:0;left:0;right:0;padding:10px;background:#BC4438;color:#fff;"

--- a/src/hangarfit/viewer.py
+++ b/src/hangarfit/viewer.py
@@ -78,20 +78,28 @@ def render_viewer(scene: dict, output_path: Path | str) -> None:
     Path(output_path).write_text(html, encoding="utf-8")
 
 
+# DocGerdSoft dark-surface brand (BRAND.md §4). Form controls (button, select,
+# input) don't inherit font-family, so the Geist / Geist-Mono stacks are set
+# explicitly on them; machine output (clock, readouts, ids) is mono per brand.
 _CSS = (
-    "html,body{margin:0;height:100%;background:#0d0e10;color:#e8eaed;"
-    "font:13px system-ui,sans-serif;overflow:hidden}"
+    "html,body{margin:0;height:100%;background:#0d0e10;color:#ECEEF1;"
+    'font:13px "Geist",system-ui,sans-serif;overflow:hidden}'
     "#c{display:block;width:100vw;height:100vh}"
     "#hud{position:fixed;left:0;right:0;bottom:0;padding:10px 14px;"
-    "background:rgba(18,20,24,.86);display:flex;gap:10px;align-items:center;flex-wrap:wrap}"
-    "#hud button{cursor:pointer;background:#2a2d33;color:#e8eaed;border:1px solid #3b4046;"
+    "background:rgba(21,23,26,.86);border-top:1px solid #2A2E33;"
+    "display:flex;gap:10px;align-items:center;flex-wrap:wrap}"
+    "#hud button{cursor:pointer;background:#1B1E22;color:#ECEEF1;border:1px solid #2A2E33;"
+    'font:500 13px "Geist",system-ui,sans-serif;'
     "border-radius:6px;padding:5px 10px}#hud button:disabled{opacity:.4;cursor:default}"
-    "#scrub{flex:1;min-width:160px}"
-    "#banner{position:fixed;top:0;left:0;right:0;padding:10px;background:#7a1f1f;color:#fff;"
+    "#hud button:focus,#scrub:focus{outline:2px solid #3FA3D6;outline-offset:2px}"
+    "#scrub{flex:1;min-width:160px;accent-color:#3FA3D6}"
+    "#banner{position:fixed;top:0;left:0;right:0;padding:10px;background:#BC4438;color:#fff;"
     "text-align:center;z-index:9;font-weight:600}"
-    "#placeholder{position:fixed;top:0;left:0;right:0;padding:7px;background:#b00020;"
-    "color:#fff;text-align:center;z-index:8;font-weight:700;letter-spacing:.02em}"
-    "#readouts{color:#aeb6c2;font-variant-numeric:tabular-nums}"
+    "#placeholder{position:fixed;top:0;left:0;right:0;padding:7px;background:#D6A23E;"
+    "color:#14161A;text-align:center;z-index:8;font-weight:700;letter-spacing:.02em}"
+    '#clock,#active,#readouts,.sw{font-family:"Geist Mono",ui-monospace,'
+    '"SF Mono",Menlo,monospace;font-feature-settings:"tnum" 1,"zero" 1}'
+    "#readouts{color:#C2C7CD;font-variant-numeric:tabular-nums}"
     "#legend{display:flex;gap:8px;flex-wrap:wrap}"
     ".sw{display:inline-flex;align-items:center;gap:4px}"
     ".sw i{width:11px;height:11px;border-radius:2px;display:inline-block}"

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -18,6 +18,7 @@ from hangarfit.geometry import aircraft_parts_world, oriented_rect
 from hangarfit.loader import load_layout
 from hangarfit.models import Aircraft, Part, Placement, Wheels
 from hangarfit.towplanner import back_first_order, plan_fill
+from hangarfit.visualize import PLANES, PLANES_DARK
 
 LAYOUT = "tests/fixtures/valid_left_side_nesting.yaml"
 
@@ -26,13 +27,26 @@ LAYOUT = "tests/fixtures/valid_left_side_nesting.yaml"
 
 
 def test_color_map_is_sorted_id_keyed():
-    assert scene._color_map(["b", "a"]) == {"a": scene.PLANES[0], "b": scene.PLANES[1]}
+    assert scene._color_map(["b", "a"]) == {
+        "a": PLANES_DARK[0],
+        "b": PLANES_DARK[1],
+    }
 
 
 def test_color_map_wraps_palette():
-    ids = [f"p{i:02d}" for i in range(len(scene.PLANES) + 2)]
+    ids = [f"p{i:02d}" for i in range(len(PLANES_DARK) + 2)]
     cm = scene._color_map(ids)
-    assert cm[ids[0]] == cm[ids[len(scene.PLANES)]]  # wraps with %
+    assert cm[ids[0]] == cm[ids[len(PLANES_DARK)]]  # wraps with %
+
+
+def test_plane_colors_are_dark_palette():
+    """#415: the 3D scene emits the dark-lifted fleet fills (PLANES_DARK), not
+    the light 2D PLANES — brand parity on the #0D0E10 surface."""
+    lay = load_layout(LAYOUT)
+    emitted = {b["color"] for b in scene._plane_blocks(lay)}
+    assert emitted, "expected at least one plane block"
+    assert emitted <= set(PLANES_DARK)
+    assert emitted.isdisjoint(set(PLANES) - set(PLANES_DARK))
 
 
 def test_hangar_block_shape():

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -102,6 +102,31 @@ def test_html_embeds_honesty_banner_and_readouts(tmp_path):
     assert scene_json["readouts"] is not None
 
 
+def test_html_carries_brand_3d_tokens(tmp_path):
+    # #415: the generated viewer embeds the DocGerdSoft dark-surface brand. These
+    # are string-presence guards (pixels are checked by the headless screenshot);
+    # every viewer.js literal is always in the inlined module text and every CSS
+    # token always in the <style> block, so one fixture suffices.
+    html = _html(tmp_path)
+    # HUD chrome (viewer.py _CSS)
+    assert "#D6A23E" in html  # placeholder/honesty banner -> warning amber
+    assert "#14161A" in html  # ...with dark ink on the amber
+    assert "#BC4438" in html  # error banner -> danger red
+    assert "outline:2px solid #3FA3D6" in html  # accent focus ring
+    assert "accent-color:#3FA3D6" in html  # branded range scrubber
+    assert "#C2C7CD" in html  # readouts -> --graphite-strong dark
+    assert '"Geist Mono"' in html  # machine-output mono stack
+    # Scene shell + lights (viewer.js)
+    assert "0x15171a" in html  # floor -> --surface dark
+    assert "0x202428" in html  # grid minor -> --hairline-2 dark
+    assert "0x7b63a3" in html  # maintenance bay -> maint violet
+    assert "opacity: 0.20" in html  # walls -> lifted opacity
+    assert "0xcfe3f2" in html  # fill light -> pale accent tint
+    # Never-hue-alone conflict cue (viewer.js)
+    assert "⚠ conflict" in html  # non-colour label suffix the 3D box can't hatch
+    assert "ui-monospace" in html  # mono label stack
+
+
 def test_static_scene_renders(tmp_path):
     # A layout with no MovesPlan → static scene, still a valid HTML artifact.
     lay = load_layout(LAYOUT)


### PR DESCRIPTION
Closes #415

Render-only application of the ratified DocGerdSoft **dark-surface brand** to the `hangarfit view` 3D viewer. The brand spec landed first as `docs/assets/BRAND.md` (the in-repo source of truth, #414); this PR applies it.

## What changed

- **`scene.py`** — `_color_map` emits the dark-lifted `PLANES_DARK` fleet fill, keyed by the **same sorted plane id**, so 2D↔3D plane identity is preserved (no hue reassignment).
- **`_viewer_assets/viewer.js`** — scene shell on brand tokens (floor `#15171A`, grid minor `#202428`, walls unified on STATUS `wall #3B4046` @0.20, maintenance bay → `maint #7B63A3`), accent fill light (`#CFE3F2`), label ink/glass + **mono** id text, and the new **`⚠ conflict` label cue** (the non-colour "never hue alone" redundancy a 3D box can't hatch).
- **`viewer.py` `_CSS`** — HUD chrome on the dark neutral core, **accent focus ring**, **amber honesty banner** (`#D6A23E`, replacing the off-system red), danger banner `#BC4438`, readouts `#C2C7CD`, Geist/Geist-Mono font stacks.
- **`docs/assets/BRAND.md`** — new; the brand source of truth.
- Tests: `test_scene.py` colour pin moved to `PLANES_DARK` + a dark-palette guard; `test_viewer.py` gains a brand-token regression guard.

## Invariants held

- **Render-only.** No change to the `scene/v1` contract, the Python-owned determinant-−1 transform (`geometry.local_to_world`), or the collision model (ADR-0015 / ADR-0017).
- `build_scene` stays **byte-deterministic** (`test_build_scene_is_byte_deterministic` green — the colour swap is a pure constant substitution).
- Viewer stays **offline / self-contained**; ids still rendered via `fillText` (never `innerHTML`).
- New colours are CVD-safe (Okabe–Ito-derived, #326).

## Verification

- Full suite **1201 passed** (9 @slow deselected); ruff + ruff-format + mypy clean.
- Headless swiftshader screenshots (towable animated + a conflicted/placeholder scene): dark room renders, amber honesty banner shows, conflicting planes render in conflict red **with `⚠ conflict` label chips**, and **no transform-mismatch banner**.

## Follow-ups filed

- #418 — 2D parity (bay→`maint` violet, placeholder→`warning` amber in `visualize.py`), deliberately out of this 3D-only scope.
- #419 — centralize brand tokens into one machine-readable source (consume, don't hard-code per file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)