### PR TITLE
spike(#381): solve→tow profiling harness + measurement-first findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,19 @@ google-chrome --headless=new --use-gl=angle --use-angle=swiftshader \
   --enable-unsafe-swiftshader --virtual-time-budget=8000 \
   --screenshot=out.png "file://$PWD/out.html"
 
+# Solve→tow profiling harness (DEV/CI-ONLY, #381 — top-level `bench/`, NOT shipped
+# in the wheel; `pip install` / `python -m build` / pytest never touch it). Splits
+# each regime's wall-clock into placement vs routing and asserts validity /
+# path-validity / determinism per regime, exiting non-zero on any failure (the
+# substrate for #403/F6's CI gate). Binds on `max_restarts`, NOT wall-clock, so the
+# work — and thus the numbers — is reproducible run-to-run and machine-to-machine.
+# Findings + the ranked speedup levers: docs/spikes/solve-tow-profiling.md (and
+# bench/README.md). GOTCHA: only the FAST regimes faithfully mirror
+# `solve(plan_paths=True)`; the heavy regimes pass a tighter global tow cap to
+# bound the un-routable case, so their routing time is a harness-specific lower bound.
+python -m bench.profile_pipeline                    # fast regimes: timing + correctness verdicts
+python -m bench.profile_pipeline --heavy --profile  # + heavy regimes + cProfile stage breakdown
+
 # Viewer TypeScript toolchain (DEV/CI-ONLY — ADR-0020, top-level `viewer/`). You
 # need Node ONLY to change the viewer; `pip install` / `python -m build` / pytest
 # never invoke npm. The wheel ships the COMMITTED bundle

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,64 @@
+# `bench/` — solve→tow profiling harness (#381)
+
+A committed, repeatable measurement substrate for the `hangarfit` **solve → tow**
+pipeline. It exists so future perf work measures against a fixed baseline instead
+of anecdotes ("601 s → 136 s on my machine"), and so the v0.11.0 reliability
+roadmap (#403/F6) has a ready foothold for turning the three correctness
+invariants into always-on CI gates.
+
+**Not shipped in the wheel.** This package lives outside `src/`, so
+`pip install hangarfit` / `python -m build` / the test suite never touch it. It is
+a dev/CI tool only.
+
+## Run it
+
+```bash
+python -m bench.profile_pipeline                 # fast regimes, timing + verdicts table
+python -m bench.profile_pipeline --heavy         # + 9-plane fill and tight placeholder
+python -m bench.profile_pipeline --profile       # + cProfile stage attribution
+python -m bench.profile_pipeline --regime trivial_single --profile
+python -m bench.profile_pipeline --json          # machine-readable
+```
+
+Exit code is **non-zero** if any regime fails an invariant — the seed of the F6
+CI gate.
+
+## What it measures
+
+Per regime it splits wall-clock into **placement** (the RR-MC restart loop) vs
+**routing** (the bounded Hybrid-A* tow planner) and asserts three invariants:
+
+| Invariant | Check |
+|---|---|
+| **validity** | every returned layout scores `(0, 0.0)` under `collisions.check` |
+| **path-validity** | every committed tow arc passes `path_first_conflict` at `0.05 m / 1°`, re-validated against the *faithful* back-first obstacle context |
+| **determinism** | a second run yields a byte-identical layout + plan digest (ADR-0003, `max_restarts`-scoped) |
+
+`--profile` additionally buckets a routing cProfile into the sub-stages named in
+#381: grid-heuristic build, Reeds–Shepp enumeration, fast `_motion_clear`, exact
+`_parts_conflict`, shapely `polygon_overlap`, and the `path_first_conflict`
+re-check.
+
+## Design notes
+
+* **Bound on `max_restarts`, not `budget_s`.** Fixing the restart count makes the
+  *work* deterministic, so wall-clock is comparable run-to-run and machine-to-
+  machine — the same reason ADR-0003 scopes determinism to `max_restarts`. A
+  wall-clock budget would let the achieved restart count drift under CPU load.
+* **Routing via a direct `plan_fill` call.** `solve()` forwards only the
+  *per-plane* tow budget; the global fill cap (`max_total_expansions`) is reachable
+  only by calling `plan_fill` directly. Routing through it lets the heavy
+  regimes bound the un-routable "gives-up" failure mode instead of running to the
+  16000-expansion module default (~hundreds of seconds). Because
+  `solve(plan_paths=True)` internally calls the *same* `plan_fill` on the selected
+  layouts, `placement_s + routing_s` is a faithful decomposition of the
+  end-to-end wall-clock.
+
+The regimes themselves are defined in [`regimes.py`](regimes.py); they reference
+committed `tests/fixtures/*.yaml` scenarios so the harness has no private data.
+
+> **Editor note:** the intra-package imports (`from .regimes import …`) may show
+> as unresolved in Pyright — the repo intentionally ships no `pyrightconfig.json`
+> ([.claude/README.md](../.claude/README.md): *mypy is the CI gate, Pyright is the
+> live editor signal*), and `bench/` is outside the mypy/CI scope. Run via
+> `python -m bench.profile_pipeline`; the imports resolve correctly at runtime.

--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -1,0 +1,9 @@
+"""Solve→tow profiling/benchmark harness (#381).
+
+A committed, repeatable measurement substrate for the hangarfit ``solve`` → tow
+pipeline. Not shipped in the wheel (lives outside ``src/``); it is a dev/CI tool
+that future perf work measures against, turning anecdotal "601 s → 136 s on my
+machine" numbers into regression-guarded ones.
+
+Entry point: ``python -m bench.profile_pipeline`` (see that module's ``--help``).
+"""

--- a/bench/harness.py
+++ b/bench/harness.py
@@ -1,0 +1,348 @@
+"""Profiling/benchmark harness for the solve→tow pipeline (#381).
+
+Splits each regime's wall-clock into **placement** (the RR-MC restart loop) vs
+**routing** (the bounded Hybrid-A* tow planner), asserts the three correctness
+invariants the v0.11.0 roadmap wants guarded, and produces a cProfile
+attribution of where the routing time actually goes.
+
+The three always-checkable invariants (the substrate F6/#403 turns into CI
+gates):
+
+* **VALIDITY** — every returned layout scores ``(0, 0.0)`` under
+  :func:`collisions.check`.
+* **PATH-VALIDITY** — every committed tow arc passes
+  :func:`towplanner.path_first_conflict` at the fine ``0.05 m / 1°`` sampling,
+  re-validated against the *faithful* back-first obstacle context.
+* **DETERMINISM** — a second run of the same regime yields a byte-identical
+  layout + plan digest (ADR-0003, ``max_restarts``-scoped).
+
+Timing method: ``solve(plan_paths=False)`` is timed for placement; routing is
+driven by a **direct** ``plan_fill`` call on each selected layout (``solve()``
+forwards only the per-plane budget, so the direct call is the only way to set
+the global expansion cap and bound the un-routable regimes). Because
+``solve(plan_paths=True)`` internally calls exactly the same ``plan_fill`` on
+the selected layouts, ``placement_s + routing_s`` is a faithful decomposition
+of the end-to-end wall-clock.
+"""
+
+from __future__ import annotations
+
+import cProfile
+import io
+import pstats
+import time
+from dataclasses import dataclass, field
+
+from hangarfit.collisions import check as check_layout
+from hangarfit.loader import load_scenario
+from hangarfit.models import Layout, Placement, Scenario, SolveResult
+from hangarfit.solver import SearchConfig, solve
+from hangarfit.towplanner import (
+    MovesPlan,
+    NoFeasiblePlanError,
+    Pose,
+    path_first_conflict,
+    plan_fill,
+)
+
+from .regimes import FAST_REGIMES, REGIMES, Regime
+
+# Functions whose cumulative time a routing cProfile is bucketed into. Keys are
+# the human-facing stage names from #381; values are (module-substring,
+# function-name) pairs matched against pstats rows. Ordered most→least specific.
+_ROUTING_STAGES: tuple[tuple[str, tuple[str, str]], ...] = (
+    ("grid-heuristic build", ("towplanner", "_build_grid_heuristic")),
+    ("Reeds-Shepp enumeration", ("towplanner", "_rs_solve_normalised")),
+    ("motion-clear (fast collision)", ("towplanner", "_motion_clear")),
+    ("exact parts-conflict", ("collisions", "_parts_conflict")),
+    ("polygon overlap (shapely)", ("collisions", "polygon_overlap")),
+    ("path_first_conflict re-check", ("towplanner", "path_first_conflict")),
+    ("collisions.check", ("collisions", "check")),
+)
+
+_PLACEMENT_STAGES: tuple[tuple[str, tuple[str, str]], ...] = (
+    ("descent step", ("solver", "_descent_step")),
+    ("spread post-pass", ("solver", "_spread")),
+    ("inter-plane energy", ("solver", "_inter_plane_energy")),
+    ("collisions.check", ("collisions", "check")),
+    ("exact parts-conflict", ("collisions", "_parts_conflict")),
+    ("polygon overlap (shapely)", ("collisions", "polygon_overlap")),
+)
+
+
+@dataclass
+class RouteOutcome:
+    """The result of routing a single selected layout."""
+
+    routed: bool
+    routing_s: float
+    plan: MovesPlan | None
+    note: str = ""
+
+
+@dataclass
+class RegimeResult:
+    """One regime's measured timing + correctness verdicts."""
+
+    key: str
+    n_planes: int
+    spread: bool
+    restarts_done: int
+    placement_s: float
+    routing_s: float
+    n_layouts: int
+    n_routed: int
+    layouts_valid: bool
+    paths_valid: bool
+    deterministic: bool
+    status: str
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def total_s(self) -> float:
+        return self.placement_s + self.routing_s
+
+
+# ── scenario / search wiring ────────────────────────────────────────────────
+
+
+def load_regime_scenario(regime: Regime) -> Scenario:
+    """Load a regime's scenario (relative fleet/hangar refs resolve correctly)."""
+    return load_scenario(regime.scenario)
+
+
+def _search_config(regime: Regime) -> SearchConfig:
+    return SearchConfig(spread=regime.spread, max_restarts=regime.max_restarts)
+
+
+def _solve_placement(regime: Regime, scenario: Scenario) -> SolveResult:
+    """Run placement only (no tow planning). Bounded by ``max_restarts``."""
+    return solve(
+        scenario,
+        budget_s=1_000.0,  # effectively unbounded — max_restarts is the binding gate
+        alternatives=regime.alternatives,
+        seed=regime.seed,
+        search=_search_config(regime),
+        plan_paths=False,
+    )
+
+
+def _route_layout(regime: Regime, layout: Layout) -> RouteOutcome:
+    """Route one layout via a bounded direct ``plan_fill`` call."""
+    start = time.perf_counter()
+    try:
+        plan = plan_fill(
+            layout,
+            heuristic=regime.tow_heuristic,
+            max_expansions=regime.tow_max_expansions,
+            max_total_expansions=regime.tow_max_total_expansions,
+        )
+    except NoFeasiblePlanError as exc:
+        return RouteOutcome(
+            routed=False,
+            routing_s=time.perf_counter() - start,
+            plan=None,
+            note=f"un-routable ({exc.conflict.kind})",
+        )
+    return RouteOutcome(routed=True, routing_s=time.perf_counter() - start, plan=plan)
+
+
+# ── correctness checks ──────────────────────────────────────────────────────
+
+
+def _layout_score(layout: Layout) -> tuple[int, float]:
+    cr = check_layout(layout)
+    return (len(cr.conflicts), cr.total_penetration_m2)
+
+
+def _path_failures(plan: MovesPlan, target: Layout) -> list[str]:
+    """Re-validate every move's arc against its faithful back-first context.
+
+    Rebuilds the exact obstacle layout ``plan_fill`` saw when it committed each
+    move (the already-committed planes, in execution order) and re-runs the
+    fine-sampled ``path_first_conflict``. Duplicates ``plan_fill``'s internal
+    safety net by design — an independent assertion that the *shipped* plan is
+    collision-free, which is what a regression gate wants.
+    """
+    by_id = {p.plane_id: p for p in target.placements}
+    placed: list[Placement] = []
+    failures: list[str] = []
+    for move in plan.moves:
+        placed_layout = Layout(
+            fleet=target.fleet,
+            hangar=target.hangar,
+            placements=tuple(placed),
+            maintenance_plane=target.maintenance_plane,
+        )
+        original = by_id[move.plane_id]
+        conflict = path_first_conflict(
+            move.path,
+            target.fleet[move.plane_id],
+            mover_on_carts=original.on_carts,
+            placed=placed_layout,
+            step_m=0.05,
+            step_deg=1.0,
+        )
+        if conflict is not None:
+            failures.append(f"{move.plane_id}:{conflict.kind}")
+        placed.append(original)
+    return failures
+
+
+def _layout_digest(layout: Layout) -> str:
+    """Order-preserving, exact-float digest of a layout's placements."""
+    return "|".join(
+        f"{p.plane_id},{p.x_m!r},{p.y_m!r},{p.heading_deg!r},{p.on_carts}"
+        for p in layout.placements
+    )
+
+
+def _plan_digest(plan: MovesPlan | None) -> str:
+    """Exact digest of a plan's moves (target slot + arc segment lengths)."""
+    if plan is None:
+        return "None"
+    parts: list[str] = []
+    for move in plan.moves:
+        slot: Pose = move.target_slot
+        seglen = ",".join(f"{s.length_m!r}" for s in move.path.segments)
+        parts.append(f"{move.plane_id}@{slot.x_m!r},{slot.y_m!r},{slot.heading_deg!r}[{seglen}]")
+    return "|".join(parts)
+
+
+def _result_digest(result: SolveResult, plans: list[MovesPlan | None]) -> str:
+    layouts = ";".join(_layout_digest(layout) for layout in result.layouts)
+    plan_digest = ";".join(_plan_digest(p) for p in plans)
+    return f"{result.status}#{layouts}#{plan_digest}"
+
+
+# ── top-level run ───────────────────────────────────────────────────────────
+
+
+def run_regime(regime: Regime) -> RegimeResult:
+    """Measure one regime end-to-end: timing + the three correctness verdicts."""
+    scenario = load_regime_scenario(regime)
+
+    start = time.perf_counter()
+    result = _solve_placement(regime, scenario)
+    placement_s = time.perf_counter() - start
+
+    routing_s = 0.0
+    plans: list[MovesPlan | None] = []
+    n_routed = 0
+    notes: list[str] = []
+    for layout in result.layouts:
+        outcome = _route_layout(regime, layout)
+        routing_s += outcome.routing_s
+        plans.append(outcome.plan)
+        if outcome.routed:
+            n_routed += 1
+        elif outcome.note:
+            notes.append(outcome.note)
+
+    layouts_valid = all(_layout_score(layout) == (0, 0.0) for layout in result.layouts)
+    path_fails: list[str] = []
+    for layout, plan in zip(result.layouts, plans, strict=True):
+        if plan is not None:
+            path_fails.extend(_path_failures(plan, layout))
+    if path_fails:
+        notes.append("path failures: " + ", ".join(path_fails))
+
+    # Determinism: a second identical run must produce a byte-identical digest.
+    digest1 = _result_digest(result, plans)
+    result2 = _solve_placement(regime, scenario)
+    plans2 = [_route_layout(regime, layout).plan for layout in result2.layouts]
+    deterministic = _result_digest(result2, plans2) == digest1
+
+    return RegimeResult(
+        key=regime.key,
+        n_planes=regime.n_planes,
+        spread=regime.spread,
+        restarts_done=result.diagnostics.restarts_attempted,
+        placement_s=placement_s,
+        routing_s=routing_s,
+        n_layouts=len(result.layouts),
+        n_routed=n_routed,
+        layouts_valid=layouts_valid,
+        paths_valid=not path_fails,
+        deterministic=deterministic,
+        status=result.status,
+        notes=notes,
+    )
+
+
+# ── cProfile attribution ────────────────────────────────────────────────────
+
+
+def _bucket_profile(
+    stats: pstats.Stats, stages: tuple[tuple[str, tuple[str, str]], ...]
+) -> list[tuple[str, float, int]]:
+    """Extract (stage, cumulative_seconds, ncalls) for each named stage."""
+    rows: list[tuple[str, float, int]] = []
+    raw = stats.stats  # type: ignore[attr-defined]  # {(file, line, func): (cc, nc, tt, ct, callers)}
+    for stage, (mod_sub, func) in stages:
+        cum = 0.0
+        ncalls = 0
+        for key, entry in raw.items():
+            filename, fname = key[0], key[2]
+            if fname == func and mod_sub in filename:
+                cum += entry[3]  # ct = cumulative time
+                ncalls += entry[1]  # nc = number of calls
+        rows.append((stage, cum, ncalls))
+    return rows
+
+
+def profile_routing(regime: Regime) -> tuple[float, list[tuple[str, float, int]], str]:
+    """cProfile a single ``plan_fill`` on the regime's first selected layout.
+
+    Returns (total_routing_seconds, stage_buckets, pstats_top_text).
+    """
+    scenario = load_regime_scenario(regime)
+    result = _solve_placement(regime, scenario)
+    if not result.layouts:
+        return (0.0, [], "(no layout to route)")
+    layout = result.layouts[0]
+
+    profiler = cProfile.Profile()
+    start = time.perf_counter()
+    profiler.enable()
+    try:
+        plan_fill(
+            layout,
+            heuristic=regime.tow_heuristic,
+            max_expansions=regime.tow_max_expansions,
+            max_total_expansions=regime.tow_max_total_expansions,
+        )
+    except NoFeasiblePlanError:
+        pass
+    finally:
+        profiler.disable()
+    elapsed = time.perf_counter() - start
+
+    stats = pstats.Stats(profiler)
+    buf = io.StringIO()
+    stats.stream = buf  # type: ignore[attr-defined]
+    stats.sort_stats("cumulative").print_stats(18)
+    return (elapsed, _bucket_profile(stats, _ROUTING_STAGES), buf.getvalue())
+
+
+def profile_placement(regime: Regime) -> tuple[float, list[tuple[str, float, int]], str]:
+    """cProfile the placement solve (no tow planning)."""
+    scenario = load_regime_scenario(regime)
+    profiler = cProfile.Profile()
+    start = time.perf_counter()
+    profiler.enable()
+    _solve_placement(regime, scenario)
+    profiler.disable()
+    elapsed = time.perf_counter() - start
+
+    stats = pstats.Stats(profiler)
+    buf = io.StringIO()
+    stats.stream = buf  # type: ignore[attr-defined]
+    stats.sort_stats("cumulative").print_stats(18)
+    return (elapsed, _bucket_profile(stats, _PLACEMENT_STAGES), buf.getvalue())
+
+
+def run_all(*, include_heavy: bool = False) -> list[RegimeResult]:
+    """Run every regime (fast set by default) and return their results."""
+    regimes = REGIMES if include_heavy else FAST_REGIMES
+    return [run_regime(r) for r in regimes]

--- a/bench/harness.py
+++ b/bench/harness.py
@@ -19,10 +19,14 @@ gates):
 Timing method: ``solve(plan_paths=False)`` is timed for placement; routing is
 driven by a **direct** ``plan_fill`` call on each selected layout (``solve()``
 forwards only the per-plane budget, so the direct call is the only way to set
-the global expansion cap and bound the un-routable regimes). Because
-``solve(plan_paths=True)`` internally calls exactly the same ``plan_fill`` on
-the selected layouts, ``placement_s + routing_s`` is a faithful decomposition
-of the end-to-end wall-clock.
+the global expansion cap and bound the un-routable regimes). For a regime with
+``tow_max_total_expansions=None`` (the fast set), this direct call is *exactly*
+what ``solve(plan_paths=True)`` runs internally, so ``placement_s + routing_s``
+is a faithful decomposition of the end-to-end wall-clock. The heavy regimes
+deliberately pass a **tighter** global cap than ``solve()`` ever does (to bound
+the un-routable "gives-up" case), so their ``routing_s`` and "un-routable" verdict
+are harness-specific — a *lower bound* on what ``solve()`` would spend before
+bailing at the 16000-expansion module default, not a reproduction of it.
 """
 
 from __future__ import annotations
@@ -50,14 +54,23 @@ from .regimes import FAST_REGIMES, REGIMES, Regime
 # Functions whose cumulative time a routing cProfile is bucketed into. Keys are
 # the human-facing stage names from #381; values are (module-substring,
 # function-name) pairs matched against pstats rows. Ordered most→least specific.
+# NOTE: bucket times are *cumulative* (pstats ct), so an outer stage subsumes
+# the inner ones it calls — they overlap and do NOT sum to 100% of the stage
+# wall (e.g. path_first_conflict ⊃ collisions.check ⊃ _parts_conflict ⊃
+# polygon_overlap ⊃ aircraft_parts_world). The module-substring in each value
+# matches a function by its *defining* file, so polygon_overlap and
+# aircraft_parts_world key on "geometry" (where they are defined), not on the
+# importing module — keying them on "collisions" would silently never match.
 _ROUTING_STAGES: tuple[tuple[str, tuple[str, str]], ...] = (
     ("grid-heuristic build", ("towplanner", "_build_grid_heuristic")),
     ("Reeds-Shepp enumeration", ("towplanner", "_rs_solve_normalised")),
     ("motion-clear (fast collision)", ("towplanner", "_motion_clear")),
-    ("exact parts-conflict", ("collisions", "_parts_conflict")),
-    ("polygon overlap (shapely)", ("collisions", "polygon_overlap")),
+    ("mover bounds (in-transit)", ("towplanner", "_mover_motion_bounds_conflict")),
     ("path_first_conflict re-check", ("towplanner", "path_first_conflict")),
     ("collisions.check", ("collisions", "check")),
+    ("exact parts-conflict", ("collisions", "_parts_conflict")),
+    ("polygon overlap (shapely)", ("geometry", "polygon_overlap")),
+    ("world-part build (shapely)", ("geometry", "aircraft_parts_world")),
 )
 
 _PLACEMENT_STAGES: tuple[tuple[str, tuple[str, str]], ...] = (
@@ -66,7 +79,8 @@ _PLACEMENT_STAGES: tuple[tuple[str, tuple[str, str]], ...] = (
     ("inter-plane energy", ("solver", "_inter_plane_energy")),
     ("collisions.check", ("collisions", "check")),
     ("exact parts-conflict", ("collisions", "_parts_conflict")),
-    ("polygon overlap (shapely)", ("collisions", "polygon_overlap")),
+    ("polygon overlap (shapely)", ("geometry", "polygon_overlap")),
+    ("world-part build (shapely)", ("geometry", "aircraft_parts_world")),
 )
 
 
@@ -198,14 +212,24 @@ def _layout_digest(layout: Layout) -> str:
 
 
 def _plan_digest(plan: MovesPlan | None) -> str:
-    """Exact digest of a plan's moves (target slot + arc segment lengths)."""
+    """Exact digest of a plan's moves (target slot + full arc shape).
+
+    Each segment contributes its ``kind`` (L/S/R), ``gear`` (±1), and exact
+    ``length_m`` plus the arc's ``turn_radius_m`` — not length alone — so two
+    arcs that share a target slot and per-leg lengths but differ in steering,
+    travel direction, or radius do not collapse to the same digest (which would
+    let an arc-*shape* non-determinism slip through as ``det = ok``).
+    """
     if plan is None:
         return "None"
     parts: list[str] = []
     for move in plan.moves:
         slot: Pose = move.target_slot
