### PR TITLE
feat(solver): soft PlaneConstraint.priority weights the spread repulsion (#441)

### DIFF
--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -455,10 +455,13 @@ def _build_plane_constraint(plane_id: str, data: Any) -> PlaneConstraint:
           <plane_id>:
             pin: { x_m: <float>, y_m: <float>, heading_deg: <float>, on_carts: <bool> }
             force_on_carts: <bool>
+            priority: <float>   # soft, >= 0 (#441)
 
-    Both ``pin`` and ``force_on_carts`` are optional. Omitting both
+    ``pin``, ``force_on_carts`` and ``priority`` are all optional. Omitting all
     yields a "free" constraint (the solver may place the plane anywhere
-    within physical / cart-rule limits).
+    within physical / cart-rule limits). ``priority`` is a soft spread weight
+    (see :class:`~hangarfit.models.PlaneConstraint`); its range is validated by
+    ``Scenario.__post_init__``.
 
     **Implicit ``pin.plane_id``** — the loader fills :attr:`Placement.plane_id`
     from the constraint key, so authors don't repeat the plane id under
@@ -498,7 +501,13 @@ def _build_plane_constraint(plane_id: str, data: Any) -> PlaneConstraint:
     if force_on_carts is not None:
         force_on_carts = _to_bool(force_on_carts, "force_on_carts")
 
-    return PlaneConstraint(pin=pin, force_on_carts=force_on_carts)
+    # Soft per-plane spread weight (#441). Range/finiteness is enforced by
+    # Scenario.__post_init__ (alongside pin/force_on_carts validation).
+    priority = data.get("priority")
+    if priority is not None:
+        priority = _to_float(priority, "priority")
+
+    return PlaneConstraint(pin=pin, force_on_carts=force_on_carts, priority=priority)
 
 
 def _extract_maintenance_plane(raw: dict, path: Path) -> str | None:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -71,9 +71,17 @@ def _to_float(value: Any, field_name: str) -> float:
     downstream consumers (e.g. ``_wing_spar_x``) silently propagate them
     into geometry calculations, where NaN comparisons always return False
     and inf values produce nonsensical coordinates.
+
+    ``bool`` is rejected too: it is an ``int`` subclass, so ``float(True)`` is a
+    silent ``1.0`` — the same YAML footgun ``_to_int`` / ``_to_bool`` guard
+    against (``yes``/``on`` coerce to ``True`` under YAML 1.1). Without this a
+    ``priority: true`` (#441) — or any ``true`` fat-fingered into a numeric
+    field — would parse to a plausible-but-wrong number instead of erroring.
     """
     if value is None:
         raise LoaderError(f"{field_name!r}: expected number, got null")
+    if isinstance(value, bool):
+        raise LoaderError(f"{field_name!r}: expected number, got {value!r} (bool)")
     try:
         result = float(value)
     except (TypeError, ValueError) as e:

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -595,15 +595,25 @@ class CheckResult:
 
 @dataclass(frozen=True, slots=True)
 class PlaneConstraint:
-    """Per-plane HARD constraints for a Scenario.
+    """Per-plane constraints for a Scenario.
 
-    All fields optional — a constraint with everything None means 'free'
+    ``pin`` and ``force_on_carts`` are HARD constraints; ``priority`` is a SOFT
+    preference. All optional — a constraint with everything None means 'free'
     (the solver may place the plane anywhere within physical / cart-rule
     limits). See spec §3.2 for the rationale.
+
+    ``priority`` (#441) is a non-negative soft importance weight (``None`` ≡ the
+    neutral ``0.0``): the spread post-pass weights each plane-pair's repulsion
+    energy by ``(1 + priority_i)·(1 + priority_j)``, so a higher-priority plane
+    is pushed to more clearance. With every ``priority`` unset the weights are
+    all ``1.0`` and the search is byte-identical to the pre-#441 behaviour
+    (ADR-0003). It never overrides a hard ``pin``. Groundwork for the future
+    interactive editor (#442), which exports per-plane priorities.
     """
 
     pin: Placement | None = None
     force_on_carts: bool | None = None
+    priority: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -736,6 +746,21 @@ class Scenario:
                     f"{constraint.pin.on_carts} and force_on_carts="
                     f"{constraint.force_on_carts} disagree (contradictory)"
                 )
