### PR TITLE
ci(#462): Dependabot npm coverage for the viewer toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,33 @@ updates:
       prefix: "deps"
       include: "scope"
 
+  # The npm ecosystem entry covers the viewer's dev/CI-only TypeScript
+  # toolchain (viewer/package.json + viewer/package-lock.json, ADR-0020).
+  # These devDependencies are never published and never shipped in the wheel,
+  # but they still need security/version monitoring like any other lockfile.
+  - package-ecosystem: npm
+    directory: "/viewer"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "ci"]
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    # `three` and `@types/three` are pinned to 0.160.x in lockstep with the
+    # vendored three.js r160 (src/hangarfit/_viewer_assets/three/VENDOR.md).
+    # The ci.yml skew guard fails if either drifts from the vendored
+    # major.minor, so a Dependabot bump would always be un-mergeable. These
+    # are bumped by hand via the VENDOR.md vendor-bump process, not here.
+    # (The test-only `three` devDep is the same package as `three` above, so
+    # the single ignore rule covers it too.) Every other viewer devDep
+    # (esbuild, typescript, eslint, @types/node, globals, typescript-eslint,
+    # @eslint/js) stays free for Dependabot to update.
+    ignore:
+      - dependency-name: "three"
+      - dependency-name: "@types/three"
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Closes #462

## What

Adds an `npm` package-ecosystem entry to `.github/dependabot.yml` pointing at `/viewer`, so the viewer's dev/CI-only TypeScript toolchain (`viewer/package.json` + `viewer/package-lock.json`, ADR-0020) gets the same security/version monitoring the `pip` and `github-actions` ecosystems already enjoy. Previously these npm devDependencies were entirely unmonitored.

## Style match

- `directory: "/viewer"` — where the manifest + lockfile actually live.
- Weekly Monday cadence, `open-pull-requests-limit: 5`, and a `deps` commit-message prefix all mirror the existing `pip` entry.
- Labels `["dependencies", "ci"]` (matching the github-actions entry's labels for a CI-toolchain dependency).

## Why `three` and `@types/three` are under `ignore`

`viewer/package.json` pins `three`, `@types/three`, and a test-only `three` devDep to **0.160.x in lockstep with the vendored three.js r160** (`src/hangarfit/_viewer_assets/three/VENDOR.md`). The ci.yml job *"three <-> @types/three <-> three(devDep) version-skew guard"* fails if any of them drifts from the vendored major.minor. A Dependabot PR bumping `three` or `@types/three` would therefore **always** trip that guard and be un-mergeable until a coordinated, hand-done VENDOR.md vendor bump. So both are added under `ignore` with an explanatory comment. The test-only `three` devDep is the same npm package as `three`, so the single `three` ignore rule covers it too.

Every other viewer devDep (esbuild, typescript, eslint, @types/node, globals, typescript-eslint, @eslint/js) stays **free** for Dependabot to update.

YAML validated with `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)