### PR TITLE
perf(#453): memoize aircraft_parts_world per solve (byte-identical, 2.3x placement)

### DIFF
--- a/src/hangarfit/collisions.py
+++ b/src/hangarfit/collisions.py
@@ -48,14 +48,14 @@ which plane is iterated first.
 
 from __future__ import annotations
 
-from .geometry import WorldPart, aircraft_parts_world, polygon_overlap, polygon_overlap_area
+from .geometry import WorldPart, cached_parts_world, polygon_overlap, polygon_overlap_area
 from .models import CheckResult, Conflict, Hangar, Layout
 
 
 def check(layout: Layout) -> CheckResult:
     """Run all geometric checks and return a :class:`CheckResult`."""
     world_parts: dict[str, list[WorldPart]] = {
-        p.plane_id: aircraft_parts_world(layout.fleet[p.plane_id], p) for p in layout.placements
+        p.plane_id: cached_parts_world(layout.fleet[p.plane_id], p) for p in layout.placements
     }
     conflicts: list[Conflict] = []
     conflicts.extend(_hangar_bounds_conflicts(world_parts, layout.hangar))

--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -268,6 +268,12 @@ def cached_parts_world(aircraft: Aircraft, placement: Placement) -> list[WorldPa
     scope; the returned list MUST be treated read-only (it may be shared). When
     no scope is active this delegates straight to :func:`aircraft_parts_world`,
     so non-solve callers stay byte-identical (just uncached).
+
+    Caller contract: the key omits the parts/geometry, so within one scope a
+    given ``plane_id`` must always resolve to the same aircraft geometry. That
+    holds because a single ``solve()`` is driven by one fixed ``scenario.fleet``
+    (one :class:`~hangarfit.models.Aircraft` per id) — which is exactly why the
+    cache is per-solve and never module-global.
     """
     cache = _pose_cache.get()
     if cache is None:

--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -22,6 +22,9 @@ catch any regression — see ``tests/test_geometry.py``.
 from __future__ import annotations
 
 import math
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 
 from shapely.geometry import Polygon
@@ -207,3 +210,74 @@ def aircraft_parts_world(
             )
         )
     return world_parts
+
+
+# ---------------------------------------------------------------------------
+# Per-solve memoization of aircraft_parts_world (#453)
+# ---------------------------------------------------------------------------
+#
+# The #381 profiling spike measured aircraft_parts_world as the solve→tow
+# pipeline's single cross-cutting bottleneck: it rebuilds every part polygon
+# from scratch on *every* collision/clearance check, and 83.8 % of those
+# rebuilds are for a pose already seen this solve. The cure is a per-``solve()``
+# cache, keyed on the pose, consulted at the hot call sites via
+# ``cached_parts_world`` and scoped by ``pose_cache_scope``.
+#
+# Determinism (ADR-0003): the transform above is referentially transparent, so
+# a hit returns the byte-identical WorldParts the pure function would have
+# built. WorldPart is frozen/slots and every consumer is read-only, so sharing
+# the cached objects is safe. The key uses *exact* float equality, so a
+# near-miss is a clean miss (recompute → correct), never a false hit. The cache
+# lives in a ContextVar reset on scope exit, so two sequential solves each get a
+# fresh cache and the determinism-guard's double-run stays byte-identical. It is
+# a plain unbounded dict with NO eviction — an LRU/eviction variant was rejected
+# by the spike (it can perturb basin selection), and a module-global cache would
+# return *stale* geometry if a later scenario reused a plane id for a different
+# aircraft. Hence the per-solve lifetime.
+
+# Cache key: (plane_id, x_m, y_m, heading_deg). ``on_carts`` is deliberately
+# absent — carts do not affect aircraft_parts_world, so it would be an inert
+# (dead) component of the key.
+_PoseKey = tuple[str, float, float, float]
+_pose_cache: ContextVar[dict[_PoseKey, list[WorldPart]] | None] = ContextVar(
+    "aircraft_parts_world_cache", default=None
+)
+
+
+@contextmanager
+def pose_cache_scope() -> Iterator[None]:
+    """Activate a fresh per-solve ``aircraft_parts_world`` cache for the block.
+
+    Inside the ``with`` block, :func:`cached_parts_world` memoizes by pose;
+    outside it (the default) :func:`cached_parts_world` is a pure passthrough.
+    The cache is reset on exit, so nested or sequential scopes never share
+    state — which is what keeps a double-run solve byte-identical (ADR-0003).
+    """
+    token = _pose_cache.set({})
+    try:
+        yield
+    finally:
+        _pose_cache.reset(token)
+
+
+def cached_parts_world(aircraft: Aircraft, placement: Placement) -> list[WorldPart]:
+    """Pose-memoized :func:`aircraft_parts_world` for the active solve scope.
+
+    When a :func:`pose_cache_scope` is active, the result is cached on
+    ``(plane_id, x_m, y_m, heading_deg)`` and reused for the lifetime of that
+    scope; the returned list MUST be treated read-only (it may be shared). When
+    no scope is active this delegates straight to :func:`aircraft_parts_world`,
+    so non-solve callers stay byte-identical (just uncached).
+    """
+    cache = _pose_cache.get()
+    if cache is None:
+        return aircraft_parts_world(aircraft, placement)
+    key: _PoseKey = (
+        placement.plane_id,
+        placement.x_m,
+        placement.y_m,
+        placement.heading_deg,
+    )
+    if key not in cache:
+        cache[key] = aircraft_parts_world(aircraft, placement)
+    return cache[key]

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -29,7 +29,7 @@ import time
 from typing import Literal, NamedTuple
 
 from hangarfit.collisions import check as check_layout
-from hangarfit.geometry import WorldPart, aircraft_parts_world
+from hangarfit.geometry import WorldPart, cached_parts_world, pose_cache_scope
 from hangarfit.models import (
     Aircraft,
     CheckResult,
@@ -99,6 +99,40 @@ def solve(
     ``tow_heuristic="euclidean"`` to opt out, or a larger ``tow_max_expansions``
     to widen the per-plane budget. All RNG-free, so determinism holds (ADR-0003).
     """
+    # Per-solve aircraft_parts_world memoization (#453). The #381 profile found
+    # this transform is the pipeline's hot spot, with ≈84 % of calls rebuilding
+    # an already-seen pose. Running the whole solve (placement + spread +
+    # tow-planning) inside one fresh cache collapses those rebuilds; the cache
+    # resets on exit, so a double-run stays byte-identical (ADR-0003). The body
+    # lives in `_run_solve` so this scope wraps every geometry call without a
+    # 197-line reindent.
+    with pose_cache_scope():
+        return _run_solve(
+            scenario,
+            budget_s=budget_s,
+            alternatives=alternatives,
+            seed=seed,
+            diversity=diversity,
+            search=search,
+            plan_paths=plan_paths,
+            tow_heuristic=tow_heuristic,
+            tow_max_expansions=tow_max_expansions,
+        )
+
+
+def _run_solve(
+    scenario: Scenario,
+    *,
+    budget_s: float,
+    alternatives: int,
+    seed: int | None,
+    diversity: DiversityConfig | None,
+    search: SearchConfig | None,
+    plan_paths: bool,
+    tow_heuristic: Literal["euclidean", "grid"],
+    tow_max_expansions: int | None,
+) -> SolveResult:
+    """Body of :func:`solve`, run inside an active ``pose_cache_scope`` (#453)."""
     if diversity is None:
         diversity = DiversityConfig()
     if search is None:
@@ -835,7 +869,7 @@ def _inter_plane_energy(
     if len(ids) < 2:
         return 0.0
     world: dict[str, list[WorldPart]] = {
-        pid: aircraft_parts_world(scenario.fleet[pid], placements[pid]) for pid in ids
+        pid: cached_parts_world(scenario.fleet[pid], placements[pid]) for pid in ids
     }
     w = {pid: _priority_weight(scenario, pid) for pid in ids}
     energy = 0.0
@@ -897,7 +931,7 @@ def _spread_quality(
     if len(ids) < 2:
         return (math.inf, 0.0)
     world: dict[str, list[WorldPart]] = {
-        pid: aircraft_parts_world(scenario.fleet[pid], placements[pid]) for pid in ids
+        pid: cached_parts_world(scenario.fleet[pid], placements[pid]) for pid in ids
     }
     w = {pid: _priority_weight(scenario, pid) for pid in ids}
     min_gap = math.inf

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -106,6 +106,10 @@ def solve(
     # resets on exit, so a double-run stays byte-identical (ADR-0003). The body
     # lives in `_run_solve` so this scope wraps every geometry call without a
     # 197-line reindent.
+    #
+    # Re-baselining against pre-#453 output must pin `max_restarts` (or
+    # `spread=False`): the speedup changes how many restarts fit a wall-clock
+    # `budget_s`, which #267 already scopes OUT of the byte-identical guarantee.
     with pose_cache_scope():
         return _run_solve(
             scenario,

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -34,7 +34,7 @@ from shapely.geometry import Point, Polygon
 # Importing a sibling-module private is the same pattern as `check as _check`.
 from hangarfit.collisions import _parts_conflict
 from hangarfit.collisions import check as _check
-from hangarfit.geometry import WorldPart, aircraft_parts_world
+from hangarfit.geometry import WorldPart, cached_parts_world
 from hangarfit.models import Aircraft, Conflict, Hangar, Layout, Placement
 
 SegmentKind = Literal["L", "S", "R"]
@@ -976,7 +976,7 @@ def _mover_motion_bounds_conflict(
     door_half = hangar.door.width_m / 2.0
     door_lo = hangar.door.center_x_m - door_half
     door_hi = hangar.door.center_x_m + door_half
-    for world_part in aircraft_parts_world(mover, placement):
+    for world_part in cached_parts_world(mover, placement):
         for x, y in list(world_part.polygon.exterior.coords)[:-1]:
             # Side walls + back wall (unchanged): the static rule is
             # `0 <= x <= width and 0 <= y <= length`.
@@ -1460,7 +1460,7 @@ def _build_obstacles(placed: Layout, *, mover_id: str) -> _Obstacles:
     for placement in placed.placements:
         if placement.plane_id == mover_id:
             continue
-        parts.extend(aircraft_parts_world(placed.fleet[placement.plane_id], placement))
+        parts.extend(cached_parts_world(placed.fleet[placement.plane_id], placement))
     bay = placed.hangar.maintenance_bay
     return _Obstacles(
         world_parts=tuple(parts),
@@ -1511,7 +1511,7 @@ def _motion_clear(mover: Aircraft, pose: Pose, obstacles: _Obstacles, hangar: Ha
     module note above and the safety-net re-check in :func:`plan_path`.
     """
     placement = Placement(mover.id, pose.x_m, pose.y_m, pose.heading_deg, on_carts=False)
-    mover_parts = aircraft_parts_world(mover, placement)
+    mover_parts = cached_parts_world(mover, placement)
 
     # (A) Hangar bounds (front-gap-exempt for the mover).
     if _mover_motion_bounds_conflict(mover, placement, hangar) is not None:

--- a/tests/test_parts_cache.py
+++ b/tests/test_parts_cache.py
@@ -19,6 +19,8 @@ the ``determinism-guard`` reviewer cares about:
 
 from __future__ import annotations
 
+import pytest
+
 from hangarfit.geometry import aircraft_parts_world, cached_parts_world, pose_cache_scope
 from hangarfit.models import Aircraft, Part, Placement, Wheels
 
@@ -29,7 +31,7 @@ def _probe_aircraft() -> Aircraft:
         name="Probe",
         wing_position="high",
         gear="tailwheel",
-        movement_mode="always_own_gear",  # type: ignore[arg-type]
+        movement_mode="always_own_gear",
         turn_radius_m=5.0,
         measured=False,
         parts=(
@@ -42,6 +44,18 @@ def _probe_aircraft() -> Aircraft:
                 angle_deg=0.0,
                 z_bottom_m=0.0,
                 z_top_m=1.0,
+            ),
+            # A second (wing) part so the cache tests exercise a multi-part
+            # WorldPart list, not just a single polygon.
+            Part(
+                kind="wing",
+                length_m=1.4,
+                width_m=10.0,
+                offset_x_m=0.6,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=1.0,
+                z_top_m=1.3,
             ),
         ),
         wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
@@ -123,3 +137,20 @@ def test_scope_resets_to_passthrough_on_exit() -> None:
     after_a = cached_parts_world(ac, pl)
     after_b = cached_parts_world(ac, pl)
     assert after_b is not after_a  # no active cache → uncached passthrough
+
+
+def test_scope_resets_after_exception() -> None:
+    """A raise inside the scope still resets the cache (try/finally), so a later
+    solve can never inherit a stale cache from a crashed one."""
+    ac = _probe_aircraft()
+    pl = Placement(plane_id="probe", x_m=3.0, y_m=4.0, heading_deg=30.0, on_carts=False)
+
+    class _Boom(Exception):
+        pass
+
+    with pytest.raises(_Boom), pose_cache_scope():
+        cached_parts_world(ac, pl)
+        raise _Boom
+    after_a = cached_parts_world(ac, pl)
+    after_b = cached_parts_world(ac, pl)
+    assert after_a is not after_b  # finally-reset → passthrough resumed, uncached

--- a/tests/test_parts_cache.py
+++ b/tests/test_parts_cache.py
@@ -1,0 +1,125 @@
+"""Tests for the per-solve ``aircraft_parts_world`` memoization seam (#453).
+
+The #381 profiling spike measured ``geometry.aircraft_parts_world`` as the
+single cross-cutting bottleneck (83.8 % of its calls on ``roomy_three`` are
+redundant rebuilds of an already-seen pose). The fix is a per-``solve()`` cache,
+held in a :class:`contextvars.ContextVar`, consulted by
+:func:`hangarfit.geometry.cached_parts_world` and scoped by
+:func:`hangarfit.geometry.pose_cache_scope`.
+
+These tests pin the cache's **correctness and determinism contract** — the part
+the ``determinism-guard`` reviewer cares about:
+
+* a repeated pose is a **hit** (same object back — no recompute),
+* an exact-float-different pose is a **miss** (no false hit; correct geometry),
+* outside a scope the wrapper is a pure passthrough (byte-identical, uncached),
+* each scope owns a **fresh** dict, so two sequential solves never share state
+  (this is what makes the guard's double-run byte-identical).
+"""
+
+from __future__ import annotations
+
+from hangarfit.geometry import aircraft_parts_world, cached_parts_world, pose_cache_scope
+from hangarfit.models import Aircraft, Part, Placement, Wheels
+
+
+def _probe_aircraft() -> Aircraft:
+    return Aircraft(
+        id="probe",
+        name="Probe",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",  # type: ignore[arg-type]
+        turn_radius_m=5.0,
+        measured=False,
+        parts=(
+            Part(
+                kind="fuselage_aft",
+                length_m=6.0,
+                width_m=1.0,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.0,
+            ),
+        ),
+        wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
+    )
+
+
+def _coords(parts: list) -> list:
+    """Exterior coords of every part polygon — a bit-exact geometry fingerprint."""
+    return [list(p.polygon.exterior.coords) for p in parts]
+
+
+def test_repeated_pose_is_a_cache_hit() -> None:
+    """Inside a scope, the same pose returns the *same* object (no recompute)."""
+    ac = _probe_aircraft()
+    pl = Placement(plane_id="probe", x_m=3.0, y_m=4.0, heading_deg=30.0, on_carts=False)
+    with pose_cache_scope():
+        first = cached_parts_world(ac, pl)
+        second = cached_parts_world(ac, pl)
+    assert second is first  # hit: identical object, geometry not rebuilt
+    # and it is the same geometry the pure transform produces
+    assert _coords(first) == _coords(aircraft_parts_world(ac, pl))
+
+
+def test_exact_float_different_pose_is_a_miss_not_a_false_hit() -> None:
+    """A pose nudged by 1e-12 is a distinct key → recomputed correct geometry."""
+    ac = _probe_aircraft()
+    pl = Placement(plane_id="probe", x_m=3.0, y_m=4.0, heading_deg=30.0, on_carts=False)
+    pl_nudged = Placement(
+        plane_id="probe", x_m=3.0 + 1e-12, y_m=4.0, heading_deg=30.0, on_carts=False
+    )
+    with pose_cache_scope():
+        base = cached_parts_world(ac, pl)
+        nudged = cached_parts_world(ac, pl_nudged)
+    assert nudged is not base  # exact-float key → clean miss, never a false hit
+    # the miss recomputed the *correct* geometry for the nudged pose
+    assert _coords(nudged) == _coords(aircraft_parts_world(ac, pl_nudged))
+
+
+def test_distinct_heading_is_a_miss() -> None:
+    """heading is part of the key: a different heading does not collide."""
+    ac = _probe_aircraft()
+    pl = Placement(plane_id="probe", x_m=3.0, y_m=4.0, heading_deg=30.0, on_carts=False)
+    pl_rot = Placement(plane_id="probe", x_m=3.0, y_m=4.0, heading_deg=31.0, on_carts=False)
+    with pose_cache_scope():
+        a = cached_parts_world(ac, pl)
+        b = cached_parts_world(ac, pl_rot)
+    assert b is not a
+    assert _coords(b) == _coords(aircraft_parts_world(ac, pl_rot))
+
+
+def test_passthrough_without_scope_is_pure_and_uncached() -> None:
+    """No active scope → byte-identical to the pure transform, and not cached."""
+    ac = _probe_aircraft()
+    pl = Placement(plane_id="probe", x_m=1.0, y_m=2.0, heading_deg=45.0, on_carts=False)
+    first = cached_parts_world(ac, pl)
+    second = cached_parts_world(ac, pl)
+    assert _coords(first) == _coords(aircraft_parts_world(ac, pl))
+    # no module-global caching leaks across calls when no scope is active
+    assert second is not first
+
+
+def test_each_scope_owns_a_fresh_cache() -> None:
+    """Two sequential scopes never share entries (the double-run determinism key)."""
+    ac = _probe_aircraft()
+    pl = Placement(plane_id="probe", x_m=3.0, y_m=4.0, heading_deg=30.0, on_carts=False)
+    with pose_cache_scope():
+        first = cached_parts_world(ac, pl)
+    with pose_cache_scope():
+        second = cached_parts_world(ac, pl)
+    assert second is not first  # fresh dict per scope → recomputed, no carryover
+
+
+def test_scope_resets_to_passthrough_on_exit() -> None:
+    """After a scope exits, the wrapper returns to pure passthrough (cache gone)."""
+    ac = _probe_aircraft()
+    pl = Placement(plane_id="probe", x_m=3.0, y_m=4.0, heading_deg=30.0, on_carts=False)
+    with pose_cache_scope():
+        cached_parts_world(ac, pl)
+    after_a = cached_parts_world(ac, pl)
+    after_b = cached_parts_world(ac, pl)
+    assert after_b is not after_a  # no active cache → uncached passthrough


### PR DESCRIPTION
## What & why
The [#381 profiling spike](https://github.com/DocGerd/hangarfit/blob/develop/docs/spikes/solve-tow-profiling.md) measured `geometry.aircraft_parts_world` as the solve→tow pipeline's single cross-cutting bottleneck — rebuilt from scratch on every collision/clearance check, with **~84 % of calls re-deriving an already-seen pose** (314,460 calls / 50,889 unique poses on roomy-3). The spike ratified memoization as **F6's "one cheap lever"**; this is the first step of the v0.11.0 chain (#453 → #403 CI-gate → #404 → #402).

## Mechanism — ContextVar-scoped per-solve cache
A plain per-`solve()` dict, **exact float-tuple key** `(plane_id, x_m, y_m, heading_deg)`, **no eviction**, held in a `ContextVar` and consulted via a thin `cached_parts_world` wrapper:
- **`geometry.py`** — the determinant-−1 transform is **untouched**; the caching seam (`pose_cache_scope` + `cached_parts_world`) sits beside it.
- **`solver.py`** — `solve()` runs its whole body inside one fresh scope (delegated to `_run_solve` to avoid a 197-line reindent), so placement + spread + tow-planning share one cache; reset on exit → a double-run stays byte-identical.
- **Hot call sites swapped:** `collisions.check`; `solver._inter_plane_energy`/`_spread_quality`; `towplanner._build_obstacles`/`_motion_clear` + the per-pose mover-bounds check (collapses the spike's measured 2.0× double-build). `visualize`/`scene`/`metrics` stay on the pure transform (not in the solve hot loop).

## Determinism (ADR-0003) — byte-identical
- Referentially-transparent transform → a hit returns byte-identical `WorldPart`s (frozen/slots, read-only consumers); exact-float key → a near-miss is a clean **miss**, never a false hit; plain dict / **no eviction** (an LRU variant perturbs basin selection per the spike); **per-solve lifetime** (a module-global cache could return stale geometry if a later scenario reused a plane id).
- **Verified byte-identical vs develop** at fixed `max_restarts` across seeds 1/2/3/5/7 (identical SolveResult digests; `min_gap` to full float precision). Solver/tow canaries unchanged; full non-slow suite (**1251 passed**) + the slow determinism set green.

## Bench (`python -m bench.profile_pipeline`, max_restarts-bound → reproducible)
| regime | restarts | placement before | after | speedup | valid/path/det |
|---|---|---|---|---|---|
| **roomy_three_spread_on** | 30/30 | 42.28 s | **18.72 s** | **2.3×** | ✅ |
| trivial_single | 20/20 | 0.004 s | 0.004 s | — | ✅ |
| roomy_three_spread_off | 1/1 | 0.001 s | 0.001 s | — | ✅ |

`restarts_done` unchanged (same work); validity/path/determinism verdicts unchanged.

## ⚠️ Pre-existing test note (NOT introduced here)
While running the **@slow** suite (which CI skips — it runs `-m 'not slow'`), I found `test_real_solve_spread_fallback_end_to_end` **fails identically on clean develop**: improved towability made seed=5 + spread directly tow-routable, so the ADR-0016 spread-off fallback no longer fires (empty stderr). Filed **#457** with evidence + a robust-fix proposal. It is unrelated to this byte-identical change (develop ≡ this branch at fixed `max_restarts`).

## Tests
New `tests/test_parts_cache.py`: cache hit (same object), exact-float miss (no false hit), heading-distinct miss, no-scope passthrough, fresh-cache-per-scope, scope-reset-on-exit.

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)