+
+            # priority (#441): a non-negative, finite soft weight. A negative
+            # weight would invert the spread repulsion (nonsensical), and a
+            # non-finite one would poison the energy sum.
+            if constraint.priority is not None:
+                if not math.isfinite(constraint.priority):
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].priority="
+                        f"{constraint.priority!r} must be finite"
+                    )
+                if constraint.priority < 0.0:
+                    raise ValueError(
+                        f"Scenario.constraints[{plane_id!r}].priority="
+                        f"{constraint.priority!r} must be >= 0.0 (a soft importance weight)"
+                    )
 
         object.__setattr__(self, "fleet", MappingProxyType(dict(self.fleet)))
         # Always copy+wrap constraints — mirrors the unconditional pattern on

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -609,6 +609,12 @@ class PlaneConstraint:
     all ``1.0`` and the search is byte-identical to the pre-#441 behaviour
     (ADR-0003). It never overrides a hard ``pin``. Groundwork for the future
     interactive editor (#442), which exports per-plane priorities.
+
+    It is ``float | None`` (not ``float = 0.0`` like ``SearchConfig.back_bias_weight``)
+    to stay consistent with its optional siblings here (``pin``/``force_on_carts``,
+    where ``None`` means 'free') and to let #442 distinguish 'user never set a
+    priority' from an explicit ``0.0`` on round-trip; both collapse to weight
+    ``1.0`` in the solver today.
     """
 
     pin: Placement | None = None

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -798,19 +798,38 @@ def _initial_placement_for_plane(
     )
 
 
+def _priority_weight(scenario: Scenario, pid: str) -> float:
+    """Soft spread weight for plane ``pid``: ``1.0 + priority`` (#441).
+
+    A plane's soft :attr:`~hangarfit.models.PlaneConstraint.priority` (default
+    ``None`` ≡ the neutral ``0.0``) scales how hard the spread post-pass works to
+    clear space around it: each plane-pair's repulsion energy is weighted by
+    ``w_i · w_j``. With every priority unset every weight is exactly ``1.0``, so
+    ``w_i · w_j == 1.0`` and ``1.0 * exp(x) == exp(x)`` — the energy, and hence
+    the whole search, is byte-identical to the pre-#441 behaviour (ADR-0003).
+    The non-negative range is enforced by ``Scenario.__post_init__``.
+    """
+    constraint = scenario.constraints.get(pid)
+    priority = constraint.priority if constraint is not None else None
+    return 1.0 + (priority if priority is not None else 0.0)
+
+
 def _inter_plane_energy(
     placements: dict[str, Placement],
     scenario: Scenario,
     scale: float,
 ) -> float:
-    """Smooth repulsion energy ``E = Σ_{i<j} exp(−gap_ij / scale)`` (spec §4).
+    """Smooth repulsion energy ``E = Σ_{i<j} w_i·w_j·exp(−gap_ij / scale)`` (spec §4).
 
     ``gap_ij`` is the minimum plan-view edge-to-edge distance between plane
     ``i``'s and plane ``j``'s world parts (shapely ``polygon.distance``).
     Lower ``E`` ⇒ planes further apart; close pairs dominate the sum, so
     minimizing it maximizes the *minimum* gap (a smooth maximin surrogate).
-    Returns ``0.0`` when fewer than two planes are present. Ignores z
-    (plan-view only) — see ADR-0008 for the nesting limitation.
+    ``w_i·w_j`` is the soft-priority pair weight (:func:`_priority_weight`, #441);
+    it is identically ``1.0`` when no priorities are set, so this reduces to the
+    unweighted ``Σ exp(−gap/scale)`` byte-for-byte (ADR-0003). Returns ``0.0``
+    when fewer than two planes are present. Ignores z (plan-view only) — see
+    ADR-0008 for the nesting limitation.
     """
     ids = sorted(placements)
     if len(ids) < 2:
@@ -818,13 +837,14 @@ def _inter_plane_energy(
     world: dict[str, list[WorldPart]] = {
         pid: aircraft_parts_world(scenario.fleet[pid], placements[pid]) for pid in ids
     }
+    w = {pid: _priority_weight(scenario, pid) for pid in ids}
     energy = 0.0
     for i in range(len(ids)):
         for j in range(i + 1, len(ids)):
             gap = min(
                 pa.polygon.distance(pb.polygon) for pa in world[ids[i]] for pb in world[ids[j]]
             )
-            energy += math.exp(-gap / scale)
+            energy += w[ids[i]] * w[ids[j]] * math.exp(-gap / scale)
     return energy
 
 
@@ -863,12 +883,15 @@ def _spread_quality(
     """Return ``(min_gap, energy)`` for a layout in one pass over plane-pairs.
 
     ``min_gap`` is the minimum plan-view edge-to-edge distance between any two
-    planes' world parts (``math.inf`` when <2 planes — no pairs). ``energy``
-    is the same ``Σ exp(−gap/scale)`` repulsion :func:`_inter_plane_energy`
-    computes; returning both from one pairwise sweep avoids paying the
-    (expensive) shapely distances twice when scoring a candidate basin. The
-    hot ``_spread`` loop keeps using the energy-only :func:`_inter_plane_energy`
-    — this is called once per accepted basin, not per perturbation.
+    planes' world parts (``math.inf`` when <2 planes — no pairs); it is the raw
+    geometric gap and is **never** priority-weighted, so basin selection stays
+    maximin-primary (ADR-0008). ``energy`` is the same priority-weighted
+    ``Σ w_i·w_j·exp(−gap/scale)`` repulsion :func:`_inter_plane_energy` computes
+    (#441; identically the unweighted sum when no priorities are set, ADR-0003);
+    returning both from one pairwise sweep avoids paying the (expensive) shapely
+    distances twice when scoring a candidate basin. The hot ``_spread`` loop
+    keeps using the energy-only :func:`_inter_plane_energy` — this is called once
+    per accepted basin, not per perturbation.
     """
     ids = sorted(placements)
     if len(ids) < 2:
@@ -876,6 +899,7 @@ def _spread_quality(
     world: dict[str, list[WorldPart]] = {
         pid: aircraft_parts_world(scenario.fleet[pid], placements[pid]) for pid in ids
     }
+    w = {pid: _priority_weight(scenario, pid) for pid in ids}
     min_gap = math.inf
     energy = 0.0
     for i in range(len(ids)):
@@ -884,7 +908,7 @@ def _spread_quality(
                 pa.polygon.distance(pb.polygon) for pa in world[ids[i]] for pb in world[ids[j]]
             )
             min_gap = min(min_gap, gap)
-            energy += math.exp(-gap / scale)
+            energy += w[ids[i]] * w[ids[j]] * math.exp(-gap / scale)
     return (min_gap, energy)
 
 

--- a/tests/test_loader_scenario.py
+++ b/tests/test_loader_scenario.py
@@ -222,6 +222,53 @@ def test_load_scenario_typo_fleet_in_entry_suggests_via_difflib(tmp_path):
     assert "did you mean 'aviat_husky'?" in msg
 
 
+# ── #441: soft PlaneConstraint.priority in scenario YAML ─────────────────
+
+
+def test_load_scenario_with_priority(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(
+        tmp_path,
+        "fleet_in: [aviat_husky, ctsl]\nconstraints:\n  aviat_husky:\n    priority: 2.5\n",
+    )
+    s = load_scenario(p)
+    assert s.constraints["aviat_husky"].priority == 2.5
+
+
+def test_load_scenario_priority_null_is_none(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(
+        tmp_path,
+        "fleet_in: [aviat_husky]\nconstraints:\n  aviat_husky:\n    priority: null\n",
+    )
+    s = load_scenario(p)
+    assert s.constraints["aviat_husky"].priority is None
+
+
+def test_load_scenario_rejects_negative_priority(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(
+        tmp_path,
+        "fleet_in: [aviat_husky]\nconstraints:\n  aviat_husky:\n    priority: -1.0\n",
+    )
+    with pytest.raises(LoaderError, match="priority"):
+        load_scenario(p)
+
+
+def test_load_scenario_rejects_non_finite_priority(tmp_path):
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(
+        tmp_path,
+        "fleet_in: [aviat_husky]\nconstraints:\n  aviat_husky:\n    priority: .nan\n",
+    )
+    with pytest.raises(LoaderError, match="finite"):
+        load_scenario(p)
+
+
 def test_scenario_post_init_backstop_still_fires_on_direct_construction():
     """Direct-construction path: Scenario.__post_init__ still raises ValueError
     when maintenance_plane is not in fleet_in, bypassing the loader guard.

--- a/tests/test_loader_scenario.py
+++ b/tests/test_loader_scenario.py
@@ -269,6 +269,21 @@ def test_load_scenario_rejects_non_finite_priority(tmp_path):
         load_scenario(p)
 
 
+@pytest.mark.parametrize("yaml_bool", ["true", "false", "yes", "on"])
+def test_load_scenario_rejects_bool_priority(tmp_path, yaml_bool):
+    """`bool` is an int subclass, so float(True)==1.0 would silently parse a
+    fat-fingered `priority: true`/`yes` as a plausible-but-wrong weight. Rejected
+    at _to_float, like the _to_int/_to_bool siblings (silent-failure review)."""
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(
+        tmp_path,
+        f"fleet_in: [aviat_husky]\nconstraints:\n  aviat_husky:\n    priority: {yaml_bool}\n",
+    )
+    with pytest.raises(LoaderError, match="bool"):
+        load_scenario(p)
+
+
 def test_scenario_post_init_backstop_still_fires_on_direct_construction():
     """Direct-construction path: Scenario.__post_init__ still raises ValueError
     when maintenance_plane is not in fleet_in, bypassing the loader guard.

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -35,6 +35,16 @@ def test_plane_constraint_can_carry_force_on_carts():
     assert c.pin is None
 
 
+def test_plane_constraint_priority_defaults_to_none():
+    assert PlaneConstraint().priority is None
+
+
+def test_plane_constraint_can_carry_priority():
+    c = PlaneConstraint(priority=2.5)
+    assert c.priority == 2.5
+    assert c.pin is None and c.force_on_carts is None
+
+
 # ── Scenario ────────────────────────────────────────────────────────────
 
 # Helpers: build a minimal in-memory fleet + hangar for Scenario tests.
@@ -555,3 +565,61 @@ def test_search_config_defaults():
     assert s.k_stall == 50
     assert s.pos_sigma_m == 0.5
     assert s.heading_sigma_deg == 10.0
+
+
+# ── #441: soft PlaneConstraint.priority validation ──────────────────────
+
+
+def test_scenario_accepts_priority(fleet, hangar):
+    """A non-negative finite priority is accepted (soft weight)."""
+    s = Scenario(
+        fleet=fleet,
+        hangar=hangar,
+        fleet_in=("aviat_husky", "ctsl"),
+        constraints={"aviat_husky": PlaneConstraint(priority=3.0)},
+    )
+    assert s.constraints["aviat_husky"].priority == 3.0
+
+
+def test_scenario_accepts_priority_zero(fleet, hangar):
+    """0.0 is the neutral weight and explicitly allowed."""
+    Scenario(
+        fleet=fleet,
+        hangar=hangar,
+        fleet_in=("aviat_husky",),
+        constraints={"aviat_husky": PlaneConstraint(priority=0.0)},
+    )
+
+
+def test_scenario_rejects_negative_priority(fleet, hangar):
+    with pytest.raises(ValueError, match="priority"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("aviat_husky",),
+            constraints={"aviat_husky": PlaneConstraint(priority=-1.0)},
+        )
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_scenario_rejects_non_finite_priority(fleet, hangar, bad):
+    with pytest.raises(ValueError, match="finite"):
+        Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=("aviat_husky",),
+            constraints={"aviat_husky": PlaneConstraint(priority=bad)},
+        )
+
+
+def test_scenario_priority_coexists_with_pin_and_force_on_carts(fleet, hangar):
+    """priority is soft — it stacks with the hard constraints, no conflict."""
+    pin = Placement(plane_id="ctsl", x_m=2.0, y_m=10.0, heading_deg=0.0, on_carts=True)
+    s = Scenario(
+        fleet=fleet,
+        hangar=hangar,
+        fleet_in=("ctsl",),
+        constraints={"ctsl": PlaneConstraint(pin=pin, force_on_carts=True, priority=4.0)},
+    )
+    c = s.constraints["ctsl"]
+    assert c.priority == 4.0 and c.pin == pin and c.force_on_carts is True

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -5,12 +5,13 @@ Also covers the _resolve_spread_scale / _spread_quality helpers (#267).
 
 from __future__ import annotations
 
+import dataclasses
 import math
 
 import pytest
 
 from hangarfit.loader import load_scenario
-from hangarfit.models import DiversityConfig, Layout, SearchConfig
+from hangarfit.models import DiversityConfig, Layout, PlaneConstraint, SearchConfig
 from hangarfit.solver import _select_spread_diverse, _SpreadCandidate, solve
 
 
@@ -372,3 +373,95 @@ def test_best_of_all_never_worse_than_first_basin_over_sweep():
         "best-of-all improved no seed over first-basin — the fix is not being "
         "exercised on this fixture (expected several nesting-prone seeds to improve)"
     )
+
+
+# ── #441: soft PlaneConstraint.priority weights the spread repulsion ─────
+
+
+def _with_priority(scenario, **priorities):
+    """A copy of ``scenario`` with ``PlaneConstraint.priority`` set per plane id."""
+    cons = dict(scenario.constraints)
+    for pid, p in priorities.items():
+        cons[pid] = dataclasses.replace(cons.get(pid, PlaneConstraint()), priority=p)
+    return dataclasses.replace(scenario, constraints=cons)
+
+
+def _placements_key(result):
+    return [(p.plane_id, p.x_m, p.y_m, p.heading_deg) for p in result.layouts[0].placements]
+
+
+def test_priority_weight_helper():
+    from hangarfit.solver import _priority_weight
+
+    s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    pid = sorted(s.fleet_in)[0]
+    assert _priority_weight(s, pid) == 1.0  # unset → neutral 1.0
+    s2 = _with_priority(s, **{pid: 2.0})
+    assert _priority_weight(s2, pid) == 3.0  # 1.0 + 2.0
+    assert _priority_weight(s2, sorted(s.fleet_in)[1]) == 1.0  # others unaffected
+
+
+def test_inter_plane_energy_inert_when_all_priorities_zero():
+    """priority 0.0 on every plane is byte-identical to no constraints (ADR-0003)."""
+    from hangarfit.solver import _inter_plane_energy, _resolve_spread_scale
+
+    s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    res = solve(s, seed=0, search=SearchConfig(max_restarts=3), plan_paths=False)
+    placements = {p.plane_id: p for p in res.layouts[0].placements}
+    scale = _resolve_spread_scale(s, SearchConfig())
+    base = _inter_plane_energy(placements, s, scale)
+    s0 = _with_priority(s, **{pid: 0.0 for pid in s.fleet_in})
+    assert _inter_plane_energy(placements, s0, scale) == base  # exact, not approx
+
+
+def test_inter_plane_energy_strictly_increases_with_priority():
+    """A positive priority weights that plane's pairs up, raising total energy."""
+    from hangarfit.solver import _inter_plane_energy, _resolve_spread_scale
+
+    s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    res = solve(s, seed=0, search=SearchConfig(max_restarts=3), plan_paths=False)
+    placements = {p.plane_id: p for p in res.layouts[0].placements}
+    assert len(placements) >= 2
+    scale = _resolve_spread_scale(s, SearchConfig())
+    base = _inter_plane_energy(placements, s, scale)
+    hi = _with_priority(s, **{sorted(s.fleet_in)[0]: 3.0})
+    assert _inter_plane_energy(placements, hi, scale) > base
+
+
+def test_solve_priority_zero_byte_identical_to_no_constraints():
+    """Inert-by-default at solve() level: all-zero priority selects the SAME
+    layout as no priority, same seed (ADR-0003, max_restarts-scoped)."""
+    s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    base = solve(s, seed=3, search=SearchConfig(max_restarts=4), plan_paths=False)
+    s0 = _with_priority(s, **{pid: 0.0 for pid in s.fleet_in})
+    zero = solve(s0, seed=3, search=SearchConfig(max_restarts=4), plan_paths=False)
+    assert base.layouts and zero.layouts
+    assert _placements_key(base) == _placements_key(zero)
+
+
+def test_solve_with_priority_is_deterministic():
+    """ADR-0003 still holds with priority active: same seed → byte-identical."""
+    base = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    s = _with_priority(base, **{sorted(base.fleet_in)[0]: 6.0})
+    a = solve(s, seed=1, search=SearchConfig(max_restarts=4), plan_paths=False)
+    b = solve(s, seed=1, search=SearchConfig(max_restarts=4), plan_paths=False)
+    assert a.layouts and b.layouts
+    assert _placements_key(a) == _placements_key(b)
+
+
+def test_solve_priority_changes_the_selected_layout():
+    """The soft weight actually influences placement: a large priority on one
+    plane shifts the spread-selected layout away from the no-priority one (same
+    seed). Proves the hook is live, not just inert — distinct from the inertness
+    and determinism guarantees above."""
+    base_s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    pid = sorted(base_s.fleet_in)[0]
+    base = solve(base_s, seed=0, search=SearchConfig(max_restarts=4), plan_paths=False)
+    hi = solve(
+        _with_priority(base_s, **{pid: 20.0}),
+        seed=0,
+        search=SearchConfig(max_restarts=4),
+        plan_paths=False,
+    )
+    assert base.layouts and hi.layouts
+    assert _placements_key(base) != _placements_key(hi)


### PR DESCRIPTION
## What

Groundwork for the future interactive editor (#442), which exports per-plane **priorities** + must-positions. Adds a soft `PlaneConstraint.priority` and wires it into the solver's spread post-pass.

A non-negative soft `priority` (`None` ≡ the neutral `0.0`) scales how hard the spread works to clear space around a plane: each plane-pair's repulsion energy is weighted by `(1 + priority_i)·(1 + priority_j)`. A higher-priority plane is pushed to more clearance.

## Changes
- **`models.py`** — `PlaneConstraint.priority: float | None = None`; `Scenario.__post_init__` rejects negative / non-finite priority. It's **soft**, so it coexists with `pin`/`force_on_carts` and is permitted on any constrained plane.
- **`loader.py`** — parse `priority:` from the scenario YAML `constraints` block via `_to_float` (which already rejects non-finite); range checked by `Scenario`.
- **`solver.py`** — `_priority_weight()` helper; `_inter_plane_energy` and `_spread_quality` weight each pair term by `w_i·w_j`. **`min_gap` stays the RAW geometric gap** (never weighted), so basin selection stays maximin-primary (ADR-0008).

## Determinism (ADR-0003) — inert by default
With every priority unset, every weight is **exactly `1.0`**, so `w_i·w_j == 1.0` and `1.0*exp(x) == exp(x)` — the energy, the spread trajectory, and the whole search are **byte-identical** to pre-#441. So every existing scenario/test is unaffected (full `pytest` 1241 green, including the determinism canaries).

Tests pin: the weight helper; energy inertness at 0 (**exact `==`**); energy strictly rises with priority; `solve(all-zero) == solve(no-constraints)`; solve stays deterministic with priority active; and a large priority **actually changes** the selected layout (the hook is live, not just inert).

## Note on mechanism
The original plan's "candidate-ranking tie-break" turned out to be a **no-op** — a descent/spread step's candidates are all the *same* plane, so a per-plane priority can't differentiate them. Energy-weighting is the only determinism-safe mechanism that actually bites (user-approved 2026-06-05). Independent of the #439/#440 viewer stack (Python-only); develop merged in.

Closes #441. Refs #436, #442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)