### PR TITLE
feat(#403): F6 — always-on bench CI gate (validity + path-validity + determinism + speed)

### DIFF
--- a/.github/workflows/bench-gates.yml
+++ b/.github/workflows/bench-gates.yml
@@ -32,7 +32,15 @@ concurrency:
 jobs:
   bench-gates:
     name: bench gates (validity + path-validity + determinism + speed)
-    runs-on: ubuntu-latest
+    # Pin the runner IMAGE (not the floating `ubuntu-latest` label the rest of CI
+    # uses): this job's speed ceilings are calibrated to a specific runner class
+    # (see bench/profile_pipeline.py::_SPEED_CEILING_S), so a silent `ubuntu-latest`
+    # default bump (e.g. the 22.04 → 24.04 rollover) would shift the timing basis
+    # out from under the calibration with no committed file changing to flag it.
+    # Pinning makes a runner-class change a LOUD, deliberate event (image removed →
+    # recalibrate + bump this pin in lockstep with the ceilings). The other CI jobs
+    # are not timing-sensitive, so they stay on `ubuntu-latest`.
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 

--- a/.github/workflows/bench-gates.yml
+++ b/.github/workflows/bench-gates.yml
@@ -1,0 +1,69 @@
+name: bench gates
+
+# F6 (#403): promote the three solve→tow correctness invariants — VALIDITY,
+# PATH-VALIDITY, DETERMINISM — plus a SPEED tripwire into an always-on regression
+# gate. The substrate is the committed `bench/` harness (#381): it binds on
+# `max_restarts` (not wall-clock), so the *work* is fixed and the numbers are
+# comparable run-to-run and machine-to-machine. `--gate` runs the FAST regime set
+# and exits non-zero on any invariant failure or a per-regime speed-ceiling breach
+# (the ceilings live in bench/profile_pipeline.py::_SPEED_CEILING_S and are a
+# catastrophic-regression tripwire, not a microbenchmark — see
+# docs/spikes/solve-tow-profiling.md §"F6 — the CI gates").
+#
+# Deliberately a SEPARATE workflow from ci.yml (the Python test/lint matrix): a
+# bench regression is a distinct signal from a unit-test failure, and a separate
+# file keeps each concern independently editable. This job is NOT yet a *required*
+# status check — it runs on every develop/main PR, but the repo owner adds it to
+# branch protection's required set when ready.
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  bench-gates:
+    name: bench gates (validity + path-validity + determinism + speed)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python 3.12
+        # The single supported Python (ADR-0009) — the interpreter every other CI
+        # job runs and the one the bench numbers were calibrated against.
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-dev.txt
+            requirements-build.txt
+
+      - name: Install dev deps (hash-pinned)
+        # Same hash-pinned install dance as ci.yml's test job: the bench harness
+        # imports the runtime deps (shapely / pyyaml) via the hangarfit package.
+        run: pip install --require-hashes -r requirements-dev.txt
+
+      - name: Install build toolchain (hash-pinned)
+        run: pip install --require-hashes -r requirements-build.txt
+
+      - name: Install project (editable, no deps)
+        # MUST run after the build-toolchain install: --no-build-isolation reuses
+        # the hash-verified host setuptools/wheel rather than letting pip refetch
+        # them unpinned (mirrors ci.yml's editable install, same PEP-517 rationale).
+        run: pip install -e . --no-deps --no-build-isolation
+
+      - name: Run bench gates (fast regimes — correctness + speed)
+        # Exit non-zero on any VALIDITY / PATH-VALIDITY / DETERMINISM failure or a
+        # speed-ceiling breach. `bench/` lives outside src/ and ships in no wheel,
+        # so it is invoked as a module, not via the installed console script.
+        run: python -m bench.profile_pipeline --gate

--- a/bench/profile_pipeline.py
+++ b/bench/profile_pipeline.py
@@ -29,6 +29,81 @@ from .harness import (
 )
 from .regimes import FAST_REGIMES, REGIMES, regime_by_key
 
+# ── speed-regression tripwire ceilings (the F6/#403 CI gate) ─────────────────
+#
+# Per-regime wall-clock ceilings (seconds) enforced ONLY under ``--gate``. These
+# are a *catastrophic-regression tripwire, not a microbenchmark*: CI runs on
+# shared 2-vCPU runners with multi-x run-to-run variance, so a tight ceiling
+# would flake. The regimes bind on ``max_restarts`` (regimes.py), which fixes the
+# *work*, so the only thing that varies is machine speed — and the ceiling is set
+# with enough headroom (~2-3x the observed CI median) to absorb that while still
+# tripping on a real multi-x regression. Worked example: reverting #453's
+# ``aircraft_parts_world`` memoization roughly *doubled* ``roomy_three_spread_on``
+# placement (18.7 s → 42.3 s on the dev machine) — exactly the class of
+# accidental algorithmic regression this gate exists to catch.
+#
+# Calibration: values are sized against the ubuntu-latest runner numbers printed
+# by the ``bench gates`` workflow itself (see docs/spikes/solve-tow-profiling.md,
+# §"F6 — the CI gates"). Recalibrate — and only then — when the regimes change,
+# the lever set changes, or GitHub changes the runner class. The gate refuses to
+# run a regime that has no ceiling defined (see ``_evaluate_gate``) so a newly
+# added regime can never silently escape the speed check.
+_SPEED_CEILING_S: dict[str, float] = {
+    "trivial_single": 10.0,
+    "roomy_three_spread_on": 90.0,
+    "roomy_three_spread_off": 20.0,
+}
+
+
+def _evaluate_gate(results: list[RegimeResult]) -> list[str]:
+    """Return a list of human-readable gate failures (empty == gate passes).
+
+    Enforces all three correctness invariants (validity / path-validity /
+    determinism — already reflected in each ``RegimeResult``) *plus* the speed
+    ceiling. A regime with no ceiling defined is itself a failure, so the gate
+    targets exactly the fast set and a new regime cannot slip past the speed
+    check unnoticed.
+    """
+    failures: list[str] = []
+    for r in results:
+        if not r.layouts_valid:
+            failures.append(f"{r.key}: VALIDITY — a layout did not score (0, 0.0)")
+        if not r.paths_valid:
+            failures.append(f"{r.key}: PATH-VALIDITY — a committed tow arc conflicts")
+        if not r.deterministic:
+            failures.append(f"{r.key}: DETERMINISM — second run digest differed")
+        ceiling = _SPEED_CEILING_S.get(r.key)
+        if ceiling is None:
+            failures.append(
+                f"{r.key}: NO SPEED CEILING defined — add one to "
+                "bench/profile_pipeline.py::_SPEED_CEILING_S (the gate targets the fast set)"
+            )
+        elif r.total_s > ceiling:
+            failures.append(f"{r.key}: SPEED — {r.total_s:.1f}s exceeds the {ceiling:.1f}s ceiling")
+    return failures
+
+
+def _print_gate_summary(results: list[RegimeResult], failures: list[str]) -> None:
+    """Print a PASS/FAIL gate summary to stderr (keeps --json stdout clean)."""
+    print("\n── bench gate (validity + path-validity + determinism + speed) ──", file=sys.stderr)
+    for r in results:
+        ceiling = _SPEED_CEILING_S.get(r.key)
+        budget = (
+            f"{r.total_s:.2f}s / {ceiling:.0f}s" if ceiling is not None else f"{r.total_s:.2f}s / —"
+        )
+        print(
+            f"  {r.key:<24} valid={_ok(r.layouts_valid).strip():<4} "
+            f"paths={_ok(r.paths_valid).strip():<4} det={_ok(r.deterministic).strip():<4} "
+            f"speed[{budget}]",
+            file=sys.stderr,
+        )
+    if failures:
+        print("\nGATE FAILED:", file=sys.stderr)
+        for f in failures:
+            print(f"  ✗ {f}", file=sys.stderr)
+    else:
+        print("\nGATE PASSED", file=sys.stderr)
+
 
 def _ok(flag: bool) -> str:
     return "ok  " if flag else "FAIL"
@@ -96,6 +171,13 @@ def main(argv: list[str] | None = None) -> int:
         help="also print a cProfile stage breakdown per regime",
     )
     ap.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    ap.add_argument(
+        "--gate",
+        action="store_true",
+        help="enforce the F6 CI gate: the three correctness invariants PLUS the "
+        "per-regime speed ceilings; exit non-zero on any failure. Used by the "
+        "bench-gates workflow; targets the fast regime set.",
+    )
     args = ap.parse_args(argv)
 
     if args.regime:
