### PR TITLE
feat(viewer): typed scene/brand contracts + node unit tests + interaction seam (#440)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,12 +317,12 @@ jobs:
     # Deliberately a SEPARATE job from the Python matrix above: a Node failure must
     # never block the Python test / lint / mypy / lockfile-drift jobs (the viewer is
     # built from a committed bundle the Python install never touches). This job runs
-    # `tsc --noEmit`, eslint, the three <-> @types/three version-skew guard, and
-    # (since #439) the `viewer-build-drift` byte guard — a rebuild of the committed
-    # bundle from viewer/src must reproduce src/hangarfit/_viewer_assets/viewer.js
-    # exactly. The `node --test` pure-unit job (the remaining piece of #438) lands
-    # with #440, where the affine/anchors/timeline units have tests.
-    name: viewer toolchain (typecheck + lint + build-drift)
+    # `tsc --noEmit`, eslint, the three <-> @types/three <-> three(devDep) version-skew
+    # guard, the `viewer-build-drift` byte guard (a rebuild of the committed bundle from
+    # viewer/src must reproduce src/hangarfit/_viewer_assets/viewer.js exactly), and
+    # (since #440) `node --test` for the pure units (affine/anchors/timeline) — coverage
+    # pytest cannot reach. This completes #438.
+    name: viewer toolchain (typecheck + lint + build-drift + node-test)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -345,6 +345,14 @@ jobs:
       - name: Lint (eslint)
         run: npm --prefix viewer/ run lint
 
+      - name: Unit tests (node --test, pure affine/anchors/timeline units)
+        # Node-native type-stripping runs the .ts units directly (Node pinned via
+        # .nvmrc). This is coverage pytest cannot reach: the only transform math the
+        # viewer does (affine), the cross-language oracle compare (anchors), and the
+        # timeline state machine. three is a test-only devDep (kept external from the
+        # bundle by esbuild), so the units exercise the SAME three r160 the browser runs.
+        run: npm --prefix viewer/ run test
+
       - name: viewer-build-drift (rebuilt bundle must equal the committed one)
         # The Node analogue of the lockfile-drift guards: rebuild the committed
         # bundle from viewer/src and assert it is byte-identical to what is checked
@@ -359,21 +367,29 @@ jobs:
             exit 1
           fi
 
-      - name: three <-> @types/three version-skew guard
-        # Assert the vendored three (VENDOR.md) and the @types/three the viewer
-        # type-checks against agree on major.minor, so the API the TS is checked
-        # against cannot drift from the three the viewer actually runs (ADR-0020).
+      - name: three <-> @types/three <-> three(devDep) version-skew guard
+        # Assert the vendored three (VENDOR.md, what the BROWSER runs), the
+        # @types/three the viewer type-checks against, and the test-only `three`
+        # devDep (what `node --test` runs, #440) all agree on major.minor — so the
+        # API the TS is checked against and node-tested against cannot drift from the
+        # three the browser actually runs (ADR-0020).
         run: |
           vendor=$(grep -oE 'three@0\.[0-9]+\.[0-9]+' src/hangarfit/_viewer_assets/three/VENDOR.md | head -1 | sed 's/^three@//')
           types=$(node -p "require('./viewer/package.json').devDependencies['@types/three']")
+          three_dev=$(node -p "require('./viewer/package.json').devDependencies['three']")
           if [ -z "$vendor" ]; then
             echo "::error::could not parse the vendored three version from VENDOR.md — update the skew guard in ci.yml."
             exit 1
           fi
           vendor_mm=${vendor%.*}
           types_mm=$(printf '%s' "$types" | grep -oE '^[0-9]+\.[0-9]+')
-          echo "vendored three=$vendor (major.minor=$vendor_mm); @types/three=$types (major.minor=$types_mm)"
+          three_dev_mm=$(printf '%s' "$three_dev" | grep -oE '^[0-9]+\.[0-9]+')
+          echo "vendored three=$vendor (mm=$vendor_mm); @types/three=$types (mm=$types_mm); three devDep=$three_dev (mm=$three_dev_mm)"
           if [ "$vendor_mm" != "$types_mm" ]; then
             echo "::error::@types/three ($types_mm) does not match vendored three ($vendor_mm). Bump @types/three in viewer/package.json in lockstep with VENDOR.md (ADR-0020)."
+            exit 1
+          fi
+          if [ "$vendor_mm" != "$three_dev_mm" ]; then
+            echo "::error::test-only three devDep ($three_dev_mm) does not match vendored three ($vendor_mm). Bump it in viewer/package.json in lockstep with VENDOR.md (ADR-0020)."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,12 +317,12 @@ jobs:
     # Deliberately a SEPARATE job from the Python matrix above: a Node failure must
     # never block the Python test / lint / mypy / lockfile-drift jobs (the viewer is
     # built from a committed bundle the Python install never touches). This job runs
-    # the checks that are greenable for the scaffold — `tsc --noEmit`, eslint, and the
-    # three <-> @types/three version-skew guard. The `viewer-build-drift` byte guard
-    # and the `node --test` pure-unit job (the rest of #438) land with the real port
-    # (#439), where the committed viewer.js equals esbuild(viewer/src) and the pure
-    # units (affine/anchors/timeline) exist to test.
-    name: viewer toolchain (typecheck + lint)
+    # `tsc --noEmit`, eslint, the three <-> @types/three version-skew guard, and
+    # (since #439) the `viewer-build-drift` byte guard — a rebuild of the committed
+    # bundle from viewer/src must reproduce src/hangarfit/_viewer_assets/viewer.js
+    # exactly. The `node --test` pure-unit job (the remaining piece of #438) lands
+    # with #440, where the affine/anchors/timeline units have tests.
+    name: viewer toolchain (typecheck + lint + build-drift)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -344,6 +344,20 @@ jobs:
 
       - name: Lint (eslint)
         run: npm --prefix viewer/ run lint
+
+      - name: viewer-build-drift (rebuilt bundle must equal the committed one)
+        # The Node analogue of the lockfile-drift guards: rebuild the committed
+        # bundle from viewer/src and assert it is byte-identical to what is checked
+        # in. Drift means either a viewer/src edit without a rebuild, or an
+        # unpinned-toolchain change — exactly what the guard should catch. The
+        # bundle is unminified + esbuild/Node are exact-pinned, so a green diff is
+        # deterministic (ADR-0020). Writes the canonical path (VIEWER_OUTFILE unset).
+        run: |
+          npm --prefix viewer/ run build
+          if ! git diff --exit-code -- src/hangarfit/_viewer_assets/viewer.js; then
+            echo "::error::src/hangarfit/_viewer_assets/viewer.js is out of sync with viewer/src. Run 'npm --prefix viewer/ run build' and commit the rebuilt bundle (ADR-0020)."
+            exit 1
+          fi
 
       - name: three <-> @types/three version-skew guard
         # Assert the vendored three (VENDOR.md) and the @types/three the viewer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,10 +299,10 @@ npm --prefix viewer/ ci          # install from the committed lockfile (CI uses 
 npm --prefix viewer/ run build   # rebuild ../src/hangarfit/_viewer_assets/viewer.js
 npm --prefix viewer/ run typecheck   # tsc --noEmit (strict)
 npm --prefix viewer/ run lint    # eslint (flat config, ESLint 10)
-npm --prefix viewer/ run test    # node --test — no-op until the pure units land (#439/#440)
+npm --prefix viewer/ run test    # node --test — no-op until the pure-unit tests land (#440)
 # After editing any viewer/src/*.ts, REBUILD and commit viewer.js in the same change
-# or the `viewer-build-drift` CI guard (scope of #438, lands with the #439 port) will
-# fail. To verify
+# or the `viewer-build-drift` CI guard (#438, live since the #439 port) will fail —
+# it rebuilds the bundle and diffs it against the committed viewer.js. To verify
 # a build WITHOUT clobbering the committed bundle, redirect the output:
 VIEWER_OUTFILE=/tmp/viewer-scratch.js npm --prefix viewer/ run build
 # three stays vendored & external (resolved by viewer.py's import-map); @types/three

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -1,232 +1,189 @@
-// hangarfit 3D viewer — a thin consumer of the hangarfit.scene/v1 contract.
-//
-// It performs NO transform math: every plane-local→world placement arrives as a
-// 2x3 affine [a,b,tx,c,d,ty] computed in Python from geometry.local_to_world
-// (the determinant-−1 transform, ADR-0002/ADR-0017). The viewer drops each
-// affine into a THREE.Matrix4 and assigns it to a statically-built plane group.
-//
-// World convention (matches hangarfit core): x = right along the door wall,
-// y = deeper into the hangar, z = up. We make Three.js +Z-up so the affine's
-// z-row is identity and box height runs along world up. Reflected matrices
-// (det −1) render correctly because every material is DoubleSide.
-//
-// All colours/opacities are read from the injected BRAND blob (Python `brand.py`,
-// emitted by viewer.py as <script id="brand">) — do NOT hard-code `0x` colour
-// literals here. Colours arrive as `#RRGGBB` strings and go straight into
-// `new THREE.Color(str)`; opacities/intensities are plain numbers (#419).
-import * as THREE from 'three';
-import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-
-const SCENE = JSON.parse(document.getElementById('scene').textContent);
-const BRAND = JSON.parse(document.getElementById('brand').textContent);
-const H = SCENE.hangar;
-
-// #401 honesty banner + actionable readouts. The banner text is static (set in
-// the HTML); we only unhide it. Readouts are numbers from the scene — no user
-// HTML, set via textContent.
-if (SCENE.placeholder) document.getElementById('placeholder').hidden = false;
-if (SCENE.readouts) {
-  const fmtM = (v) => (v == null ? 'n/a' : v.toFixed(2) + ' m');
-  document.getElementById('readouts').textContent =
-    'gap ' + fmtM(SCENE.readouts.min_gap_m) +
-    ' · wing-over-tail ' + fmtM(SCENE.readouts.min_wing_over_tail_clearance_m);
+// src/dom.ts
+function byId(id) {
+  const el = document.getElementById(id);
+  if (el === null) throw new Error(`viewer: missing #${id} element`);
+  return el;
 }
-
 function banner(msg) {
-  const b = document.getElementById('banner');
+  const b = byId("banner");
   b.hidden = false;
   b.textContent = msg;
 }
-
-// ── renderer / scene / camera ────────────────────────────────────────────────
-const canvas = document.getElementById('c');
-let renderer;
-try {
-  renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-} catch (e) {
-  banner('WebGL is unavailable in this browser: ' + e.message);
-  throw e;
-}
-renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-renderer.setSize(window.innerWidth, window.innerHeight);
-renderer.shadowMap.enabled = true; // contact shadows (#400)
-renderer.shadowMap.type = THREE.PCFSoftShadowMap; // soft edges
-
-const scene = new THREE.Scene();
-scene.background = new THREE.Color(BRAND.sceneBg);
-
-const cam = new THREE.PerspectiveCamera(55, window.innerWidth / window.innerHeight, 0.1, 2000);
-cam.up.set(0, 0, 1); // +Z up — set BEFORE OrbitControls reads it.
-
-const controls = new OrbitControls(cam, renderer.domElement);
-controls.enableDamping = true;
-controls.dampingFactor = 0.08;
-
-const span = Math.max(H.width_m, H.length_m);
-function home() {
-  cam.position.set(H.width_m * 0.5, -H.length_m * 0.55, span * 0.95);
-  controls.target.set(H.width_m / 2, H.length_m / 2, 0.5);
-  controls.update();
-}
-home();
-
-// Lighting (#400). The key sun casts contact shadows so vertical clearance is
-// legible — a high wing's shadow falling across a neighbour's tail is the whole
-// reason the 3D viewer exists (ADR-0017). A soft fill from the opposite side keeps
-// shaded faces readable, and a (slightly lowered) hemisphere ambient lets shadows
-// darken without going black.
-scene.add(new THREE.HemisphereLight(
-  new THREE.Color(BRAND.hemisphereSky), new THREE.Color(BRAND.hemisphereGround), BRAND.hemisphereIntensity,
-));
-const sun = new THREE.DirectionalLight(new THREE.Color(BRAND.sun), BRAND.sunIntensity);
-sun.position.set(H.width_m * 0.35, -H.length_m * 0.15, span * 1.1);
-sun.target.position.set(H.width_m / 2, H.length_m / 2, 0); // aim at hangar centre
-scene.add(sun.target);
-sun.castShadow = true;
-sun.shadow.mapSize.set(2048, 2048);
-sun.shadow.normalBias = 0.04; // suppress acne on the det-−1 reflected boxes
-const sc = sun.shadow.camera; // ortho frustum sized to the hangar span
-sc.left = -span;
-sc.right = span;
-sc.top = span;
-sc.bottom = -span;
-sc.near = 0.5;
-sc.far = span * 3.5;
-sc.updateProjectionMatrix();
-scene.add(sun);
-const fill = new THREE.DirectionalLight(new THREE.Color(BRAND.fill), BRAND.fillIntensity); // soft fill: pale tint of the horizon accent #3FA3D6, no shadow
-fill.position.set(H.width_m * 0.7, H.length_m * 1.2, span * 0.6);
-scene.add(fill);
-
-// ── affine → Matrix4 (z-row identity; det may be −1, that's intentional) ─────
-function affineMatrix(aff) {
-  const [a, b, tx, c, d, ty] = aff;
-  const m = new THREE.Matrix4();
-  // row-major: maps local (u,v,w,1) → world (a·u+b·v+tx, c·u+d·v+ty, w).
-  m.set(
-    a, b, 0, tx,
-    c, d, 0, ty,
-    0, 0, 1, 0,
-    0, 0, 0, 1,
-  );
-  return m;
+function disableControl(id) {
+  byId(id).disabled = true;
 }
 
-// ── hangar: floor, grid, walls (split at door), maintenance bay ──────────────
-const WALL_H = 3.0;
-const wallMeshes = [];
-function addHangar() {
-  const floor = new THREE.Mesh(
-    new THREE.PlaneGeometry(H.width_m, H.length_m),
-    new THREE.MeshStandardMaterial({
-      color: new THREE.Color(BRAND.floor), roughness: 1, side: THREE.DoubleSide,
-    }),
-  );
-  floor.position.set(H.width_m / 2, H.length_m / 2, 0); // PlaneGeometry lies in XY (normal +Z)
-  floor.receiveShadow = true; // catches the planes' contact shadows (#400)
-  scene.add(floor);
+// src/renderer.ts
+import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+function createRenderer(canvas2, H2, BRAND2) {
+  let renderer2;
+  try {
+    renderer2 = new THREE.WebGLRenderer({ canvas: canvas2, antialias: true });
+  } catch (e) {
+    banner("WebGL is unavailable in this browser: " + e.message);
+    throw e;
+  }
+  renderer2.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer2.setSize(window.innerWidth, window.innerHeight);
+  renderer2.shadowMap.enabled = true;
+  renderer2.shadowMap.type = THREE.PCFSoftShadowMap;
+  const scene2 = new THREE.Scene();
+  scene2.background = new THREE.Color(BRAND2.sceneBg);
+  const cam2 = new THREE.PerspectiveCamera(55, window.innerWidth / window.innerHeight, 0.1, 2e3);
+  cam2.up.set(0, 0, 1);
+  const controls2 = new OrbitControls(cam2, renderer2.domElement);
+  controls2.enableDamping = true;
+  controls2.dampingFactor = 0.08;
+  const span2 = Math.max(H2.width_m, H2.length_m);
+  const home2 = () => {
+    cam2.position.set(H2.width_m * 0.5, -H2.length_m * 0.55, span2 * 0.95);
+    controls2.target.set(H2.width_m / 2, H2.length_m / 2, 0.5);
+    controls2.update();
+  };
+  home2();
+  scene2.add(new THREE.HemisphereLight(
+    new THREE.Color(BRAND2.hemisphereSky),
+    new THREE.Color(BRAND2.hemisphereGround),
+    BRAND2.hemisphereIntensity
+  ));
+  const sun = new THREE.DirectionalLight(new THREE.Color(BRAND2.sun), BRAND2.sunIntensity);
+  sun.position.set(H2.width_m * 0.35, -H2.length_m * 0.15, span2 * 1.1);
+  sun.target.position.set(H2.width_m / 2, H2.length_m / 2, 0);
+  scene2.add(sun.target);
+  sun.castShadow = true;
+  sun.shadow.mapSize.set(2048, 2048);
+  sun.shadow.normalBias = 0.04;
+  const sc = sun.shadow.camera;
+  sc.left = -span2;
+  sc.right = span2;
+  sc.top = span2;
+  sc.bottom = -span2;
+  sc.near = 0.5;
+  sc.far = span2 * 3.5;
+  sc.updateProjectionMatrix();
+  scene2.add(sun);
+  const fill = new THREE.DirectionalLight(new THREE.Color(BRAND2.fill), BRAND2.fillIntensity);
+  fill.position.set(H2.width_m * 0.7, H2.length_m * 1.2, span2 * 0.6);
+  scene2.add(fill);
+  return { renderer: renderer2, scene: scene2, cam: cam2, controls: controls2, span: span2, home: home2 };
+}
 
-  const grid = new THREE.GridHelper(
-    span, Math.round(span), new THREE.Color(BRAND.gridMajor), new THREE.Color(BRAND.gridMinor),
+// src/hangar.ts
+import * as THREE2 from "three";
+var WALL_H = 3;
+function addHangar(scene2, H2, BRAND2, span2) {
+  const wallMeshes2 = [];
+  const floor = new THREE2.Mesh(
+    new THREE2.PlaneGeometry(H2.width_m, H2.length_m),
+    new THREE2.MeshStandardMaterial({
+      color: new THREE2.Color(BRAND2.floor),
+      roughness: 1,
+      side: THREE2.DoubleSide
+    })
   );
-  grid.rotation.x = Math.PI / 2; // GridHelper is in XZ by default → rotate into XY
-  grid.position.set(H.width_m / 2, H.length_m / 2, 0.003);
-  scene.add(grid);
-
+  floor.position.set(H2.width_m / 2, H2.length_m / 2, 0);
+  floor.receiveShadow = true;
+  scene2.add(floor);
+  const grid = new THREE2.GridHelper(
+    span2,
+    Math.round(span2),
+    new THREE2.Color(BRAND2.gridMajor),
+    new THREE2.Color(BRAND2.gridMinor)
+  );
+  grid.rotation.x = Math.PI / 2;
+  grid.position.set(H2.width_m / 2, H2.length_m / 2, 3e-3);
+  scene2.add(grid);
   const t = 0.08;
   const addWall = (sx, sy, x, y) => {
-    const m = new THREE.MeshStandardMaterial({
-      color: new THREE.Color(BRAND.walls), transparent: true, opacity: BRAND.wallsOpacity,
-      side: THREE.DoubleSide,
+    const m = new THREE2.MeshStandardMaterial({
+      color: new THREE2.Color(BRAND2.walls),
+      transparent: true,
+      opacity: BRAND2.wallsOpacity,
+      side: THREE2.DoubleSide
     });
-    const mesh = new THREE.Mesh(new THREE.BoxGeometry(sx, sy, WALL_H), m);
+    const mesh = new THREE2.Mesh(new THREE2.BoxGeometry(sx, sy, WALL_H), m);
     mesh.position.set(x, y, WALL_H / 2);
-    scene.add(mesh);
-    wallMeshes.push(mesh);
+    scene2.add(mesh);
+    wallMeshes2.push(mesh);
   };
-  addWall(t, H.length_m, 0, H.length_m / 2);             // left
-  addWall(t, H.length_m, H.width_m, H.length_m / 2);     // right
-  addWall(H.width_m, t, H.width_m / 2, H.length_m);      // back
-  const dl = H.door.center_x_m - H.door.width_m / 2;
-  const dr = H.door.center_x_m + H.door.width_m / 2;
-  if (dl > 1e-6) addWall(dl, t, dl / 2, 0);              // front, left of door
-  if (dr < H.width_m - 1e-6) addWall(H.width_m - dr, t, (dr + H.width_m) / 2, 0); // front, right
-
-  const bay = H.maintenance_bay;
+  addWall(t, H2.length_m, 0, H2.length_m / 2);
+  addWall(t, H2.length_m, H2.width_m, H2.length_m / 2);
+  addWall(H2.width_m, t, H2.width_m / 2, H2.length_m);
+  const dl = H2.door.center_x_m - H2.door.width_m / 2;
+  const dr = H2.door.center_x_m + H2.door.width_m / 2;
+  if (dl > 1e-6) addWall(dl, t, dl / 2, 0);
+  if (dr < H2.width_m - 1e-6) addWall(H2.width_m - dr, t, (dr + H2.width_m) / 2, 0);
+  const bay = H2.maintenance_bay;
   if (bay && bay.closed) {
-    const bm = new THREE.Mesh(
-      new THREE.BoxGeometry(bay.width_m, bay.depth_m, WALL_H),
-      new THREE.MeshStandardMaterial({
-        color: new THREE.Color(BRAND.bay), transparent: true, opacity: BRAND.bayOpacity,
-      }),
+    const bm = new THREE2.Mesh(
+      new THREE2.BoxGeometry(bay.width_m, bay.depth_m, WALL_H),
+      new THREE2.MeshStandardMaterial({
+        color: new THREE2.Color(BRAND2.bay),
+        transparent: true,
+        opacity: BRAND2.bayOpacity
+      })
     );
-    bm.position.set(bay.center_x_m, H.length_m - bay.depth_m / 2, WALL_H / 2);
-    scene.add(bm);
+    bm.position.set(bay.center_x_m, H2.length_m - bay.depth_m / 2, WALL_H / 2);
+    scene2.add(bm);
   }
+  return wallMeshes2;
 }
-addHangar();
-document.getElementById('walls').addEventListener('change', (e) => {
-  wallMeshes.forEach((m) => { m.visible = e.target.checked; });
-});
 
-// ── gear / cart render constants (#399) ──────────────────────────────────────
-// Render *sizes* live here in the viewer layer, never in fleet.yaml (the canonical
-// data carries only plane-local wheel POSITIONS, ADR-0013). Values mirror the 2D
-// path's constants in visualize.py so 2D and 3D read alike; the remaining three
-// (WHEEL_WIDTH_M, LEG_WIDTH_M, CART_PALLET_HEIGHT_M) have no 2D analogue — the
-// top-down PNG has no z and draws no gear leg — and are glyph extents chosen to
-// read at fuselage scale.
-const WHEEL_RADIUS_M = 0.18; // visualize._WHEEL_RADIUS_M
-const WHEEL_WIDTH_M = 0.12; // tyre width — 3D-only glyph depth
-const LEG_WIDTH_M = 0.06; // thin gear-leg strut up to the belly — 3D-only glyph
-const CART_PALLET_HALF_EXTENT_M = 0.4; // visualize._CART_PALLET_HALF_EXTENT_M
-const CART_PALLET_HEIGHT_M = 0.12; // dolly deck thickness — 3D-only glyph depth
-const WHEEL_COLOR = new THREE.Color(BRAND.wheel); // brand.WHEEL_COLOR (= visualize._WHEEL_COLOR)
-const CART_DECK_COLOR = new THREE.Color(BRAND.cartDeck); // brand.CART_DECK_COLOR (= visualize._CART_DECK_COLOR)
-// Shared materials (DoubleSide: the plane Group matrix may be det −1).
-const gearMat = new THREE.MeshStandardMaterial({
-  color: WHEEL_COLOR, side: THREE.DoubleSide, roughness: 0.6, metalness: 0.1,
-});
-const palletMat = new THREE.MeshStandardMaterial({
-  color: CART_DECK_COLOR, side: THREE.DoubleSide, roughness: 0.9, metalness: 0.0,
-});
+// src/planes.ts
+import * as THREE5 from "three";
 
-// Draw gear (a wheel at each point + a short leg up to the belly where there is
-// clearance) and, when carted, a pallet deck under each wheel, all parented to the
-// plane's affine Group `g` so they inherit the verified plane-local→world transform
-// and animate along the tow path for free. Wheel world positions are oracle-checked
-// in checkAnchors().
-function addGear(g, p) {
-  // Belly = lowest box bottom; the leg rises from the wheel top to it. A plane
-  // with no boxes falls back to a wheel-diameter belly so a stub leg still renders.
+// src/gear.ts
+import * as THREE3 from "three";
+var WHEEL_RADIUS_M = 0.18;
+var WHEEL_WIDTH_M = 0.12;
+var LEG_WIDTH_M = 0.06;
+var CART_PALLET_HALF_EXTENT_M = 0.4;
+var CART_PALLET_HEIGHT_M = 0.12;
+function makeGearMaterials(BRAND2) {
+  const WHEEL_COLOR = new THREE3.Color(BRAND2.wheel);
+  const CART_DECK_COLOR = new THREE3.Color(BRAND2.cartDeck);
+  return {
+    gearMat: new THREE3.MeshStandardMaterial({
+      color: WHEEL_COLOR,
+      side: THREE3.DoubleSide,
+      roughness: 0.6,
+      metalness: 0.1
+    }),
+    palletMat: new THREE3.MeshStandardMaterial({
+      color: CART_DECK_COLOR,
+      side: THREE3.DoubleSide,
+      roughness: 0.9,
+      metalness: 0
+    })
+  };
+}
+function addGear(g, p, mats) {
   let belly = Infinity;
   for (const b of p.boxes) belly = Math.min(belly, b.cz - b.height_m / 2);
   if (!isFinite(belly)) belly = 2 * WHEEL_RADIUS_M;
   const deck = p.on_carts ? CART_PALLET_HEIGHT_M : 0;
   for (const [u, v] of p.wheels) {
-    // Cylinder's default axis is +Y = local v (lateral), so the disc lies in the
-    // forward/up (u,w) plane — a wheel that rolls forward. No rotation needed.
     const wheelZ = deck + WHEEL_RADIUS_M;
-    const wheel = new THREE.Mesh(
-      new THREE.CylinderGeometry(WHEEL_RADIUS_M, WHEEL_RADIUS_M, WHEEL_WIDTH_M, 16),
-      gearMat,
+    const wheel = new THREE3.Mesh(
+      new THREE3.CylinderGeometry(WHEEL_RADIUS_M, WHEEL_RADIUS_M, WHEEL_WIDTH_M, 16),
+      mats.gearMat
     );
     wheel.position.set(u, v, wheelZ);
     wheel.castShadow = true;
     g.add(wheel);
-
     const wheelTop = wheelZ + WHEEL_RADIUS_M;
     const legH = belly - wheelTop;
     if (legH > 0.01) {
-      const leg = new THREE.Mesh(new THREE.BoxGeometry(LEG_WIDTH_M, LEG_WIDTH_M, legH), gearMat);
+      const leg = new THREE3.Mesh(new THREE3.BoxGeometry(LEG_WIDTH_M, LEG_WIDTH_M, legH), mats.gearMat);
       leg.position.set(u, v, wheelTop + legH / 2);
       leg.castShadow = true;
       g.add(leg);
     }
     if (p.on_carts) {
-      const pallet = new THREE.Mesh(
-        new THREE.BoxGeometry(2 * CART_PALLET_HALF_EXTENT_M, 2 * CART_PALLET_HALF_EXTENT_M, deck),
-        palletMat,
+      const pallet = new THREE3.Mesh(
+        new THREE3.BoxGeometry(2 * CART_PALLET_HALF_EXTENT_M, 2 * CART_PALLET_HALF_EXTENT_M, deck),
+        mats.palletMat
       );
       pallet.position.set(u, v, deck / 2);
       pallet.castShadow = true;
@@ -236,311 +193,343 @@ function addGear(g, p) {
   }
 }
 
-// ── planes: one Group of boxes each, built ONCE in plane-local coords ────────
-const CONFLICT = BRAND.conflict; // '#RRGGBB' string → new THREE.Color(CONFLICT)
-const groups = {};
-const legend = document.getElementById('legend');
-
-// Kind-based materials (#400): translucent wings reveal vertical stacking; thin
-// metallic struts; a darker cockpit (fuselage_front) tint echoing the 2D render's
-// cockpit shading (same intent, not a perceptual match — 3D darkens in linear
-// space); everything else opaque body colour. DoubleSide for the det-−1 group.
-function boxMaterial(b, colour) {
-  const base = { color: colour, side: THREE.DoubleSide, roughness: 0.7, metalness: 0.05 };
-  if (b.kind === 'wing') {
-    return new THREE.MeshStandardMaterial({ ...base, transparent: true, opacity: 0.5 });
-  }
-  if (b.kind === 'strut') {
-    return new THREE.MeshStandardMaterial({ ...base, roughness: 0.35, metalness: 0.85 });
-  }
-  if (b.kind === 'fuselage_front') {
-    return new THREE.MeshStandardMaterial({ ...base, color: colour.clone().multiplyScalar(0.55) });
-  }
-  return new THREE.MeshStandardMaterial(base);
-}
-
-// Identity cues (#400), HUD-toggleable: a billboarded id label and a nose cone at
-// the plane-local +x tip show which plane is which and which way it faces.
-const labelMeshes = [];
-const noseMeshes = [];
-function makeLabel(text, conflicted = false) {
-  // Plane ids are machine output → mono (brand). A conflicted plane carries the
-  // non-colour "never hue alone" cue 3D can't hatch: a " ⚠ conflict" suffix and
-  // the conflict-ink chip instead of the surface glass (BRAND.md §3).
-  const shown = conflicted ? text + ' ⚠ conflict' : text;
+// src/labels.ts
+import * as THREE4 from "three";
+function makeLabel(text, BRAND2, conflicted = false) {
+  const shown = conflicted ? text + " ⚠ conflict" : text;
   const fontPx = 64, padX = 14, padY = 8;
   const fontStack = "px ui-monospace, 'SF Mono', Menlo, monospace";
-  const measure = document.createElement('canvas').getContext('2d');
+  const measure = document.createElement("canvas").getContext("2d");
   measure.font = fontPx + fontStack;
   const tw = Math.ceil(measure.measureText(shown).width);
-  const canvas = document.createElement('canvas');
-  canvas.width = tw + padX * 2;
-  canvas.height = fontPx + padY * 2;
-  const ctx = canvas.getContext('2d');
+  const canvas2 = document.createElement("canvas");
+  canvas2.width = tw + padX * 2;
+  canvas2.height = fontPx + padY * 2;
+  const ctx = canvas2.getContext("2d");
   ctx.font = fontPx + fontStack;
-  ctx.textBaseline = 'middle';
-  ctx.fillStyle = conflicted ? BRAND.labelConflictChip : BRAND.labelChipBg;
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-  ctx.fillStyle = BRAND.labelText;
-  ctx.fillText(shown, padX, canvas.height / 2); // SAFE: canvas fillText, never innerHTML (ids are user YAML)
-  const tex = new THREE.CanvasTexture(canvas);
+  ctx.textBaseline = "middle";
+  ctx.fillStyle = conflicted ? BRAND2.labelConflictChip : BRAND2.labelChipBg;
+  ctx.fillRect(0, 0, canvas2.width, canvas2.height);
+  ctx.fillStyle = BRAND2.labelText;
+  ctx.fillText(shown, padX, canvas2.height / 2);
+  const tex = new THREE4.CanvasTexture(canvas2);
   tex.anisotropy = 4;
-  const sprite = new THREE.Sprite(
-    new THREE.SpriteMaterial({ map: tex, transparent: true, depthTest: false }),
+  const sprite = new THREE4.Sprite(
+    new THREE4.SpriteMaterial({ map: tex, transparent: true, depthTest: false })
   );
-  const hWorld = 0.9; // label height in world metres
-  sprite.scale.set((hWorld * canvas.width) / canvas.height, hWorld, 1);
-  sprite.renderOrder = 999; // float above geometry (depthTest off)
+  const hWorld = 0.9;
+  sprite.scale.set(hWorld * canvas2.width / canvas2.height, hWorld, 1);
+  sprite.renderOrder = 999;
   return sprite;
 }
-function addLabelAndNose(g, p, colour, conflicted) {
+function addLabelAndNose(g, p, colour, conflicted, BRAND2, labelMeshes2, noseMeshes2) {
   let maxTop = 0, sx = 0, sy = 0, noseX = -Infinity, noseZ = 0;
   for (const b of p.boxes) {
     maxTop = Math.max(maxTop, b.cz + b.height_m / 2);
     sx += b.cx;
     sy += b.cy;
     noseX = Math.max(noseX, b.cx + b.length_m / 2);
-    if (b.kind === 'fuselage_front') noseZ = b.cz;
+    if (b.kind === "fuselage_front") noseZ = b.cz;
   }
   const n = p.boxes.length || 1;
   if (!isFinite(noseX)) noseX = 0;
   if (noseZ === 0) noseZ = maxTop * 0.5;
-
-  const label = makeLabel(p.id, conflicted);
-  label.position.set(sx / n, sy / n, maxTop + 1.0); // above the plane, in plane-local
+  const label = makeLabel(p.id, BRAND2, conflicted);
+  label.position.set(sx / n, sy / n, maxTop + 1);
   g.add(label);
-  labelMeshes.push(label);
-
+  labelMeshes2.push(label);
   const noseLen = 0.7, noseR = 0.28;
-  const nose = new THREE.Mesh(
-    new THREE.ConeGeometry(noseR, noseLen, 14),
-    new THREE.MeshStandardMaterial({
-      color: colour, emissive: colour.clone().multiplyScalar(0.25),
-      side: THREE.DoubleSide, roughness: 0.5, metalness: 0.1,
-    }),
+  const nose = new THREE4.Mesh(
+    new THREE4.ConeGeometry(noseR, noseLen, 14),
+    new THREE4.MeshStandardMaterial({
+      color: colour,
+      emissive: colour.clone().multiplyScalar(0.25),
+      side: THREE4.DoubleSide,
+      roughness: 0.5,
+      metalness: 0.1
+    })
   );
-  nose.rotation.z = -Math.PI / 2; // default +Y tip → +x (plane-local nose)
+  nose.rotation.z = -Math.PI / 2;
   nose.position.set(noseX + noseLen / 2, 0, noseZ);
   nose.castShadow = true;
   g.add(nose);
-  noseMeshes.push(nose);
+  noseMeshes2.push(nose);
 }
 
-for (const p of SCENE.planes) {
-  const g = new THREE.Group();
-  g.matrixAutoUpdate = false; // we drive g.matrix per frame from the affine
-  const conflicted = SCENE.conflicts.includes(p.id);
-  const colour = new THREE.Color(conflicted ? CONFLICT : p.color);
-  for (const b of p.boxes) {
-    // local X = u (forward/length), local Y = v (right/width), local Z = w (height).
-    const mesh = new THREE.Mesh(
-      new THREE.BoxGeometry(b.length_m, b.width_m, b.height_m),
-      boxMaterial(b, colour),
-    );
-    mesh.position.set(b.cx, b.cy, b.cz);
-    mesh.rotation.z = THREE.MathUtils.degToRad(b.angle_deg); // CCW about local up, as oriented_rect
-    mesh.castShadow = true;
-    mesh.receiveShadow = true; // planes catch each other's shadows (vertical clearance)
-    g.add(mesh);
+// src/planes.ts
+function boxMaterial(b, colour) {
+  const base = { color: colour, side: THREE5.DoubleSide, roughness: 0.7, metalness: 0.05 };
+  if (b.kind === "wing") {
+    return new THREE5.MeshStandardMaterial({ ...base, transparent: true, opacity: 0.5 });
   }
-  addGear(g, p); // wheels + legs (+ pallets when carted), same affine Group
-  addLabelAndNose(g, p, colour, conflicted); // id label + nose arrow, HUD-toggleable
-  groups[p.id] = g;
-  scene.add(g);
-
-  // Build the legend chip with safe DOM methods (no innerHTML): plane ids come
-  // from user YAML, so avoid any HTML-injection surface even on a local file.
-  const sw = document.createElement('span');
-  sw.className = 'sw';
-  const dot = document.createElement('i');
-  dot.style.background = conflicted ? BRAND.conflict : p.color;
-  sw.appendChild(dot);
-  sw.appendChild(document.createTextNode(p.id));
-  legend.appendChild(sw);
+  if (b.kind === "strut") {
+    return new THREE5.MeshStandardMaterial({ ...base, roughness: 0.35, metalness: 0.85 });
+  }
+  if (b.kind === "fuselage_front") {
+    return new THREE5.MeshStandardMaterial({ ...base, color: colour.clone().multiplyScalar(0.55) });
+  }
+  return new THREE5.MeshStandardMaterial(base);
+}
+function addPlanes(scene2, SCENE2, BRAND2) {
+  const CONFLICT = BRAND2.conflict;
+  const groups2 = {};
+  const labelMeshes2 = [];
+  const noseMeshes2 = [];
+  const legend = byId("legend");
+  const gearMats = makeGearMaterials(BRAND2);
+  for (const p of SCENE2.planes) {
+    const g = new THREE5.Group();
+    g.matrixAutoUpdate = false;
+    const conflicted = SCENE2.conflicts.includes(p.id);
+    const colour = new THREE5.Color(conflicted ? CONFLICT : p.color);
+    for (const b of p.boxes) {
+      const mesh = new THREE5.Mesh(
+        new THREE5.BoxGeometry(b.length_m, b.width_m, b.height_m),
+        boxMaterial(b, colour)
+      );
+      mesh.position.set(b.cx, b.cy, b.cz);
+      mesh.rotation.z = THREE5.MathUtils.degToRad(b.angle_deg);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      g.add(mesh);
+    }
+    addGear(g, p, gearMats);
+    addLabelAndNose(g, p, colour, conflicted, BRAND2, labelMeshes2, noseMeshes2);
+    groups2[p.id] = g;
+    scene2.add(g);
+    const sw = document.createElement("span");
+    sw.className = "sw";
+    const dot = document.createElement("i");
+    dot.style.background = conflicted ? BRAND2.conflict : p.color;
+    sw.appendChild(dot);
+    sw.appendChild(document.createTextNode(p.id));
+    legend.appendChild(sw);
+  }
+  return { groups: groups2, labelMeshes: labelMeshes2, noseMeshes: noseMeshes2 };
 }
 
-// Labels + nose arrows share one HUD toggle (#400). They are children of each
-// plane Group, so a hidden (not-yet-entered) plane hides its label too.
-document.getElementById('labels').addEventListener('change', (e) => {
-  const on = e.target.checked;
-  for (const m of labelMeshes) m.visible = on;
-  for (const m of noseMeshes) m.visible = on;
-});
+// src/anchors.ts
+import * as THREE7 from "three";
 
-// ── load-time anchor self-check: recompute final world corners and compare ───
-function boxCornersLocal(b) {
-  const h = THREE.MathUtils.degToRad(b.angle_deg);
-  const cs = Math.cos(h), sn = Math.sin(h);
-  const hl = b.length_m / 2, hw = b.width_m / 2;
-  // oriented_rect corner order, rotated CCW about (cx,cy): (+hl,-hw),(+hl,+hw),(-hl,+hw),(-hl,-hw)
-  return [[hl, -hw], [hl, hw], [-hl, hw], [-hl, -hw]].map(
-    ([lx, ly]) => [b.cx + lx * cs - ly * sn, b.cy + lx * sn + ly * cs],
+// src/affine.ts
+import * as THREE6 from "three";
+function affineMatrix(aff) {
+  const [a, b, tx, c, d, ty] = aff;
+  const m = new THREE6.Matrix4();
+  m.set(
+    a,
+    b,
+    0,
+    tx,
+    c,
+    d,
+    0,
+    ty,
+    0,
+    0,
+    1,
+    0,
+    0,
+    0,
+    0,
+    1
   );
+  return m;
 }
 function applyAffine(aff, u, v) {
   const [a, b, tx, c, d, ty] = aff;
   return [a * u + b * v + tx, c * u + d * v + ty];
 }
-// Must FAIL LOUD (banner), never throw — a throw here aborts module evaluation
-// and blanks the page with no signal, which is the opposite of the ADR-0017
-// fail-loud contract. So: structural problems (missing affine/anchors, box/anchor
-// count mismatch) banner instead of being skipped or indexing into undefined, and
-// the whole thing is wrapped so any unforeseen error still surfaces as a banner.
-(function checkAnchors() {
-  try {
-    let maxErr = 0;
-    let structural = '';
-    for (const p of SCENE.planes) {
-      const aff = SCENE.final_poses[p.id];
-      const want = SCENE.anchors[p.id];
-      if (!aff || !want) {
-        structural = 'missing affine/anchors for ' + p.id;
-        break;
-      }
-      if (want.length !== p.boxes.length) {
-        structural = 'anchor/box count mismatch for ' + p.id;
-        break;
-      }
-      p.boxes.forEach((b, bi) => {
-        boxCornersLocal(b).forEach(([u, v], ci) => {
-          const [wx, wy] = applyAffine(aff, u, v);
-          maxErr = Math.max(maxErr, Math.abs(wx - want[bi][ci][0]), Math.abs(wy - want[bi][ci][1]));
-        });
-      });
-      // Gear oracle (#399): the wheels[] ride the same affine Group as the boxes,
-      // so a wrong transform corrupts both — but viewer.js is not pytest-covered,
-      // so we cross-check the wheel world positions against the Python oracle too.
-      const gw = SCENE.gear_anchors[p.id];
-      if (!gw || !p.wheels) {
-        structural = 'missing gear anchors/wheels for ' + p.id;
-        break;
-      }
-      if (gw.length !== p.wheels.length) {
-        structural = 'gear anchor/wheel count mismatch for ' + p.id;
-        break;
-      }
-      p.wheels.forEach(([u, v], wi) => {
+
+// src/anchors.ts
+function boxCornersLocal(b) {
+  const h = THREE7.MathUtils.degToRad(b.angle_deg);
+  const cs = Math.cos(h), sn = Math.sin(h);
+  const hl = b.length_m / 2, hw = b.width_m / 2;
+  const corners = [[hl, -hw], [hl, hw], [-hl, hw], [-hl, -hw]];
+  return corners.map(
+    ([lx, ly]) => [b.cx + lx * cs - ly * sn, b.cy + lx * sn + ly * cs]
+  );
+}
+function checkAnchors(scene2) {
+  let maxErr = 0;
+  let structural = "";
+  for (const p of scene2.planes) {
+    const aff = scene2.final_poses[p.id];
+    const want = scene2.anchors[p.id];
+    if (!aff || !want) {
+      structural = "missing affine/anchors for " + p.id;
+      break;
+    }
+    if (want.length !== p.boxes.length) {
+      structural = "anchor/box count mismatch for " + p.id;
+      break;
+    }
+    p.boxes.forEach((b, bi) => {
+      boxCornersLocal(b).forEach(([u, v], ci) => {
         const [wx, wy] = applyAffine(aff, u, v);
-        maxErr = Math.max(maxErr, Math.abs(wx - gw[wi][0]), Math.abs(wy - gw[wi][1]));
+        maxErr = Math.max(maxErr, Math.abs(wx - want[bi][ci][0]), Math.abs(wy - want[bi][ci][1]));
       });
+    });
+    const gw = scene2.gear_anchors[p.id];
+    if (!gw || !p.wheels) {
+      structural = "missing gear anchors/wheels for " + p.id;
+      break;
     }
-    if (structural) {
-      banner('TRANSFORM CHECK FAILED (' + structural + ') — do not trust this render.');
-    } else if (maxErr > 1e-6) {
-      banner(
-        'TRANSFORM CHECK FAILED (maxErr=' + maxErr.toExponential(2) +
-        '): viewer affine disagrees with the Python oracle — do not trust this render.',
-      );
+    if (gw.length !== p.wheels.length) {
+      structural = "gear anchor/wheel count mismatch for " + p.id;
+      break;
     }
-  } catch (e) {
-    banner('TRANSFORM CHECK ERRORED: ' + e.message + ' — do not trust this render.');
+    p.wheels.forEach(([u, v], wi) => {
+      const [wx, wy] = applyAffine(aff, u, v);
+      maxErr = Math.max(maxErr, Math.abs(wx - gw[wi][0]), Math.abs(wy - gw[wi][1]));
+    });
   }
-})();
+  return { structural, maxErr };
+}
 
-// ── timeline state machine (hidden → animating → parked) ─────────────────────
-const TL = SCENE.timeline;
-const SEGS = TL.segments;
-const TOTAL = TL.total_s;
-const hasAnim = TOTAL > 0 && SEGS.length > 0;
-const segByPlane = {};
-for (const s of SEGS) segByPlane[s.plane_id] = s;
-
-function affineAt(pid, t) {
+// src/timeline.ts
+function affineAt(segByPlane, finals, pid, t) {
   const seg = segByPlane[pid];
   if (!seg) {
-    // Static plane: render at its parked pose, but hide (rather than draw at the
-    // world origin) if a malformed scene is missing its final pose — the anchor
-    // self-check already banners this case.
-    const aff = SCENE.final_poses[pid];
+    const aff = finals[pid];
     return aff ? { vis: true, aff } : { vis: false, aff: null };
   }
-  if (t < seg.start_s) return { vis: false, aff: null };       // not entered yet
-  if (t >= seg.end_s) return { vis: true, aff: SCENE.final_poses[pid] };
+  if (t < seg.start_s) return { vis: false, aff: null };
+  if (t >= seg.end_s) return { vis: true, aff: finals[pid] };
   const frac = (t - seg.start_s) / (seg.end_s - seg.start_s);
   const i = Math.round(frac * (seg.samples.length - 1));
   return { vis: true, aff: seg.samples[i] };
 }
-
-function applyTime(t) {
-  for (const p of SCENE.planes) {
-    const { vis, aff } = affineAt(p.id, t);
-    const g = groups[p.id];
-    g.visible = vis;
-    if (vis && aff) {
-      g.matrix.copy(affineMatrix(aff));
-      g.matrixWorldNeedsUpdate = true;
+function createTimeline(scene2, groups2) {
+  const TL = scene2.timeline;
+  const SEGS = TL.segments;
+  const TOTAL = TL.total_s;
+  const hasAnim = TOTAL > 0 && SEGS.length > 0;
+  const segByPlane = {};
+  for (const s of SEGS) segByPlane[s.plane_id] = s;
+  const finals = scene2.final_poses;
+  const active = byId("active");
+  const clock = byId("clock");
+  const applyTime = (t) => {
+    for (const p of scene2.planes) {
+      const { vis, aff } = affineAt(segByPlane, finals, p.id, t);
+      const g = groups2[p.id];
+      g.visible = vis;
+      if (vis && aff) {
+        g.matrix.copy(affineMatrix(aff));
+        g.matrixWorldNeedsUpdate = true;
+      }
     }
-  }
-  const cur = SEGS.find((s) => t >= s.start_s && t < s.end_s);
-  document.getElementById('active').textContent = cur ? 'towing: ' + cur.plane_id : '';
-  document.getElementById('clock').textContent = t.toFixed(1) + 's';
+    const cur = SEGS.find((s) => t >= s.start_s && t < s.end_s);
+    active.textContent = cur ? "towing: " + cur.plane_id : "";
+    clock.textContent = t.toFixed(1) + "s";
+  };
+  return { total: TOTAL, hasAnim, segs: SEGS, applyTime };
 }
 
-// ── HUD wiring ───────────────────────────────────────────────────────────────
-let t = 0;
-let playing = false;
-let speed = 1;
-const scrub = document.getElementById('scrub');
-const playBtn = document.getElementById('play');
-const speedSel = document.getElementById('speed');
-speedSel.addEventListener('change', () => { speed = parseFloat(speedSel.value); });
-
-if (!hasAnim) {
-  ['play', 'prev', 'next', 'scrub', 'speed'].forEach((id) => {
-    document.getElementById(id).disabled = true;
+// src/hud.ts
+function startHud(deps) {
+  const { timeline: timeline2, home: home2, controls: controls2, renderer: renderer2, scene: scene2, cam: cam2 } = deps;
+  const { total: TOTAL, hasAnim, segs: SEGS, applyTime } = timeline2;
+  let t = 0;
+  let playing = false;
+  let speed = 1;
+  const scrub = byId("scrub");
+  const playBtn = byId("play");
+  const speedSel = byId("speed");
+  speedSel.addEventListener("change", () => {
+    speed = parseFloat(speedSel.value);
   });
-}
-
-scrub.addEventListener('input', () => {
-  t = (scrub.value / 1000) * TOTAL;
-  playing = false;
-  playBtn.textContent = '▶';
-  applyTime(t);
-});
-playBtn.addEventListener('click', () => {
-  if (!hasAnim) return;
-  playing = !playing;
-  playBtn.textContent = playing ? '❚❚' : '▶';
-  if (t >= TOTAL) t = 0;
-});
-function stepTo(dir) {
-  const bounds = [0, ...SEGS.map((s) => s.end_s)];
-  let i = bounds.findIndex((b) => b > t + 1e-6);
-  if (i < 0) i = bounds.length - 1;
-  t = dir > 0 ? bounds[Math.min(i, bounds.length - 1)] : bounds[Math.max(0, i - 2)];
-  playing = false;
-  playBtn.textContent = '▶';
-  if (hasAnim) scrub.value = String((t / TOTAL) * 1000);
-  applyTime(t);
-}
-document.getElementById('next').addEventListener('click', () => stepTo(1));
-document.getElementById('prev').addEventListener('click', () => stepTo(-1));
-document.getElementById('reset').addEventListener('click', home);
-
-window.addEventListener('resize', () => {
-  cam.aspect = window.innerWidth / window.innerHeight;
-  cam.updateProjectionMatrix();
-  renderer.setSize(window.innerWidth, window.innerHeight);
-});
-
-// ── render loop ──────────────────────────────────────────────────────────────
-let last = performance.now();
-function loop(now) {
-  requestAnimationFrame(loop);
-  const dt = (now - last) / 1000;
-  last = now;
-  if (playing && hasAnim) {
-    t += dt * speed;
-    if (t >= TOTAL) {
-      t = TOTAL;
-      playing = false;
-      playBtn.textContent = '▶';
-    }
-    scrub.value = String((t / TOTAL) * 1000);
+  if (!hasAnim) {
+    ["play", "prev", "next", "scrub", "speed"].forEach(disableControl);
   }
-  applyTime(t);
-  controls.update();
-  renderer.render(scene, cam);
+  scrub.addEventListener("input", () => {
+    t = Number(scrub.value) / 1e3 * TOTAL;
+    playing = false;
+    playBtn.textContent = "▶";
+    applyTime(t);
+  });
+  playBtn.addEventListener("click", () => {
+    if (!hasAnim) return;
+    playing = !playing;
+    playBtn.textContent = playing ? "❚❚" : "▶";
+    if (t >= TOTAL) t = 0;
+  });
+  const stepTo = (dir) => {
+    const bounds = [0, ...SEGS.map((s) => s.end_s)];
+    let i = bounds.findIndex((b) => b > t + 1e-6);
+    if (i < 0) i = bounds.length - 1;
+    t = dir > 0 ? bounds[Math.min(i, bounds.length - 1)] : bounds[Math.max(0, i - 2)];
+    playing = false;
+    playBtn.textContent = "▶";
+    if (hasAnim) scrub.value = String(t / TOTAL * 1e3);
+    applyTime(t);
+  };
+  byId("next").addEventListener("click", () => stepTo(1));
+  byId("prev").addEventListener("click", () => stepTo(-1));
+  byId("reset").addEventListener("click", home2);
+  window.addEventListener("resize", () => {
+    cam2.aspect = window.innerWidth / window.innerHeight;
+    cam2.updateProjectionMatrix();
+    renderer2.setSize(window.innerWidth, window.innerHeight);
+  });
+  let last = performance.now();
+  const loop = (now) => {
+    requestAnimationFrame(loop);
+    const dt = (now - last) / 1e3;
+    last = now;
+    if (playing && hasAnim) {
+      t += dt * speed;
+      if (t >= TOTAL) {
+        t = TOTAL;
+        playing = false;
+        playBtn.textContent = "▶";
+      }
+      scrub.value = String(t / TOTAL * 1e3);
+    }
+    applyTime(t);
+    controls2.update();
+    renderer2.render(scene2, cam2);
+  };
+  applyTime(0);
+  requestAnimationFrame(loop);
 }
-applyTime(0);
-requestAnimationFrame(loop);
+
+// src/main.ts
+var SCENE = JSON.parse(byId("scene").textContent ?? "null");
+var BRAND = JSON.parse(byId("brand").textContent ?? "null");
+var H = SCENE.hangar;
+if (SCENE.placeholder) byId("placeholder").hidden = false;
+if (SCENE.readouts) {
+  const fmtM = (v) => v == null ? "n/a" : v.toFixed(2) + " m";
+  byId("readouts").textContent = "gap " + fmtM(SCENE.readouts.min_gap_m) + " · wing-over-tail " + fmtM(SCENE.readouts.min_wing_over_tail_clearance_m);
+}
+var canvas = byId("c");
+var { renderer, scene, cam, controls, span, home } = createRenderer(canvas, H, BRAND);
+var wallMeshes = addHangar(scene, H, BRAND, span);
+var wallsToggle = byId("walls");
+wallsToggle.addEventListener("change", () => {
+  for (const m of wallMeshes) m.visible = wallsToggle.checked;
+});
+var { groups, labelMeshes, noseMeshes } = addPlanes(scene, SCENE, BRAND);
+var labelsToggle = byId("labels");
+labelsToggle.addEventListener("change", () => {
+  const on = labelsToggle.checked;
+  for (const m of labelMeshes) m.visible = on;
+  for (const m of noseMeshes) m.visible = on;
+});
+try {
+  const { structural, maxErr } = checkAnchors(SCENE);
+  if (structural) {
+    banner("TRANSFORM CHECK FAILED (" + structural + ") — do not trust this render.");
+  } else if (maxErr > 1e-6) {
+    banner(
+      "TRANSFORM CHECK FAILED (maxErr=" + maxErr.toExponential(2) + "): viewer affine disagrees with the Python oracle — do not trust this render."
+    );
+  }
+} catch (e) {
+  banner("TRANSFORM CHECK ERRORED: " + e.message + " — do not trust this render.");
+}
+var timeline = createTimeline(SCENE, groups);
+startHud({ timeline, home, controls, renderer, scene, cam });

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -342,3 +342,67 @@ def test_build_scene_readouts_none_for_unchecked_invalid_layout():
     lay = _ll("tests/fixtures/invalid_fuselage_wing_overlap.yaml")
     sc = scene.build_scene(lay)  # no check_result
     assert sc["readouts"] is None
+
+
+# ── #440: scene/v1 ↔ TypeScript contract key-set parity ─────────────────────
+#
+# The TS viewer types its scene/v1 consumption against hand-written mirrors
+# (viewer/src/scene-contract.ts, brand-contract.ts). These guard against the
+# documented desync risk (ADR-0020): if scene.py/brand.py grow or drop a key and
+# the TS mirror is not updated in lockstep, these fail the test the maintainer
+# already runs — the near-term substitute for the deferred JSON-Schema
+# single-source (spike #444). They pin KEY SETS only; runtime checkAnchors() still
+# guards transform *values*.
+import re  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+_VIEWER_SRC = Path(__file__).resolve().parent.parent / "viewer" / "src"
+
+
+def _ts_interface_fields(filename: str, interface: str) -> set[str]:
+    """Field names declared in `export interface <interface> { … }`.
+
+    Interfaces in these contracts have flat bodies (no inline object-literal
+    types), so the first column-0 `}` closes the block.
+    """
+    text = (_VIEWER_SRC / filename).read_text(encoding="utf-8")
+    m = re.search(rf"export interface {interface}\s*\{{(.*?)\n\}}", text, re.S)
+    assert m is not None, f"interface {interface} not found in {filename}"
+    return {
+        fm.group(1)
+        for line in m.group(1).splitlines()
+        if (fm := re.match(r"\s*(\w+)\??\s*:", line))
+    }
+
+
+def _animated_scene() -> dict:
+    lay = load_layout(LAYOUT)
+    return scene.build_scene(lay, moves_plan=plan_fill(lay))
+
+
+def test_brand_contract_ts_keys_match_brand_py():
+    from hangarfit import brand
+
+    assert _ts_interface_fields("brand-contract.ts", "BrandTokens") == set(
+        brand.viewer_brand_tokens()
+    )
+
+
+def test_scene_contract_ts_top_level_keys_match_scene_py():
+    assert _ts_interface_fields("scene-contract.ts", "SceneV1") == set(_animated_scene())
+
+
+def test_scene_contract_ts_nested_keys_match_scene_py():
+    sc = _animated_scene()
+    cases = {
+        "HangarData": sc["hangar"],
+        "DoorData": sc["hangar"]["door"],
+        "MaintenanceBay": sc["hangar"]["maintenance_bay"],
+        "PlaneData": sc["planes"][0],
+        "BoxData": sc["planes"][0]["boxes"][0],
+        "TimelineData": sc["timeline"],
+        "SegmentData": sc["timeline"]["segments"][0],
+        "Readouts": sc["readouts"],
+    }
+    for interface, obj in cases.items():
+        assert _ts_interface_fields("scene-contract.ts", interface) == set(obj), interface

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -165,6 +165,24 @@ def test_inlined_viewer_js_has_no_script_close():
     assert "</script" not in src.lower()
 
 
+def test_inlined_viewer_js_is_the_committed_bundle_verbatim(tmp_path):
+    # #439: viewer.js is now an esbuild artifact built from viewer/src/*.ts. The
+    # CI `viewer-build-drift` guard pins one half — viewer.js == esbuild(viewer/src);
+    # this pins the other half — the assembler inlines the committed bundle RAW,
+    # byte-for-byte, into the <script type="module">. Together they guarantee the
+    # shipped HTML carries exactly the reviewed, drift-guarded bytes. (A full-HTML
+    # golden hash is deliberately avoided: it would be brittle against every bundle
+    # rebuild / brand / vendored-three bump; the two-call determinism test below
+    # pins assembly stability instead.)
+    html = _html(tmp_path)
+    src = (
+        resources.files("hangarfit._viewer_assets")
+        .joinpath("viewer.js")
+        .read_text(encoding="utf-8")
+    )
+    assert src in html
+
+
 # ── #419: the injected canonical BRAND token blob ───────────────────────────
 
 

--- a/viewer/esbuild.config.mjs
+++ b/viewer/esbuild.config.mjs
@@ -1,11 +1,10 @@
 // Build the committed viewer bundle from viewer/src/*.ts.
 //
 // ADR-0020: this toolchain is DEV/CI-ONLY. `pip install` and the wheel build never
-// invoke it — they consume the committed src/hangarfit/_viewer_assets/viewer.js. Once
-// the `viewer-build-drift` CI guard lands (scope of #438, with the #439 port) it will
-// rebuild and assert the committed bundle equals this output, keeping the shipped
-// artifact in sync with the TS source. (During the #437 scaffold the committed
-// viewer.js is the hand-written renderer, not this output — see ADR-0020.)
+// invoke it — they consume the committed src/hangarfit/_viewer_assets/viewer.js. The
+// `viewer-build-drift` CI guard (#438, live since the #439 port) rebuilds and asserts
+// the committed bundle equals this output, keeping the shipped artifact in sync with
+// the TS source: since #439 the committed viewer.js IS this esbuild output.
 //
 // three stays EXTERNAL: the bare `three` / OrbitControls imports are left in the output
 // and resolved at HTML-assembly time by viewer.py's `data:` import-map over the vendored

--- a/viewer/eslint.config.js
+++ b/viewer/eslint.config.js
@@ -16,7 +16,7 @@ export default defineConfig([
     languageOptions: { globals: globals.node },
   },
   {
-    files: ["src/**/*.ts"],
+    files: ["src/**/*.ts", "test/**/*.ts"],
     extends: [tseslint.configs.recommended],
   },
 ]);

--- a/viewer/package-lock.json
+++ b/viewer/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "devDependencies": {
         "@eslint/js": "10.0.1",
+        "@types/node": "24.13.0",
         "@types/three": "0.160.0",
         "esbuild": "0.28.0",
         "eslint": "10.4.1",
         "globals": "17.6.0",
+        "three": "0.160.0",
         "typescript": "5.9.3",
         "typescript-eslint": "8.60.1"
       }
@@ -673,6 +675,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.0.tgz",
+      "integrity": "sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@types/stats.js": {
       "version": "0.17.4",
@@ -1651,6 +1663,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/three": {
+      "version": "0.160.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
+      "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -1731,6 +1750,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -12,10 +12,12 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
+    "@types/node": "24.13.0",
     "@types/three": "0.160.0",
     "esbuild": "0.28.0",
     "eslint": "10.4.1",
     "globals": "17.6.0",
+    "three": "0.160.0",
     "typescript": "5.9.3",
     "typescript-eslint": "8.60.1"
   }

--- a/viewer/src/affine.ts
+++ b/viewer/src/affine.ts
@@ -5,7 +5,7 @@
 // drops the Python-computed 2x3 affine into a THREE.Matrix4. The viewer never
 // DERIVES an affine — Python owns the determinant-−1 transform (ADR-0002/0017).
 import * as THREE from 'three';
-import type { Affine } from './scene-contract';
+import type { Affine } from './scene-contract.ts';
 
 /** 2x3 affine `[a,b,tx,c,d,ty]` → THREE.Matrix4 mapping local (u,v,w,1) → world. */
 export function affineMatrix(aff: Affine): THREE.Matrix4 {

--- a/viewer/src/affine.ts
+++ b/viewer/src/affine.ts
@@ -1,0 +1,28 @@
+// ── affine → Matrix4 (z-row identity; det may be −1, that's intentional) ─────
+//
+// The ONLY arithmetic the viewer does on poses. `applyAffine` is pure (the
+// oracle compare in anchors.ts and the #440 node tests use it); `affineMatrix`
+// drops the Python-computed 2x3 affine into a THREE.Matrix4. The viewer never
+// DERIVES an affine — Python owns the determinant-−1 transform (ADR-0002/0017).
+import * as THREE from 'three';
+import type { Affine } from './scene-contract';
+
+/** 2x3 affine `[a,b,tx,c,d,ty]` → THREE.Matrix4 mapping local (u,v,w,1) → world. */
+export function affineMatrix(aff: Affine): THREE.Matrix4 {
+  const [a, b, tx, c, d, ty] = aff;
+  const m = new THREE.Matrix4();
+  // row-major: maps local (u,v,w,1) → world (a·u+b·v+tx, c·u+d·v+ty, w).
+  m.set(
+    a, b, 0, tx,
+    c, d, 0, ty,
+    0, 0, 1, 0,
+    0, 0, 0, 1,
+  );
+  return m;
+}
+
+/** Apply a 2x3 affine to a local (u,v), returning world (x,y). PURE. */
+export function applyAffine(aff: Affine, u: number, v: number): [number, number] {
+  const [a, b, tx, c, d, ty] = aff;
+  return [a * u + b * v + tx, c * u + d * v + ty];
+}

--- a/viewer/src/anchors.ts
+++ b/viewer/src/anchors.ts
@@ -1,0 +1,76 @@
+// ── load-time anchor self-check: recompute final world corners and compare ───
+//
+// This is the ONLY thing pinning the JS matrix path to the Python oracle, and
+// the ADR-0017 backstop. It is PURE here — `checkAnchors(scene)` returns a
+// result; the fail-loud `banner()` side-effect stays at the thin edge in
+// main.ts, so the comparison is node-testable without a DOM (#440). The
+// structural-vs-tolerance reporting (and the "never throw" wrapping) is
+// preserved behaviour-identically by the caller.
+import * as THREE from 'three';
+import { applyAffine } from './affine';
+import type { BoxData, SceneV1 } from './scene-contract';
+
+/** oriented_rect corner order, rotated CCW about (cx,cy):
+ *  (+hl,-hw),(+hl,+hw),(-hl,+hw),(-hl,-hw). */
+export function boxCornersLocal(b: BoxData): [number, number][] {
+  const h = THREE.MathUtils.degToRad(b.angle_deg);
+  const cs = Math.cos(h), sn = Math.sin(h);
+  const hl = b.length_m / 2, hw = b.width_m / 2;
+  const corners: [number, number][] = [[hl, -hw], [hl, hw], [-hl, hw], [-hl, -hw]];
+  return corners.map(
+    ([lx, ly]) => [b.cx + lx * cs - ly * sn, b.cy + lx * sn + ly * cs] as [number, number],
+  );
+}
+
+/** Result of the oracle compare. `structural` non-empty => a structural problem
+ * (missing/mismatched data) found first; otherwise `maxErr` is the largest
+ * |viewer − oracle| coordinate error over all box corners and wheels. */
+export interface AnchorCheckResult {
+  structural: string;
+  maxErr: number;
+}
+
+/**
+ * Recompute each plane's world box corners + wheel positions from geometry and
+ * its final affine, and compare to the Python oracle (`anchors`, `gear_anchors`).
+ * PURE — no DOM, no throw. main.ts banners on `structural` or `maxErr > 1e-6`.
+ */
+export function checkAnchors(scene: SceneV1): AnchorCheckResult {
+  let maxErr = 0;
+  let structural = '';
+  for (const p of scene.planes) {
+    const aff = scene.final_poses[p.id];
+    const want = scene.anchors[p.id];
+    if (!aff || !want) {
+      structural = 'missing affine/anchors for ' + p.id;
+      break;
+    }
+    if (want.length !== p.boxes.length) {
+      structural = 'anchor/box count mismatch for ' + p.id;
+      break;
+    }
+    p.boxes.forEach((b, bi) => {
+      boxCornersLocal(b).forEach(([u, v], ci) => {
+        const [wx, wy] = applyAffine(aff, u, v);
+        maxErr = Math.max(maxErr, Math.abs(wx - want[bi][ci][0]), Math.abs(wy - want[bi][ci][1]));
+      });
+    });
+    // Gear oracle (#399): the wheels[] ride the same affine Group as the boxes,
+    // so a wrong transform corrupts both — but viewer.js is not pytest-covered,
+    // so we cross-check the wheel world positions against the Python oracle too.
+    const gw = scene.gear_anchors[p.id];
+    if (!gw || !p.wheels) {
+      structural = 'missing gear anchors/wheels for ' + p.id;
+      break;
+    }
+    if (gw.length !== p.wheels.length) {
+      structural = 'gear anchor/wheel count mismatch for ' + p.id;
+      break;
+    }
+    p.wheels.forEach(([u, v], wi) => {
+      const [wx, wy] = applyAffine(aff, u, v);
+      maxErr = Math.max(maxErr, Math.abs(wx - gw[wi][0]), Math.abs(wy - gw[wi][1]));
+    });
+  }
+  return { structural, maxErr };
+}

--- a/viewer/src/anchors.ts
+++ b/viewer/src/anchors.ts
@@ -7,8 +7,8 @@
 // structural-vs-tolerance reporting (and the "never throw" wrapping) is
 // preserved behaviour-identically by the caller.
 import * as THREE from 'three';
-import { applyAffine } from './affine';
-import type { BoxData, SceneV1 } from './scene-contract';
+import { applyAffine } from './affine.ts';
+import type { BoxData, SceneV1 } from './scene-contract.ts';
 
 /** oriented_rect corner order, rotated CCW about (cx,cy):
  *  (+hl,-hw),(+hl,+hw),(-hl,+hw),(-hl,-hw). */

--- a/viewer/src/brand-contract.ts
+++ b/viewer/src/brand-contract.ts
@@ -1,0 +1,38 @@
+// Typed mirror of the BRAND token blob (Python `brand.py`, ADR-0019 / #419),
+// injected by `viewer.py` as `<script id="brand">`. Colours arrive as
+// `#RRGGBB` strings (straight into `new THREE.Color(str)`); opacities and
+// intensities are plain numbers. Do NOT hard-code `0x` colour literals in the
+// viewer — every colour is a brand token (#419).
+//
+// LEAN for #439 (only the tokens the renderer reads); the full token parity
+// test against `brand.py` lands in #440.
+
+export interface BrandTokens {
+  sceneBg: string;
+
+  hemisphereSky: string;
+  hemisphereGround: string;
+  hemisphereIntensity: number;
+
+  sun: string;
+  sunIntensity: number;
+  fill: string;
+  fillIntensity: number;
+
+  floor: string;
+  gridMajor: string;
+  gridMinor: string;
+
+  walls: string;
+  wallsOpacity: number;
+  bay: string;
+  bayOpacity: number;
+
+  wheel: string;
+  cartDeck: string;
+
+  conflict: string;
+  labelConflictChip: string;
+  labelChipBg: string;
+  labelText: string;
+}

--- a/viewer/src/brand-contract.ts
+++ b/viewer/src/brand-contract.ts
@@ -4,8 +4,9 @@
 // intensities are plain numbers. Do NOT hard-code `0x` colour literals in the
 // viewer — every colour is a brand token (#419).
 //
-// LEAN for #439 (only the tokens the renderer reads); the full token parity
-// test against `brand.py` lands in #440.
+// The complete mirror of `brand.viewer_brand_tokens()`; a Python key-set parity
+// test in `tests/test_scene.py` fails if `brand.py` and these keys drift apart
+// (the same desync guard as `scene-contract.ts`).
 
 export interface BrandTokens {
   sceneBg: string;

--- a/viewer/src/dom.ts
+++ b/viewer/src/dom.ts
@@ -1,0 +1,33 @@
+// DOM helpers shared across the viewer modules.
+//
+// `banner()` is the load-bearing fail-loud edge (ADR-0017): the anchor
+// self-check and the WebGL-unavailable path surface here, never via a thrown
+// error that would blank the page. The banner text for the self-check is built
+// by the caller (main.ts) so the comparison itself stays pure/DOM-free
+// (node-tested in #440).
+
+/**
+ * `getElementById` narrowed to the requested element type. The viewer's HTML
+ * (assembled by `viewer.py`) always carries these ids, so a missing one is a
+ * real assembly bug — throw a clear error rather than propagate `null` (this
+ * mirrors the original's implicit null-deref crash, with a legible message).
+ * Not used inside `checkAnchors`, so it does not weaken the fail-loud contract.
+ */
+export function byId<T extends HTMLElement = HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (el === null) throw new Error(`viewer: missing #${id} element`);
+  return el as T;
+}
+
+/** Unhide the `#banner` and set its text. Never throws on a present banner. */
+export function banner(msg: string): void {
+  const b = byId('banner');
+  b.hidden = false;
+  b.textContent = msg;
+}
+
+/** Disable a HUD form control by id (button / range / select all carry the same
+ * `.disabled` IDL attribute — typing as a button suffices to reach it). */
+export function disableControl(id: string): void {
+  byId<HTMLButtonElement>(id).disabled = true;
+}

--- a/viewer/src/gear.ts
+++ b/viewer/src/gear.ts
@@ -1,0 +1,83 @@
+// ── gear / cart render constants (#399) ──────────────────────────────────────
+// Render *sizes* live here in the viewer layer, never in fleet.yaml (the canonical
+// data carries only plane-local wheel POSITIONS, ADR-0013). Values mirror the 2D
+// path's constants in visualize.py so 2D and 3D read alike; the remaining three
+// (WHEEL_WIDTH_M, LEG_WIDTH_M, CART_PALLET_HEIGHT_M) have no 2D analogue — the
+// top-down PNG has no z and draws no gear leg — and are glyph extents chosen to
+// read at fuselage scale.
+import * as THREE from 'three';
+import type { BrandTokens } from './brand-contract';
+import type { PlaneData } from './scene-contract';
+
+export const WHEEL_RADIUS_M = 0.18; // visualize._WHEEL_RADIUS_M
+export const WHEEL_WIDTH_M = 0.12; // tyre width — 3D-only glyph depth
+export const LEG_WIDTH_M = 0.06; // thin gear-leg strut up to the belly — 3D-only glyph
+export const CART_PALLET_HALF_EXTENT_M = 0.4; // visualize._CART_PALLET_HALF_EXTENT_M
+export const CART_PALLET_HEIGHT_M = 0.12; // dolly deck thickness — 3D-only glyph depth
+
+export interface GearMaterials {
+  gearMat: THREE.MeshStandardMaterial;
+  palletMat: THREE.MeshStandardMaterial;
+}
+
+/** The shared wheel/leg + pallet-deck materials, built ONCE from BRAND (the
+ * original created these at module scope; BRAND only exists at runtime, so the
+ * single-instance sharing moves into this factory). DoubleSide: the plane Group
+ * matrix may be det −1. */
+export function makeGearMaterials(BRAND: BrandTokens): GearMaterials {
+  const WHEEL_COLOR = new THREE.Color(BRAND.wheel); // brand.WHEEL_COLOR (= visualize._WHEEL_COLOR)
+  const CART_DECK_COLOR = new THREE.Color(BRAND.cartDeck); // brand.CART_DECK_COLOR
+  return {
+    gearMat: new THREE.MeshStandardMaterial({
+      color: WHEEL_COLOR, side: THREE.DoubleSide, roughness: 0.6, metalness: 0.1,
+    }),
+    palletMat: new THREE.MeshStandardMaterial({
+      color: CART_DECK_COLOR, side: THREE.DoubleSide, roughness: 0.9, metalness: 0.0,
+    }),
+  };
+}
+
+// Draw gear (a wheel at each point + a short leg up to the belly where there is
+// clearance) and, when carted, a pallet deck under each wheel, all parented to the
+// plane's affine Group `g` so they inherit the verified plane-local→world transform
+// and animate along the tow path for free. Wheel world positions are oracle-checked
+// in checkAnchors().
+export function addGear(g: THREE.Group, p: PlaneData, mats: GearMaterials): void {
+  // Belly = lowest box bottom; the leg rises from the wheel top to it. A plane
+  // with no boxes falls back to a wheel-diameter belly so a stub leg still renders.
+  let belly = Infinity;
+  for (const b of p.boxes) belly = Math.min(belly, b.cz - b.height_m / 2);
+  if (!isFinite(belly)) belly = 2 * WHEEL_RADIUS_M;
+  const deck = p.on_carts ? CART_PALLET_HEIGHT_M : 0;
+  for (const [u, v] of p.wheels) {
+    // Cylinder's default axis is +Y = local v (lateral), so the disc lies in the
+    // forward/up (u,w) plane — a wheel that rolls forward. No rotation needed.
+    const wheelZ = deck + WHEEL_RADIUS_M;
+    const wheel = new THREE.Mesh(
+      new THREE.CylinderGeometry(WHEEL_RADIUS_M, WHEEL_RADIUS_M, WHEEL_WIDTH_M, 16),
+      mats.gearMat,
+    );
+    wheel.position.set(u, v, wheelZ);
+    wheel.castShadow = true;
+    g.add(wheel);
+
+    const wheelTop = wheelZ + WHEEL_RADIUS_M;
+    const legH = belly - wheelTop;
+    if (legH > 0.01) {
+      const leg = new THREE.Mesh(new THREE.BoxGeometry(LEG_WIDTH_M, LEG_WIDTH_M, legH), mats.gearMat);
+      leg.position.set(u, v, wheelTop + legH / 2);
+      leg.castShadow = true;
+      g.add(leg);
+    }
+    if (p.on_carts) {
+      const pallet = new THREE.Mesh(
+        new THREE.BoxGeometry(2 * CART_PALLET_HALF_EXTENT_M, 2 * CART_PALLET_HALF_EXTENT_M, deck),
+        mats.palletMat,
+      );
+      pallet.position.set(u, v, deck / 2);
+      pallet.castShadow = true;
+      pallet.receiveShadow = true;
+      g.add(pallet);
+    }
+  }
+}

--- a/viewer/src/gear.ts
+++ b/viewer/src/gear.ts
@@ -6,8 +6,8 @@
 // top-down PNG has no z and draws no gear leg — and are glyph extents chosen to
 // read at fuselage scale.
 import * as THREE from 'three';
-import type { BrandTokens } from './brand-contract';
-import type { PlaneData } from './scene-contract';
+import type { BrandTokens } from './brand-contract.ts';
+import type { PlaneData } from './scene-contract.ts';
 
 export const WHEEL_RADIUS_M = 0.18; // visualize._WHEEL_RADIUS_M
 export const WHEEL_WIDTH_M = 0.12; // tyre width — 3D-only glyph depth

--- a/viewer/src/hangar.ts
+++ b/viewer/src/hangar.ts
@@ -1,0 +1,63 @@
+// ── hangar: floor, grid, walls (split at door), maintenance bay ──────────────
+import * as THREE from 'three';
+import type { BrandTokens } from './brand-contract';
+import type { HangarData } from './scene-contract';
+
+export const WALL_H = 3.0;
+
+/** Build floor, grid, the four walls (front split at the door) and a closed
+ * maintenance bay. Returns the wall meshes so main.ts can wire the walls toggle. */
+export function addHangar(
+  scene: THREE.Scene, H: HangarData, BRAND: BrandTokens, span: number,
+): THREE.Mesh[] {
+  const wallMeshes: THREE.Mesh[] = [];
+
+  const floor = new THREE.Mesh(
+    new THREE.PlaneGeometry(H.width_m, H.length_m),
+    new THREE.MeshStandardMaterial({
+      color: new THREE.Color(BRAND.floor), roughness: 1, side: THREE.DoubleSide,
+    }),
+  );
+  floor.position.set(H.width_m / 2, H.length_m / 2, 0); // PlaneGeometry lies in XY (normal +Z)
+  floor.receiveShadow = true; // catches the planes' contact shadows (#400)
+  scene.add(floor);
+
+  const grid = new THREE.GridHelper(
+    span, Math.round(span), new THREE.Color(BRAND.gridMajor), new THREE.Color(BRAND.gridMinor),
+  );
+  grid.rotation.x = Math.PI / 2; // GridHelper is in XZ by default → rotate into XY
+  grid.position.set(H.width_m / 2, H.length_m / 2, 0.003);
+  scene.add(grid);
+
+  const t = 0.08;
+  const addWall = (sx: number, sy: number, x: number, y: number): void => {
+    const m = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(BRAND.walls), transparent: true, opacity: BRAND.wallsOpacity,
+      side: THREE.DoubleSide,
+    });
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(sx, sy, WALL_H), m);
+    mesh.position.set(x, y, WALL_H / 2);
+    scene.add(mesh);
+    wallMeshes.push(mesh);
+  };
+  addWall(t, H.length_m, 0, H.length_m / 2);             // left
+  addWall(t, H.length_m, H.width_m, H.length_m / 2);     // right
+  addWall(H.width_m, t, H.width_m / 2, H.length_m);      // back
+  const dl = H.door.center_x_m - H.door.width_m / 2;
+  const dr = H.door.center_x_m + H.door.width_m / 2;
+  if (dl > 1e-6) addWall(dl, t, dl / 2, 0);              // front, left of door
+  if (dr < H.width_m - 1e-6) addWall(H.width_m - dr, t, (dr + H.width_m) / 2, 0); // front, right
+
+  const bay = H.maintenance_bay;
+  if (bay && bay.closed) {
+    const bm = new THREE.Mesh(
+      new THREE.BoxGeometry(bay.width_m, bay.depth_m, WALL_H),
+      new THREE.MeshStandardMaterial({
+        color: new THREE.Color(BRAND.bay), transparent: true, opacity: BRAND.bayOpacity,
+      }),
+    );
+    bm.position.set(bay.center_x_m, H.length_m - bay.depth_m / 2, WALL_H / 2);
+    scene.add(bm);
+  }
+  return wallMeshes;
+}

--- a/viewer/src/hangar.ts
+++ b/viewer/src/hangar.ts
@@ -1,7 +1,7 @@
 // ── hangar: floor, grid, walls (split at door), maintenance bay ──────────────
 import * as THREE from 'three';
-import type { BrandTokens } from './brand-contract';
-import type { HangarData } from './scene-contract';
+import type { BrandTokens } from './brand-contract.ts';
+import type { HangarData } from './scene-contract.ts';
 
 export const WALL_H = 3.0;
 

--- a/viewer/src/hud.ts
+++ b/viewer/src/hud.ts
@@ -1,8 +1,8 @@
 // ── HUD wiring + render loop ─────────────────────────────────────────────────
 import type * as THREE from 'three';
-import { byId, disableControl } from './dom';
+import { byId, disableControl } from './dom.ts';
 import type { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import type { Timeline } from './timeline';
+import type { Timeline } from './timeline.ts';
 
 export interface HudDeps {
   timeline: Timeline;

--- a/viewer/src/hud.ts
+++ b/viewer/src/hud.ts
@@ -1,0 +1,86 @@
+// ── HUD wiring + render loop ─────────────────────────────────────────────────
+import type * as THREE from 'three';
+import { byId, disableControl } from './dom';
+import type { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import type { Timeline } from './timeline';
+
+export interface HudDeps {
+  timeline: Timeline;
+  home: () => void;
+  controls: OrbitControls;
+  renderer: THREE.WebGLRenderer;
+  scene: THREE.Scene;
+  cam: THREE.PerspectiveCamera;
+}
+
+/** Wire the play/scrub/step/speed controls + resize, then start the render loop. */
+export function startHud(deps: HudDeps): void {
+  const { timeline, home, controls, renderer, scene, cam } = deps;
+  const { total: TOTAL, hasAnim, segs: SEGS, applyTime } = timeline;
+
+  let t = 0;
+  let playing = false;
+  let speed = 1;
+  const scrub = byId<HTMLInputElement>('scrub');
+  const playBtn = byId('play');
+  const speedSel = byId<HTMLSelectElement>('speed');
+  speedSel.addEventListener('change', () => { speed = parseFloat(speedSel.value); });
+
+  if (!hasAnim) {
+    ['play', 'prev', 'next', 'scrub', 'speed'].forEach(disableControl);
+  }
+
+  scrub.addEventListener('input', () => {
+    t = (Number(scrub.value) / 1000) * TOTAL;
+    playing = false;
+    playBtn.textContent = '▶';
+    applyTime(t);
+  });
+  playBtn.addEventListener('click', () => {
+    if (!hasAnim) return;
+    playing = !playing;
+    playBtn.textContent = playing ? '❚❚' : '▶';
+    if (t >= TOTAL) t = 0;
+  });
+  const stepTo = (dir: number): void => {
+    const bounds = [0, ...SEGS.map((s) => s.end_s)];
+    let i = bounds.findIndex((b) => b > t + 1e-6);
+    if (i < 0) i = bounds.length - 1;
+    t = dir > 0 ? bounds[Math.min(i, bounds.length - 1)] : bounds[Math.max(0, i - 2)];
+    playing = false;
+    playBtn.textContent = '▶';
+    if (hasAnim) scrub.value = String((t / TOTAL) * 1000);
+    applyTime(t);
+  };
+  byId('next').addEventListener('click', () => stepTo(1));
+  byId('prev').addEventListener('click', () => stepTo(-1));
+  byId('reset').addEventListener('click', home);
+
+  window.addEventListener('resize', () => {
+    cam.aspect = window.innerWidth / window.innerHeight;
+    cam.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  });
+
+  // ── render loop ──────────────────────────────────────────────────────────
+  let last = performance.now();
+  const loop = (now: number): void => {
+    requestAnimationFrame(loop);
+    const dt = (now - last) / 1000;
+    last = now;
+    if (playing && hasAnim) {
+      t += dt * speed;
+      if (t >= TOTAL) {
+        t = TOTAL;
+        playing = false;
+        playBtn.textContent = '▶';
+      }
+      scrub.value = String((t / TOTAL) * 1000);
+    }
+    applyTime(t);
+    controls.update();
+    renderer.render(scene, cam);
+  };
+  applyTime(0);
+  requestAnimationFrame(loop);
+}

--- a/viewer/src/interaction/README.md
+++ b/viewer/src/interaction/README.md
@@ -1,0 +1,43 @@
+# `interaction/` — the editor extension seam (inert)
+
+This directory is the **extension seam** for the future interactive plane-placement
+editor (deferred — issue #442, the Stage 2 of the roadmap in ADR-0020 / the spec).
+
+**It is intentionally inert.** Right now it holds this `README.md` and **no `.ts`
+files**, so esbuild bundles nothing from here and the committed
+`src/hangarfit/_viewer_assets/viewer.js` is byte-unchanged. The `viewer-build-drift`
+CI guard stays green until a real module lands with #442.
+
+## The contract this seam will implement (#442)
+
+The viewer is, and stays, a **thin read-only consumer** of `scene/v1` whose geometry
+is computed in Python (ADR-0002/0017/0020). The editor does **not** change that: it
+captures user **intent** and hands it back to the Python solver. When #442 lands, an
+`interaction/` module will:
+
+1. **Read** the typed `scene-contract.ts` models to know what is on screen.
+2. **Build an intent object** mirroring `Scenario.constraints`:
+
+   ```ts
+   interface Intent {
+     selectedPlaneIds: string[];
+     priorities: Record<string, number>;            // soft PlaneConstraint.priority (#441)
+     mustPositions: Record<string, { x: number; y: number; heading: number }>; // hard pin
+   }
+   ```
+
+   "must positions" map to `PlaneConstraint.pin`; "priorities" to the soft
+   `PlaneConstraint.priority` groundwork (#441). `intent-contract.ts` becomes the
+   typed mirror of this artifact.
+3. **Export a `Scenario` / constraints YAML** the Python solver consumes. The user
+   re-runs `hangarfit solve` and re-opens the viewer (the Stage-2 round-trip file);
+   Stage 3 (#445) delivers the same intent object over a `hangarfit serve` localhost
+   API instead of a file. **Python stays the solver authority** in every stage.
+
+## The one hard rule
+
+A module in `interaction/` **must never import `affine.ts` or `anchors.ts`** to
+re-derive geometry. It captures intent and serializes it; the determinant-−1
+transform stays owned by tested Python (`geometry.local_to_world`), and the browser
+never re-derives authoritative geometry (ADR-0002/0020). The runtime `checkAnchors()`
+self-check remains the cross-language backstop.

--- a/viewer/src/labels.ts
+++ b/viewer/src/labels.ts
@@ -2,8 +2,8 @@
 // HUD-toggleable. A billboarded id label and a nose cone at the plane-local +x
 // tip show which plane is which and which way it faces.
 import * as THREE from 'three';
-import type { BrandTokens } from './brand-contract';
-import type { PlaneData } from './scene-contract';
+import type { BrandTokens } from './brand-contract.ts';
+import type { PlaneData } from './scene-contract.ts';
 
 export function makeLabel(text: string, BRAND: BrandTokens, conflicted = false): THREE.Sprite {
   // Plane ids are machine output → mono (brand). A conflicted plane carries the

--- a/viewer/src/labels.ts
+++ b/viewer/src/labels.ts
@@ -1,0 +1,80 @@
+// ── identity cues (#400): billboarded id label + nose cone ───────────────────
+// HUD-toggleable. A billboarded id label and a nose cone at the plane-local +x
+// tip show which plane is which and which way it faces.
+import * as THREE from 'three';
+import type { BrandTokens } from './brand-contract';
+import type { PlaneData } from './scene-contract';
+
+export function makeLabel(text: string, BRAND: BrandTokens, conflicted = false): THREE.Sprite {
+  // Plane ids are machine output → mono (brand). A conflicted plane carries the
+  // non-colour "never hue alone" cue 3D can't hatch: a " ⚠ conflict" suffix and
+  // the conflict-ink chip instead of the surface glass (BRAND.md §3).
+  const shown = conflicted ? text + ' ⚠ conflict' : text;
+  const fontPx = 64, padX = 14, padY = 8;
+  const fontStack = "px ui-monospace, 'SF Mono', Menlo, monospace";
+  const measure = document.createElement('canvas').getContext('2d')!;
+  measure.font = fontPx + fontStack;
+  const tw = Math.ceil(measure.measureText(shown).width);
+  const canvas = document.createElement('canvas');
+  canvas.width = tw + padX * 2;
+  canvas.height = fontPx + padY * 2;
+  const ctx = canvas.getContext('2d')!;
+  ctx.font = fontPx + fontStack;
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = conflicted ? BRAND.labelConflictChip : BRAND.labelChipBg;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = BRAND.labelText;
+  ctx.fillText(shown, padX, canvas.height / 2); // SAFE: canvas fillText, never innerHTML (ids are user YAML)
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.anisotropy = 4;
+  const sprite = new THREE.Sprite(
+    new THREE.SpriteMaterial({ map: tex, transparent: true, depthTest: false }),
+  );
+  const hWorld = 0.9; // label height in world metres
+  sprite.scale.set((hWorld * canvas.width) / canvas.height, hWorld, 1);
+  sprite.renderOrder = 999; // float above geometry (depthTest off)
+  return sprite;
+}
+
+/** Add the id label sprite + nose cone to a plane Group, pushing them onto the
+ * shared toggle arrays so the HUD "labels" switch can hide them all at once. */
+export function addLabelAndNose(
+  g: THREE.Group,
+  p: PlaneData,
+  colour: THREE.Color,
+  conflicted: boolean,
+  BRAND: BrandTokens,
+  labelMeshes: THREE.Sprite[],
+  noseMeshes: THREE.Mesh[],
+): void {
+  let maxTop = 0, sx = 0, sy = 0, noseX = -Infinity, noseZ = 0;
+  for (const b of p.boxes) {
+    maxTop = Math.max(maxTop, b.cz + b.height_m / 2);
+    sx += b.cx;
+    sy += b.cy;
+    noseX = Math.max(noseX, b.cx + b.length_m / 2);
+    if (b.kind === 'fuselage_front') noseZ = b.cz;
+  }
+  const n = p.boxes.length || 1;
+  if (!isFinite(noseX)) noseX = 0;
+  if (noseZ === 0) noseZ = maxTop * 0.5;
+
+  const label = makeLabel(p.id, BRAND, conflicted);
+  label.position.set(sx / n, sy / n, maxTop + 1.0); // above the plane, in plane-local
+  g.add(label);
+  labelMeshes.push(label);
+
+  const noseLen = 0.7, noseR = 0.28;
+  const nose = new THREE.Mesh(
+    new THREE.ConeGeometry(noseR, noseLen, 14),
+    new THREE.MeshStandardMaterial({
+      color: colour, emissive: colour.clone().multiplyScalar(0.25),
+      side: THREE.DoubleSide, roughness: 0.5, metalness: 0.1,
+    }),
+  );
+  nose.rotation.z = -Math.PI / 2; // default +Y tip → +x (plane-local nose)
+  nose.position.set(noseX + noseLen / 2, 0, noseZ);
+  nose.castShadow = true;
+  g.add(nose);
+  noseMeshes.push(nose);
+}

--- a/viewer/src/main.ts
+++ b/viewer/src/main.ts
@@ -10,15 +10,15 @@
 //
 // This file keeps viewer.js's exact init ORDER; the heavy lifting lives in the
 // sibling section modules so the port is reviewable section-by-section.
-import { banner, byId } from './dom';
-import { createRenderer } from './renderer';
-import { addHangar } from './hangar';
-import { addPlanes } from './planes';
-import { checkAnchors } from './anchors';
-import { createTimeline } from './timeline';
-import { startHud } from './hud';
-import type { BrandTokens } from './brand-contract';
-import type { SceneV1 } from './scene-contract';
+import { banner, byId } from './dom.ts';
+import { createRenderer } from './renderer.ts';
+import { addHangar } from './hangar.ts';
+import { addPlanes } from './planes.ts';
+import { checkAnchors } from './anchors.ts';
+import { createTimeline } from './timeline.ts';
+import { startHud } from './hud.ts';
+import type { BrandTokens } from './brand-contract.ts';
+import type { SceneV1 } from './scene-contract.ts';
 
 const SCENE = JSON.parse(byId('scene').textContent ?? 'null') as SceneV1;
 const BRAND = JSON.parse(byId('brand').textContent ?? 'null') as BrandTokens;

--- a/viewer/src/main.ts
+++ b/viewer/src/main.ts
@@ -1,16 +1,82 @@
-// Placeholder entry for the #437 toolchain scaffold (ADR-0020 / epic #436).
+// hangarfit 3D viewer — entry / orchestration (esbuild bundles this + the sibling
+// modules into the committed src/hangarfit/_viewer_assets/viewer.js, ADR-0020).
 //
-// The real viewer — viewer.js's nine comment-delimited sections ported to typed
-// modules (affine, anchors, renderer, hangar, gear, planes, labels, timeline, hud, …)
-// — lands as ONE atomic, behavior-neutral PR in #439. This stub renders nothing; it
-// exists only so the esbuild -> tsc -> eslint pipeline is real and reproducible before
-// the port, and so #437 ships a buildable, guardable toolchain without touching the
-// working committed viewer.js.
+// A thin consumer of the hangarfit.scene/v1 contract: it performs NO transform
+// math. Every plane-local→world placement arrives as a 2x3 affine [a,b,tx,c,d,ty]
+// computed in Python from geometry.local_to_world (the determinant-−1 transform,
+// ADR-0002/ADR-0017). The viewer drops each affine into a THREE.Matrix4 and
+// assigns it to a statically-built plane group. All colours/opacities are read
+// from the injected BRAND blob (Python brand.py) — never hard-coded here (#419).
 //
-// The typed export below is inert (nothing imports it; it renders nothing) but is
-// preserved as the entry's public API, so the build produces a non-empty, deterministic
-// bundle that demonstrably exercises esbuild's TS type-stripping.
-export const SCAFFOLD: { readonly epic: number; readonly issue: number } = {
-  epic: 436,
-  issue: 437,
-};
+// This file keeps viewer.js's exact init ORDER; the heavy lifting lives in the
+// sibling section modules so the port is reviewable section-by-section.
+import { banner, byId } from './dom';
+import { createRenderer } from './renderer';
+import { addHangar } from './hangar';
+import { addPlanes } from './planes';
+import { checkAnchors } from './anchors';
+import { createTimeline } from './timeline';
+import { startHud } from './hud';
+import type { BrandTokens } from './brand-contract';
+import type { SceneV1 } from './scene-contract';
+
+const SCENE = JSON.parse(byId('scene').textContent ?? 'null') as SceneV1;
+const BRAND = JSON.parse(byId('brand').textContent ?? 'null') as BrandTokens;
+const H = SCENE.hangar;
+
+// #401 honesty banner + actionable readouts. The banner text is static (set in
+// the HTML); we only unhide it. Readouts are numbers from the scene — no user
+// HTML, set via textContent.
+if (SCENE.placeholder) byId('placeholder').hidden = false;
+if (SCENE.readouts) {
+  const fmtM = (v: number | null): string => (v == null ? 'n/a' : v.toFixed(2) + ' m');
+  byId('readouts').textContent =
+    'gap ' + fmtM(SCENE.readouts.min_gap_m) +
+    ' · wing-over-tail ' + fmtM(SCENE.readouts.min_wing_over_tail_clearance_m);
+}
+
+// renderer / scene / camera / lights
+const canvas = byId<HTMLCanvasElement>('c');
+const { renderer, scene, cam, controls, span, home } = createRenderer(canvas, H, BRAND);
+
+// hangar + walls toggle
+const wallMeshes = addHangar(scene, H, BRAND, span);
+const wallsToggle = byId<HTMLInputElement>('walls');
+wallsToggle.addEventListener('change', () => {
+  for (const m of wallMeshes) m.visible = wallsToggle.checked;
+});
+
+// planes (boxes + gear + label/nose) + labels toggle
+const { groups, labelMeshes, noseMeshes } = addPlanes(scene, SCENE, BRAND);
+// Labels + nose arrows share one HUD toggle (#400). They are children of each
+// plane Group, so a hidden (not-yet-entered) plane hides its label too.
+const labelsToggle = byId<HTMLInputElement>('labels');
+labelsToggle.addEventListener('change', () => {
+  const on = labelsToggle.checked;
+  for (const m of labelMeshes) m.visible = on;
+  for (const m of noseMeshes) m.visible = on;
+});
+
+// ── load-time anchor self-check ──────────────────────────────────────────────
+// Must FAIL LOUD (banner), never throw — a throw here aborts module evaluation
+// and blanks the page with no signal, the opposite of the ADR-0017 fail-loud
+// contract. The pure compare lives in anchors.ts; this edge banners structural
+// problems / a >1e-6 mismatch, and wraps everything so any unforeseen error
+// still surfaces as a banner.
+try {
+  const { structural, maxErr } = checkAnchors(SCENE);
+  if (structural) {
+    banner('TRANSFORM CHECK FAILED (' + structural + ') — do not trust this render.');
+  } else if (maxErr > 1e-6) {
+    banner(
+      'TRANSFORM CHECK FAILED (maxErr=' + maxErr.toExponential(2) +
+      '): viewer affine disagrees with the Python oracle — do not trust this render.',
+    );
+  }
+} catch (e) {
+  banner('TRANSFORM CHECK ERRORED: ' + (e as Error).message + ' — do not trust this render.');
+}
+
+// timeline + HUD wiring + render loop
+const timeline = createTimeline(SCENE, groups);
+startHud({ timeline, home, controls, renderer, scene, cam });

--- a/viewer/src/planes.ts
+++ b/viewer/src/planes.ts
@@ -1,10 +1,10 @@
 // ── planes: one Group of boxes each, built ONCE in plane-local coords ────────
 import * as THREE from 'three';
-import { byId } from './dom';
-import { addGear, makeGearMaterials } from './gear';
-import { addLabelAndNose } from './labels';
-import type { BrandTokens } from './brand-contract';
-import type { BoxData, SceneV1 } from './scene-contract';
+import { byId } from './dom.ts';
+import { addGear, makeGearMaterials } from './gear.ts';
+import { addLabelAndNose } from './labels.ts';
+import type { BrandTokens } from './brand-contract.ts';
+import type { BoxData, SceneV1 } from './scene-contract.ts';
 
 export interface PlanesBundle {
   groups: Record<string, THREE.Group>;

--- a/viewer/src/planes.ts
+++ b/viewer/src/planes.ts
@@ -1,0 +1,77 @@
+// ── planes: one Group of boxes each, built ONCE in plane-local coords ────────
+import * as THREE from 'three';
+import { byId } from './dom';
+import { addGear, makeGearMaterials } from './gear';
+import { addLabelAndNose } from './labels';
+import type { BrandTokens } from './brand-contract';
+import type { BoxData, SceneV1 } from './scene-contract';
+
+export interface PlanesBundle {
+  groups: Record<string, THREE.Group>;
+  labelMeshes: THREE.Sprite[];
+  noseMeshes: THREE.Mesh[];
+}
+
+// Kind-based materials (#400): translucent wings reveal vertical stacking; thin
+// metallic struts; a darker cockpit (fuselage_front) tint echoing the 2D render's
+// cockpit shading (same intent, not a perceptual match — 3D darkens in linear
+// space); everything else opaque body colour. DoubleSide for the det-−1 group.
+export function boxMaterial(b: BoxData, colour: THREE.Color): THREE.MeshStandardMaterial {
+  const base = { color: colour, side: THREE.DoubleSide, roughness: 0.7, metalness: 0.05 };
+  if (b.kind === 'wing') {
+    return new THREE.MeshStandardMaterial({ ...base, transparent: true, opacity: 0.5 });
+  }
+  if (b.kind === 'strut') {
+    return new THREE.MeshStandardMaterial({ ...base, roughness: 0.35, metalness: 0.85 });
+  }
+  if (b.kind === 'fuselage_front') {
+    return new THREE.MeshStandardMaterial({ ...base, color: colour.clone().multiplyScalar(0.55) });
+  }
+  return new THREE.MeshStandardMaterial(base);
+}
+
+/** Build every plane's affine Group (boxes + gear + label/nose), add it to the
+ * scene, and build the legend chips with safe DOM methods. Returns the per-plane
+ * groups (driven by the timeline) and the toggle arrays. */
+export function addPlanes(scene: THREE.Scene, SCENE: SceneV1, BRAND: BrandTokens): PlanesBundle {
+  const CONFLICT = BRAND.conflict; // '#RRGGBB' string → new THREE.Color(CONFLICT)
+  const groups: Record<string, THREE.Group> = {};
+  const labelMeshes: THREE.Sprite[] = [];
+  const noseMeshes: THREE.Mesh[] = [];
+  const legend = byId('legend');
+  const gearMats = makeGearMaterials(BRAND);
+
+  for (const p of SCENE.planes) {
+    const g = new THREE.Group();
+    g.matrixAutoUpdate = false; // we drive g.matrix per frame from the affine
+    const conflicted = SCENE.conflicts.includes(p.id);
+    const colour = new THREE.Color(conflicted ? CONFLICT : p.color);
+    for (const b of p.boxes) {
+      // local X = u (forward/length), local Y = v (right/width), local Z = w (height).
+      const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(b.length_m, b.width_m, b.height_m),
+        boxMaterial(b, colour),
+      );
+      mesh.position.set(b.cx, b.cy, b.cz);
+      mesh.rotation.z = THREE.MathUtils.degToRad(b.angle_deg); // CCW about local up, as oriented_rect
+      mesh.castShadow = true;
+      mesh.receiveShadow = true; // planes catch each other's shadows (vertical clearance)
+      g.add(mesh);
+    }
+    addGear(g, p, gearMats); // wheels + legs (+ pallets when carted), same affine Group
+    addLabelAndNose(g, p, colour, conflicted, BRAND, labelMeshes, noseMeshes); // id label + nose arrow
+    groups[p.id] = g;
+    scene.add(g);
+
+    // Build the legend chip with safe DOM methods (no innerHTML): plane ids come
+    // from user YAML, so avoid any HTML-injection surface even on a local file.
+    const sw = document.createElement('span');
+    sw.className = 'sw';
+    const dot = document.createElement('i');
+    dot.style.background = conflicted ? BRAND.conflict : p.color;
+    sw.appendChild(dot);
+    sw.appendChild(document.createTextNode(p.id));
+    legend.appendChild(sw);
+  }
+  return { groups, labelMeshes, noseMeshes };
+}

--- a/viewer/src/renderer.ts
+++ b/viewer/src/renderer.ts
@@ -1,0 +1,85 @@
+// ── renderer / scene / camera / lights ───────────────────────────────────────
+//
+// World convention (matches hangarfit core): x = right along the door wall,
+// y = deeper into the hangar, z = up. We make Three.js +Z-up so the affine's
+// z-row is identity and box height runs along world up. Reflected matrices
+// (det −1) render correctly because every material is DoubleSide.
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { banner } from './dom';
+import type { BrandTokens } from './brand-contract';
+import type { HangarData } from './scene-contract';
+
+export interface RendererBundle {
+  renderer: THREE.WebGLRenderer;
+  scene: THREE.Scene;
+  cam: THREE.PerspectiveCamera;
+  controls: OrbitControls;
+  span: number;
+  home: () => void;
+}
+
+export function createRenderer(
+  canvas: HTMLCanvasElement, H: HangarData, BRAND: BrandTokens,
+): RendererBundle {
+  let renderer: THREE.WebGLRenderer;
+  try {
+    renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+  } catch (e) {
+    banner('WebGL is unavailable in this browser: ' + (e as Error).message);
+    throw e;
+  }
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.shadowMap.enabled = true; // contact shadows (#400)
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap; // soft edges
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(BRAND.sceneBg);
+
+  const cam = new THREE.PerspectiveCamera(55, window.innerWidth / window.innerHeight, 0.1, 2000);
+  cam.up.set(0, 0, 1); // +Z up — set BEFORE OrbitControls reads it.
+
+  const controls = new OrbitControls(cam, renderer.domElement);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.08;
+
+  const span = Math.max(H.width_m, H.length_m);
+  const home = (): void => {
+    cam.position.set(H.width_m * 0.5, -H.length_m * 0.55, span * 0.95);
+    controls.target.set(H.width_m / 2, H.length_m / 2, 0.5);
+    controls.update();
+  };
+  home();
+
+  // Lighting (#400). The key sun casts contact shadows so vertical clearance is
+  // legible — a high wing's shadow falling across a neighbour's tail is the whole
+  // reason the 3D viewer exists (ADR-0017). A soft fill from the opposite side keeps
+  // shaded faces readable, and a (slightly lowered) hemisphere ambient lets shadows
+  // darken without going black.
+  scene.add(new THREE.HemisphereLight(
+    new THREE.Color(BRAND.hemisphereSky), new THREE.Color(BRAND.hemisphereGround), BRAND.hemisphereIntensity,
+  ));
+  const sun = new THREE.DirectionalLight(new THREE.Color(BRAND.sun), BRAND.sunIntensity);
+  sun.position.set(H.width_m * 0.35, -H.length_m * 0.15, span * 1.1);
+  sun.target.position.set(H.width_m / 2, H.length_m / 2, 0); // aim at hangar centre
+  scene.add(sun.target);
+  sun.castShadow = true;
+  sun.shadow.mapSize.set(2048, 2048);
+  sun.shadow.normalBias = 0.04; // suppress acne on the det-−1 reflected boxes
+  const sc = sun.shadow.camera; // ortho frustum sized to the hangar span
+  sc.left = -span;
+  sc.right = span;
+  sc.top = span;
+  sc.bottom = -span;
+  sc.near = 0.5;
+  sc.far = span * 3.5;
+  sc.updateProjectionMatrix();
+  scene.add(sun);
+  // soft fill: pale tint of the horizon accent #3FA3D6, no shadow
+  const fill = new THREE.DirectionalLight(new THREE.Color(BRAND.fill), BRAND.fillIntensity);
+  fill.position.set(H.width_m * 0.7, H.length_m * 1.2, span * 0.6);
+  scene.add(fill);
+
+  return { renderer, scene, cam, controls, span, home };
+}

--- a/viewer/src/renderer.ts
+++ b/viewer/src/renderer.ts
@@ -6,9 +6,9 @@
 // (det −1) render correctly because every material is DoubleSide.
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import { banner } from './dom';
-import type { BrandTokens } from './brand-contract';
-import type { HangarData } from './scene-contract';
+import { banner } from './dom.ts';
+import type { BrandTokens } from './brand-contract.ts';
+import type { HangarData } from './scene-contract.ts';
 
 export interface RendererBundle {
   renderer: THREE.WebGLRenderer;

--- a/viewer/src/scene-contract.ts
+++ b/viewer/src/scene-contract.ts
@@ -1,10 +1,12 @@
 // Typed mirror of the `hangarfit.scene/v1` contract (Python `scene.py`).
 //
 // This is the EXTENSION SEAM (ADR-0020): an additive scene field becomes an
-// additive interface field here. #439 keeps these LEAN — just enough for the
-// port to typecheck under `strict`. The full schema-faithful depth + the Python
-// key-set parity test land in #440 (spec §Decisions 6); the runtime
-// `checkAnchors()` self-check still guards the transform *values* regardless.
+// additive interface field here. It is the schema-faithful mirror of
+// `docs/architecture/scene-v1-schema.md`; a Python key-set parity test in
+// `tests/test_scene.py` fails if `scene.py`'s emitted keys and these interfaces
+// drift apart (the near-term desync guard — JSON-Schema single-source is the
+// deferred principled fix, spike #444). The runtime `checkAnchors()` self-check
+// still guards the transform *values* regardless.
 //
 // The viewer performs NO transform math (ADR-0002): every plane-local→world
 // placement arrives here as a 2x3 affine computed in Python.
@@ -38,10 +40,11 @@ export interface DoorData {
 }
 
 export interface MaintenanceBay {
-  closed: boolean;
+  closed: boolean; // true iff layout.maintenance_plane is set
   width_m: number;
   depth_m: number;
   center_x_m: number;
+  plane_id: string | null; // the absent occupant, or null
 }
 
 export interface HangarData {
@@ -69,6 +72,9 @@ export interface Readouts {
 }
 
 export interface SceneV1 {
+  schema: string; // always "hangarfit.scene/v1"
+  units: string; // always "m"
+  coordinate_note: string; // human reminder of the coordinate convention
   hangar: HangarData;
   planes: PlaneData[];
   conflicts: string[];

--- a/viewer/src/scene-contract.ts
+++ b/viewer/src/scene-contract.ts
@@ -1,0 +1,84 @@
+// Typed mirror of the `hangarfit.scene/v1` contract (Python `scene.py`).
+//
+// This is the EXTENSION SEAM (ADR-0020): an additive scene field becomes an
+// additive interface field here. #439 keeps these LEAN — just enough for the
+// port to typecheck under `strict`. The full schema-faithful depth + the Python
+// key-set parity test land in #440 (spec §Decisions 6); the runtime
+// `checkAnchors()` self-check still guards the transform *values* regardless.
+//
+// The viewer performs NO transform math (ADR-0002): every plane-local→world
+// placement arrives here as a 2x3 affine computed in Python.
+
+/** A 2x3 affine `[a, b, tx, c, d, ty]` mapping local (u,v) → world (x,y). */
+export type Affine = [number, number, number, number, number, number];
+
+/** One box of a plane's parts model, in plane-local coordinates. */
+export interface BoxData {
+  kind: string; // 'wing' | 'strut' | 'fuselage_front' | body kinds…
+  cx: number;
+  cy: number;
+  cz: number;
+  length_m: number;
+  width_m: number;
+  height_m: number;
+  angle_deg: number;
+}
+
+export interface PlaneData {
+  id: string;
+  color: string; // '#RRGGBB'
+  boxes: BoxData[];
+  wheels: [number, number][]; // plane-local wheel (u,v) positions (ADR-0013)
+  on_carts: boolean;
+}
+
+export interface DoorData {
+  center_x_m: number;
+  width_m: number;
+}
+
+export interface MaintenanceBay {
+  closed: boolean;
+  width_m: number;
+  depth_m: number;
+  center_x_m: number;
+}
+
+export interface HangarData {
+  width_m: number;
+  length_m: number;
+  door: DoorData;
+  maintenance_bay?: MaintenanceBay | null;
+}
+
+export interface SegmentData {
+  plane_id: string;
+  start_s: number;
+  end_s: number;
+  samples: Affine[];
+}
+
+export interface TimelineData {
+  segments: SegmentData[];
+  total_s: number;
+}
+
+export interface Readouts {
+  min_gap_m: number | null;
+  min_wing_over_tail_clearance_m: number | null;
+}
+
+export interface SceneV1 {
+  hangar: HangarData;
+  planes: PlaneData[];
+  conflicts: string[];
+  /** Final parked pose per plane id. */
+  final_poses: Record<string, Affine>;
+  /** Oracle world box corners per plane: [box][corner][x|y]. */
+  anchors: Record<string, number[][][]>;
+  /** Oracle world wheel positions per plane: [wheel][x|y]. */
+  gear_anchors: Record<string, number[][]>;
+  timeline: TimelineData;
+  placeholder?: boolean;
+  readouts?: Readouts | null;
+}

--- a/viewer/src/scene-contract.ts
+++ b/viewer/src/scene-contract.ts
@@ -51,7 +51,7 @@ export interface HangarData {
   width_m: number;
   length_m: number;
   door: DoorData;
-  maintenance_bay?: MaintenanceBay | null;
+  maintenance_bay: MaintenanceBay; // always emitted (a dict; `closed` distinguishes occupied)
 }
 
 export interface SegmentData {
@@ -85,6 +85,6 @@ export interface SceneV1 {
   /** Oracle world wheel positions per plane: [wheel][x|y]. */
   gear_anchors: Record<string, number[][]>;
   timeline: TimelineData;
-  placeholder?: boolean;
-  readouts?: Readouts | null;
+  placeholder: boolean; // always emitted (true iff any placed aircraft is unmeasured)
+  readouts: Readouts | null; // always emitted; null when the layout is invalid
 }

--- a/viewer/src/timeline.ts
+++ b/viewer/src/timeline.ts
@@ -1,0 +1,66 @@
+// ── timeline state machine (hidden → animating → parked) ─────────────────────
+import type * as THREE from 'three';
+import { affineMatrix } from './affine';
+import { byId } from './dom';
+import type { Affine, SceneV1, SegmentData } from './scene-contract';
+
+/** Pose + visibility of a plane at time `t`. PURE given `(segByPlane, finals, pid, t)`
+ * — no THREE, no DOM (node-tested in #440). A static plane (no segment) renders at
+ * its parked pose, or hides if a malformed scene is missing its final pose (the
+ * anchor self-check already banners that). */
+export function affineAt(
+  segByPlane: Record<string, SegmentData>,
+  finals: Record<string, Affine>,
+  pid: string,
+  t: number,
+): { vis: boolean; aff: Affine | null } {
+  const seg = segByPlane[pid];
+  if (!seg) {
+    const aff = finals[pid];
+    return aff ? { vis: true, aff } : { vis: false, aff: null };
+  }
+  if (t < seg.start_s) return { vis: false, aff: null };        // not entered yet
+  if (t >= seg.end_s) return { vis: true, aff: finals[pid] };
+  const frac = (t - seg.start_s) / (seg.end_s - seg.start_s);
+  const i = Math.round(frac * (seg.samples.length - 1));
+  return { vis: true, aff: seg.samples[i] };
+}
+
+export interface Timeline {
+  total: number;
+  hasAnim: boolean;
+  segs: SegmentData[];
+  applyTime: (t: number) => void;
+}
+
+/** Wire the timeline to the built plane Groups + the `#active`/`#clock` readouts.
+ * `applyTime(t)` is the per-frame impure edge around the pure `affineAt`. */
+export function createTimeline(scene: SceneV1, groups: Record<string, THREE.Group>): Timeline {
+  const TL = scene.timeline;
+  const SEGS = TL.segments;
+  const TOTAL = TL.total_s;
+  const hasAnim = TOTAL > 0 && SEGS.length > 0;
+  const segByPlane: Record<string, SegmentData> = {};
+  for (const s of SEGS) segByPlane[s.plane_id] = s;
+  const finals = scene.final_poses;
+
+  const active = byId('active');
+  const clock = byId('clock');
+
+  const applyTime = (t: number): void => {
+    for (const p of scene.planes) {
+      const { vis, aff } = affineAt(segByPlane, finals, p.id, t);
+      const g = groups[p.id];
+      g.visible = vis;
+      if (vis && aff) {
+        g.matrix.copy(affineMatrix(aff));
+        g.matrixWorldNeedsUpdate = true;
+      }
+    }
+    const cur = SEGS.find((s) => t >= s.start_s && t < s.end_s);
+    active.textContent = cur ? 'towing: ' + cur.plane_id : '';
+    clock.textContent = t.toFixed(1) + 's';
+  };
+
+  return { total: TOTAL, hasAnim, segs: SEGS, applyTime };
+}

--- a/viewer/src/timeline.ts
+++ b/viewer/src/timeline.ts
@@ -1,8 +1,8 @@
 // ── timeline state machine (hidden → animating → parked) ─────────────────────
 import type * as THREE from 'three';
-import { affineMatrix } from './affine';
-import { byId } from './dom';
-import type { Affine, SceneV1, SegmentData } from './scene-contract';
+import { affineMatrix } from './affine.ts';
+import { byId } from './dom.ts';
+import type { Affine, SceneV1, SegmentData } from './scene-contract.ts';
 
 /** Pose + visibility of a plane at time `t`. PURE given `(segByPlane, finals, pid, t)`
  * — no THREE, no DOM (node-tested in #440). A static plane (no segment) renders at

--- a/viewer/test/affine.test.ts
+++ b/viewer/test/affine.test.ts
@@ -1,0 +1,42 @@
+// node --test units for the pure affine math (#440). This is coverage pytest
+// cannot reach: the only arithmetic the viewer does on Python-emitted poses.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { affineMatrix, applyAffine } from '../src/affine.ts';
+import type { Affine } from '../src/scene-contract.ts';
+
+test('applyAffine maps local (u,v) → world (x,y)', () => {
+  const aff: Affine = [2, 0, 1, 0, 3, 5]; // [a,b,tx,c,d,ty]
+  // x = a·u + b·v + tx = 2·1 + 0·1 + 1 = 3 ; y = c·u + d·v + ty = 0·1 + 3·1 + 5 = 8
+  assert.deepEqual(applyAffine(aff, 1, 1), [3, 8]);
+  const id: Affine = [1, 0, 0, 0, 1, 0];
+  assert.deepEqual(applyAffine(id, 4, -2), [4, -2]);
+});
+
+test('applyAffine: translation is f(0,0)', () => {
+  const aff: Affine = [0.5, -0.5, 2, 0.5, 0.5, -1];
+  assert.deepEqual(applyAffine(aff, 0, 0), [2, -1]);
+});
+
+test('affineMatrix drops the 2x3 into a THREE.Matrix4 with z-row identity', () => {
+  const m = affineMatrix([2, 3, 7, 5, 11, 13]);
+  // THREE.Matrix4.elements is COLUMN-major; the row-major set() above transposes.
+  assert.deepEqual(Array.from(m.elements), [
+    2, 5, 0, 0, // column 0
+    3, 11, 0, 0, // column 1
+    0, 0, 1, 0, // column 2 (z-row identity → box height passes through)
+    7, 13, 0, 1, // column 3 (translation)
+  ]);
+});
+
+test('a heading affine is a determinant-−1 reflection (ADR-0002), preserved by affineMatrix', () => {
+  const h = (30 * Math.PI) / 180;
+  // geometry.local_to_world linear part: [[sin, cos],[cos, −sin]] → det = −1.
+  const aff: Affine = [Math.sin(h), Math.cos(h), 4, Math.cos(h), -Math.sin(h), 9];
+  const [a, b, , c, d] = aff;
+  assert.ok(Math.abs(a * d - b * c - -1) < 1e-12);
+  // affineMatrix must carry the same −1 (elements col-major: a=e0, c=e1, b=e4, d=e5).
+  const e = affineMatrix(aff).elements;
+  const det2 = e[0] * e[5] - e[4] * e[1];
+  assert.ok(Math.abs(det2 - -1) < 1e-12);
+});

--- a/viewer/test/anchors.test.ts
+++ b/viewer/test/anchors.test.ts
@@ -31,13 +31,20 @@ function makeScene(aff: Affine, b: BoxData, wheel: [number, number]): SceneV1 {
     schema: 'hangarfit.scene/v1',
     units: 'm',
     coordinate_note: '',
-    hangar: { width_m: 10, length_m: 10, door: { center_x_m: 5, width_m: 4 } },
+    hangar: {
+      width_m: 10,
+      length_m: 10,
+      door: { center_x_m: 5, width_m: 4 },
+      maintenance_bay: { center_x_m: 5, width_m: 2, depth_m: 2, closed: false, plane_id: null },
+    },
     planes: [{ id: 'p', color: '#ffffff', boxes: [b], wheels: [wheel], on_carts: false }],
     conflicts: [],
     final_poses: { p: aff },
     anchors: { p: [corners] },
     gear_anchors: { p: [applyAffine(aff, wheel[0], wheel[1])] },
     timeline: { segments: [], total_s: 0 },
+    placeholder: false,
+    readouts: null,
   };
 }
 

--- a/viewer/test/anchors.test.ts
+++ b/viewer/test/anchors.test.ts
@@ -1,0 +1,76 @@
+// node --test units for the anchor self-check (#440). checkAnchors() is the
+// ADR-0017 cross-language backstop; the pure compare is testable here without a
+// DOM (the fail-loud banner stays at the main.ts edge). Includes the
+// structural-mismatch branches the headless render can't easily exercise.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { boxCornersLocal, checkAnchors } from '../src/anchors.ts';
+import { applyAffine } from '../src/affine.ts';
+import type { Affine, BoxData, SceneV1 } from '../src/scene-contract.ts';
+
+function box(over: Partial<BoxData> = {}): BoxData {
+  return { kind: 'body', cx: 0, cy: 0, cz: 0.5, length_m: 2, width_m: 4, height_m: 1, angle_deg: 0, ...over };
+}
+
+test('boxCornersLocal: axis-aligned box → ±half-extent corners in oriented_rect order', () => {
+  // hl=1, hw=2 ; order (+hl,−hw),(+hl,+hw),(−hl,+hw),(−hl,−hw)
+  assert.deepEqual(boxCornersLocal(box()), [[1, -2], [1, 2], [-1, 2], [-1, -2]]);
+});
+
+test('boxCornersLocal: 90° CCW rotation about the box centre', () => {
+  const c = boxCornersLocal(box({ angle_deg: 90 }));
+  // (hl,−hw)=(1,−2) rotated +90° about origin → (2, 1)
+  assert.ok(Math.abs(c[0][0] - 2) < 1e-12 && Math.abs(c[0][1] - 1) < 1e-12);
+});
+
+// Build a scene whose anchors / gear_anchors are the TRUE oracle values for a
+// given affine, so a faithful viewer compare yields maxErr 0.
+function makeScene(aff: Affine, b: BoxData, wheel: [number, number]): SceneV1 {
+  const corners = boxCornersLocal(b).map(([u, v]) => applyAffine(aff, u, v));
+  return {
+    schema: 'hangarfit.scene/v1',
+    units: 'm',
+    coordinate_note: '',
+    hangar: { width_m: 10, length_m: 10, door: { center_x_m: 5, width_m: 4 } },
+    planes: [{ id: 'p', color: '#ffffff', boxes: [b], wheels: [wheel], on_carts: false }],
+    conflicts: [],
+    final_poses: { p: aff },
+    anchors: { p: [corners] },
+    gear_anchors: { p: [applyAffine(aff, wheel[0], wheel[1])] },
+    timeline: { segments: [], total_s: 0 },
+  };
+}
+
+const AFF: Affine = [Math.sin(0.3), Math.cos(0.3), 4, Math.cos(0.3), -Math.sin(0.3), 9];
+
+test('matching oracle → no structural error, maxErr ~0', () => {
+  const r = checkAnchors(makeScene(AFF, box(), [0, 1]));
+  assert.equal(r.structural, '');
+  assert.ok(r.maxErr < 1e-9);
+});
+
+test('a corrupted corner pushes maxErr above the 1e-6 tolerance', () => {
+  const s = makeScene(AFF, box(), [0, 1]);
+  s.anchors.p[0][0][0] += 0.01; // corrupt one box-corner x
+  const r = checkAnchors(s);
+  assert.equal(r.structural, '');
+  assert.ok(r.maxErr >= 0.01 - 1e-9);
+});
+
+test('anchor/box count mismatch → structural banner (compares before tolerance)', () => {
+  const s = makeScene(AFF, box(), [0, 1]);
+  s.anchors.p = []; // 0 anchor boxes vs 1 real box
+  assert.match(checkAnchors(s).structural, /anchor\/box count mismatch/);
+});
+
+test('missing gear anchors → structural banner', () => {
+  const s = makeScene(AFF, box(), [0, 1]);
+  s.gear_anchors = {}; // gear oracle absent
+  assert.match(checkAnchors(s).structural, /missing gear anchors\/wheels/);
+});
+
+test('missing final pose / anchors → structural banner', () => {
+  const s = makeScene(AFF, box(), [0, 1]);
+  s.anchors = {};
+  assert.match(checkAnchors(s).structural, /missing affine\/anchors/);
+});

--- a/viewer/test/timeline.test.ts
+++ b/viewer/test/timeline.test.ts
@@ -1,0 +1,39 @@
+// node --test units for the timeline state machine (#440). affineAt() is pure
+// given (segByPlane, finals, pid, t) — the hidden → animating → parked
+// transitions of scene-v1-schema.md, untestable from pytest.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { affineAt } from '../src/timeline.ts';
+import type { Affine, SegmentData } from '../src/scene-contract.ts';
+
+const FINAL: Affine = [1, 0, 9, 0, 1, 0];
+const A0: Affine = [1, 0, 0, 0, 1, 0];
+const A1: Affine = [1, 0, 5, 0, 1, 0];
+const A2: Affine = [1, 0, 9, 0, 1, 0];
+const seg: SegmentData = { plane_id: 'p', start_s: 2, end_s: 6, samples: [A0, A1, A2] };
+const segByPlane: Record<string, SegmentData> = { p: seg };
+const finals: Record<string, Affine> = { p: FINAL, q: FINAL };
+
+test('static plane (no segment) → shown at its final pose', () => {
+  assert.deepEqual(affineAt({}, finals, 'q', 3), { vis: true, aff: FINAL });
+});
+
+test('static plane missing its final pose → hidden (the self-check banners it)', () => {
+  assert.deepEqual(affineAt({}, {}, 'q', 3), { vis: false, aff: null });
+});
+
+test('before start_s → hidden (not entered yet)', () => {
+  assert.deepEqual(affineAt(segByPlane, finals, 'p', 1.9), { vis: false, aff: null });
+});
+
+test('at / after end_s → parked at the final pose', () => {
+  assert.deepEqual(affineAt(segByPlane, finals, 'p', 6), { vis: true, aff: FINAL });
+  assert.deepEqual(affineAt(segByPlane, finals, 'p', 99), { vis: true, aff: FINAL });
+});
+
+test('mid-animation → sample chosen by the rounded fraction', () => {
+  // n=3 samples; frac=(t−2)/(6−2); i=round(frac·2)
+  assert.deepEqual(affineAt(segByPlane, finals, 'p', 2), { vis: true, aff: A0 }); // frac 0 → i0
+  assert.deepEqual(affineAt(segByPlane, finals, 'p', 4), { vis: true, aff: A1 }); // frac .5 → i1
+  assert.deepEqual(affineAt(segByPlane, finals, 'p', 5.9), { vis: true, aff: A2 }); // frac .975 → round 2
+});

--- a/viewer/tsconfig.json
+++ b/viewer/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "es2022",
     "module": "es2022",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "lib": ["es2022", "dom", "dom.iterable"],
     "strict": true,
     "noEmit": true,
@@ -15,5 +16,5 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
## What

Builds the typing depth + test layer on top of the #439 port, and **completes #438**.

> **⚠️ Stacked on #439.** Per CLAUDE.md's stacked-PR rule the base is `develop` (so CI + `Closes` linkage fire), so this diff shows the cumulative #439 + #440 changes until #439 merges. **Merge order: #439 → #440.** The #440-only delta is: `scene-contract.ts` deepening, the `.ts`-extension import change, `viewer/test/*`, `viewer/src/interaction/README.md`, `tests/test_scene.py` parity tests, `viewer/package.json` devDeps, and the ci.yml node-test/skew additions.

## Contracts (the extension seam)
- **`scene-contract.ts`** deepened to the full `hangarfit.scene/v1` mirror (`docs/architecture/scene-v1-schema.md`): adds `schema`/`units`/`coordinate_note` + `maintenance_bay.plane_id`. `brand-contract.ts` was already a faithful 21-token mirror. Additive scene field → additive interface field (ADR-0020).
- **`tests/test_scene.py` key-set parity tests** — the TS interfaces (`SceneV1`/`HangarData`/`DoorData`/`MaintenanceBay`/`PlaneData`/`BoxData`/`TimelineData`/`SegmentData`/`Readouts`/`BrandTokens`) must match `scene.py`/`brand.py` emitted keys, or the maintainer's own `pytest` run fails. The near-term desync guard; JSON-Schema single-source is the deferred fix (spike #444).

## node --test units (coverage pytest can't reach)
- `affine` (the only transform math, incl. the **det-−1 reflection**), `anchors` (the cross-language oracle compare incl. the structural-mismatch branches), `timeline` (hidden→animating→parked). 16 tests, run by **Node-native type-stripping**.
- Internal imports gain explicit **`.ts` extensions** (+ `allowImportingTsExtensions`) so Node resolves them. esbuild inlines internal modules, so the committed bundle is **byte-unchanged** (sha `f8235de6…`, drift guard still green — verified).
- **`three@0.160.0` added as a TEST-ONLY devDep** so node --test exercises the same three r160 the browser runs; esbuild keeps it **external** (not in the bundle/wheel) and `viewer/` is outside `src/` (not shipped). The skew guard now pins vendored ⇔ `@types/three` ⇔ `three`(devDep) together.

## CI + seam
- The `viewer-toolchain` job gains the **`node --test`** step — the remaining piece of **#438**, now complete.
- `viewer/src/interaction/` adds the **inert README-only** editor seam (#442 groundwork; no `.ts`, bundle unchanged).

## Verification
Full `pytest` (1222 passed, +3 parity) + `ruff` + `mypy` green; `tsc --noEmit` + `eslint` + `node --test` (16) + `viewer-build-drift` (bundle byte-unchanged) all green.

Closes #440. Closes #438. Refs #436, #442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)