### PR TITLE
docs: ADR-0020 + spec — viewer TypeScript migration (modular, typed, editor-ready)

### DIFF
--- a/docs/adr/0017-3d-viewer-architecture.md
+++ b/docs/adr/0017-3d-viewer-architecture.md
@@ -1,6 +1,11 @@
 # ADR-0017: 3D viewer — a `scene/v1` JSON seam fed to a self-contained offline Three.js HTML, with the transform owned by Python
 
-- **Status:** Accepted
+- **Status:** Accepted — the **"No build toolchain" decision driver and the *thin
+  read-only renderer* posture are superseded by [ADR-0020](0020-viewer-typescript-architecture.md)**
+  (the viewer becomes a typed, modular TypeScript application built by a dev-only
+  toolchain). Everything else here — the `scene/v1` seam, the single offline HTML
+  deliverable, and the **load-bearing Python-owned determinant-−1 transform** — is
+  retained and explicitly reaffirmed by ADR-0020.
 
 - **Date:** 2026-06-03
 - **Deciders:** Patrick Kuhn (DocGerd)

--- a/docs/adr/0020-viewer-typescript-architecture.md
+++ b/docs/adr/0020-viewer-typescript-architecture.md
@@ -36,7 +36,7 @@ posture, or the Python-owned transform?**
 - **Type safety over the `scene/v1` contract** — catch shape errors at dev/CI time,
   not in a late headless screenshot.
 - **Modular, extendable structure** — a foundation an interaction layer can plug into,
-  not a 546-line monolith.
+  not a single-file monolith.
 - **Preserve every ADR-0017 invariant that still holds** — Python owns the det-−1
   transform (ADR-0002); the viewer does no transform math; one self-contained offline
   HTML; deterministic output; fail-loud in-browser anchor self-check.
@@ -54,7 +54,14 @@ posture, or the Python-owned transform?**
    `viewer.py` resolve each via additional `data:`-URL import-map entries.
 3. **No-npm, JSDoc-typed plain-JS modules** — keep hand-written `.js`, add `// @ts-check`
    + JSDoc typedefs, type-check with the existing editor LSP.
+4. **Vite (+ `vite-plugin-singlefile`)** — a full dev server / HMR toolchain that also
+   inlines to one offline HTML.
 0. **Status quo** — keep the single untyped `viewer.js`.
+
+A cross-cutting sub-decision under the chosen option is **where the Node project lives**:
+nested inside the Python package at `src/hangarfit/_viewer_assets/src/` vs a **separate
+top-level `viewer/`** directory that only *emits* the artifact into the package (see the
+first Supporting choice).
 
 ## Decision Outcome
 
@@ -66,26 +73,59 @@ artifact*, enforced exactly like the repo's existing lockfile-drift guards.
 
 Supporting choices:
 
-- **esbuild, three external or bundled.** esbuild bundles `src/*.ts` → one ESM
-  `viewer.js`, emitted **unminified** at `target: es2020` so the committed diff is
-  legible and reviewable (matching the repo's choice to commit *readable* vendored
-  three). Recommended direction: promote `three` to a **pinned npm dependency bundled
-  into the output** (npm integrity-hashed supply chain; one self-contained file; drops
-  the base64 `data:` import-map machinery). Keeping `three` **vendored & external** —
-  unchanged `viewer.py`, the `data:` import-map preserved — is the documented
-  conservative fallback. Either way the **offline single-file deliverable is preserved**
-  and `@types/three` stays types-only.
-- **`@types/three` pinned to `0.160.x`** to match vendored/​bundled three **r160**
+- **Top-level `viewer/` project; the bundle is emitted *into* the package.** The whole
+  Node project — `package.json`, `package-lock.json`, `tsconfig.json`,
+  `esbuild.config.mjs`, eslint config, `node_modules/` — lives in a **new top-level
+  `viewer/` directory, *outside* the importable Python package**. esbuild emits the one
+  committed artifact to `outfile: ../src/hangarfit/_viewer_assets/viewer.js`, exactly where
+  `viewer.py` already reads it via `importlib.resources`. This keeps
+  `find_packages(where="src")` returning exactly `{hangarfit, _viewer_assets,
+  _viewer_assets.three}` with **zero** packaging changes and makes wheel /
+  discovery / ruff / mypy / editable-install hygiene **structural rather than
+  discipline-dependent** — a nested `_viewer_assets/src/` would expose
+  `hangarfit._viewer_assets.src` as a PEP-420 namespace subpackage and let any future
+  `*.js`→`**/*.js` glob ship `node_modules` + the TS sources into the wheel. This mirrors
+  how comparable Python-packages-shipping-a-JS-build lay out (ipywidgets, JupyterLab
+  extension cookiecutter, Streamlit component template). Node commands use
+  `npm --prefix viewer/ …` (Pattern-A, keeps the Bash allowlist matching).
+- **esbuild; Three.js stays vendored & external + Python-inlined (recommended).** esbuild
+  bundles `viewer/src/*.ts` → one ESM `viewer.js`, emitted **unminified** at
+  `target: es2022` for a legible, code-reviewable committed diff. **Three.js stays
+  vendored & external**: the bare `three` / OrbitControls imports keep resolving through
+  the existing `data:` import-map and **`viewer.py` is unchanged**. Bundling three from
+  npm is an explicit **deferred** option, *not* the default — `three.module.js` is
+  ~1.27 MB vs `viewer.js`'s ~22 KB, so bundling would bloat the byte-diffed drift artifact
+  ~58× and make it esbuild-version-churn-sensitive, **eroding the very
+  `viewer-build-drift` guard this ADR makes load-bearing**, and would move asset assembly
+  off the Python-authority seam `viewer.py` owns. (three is already SHA-256-pinned in
+  `VENDOR.md`, so npm integrity-hashing — the only upside of bundling — is largely
+  redundant.) The **offline single-file deliverable is preserved either way**; `@types/three`
+  stays types-only.
+- **Exact-pin the toolchain.** esbuild's semver treats **minor** releases as
+  *intentionally* backwards-incompatible, so the lockfile must **exact-pin** esbuild
+  (never `^`/`~`) and Node is pinned (`.nvmrc` / `setup-node`) — otherwise the drift guard
+  flakes on a routine toolchain bump instead of catching a source edit.
+- **`@types/three` pinned to `0.160.x`** to match vendored three **r160**
   (`_viewer_assets/three/VENDOR.md`); a CI guard asserts the two agree so the API the
   TS type-checks against can't drift from the three the viewer actually runs.
 - **Determinism via the lockfile-drift idiom.** A `viewer-build-drift` CI job rebuilds
-  the bundle (`npm ci` → `npm run build`) and fails on any diff against the committed
-  `viewer.js` — the same shape as `lockfile-drift`, with a stricter (sha256/byte)
-  invariant.
+  the bundle (`npm --prefix viewer/ ci` → `npm --prefix viewer/ run build`) and fails on
+  any diff against the committed `viewer.js` — the same shape as `lockfile-drift`, with a
+  stricter (sha256/byte) invariant.
 - **The transform stays in Python.** The browser keeps applying Python-emitted affines
   only; the future interaction layer captures *intent* and exports a `Scenario`/
   constraints artifact for the Python solver — it must never import the affine/anchor
   modules to re-derive geometry.