@@ -141,7 +223,16 @@ def main(argv: list[str] | None = None) -> int:
             for r in regimes:
                 _print_profile(r.key)
 
-    # Exit non-zero if any correctness invariant failed — the seed of the F6 gate.
+    if args.gate:
+        # F6 CI gate: enforce correctness invariants AND the speed ceilings.
+        # Summary goes to stderr so it never corrupts --json on stdout.
+        failures = _evaluate_gate(results)
+        _print_gate_summary(results, failures)
+        return 0 if not failures else 1
+
+    # Default (non-gate) behaviour: exit non-zero only on a correctness invariant
+    # failure — the seed the F6 gate builds on. Speed is reported, never enforced,
+    # so the profiling tool stays usable on a slow or loaded dev machine.
     ok = all(r.layouts_valid and r.paths_valid and r.deterministic for r in results)
     return 0 if ok else 1
 

--- a/bench/profile_pipeline.py
+++ b/bench/profile_pipeline.py
@@ -33,24 +33,32 @@ from .regimes import FAST_REGIMES, REGIMES, regime_by_key
 #
 # Per-regime wall-clock ceilings (seconds) enforced ONLY under ``--gate``. These
 # are a *catastrophic-regression tripwire, not a microbenchmark*: CI runs on
-# shared 2-vCPU runners with multi-x run-to-run variance, so a tight ceiling
-# would flake. The regimes bind on ``max_restarts`` (regimes.py), which fixes the
-# *work*, so the only thing that varies is machine speed — and the ceiling is set
-# with enough headroom (~2-3x the observed CI median) to absorb that while still
-# tripping on a real multi-x regression. Worked example: reverting #453's
-# ``aircraft_parts_world`` memoization roughly *doubled* ``roomy_three_spread_on``
-# placement (18.7 s → 42.3 s on the dev machine) — exactly the class of
-# accidental algorithmic regression this gate exists to catch.
+# shared GitHub-hosted runners with multi-x run-to-run variance, so a tight
+# ceiling would flake. The regimes bind on ``max_restarts`` (regimes.py), which
+# fixes the *work*, so the only thing that varies is machine speed — and each
+# ceiling carries enough headroom to absorb that while still tripping on a real
+# multi-x regression.
 #
