### PR TITLE
fix(deps): bump pip 26.1.1 → 26.1.2 (PYSEC-2026-196 / CVE-2026-8643)

### DIFF
--- a/requirements-pip-tools.txt
+++ b/requirements-pip-tools.txt
@@ -34,9 +34,9 @@ wheel==0.47.0 \
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.1 \
-    --hash=sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb \
-    --hash=sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78
+pip==26.1.2 \
+    --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
+    --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
     # via pip-tools
 setuptools==82.0.1 \
     --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \


### PR DESCRIPTION
## What
Bumps `pip` **26.1.1 → 26.1.2** in the hash-pinned bootstrap lockfile `requirements-pip-tools.txt`, clearing OpenSSF Scorecard code-scanning **alert #12** (Vulnerabilities, security-severity **high**): the project depended on a pip vulnerable to **PYSEC-2026-196 / CVE-2026-8643** (all pip `< 26.1.2`, fixed in 26.1.2; pypa/pip#14000).

## How
Regenerated with the canonical drift-guard command + `--upgrade-package pip`:
```
pip-compile --generate-hashes --no-strip-extras --allow-unsafe --upgrade-package pip \
  -o requirements-pip-tools.txt requirements-pip-tools.in
```
- 3-line diff (the pip line + its 2 hashes); **no other pin changed**.
- **Byte-stable** under the canonical (no-`--upgrade`) regen command → the `lockfile drift check` job passes.
- pip is **build-time only** (the bootstrap toolchain the lockfile-drift guards install with `--require-hashes`); the shipped wheel is unaffected.

## Verification
- `pip==26.1.2` confirmed on PyPI; hashes produced by pip-compile.
- Ran the canonical regen twice → byte-identical output (idempotent), so CI's drift guard reproduces this exact file.

The Scorecard alert auto-resolves on the next weekly Scorecard run after merge.

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)