+- **Contract-drift guard (cheap now, single-source later).** `scene-contract.ts` /
+  `brand-contract.ts` are hand-written typed mirrors of `scene.py` / `brand.py`; a Python
+  **key-set parity test** (in `tests/test_scene.py`, which already pins byte-determinism)
+  asserts `build_scene()`'s top-level keys match the TS contract's expected set, and a
+  brand parity test checks the token-name set — closing the silent cross-language drift gap
+  at **zero new deps**. A JSON-Schema single-source (`scene-v1.schema.json` →
+  `json-schema-to-typescript` + Python `jsonschema`) is the **deferred** principled target
+  (spike #444), to adopt when `scene/v1` starts to churn; JSON Schema can express *shape*
+  but not the det-−1 affine tuple, so the runtime `checkAnchors()` stays the load-bearing
+  transform-**value** guard regardless.
 
 ### Why not Option 2?
 
@@ -104,6 +144,18 @@ modules (Option 2's import-map problem) or keep one big file (defeats "modular")
 still needs `tsc` to type-check — so it is not truly zero-toolchain. It is the right
 answer only if the goal were "add types to the existing single file with zero build,"
 which is not where the viewer is going. Recorded as the fallback if Node is vetoed.
+
+### Why not Option 4?
+
+Vite is the conventional choice for a TS web app and `vite-plugin-singlefile` can produce
+the inlined offline HTML, so it is a genuine candidate for the *eventual* interactive
+editor. It is **deferred, not rejected**: its Rollup/Rolldown output is less trivially
+byte-reproducible than esbuild's, which is hazardous under a byte-diff drift guard, and it
+adds a much larger pinned supply-chain surface for no benefit to the current render-only
+bundle. esbuild's own watch/serve covers iteration, and because Vite uses esbuild
+internally a later migration stays open — to be revisited only on a concrete trigger (the
+editor needs HMR-grade tooling or a Vite-only plugin), so it is recorded here rather than
+re-proposed ad hoc.
 
 ### Why not Option 0?
 
@@ -134,9 +186,12 @@ language pytest cannot exercise — the precise hazard ADR-0002/0017 guard again
 
 ### Neutral
 
-- If `three` is bundled from npm, the `data:` import-map and the separate vendored
-  `three/` source files may be retired; if it stays external, they are unchanged. Both
-  are in-policy under this ADR.
+- `three` stays vendored & external (recommended), so the `data:` import-map and the
+  vendored `three/` source files are unchanged. The deferred bundle-from-npm option would
+  retire them, but only behind a separate, explicitly-justified decision.
+- A second top-level project root (`viewer/`) is introduced; contributors edit the viewer
+  via Node there (`npm --prefix viewer/ …`) but still build the wheel and run pytest with
+  no Node at all.
 
 ## Compliance
 
@@ -146,8 +201,13 @@ language pytest cannot exercise — the precise hazard ADR-0002/0017 guard again
 - **`tsc --noEmit`** + **eslint** + **`node --test`** for the pure units run in CI.
 - A **three-version↔`@types/three` skew guard** asserts `VENDOR.md` and `package.json`
   agree on the three major.minor.
-- A **packaging assertion** confirms the built sdist/wheel contains `viewer.js` but not
-  `src/*.ts`, `node_modules/`, or `package.json` (Node stays out of the install path).
+- A **contract parity test** (`tests/test_scene.py`) asserts `build_scene()`'s top-level
+  key set matches `scene-contract.ts`; a brand parity test matches `brand.py`'s token names.
+- The TypeScript toolchain lives in the top-level `viewer/` dir, *outside* `src/`, so
+  nothing it touches can enter the package by construction; package-data is tightened from
+  `*.js` to the explicit `viewer.js`, and a **packaging assertion** confirms the built
+  sdist/wheel contains `viewer.js` but no `node_modules/`, `*.ts`, or `package.json` (Node
+  stays out of the install path).
 - The unchanged in-browser `checkAnchors()` fails loud on the `#banner` if the JS matrix
   path diverges from the Python oracle; `tests/test_viewer.py` keeps the offline +
   `</script>`-escape asserts.
@@ -163,6 +223,9 @@ language pytest cannot exercise — the precise hazard ADR-0002/0017 guard again
   schema reference [`docs/architecture/scene-v1-schema.md`](../architecture/scene-v1-schema.md).
 - Related issues / PRs: #436 (epic), #437 (toolchain), #438 (CI), #439 (port), #440
   (typed contract + interaction seam), #441 (Python `priority` groundwork), #442
-  (deferred interactive editor); follows #423, subsumes #433.
-- External references: [esbuild](https://esbuild.github.io/) (reproducible builds),
-  [`@types/three`](https://www.npmjs.com/package/@types/three), Three.js r160.
+  (deferred interactive editor), #444 (deferred JSON-Schema single-source spike); follows
+  #423, subsumes #433.
+- External references: [esbuild](https://esbuild.github.io/) (reproducible builds,
+  semver: minor = breaking), [`@types/three`](https://www.npmjs.com/package/@types/three),
+  Three.js r160, [`vite-plugin-singlefile`](https://github.com/richmolj/vite-plugin-singlefile)
+  (the deferred Vite path).

--- a/docs/adr/0020-viewer-typescript-architecture.md
+++ b/docs/adr/0020-viewer-typescript-architecture.md
@@ -1,0 +1,168 @@
+# ADR-0020: The viewer is a typed, modular TypeScript application built by a dev-only toolchain; the Python-owned transform is retained
+
+- **Status:** Proposed
+  <!-- Proposed at PR-open; Accepted at PR-merge. Supersedes ADR-0017's
+       "No build toolchain" / thin-renderer sub-decision (see below). -->
+
+- **Date:** 2026-06-04
+- **Deciders:** Patrick Kuhn (DocGerd)
+
+> **Scope of this ADR.** It revisits exactly **one** part of
+> [ADR-0017](0017-3d-viewer-architecture.md): the "**No build toolchain**" decision
+> driver and the *thin read-only renderer* posture that flowed from it. ADR-0017's
+> **load-bearing correctness decision — the determinant-−1 plane-local→world
+> transform is owned by Python and never re-derived in JavaScript (ADR-0002) — is
+> reaffirmed unchanged**, as are the `scene/v1` seam and the single offline HTML
+> deliverable. ADR-0017 is updated to *Accepted (build-toolchain decision
+> superseded by ADR-0020)*.
+
+## Context & Problem Statement
+
+`hangarfit view` ships its 3D viewer as one hand-written, untyped, ~546-line ES
+module (`src/hangarfit/_viewer_assets/viewer.js`) — the only application JavaScript
+in an otherwise Python-only repo, with **zero static analysis in CI** (ruff is
+Python-only; the `typescript-lsp`/`jsconfig.json` from #423 is editor-only). ADR-0017
+deliberately rejected a build toolchain when the viewer was a *render-only* artifact.
+That premise is changing: the user's outlook is an **interactive editor** — let a user
+select which planes go into the hangar and assign **priorities** and **"must
+positions"** to certain aircraft. Untyped, single-file growth toward that is risk
+concentrated in the repo's only untested language. The question this ADR answers: **how
+do we make the viewer typed, modular, and extendable for that future without losing the
+offline single-file deliverable, the build/output determinism, the OpenSSF supply-chain
+posture, or the Python-owned transform?**
+
+## Decision Drivers
+
+- **Type safety over the `scene/v1` contract** — catch shape errors at dev/CI time,
+  not in a late headless screenshot.
+- **Modular, extendable structure** — a foundation an interaction layer can plug into,
+  not a 546-line monolith.
+- **Preserve every ADR-0017 invariant that still holds** — Python owns the det-−1
+  transform (ADR-0002); the viewer does no transform math; one self-contained offline
+  HTML; deterministic output; fail-loud in-browser anchor self-check.
+- **Keep the supply-chain surface out of the install/runtime path** — a flying-club
+  laptop and `pip install` must stay Node-free; the OpenSSF-scored, hash-pinned
+  discipline must extend to any new toolchain rather than be breached by it.
+
+## Considered Options
+
+1. **A dev-only TypeScript toolchain (esbuild + tsc + eslint) that bundles modular
+   `*.ts` into a single, committed `viewer.js` artifact** (chosen). Node is required
+   only to *change* the viewer (dev/CI); the wheel and `pip install` consume the
+   committed bundle and never invoke npm.
+2. **`tsc`-only, multi-module, no bundler** — emit one `.js` per module and have
+   `viewer.py` resolve each via additional `data:`-URL import-map entries.
+3. **No-npm, JSDoc-typed plain-JS modules** — keep hand-written `.js`, add `// @ts-check`
+   + JSDoc typedefs, type-check with the existing editor LSP.
+0. **Status quo** — keep the single untyped `viewer.js`.
+
+## Decision Outcome
+
+**Chosen option: Option 1**, because it is the only option that delivers *real
+TypeScript + a shipped-modular, editor-ready structure* while keeping the **install and
+runtime paths Node-free**: the toolchain is a dev/CI concern, the distributed artifact is
+a single committed `viewer.js`, and determinism becomes *reproducibility of that
+artifact*, enforced exactly like the repo's existing lockfile-drift guards.
+
+Supporting choices:
+
+- **esbuild, three external or bundled.** esbuild bundles `src/*.ts` → one ESM
+  `viewer.js`, emitted **unminified** at `target: es2020` so the committed diff is
+  legible and reviewable (matching the repo's choice to commit *readable* vendored
+  three). Recommended direction: promote `three` to a **pinned npm dependency bundled
+  into the output** (npm integrity-hashed supply chain; one self-contained file; drops
+  the base64 `data:` import-map machinery). Keeping `three` **vendored & external** —
+  unchanged `viewer.py`, the `data:` import-map preserved — is the documented
+  conservative fallback. Either way the **offline single-file deliverable is preserved**
+  and `@types/three` stays types-only.
+- **`@types/three` pinned to `0.160.x`** to match vendored/​bundled three **r160**
+  (`_viewer_assets/three/VENDOR.md`); a CI guard asserts the two agree so the API the
+  TS type-checks against can't drift from the three the viewer actually runs.
+- **Determinism via the lockfile-drift idiom.** A `viewer-build-drift` CI job rebuilds
+  the bundle (`npm ci` → `npm run build`) and fails on any diff against the committed
+  `viewer.js` — the same shape as `lockfile-drift`, with a stricter (sha256/byte)
+  invariant.
+- **The transform stays in Python.** The browser keeps applying Python-emitted affines
+  only; the future interaction layer captures *intent* and exports a `Scenario`/
+  constraints artifact for the Python solver — it must never import the affine/anchor
+  modules to re-derive geometry.
+
+### Why not Option 2?
+
+A `tsc`-only multi-module layout forces `viewer.py` to grow one `data:`-URL import-map
+entry and one `_asset_text` read per emitted module, changing the HTML assembly and its
+byte output and multiplying the offline `data:` surface — reopening exactly the
+complexity ADR-0017 minimized — for **no** modularity benefit over a single bundle. The
+contract we want to protect (one `viewer.js`, deterministic assembly) is best served by a
+single bundled artifact, not N inlined modules.
+
+### Why not Option 3?
+
+JSDoc-typed plain JS has the smallest supply-chain surface but does not deliver the
+stated goal: a *shipped-modular*, editor-ready foundation. It would either ship N `.js`
+modules (Option 2's import-map problem) or keep one big file (defeats "modular"), and it
+still needs `tsc` to type-check — so it is not truly zero-toolchain. It is the right
+answer only if the goal were "add types to the existing single file with zero build,"
+which is not where the viewer is going. Recorded as the fallback if Node is vetoed.
+
+### Why not Option 0?
+
+Untyped single-file growth toward an interactive editor concentrates risk in the one
+language pytest cannot exercise — the precise hazard ADR-0002/0017 guard against. The
+`scene/v1` contract and the future intent artifact both deserve compile-time types.
+
+## Consequences
+
+### Positive
+
+- A typed `scene/v1` contract and a modular structure the future interaction layer plugs
+  into; pure units (`affine`, `anchors`, `timeline`) become **node-unit-testable** — new
+  coverage the single-file design could not have.
+- ADR-0017's correctness invariants are all preserved: Python-owned transform, offline
+  single file, deterministic output, fail-loud anchor check.
+- Determinism is *stronger*, not weaker: a CI guard pins the committed bundle.
+
+### Negative
+
+- Adds a pinned **dev/CI** npm surface (`typescript`, `esbuild`, `@types/three`,
+  `eslint`). Mitigated: committed `package-lock.json` + `npm ci`, minimal pinned deps,
+  the `viewer-build-drift` guard, and **never** in the wheel build or `pip install`.
+- Contributors need Node to *change* the viewer (not to build the wheel or run pytest).
+- The new bundle's bytes will **not** equal the old hand-written `viewer.js`; equivalence
+  to the prior viewer is **semantic** (verified by the headless render + anchor check),
+  not a byte-diff. This is stated so reviewers don't chase an impossible diff.
+
+### Neutral
+
+- If `three` is bundled from npm, the `data:` import-map and the separate vendored
+  `three/` source files may be retired; if it stays external, they are unchanged. Both
+  are in-policy under this ADR.
+
+## Compliance
+
+- **`viewer-build-drift` CI job** rebuilds the bundle and fails on any diff against the
+  committed `viewer.js` (the determinism/reproducibility check) — see
+  `.github/workflows/ci.yml` (added by issue #438).
+- **`tsc --noEmit`** + **eslint** + **`node --test`** for the pure units run in CI.
+- A **three-version↔`@types/three` skew guard** asserts `VENDOR.md` and `package.json`
+  agree on the three major.minor.
+- A **packaging assertion** confirms the built sdist/wheel contains `viewer.js` but not
+  `src/*.ts`, `node_modules/`, or `package.json` (Node stays out of the install path).
+- The unchanged in-browser `checkAnchors()` fails loud on the `#banner` if the JS matrix
+  path diverges from the Python oracle; `tests/test_viewer.py` keeps the offline +
+  `</script>`-escape asserts.
+
+## More Information
+
+- Related ADRs: [ADR-0017](0017-3d-viewer-architecture.md) (the viewer architecture whose
+  build-toolchain sub-decision this supersedes), [ADR-0002](0002-determinant-minus-one-transform.md)
+  (the transform retained in Python), [ADR-0019](0019-brand-tokens-single-source.md) (the
+  BRAND blob the typed `brand-contract.ts` mirrors), [ADR-0003](0003-rr-mc-solver-algorithm.md)
+  (the determinism spirit the build-drift guard extends).
+- Related specs: [`docs/superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md`](../superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md);
+  schema reference [`docs/architecture/scene-v1-schema.md`](../architecture/scene-v1-schema.md).
+- Related issues / PRs: #436 (epic), #437 (toolchain), #438 (CI), #439 (port), #440
+  (typed contract + interaction seam), #441 (Python `priority` groundwork), #442
+  (deferred interactive editor); follows #423, subsumes #433.
+- External references: [esbuild](https://esbuild.github.io/) (reproducible builds),
+  [`@types/three`](https://www.npmjs.com/package/@types/three), Three.js r160.

--- a/docs/adr/0020-viewer-typescript-architecture.md
+++ b/docs/adr/0020-viewer-typescript-architecture.md
@@ -80,9 +80,10 @@ Supporting choices:
   `esbuild.config.mjs`, eslint config, `node_modules/` — lives in a **new top-level
   `viewer/` directory, *outside* the importable Python package**. esbuild emits the one
   committed artifact to `outfile: ../src/hangarfit/_viewer_assets/viewer.js`, exactly where
-  `viewer.py` already reads it via `importlib.resources`. This keeps
-  `find_packages(where="src")` returning exactly `{hangarfit, _viewer_assets,
-  _viewer_assets.three}` with **zero** packaging changes and makes wheel /
+  `viewer.py` already reads it via `importlib.resources`. This keeps the declarative
+  `[tool.setuptools.packages.find]` (`where = ["src"]`) discovering exactly
+  `{hangarfit, hangarfit._viewer_assets, hangarfit._viewer_assets.three}` with **zero**
+  packaging changes and makes wheel /
   discovery / ruff / mypy / editable-install hygiene **structural rather than
   discipline-dependent** — a nested `_viewer_assets/src/` would expose
   `hangarfit._viewer_assets.src` as a PEP-420 namespace subpackage and let any future
@@ -230,5 +231,5 @@ language pytest cannot exercise — the precise hazard ADR-0002/0017 guard again
   serve` — own ADR); follows #423, subsumes #433.
 - External references: [esbuild](https://esbuild.github.io/) (reproducible builds,
   semver: minor = breaking), [`@types/three`](https://www.npmjs.com/package/@types/three),
-  Three.js r160, [`vite-plugin-singlefile`](https://github.com/richmolj/vite-plugin-singlefile)
+  Three.js r160, [`vite-plugin-singlefile`](https://github.com/richardtallent/vite-plugin-singlefile)
   (the deferred Vite path).

--- a/docs/adr/0020-viewer-typescript-architecture.md
+++ b/docs/adr/0020-viewer-typescript-architecture.md
@@ -25,8 +25,10 @@ Python-only; the `typescript-lsp`/`jsconfig.json` from #423 is editor-only). ADR
 deliberately rejected a build toolchain when the viewer was a *render-only* artifact.
 That premise is changing: the user's outlook is an **interactive editor** — let a user
 select which planes go into the hangar and assign **priorities** and **"must
-positions"** to certain aircraft. Untyped, single-file growth toward that is risk
-concentrated in the repo's only untested language. The question this ADR answers: **how
+positions"** to certain aircraft — and, ultimately, a **full frontend that triggers the
+solve itself** (a local `hangarfit serve` backend; Python stays the solver/authority — see
+the spec's Roadmap and #445). Untyped, single-file growth toward that is risk concentrated
+in the repo's only untested language. The question this ADR answers: **how
 do we make the viewer typed, modular, and extendable for that future without losing the
 offline single-file deliverable, the build/output determinism, the OpenSSF supply-chain
 posture, or the Python-owned transform?**
@@ -223,8 +225,9 @@ language pytest cannot exercise — the precise hazard ADR-0002/0017 guard again
   schema reference [`docs/architecture/scene-v1-schema.md`](../architecture/scene-v1-schema.md).
 - Related issues / PRs: #436 (epic), #437 (toolchain), #438 (CI), #439 (port), #440
   (typed contract + interaction seam), #441 (Python `priority` groundwork), #442
-  (deferred interactive editor), #444 (deferred JSON-Schema single-source spike); follows
-  #423, subsumes #433.
+  (deferred interactive editor — Stage 2 round-trip), #444 (deferred JSON-Schema
+  single-source spike), #445 (deferred Stage 3: viewer-as-full-frontend via `hangarfit
+  serve` — own ADR); follows #423, subsumes #433.
 - External references: [esbuild](https://esbuild.github.io/) (reproducible builds,
   semver: minor = breaking), [`@types/three`](https://www.npmjs.com/package/@types/three),
   Three.js r160, [`vite-plugin-singlefile`](https://github.com/richmolj/vite-plugin-singlefile)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -94,6 +94,7 @@ manual workflow above is canonical.
 | 0014 | [Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail](0014-merge-commit-only-history-strategy.md) | Accepted |
 | 0015 | [Wheels do not participate in the static collision model (gear stays render/motion data)](0015-wheels-not-in-collision-model.md) | Accepted |
 | 0016 | [Spread-vs-towability — CLI re-solves spread-off as a backstop when a default-spread layout is un-routable](0016-spread-towability-fallback.md) | Proposed |
-| 0017 | [3D viewer — `scene/v1` JSON seam → self-contained offline Three.js HTML, transform owned by Python](0017-3d-viewer-architecture.md) | Accepted |
+| 0017 | [3D viewer — `scene/v1` JSON seam → self-contained offline Three.js HTML, transform owned by Python](0017-3d-viewer-architecture.md) | Accepted (build-toolchain / thin-renderer decision superseded by [ADR-0020](0020-viewer-typescript-architecture.md)) |
 | 0018 | [Model the non-rectangular hangar footprint — list of keep-out rects + derived Shapely floor polygon for containment](0018-non-rectangular-hangar-footprint.md) | Proposed |
 | 0019 | [Brand tokens live in one Python module (`brand.py`), injected into the viewer as a canonical BRAND blob](0019-brand-tokens-single-source.md) | Proposed |
+| 0020 | [The viewer is a typed, modular TypeScript application built by a dev-only toolchain; the Python-owned transform is retained](0020-viewer-typescript-architecture.md) | Proposed |

--- a/docs/superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md
+++ b/docs/superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md
@@ -1,0 +1,184 @@
+# Viewer TypeScript migration — modular, typed, editor-ready (epic #436)
+
+- **Date:** 2026-06-04
+- **Epic:** #436. **Issues:** #437 (toolchain scaffold), #438 (CI guard), #439
+  (port viewer.js → TS), #440 (typed scene-contract + interaction seam + node tests),
+  #441 (Python `PlaneConstraint.priority` groundwork), #442 (deferred interactive
+  editor). Follows #423 (`typescript-lsp` + `jsconfig.json`); subsumes #433.
+- **Status:** design record authored before implementation. Decision basis recorded in
+  [ADR-0020](../../adr/0020-viewer-typescript-architecture.md). User-approved the
+  shaping choices on 2026-06-04 (build approach: design for the future app, not the
+  current thin-renderer constraints; this pass is design + issues only; the interactive
+  feature is tracked + groundwork).
+
+## Problem
+
+The `hangarfit view` 3D viewer is one hand-written, untyped, ~546-line ES module
+(`src/hangarfit/_viewer_assets/viewer.js`) — the repo's only application JavaScript and
+its only code with **no static analysis in CI**. [ADR-0017](../../adr/0017-3d-viewer-architecture.md)
+kept it a *thin read-only renderer* with no build toolchain, which fit "render what
+Python computed."
+
+The user's outlook changes the premise: the JS app should grow into an **interactive
+editor** — select which planes go into the hangar, and assign **priorities** and **"must
+positions"** to certain aircraft. Untyped single-file growth toward that is risk in the
+one language pytest cannot reach. We want a typed, modular, extendable foundation —
+**without** giving up the offline single-file deliverable, output determinism, the
+OpenSSF supply-chain posture, or the Python-owned transform.
+
+## What already supports this (no core changes needed)
+
+- **The seam is already a clean data contract.** `scene.py` emits a deterministic
+  `hangarfit.scene/v1` dict; the viewer is a pure consumer. Typing it is additive.
+- **The transform already lives in one tested place.** `geometry.local_to_world` is the
+  single det-−1 definition; `scene.py` emits per-frame affines `[a,b,tx,c,d,ty]`. The TS
+  viewer keeps applying them and re-derives nothing (ADR-0002).
+- **The constraint machinery for "must positions" already exists.** `PlaneConstraint.pin`
+  (models.py) hard-fixes a plane's `(x,y,heading)`; `Scenario.constraints` validates it.
+  Only a *soft* `priority` is missing (#441).
+- **`viewer.js` is already internally modular.** Its comment-delimited sections
+  (renderer, affine, hangar, gear, planes, labels, anchors, timeline, HUD) map 1:1 onto
+  TS modules, so the port is mechanical and reviewable section-by-section.
+
+## Goals
+
+- Real **TypeScript**, modular under `src/hangarfit/_viewer_assets/src/*.ts`, typed
+  against the `scene/v1` contract and `@types/three`.
+- A **dev/CI-only** Node toolchain (esbuild + tsc + eslint) that **never** enters
+  `pip install`, the wheel build, or the runtime — the committed bundle is the artifact.
+- **Reproducible** output, guarded in CI like the existing hash-pinned lockfiles.
+- An **extension seam** (typed `scene-contract.ts` + an inert `interaction/` namespace)
+  the future editor plugs into.
+- Every ADR-0017 invariant preserved: offline single file, no JS transform math, the
+  fail-loud anchor self-check, deterministic assembly.
+
+## Non-goals (this epic)
+
+- Building the interactive editor (selection / priorities / must-positions UI) — that is
+  the deferred #442; this epic only lays its seam.
+- Re-deriving any transform / collision / solver math in JavaScript.
+- A runtime Node server, client-side solving, or shipping `node_modules` in the wheel.
+- Byte-identity with the *old* `viewer.js` (a bundled TS port differs in bytes by
+  construction — see §Verification).
+
+## Decisions (basis in ADR-0020)
+
+1. **Build approach:** esbuild bundles modular `*.ts` → a single **committed**
+   `viewer.js`, emitted **unminified**, `target: es2020`, for a legible diff. Node is
+   dev/CI-only.
+2. **three:** recommended — promote to a **pinned npm dependency bundled into the
+   output** (drops the base64 `data:` import-map); **fallback** — keep vendored &
+   external with the import-map unchanged. Decided concretely in #437; both preserve the
+   offline single-file deliverable.
+3. **Types:** `@types/three` pinned to `0.160.x` (matches vendored three r160), types-only.
+4. **Determinism:** redefined as *reproducibility of the committed bundle*, enforced by a
+   `viewer-build-drift` CI job (rebuild + sha256/diff), mirroring `lockfile-drift`.
+5. **Transform ownership:** unchanged — Python owns it; the editor exports a `Scenario`
+   artifact for the solver.
+
+## Architecture — module map
+
+TS sources excluded from the wheel; only the emitted `viewer.js` ships.
+
+```
+src/hangarfit/_viewer_assets/
+  viewer.js                    # COMMITTED esbuild artifact — the only shipped JS
+  src/
+    main.ts                    # entry: init in viewer.js's exact current order
+    scene-contract.ts          # typed scene/v1 (the extension seam) — pure types
+    brand-contract.ts          # typed BRAND token blob (#419)
+    dom.ts                      # element lookups, banner(), readouts wiring (#401)
+    affine.ts                   # affineMatrix()->Matrix4, applyAffine() — PURE, tested
+    anchors.ts                  # boxCornersLocal() + oracle-compare — PURE; banner at edge
+    renderer.ts                 # renderer/scene/camera/lights/OrbitControls, home(), resize
+    hangar.ts                   # floor/grid/walls(door split)/bay + walls toggle
+    gear.ts                     # wheels/legs/pallets + render constants
+    planes.ts                   # boxMaterial(), per-plane Group loop, legend chips
+    labels.ts                   # makeLabel() (CanvasTexture, safe fillText), nose, toggle
+    timeline.ts                 # segByPlane, affineAt() — PURE, tested; applyTime()
+    hud.ts                      # play/scrub/step/speed wiring + render loop
+    interaction/                # FUTURE seam — README.md only now (no .ts; bundle unchanged)
+  three/                        # vendored r160 (retained if three stays external)
+  package.json, package-lock.json, tsconfig.json, esbuild.config.mjs, eslint config
+```
+
+**Pure, testable units** (the high-value extraction, covered by `node --test` in #440):
+`affine.ts` (the only math the viewer does), `anchors.ts` (the cross-language oracle
+compare; banner side-effect stays at the thin edge so the comparison is testable without
+a DOM), `timeline.ts` (`affineAt` is pure given `(segByPlane, finals, t)`).
+
+**The `checkAnchors()` backstop** (viewer.js 389–438) is ported behavior-identically: it
+recomputes world corners + wheel positions from geometry + the final affine and **fails
+loud on the `#banner`** (never throws) if they diverge from the Python oracle past 1e-6.
+It is the only thing pinning the JS matrix path to Python and is non-negotiable.
+
+## The future-editor seam (deferred — #442)
+
+The `interaction/` namespace documents the contract now and stays inert (README-only) so
+the bundle is unchanged. When #442 lands, an `interaction/` module:
+
+- reads `scene-contract` types;
+- builds an **intent object** mirroring `Scenario.constraints`:
+  `{ selectedPlaneIds, priorities: Record<id, number>, mustPositions: Record<id, {x,y,heading}> }`
+  — "must positions" → `PlaneConstraint.pin` (hard), "priorities" → the new soft
+  `PlaneConstraint.priority` (#441);
+- **exports a `Scenario`/constraints YAML** the Python solver consumes (round-trip); the
+  user re-runs `hangarfit solve` and a fresh viewer renders the result;
+- **must never import `affine.ts`/`anchors.ts`** to re-derive geometry (ADR-0002/0020):
+  Python remains the authority/solver.
+
+`intent-contract.ts` becomes the typed mirror of that artifact when #442 lands.
+
+## Build & CI
+
+- **#437 scaffold:** `package.json` (devDeps only), committed integrity-pinned
+  `package-lock.json` (`npm ci`), strict `tsconfig.json`, `esbuild.config.mjs`
+  (unminified, es2020), eslint, `@types/three@0.160.x`, `.gitignore node_modules`. A
+  packaging assertion proves `src/*.ts` / node artifacts stay out of the sdist/wheel.
+- **#438 CI** (new Node job, pinned `setup-node`): `viewer-build-drift` (rebuild + diff
+  the committed `viewer.js`, `::error::` on drift), `tsc --noEmit`, eslint, `node --test`,
+  the three↔types skew guard. Python-3.12 jobs untouched. Recommend making
+  `viewer-build-drift` + `tsc` required checks on `develop`.
+
+## Verification
+
+- **Reproducibility:** `viewer-build-drift` is the determinism pin — `npm ci && npm run
+  build` must reproduce the committed `viewer.js` byte-for-byte (unminified + pinned
+  toolchain).
+- **Semantic equivalence to the old viewer** (NOT a byte-diff — the bundle's bytes
+  necessarily differ): the documented headless check renders a fixture and asserts the
+  `#banner` TRANSFORM CHECK stays **hidden**:
+  ```
+  google-chrome --headless=new --use-gl=angle --use-angle=swiftshader \
+    --enable-unsafe-swiftshader --virtual-time-budget=8000 \
+    --screenshot=out.png "file://$PWD/out.html"
+  ```
+  Optionally grep `--dump-dom` for the banner text as a hard gate. (swiftshader WebGL
+  "ReadPixels stall" / dbus/UPower lines are noise.)
+- **Assembly determinism:** extend `tests/test_viewer.py` with a golden-HTML pin for a
+  fixed fixture, plus the unchanged offline + `</script>`-escape asserts.
+- **Pure units:** `node --test` covers `affine` (matrix algebra), `anchors`
+  (oracle-compare incl. structural-mismatch banners), `timeline` (hidden→animating→
+  parked) — coverage pytest cannot reach.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Supply-chain surface vs ADR-0017 | dev/CI-only; committed artifact; `npm ci` + pinned lockfile; minimal pinned devDeps; never in wheel/install path; ADR-0020 distinguishes this from ADR-0017's rejected *runtime* node app. |
+| esbuild output drift across versions/machines | exact-pin esbuild in the lockfile; unminified + fixed target → byte-stable per version; `viewer-build-drift` is the backstop (drift = guard failure, not silent change). |
+| Node leaking into the install path | wheel ships only the committed `viewer.js` (package-data `*.js` top-level glob excludes `src/`); build-system untouched; packaging assertion. |
+| `@types/three` skew vs three r160 | pin `@types/three@0.160.x`; CI skew guard; the VENDOR.md refresh procedure bumps types in lockstep. |
+| JS untestable by pytest | extract pure units + `node --test`; in-browser `checkAnchors` + headless banner-grep as integration backstop; `test_scene.py` still pins the producer side. |
+| Half-ported intermediate states | the port (#439) is one atomic, behavior-neutral PR committing `viewer.js` + `src/*.ts` together. |
+
+## Impact map
+
+- **New (dev-only):** `_viewer_assets/src/*.ts`, `package.json`, `package-lock.json`,
+  `tsconfig.json`, `esbuild.config.mjs`, eslint config; `.github/workflows/ci.yml` Node job.
+- **Changed:** `_viewer_assets/viewer.js` (becomes the build artifact); possibly
+  `viewer.py` (only if three moves to bundled — the import-map is then dropped);
+  `tests/test_viewer.py` (golden pin); `CLAUDE.md` + `.claude/README.md` (build commands);
+  `pyproject.toml` (confirm package-data excludes TS/node); `VENDOR.md` (types-lockstep note).
+- **Deferred:** `models.py`/`solver.py`/`loader.py` for `priority` (#441);
+  `interaction/*.ts` for the editor (#442).

--- a/docs/superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md
+++ b/docs/superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md
@@ -167,8 +167,9 @@ and **must never import `affine.ts`/`anchors.ts`** to re-derive geometry.
 
 **Stage 3 — full frontend via `hangarfit serve` (deferred — #445, own ADR).** The exact
 same intent object + `Scenario` contract is delivered over a **localhost HTTP API** instead
-of a file: a new `hangarfit serve` subcommand wraps the existing `solve`/`check`/`scene`
-path; the browser POSTs intent, the server runs the *unchanged* Python solver
+of a file: a new `hangarfit serve` subcommand wraps the existing `solve`/`check` pipeline
+(reusing the internal `scene.py` builder — `scene` is a module, not a CLI command);
+the browser POSTs intent, the server runs the *unchanged* Python solver
 (determinism + det-−1 untouched), and returns a `scene/v1` the viewer renders — making it a
 click-to-solve frontend. The **offline single-file export survives** (ADR-0017) as the
 shareable/pure-view artifact; `serve` is an *additional* deployment, not a replacement.

--- a/docs/superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md
+++ b/docs/superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md
@@ -36,13 +36,15 @@ OpenSSF supply-chain posture, or the Python-owned transform.
 - **The constraint machinery for "must positions" already exists.** `PlaneConstraint.pin`
   (models.py) hard-fixes a plane's `(x,y,heading)`; `Scenario.constraints` validates it.
   Only a *soft* `priority` is missing (#441).
-- **`viewer.js` is already internally modular.** Its comment-delimited sections
-  (renderer, affine, hangar, gear, planes, labels, anchors, timeline, HUD) map 1:1 onto
-  TS modules, so the port is mechanical and reviewable section-by-section.
+- **`viewer.js` is already internally modular.** Its nine comment-delimited sections
+  (renderer/scene/camera, affine, hangar, gear, planes [label code lives here], anchor
+  self-check, timeline, HUD wiring, render loop) map *closely* onto TS modules — `labels.ts`
+  is extracted from the planes section and `hud.ts` folds in the render loop — so the port
+  is mechanical and reviewable section-by-section.
 
 ## Goals
 
-- Real **TypeScript**, modular under `src/hangarfit/_viewer_assets/src/*.ts`, typed
+- Real **TypeScript**, modular under a top-level `viewer/src/*.ts` project, typed
   against the `scene/v1` contract and `@types/three`.
 - A **dev/CI-only** Node toolchain (esbuild + tsc + eslint) that **never** enters
   `pip install`, the wheel build, or the runtime — the committed bundle is the artifact.
@@ -63,43 +65,69 @@ OpenSSF supply-chain posture, or the Python-owned transform.
 
 ## Decisions (basis in ADR-0020)
 
-1. **Build approach:** esbuild bundles modular `*.ts` → a single **committed**
-   `viewer.js`, emitted **unminified**, `target: es2020`, for a legible diff. Node is
-   dev/CI-only.
-2. **three:** recommended — promote to a **pinned npm dependency bundled into the
-   output** (drops the base64 `data:` import-map); **fallback** — keep vendored &
-   external with the import-map unchanged. Decided concretely in #437; both preserve the
-   offline single-file deliverable.
-3. **Types:** `@types/three` pinned to `0.160.x` (matches vendored three r160), types-only.
-4. **Determinism:** redefined as *reproducibility of the committed bundle*, enforced by a
+1. **Layout:** the Node project lives in a **new top-level `viewer/`** directory, *outside*
+   the Python package; esbuild emits the one committed artifact to
+   `outfile: ../src/hangarfit/_viewer_assets/viewer.js`. This needs **zero** `pyproject.toml`
+   packaging changes and makes wheel/discovery/ruff/mypy/editable hygiene structural (a
+   nested `_viewer_assets/src/` would expose a namespace subpackage and risk a `**/*.js`
+   glob shipping `node_modules`).
+2. **Build approach:** esbuild bundles `viewer/src/*.ts` → a single **committed**
+   `viewer.js`, emitted **unminified**, `target: es2022`, for a legible diff. esbuild and
+   Node are **exact-pinned** (esbuild minor releases are breaking; `.nvmrc` / `setup-node`)
+   so the drift guard catches source edits, not toolchain bumps. Node is dev/CI-only.
+3. **three (recommended): stays vendored & external + Python-inlined** via the existing
+   `data:` import-map — `viewer.py` is unchanged. Bundling three from npm is a **deferred**
+   option, not the default: it would bloat the byte-diffed drift artifact ~58× (1.27 MB
+   three vs 22 KB viewer.js) and erode the `viewer-build-drift` guard. Either way the
+   offline single-file deliverable is preserved.
+4. **Types:** `@types/three` pinned to `0.160.x` (matches vendored three r160), types-only.
+5. **Determinism:** redefined as *reproducibility of the committed bundle*, enforced by a
    `viewer-build-drift` CI job (rebuild + sha256/diff), mirroring `lockfile-drift`.
-5. **Transform ownership:** unchanged — Python owns it; the editor exports a `Scenario`
+6. **Contract sync (near-term):** hand-written `scene-contract.ts`/`brand-contract.ts` +
+   cheap Python **key-set parity tests** in `tests/test_scene.py`; JSON-Schema single-source
+   is the deferred principled target (spike #444).
+7. **Transform ownership:** unchanged — Python owns it; the editor exports a `Scenario`
    artifact for the solver.
+8. **Vite** (+ `vite-plugin-singlefile`) considered and **deferred** (output less
+   byte-reproducible under a diff guard; larger surface) — revisit only on a concrete
+   editor-tooling trigger.
 
 ## Architecture — module map
 
-TS sources excluded from the wheel; only the emitted `viewer.js` ships.
+The Node project lives in a **top-level `viewer/`** dir (never imported, never shipped);
+esbuild emits the one committed `viewer.js` into the existing package asset path. Only that
+emitted artifact (+ vendored three) ships in the wheel; nothing under `viewer/` does.
 
 ```
-src/hangarfit/_viewer_assets/
-  viewer.js                    # COMMITTED esbuild artifact — the only shipped JS
+viewer/                          # NEW top-level Node project (NOT importable, gitignored node_modules)
+  package.json                   # devDependencies ONLY: typescript, esbuild (exact pin),
+                                 #   eslint + TS parser, @types/three@0.160.x; no runtime deps
+  package-lock.json              # committed + integrity-pinned; CI uses `npm --prefix viewer/ ci`
+  tsconfig.json                  # strict; target es2022; noEmit for the typecheck pass
+  esbuild.config.mjs             # bundle, format esm, target es2022, minify:false,
+                                 #   external:['three','three/addons/controls/OrbitControls.js'],
+                                 #   outfile:'../src/hangarfit/_viewer_assets/viewer.js'
+  eslint config · .nvmrc         # eslint (TS) + pinned Node major
   src/
-    main.ts                    # entry: init in viewer.js's exact current order
-    scene-contract.ts          # typed scene/v1 (the extension seam) — pure types
-    brand-contract.ts          # typed BRAND token blob (#419)
-    dom.ts                      # element lookups, banner(), readouts wiring (#401)
-    affine.ts                   # affineMatrix()->Matrix4, applyAffine() — PURE, tested
-    anchors.ts                  # boxCornersLocal() + oracle-compare — PURE; banner at edge
-    renderer.ts                 # renderer/scene/camera/lights/OrbitControls, home(), resize
-    hangar.ts                   # floor/grid/walls(door split)/bay + walls toggle
-    gear.ts                     # wheels/legs/pallets + render constants
-    planes.ts                   # boxMaterial(), per-plane Group loop, legend chips
-    labels.ts                   # makeLabel() (CanvasTexture, safe fillText), nose, toggle
-    timeline.ts                 # segByPlane, affineAt() — PURE, tested; applyTime()
-    hud.ts                      # play/scrub/step/speed wiring + render loop
-    interaction/                # FUTURE seam — README.md only now (no .ts; bundle unchanged)
-  three/                        # vendored r160 (retained if three stays external)
-  package.json, package-lock.json, tsconfig.json, esbuild.config.mjs, eslint config
+    main.ts                      # entry: init in viewer.js's exact current order
+    scene-contract.ts            # typed scene/v1 mirror of scene.py (the extension seam) — pure types
+    brand-contract.ts            # typed BRAND token mirror of brand.py (#419/ADR-0019)
+    dom.ts                       # element lookups, banner(), readouts wiring (#401)
+    affine.ts                    # affineMatrix()->Matrix4, applyAffine() — PURE, node-tested
+    anchors.ts                   # boxCornersLocal() + oracle-compare — PURE; banner at edge
+    renderer.ts                  # renderer/scene/camera/lights/OrbitControls, home(), resize
+    hangar.ts                    # floor/grid/walls(door split)/bay + walls toggle
+    gear.ts                      # wheels/legs/pallets + render constants
+    planes.ts                    # boxMaterial(), per-plane Group loop, legend chips
+    labels.ts                    # makeLabel() (CanvasTexture, safe fillText), nose, toggle
+    timeline.ts                  # segByPlane, affineAt() — PURE, node-tested; applyTime()
+    hud.ts                       # play/scrub/step/speed wiring + render loop
+    interaction/                 # FUTURE seam — README.md only now (no .ts; bundle unchanged)
+  test/                          # node --test units for affine/anchors/timeline
+
+src/hangarfit/_viewer_assets/
+  viewer.js                      # COMMITTED esbuild OUTPUT — the only shipped JS (package-data)
+  three/                         # vendored r160 — three stays external + Python-inlined
 ```
 
 **Pure, testable units** (the high-value extraction, covered by `node --test` in #440):
@@ -107,10 +135,12 @@ src/hangarfit/_viewer_assets/
 compare; banner side-effect stays at the thin edge so the comparison is testable without
 a DOM), `timeline.ts` (`affineAt` is pure given `(segByPlane, finals, t)`).
 
-**The `checkAnchors()` backstop** (viewer.js 389–438) is ported behavior-identically: it
-recomputes world corners + wheel positions from geometry + the final affine and **fails
-loud on the `#banner`** (never throws) if they diverge from the Python oracle past 1e-6.
-It is the only thing pinning the JS matrix path to Python and is non-negotiable.
+**The `checkAnchors()` backstop** — the load-time anchor self-check IIFE in `viewer.js`
+(grep `checkAnchors`; line numbers shift with brand/edit churn, so we cite the function,
+not a range) — is ported behavior-identically: it recomputes world corners + wheel
+positions from geometry + the final affine and **fails loud on the `#banner`** (never
+throws) if they diverge from the Python oracle past 1e-6. It is the only thing pinning the
+JS matrix path to Python and is non-negotiable.
 
 ## The future-editor seam (deferred — #442)
 
@@ -131,14 +161,20 @@ the bundle is unchanged. When #442 lands, an `interaction/` module:
 
 ## Build & CI
 
-- **#437 scaffold:** `package.json` (devDeps only), committed integrity-pinned
-  `package-lock.json` (`npm ci`), strict `tsconfig.json`, `esbuild.config.mjs`
-  (unminified, es2020), eslint, `@types/three@0.160.x`, `.gitignore node_modules`. A
-  packaging assertion proves `src/*.ts` / node artifacts stay out of the sdist/wheel.
-- **#438 CI** (new Node job, pinned `setup-node`): `viewer-build-drift` (rebuild + diff
-  the committed `viewer.js`, `::error::` on drift), `tsc --noEmit`, eslint, `node --test`,
-  the three↔types skew guard. Python-3.12 jobs untouched. Recommend making
-  `viewer-build-drift` + `tsc` required checks on `develop`.
+- **#437 scaffold** (all under top-level `viewer/`): `package.json` (devDeps only),
+  committed integrity-pinned `package-lock.json` (`npm --prefix viewer/ ci`), strict
+  `tsconfig.json`, `esbuild.config.mjs` (unminified, es2022, three external,
+  `outfile=../src/hangarfit/_viewer_assets/viewer.js`), eslint, `.nvmrc`,
+  `@types/three@0.160.x` (exact-pinned, like esbuild). `.gitignore` adds
+  `viewer/node_modules/`. Tighten package-data from `*.js` to the explicit `viewer.js`; a
+  packaging assertion proves no `*.ts`/`node_modules`/`package.json` reach the sdist/wheel
+  (trivially true since `viewer/` is outside `src/`).
+- **#438 CI** (new Node job, pinned `setup-node`/`.nvmrc`): `viewer-build-drift`
+  (`npm --prefix viewer/ ci && npm --prefix viewer/ run build` → `git diff --exit-code --
+  src/hangarfit/_viewer_assets/viewer.js`, `::error::` on drift), `tsc --noEmit`, eslint,
+  `node --test`, the three↔types skew guard. Python-3.12 jobs untouched (a Node failure
+  must never block the Python matrix). Recommend making `viewer-build-drift` + `tsc`
+  required checks on `develop`.
 
 ## Verification
 
@@ -166,19 +202,22 @@ the bundle is unchanged. When #442 lands, an `interaction/` module:
 | Risk | Mitigation |
 |---|---|
 | Supply-chain surface vs ADR-0017 | dev/CI-only; committed artifact; `npm ci` + pinned lockfile; minimal pinned devDeps; never in wheel/install path; ADR-0020 distinguishes this from ADR-0017's rejected *runtime* node app. |
-| esbuild output drift across versions/machines | exact-pin esbuild in the lockfile; unminified + fixed target → byte-stable per version; `viewer-build-drift` is the backstop (drift = guard failure, not silent change). |
-| Node leaking into the install path | wheel ships only the committed `viewer.js` (package-data `*.js` top-level glob excludes `src/`); build-system untouched; packaging assertion. |
-| `@types/three` skew vs three r160 | pin `@types/three@0.160.x`; CI skew guard; the VENDOR.md refresh procedure bumps types in lockstep. |
+| esbuild semver: **minor = breaking** | **exact-pin** esbuild (never `^`/`~`) + pin Node (`.nvmrc`/`setup-node`); unminified + fixed target → byte-stable per version; `viewer-build-drift` is the backstop (drift = guard failure, not silent change). |
+| Node leaking into the install path | the Node project is in top-level `viewer/`, *outside* `src/`, so nothing it touches can be discovered/shipped by construction; package-data tightened to explicit `viewer.js`; packaging assertion. |
+| `@types/three` skew vs three r160 | pin `@types/three@0.160.x`; CI skew guard (VENDOR.md vs package.json); the VENDOR.md refresh procedure bumps types in lockstep. |
+| Hand-mirrored `scene-contract.ts`/`brand-contract.ts` silently desync from `scene.py`/`brand.py` | Python key-set parity tests in `tests/test_scene.py` (+ brand token-name parity) — fail the test the maintainer already runs; JSON-Schema single-source is the deferred principled fix (#444); runtime `checkAnchors()` still guards transform *values*. |
 | JS untestable by pytest | extract pure units + `node --test`; in-browser `checkAnchors` + headless banner-grep as integration backstop; `test_scene.py` still pins the producer side. |
-| Half-ported intermediate states | the port (#439) is one atomic, behavior-neutral PR committing `viewer.js` + `src/*.ts` together. |
+| Half-ported intermediate states | the port (#439) is one atomic, behavior-neutral PR committing `viewer.js` + `viewer/src/*.ts` together. |
 
 ## Impact map
 
-- **New (dev-only):** `_viewer_assets/src/*.ts`, `package.json`, `package-lock.json`,
-  `tsconfig.json`, `esbuild.config.mjs`, eslint config; `.github/workflows/ci.yml` Node job.
-- **Changed:** `_viewer_assets/viewer.js` (becomes the build artifact); possibly
-  `viewer.py` (only if three moves to bundled — the import-map is then dropped);
+- **New (dev-only, all under top-level `viewer/`):** `viewer/src/*.ts`, `viewer/test/*`,
+  `viewer/package.json`, `viewer/package-lock.json`, `viewer/tsconfig.json`,
+  `viewer/esbuild.config.mjs`, `viewer/eslint` config, `viewer/.nvmrc`;
+  `.github/workflows/ci.yml` Node job; `.gitignore` (`viewer/node_modules/`).
+- **Changed:** `_viewer_assets/viewer.js` (becomes the esbuild artifact — `viewer.py`
+  **unchanged**, since three stays external); `tests/test_scene.py` (contract parity test);
   `tests/test_viewer.py` (golden pin); `CLAUDE.md` + `.claude/README.md` (build commands);
-  `pyproject.toml` (confirm package-data excludes TS/node); `VENDOR.md` (types-lockstep note).
+  `pyproject.toml` (tighten package-data `*.js`→`viewer.js`); `VENDOR.md` (types-lockstep note).
 - **Deferred:** `models.py`/`solver.py`/`loader.py` for `priority` (#441);
-  `interaction/*.ts` for the editor (#442).
+  `viewer/src/interaction/*.ts` for the editor (#442); `scene-v1.schema.json` single-source (#444).

--- a/docs/superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md
+++ b/docs/superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md
@@ -142,22 +142,41 @@ positions from geometry + the final affine and **fails loud on the `#banner`** (
 throws) if they diverge from the Python oracle past 1e-6. It is the only thing pinning the
 JS matrix path to Python and is non-negotiable.
 
-## The future-editor seam (deferred — #442)
+## Roadmap — viewer → editor → full frontend
 
-The `interaction/` namespace documents the contract now and stays inert (README-only) so
-the bundle is unchanged. When #442 lands, an `interaction/` module:
+This migration is **Stage 1** of a deliberate trajectory. The end-state is a **full
+frontend to the Python tool**: the viewer not only edits inputs but **triggers the solve
+itself**. The invariant across all stages: **Python stays the solver/authority** — the
+browser never re-derives the det-−1 transform or solves geometry (ADR-0002/0017/0020).
 
-- reads `scene-contract` types;
-- builds an **intent object** mirroring `Scenario.constraints`:
-  `{ selectedPlaneIds, priorities: Record<id, number>, mustPositions: Record<id, {x,y,heading}> }`
-  — "must positions" → `PlaneConstraint.pin` (hard), "priorities" → the new soft
-  `PlaneConstraint.priority` (#441);
-- **exports a `Scenario`/constraints YAML** the Python solver consumes (round-trip); the
-  user re-runs `hangarfit solve` and a fresh viewer renders the result;
-- **must never import `affine.ts`/`anchors.ts`** to re-derive geometry (ADR-0002/0020):
-  Python remains the authority/solver.
+| Stage | What | Trigger model | Issue |
+|---|---|---|---|
+| **1 — Foundation** *(this epic)* | read-only viewer → typed, modular TS app + extension seam | n/a (renders a Python-built `scene/v1`) | #436 |
+| **2 — Interactive editor** | select planes; assign **priorities** + **must-positions**; capture *intent* | **round-trip file**: export a `Scenario` YAML, user re-runs `hangarfit solve`, re-open viewer | #442 (+ Python `priority` #441) |
+| **3 — Full frontend** | the viewer **triggers the solve** and live-re-renders | **local served backend**: `hangarfit serve` exposes a localhost HTTP API over the existing CLI/solver; the browser POSTs the intent and renders the returned `scene/v1` | #445 *(own future ADR)* |
 
-`intent-contract.ts` becomes the typed mirror of that artifact when #442 lands.
+**Stage 2 — the `interaction/` seam (deferred — #442).** The `interaction/` namespace
+documents the contract now and stays inert (README-only) so the bundle is unchanged. When
+#442 lands, an `interaction/` module: reads `scene-contract` types; builds an **intent
+object** mirroring `Scenario.constraints` —
+`{ selectedPlaneIds, priorities: Record<id, number>, mustPositions: Record<id, {x,y,heading}> }`
+("must positions" → `PlaneConstraint.pin`, "priorities" → the soft `PlaneConstraint.priority`
+#441); **exports a `Scenario`/constraints YAML** the Python solver consumes (round-trip);
+and **must never import `affine.ts`/`anchors.ts`** to re-derive geometry.
+`intent-contract.ts` becomes the typed mirror of that artifact.
+
+**Stage 3 — full frontend via `hangarfit serve` (deferred — #445, own ADR).** The exact
+same intent object + `Scenario` contract is delivered over a **localhost HTTP API** instead
+of a file: a new `hangarfit serve` subcommand wraps the existing `solve`/`check`/`scene`
+path; the browser POSTs intent, the server runs the *unchanged* Python solver
+(determinism + det-−1 untouched), and returns a `scene/v1` the viewer renders — making it a
+click-to-solve frontend. The **offline single-file export survives** (ADR-0017) as the
+shareable/pure-view artifact; `serve` is an *additional* deployment, not a replacement.
+Because it shifts the deployment model (a local server vs a double-clicked file), it gets
+its **own ADR** when scheduled; alternatives weighed there: desktop wrapper
+(Tauri/pywebview) and — explicitly rejected — in-browser WASM solving (re-opens
+ADR-0002/0003). The Stage-2 round-trip file is the stepping stone: Stage 3 reuses its
+contract verbatim, just over HTTP.
 
 ## Build & CI
 


### PR DESCRIPTION
## What

**Design + issues only** (per the user's choices). This PR carries the design artifacts for migrating the `hangarfit view` 3D viewer from one hand-written, untyped ~546-line ES module into a **typed, modular TypeScript application** built by a **dev/CI-only** toolchain — the foundation for a future interactive plane-placement editor (select planes, assign **priorities** and **"must positions"**).

- **`docs/adr/0020-viewer-typescript-architecture.md`** — supersedes ADR-0017's *"No build toolchain" / thin-renderer* sub-decision while **reaffirming** the load-bearing Python-owned determinant-−1 transform (ADR-0002), the `scene/v1` seam, and the offline single-file deliverable. Chosen option: esbuild bundles `*.ts` → a committed `viewer.js`; Node never enters `pip install`/the wheel; determinism becomes *reproducibility of the committed bundle*, guarded in CI like `lockfile-drift`.
- **`docs/superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md`** — full migration design: module map, the inert `interaction/` extension seam, build/CI, verification (reproducible bundle + headless anchor check; semantic, *not* byte-identical to the old viewer), risks.
- ADR index updated; ADR-0017 status annotated.

## No code in this PR

Per the spec-before-code discipline, no toolchain/source/CI lands here. Implementation is tracked under epic **#436**:

| # | Issue | Note |
|---|---|---|
| #437 | dev TS toolchain scaffold (esbuild + tsc + eslint, `@types/three`@0.160.x) | blocks #439 |
| #438 | CI: `viewer-build-drift` + tsc/eslint/node-test + three↔types skew guard | may fold into #437 |
| #439 | port `viewer.js` → modular TS (behavior-neutral; **subsumes #433**) | atomic PR |
| #440 | typed `scene-contract.ts` + inert `interaction/` seam + node unit tests | the extension seam |
| #441 | (Python, groundwork) soft `PlaneConstraint.priority` | determinism-sensitive |
| #442 | (deferred/tracking) interactive editor → exports a `Scenario` | depends on #440 + #441 |

Sequencing: #437 → #438 → #439 → #440; #442 ⇐ #440, #441.

## Invariant retained

The browser stays an **intent-capture** surface — it never re-derives the det-−1 transform or solves geometry; the future editor exports a `Scenario`/constraints artifact for the **Python solver** (the authority). ADR-0002/0017's transform decision is explicitly reaffirmed.

## Review notes

- Docs-only diff (4 files); no `src/`, CI, or tooling changes.
- Conforms to `docs/adr/template.md` (≥2 genuine options + Why-not paragraphs + Compliance) and the repo spec format.

Refs #436 (epic stays open until the follow-ups land). Follows #423; the port (#439) subsumes #433.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HB63dCSd817nLAKovxrF1n)_