-# Calibration: values are sized against the ubuntu-latest runner numbers printed
-# by the ``bench gates`` workflow itself (see docs/spikes/solve-tow-profiling.md,
-# §"F6 — the CI gates"). Recalibrate — and only then — when the regimes change,
-# the lever set changes, or GitHub changes the runner class. The gate refuses to
-# run a regime that has no ceiling defined (see ``_evaluate_gate``) so a newly
-# added regime can never silently escape the speed check.
+# Calibration (2026-06-06, ubuntu-24.04 GitHub-hosted runner, as measured by the
+# ``bench gates`` workflow itself): trivial_single 0.6 s, roomy_three_spread_on
+# 54.6 s, roomy_three_spread_off 2.7 s. The binding ceiling is
+# ``roomy_three_spread_on`` at 100 s (~1.8x the CI median): it trips on the
+# canonical regression — reverting #453's ``aircraft_parts_world`` memoization,
+# which ~2.3x'd that regime's placement (18.7 s → 42.3 s on the dev machine, i.e.
+# ~123 s on this runner) — while tolerating ordinary CI variance. The two tiny
+# regimes keep deliberately generous absolute ceilings: their absolute times are
+# small enough that proportional jitter is larger, and they exist to catch a
+# catastrophic blow-up (e.g. spread-OFF losing its 1-restart early-exit), not to
+# police drift.
+#
+# Recalibrate — and only then — when the regimes change, the lever set changes,
+# or GitHub changes the runner class; re-confirm the ceiling still trips on a
+# memoization-revert. The gate refuses to run a regime that has no ceiling defined
+# (see ``_evaluate_gate``) so a newly added regime can never silently escape it.
+# See docs/spikes/solve-tow-profiling.md §"F6 — the CI gates".
 _SPEED_CEILING_S: dict[str, float] = {
     "trivial_single": 10.0,
-    "roomy_three_spread_on": 90.0,
+    "roomy_three_spread_on": 100.0,
     "roomy_three_spread_off": 20.0,
 }
 

--- a/docs/spikes/solve-tow-profiling.md
+++ b/docs/spikes/solve-tow-profiling.md
@@ -303,15 +303,23 @@ fixed and the only thing that varies is machine speed, so a generous absolute
 ceiling is a sound, low-flake design. A regime with no ceiling defined is itself a
 gate failure, so a newly added regime cannot silently escape the speed check.
 
