### PR TITLE
test(towplanner): guard the #262 entry-cone's legal strict-win post-#411

### DIFF
--- a/tests/test_towplanner_entry_cone.py
+++ b/tests/test_towplanner_entry_cone.py
@@ -6,9 +6,12 @@ Tests are grouped into four blocks:
 2. Candidate filtering: poses that clip side/back walls are dropped before the search;
    if all are filtered the fallback straight-in centre pose is returned.
 3. Multi-start plan_path: the search accepts the cone and seeds all surviving entries.
-4. Door-gate (#411): for an off-to-the-side slot the cone does NOT corner-cut
-   through the solid front wall beside the door — its best legal path equals the
-   v1 straight-in baseline (the prior sub-cm "win" was a jamb wall-clip).
+4. Door-gate (#411) + legal strict win (#420): for an off-to-the-side slot the
+   cone does NOT corner-cut through the solid front wall beside the door (its best
+   legal path equals the v1 baseline there; the prior sub-cm "win" was a jamb
+   wall-clip). But on a STEEPLY-angled off-side slot the cone's angled door entry
+   yields a strictly shorter LEGAL path than v1 (#420), so the cone earns its
+   path-length keep post-#411.
 """
 
 from __future__ import annotations
@@ -407,8 +410,9 @@ def test_off_side_slot_cone_does_not_corner_cut_through_jamb() -> None:
     planner does not corner-cut through the jamb even when shorter; reverting the
     door-gate would make the cone beat v1 again and fail this test. (The #262
     cone still provides valid multi-start search + determinism, guarded by the
-    other tests in this module; whether it yields a *legal* strict path win on any
-    fixture is tracked as a follow-up.)
+    other tests in this module; that it ALSO yields a *legal* strict path win on a
+    steeply-angled off-side slot is now guarded by
+    ``test_steeply_angled_off_side_slot_cone_yields_legal_strict_win`` — #420.)
     """
     from hangarfit.towplanner import path_first_conflict
 
@@ -460,3 +464,66 @@ def test_off_side_slot_cone_does_not_corner_cut_through_jamb() -> None:
     # protrudes to y < 0 beside the door (the door-gate lives in path_first_conflict).
     assert path_first_conflict(arc_v1, plane, mover_on_carts=False, placed=placed) is None
     assert path_first_conflict(arc_cone, plane, mover_on_carts=False, placed=placed) is None
+
+
+def test_steeply_angled_off_side_slot_cone_yields_legal_strict_win() -> None:
+    """#420 strict-win guard: on a steeply-angled, off-to-the-side slot the
+    entry-cone's *angled* door entry produces a strictly shorter LEGAL path than
+    the v1 straight-in — restoring the intentional path-length guard #411 retired.
+
+    After #411 made the front-gap exemption door-aware, the only test that proved
+    the cone beat v1 (``test_off_side_slot_cone_does_not_corner_cut_through_jamb``)
+    lost its win — that win had been an illegal jamb corner-cut. #420 reassessed
+    whether the cone still earns its path-length keep. It does: a broad geometry
+    sweep found many *legal* wins on steeply-turned (90°/135°) off-side slots (the
+    cone also wins on obstacle-forced detours). This fixture pins one.
+
+    The slot is at (21, 10) heading 135° — far to the right of the door interval
+    [6, 18], facing back across the hangar. v1 clamps its straight-in entry to the
+    right door edge (x=18, heading 0°). The cone additionally fans angled entries
+    at the door; the −30° (330°) entry at the door edge pre-aligns the nose toward
+    the off-side slot, so the search reaches the goal via a ~0.18 m shorter arc
+    whose swept footprint stays within bounds and the door opening (legal under
+    the #411 gate). The win is deterministic (closed-form Reeds–Shepp + the RNG-free
+    search, ADR-0003), so it is a stable guard: dropping the cone (``entries=None``)
+    would make the cone path equal v1 again and fail this test.
+    """
+    from hangarfit.towplanner import path_first_conflict
+
+    h = _hangar(width_m=24.0, length_m=26.0, door_center=12.0, door_width=12.0)
+    plane = _box_plane("A", turn_radius_m=4.0)
+    placed = Layout(fleet={"A": plane}, hangar=h, placements=())
+
+    slot = _slot("A", x=21.0, y=10.0, h=135.0)
+    goal = Pose.from_placement(slot)
+
+    # v1 baseline: the single straight-in entry, clamped to the right door edge.
+    v1_entry = entry_pose(slot, h)
+    arc_v1 = plan_path(plane, v1_entry, goal, hangar=h, placed=placed, mover_on_carts=False)
+
+    # Cone: the multi-start fan (includes v1's straight-in among its 15 poses).
+    cone = entry_poses(slot, h)
+    arc_cone = plan_path(
+        plane, v1_entry, goal, hangar=h, placed=placed, mover_on_carts=False, entries=cone
+    )
+    arc_cone_again = plan_path(
+        plane, v1_entry, goal, hangar=h, placed=placed, mover_on_carts=False, entries=cone
+    )
+
+    # Strict legal win: the cone is meaningfully shorter than the v1 straight-in
+    # (measured margin ~0.18 m; the threshold leaves float headroom while proving
+    # it is a real win, not a tie).
+    assert arc_cone.length_m < arc_v1.length_m - 0.05, (
+        f"cone path {arc_cone.length_m:.4f} m should strictly beat v1 "
+        f"{arc_v1.length_m:.4f} m on this steeply-angled off-side slot"
+    )
+    # The winning start is an ANGLED cone entry, not the heading-0 straight-in —
+    # i.e. the cone's fan is what delivers the win, not the v1 pose it also holds.
+    assert arc_cone.start.heading_deg != 0.0
+    # Both paths are exact-oracle clean (incl. the #411 door-gate: no y<0
+    # protrusion outside the door opening).
+    assert path_first_conflict(arc_v1, plane, mover_on_carts=False, placed=placed) is None
+    assert path_first_conflict(arc_cone, plane, mover_on_carts=False, placed=placed) is None
+    # Deterministic (ADR-0003): the win is stable, not a float-tie artifact.
+    assert arc_cone.segments == arc_cone_again.segments
+    assert arc_cone.length_m == pytest.approx(arc_cone_again.length_m)

--- a/tests/test_towplanner_entry_cone.py
+++ b/tests/test_towplanner_entry_cone.py
@@ -481,12 +481,28 @@ def test_steeply_angled_off_side_slot_cone_yields_legal_strict_win() -> None:
     The slot is at (21, 10) heading 135° — far to the right of the door interval
     [6, 18], facing back across the hangar. v1 clamps its straight-in entry to the
     right door edge (x=18, heading 0°). The cone additionally fans angled entries
-    at the door; the −30° (330°) entry at the door edge pre-aligns the nose toward
-    the off-side slot, so the search reaches the goal via a ~0.18 m shorter arc
-    whose swept footprint stays within bounds and the door opening (legal under
-    the #411 gate). The win is deterministic (closed-form Reeds–Shepp + the RNG-free
-    search, ADR-0003), so it is a stable guard: dropping the cone (``entries=None``)
-    would make the cone path equal v1 again and fail this test.
+    at the door; the −30° (330°) entry at the door edge pre-aligns the nose so the
+    search needs far less corrective turning at the door (the v1 straight-in opens
+    with a ~3.1 m turn arc; the angled entry ~0.18 m), reaching the goal via a
+    ~0.18 m shorter total arc whose swept footprint stays within bounds and the
+    door opening (legal under the #411 gate). The win is deterministic — closed-form
+    Reeds–Shepp (ADR-0010) + the RNG-free search (ADR-0003) — so it is a stable
+    guard: dropping the cone (``entries=None``) makes the cone path equal v1 again
+    and fails this test.
+
+    Two notes for a future maintainer:
+
+    - **This is a point-wise win, not a universal one.** The bounded multi-start
+      Hybrid-A* returns the first goal-reaching start under its expansion budget /
+      heuristic ordering, NOT the global minimum across the cone's seeds — so off
+      this fixture the cone can even be *longer* than v1 despite the cone fan
+      containing the v1 pose. Do NOT add a "the cone is never worse than v1" test;
+      it would be wrong.
+    - **The fixture sits inside a fairly narrow win region** (sensitive to
+      ``turn_radius_m`` and the slot's x / y / heading). The ~0.18 m margin is
+      ~3.6× the 0.05 m threshold here, so the test is stable — but if it breaks
+      after a geometry or ``_box_plane`` turn-radius change, re-derive a winning
+      fixture; don't just lower the threshold.
     """
     from hangarfit.towplanner import path_first_conflict
 


### PR DESCRIPTION
Closes #420

## Background
#411 made the tow planner's front-gap exemption **door-aware**. While landing it, the only test proving the #262 entry-cone delivered a path-length benefit (`test_off_side_slot_cone_does_not_corner_cut_through_jamb`) lost its win — that "win" had been an illegal jamb corner-cut (a box dipping to `y<0` just left of the door edge), which #411 correctly forbids. The test was reframed into a door-gate guard, leaving **no test proving the cone yields any legal path-length benefit** — so it could silently become a no-op.

## What I did
Reassessed empirically with a broad geometry sweep (248 configs: open-space off-side/angled slots + obstacle-on-the-v1-lane cases). **The prior "probably impossible post-#411" hypothesis is falsified** — there are many *legal* strict wins, concentrated on **steeply-turned (90°/135°) off-to-the-side slots** (and obstacle-forced detours). The cone genuinely earns its path-length keep.

This adds **one strict-win regression guard** pinning a clean case:
- hangar 24×26, door `[6,18]`; box plane `r=4`; slot `(21, 10, 135°)` — far right of the door, facing back.
- v1 clamps its straight-in entry to the right door edge `(18, 0°)` → **17.829 m**.
- The cone's **−30° (330°) entry** at the door edge pre-aligns the nose toward the off-side slot → **17.650 m** (~0.18 m shorter).
- Both paths are exact-oracle clean (incl. the #411 door-gate), and the win is **deterministic** (closed-form Reeds–Shepp + RNG-free search, ADR-0010/ADR-0003) — a stable guard. Dropping the cone (`entries=None`) makes the cone path equal v1 again and fails the test.

The guard asserts: `len_cone < len_v1 − 0.05`, the winning start is an **angled** entry (not heading 0 — proving the cone's fan does the work, not the v1 pose it also contains), both legal, and deterministic across two runs.

## Outcome
**The entry-cone is KEPT** (not simplified/retired) — it provides a genuine, legal, deterministic path-length benefit post-#411. Updates the module docstring (Block 4) and the reframed test's `#420` follow-up breadcrumb to point at the new guard.

**Test-only change** — `towplanner.py` is untouched, so the determinism contract is unaffected (the new test itself re-asserts determinism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)