-        seglen = ",".join(f"{s.length_m!r}" for s in move.path.segments)
-        parts.append(f"{move.plane_id}@{slot.x_m!r},{slot.y_m!r},{slot.heading_deg!r}[{seglen}]")
+        segs = ",".join(f"{s.kind}{s.gear:+d}:{s.length_m!r}" for s in move.path.segments)
+        parts.append(
+            f"{move.plane_id}@{slot.x_m!r},{slot.y_m!r},{slot.heading_deg!r}"
+            f"r{move.path.turn_radius_m!r}[{segs}]"
+        )
     return "|".join(parts)
 
 

--- a/bench/profile_pipeline.py
+++ b/bench/profile_pipeline.py
@@ -59,6 +59,8 @@ def _print_profile(key: str) -> None:
     regime = regime_by_key(key)
     print(f"\n═══ cProfile: {regime.key} — {regime.description} ═══")
 
+    print("  (bucket times are cumulative — nested stages overlap, do not sum to 100%)")
+
     p_elapsed, p_buckets, _ = profile_placement(regime)
     print(f"\n  PLACEMENT  ({p_elapsed:.3f} s wall)")
     for stage, cum, ncalls in p_buckets:

--- a/bench/profile_pipeline.py
+++ b/bench/profile_pipeline.py
@@ -1,0 +1,148 @@
+"""CLI for the solve→tow profiling/benchmark harness (#381).
+
+Examples::
+
+    python -m bench.profile_pipeline                # fast regimes, timing table
+    python -m bench.profile_pipeline --heavy        # + 9-plane and tight-fill
+    python -m bench.profile_pipeline --profile      # + cProfile stage breakdown
+    python -m bench.profile_pipeline --regime trivial_single --profile
+    python -m bench.profile_pipeline --json         # machine-readable
+
+The timing table reports, per regime, the placement vs routing wall-clock split
+and the three correctness verdicts (validity / path-validity / determinism).
+With ``--profile`` it additionally prints a cProfile attribution of where the
+*routing* time goes (the dominant cost on multi-plane fills) bucketed into the
+sub-stages named in #381.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from .harness import (
+    RegimeResult,
+    profile_placement,
+    profile_routing,
+    run_regime,
+)
+from .regimes import FAST_REGIMES, REGIMES, regime_by_key
+
+
+def _ok(flag: bool) -> str:
+    return "ok  " if flag else "FAIL"
+
+
+def _print_table(results: list[RegimeResult]) -> None:
+    header = (
+        f"{'regime':<24}{'planes':>7}{'spread':>7}{'restarts':>9}"
+        f"{'place_s':>9}{'route_s':>9}{'total_s':>9}"
+        f"{'routed':>8}{'valid':>6}{'paths':>6}{'det':>5}"
+    )
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        print(
+            f"{r.key:<24}{r.n_planes:>7}{('on' if r.spread else 'off'):>7}"
+            f"{r.restarts_done:>9}{r.placement_s:>9.3f}{r.routing_s:>9.3f}"
+            f"{r.total_s:>9.3f}{f'{r.n_routed}/{r.n_layouts}':>8}"
+            f"{_ok(r.layouts_valid):>6}{_ok(r.paths_valid):>6}{_ok(r.deterministic):>5}"
+        )
+    print()
+    for r in results:
+        if r.notes:
+            print(f"  {r.key}: " + "; ".join(r.notes))
+
+
+def _print_profile(key: str) -> None:
+    regime = regime_by_key(key)
+    print(f"\n═══ cProfile: {regime.key} — {regime.description} ═══")
+
+    p_elapsed, p_buckets, _ = profile_placement(regime)
+    print(f"\n  PLACEMENT  ({p_elapsed:.3f} s wall)")
+    for stage, cum, ncalls in p_buckets:
+        pct = (100.0 * cum / p_elapsed) if p_elapsed else 0.0
+        print(f"    {stage:<32}{cum:>8.3f} s  {pct:>5.1f}%  ({ncalls:,} calls)")
+
+    r_elapsed, r_buckets, r_top = profile_routing(regime)
+    print(f"\n  ROUTING    ({r_elapsed:.3f} s wall)")
+    for stage, cum, ncalls in r_buckets:
+        pct = (100.0 * cum / r_elapsed) if r_elapsed else 0.0
+        print(f"    {stage:<32}{cum:>8.3f} s  {pct:>5.1f}%  ({ncalls:,} calls)")
+    print("\n  routing pstats (top 18 by cumulative):")
+    for line in r_top.splitlines():
+        print(f"    {line}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="solve→tow profiling harness (#381)")
+    ap.add_argument(
+        "--regime",
+        action="append",
+        metavar="KEY",
+        help="run only these regime keys (repeatable); default = fast set",
+    )
+    ap.add_argument(
+        "--heavy",
+        action="store_true",
+        help="include heavy regimes (9-plane fill, tight un-routable placeholder)",
+    )
+    ap.add_argument(
+        "--profile",
+        action="store_true",
+        help="also print a cProfile stage breakdown per regime",
+    )
+    ap.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = ap.parse_args(argv)
+
+    if args.regime:
+        try:
+            regimes = [regime_by_key(k) for k in args.regime]
+        except KeyError as exc:
+            print(f"unknown regime: {exc}", file=sys.stderr)
+            print("known:", ", ".join(r.key for r in REGIMES), file=sys.stderr)
+            return 2
+    else:
+        regimes = list(REGIMES if args.heavy else FAST_REGIMES)
+
+    results = [run_regime(r) for r in regimes]
+
+    if args.json:
+        print(
+            json.dumps(
+                [
+                    {
+                        "key": r.key,
+                        "n_planes": r.n_planes,
+                        "spread": r.spread,
+                        "restarts_done": r.restarts_done,
+                        "placement_s": r.placement_s,
+                        "routing_s": r.routing_s,
+                        "total_s": r.total_s,
+                        "n_layouts": r.n_layouts,
+                        "n_routed": r.n_routed,
+                        "layouts_valid": r.layouts_valid,
+                        "paths_valid": r.paths_valid,
+                        "deterministic": r.deterministic,
+                        "status": r.status,
+                        "notes": r.notes,
+                    }
+                    for r in results
+                ],
+                indent=2,
+            )
+        )
+    else:
+        _print_table(results)
+        if args.profile:
+            for r in regimes:
+                _print_profile(r.key)
+
+    # Exit non-zero if any correctness invariant failed — the seed of the F6 gate.
+    ok = all(r.layouts_valid and r.paths_valid and r.deterministic for r in results)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/regimes.py
+++ b/bench/regimes.py
@@ -1,0 +1,120 @@
+"""Benchmark regimes for the solve→tow profiling harness (#381).
+
+Each :class:`Regime` is a fixed-seed, bounded scenario spanning a corner of the
+performance space the v0.11.0 roadmap cares about: trivial / roomy-multi /
+tight-placeholder, crossed with spread-on vs spread-off.
+
+Two deliberate reproducibility choices:
+
+* **Bind on ``max_restarts``, not the wall-clock ``budget_s``.** Fixing the
+  restart count makes the *work* deterministic, so wall-clock numbers are
+  comparable across runs and machines (the same reason ADR-0003 scopes the
+  determinism contract to ``max_restarts``). A wall-clock budget would let the
+  achieved restart count drift under CPU load and make the numbers noise.
+* **An optional global ``tow_max_total_expansions`` cap.** ``solve()`` forwards
+  only the *per-plane* tow budget, so an un-routable fill would run to the
+  module's 16000-expansion global default (~hundreds of seconds). The harness
+  routes via a direct ``plan_fill`` call (see :mod:`bench.harness`) so this cap
+  bounds the "gives-up" failure mode and keeps the heavy regimes affordable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+
+
+@dataclass(frozen=True)
+class Regime:
+    """One fixed-seed, bounded benchmark point.
+
+    ``tow_max_expansions`` is the per-plane Hybrid-A* budget (``plan_fill``'s
+    ``max_expansions``); ``tow_max_total_expansions`` is the global fill cap
+    (``plan_fill``'s ``max_total_expansions``). ``None`` on either means the
+    ``towplanner`` module default. ``heavy`` regimes are excluded from the
+    default fast set (they do substantial — sometimes un-routable — routing).
+    """
+
+    key: str
+    description: str
+    scenario: Path
+    seed: int
+    max_restarts: int
+    spread: bool
+    n_planes: int
+    alternatives: int = 1
+    tow_heuristic: Literal["euclidean", "grid"] = "grid"
+    tow_max_expansions: int | None = None
+    tow_max_total_expansions: int | None = None
+    heavy: bool = False
+
+
+REGIMES: tuple[Regime, ...] = (
+    Regime(
+        key="trivial_single",
+        description="1 plane, 30x25 m hangar — search barely does anything",
+        scenario=FIXTURES / "solve_trivial_single_plane.yaml",
+        seed=1,
+        max_restarts=20,
+        spread=True,
+        n_planes=1,
+    ),
+    Regime(
+        key="roomy_three_spread_on",
+        description="3 planes, 30x25 m hangar, spread ON (the default path)",
+        scenario=FIXTURES / "solve_fresh_alternatives_three.yaml",
+        seed=1,
+        max_restarts=30,
+        spread=True,
+        n_planes=3,
+    ),
+    Regime(
+        key="roomy_three_spread_off",
+        description="3 planes, 30x25 m hangar, spread OFF (--no-spread fast path)",
+        scenario=FIXTURES / "solve_fresh_alternatives_three.yaml",
+        seed=1,
+        max_restarts=30,
+        spread=False,
+        n_planes=3,
+    ),
+    Regime(
+        # Few restarts on purpose: the spread post-pass dominates placement
+        # (see the #381 report), so this regime is here to characterise heavy
+        # 9-plane *routing*, not to re-measure spread placement cost.
+        key="full_nine_spread_on",
+        description="9 planes, 30x25 m hangar — heaviest routing (multi-plane fill)",
+        scenario=FIXTURES / "solve_all_nine_large_hangar.yaml",
+        seed=1,
+        max_restarts=4,
+        spread=True,
+        n_planes=9,
+        tow_max_total_expansions=8000,
+        heavy=True,
+    ),
+    Regime(
+        key="tight_six_placeholder",
+        description="6 planes, 25x18 m placeholder — tight, routing likely bails",
+        scenario=FIXTURES / "solve_fresh_six_planes.yaml",
+        seed=1,
+        max_restarts=6,
+        spread=True,
+        n_planes=6,
+        tow_max_total_expansions=4000,
+        heavy=True,
+    ),
+)
+
+
+FAST_REGIMES: tuple[Regime, ...] = tuple(r for r in REGIMES if not r.heavy)
+
+
+def regime_by_key(key: str) -> Regime:
+    """Look up a regime by its ``key``; raise ``KeyError`` if unknown."""
+    for regime in REGIMES:
+        if regime.key == key:
+            return regime
+    raise KeyError(key)

--- a/docs/spikes/solve-tow-profiling.md
+++ b/docs/spikes/solve-tow-profiling.md
@@ -63,9 +63,13 @@ numbers trustworthy and comparable:
   tow budget; the global fill cap (`max_total_expansions`) is reachable only by
   calling `plan_fill` directly. Routing through it lets the un-routable regimes be
   bounded instead of running to the 16000-expansion module default (~hundreds of
-  seconds). Because `solve(plan_paths=True)` internally calls the *same*
-  `plan_fill` on the selected layouts, `placement_s + routing_s` is a faithful
-  decomposition of end-to-end wall-clock.
+  seconds). For the **fast** regimes (`tow_max_total_expansions=None`) this is
+  *exactly* what `solve(plan_paths=True)` runs internally, so `placement_s +
+  routing_s` is a faithful decomposition of end-to-end wall-clock. The two
+  **heavy** regimes deliberately pass a tighter global cap than `solve()` ever
+  does, so their `routing_s` / "un-routable" verdict is a harness-specific *lower
+  bound* on what `solve()` would spend before bailing at its 16000 default — not
+  a reproduction of it.
 
 The harness also asserts three correctness invariants per regime (the substrate
 F6/#403 will promote to always-on CI gates): **validity** (every layout scores
@@ -167,20 +171,27 @@ Two things this nails down:
   it, again, `aircraft_parts_world` → shapely. (`tight_six` is identical: 98.0 %
   `_motion_clear`, 227,497 calls → 455,009 `aircraft_parts_world` → 4.55 M
   polygons.)
-- **`_motion_clear` rebuilds the *constant* obstacle geometry every pose sample.**
-  The obstacle set does not change during a single `plan_path` search — only the
-  mover's pose does — yet all 432 k `_motion_clear` calls reconstruct every
-  obstacle's world parts from scratch. Building obstacle parts **once per
-  `plan_path` and reusing them** is the routing-side twin of the placement-side
-  world-part caching, and it is equally byte-identical.
+- **The routing redundancy is the *mover's* parts rebuilt twice per pose — not
+  the obstacles.** Obstacle geometry is *already* built once per `plan_path` and
+  reused for every sample (`_Obstacles` / `_build_obstacles`, towplanner.py).
+  The tell is the call ratio: 432,080 `_motion_clear` → 865,459
+  `aircraft_parts_world` is exactly **2.00×**, not the ~9× you would see if all
+  eight obstacles were rebuilt per sample. The 2× is the *mover's* parts
+  reconstructed once in `_motion_clear` (towplanner.py:1514) and again in
+  `_mover_motion_bounds_conflict` (:979) for the **same** pose. A per-(plane,
+  pose) memo collapses both to one build — byte-identical, and the routing-side
+  application of the very same lever as placement.
 
 ### 5. The one root cause
 
 Every regime — placement *and* routing, routable *and* not — bottlenecks on
 `geometry.aircraft_parts_world` → `geometry.oriented_rect` → shapely `Polygon`
-construction, rebuilt from scratch on every collision/clearance check with **no
-memoization and no broad-phase**. A single un-routable 9-plane fill constructs
-**8.6 million** shapely polygons. That one function is the lever.
+construction. The one existing cache (`_Obstacles`) already holds *obstacle*
+parts constant within a `plan_path`, but everything else — every placement-side
+`collisions.check`, every `path_first_conflict` sample, and the mover in
+`_motion_clear` — rebuilds parts from scratch with **no memoization and no
+broad-phase**. A single un-routable 9-plane fill still constructs **8.6 million**
+shapely polygons. That one function is the lever.
 
 ---
 
@@ -199,7 +210,7 @@ first-pass payoff guesses in both directions. Payoff is scored against the
 | **Memoize `aircraft_parts_world`** (per-solve, exact-key, no eviction) | **high** — 83.8 % of calls are redundant rebuilds (314,460 calls / 50,889 unique poses on roomy-3); cross-cuts *both* stages and the un-routable 8.6 M-polygon case | low | **none — byte-identical** (verified end-to-end: memoized solve → identical `SolveResult` digest; GEOS distance bit-matched) | **BUILD** — this is F6's "one cheap lever" |
 | **Incremental single-plane re-scoring in `_spread`** | **high** — `_spread` is >99 % of placement | medium — the naive delta-update drifts ~1e-15 in 29 % of moves and flips acceptance; the safe form re-sums *all* pairs in canonical sorted order | safe-with-care (canonical re-sum is byte-identical; delta-update **breaks** it) | build **after** caching |
 | **AABB / circle-distance broad-phase** in `_parts_conflict` | medium — payoff overstated ~5–7×: `collisions.check` rebuilds polygons *unconditionally* before the pairwise loop the filter sits in, so it can't shrink the 86 % rebuild; caching is the real win | low | none — byte-identical (a per-axis gap is a sound lower bound) | build after caching; **do not** copy `_motion_clear`'s z-prefilter (divergence trap) |
-| Routing-side mover/obstacle parts caching across `path_first_conflict` / `_motion_clear` | high *for un-routable fills* — `_motion_clear` is 98 % of that routing and rebuilds **constant** obstacle geometry every sample | low | none — byte-identical, RNG-free planner | folds into the memoization lever |
+| Routing-side mover-parts caching across `path_first_conflict` / `_motion_clear` | high *for un-routable fills* — `_motion_clear` is 98 % of that routing; the mover's parts are rebuilt **twice per pose** (`_motion_clear` + `_mover_motion_bounds_conflict`), 2.00× ratio. (Obstacles are already cached per `plan_path`.) | low | none — byte-identical, RNG-free planner | folds into the memoization lever |
 | `incremental_collision_across_restarts` | the determinism-safe subset *is* the per-solve memoization lever above | — | safe only as per-restart, exact-key, **no eviction** (the named LRU variant breaks basin selection) | folds into the memoization lever |
 | `grid_heuristic_rebuild_caching` | **~0** — instrumented: 0 cache hits (obstacles grow monotonically); `_build_grid_heuristic` is 0.1 % of routing | — | not robustly safe (h participates in heap pop order) | **REJECT** |
 | `warm_start_tow_from_placement` | **~0** — instrumented: the analytic Reeds–Shepp shot closes in **0 expansions** on routable cases; nothing to warm-start | — | breaks (changes the returned arc) | **REJECT** |

--- a/docs/spikes/solve-tow-profiling.md
+++ b/docs/spikes/solve-tow-profiling.md
@@ -1,0 +1,263 @@
+# Spike: profiling the solve→tow pipeline — where the wall-clock actually goes
+
+- **Status:** Findings + recommendation. The benchmark/profiling harness ships
+  (`bench/`); no production speedup lands from this spike itself. Accepted levers
+  graduate to their own implementation issues (see the ranked table).
+- **Date:** 2026-06-05
+- **Spike issue:** [#381](https://github.com/DocGerd/hangarfit/issues/381)
+- **Consumes into:** [#403](https://github.com/DocGerd/hangarfit/issues/403) (F6 —
+  CI gates + one measured lever), [#404](https://github.com/DocGerd/hangarfit/issues/404)
+  (F7 — pool-stagnation early-exit), milestone
+  [#31](https://github.com/DocGerd/hangarfit/milestone/31) (v0.11.0).
+- **Prior art (don't re-tread):** [#336](https://github.com/DocGerd/hangarfit/issues/336)
+  (RRT-Connect NO-GO; grid heuristic routed aviat_husky 601 s → 136 s),
+  [#335](https://github.com/DocGerd/hangarfit/issues/335) (`_MAX_EXPANSIONS` bump),
+  [#280](https://github.com/DocGerd/hangarfit/issues/280) (spread-vs-towability
+  tension), [#331](https://github.com/DocGerd/hangarfit/issues/331)/[#332](https://github.com/DocGerd/hangarfit/issues/332)
+  (CNN NO-GO).
+
+---
+
+## TL;DR
+
+The premise everyone (including this spike's own issue and the `solve()`
+docstring) had been repeating — *"tow-planning is the dominant cost on
+multi-plane fills"* — **is false for the default path.** The measured profile
+says:
+
+1. **On the default (spread-ON) path, placement dominates routing by ~50×.** A
+   3-plane roomy solve spends **40.6 s in placement and 0.77 s in routing**.
+2. **99.6 % of that placement time is the spread post-pass** (`_spread`), and
+   inside it the cost is `collisions.check` (57 %) + `_inter_plane_energy`
+   (41 %). The "default solve is always ~30 s" pain ([#404](https://github.com/DocGerd/hangarfit/issues/404))
+   is the spread hill-climb, not the planner.
+3. **The single cross-cutting bottleneck is shapely polygon (re)construction.**
+   `geometry.aircraft_parts_world` rebuilds every aircraft's part polygons from
+   scratch on *every* collision check, in both stages. There is no memoization
+   and no AABB broad-phase before the exact overlap predicate.
+4. **The highest-leverage lever is therefore "boring" and determinism-safe:**
+   cache / broad-phase the per-check geometry. It is a pure-function
+   optimization → byte-identical output → zero ADR-0003 risk and zero canary
+   churn. Routing-side cleverness (tighter A\*, warm-start) is *low* payoff
+   because routing is already <1 s on the paths that matter.
+
+This is exactly the "pre-commit to a boring fix over a new algorithm" outcome
+[#403](https://github.com/DocGerd/hangarfit/issues/403) hoped for — and it is the
+*fourth* heavy-algorithm temptation (after the CNN×2 and RRT-Connect NO-GOs) that
+the measurement defused.
+
+---
+
+## Method
+
+The harness lives in [`bench/`](../../bench/) (`python -m bench.profile_pipeline`);
+see [`bench/README.md`](../../bench/README.md). Two deliberate choices make the
+numbers trustworthy and comparable:
+
+- **Bind on `max_restarts`, not the wall-clock `budget_s`.** Fixing the restart
+  count fixes the *work*, so wall-clock is comparable run-to-run and machine-to-
+  machine (the same reason ADR-0003 scopes determinism to `max_restarts`). A
+  wall-clock budget would let the achieved restart count drift under CPU load and
+  turn the numbers into noise.
+- **Route via a direct `plan_fill` call.** `solve()` forwards only the *per-plane*
+  tow budget; the global fill cap (`max_total_expansions`) is reachable only by
+  calling `plan_fill` directly. Routing through it lets the un-routable regimes be
+  bounded instead of running to the 16000-expansion module default (~hundreds of
+  seconds). Because `solve(plan_paths=True)` internally calls the *same*
+  `plan_fill` on the selected layouts, `placement_s + routing_s` is a faithful
+  decomposition of end-to-end wall-clock.
+
+The harness also asserts three correctness invariants per regime (the substrate
+F6/#403 will promote to always-on CI gates): **validity** (every layout scores
+`(0, 0.0)`), **path-validity** (every committed arc passes `path_first_conflict`
+at 0.05 m / 1° against the faithful back-first obstacle context), and
+**determinism** (a second run yields a byte-identical layout + plan digest).
+
+> cProfile inflates absolute time (~2×) but the **relative attribution and call
+> counts are faithful**; the un-profiled `bench` table gives true wall-clock.
+> All figures below are fixed-seed (`seed=1`) on one developer machine — read the
+> *ratios, call counts, and %-of-stage*, not the absolute seconds.
+
+### Regimes
+
+| Regime | Scenario | Planes | Hangar | Spread | Restarts |
+|---|---|---:|---|---|---:|
+| `trivial_single` | `solve_trivial_single_plane` | 1 | 30×25 | on | 20 |
+| `roomy_three_spread_on` | `solve_fresh_alternatives_three` | 3 | 30×25 | on | 30 |
+| `roomy_three_spread_off` | `solve_fresh_alternatives_three` | 3 | 30×25 | off | 30 |
+| `full_nine_spread_on` | `solve_all_nine_large_hangar` | 9 | 30×25 | on | 4 |
+| `tight_six_placeholder` | `solve_fresh_six_planes` | 6 | 25×18 | on | 6 |
+
+---
+
+## Findings
+
+### 1. Placement vs routing (un-profiled wall-clock)
+
+| Regime | placement_s | routing_s | total_s | note |
+|---|---:|---:|---:|---|
+| `trivial_single` | 0.01 | 0.20 | 0.21 | 1 plane — routing > placement only because placement is trivial |
+| `roomy_three_spread_on` | **40.64** | 0.77 | 41.41 | **placement = 53× routing** |
+| `roomy_three_spread_off` | 0.001 | 0.89 | 0.89 | spread OFF early-exits at 1 restart → placement vanishes |
+| `full_nine_spread_on` | 25.75 | **137.60** | 163.36 | un-routable (bailed @8000-cap) — routing dominates here |
+| `tight_six_placeholder` | 15.59 | **69.50** | 85.09 | un-routable (bailed @4000-cap) — routing dominates here |
+
+The `spread_on` vs `spread_off` contrast on the *same* 3-plane scenario is the
+headline: turning spread off collapses placement from **40.6 s to 1 ms**. The
+default path's entire cost is the spread post-pass.
+
+### 2. Where placement time goes (`roomy_three_spread_on` cProfile)
+
+| Stage | cum. time | % of placement | calls |
+|---|---:|---:|---:|
+| spread post-pass (`_spread`) | 88.76 s | **99.6 %** | 30 |
+| ↳ `collisions.check` | 51.00 s | 57.2 % | **56,130** |
+| ↳ `_inter_plane_energy` | 36.91 s | 41.4 % | 48,660 |
+| ↳ `_parts_conflict` | 8.62 s | 9.7 % | **2,189,070** |
+| `_descent_step` | 0.35 s | 0.4 % | 36 |
+
+The descent (finding a *valid* layout) is nearly free; the spread polish (making
+it *pretty*) is the whole bill. Each spread candidate move re-runs a **full**
+`collisions.check` and a **full** `_inter_plane_energy` even though only one
+plane moved.
+
+### 3. Where routing time goes (`trivial_single` cProfile)
+
+| Stage | cum. time | % of routing | calls |
+|---|---:|---:|---:|
+| `path_first_conflict` (final-arc re-check @0.05 m/1°) | 0.336 s | **80.8 %** | 1 |
+| ↳ `aircraft_parts_world` (shapely rebuild) | 0.317 s | — | 1,207 |
+| ↳ `collisions.check` | 0.167 s | 40.2 % | 496 |
+| `_motion_clear` (fast in-search check) | 0.058 s | 13.9 % | 100 |
+| `_build_grid_heuristic` | 0.016 s | 3.8 % | 1 |
+| Reeds–Shepp enumeration | <0.001 s | 0.1 % | 1 |
+
+Routing a single plane's path triggers **12,070 shapely `Polygon.__new__`
+calls** — every pose sample of the fine final re-validation rebuilds all world
+parts from scratch. The A\* search math (Reeds–Shepp, grid heuristic) is
+negligible; the cost is *geometry construction inside the collision checks*.
+
+### 4. Heavy regimes — where routing *does* dominate (un-routable fills)
+
+Routing only overtakes placement when the fill is **un-routable and floods the
+expansion budget**. Both heavy regimes bailed (`no_feasible_path`) at their
+bounded global cap, and there routing is the bill:
+
+| Regime | placement_s | routing_s | routed |
+|---|---:|---:|---|
+| `full_nine_spread_on` (bail @8000) | 25.75 | **137.60** | 0/1 |
+| `tight_six_placeholder` (bail @4000) | 15.59 | **69.50** | 0/1 |
+
+Routing cProfile, `full_nine_spread_on`:
+
+| Stage | cum. time | % of routing | calls |
+|---|---:|---:|---:|
+| `_motion_clear` (in-search fast check) | 312.95 s | **98.7 %** | **432,080** |
+| ↳ `aircraft_parts_world` | 243.22 s | — | **865,459** |
+| ↳ shapely `Polygon.__new__` | 149.20 s | — | **8,621,118** |
+| ↳ `_mover_motion_bounds_conflict` | 148.50 s | — | 432,744 |
+| `_build_grid_heuristic` | 0.30 s | **0.1 %** | 2 |
+| Reeds–Shepp enumeration | 0.01 s | 0.0 % | 33 |
+
+Two things this nails down:
+
+- **The grid-heuristic-rebuild hypothesis is refuted.** A reasonable guess was
+  that the Dijkstra grid rebuild dominates un-routable fills; the data says it is
+  **0.1 %**. The cost is `_motion_clear` flooding the expansion budget, and under
+  it, again, `aircraft_parts_world` → shapely. (`tight_six` is identical: 98.0 %
+  `_motion_clear`, 227,497 calls → 455,009 `aircraft_parts_world` → 4.55 M
+  polygons.)
+- **`_motion_clear` rebuilds the *constant* obstacle geometry every pose sample.**
+  The obstacle set does not change during a single `plan_path` search — only the
+  mover's pose does — yet all 432 k `_motion_clear` calls reconstruct every
+  obstacle's world parts from scratch. Building obstacle parts **once per
+  `plan_path` and reusing them** is the routing-side twin of the placement-side
+  world-part caching, and it is equally byte-identical.
+
+### 5. The one root cause
+
+Every regime — placement *and* routing, routable *and* not — bottlenecks on
+`geometry.aircraft_parts_world` → `geometry.oriented_rect` → shapely `Polygon`
+construction, rebuilt from scratch on every collision/clearance check with **no
+memoization and no broad-phase**. A single un-routable 9-plane fill constructs
+**8.6 million** shapely polygons. That one function is the lever.
+
+---
+
+## Ranked proposal table
+
+Eight candidates (the #381 seed list plus the two the profile surfaced) were each
+researched against the code and then **adversarially verified** — the verifiers
+*instrumented the live code* (cache hit-rates, A\* expansion counts, bit-level
+float divergence) rather than reasoning in the abstract, which corrected several
+first-pass payoff guesses in both directions. Payoff is scored against the
+*measured* numbers: a lever that only speeds up routing on the default path is
+**low** payoff because routing is already <1 s there.
+
+| Candidate | Payoff | Risk | Determinism | Verdict |
+|---|---|---|---|---|
+| **Memoize `aircraft_parts_world`** (per-solve, exact-key, no eviction) | **high** — 83.8 % of calls are redundant rebuilds (314,460 calls / 50,889 unique poses on roomy-3); cross-cuts *both* stages and the un-routable 8.6 M-polygon case | low | **none — byte-identical** (verified end-to-end: memoized solve → identical `SolveResult` digest; GEOS distance bit-matched) | **BUILD** — this is F6's "one cheap lever" |
+| **Incremental single-plane re-scoring in `_spread`** | **high** — `_spread` is >99 % of placement | medium — the naive delta-update drifts ~1e-15 in 29 % of moves and flips acceptance; the safe form re-sums *all* pairs in canonical sorted order | safe-with-care (canonical re-sum is byte-identical; delta-update **breaks** it) | build **after** caching |
+| **AABB / circle-distance broad-phase** in `_parts_conflict` | medium — payoff overstated ~5–7×: `collisions.check` rebuilds polygons *unconditionally* before the pairwise loop the filter sits in, so it can't shrink the 86 % rebuild; caching is the real win | low | none — byte-identical (a per-axis gap is a sound lower bound) | build after caching; **do not** copy `_motion_clear`'s z-prefilter (divergence trap) |
+| Routing-side mover/obstacle parts caching across `path_first_conflict` / `_motion_clear` | high *for un-routable fills* — `_motion_clear` is 98 % of that routing and rebuilds **constant** obstacle geometry every sample | low | none — byte-identical, RNG-free planner | folds into the memoization lever |
+| `incremental_collision_across_restarts` | the determinism-safe subset *is* the per-solve memoization lever above | — | safe only as per-restart, exact-key, **no eviction** (the named LRU variant breaks basin selection) | folds into the memoization lever |
+| `grid_heuristic_rebuild_caching` | **~0** — instrumented: 0 cache hits (obstacles grow monotonically); `_build_grid_heuristic` is 0.1 % of routing | — | not robustly safe (h participates in heap pop order) | **REJECT** |
+| `warm_start_tow_from_placement` | **~0** — instrumented: the analytic Reeds–Shepp shot closes in **0 expansions** on routable cases; nothing to warm-start | — | breaks (changes the returned arc) | **REJECT** |
+| `plane_ordering_restart_strategy` | **~0** — descent is <0.4 s; not the bottleneck | — | breaks (reorders the single seeded RNG draw sequence) | **REJECT** |
+| `astar_heuristic_tiebreak` | low — routing is cheap on the default path | — | breaks (changes which arc `plan_path` returns first) | **DEFER** |
+
+**The whole table collapses to one lever:** a per-solve, exact-key, no-eviction
+**memoization of `aircraft_parts_world`**, applied across placement
+(`collisions.check`) *and* routing (`_motion_clear` obstacle parts +
+`path_first_conflict`). It is byte-identical → zero canary churn, zero ADR-0003
+risk — exactly the "boring fix over a new algorithm" F6 pre-committed to. The
+broad-phase and incremental-`_spread` levers are smaller, byte-identical
+follow-ups *after* it. Two plausible levers (grid-rebuild caching, warm-start)
+were killed by direct measurement — the value of measuring first.
+
+### Filed follow-up issues
+
+- _(primary, → F6/#403's lever)_ [#453](https://github.com/DocGerd/hangarfit/issues/453)
+  — Cache `aircraft_parts_world` geometry per solve. **v0.11.0.**
+- _(secondary, blocked-by #453)_ [#454](https://github.com/DocGerd/hangarfit/issues/454)
+  — AABB / circle-distance broad-phase in `collisions._parts_conflict`. Backlog.
+- _(secondary, blocked-by #453)_ [#455](https://github.com/DocGerd/hangarfit/issues/455)
+  — Incremental single-plane re-scoring in `_spread` (canonical re-sum). Backlog.
+
+`grid_heuristic_rebuild_caching`, `warm_start_tow_from_placement`,
+`plane_ordering_restart_strategy` (all REJECTED) and `astar_heuristic_tiebreak`
+(DEFER) are intentionally *not* filed — recorded here so they are not
+re-proposed without new evidence.
+
+---
+
+## Determinism contract (ADR-0003) — recommendation: **keep as-is**
+
+**The contract's measured cost is near-zero.** The canary asserts byte-identity
+on `placements` / `best_partial` / `seed` — *not* on timing, and *not* on how a
+score is computed. Every high-value lever the profile surfaced (memoization,
+broad-phase, incremental moved-plane re-scoring) returns the **identical**
+conflict-count + penetration tuple, so it is byte-identical and the contract
+leaves none of those ~40 s on the table.
+
+The only forbidden lever with real headroom is **parallel restarts** (RR-MC is
+embarrassingly parallel, but bit-identical reproducibility forces a single
+`random.Random(seed)`; a parallel variant needs per-worker RNGs + a deterministic
+merge). The cheaper, byte-identical geometry-caching lever attacks the *same*
+40.6 s first — so the contract is not what stands between us and a fast solver.
+First-valid early-exit on the spread-ON path was already traded away in #267
+(best-spread-over-first-valid), and spread-OFF keeps it; #404/F7's seed-fixed,
+machine-independent early-exit is *admissible* under the contract and narrows
+#267's timing scope rather than widening it.
+
+**Recommendation: keep the contract unchanged.** Relaxing it would surrender the
+determinism canary, the shareable-seed claim, and reviewable diagnostics — for
+levers the profile shows are not the bottleneck. Pursue geometry caching,
+preserving float-summation order in the penetration and energy accumulators.
+
+---
+
+## Out of scope (unchanged from #381)
+
+Implementing the speedups (each is its own follow-up issue), CNN approaches
+(#331/#332), and articulated trailers (#204).


### PR DESCRIPTION
Closes #381.

Delivers the #381 spike's four DoD items: a committed benchmark/profiling harness, a profiling report, a ranked (adversarially-verified) proposal table with follow-ups filed, and a determinism recommendation. **No production speedup lands here** — accepted levers graduate to their own issues.

## What's in this PR
- **`bench/`** — the profiling harness (`python -m bench.profile_pipeline`). Regimes span trivial / roomy-multi / tight-placeholder × spread on/off; binds on `max_restarts` (not wall-clock) for reproducibility; routes via a direct `plan_fill` so the global expansion cap bounds the un-routable case; asserts **validity / path-validity / determinism** per regime and exits non-zero on failure (the seed of F6's CI gate).
- **`docs/spikes/solve-tow-profiling.md`** — the findings report.

No `src/` or `tests/` changes → no determinism/geometry-guard surface, no canary risk.

## Headline finding (overturns the issue's own premise)
"Tow-planning is the dominant cost on multi-plane fills" is **false for the default path**:

| Regime | placement | routing | |
|---|--:|--:|---|
| roomy 3-plane, spread **ON** | **40.6 s** | 0.77 s | placement = **53×** routing |
| roomy 3-plane, spread **OFF** | 0.001 s | 0.89 s | spread off → placement vanishes |

99.6 % of placement is the spread post-pass, bottlenecked on `collisions.check` → `aircraft_parts_world` rebuilding shapely polygons from scratch every call. The **same** root cause dominates routing on un-routable fills (98.7 % `_motion_clear` → **8.6 M** polygons on a 9-plane fill).

## Ranked outcome
Eight candidates, each adversarially verified by *instrumenting live code* (cache hit-rates, A\* expansion counts, bit-level float divergence):
- **BUILD (F6's one lever):** per-solve memoization of `aircraft_parts_world` — 83.8 % redundant rebuilds, **byte-identical** (verified end-to-end) → **#453** (v0.11.0).
- **Secondary, byte-identical, blocked-by #453:** AABB/circle broad-phase (**#454**), incremental `_spread` re-scoring with canonical re-sum (**#455**).
- **REJECTED by measurement:** grid-rebuild caching (0 cache hits), warm-start (0 expansions), plane-ordering (descent not the bottleneck).
- **DEFER:** A\* heuristic tie-break (breaks determinism, low payoff).

## Determinism contract (ADR-0003): **keep as-is**
Near-zero measured cost — every high-value lever (memoization, broad-phase, incremental re-scoring) is byte-identical. The only forbidden lever with headroom is parallel restarts, already an accepted v1 tradeoff; the cheaper byte-identical caching attacks the same 40 s first.

## Feeds forward
Calibration comments posted on **#403** (F6 — its "one lever" is #453, not the rejected grid-rebuild caching; `bench/` is the CI-gate substrate) and **#404** (F7 — spread post-pass confirmed as the "always ~30 s" cost; threshold calibratable from `--json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)