-| Regime (fast set) | dev `total_s` (post-#453) | ceiling | headroom |
-|---|---:|---:|---:|
-| `trivial_single` | ~0.2 s | 10 s | catastrophic-only |
-| `roomy_three_spread_on` | ~19 s | 90 s | ~2× the expected CI median |
-| `roomy_three_spread_off` | ~0.9 s | 20 s | catastrophic-only |
+| Regime (fast set) | dev `total_s` (post-#453) | CI median (ubuntu-24.04) | ceiling | headroom |
+|---|---:|---:|---:|---|
+| `trivial_single` | ~0.2 s | 0.6 s | 10 s | catastrophic-only |
+| `roomy_three_spread_on` | ~19 s | **54.6 s** | **100 s** | ~1.8× the CI median |
+| `roomy_three_spread_off` | ~0.9 s | 2.7 s | 20 s | catastrophic-only |
+
+The binding ceiling is `roomy_three_spread_on`. At 100 s it trips on the canonical
+regression — reverting #453's memoization ~2.3×'d that regime's placement, i.e.
+~123 s on this runner — while leaving ~1.8× headroom over the CI median for
+ordinary run-to-run variance. The two tiny regimes keep generous absolute ceilings:
+their small absolute times make proportional jitter larger, so they police a
+catastrophic blow-up (e.g. spread-OFF losing its 1-restart early-exit), not drift.
 
 > **Calibration:** ceilings are sized against the wall-clock the `bench gates`
-> job itself reports on `ubuntu-latest`. Recalibrate only when the regimes change,
-> the lever set changes, or GitHub changes the runner class — and re-confirm the
+> job itself reports on the GitHub-hosted runner (the numbers above were measured
+> on `ubuntu-24.04`, 2026-06-06). Recalibrate only when the regimes change, the
+> lever set changes, or GitHub changes the runner class — and re-confirm the
 > ceiling still trips on a memoization-revert (the canonical regression).
 
 ### What F6 deliberately did NOT do

--- a/docs/spikes/solve-tow-profiling.md
+++ b/docs/spikes/solve-tow-profiling.md
@@ -268,6 +268,63 @@ preserving float-summation order in the penetration and energy accumulators.
 
 ---
 
+## F6 — the CI gates (#403)
+
+This spike's harness was always meant to graduate from a one-off measurement into
+an **always-on regression gate** — the single highest-leverage artifact #403/F6
+called for ("correctness is not currently a guarded number"). That graduation now
+ships:
+
+- **The one measured lever** the table pre-committed to — per-solve memoization of
+  `aircraft_parts_world` ([#453](https://github.com/DocGerd/hangarfit/issues/453))
+  — landed byte-identical (2.3× placement on `roomy_three_spread_on`, 42.3 s →
+  18.7 s on the dev machine). That is F6's "exactly one cheap lever"; the broad-phase
+  ([#454](https://github.com/DocGerd/hangarfit/issues/454)) and incremental-`_spread`
+  ([#455](https://github.com/DocGerd/hangarfit/issues/455)) follow-ups stay backlog
+  until re-measured against the post-#453 baseline.
+- **The gate.** A dedicated `.github/workflows/bench-gates.yml` runs
+  `python -m bench.profile_pipeline --gate` on the **fast** regime set on every
+  develop/main PR. `--gate` enforces, and exits non-zero on, four things:
+  **VALIDITY** (every layout scores `(0, 0.0)`), **PATH-VALIDITY** (every committed
+  arc passes `path_first_conflict` at 0.05 m / 1°), **DETERMINISM** (a second run is
+  byte-identical), and **SPEED** (each regime's wall-clock stays under a per-regime
+  ceiling). The first three were already enforced by the harness's exit code since
+  #381; F6 adds the speed ceiling and the workflow.
+
+### The speed gate is a tripwire, not a microbenchmark
+
+The ceilings live in `bench/profile_pipeline.py::_SPEED_CEILING_S` and are
+deliberately **generous**. CI runs on shared 2-vCPU runners with multi-x
+run-to-run variance, so a tight ceiling would flake; the gate's job is to catch a
+**catastrophic, multi-x regression** — e.g. someone reverting #453's memoization,
+which roughly *doubles* `roomy_three_spread_on` placement — not to police a 20 %
+drift. Because the regimes bind on `max_restarts` (not wall-clock), the *work* is
+fixed and the only thing that varies is machine speed, so a generous absolute
+ceiling is a sound, low-flake design. A regime with no ceiling defined is itself a
+gate failure, so a newly added regime cannot silently escape the speed check.
+
+| Regime (fast set) | dev `total_s` (post-#453) | ceiling | headroom |
+|---|---:|---:|---:|
+| `trivial_single` | ~0.2 s | 10 s | catastrophic-only |
+| `roomy_three_spread_on` | ~19 s | 90 s | ~2× the expected CI median |
+| `roomy_three_spread_off` | ~0.9 s | 20 s | catastrophic-only |
+
+> **Calibration:** ceilings are sized against the wall-clock the `bench gates`
+> job itself reports on `ubuntu-latest`. Recalibrate only when the regimes change,
+> the lever set changes, or GitHub changes the runner class — and re-confirm the
+> ceiling still trips on a memoization-revert (the canonical regression).
+
+### What F6 deliberately did NOT do
+
+Per #403's escalation gate, the profile pointed at a **cheap** lever (#453), so F6
+shipped it inside this milestone. Had the cheapest sufficient lever been XL (a
+warm-start packer, an incremental collision check — both CUT as
+over-engineered / determinism-fragile), that would have become a separate go/no-go
+milestone decision, not an auto-build. The determinism contract (ADR-0003) is
+**unchanged**: the gate *enforces* byte-identity rather than relaxing it.
+
+---
+
 ## Out of scope (unchanged from #381)
 
 Implementing the speedups (each is its own follow-up issue), CNN approaches


### PR DESCRIPTION
## What

Promotes the `bench/` harness's three correctness invariants — plus a new **speed** tripwire — into an always-on CI regression gate, completing **F6** (#403, milestone v0.11.0).

- **`bench/profile_pipeline.py --gate`** — enforces, and exits non-zero on, four things over the **fast** regime set:
  - **VALIDITY** — every returned layout scores `(0, 0.0)` under `collisions.check`
  - **PATH-VALIDITY** — every committed tow arc passes `path_first_conflict` at 0.05 m / 1°
  - **DETERMINISM** — a second run yields a byte-identical layout + plan digest (ADR-0003, `max_restarts`-scoped)
  - **SPEED** — each regime's wall-clock stays under a per-regime ceiling (`_SPEED_CEILING_S`)

  The first three were already exit-coded by the harness since #381; F6 adds the speed ceiling. A regime with **no** ceiling defined is itself a gate failure, so a newly added regime can never silently escape the speed check.

- **`.github/workflows/bench-gates.yml`** — runs `python -m bench.profile_pipeline --gate` on every `develop`/`main` PR (and push). Deliberately a **separate** workflow from `ci.yml` (a bench regression is a distinct signal from a unit-test failure, and it keeps this file-disjoint from the `ci.yml`-touching PR #465).

## The speed gate is a tripwire, not a microbenchmark

Ceilings are **generous on purpose**. CI runs on shared 2-vCPU runners with multi-x run-to-run variance, so a tight ceiling would flake. The regimes bind on `max_restarts` (not wall-clock), so the *work* is fixed and only machine speed varies — making a generous absolute ceiling a sound, low-flake design. The gate's job is to catch a **catastrophic, multi-x regression** (e.g. reverting #453's `aircraft_parts_world` memoization, which roughly *doubles* `roomy_three_spread_on` placement), not a 20 % drift. Full rationale + calibration table: `docs/spikes/solve-tow-profiling.md` §"F6 — the CI gates".

## F6 scope notes

- The **one measured cheap lever** F6 pre-committed to — #453 memoization — already shipped byte-identical (2.3× placement). F6 here is the *gates* half.
- **determinism-guard trivially passes**: no `solver.py` / `towplanner.py` changes; solver/tow canaries untouched.
- This workflow is **not yet a required status check** — it runs on every PR; the repo owner adds it to branch protection when ready.

## Verification

- `python -m bench.profile_pipeline --gate` → **GATE PASSED** locally (trivial_single 0.2s/10s, roomy_three_spread_on 19.2s/90s, roomy_three_spread_off 0.9s/20s).
- Gate failure paths unit-checked: speed breach, each correctness invariant, and the missing-ceiling guard all flag correctly.
- ⚠️ **Ceilings will be recalibrated** against the first `bench gates` CI run's actual ubuntu-latest numbers (and the doc table updated) before this is ready.

Closes #403