### PR TITLE
ci(#461): CodeQL javascript-typescript analysis for viewer/ source

### DIFF
--- a/.github/codeql/javascript-typescript.yml
+++ b/.github/codeql/javascript-typescript.yml
@@ -1,0 +1,27 @@
+# CodeQL configuration for the `javascript-typescript` analysis (issue #461).
+#
+# The viewer toolchain (ADR-0020, #436) added a real TypeScript codebase under
+# `viewer/src/*.ts`, compiled by esbuild into the committed, wheel-shipped bundle
+# `src/hangarfit/_viewer_assets/viewer.js`. This config scopes CodeQL to OUR
+# source so static analysis covers the code we author, not the vendored r160
+# three.js that ships alongside it.
+#
+# `paths` / `paths-ignore` here are CodeQL's code-scanning path filters (applied
+# to interpreted / uncompiled languages such as JS/TS) — NOT the workflow's
+# `on.<push|pull_request>.paths`. They apply ONLY to this analysis, because the
+# config-file is wired to the `javascript-typescript` matrix entry alone; the
+# Python analysis carries no config-file and keeps scanning the whole repo.
+name: "hangarfit javascript-typescript"
+
+# Analyze only our hand-written viewer TypeScript source. The committed bundle
+# `src/hangarfit/_viewer_assets/viewer.js` is generated from these sources, so
+# scoping to `viewer/src` is sufficient (and avoids double-reporting on the
+# minified build output).
+paths:
+  - viewer/src
+
+# Exclude the vendored, third-party three.js (r160) that ships under the wheel's
+# assets directory — it is not our code. (It already falls outside the `paths`
+# allowlist above; this is an explicit belt-and-suspenders exclusion.)
+paths-ignore:
+  - src/hangarfit/_viewer_assets/three

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,11 +13,25 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (Python)
+    name: Analyze (${{ matrix.name }})
     runs-on: ubuntu-latest
     permissions:
       security-events: write
       actions: read
+
+    strategy:
+      # Don't let one language's failure cancel the other's analysis.
+      fail-fast: false
+      matrix:
+        include:
+          # Python: unchanged behaviour — scans the repo's Python, no path filter.
+          - language: python
+            name: Python
+          # JavaScript/TypeScript: our viewer source only (see config-file for the
+          # paths / paths-ignore scope that excludes the vendored three.js).
+          - language: javascript-typescript
+            name: JavaScript/TypeScript
+            config-file: ./.github/codeql/javascript-typescript.yml
 
     steps:
       - name: Checkout
@@ -26,9 +40,13 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
-          languages: python
+          languages: ${{ matrix.language }}
+          # Empty for the Python entry (matrix.config-file is unset there) — the
+          # init action treats an empty config-file as "no config", so Python
+          # keeps its default whole-repo scope.
+          config-file: ${{ matrix.config-file }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
-          category: "/language:python"
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes #461

## What

The viewer toolchain (ADR-0020, #436) added a real TypeScript codebase under `viewer/src/*.ts`, compiled by esbuild into the committed, wheel-shipped bundle `src/hangarfit/_viewer_assets/viewer.js`. Until now CodeQL scanned `python` only, so none of that JS/TS was covered by static analysis.

This converts the single `analyze` job into a per-language matrix:

- **python** — behaviour unchanged: no `config-file`, whole-repo Python scan, `category: /language:python`.
- **javascript-typescript** — new analysis, `category: /language:javascript-typescript`, scoped via a committed `config-file` (`.github/codeql/javascript-typescript.yml`) to our viewer source (`paths: [viewer/src]`) and explicitly excluding the vendored r160 three.js (`paths-ignore: src/hangarfit/_viewer_assets/three`).

`config-file` is wired **only** to the JS matrix entry; the Python entry resolves `${{ matrix.config-file }}` to an empty string, which the `init` action treats as "no config" (default whole-repo scope). Actions remain pinned by 40-char SHA; `init`/`analyze` reuse the existing `7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0` pin.

## Decision: preserve the required status check `Analyze (Python)`

The branch-protection **required** status check on `develop` is literally `Analyze (Python)`. Naming the matrix job `Analyze (${{ matrix.language }})` would have produced `Analyze (python)` (lowercase) and `Analyze (javascript-typescript)` — neither matches, so the required check would be orphaned and **every develop PR would block, waiting on a context that never reports**.

To satisfy "name is no longer Python-exclusive — make it per-language" (#461 req 6) without breaking the gate, the matrix carries a friendly `name` display field:

- python → `Analyze (Python)` (matches the existing required context byte-for-byte)
- javascript-typescript → `Analyze (JavaScript/TypeScript)`

`languages` and `category` still use the canonical `matrix.language` ids. The new JS analysis lands as an **additive** check. Optional follow-up for the repo admin: add `Analyze (JavaScript/TypeScript)` to the required-status-check list on `develop` once it has run green.

## Validation

- Both YAML files parse (`yaml.safe_load`).
- Full CodeQL-config correctness (path scoping, JS auto-build) is confirmed by the actual CodeQL run on this PR — expected per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)