### PR TITLE
Add real Airfield Herrenteich dataset (hangar + fleet + valid all-8 layout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Real Airfield Herrenteich dataset (`herrenteich/`, refs #79).** A
+  self-contained real-world dataset kept separate from the synthetic `data/`
+  placeholders: the DWG-measured hangar (15.08 m × 31.76 m, 13.46 m door), the
+  eight aircraft usually hangared there (published-spec dimensions,
+  second-source verified; adds a folded **Stemme S10** and a confirmed 18 m
+  Scheibe SF-25E; drops Fuji/Cessna 150), and a valid all-eight `layout.yaml`
+  (`hangarfit check` → exit 0) with a regression test. Surfaced two follow-ups:
+  the L-shaped hangar's office **notch** is not yet modelled (spike #424, the
+  files keep clear of it by hand), and the solver's bounding-box
+  trivial-infeasibility gate false-rejects this glider fleet (#425) — the layout
+  was found by driving the real part-collision checker directly. The default
+  `data/` demo data is unchanged.
 - **Brand source of truth in-repo (#414).** `docs/assets/BRAND.md` captures the
   hangarfit brand (DocGerdSoft lineage + the 2D tokens + the 3D dark-surface
   section + the full token table), so the viewer's colours, banners, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ This file is the durable **operational** context for the project: how we work, w
 | **The maintenance bay rule** (current `bay_intrusion` semantics) | [§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md#the-maintenance-bay-rule) + [ADR-0006](docs/adr/0006-bay-intrusion-maintenance-rule.md). The Phase 1 predecessor is preserved as [ADR-0005](docs/adr/0005-maintenance-bay-rule.md) (Superseded by ADR-0006). |
 | Fleet composition (per-plane wing type, gear, movement mode, struts, canonical wheel positions) | [`data/fleet.yaml`](data/fleet.yaml) — the source of truth; §8 calls out the strut-braced subset and the only low-wing. Wheel positions are canonical per-aircraft data ([ADR-0013](docs/adr/0013-wheels-canonical-data.md)), not renderer heuristics |
 | Hangar dimensions, door, maintenance bay rectangle | [`data/hangar.yaml`](data/hangar.yaml) — all values currently placeholders pending real measurement |
+| **The real Airfield Herrenteich dataset** (DWG-measured hangar + published-spec, second-source-verified fleet incl. a folded Stemme S10 + a valid all-8 `layout.yaml`), kept **separate** from the synthetic `data/` placeholders | [`herrenteich/`](herrenteich/README.md) — real data; `data/` stays the synthetic demo/test fixtures |
 | Default clearances (`clearance_m`, `wing_layer_clearance_m`) | [§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md#default-clearances) |
 | RR-MC solver algorithm and the determinism contract | [ADR-0003](docs/adr/0003-rr-mc-solver-algorithm.md) |
 | Diversity metric (edit-count, thresholds) | [ADR-0004](docs/adr/0004-diversity-metric.md) |
@@ -146,11 +147,13 @@ Vulnerability reporting lives in [SECURITY.md](SECURITY.md). The rationale for t
 
 ## Open questions / TBD before trusting output
 
-- **Real measurements** for every aircraft (`measured: false` in `fleet.yaml`). All current dimensions are eyeballed placeholders.
-- **Real hangar measurements** (`data/hangar.yaml`) — length, width, door position and width, maintenance bay rectangle (`center_x_m`, `width_m`, `depth_m` — back-anchored, partial-width).
-- **Placeholder hangar can't fit the full fleet.** The placeholder hangar in [`data/hangar.yaml`](data/hangar.yaml) is too tight to fit every aircraft at once under the placeholder clearance budget. The default [`layouts/example.yaml`](layouts/example.yaml) is a deliberate 6-plane subset; test fixtures that need the full fleet use [`tests/fixtures/test_hangar_large.yaml`](tests/fixtures/test_hangar_large.yaml). Real hangar measurements will reset this.
+- **`data/` is synthetic.** Every aircraft (`measured: false` in `fleet.yaml`) and the hangar in `data/hangar.yaml` are eyeballed placeholders — kept deliberately as the stable demo/test fixtures.
+- **Real data lives in [`herrenteich/`](herrenteich/README.md)** (since #426): the DWG-measured hangar (15.08 × 31.76 m, 13.46 m door) and the eight usual occupants on published-spec, second-source-verified dimensions (still `measured: false` — published specs, not on-site). Two modelling gaps it surfaced:
+  - **The real hangar is L-shaped; the model is a rectangle.** Its back-right office **notch** (~2.36 × 9.10 m) is recorded only in comments and avoided by hand; teaching the model the notch is **spike #424**.
+  - **`hangarfit solve` false-rejects glider fleets** (#425): its trivial-infeasibility gate sums *bounding boxes*, so an 18 m-span glider trips it (Σ bbox > floor) even when a nested layout is valid. The Herrenteich layout was built by driving `collisions.check` directly, **not** `solve`.
+- **Placeholder hangar can't fit the full fleet.** The placeholder hangar in [`data/hangar.yaml`](data/hangar.yaml) is too tight to fit every aircraft at once under the placeholder clearance budget. The default [`layouts/example.yaml`](layouts/example.yaml) is a deliberate 6-plane subset; test fixtures that need the full fleet use [`tests/fixtures/test_hangar_large.yaml`](tests/fixtures/test_hangar_large.yaml).
 
-The collision checker will run on placeholder data, but until the measurements are real, the output is illustrative only.
+The collision checker will run on the `data/` placeholders, but until those are real, output on them is illustrative only (the `herrenteich/` hangar is real; its fleet is published-spec).
 
 ---
 

--- a/herrenteich/README.md
+++ b/herrenteich/README.md
@@ -33,15 +33,15 @@ Teaching the model the notch is spike **#424**.
 **2. `layout.yaml` is the tool's arrangement, not the club's real parking.**
 The product solver (`hangarfit solve`) cannot produce this layout: its
 trivial-infeasibility gate sums *bounding boxes* (Σ ≈ 606 m² > the 479 m²
-floor) and bails, because an 18 m-span motor glider is mostly empty air — see
+rectangular floor) and bails, because an 18 m-span motor glider is mostly empty air — see
 **#425**. The real, part-based collision checker accepts a nested layout, so
 this one was found by driving that checker directly. Replace the placements
 with the club's real parking positions when known.
 
 ## Notable aircraft
 
-- **Scheibe SF-25E Super Falke** — 18 m span, wider than the 15.08 m door wall,
-  so it parks lengthwise. Being a monowheel it can be *tilted* (one wing up,
+- **Scheibe SF-25E Super Falke** — 18 m span, wider than the 15.08 m hangar
+  width, so it parks lengthwise. Being a monowheel it can be *tilted* (one wing up,
   the other down), which is how a glider that wide nests with its neighbours;
   the single-layer wing model is a simplification of that tilt (see
   `fleet.yaml` header).

--- a/herrenteich/README.md
+++ b/herrenteich/README.md
@@ -1,0 +1,53 @@
+# Airfield Herrenteich — real dataset
+
+A self-contained, **real-world** dataset for the club's main-building hangar,
+kept separate from the synthetic placeholders in `data/` (which stay as the
+project's stable demo/test fixtures). Nothing here is wired into the default
+CLI paths — point the tools at these files explicitly.
+
+```bash
+# Validate the "everyone home" layout (all eight usual occupants):
+hangarfit check herrenteich/layout.yaml --render herrenteich.png
+
+# 3D viewer:
+hangarfit view herrenteich/layout.yaml -o herrenteich.html
+```
+
+## Files
+
+| File | What it is |
+|---|---|
+| `hangar.yaml` | The real hangar — **15.08 m × 31.76 m**, door **13.46 m** wide. Measured 2026-06-04 from the architect's DWG. |
+| `fleet.yaml`  | The eight aircraft usually hangared here. Dimensions looked up from published specs and second-source verified (2026-06-04). |
+| `layout.yaml` | A **valid** arrangement with all eight planes parked at once (`hangarfit check` → exit 0). |
+| `scenario.yaml` | The solver input for the "everyone home" scenario. |
+
+## Two things this dataset is honest about
+
+**1. The hangar is L-shaped; the model is a rectangle.** The real back-right
+corner is notched out (~2.36 m × 9.10 m) — that's office/annex space, not
+hangar floor. The model only has a rectangle, so `hangar.yaml` records the
+bounding rectangle and the files keep planes clear of the notch by hand.
+Teaching the model the notch is spike **#424**.
+
+**2. `layout.yaml` is the tool's arrangement, not the club's real parking.**
+The product solver (`hangarfit solve`) cannot produce this layout: its
+trivial-infeasibility gate sums *bounding boxes* (Σ ≈ 606 m² > the 479 m²
+floor) and bails, because an 18 m-span motor glider is mostly empty air — see
+**#425**. The real, part-based collision checker accepts a nested layout, so
+this one was found by driving that checker directly. Replace the placements
+with the club's real parking positions when known.
+
+## Notable aircraft
+
+- **Scheibe SF-25E Super Falke** — 18 m span, wider than the 15.08 m door wall,
+  so it parks lengthwise. Being a monowheel it can be *tilted* (one wing up,
+  the other down), which is how a glider that wide nests with its neighbours;
+  the single-layer wing model is a simplification of that tilt (see
+  `fleet.yaml` header).
+- **Stemme S10** — hangared **wings folded** (11.4 m span; 23 m unfolded), which
+  is what lets a 23 m glider through a 13.46 m door.
+
+> All fleet dimensions carry `measured: false` — they are published specs, not
+> on-site measurements, so the viewer/PNG show the "PLACEHOLDER DATA" honesty
+> banner. The hangar rectangle itself is from the DWG.

--- a/herrenteich/fleet.yaml
+++ b/herrenteich/fleet.yaml
@@ -1,0 +1,320 @@
+# Airfield Herrenteich — real fleet (the aircraft usually hangared here).
+#
+# Kept separate from the synthetic data/fleet.yaml (the project's stable
+# demo/test fixture). Roster per the operator (2026-06-04): Cessna 140,
+# Flight Design CTSL, Wild Thing, Aviat Husky, Scheibe SF-25E, FK9 Mk II,
+# Stemme S10 (hangared WINGS-FOLDED), Zlin Savage. (Fuji and the Cessna 150
+# are not based here.)
+#
+# DIMENSIONS were looked up from published manufacturer / type-certificate /
+# reference specs on 2026-06-04 and each was independently second-source
+# verified (web research + cross-check). Span / length / height below reflect
+# those published figures (in metres). Verified primary dims:
+#
+#   id             span(m)  len(m)  height(m)  notes
+#   cessna_140     10.16    6.55    1.91       strut high-wing taildragger
+#   ctsl            8.59    6.60    2.34       cantilever high-wing, nosewheel
+#   wild_thing      9.15    6.49    1.90       ULBI Wild Thing WT-02, strut
+#   aviat_husky    10.82    6.88    2.26       Husky A-1C, strut taildragger
+#   scheibe_falke  18.00    7.58    1.85       SF-25E Super Falke motor glider
+#   fk9_mkii        9.85    5.85    2.15       FK9 Mk II, strut high-wing
+#   stemme_s10     23.00*   8.42    1.80       *11.40 m FOLDED (hangar config)
+#   zlin_savage     9.31    6.39    2.03       Savage Cub, strut taildragger
+#
+# measured: false is kept on every entry — these are PUBLISHED specs, not
+# on-site tape/laser measurements, so they still raise the viewer's
+# "PLACEHOLDER DATA" honesty banner. Flip to true once verified on site.
+#
+# MODELLING NOTES (see data/fleet.yaml header for the full parts-model
+# conventions and ADR-0012/0013):
+# - Each Part is an oriented rectangle: length_m along plane +x (fore-aft),
+#   width_m along plane +y (lateral = wingspan for the wing part).
+# - Part z_bottom/z_top encode the vertical layer that the nesting rule uses
+#   (a high wing may legally overhang a neighbour's lower tail/fuselage when
+#   z-disjoint). High wings sit ~1.9-2.3 m; fuselages ~0-1.5 m.
+# - scheibe_falke (SF-25E) is a MONOWHEEL motor glider: resting on its single
+#   main wheel it can be TILTED — raising one wingtip high while the other
+#   drops onto a tip outrigger/skid. It is a seesaw: one wing up necessarily
+#   means the other goes down. That tilt lets a raised half-wing overhang a
+#   neighbour AND a lowered half-wing tuck under another aircraft's high wing.
+#   The single-z parts model cannot express the tilt, so the FULL 18 m wing is
+#   modelled in the high z-layer. This is a deliberate simplification that
+#   slightly OVERSTATES the nestable span (physically only the up-tilted ~half
+#   is high at any moment). Revisit when a tilt-aware model exists.
+# - stemme_s10 is modelled in its WINGS-FOLDED hangar configuration: the
+#   wing part width is the folded 11.40 m span (unfolded 23 m would not enter
+#   the 13.46 m door). Folded outer panels raise the effective height.
+
+aircraft:
+  # ----------------------------------------------------------------------------
+  # MOTORGLIDER — Scheibe SF-25E Super Falke. 18 m span (longest in the fleet);
+  # too wide for the 15.08 m hangar nose-in, so it parks lengthwise. Cantilever,
+  # monowheel + outriggers, always on carts.
+  # ----------------------------------------------------------------------------
+  - id: scheibe_falke
+    name: "Scheibe SF-25E Super Falke"
+    wing_position: high
+    gear: monowheel
+    movement_mode: always_cart
+    turn_radius_m: null  # always_cart → towplanner uses 0 (pivot); see ADR-0007
+    measured: false
+    notes: "18 m span, folds to ~10 m (not folded here). Monowheel → tiltable (one wing up, the other down on a tip outrigger). Full wing modelled in the high z-layer to represent the up-tilted wing's nesting; see header caveat."
+    parts:
+      - kind: fuselage
+        length_m: 7.58
+        width_m: 1.1
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.0
+        width_m: 18.0
+        offset_x_m: 1.5
+        offset_y_m: 0.0
+        z_bottom_m: 1.9
+        z_top_m: 2.1
+    wheels:
+      main_offset_x_m: 0.0
+
+  # ----------------------------------------------------------------------------
+  # SELF-LAUNCHING MOTORGLIDER — Stemme S10. Hangared WINGS FOLDED (11.4 m span;
+  # 23 m unfolded). Cantilever, retractable monowheel, on own gear.
+  # ----------------------------------------------------------------------------
+  - id: stemme_s10
+    name: "Stemme S10"
+    wing_position: high
+    gear: monowheel
+    movement_mode: always_own_gear
+    turn_radius_m: 10.0  # monowheel → no wheelbase cross-check; towplanner own-gear radius
+    measured: false
+    notes: "Two-seat self-launching motor glider. WINGS-FOLDED config: wing width = 11.4 m folded span (23 m unfolded). Length 8.42 m, the longest fuselage in the fleet."
+    parts:
+      - kind: fuselage
+        length_m: 8.42
+        width_m: 1.18
+        offset_x_m: -1.5
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.4
+      - kind: wing
+        length_m: 0.82
+        width_m: 11.4
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 1.9
+        z_top_m: 2.1
+    wheels:
+      main_offset_x_m: 0.0
+
+  # ----------------------------------------------------------------------------
+  # TAILWHEEL HIGH-WING — Aviat Husky A-1C, strut-braced, always on own gear
+  # ----------------------------------------------------------------------------
+  - id: aviat_husky
+    name: "Aviat Husky A-1C"
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 6.88
+        width_m: 0.85
+        offset_x_m: -1.72
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.4
+        width_m: 10.82
+        offset_x_m: -0.52
+        offset_y_m: 0.0
+        z_bottom_m: 2.0
+        z_top_m: 2.3
+    struts:
+      fuselage_attach_x_m: -1.22
+      fuselage_attach_y_m: 0.425
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.8
+      width_m: 0.05
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 2.0
+      third_wheel_offset_x_m: -4.80
+
+  # ----------------------------------------------------------------------------
+  # ULTRALIGHT HIGH-WING — ULBI Wild Thing WT-02, strut-braced, always on carts
+  # ----------------------------------------------------------------------------
+  - id: wild_thing
+    name: "ULBI Wild Thing WT-02"
+    wing_position: high
+    gear: nosewheel
+    movement_mode: always_cart
+    turn_radius_m: null  # always_cart → towplanner uses 0 (pivot); see ADR-0007
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 6.49
+        width_m: 0.85
+        offset_x_m: -0.33
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.4
+      - kind: wing
+        length_m: 1.2
+        width_m: 9.15
+        offset_x_m: 0.67
+        offset_y_m: 0.0
+        z_bottom_m: 2.0
+        z_top_m: 2.2
+    struts:
+      fuselage_attach_x_m: 0.07
+      fuselage_attach_y_m: 0.425
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.6
+      width_m: 0.05
+    wheels:
+      main_offset_x_m: -0.10
+      track_m: 1.5
+      third_wheel_offset_x_m: 1.40
+
+  # ----------------------------------------------------------------------------
+  # TAILWHEEL HIGH-WING — Zlin Savage Cub, strut-braced, always on carts
+  # ----------------------------------------------------------------------------
+  - id: zlin_savage
+    name: "Zlin Aviation Savage Cub"
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_cart
+    turn_radius_m: null  # always_cart → towplanner uses 0 (pivot); see ADR-0007
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 6.39
+        width_m: 0.8
+        offset_x_m: -1.60
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.5
+        width_m: 9.31
+        offset_x_m: -0.50
+        offset_y_m: 0.0
+        z_bottom_m: 1.9
+        z_top_m: 2.2
+    struts:
+      fuselage_attach_x_m: -1.20
+      fuselage_attach_y_m: 0.4
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.5
+      width_m: 0.05
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 1.8
+      third_wheel_offset_x_m: -4.30
+
+  # ----------------------------------------------------------------------------
+  # CART-ELIGIBLE — Cessna 140, high-wing tailwheel, strut-braced
+  # ----------------------------------------------------------------------------
+  - id: cessna_140
+    name: "Cessna 140"
+    wing_position: high
+    gear: tailwheel
+    movement_mode: cart_eligible
+    turn_radius_m: 5.5
+    measured: false
+    notes: "V-strut treated as one strut per side"
+    parts:
+      - kind: fuselage
+        length_m: 6.55
+        width_m: 0.85
+        offset_x_m: -1.64
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.55
+        width_m: 10.16
+        offset_x_m: -0.54
+        offset_y_m: 0.0
+        z_bottom_m: 2.0
+        z_top_m: 2.3
+    struts:
+      fuselage_attach_x_m: -1.14
+      fuselage_attach_y_m: 0.425
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.7
+      width_m: 0.05
+    wheels:
+      main_offset_x_m: 0.50
+      track_m: 2.1
+      third_wheel_offset_x_m: -3.80
+
+  # ----------------------------------------------------------------------------
+  # CART-ELIGIBLE — Flight Design CTSL, high-wing nosewheel, cantilever (no struts)
+  # ----------------------------------------------------------------------------
+  - id: ctsl
+    name: "Flight Design CTSL"
+    wing_position: high
+    gear: nosewheel
+    movement_mode: cart_eligible
+    turn_radius_m: 4.0
+    measured: false
+    notes: "Cantilever wing (no struts)"
+    parts:
+      - kind: fuselage
+        length_m: 6.60
+        width_m: 1.0
+        offset_x_m: -0.33
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.4
+      - kind: wing
+        length_m: 1.4
+        width_m: 8.59
+        offset_x_m: 0.67
+        offset_y_m: 0.0
+        z_bottom_m: 1.9
+        z_top_m: 2.2
+    wheels:
+      main_offset_x_m: -0.10
+      track_m: 1.7
+      third_wheel_offset_x_m: 1.40
+
+  # ----------------------------------------------------------------------------
+  # CART-ELIGIBLE — FK9 Mk II, high-wing nosewheel, strut-braced
+  # ----------------------------------------------------------------------------
+  - id: fk9_mkii
+    name: "B&F Technik FK9 Mk II"
+    wing_position: high
+    gear: nosewheel
+    movement_mode: cart_eligible
+    turn_radius_m: 4.0
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 5.85
+        width_m: 0.85
+        offset_x_m: -0.29
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.4
+      - kind: wing
+        length_m: 1.3
+        width_m: 9.85
+        offset_x_m: 0.71
+        offset_y_m: 0.0
+        z_bottom_m: 1.9
+        z_top_m: 2.2
+    struts:
+      fuselage_attach_x_m: 0.11
+      fuselage_attach_y_m: 0.425
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.6
+      width_m: 0.05
+    wheels:
+      main_offset_x_m: -0.10
+      track_m: 1.4
+      third_wheel_offset_x_m: 1.40

--- a/herrenteich/fleet.yaml
+++ b/herrenteich/fleet.yaml
@@ -58,7 +58,7 @@ aircraft:
     movement_mode: always_cart
     turn_radius_m: null  # always_cart → towplanner uses 0 (pivot); see ADR-0007
     measured: false
-    notes: "18 m span, folds to ~10 m (not folded here). Monowheel → tiltable (one wing up, the other down on a tip outrigger). Full wing modelled in the high z-layer to represent the up-tilted wing's nesting; see header caveat."
+    notes: "18 m span (kept assembled here; folds to ~10 m per spec, incidental/unverified). Monowheel → tiltable (one wing up, the other down on a tip outrigger). Full wing modelled in the high z-layer to represent the up-tilted wing's nesting; see header caveat."
     parts:
       - kind: fuselage
         length_m: 7.58

--- a/herrenteich/hangar.yaml
+++ b/herrenteich/hangar.yaml
@@ -15,7 +15,9 @@
 # floor there. Representing the notch in the data model + the containment /
 # solver / tow algorithms is deferred to spike #424. In the coordinate
 # frame below the notch is the back-right corner: x ∈ [12.72, 15.08],
-# y ∈ [22.66, 31.76].
+# y ∈ [22.66, 31.76]. These coords are DERIVED from the rectangle dims —
+# back-right = [width-2.36, width] × [length-9.10, length] — so if length_m /
+# width_m are ever re-surveyed, recompute this box (nothing enforces it).
 #
 # ⚠ NO MAINTENANCE BAY. The real hangar has no modelled curtained bay; the
 # block below is an inert placeholder that only satisfies the schema (the

--- a/herrenteich/hangar.yaml
+++ b/herrenteich/hangar.yaml
@@ -1,0 +1,56 @@
+# Airfield Herrenteich — real hangar (main building).
+#
+# This is the REAL hangar, kept separate from the synthetic placeholder in
+# data/hangar.yaml (which stays as the project's stable demo/test fixture).
+#
+# DIMENSIONS (rectangle + door) measured 2026-06-04 by PK from the
+# architect's DWG of the main building (distances annotated on the floor
+# plan, read to the millimetre and rounded here to the centimetre).
+#
+# ⚠ NON-RECTANGULAR FOOTPRINT IS NOT YET MODELLED. The real hangar is an
+# L-shape: one back corner is notched out by ~2.36 m (x) × ~9.10 m (y) —
+# that corner is office/annex space, NOT hangar floor. The model here is
+# the full BOUNDING RECTANGLE (15.08 × 31.76), so a layout that parks a
+# plane in that back corner is NOT yet rejected even though there is no
+# floor there. Representing the notch in the data model + the containment /
+# solver / tow algorithms is deferred to spike #424. In the coordinate
+# frame below the notch is the back-right corner: x ∈ [12.72, 15.08],
+# y ∈ [22.66, 31.76].
+#
+# ⚠ NO MAINTENANCE BAY. The real hangar has no modelled curtained bay; the
+# block below is an inert placeholder that only satisfies the schema (the
+# `maintenance_bay` field is required). No layout in this folder names a
+# `maintenance.plane`, so the bay keep-out is never triggered.
+#
+# Coordinates: (0, 0) at the front-left corner of the hangar floor, looking
+# down. +x runs right along the door wall, +y runs deeper into the hangar.
+# The real door is on a side wall of the building; it is mapped here so the
+# door wall is the front wall (y = 0). Front-left (x = 0) corresponds to
+# the DWG's north door-jamb (the 0.55 m flank). See
+# `docs/architecture/08-crosscutting-concepts.md` "The coordinate
+# convention" for the full convention.
+
+length_m: 31.76         # depth from the front (door) wall to the back wall
+width_m: 15.08          # left-to-right span along the door wall
+
+door:
+  center_x_m: 7.28      # door centre along the front wall (x axis): 0.55 m
+                        # of wall to its left (x < 0.55), 1.07 m to its
+                        # right — the opening is slightly off-centre
+  width_m: 13.46        # clear door opening width
+
+maintenance_bay:
+  # INERT PLACEHOLDER — see header. Never triggered (no maintenance plane in
+  # this folder's layouts). Small back-left rectangle, well clear of the
+  # back-right office notch.
+  center_x_m: 2.0
+  width_m: 3.0
+  depth_m: 2.0
+
+clearance_m: 0.3        # minimum horizontal gap between any two aircraft parts
+wing_layer_clearance_m: 0.2  # minimum vertical gap between two parts at the same XY
+
+# Spare carts available to the cart_eligible pool. Bounds how many
+# cart_eligible planes may sit on carts in one layout; always_cart planes
+# get their own carts and do not draw from this pool.
+max_carts: 4

--- a/herrenteich/layout.yaml
+++ b/herrenteich/layout.yaml
@@ -3,7 +3,7 @@
 #
 # HOW THIS WAS PRODUCED. The product solver (`hangarfit solve`) cannot
 # generate this layout: its fast trivial-infeasibility gate sums each plane's
-# bounding-box area (Σ ≈ 606 m² > the 479 m² floor) and bails, because an
+# bounding-box area (Σ ≈ 606 m² > the 479 m² rectangular floor) and bails, because an
 # 18 m-span motor glider is a 136 m² bounding box of mostly empty air (#425). The
 # REAL, part-based collision checker (thin wing rectangles, z-disjoint
 # wing-over-fuselage nesting) accepts a nested arrangement. So this layout was

--- a/herrenteich/layout.yaml
+++ b/herrenteich/layout.yaml
@@ -1,0 +1,66 @@
+# Airfield Herrenteich — "everyone home": all eight usual occupants parked
+# in the real hangar at once. Passes `hangarfit check` (exit 0).
+#
+# HOW THIS WAS PRODUCED. The product solver (`hangarfit solve`) cannot
+# generate this layout: its fast trivial-infeasibility gate sums each plane's
+# bounding-box area (Σ ≈ 606 m² > the 479 m² floor) and bails, because an
+# 18 m-span motor glider is a 136 m² bounding box of mostly empty air (#425). The
+# REAL, part-based collision checker (thin wing rectangles, z-disjoint
+# wing-over-fuselage nesting) accepts a nested arrangement. So this layout was
+# found by a search that drives that real checker directly, and additionally
+# keeps every plane clear of the back-right office NOTCH that the rectangular
+# hangar model does not yet represent (see hangar.yaml + spike #424).
+#
+# So: this file is a VALID nested layout, but it is the tool's arrangement,
+# not a record of where the club actually parks each aircraft. Replace the
+# placements with the real parking positions when known.
+#
+# Coordinate convention (see hangar.yaml): world (0,0) front-left, +x right
+# along the door wall, +y deeper in; heading 0 = nose deep (+y), 90 = nose
+# toward +x. scheibe_falke (18 m span) cannot sit nose-in under the 15.08 m
+# width, so it parks lengthwise (heading 90).
+
+fleet: fleet.yaml
+hangar: hangar.yaml
+
+placements:
+  - plane: scheibe_falke
+    x_m: 7.5
+    y_m: 22.5
+    heading_deg: 90.0
+    on_carts: true          # always_cart
+  - plane: stemme_s10
+    x_m: 3.5
+    y_m: 13.5
+    heading_deg: 270.0
+    on_carts: false         # always_own_gear
+  - plane: aviat_husky
+    x_m: 5.5
+    y_m: 19.5
+    heading_deg: 90.0
+    on_carts: false         # always_own_gear
+  - plane: cessna_140
+    x_m: 10.5
+    y_m: 6.5
+    heading_deg: 90.0
+    on_carts: false         # cart_eligible, on own gear
+  - plane: fk9_mkii
+    x_m: 7.5
+    y_m: 10.5
+    heading_deg: 270.0
+    on_carts: false         # cart_eligible, on own gear
+  - plane: zlin_savage
+    x_m: 6.5
+    y_m: 26.5
+    heading_deg: 270.0
+    on_carts: true          # always_cart
+  - plane: wild_thing
+    x_m: 10.5
+    y_m: 16.5
+    heading_deg: 90.0
+    on_carts: true          # always_cart
+  - plane: ctsl
+    x_m: 4.5
+    y_m: 4.5
+    heading_deg: 180.0
+    on_carts: false         # cart_eligible, on own gear

--- a/herrenteich/scenario.yaml
+++ b/herrenteich/scenario.yaml
@@ -1,0 +1,16 @@
+# Airfield Herrenteich — "everyone home" scenario: all eight usual occupants
+# in the hangar at once. Used to generate herrenteich/layout.yaml via:
+#
+#   hangarfit solve herrenteich/scenario.yaml --no-spread --write-yaml herrenteich/layout.yaml
+#
+fleet: fleet.yaml
+hangar: hangar.yaml
+fleet_in:
+  - cessna_140
+  - ctsl
+  - wild_thing
+  - aviat_husky
+  - scheibe_falke
+  - fk9_mkii
+  - stemme_s10
+  - zlin_savage

--- a/herrenteich/scenario.yaml
+++ b/herrenteich/scenario.yaml
@@ -1,7 +1,12 @@
 # Airfield Herrenteich — "everyone home" scenario: all eight usual occupants
-# in the hangar at once. Used to generate herrenteich/layout.yaml via:
+# in the hangar at once. This is the canonical solver INPUT.
 #
-#   hangarfit solve herrenteich/scenario.yaml --no-spread --write-yaml herrenteich/layout.yaml
+# NOTE: `hangarfit solve` does NOT produce herrenteich/layout.yaml from this
+# scenario — its bounding-box trivial-infeasibility gate rejects this
+# glider-heavy fleet (Σ bbox ≈ 606 m² > the 479 m² rectangular floor; see #425
+# and the layout.yaml header). The committed layout was found by driving the
+# real, part-based collision checker directly. This file is kept as the
+# canonical scenario and as the reproduction case for #425.
 #
 fleet: fleet.yaml
 hangar: hangar.yaml

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -1,0 +1,57 @@
+"""Guards the real Airfield Herrenteich dataset (`herrenteich/`).
+
+These are real (DWG-measured hangar + published-spec fleet) files kept
+separate from the synthetic `data/` placeholders. The dataset's promise is
+that all eight usual occupants fit at once; this regression test pins the
+hangar dimensions and asserts the bundled layout still passes the real
+part-based collision checker, so a later edit to any of the three files
+cannot silently break it.
+"""
+
+from pathlib import Path
+
+from hangarfit import collisions
+from hangarfit.loader import load_fleet, load_hangar, load_layout
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HERRENTEICH = REPO_ROOT / "herrenteich"
+
+USUAL_OCCUPANTS = {
+    "cessna_140",
+    "ctsl",
+    "wild_thing",
+    "aviat_husky",
+    "scheibe_falke",
+    "fk9_mkii",
+    "stemme_s10",
+    "zlin_savage",
+}
+
+
+def test_hangar_dimensions() -> None:
+    hangar = load_hangar(HERRENTEICH / "hangar.yaml")
+    # Real DWG figures (rounded to cm). Door fits inside the width with the
+    # asymmetric jambs (0.55 m + 13.46 m + 1.07 m = 15.08 m).
+    assert hangar.width_m == 15.08
+    assert hangar.length_m == 31.76
+    assert hangar.door.width_m == 13.46
+    assert hangar.door.center_x_m == 7.28
+
+
+def test_fleet_roster() -> None:
+    fleet = load_fleet(HERRENTEICH / "fleet.yaml")
+    assert set(fleet) == USUAL_OCCUPANTS
+    # Stemme is hangared wings-folded: the wing part carries the folded span,
+    # which is what lets a 23 m glider fit a 15 m hangar.
+    stemme_span = next(p.width_m for p in fleet["stemme_s10"].parts if p.kind == "wing")
+    assert stemme_span == 11.4
+
+
+def test_everyone_home_layout_is_valid() -> None:
+    """All eight occupants parked at once must pass the real checker."""
+    layout = load_layout(HERRENTEICH / "layout.yaml")
+    assert {p.plane_id for p in layout.placements} == USUAL_OCCUPANTS
+    result = collisions.check(layout)
+    assert result.conflicts == (), (
+        f"herrenteich/layout.yaml is no longer valid: {[c.kind for c in result.conflicts]}"
+    )

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -11,10 +11,16 @@ cannot silently break it.
 from pathlib import Path
 
 from hangarfit import collisions
+from hangarfit.geometry import aircraft_parts_world
 from hangarfit.loader import load_fleet, load_hangar, load_layout
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HERRENTEICH = REPO_ROOT / "herrenteich"
+
+# Real office NOTCH (back-right corner): non-floor space the rectangular hangar
+# model does NOT enforce (hangar.yaml + spike #424). Derived from the rectangle
+# dims: [width-2.36, width] x [length-9.10, length].
+NOTCH = (12.72, 22.66, 15.08, 31.76)  # x_min, y_min, x_max, y_max
 
 USUAL_OCCUPANTS = {
     "cessna_140",
@@ -55,3 +61,23 @@ def test_everyone_home_layout_is_valid() -> None:
     assert result.conflicts == (), (
         f"herrenteich/layout.yaml is no longer valid: {[c.kind for c in result.conflicts]}"
     )
+
+
+def test_layout_clears_unmodelled_office_notch() -> None:
+    """No plane may sit in the back-right office notch.
+
+    ``collisions.check`` only validates the bounding rectangle, so a layout
+    edit could drift a plane into the (real, non-floor) office corner and the
+    validity test above would stay green. Pin the clearance the rectangular
+    model cannot see (#424).
+    """
+    layout = load_layout(HERRENTEICH / "layout.yaml")
+    x0, y0, x1, y1 = NOTCH
+    for placement in layout.placements:
+        parts = aircraft_parts_world(layout.fleet[placement.plane_id], placement)
+        for part in parts:
+            for x, y in part.polygon.exterior.coords:
+                assert not (x0 <= x <= x1 and y0 <= y <= y1), (
+                    f"{placement.plane_id} {part.kind} vertex ({x:.2f}, {y:.2f}) "
+                    f"is inside the unmodelled office notch — non-floor space"
+                )


### PR DESCRIPTION
## What

Adds a self-contained **real-world dataset** for the club's main-building
hangar under `herrenteich/`, kept **separate from the synthetic `data/`
placeholders** (which stay as the project's stable demo/test fixtures, untouched
by this PR).

| File | What |
|---|---|
| `herrenteich/hangar.yaml` | Real hangar — **15.08 m × 31.76 m**, door **13.46 m** @ x=7.28. Measured 2026-06-04 from the architect's DWG. |
| `herrenteich/fleet.yaml` | The **8 aircraft usually hangared here**. Dimensions looked up from published specs and independently second-source verified (2026-06-04). Adds a **Stemme S10** (hangared wings-folded, 11.4 m span); drops Fuji and the Cessna 150 (not based here). |
| `herrenteich/layout.yaml` | A **valid** all-eight arrangement — `hangarfit check` → exit 0. |
| `herrenteich/scenario.yaml` | The "everyone home" solver input. |
| `herrenteich/README.md` | Dataset guide + the two honesty caveats below. |
| `tests/test_herrenteich_dataset.py` | Pins the hangar dims + roster and asserts the layout stays valid. |

`Refs #79` — this provides real measurements as a parallel dataset rather than
replacing the `data/` placeholders, so #79 stays open for whatever the team
wants to do with the default demo data.

## How the layout was produced (and why it isn't from `solve`)

`hangarfit solve` **cannot** generate this layout: its trivial-infeasibility
gate sums each plane's *bounding box* (Σ ≈ 606 m² > the 479 m² floor) and bails,
because an 18 m-span motor glider is a 136 m² box of mostly empty air. The
**real, part-based** collision checker (thin wing rectangles, z-disjoint
wing-over-fuselage nesting) accepts a nested layout, so `layout.yaml` was found
by driving `collisions.check` directly, keeping every plane clear of the real
office notch. So it is a *valid* layout, but the tool's arrangement — not a
record of the club's real parking spots.

## Caveats (documented in-file)

1. **Hangar is L-shaped; model is a rectangle.** The real back-right corner is
   notched out (~2.36 m × 9.10 m office space). `hangar.yaml` records the
   bounding rectangle; the files keep clear of the notch by hand. Modelling it →
   spike **#424**.
2. **SF-25E wing modelled in the high z-layer.** It's a monowheel motor glider
   that tilts (one wing up, the other down on a tip outrigger), so a raised
   half-wing genuinely can nest over a neighbour — the single-z model is a
   simplification of that tilt, slightly overstating the nestable span.

## Follow-ups filed

- **#424** — spike: model the non-rectangular hangar notch (data structure + algorithms).
- **#425** — the solver bounding-box gate that false-rejects glider fleets.

## Verification

- `hangarfit check herrenteich/layout.yaml` → `valid` (exit 0).
- `tests/test_herrenteich_dataset.py` → 3 passed.
- Full non-slow suite green; `ruff check` / `ruff format --check` clean.
- No source changes — data + one test + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
