### PR TITLE
feat(solver): promote spread-off tow fallback into library solve() (#402 / F5)

### DIFF
--- a/docs/adr/0016-spread-towability-fallback.md
+++ b/docs/adr/0016-spread-towability-fallback.md
@@ -5,6 +5,28 @@
 - **Date:** 2026-06-02
 - **Deciders:** Patrick Kuhn (DocGerd)
 
+> **2026-06-06 amendment ([#402](https://github.com/DocGerd/hangarfit/issues/402) / F5 — promoted into the library `solve()`).**
+> The fallback below originally lived entirely in the CLI (`cmd_solve`) — as the
+> title and "Decision Outcome" still read. #402 moved it **into the library
+> `hangarfit.solver.solve()`** so that *every* caller of `solve(plan_paths=True)`,
+> not just the CLI, gets the tow-routable arrangement: a non-CLI caller previously
+> bypassed the rescue and got a tow-hostile, spread-maximized layout (routable from
+> the CLI, un-routable from the library — an inconsistency). The decision, trigger,
+> guard, and determinism argument are unchanged; only the **layer** moved:
+> - The trigger now fires inside `solve()` when `plan_paths=True`, the effective
+>   `search.spread` is on, the layout(s) are valid, and every plan is `None`.
+> - The re-solve uses `dataclasses.replace(effective_search, spread=False)` rather
+>   than a fresh `SearchConfig(spread=False)`, so it **inherits the caller's
+>   `max_restarts`** (deterministic, not wall-clock-bound). The carried
+>   `back_bias_weight` is inert with spread off, so the result is unchanged for the
+>   CLI's parameter regime.
+> - The swap is now a **solver fact** recorded on the new
+>   `SolverDiagnostics.spread_fallback_applied` field. The CLI no longer
+>   orchestrates the two passes; it reads that flag for the stderr note and the
+>   `--json` / `--write-yaml` provenance.
+> - **Seed-once** now happens in `solve()` (not `cmd_solve`), so the shared-seed
+>   determinism property holds for direct library callers too.
+
 ## Context & Problem Statement
 
 `hangarfit solve --render-paths` should produce "a valid layout **plus** a valid

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import secrets
 import sys
 from typing import TYPE_CHECKING
 
@@ -570,19 +569,11 @@ def cmd_solve(args: argparse.Namespace) -> int:
     # plan_paths=False: the library bundle (SolveResult.plans) is available to
     # callers, but the CLI would just pay the per-plane Hybrid-A* search cost
     # for output it never draws.
-    #
-    # Resolve the seed ONCE here (rather than letting each solve() call draw its
-    # own from system entropy when --seed is omitted) so the spread run and any
-    # no-spread fallback share an identical, reproducible seed. This keeps the
-    # ADR-0003 determinism contract intact across the two-pass fallback: a given
-    # --seed (or a given resolved entropy seed) yields the same fallback result.
-    resolved_seed = args.seed if args.seed is not None else secrets.randbits(32)
-
     result = solve(
         scenario,
         budget_s=args.budget,
         alternatives=args.alternatives,
-        seed=resolved_seed,
+        seed=args.seed,
         search=SearchConfig(
             spread=args.spread,
             back_bias_weight=_BACK_FILL_DEFAULT_WEIGHT if args.back_fill else 0.0,
@@ -592,52 +583,23 @@ def cmd_solve(args: argparse.Namespace) -> int:
         tow_max_expansions=args.tow_max_expansions,
     )
 
-    # #280 — spread-vs-towability fallback. The ADR-0008 spread post-pass
-    # (default ON) maximizes inter-plane gaps, which can push planes into
-    # positions the bounded tow planner (towplanner._MAX_EXPANSIONS) can no
-    # longer thread from the door cone: every plan comes back None and
-    # --render-paths would return a bare exit 3 ("untowable") — even though the
-    # SAME fleet+hangar routes cleanly with spread off. When the user did NOT
-    # explicitly pass --no-spread, automatically RE-SOLVE with spread disabled,
-    # tow-plan that, and — only if it actually routes at least one candidate —
-    # render the routable (tighter) arrangement instead. The swap is always
-    # reported on stderr (never silent: the user gets a different, tighter
-    # layout than a plain spread solve would yield). If the no-spread re-solve
-    # also routes nothing (genuinely too tight, e.g. the placeholder hangar),
-    # keep the original spread result so exit 3 stands unchanged.
-    #
-    # ``spread_fallback_applied`` records whether the swap actually executed.
-    # Non-interactive consumers (--json, --write-yaml) need a durable signal
-    # that a tighter no-spread arrangement was substituted (#280 "never silently
-    # swapped" for machines, not just the human stderr note).
-    spread_fallback_applied = False
-    if (
-        args.render_paths
-        and args.spread
-        and result.layouts
-        and all(plan is None for plan in result.plans)
-    ):
-        fallback = solve(
-            scenario,
-            budget_s=args.budget,
-            alternatives=args.alternatives,
-            seed=resolved_seed,
-            search=SearchConfig(spread=False),
-            plan_paths=True,
-            tow_heuristic=args.tow_heuristic,
-            tow_max_expansions=args.tow_max_expansions,
+    # Spread-vs-towability fallback (#280 → #402 / F5; ADR-0016). The re-solve
+    # that swaps in a tighter, tow-routable no-spread arrangement when the spread
+    # layout is valid-but-unroutable now lives in the library ``solve()`` so
+    # every caller benefits, not just the CLI. The CLI just SURFACES it: report
+    # the swap on stderr (never silent — the user gets a different, tighter
+    # layout than a plain spread solve would yield) and thread the durable flag
+    # into --json / --write-yaml so non-interactive consumers can rely on it.
+    spread_fallback_applied = result.diagnostics.spread_fallback_applied
+    if spread_fallback_applied:
+        print(
+            "note: layout un-routable with inter-plane spread; re-solved "
+            "with spread disabled to produce tow paths",
+            file=sys.stderr,
         )
-        if fallback.layouts and any(plan is not None for plan in fallback.plans):
-            print(
-                "note: layout un-routable with inter-plane spread; re-solved "
-                "with spread disabled to produce tow paths",
-                file=sys.stderr,
-            )
-            result = fallback
-            spread_fallback_applied = True
 
     if args.json:
-        _emit_solve_json(args.scenario, result, spread_fallback_applied=spread_fallback_applied)
+        _emit_solve_json(args.scenario, result)
     else:
         _emit_solve_human(result, alternatives=args.alternatives)
 
@@ -873,16 +835,14 @@ def _check_result_to_dict(result: CheckResult) -> dict:
 def _emit_solve_json(
     scenario_path: str,
     result: SolveResult,
-    *,
-    spread_fallback_applied: bool = False,
 ) -> None:
     """Write the hangarfit.solve/v1 payload to stdout.
 
-    ``spread_fallback_applied`` is threaded in from ``cmd_solve`` rather than
-    read off ``SolverDiagnostics`` — the swap is a CLI-level decision (#280),
-    not a solver fact, so it does not belong on ``SolverDiagnostics``. It is
-    emitted as an always-present (default False) additive diagnostics field so
-    non-interactive consumers can rely on it without a schema bump.
+    ``spread_fallback_applied`` is read straight off ``SolverDiagnostics``:
+    since #402 / F5 the spread-off re-solve is a library ``solve()`` decision
+    (not a CLI one), so it is a genuine solver fact recorded on the result. It
+    is emitted as an always-present (default False) additive diagnostics field
+    so non-interactive consumers can rely on it without a schema bump.
     """
     d = result.diagnostics
     payload = {
@@ -911,11 +871,11 @@ def _emit_solve_json(
             # choose from. Backward-compatible — no schema bump.
             "min_pairwise_gap_m": [g if math.isfinite(g) else None for g in d.min_pairwise_gap_m],
             "valid_basins_found": d.valid_basins_found,
-            # Additive (#280): True when --render-paths re-solved with spread
-            # disabled and substituted that tighter, tow-routable arrangement.
-            # Always present (False in the normal no-swap case) so consumers can
-            # rely on it. Backward-compatible — no schema bump.
-            "spread_fallback_applied": spread_fallback_applied,
+            # Additive (#280 → #402 / F5): True when solve() re-solved with
+            # spread disabled and substituted that tighter, tow-routable
+            # arrangement. Always present (False in the normal no-swap case) so
+            # consumers can rely on it. Backward-compatible — no schema bump.
+            "spread_fallback_applied": d.spread_fallback_applied,
         },
     }
     print(json.dumps(payload, indent=2))

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -840,9 +840,9 @@ def _emit_solve_json(
 
     ``spread_fallback_applied`` is read straight off ``SolverDiagnostics``:
     since #402 / F5 the spread-off re-solve is a library ``solve()`` decision
-    (not a CLI one), so it is a genuine solver fact recorded on the result. It
-    is emitted as an always-present (default False) additive diagnostics field
-    so non-interactive consumers can rely on it without a schema bump.
+    (not a CLI one), so it is a genuine solver fact recorded on the result. See
+    the ``SolverDiagnostics`` docstring for its always-present / no-schema-bump
+    contract.
     """
     d = result.diagnostics
     payload = {

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -842,6 +842,15 @@ class SolverDiagnostics:
     (no pairs). ``valid_basins_found`` is the number of valid spread-polished
     basins the search collected before selection — how much choice best-of-all
     had. Both are advisory.
+
+    ``spread_fallback_applied`` is ``True`` when :func:`hangarfit.solver.solve`
+    re-solved with the inter-plane spread post-pass disabled and substituted
+    that tighter, tow-routable arrangement because the spread layout(s) came
+    back valid but un-routable under ``plan_paths=True`` (the ADR-0016 / #280
+    fallback, promoted into the library in #402 / F5). Always present (``False``
+    in the normal no-swap case) so non-interactive consumers can rely on it.
+    Advisory: the swap changes *which* valid layout is returned, never *whether*
+    it is valid — it does not affect ``status``.
     """
 
     restarts_attempted: int
@@ -854,6 +863,7 @@ class SolverDiagnostics:
     unroutable_planes: tuple[str, ...] = ()
     min_pairwise_gap_m: tuple[float, ...] = ()
     valid_basins_found: int = 0
+    spread_fallback_applied: bool = False
 
     def __post_init__(self) -> None:
         if (self.best_partial is None) != (self.best_partial_layout is None):

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -26,6 +26,7 @@ import random as _random_module
 import secrets
 import sys
 import time
+from dataclasses import replace
 from typing import Literal, NamedTuple
 
 from hangarfit.collisions import check as check_layout
@@ -99,29 +100,76 @@ def solve(
     ``tow_heuristic="euclidean"`` to opt out, or a larger ``tow_max_expansions``
     to widen the per-plane budget. All RNG-free, so determinism holds (ADR-0003).
     """
+    # Resolve seed and search ONCE here, above the (possible) two-pass fallback
+    # below, so both passes share an identical, reproducible seed (#402 / F5):
+    # without this, a ``seed=None`` caller would draw a *different* entropy seed
+    # for each pass, making the fallback non-reproducible. A concrete seed
+    # passed down makes ``_run_solve``'s own resolution a pass-through.
+    resolved_seed = seed if seed is not None else secrets.randbits(32)
+    effective_search = search if search is not None else SearchConfig()
+
     # Per-solve aircraft_parts_world memoization (#453). The #381 profile found
     # this transform is the pipeline's hot spot, with ≈84 % of calls rebuilding
     # an already-seen pose. Running the whole solve (placement + spread +
     # tow-planning) inside one fresh cache collapses those rebuilds; the cache
     # resets on exit, so a double-run stays byte-identical (ADR-0003). The body
     # lives in `_run_solve` so this scope wraps every geometry call without a
-    # 197-line reindent.
+    # 197-line reindent. Both fallback passes share the one scope — the cache is
+    # a pure memo of a pure transform, so a warm cache changes speed, not values.
     #
     # Re-baselining against pre-#453 output must pin `max_restarts` (or
     # `spread=False`): the speedup changes how many restarts fit a wall-clock
     # `budget_s`, which #267 already scopes OUT of the byte-identical guarantee.
     with pose_cache_scope():
-        return _run_solve(
+        result = _run_solve(
             scenario,
             budget_s=budget_s,
             alternatives=alternatives,
-            seed=seed,
+            seed=resolved_seed,
             diversity=diversity,
-            search=search,
+            search=effective_search,
             plan_paths=plan_paths,
             tow_heuristic=tow_heuristic,
             tow_max_expansions=tow_max_expansions,
         )
+
+        # Spread-vs-towability fallback (#280 → #402 / F5; ADR-0016). The
+        # ADR-0008 spread post-pass (default ON) maximizes inter-plane gaps,
+        # which can push planes into positions the bounded tow planner can no
+        # longer thread from the door cone: every plan comes back ``None`` even
+        # though the SAME fleet+hangar routes cleanly with spread off. When the
+        # caller asked for tow plans, kept spread on, and got valid-but-unroutable
+        # layout(s), re-solve once with spread disabled and prefer the routable
+        # (tighter) arrangement. The re-solve inherits ``effective_search`` with
+        # only ``spread`` flipped off — so it keeps the caller's ``max_restarts``
+        # (deterministic, NOT wall-clock-bound; carried ``back_bias_weight`` is
+        # inert with spread off). RNG-free re-selection: changes WHICH valid
+        # layout is returned, never WHETHER it is valid (the ``(0, 0.0)`` gate is
+        # untouched), so determinism holds end-to-end (ADR-0003).
+        if (
+            plan_paths
+            and effective_search.spread
+            and result.layouts
+            and all(plan is None for plan in result.plans)
+        ):
+            fallback = _run_solve(
+                scenario,
+                budget_s=budget_s,
+                alternatives=alternatives,
+                seed=resolved_seed,
+                diversity=diversity,
+                search=replace(effective_search, spread=False),
+                plan_paths=True,
+                tow_heuristic=tow_heuristic,
+                tow_max_expansions=tow_max_expansions,
+            )
+            if fallback.layouts and any(plan is not None for plan in fallback.plans):
+                return replace(
+                    fallback,
+                    diagnostics=replace(fallback.diagnostics, spread_fallback_applied=True),
+                )
+
+        return result
 
 
 def _run_solve(

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -643,7 +643,7 @@ class TestSolveRenderPaths:
         )
 
     @staticmethod
-    def _result(status, layouts, plans, unroutable=()):
+    def _result(status, layouts, plans, unroutable=(), spread_fallback_applied=False):
         from hangarfit.models import SolverDiagnostics, SolveResult
 
         diag = SolverDiagnostics(
@@ -653,6 +653,7 @@ class TestSolveRenderPaths:
             best_partial_layout=None,
             seed=42,
             unroutable_planes=unroutable,
+            spread_fallback_applied=spread_fallback_applied,
         )
         return SolveResult(status=status, layouts=layouts, plans=plans, diagnostics=diag)
 
@@ -886,12 +887,16 @@ class TestSolveRenderPaths:
 
 class TestSolveRenderPathsSpreadFallback:
     """`--render-paths` auto-falls-back to no-spread when the spread layout is
-    un-routable (#280). Two individually-correct features (ADR-0008 spread,
-    bounded tow planner) compose into a worse default: spread pushes planes into
-    positions the bounded Hybrid-A* can no longer thread, so every plan is None
-    and the CLI returns a bare exit 3 — even though the same fleet+hangar routes
-    cleanly with spread off. The CLI re-solves with spread disabled, reports the
-    swap on stderr, and renders the routable arrangement instead.
+    un-routable (#280 → #402 / F5). Two individually-correct features (ADR-0008
+    spread, bounded tow planner) compose into a worse default: spread pushes
+    planes into positions the bounded Hybrid-A* can no longer thread, so every
+    plan is None — even though the same fleet+hangar routes cleanly with spread
+    off. Since #402 the spread-off re-solve lives in the library ``solve()`` (so
+    every caller benefits, not just the CLI); the orchestration is pinned in
+    ``tests/test_solver_tow_fallback.py``. These tests assert the **CLI's** half:
+    it surfaces ``diagnostics.spread_fallback_applied`` — reports the swap on
+    stderr (never silent), threads the flag into --json / --write-yaml, and maps
+    a no-swap un-routable result to exit 3.
     """
 
     @staticmethod
@@ -912,7 +917,7 @@ class TestSolveRenderPathsSpreadFallback:
         )
 
     @staticmethod
-    def _result(status, layouts, plans, unroutable=()):
+    def _result(status, layouts, plans, unroutable=(), spread_fallback_applied=False):
         from hangarfit.models import SolverDiagnostics, SolveResult
 
         diag = SolverDiagnostics(
@@ -922,6 +927,7 @@ class TestSolveRenderPathsSpreadFallback:
             best_partial_layout=None,
             seed=42,
             unroutable_planes=unroutable,
+            spread_fallback_applied=spread_fallback_applied,
         )
         return SolveResult(status=status, layouts=layouts, plans=plans, diagnostics=diag)
 
@@ -948,21 +954,20 @@ class TestSolveRenderPathsSpreadFallback:
         monkeypatch.setattr(solver_mod, "solve", fake_solve)
         return calls
 
-    def test_spread_unroutable_falls_back_to_no_spread_and_routes(
+    def test_cli_surfaces_swap_note_and_renders_when_fallback_applied(
         self, tmp_path, monkeypatch, capsys
     ):
-        # Spread layout un-routable (all-None) -> re-solve with spread off,
-        # which routes -> exit 0, paths rendered, swap reported on stderr.
+        # The library solve() already swapped in a routable no-spread layout
+        # (diagnostics.spread_fallback_applied=True). The CLI must report the
+        # swap on stderr (never silent, #280), render, and exit 0. One solve()
+        # call now — the library owns the two-pass orchestration (#402 / F5).
         from hangarfit.models import SearchConfig
 
         layout = self._layout()
         plan = self._plan(layout)
         calls = self._patch_solve_sequence(
             monkeypatch,
-            [
-                self._result("found", (layout,), (None,), unroutable=("fuji",)),
-                self._result("found", (layout,), (plan,)),
-            ],
+            [self._result("found", (layout,), (plan,), spread_fallback_applied=True)],
         )
         out = tmp_path / "p.png"
         rc = main(["solve", SMOKE_FIXTURE, "--render", str(out), "--render-paths", "--seed", "5"])
@@ -970,17 +975,16 @@ class TestSolveRenderPathsSpreadFallback:
         err = capsys.readouterr().err
         # The swap is reported, never silent (#280 acceptance).
         assert "spread" in err and "re-solved" in err
-        # Two solve() calls: spread ON, then the fallback with spread OFF.
-        assert len(calls) == 2
+        # One solve() call — the spread-off re-solve happens inside the library.
+        assert len(calls) == 1
         assert isinstance(calls[0]["search"], SearchConfig) and calls[0]["search"].spread is True
-        assert calls[1]["search"].spread is False
-        # Determinism: the fallback re-solve reuses the same resolved seed.
-        assert calls[0]["seed"] == calls[1]["seed"] == 5
+        # The CLI forwards --seed through unchanged.
+        assert calls[0]["seed"] == 5
         assert out.exists()
 
     def test_explicit_no_spread_does_not_retry(self, tmp_path, monkeypatch, capsys):
-        # The user already asked for --no-spread; there is nothing to fall back
-        # FROM. One solve() call, exit 3 stands, no swap note.
+        # The user already asked for --no-spread; the library has nothing to fall
+        # back FROM. One solve() call (spread off), exit 3 stands, no swap note.
         layout = self._layout()
         calls = self._patch_solve_sequence(
             monkeypatch, [self._result("found", (layout,), (None,), unroutable=("fuji",))]
@@ -1003,26 +1007,23 @@ class TestSolveRenderPathsSpreadFallback:
         assert calls[0]["search"].spread is False
         assert "re-solved" not in capsys.readouterr().err
 
-    def test_fallback_also_unroutable_keeps_exit_3_no_misleading_note(
+    def test_unroutable_with_no_swap_keeps_exit_3_no_misleading_note(
         self, tmp_path, monkeypatch, capsys
     ):
-        # Genuinely too tight (e.g. placeholder hangar): both spread and
-        # no-spread route nothing. The fallback ran but did not help, so we keep
-        # the original spread result and exit 3 — and must NOT claim a swap that
-        # did not happen.
+        # Genuinely too tight (e.g. placeholder hangar): the library's fallback
+        # ran but did not help, so solve() returns the valid-but-unroutable
+        # layout with spread_fallback_applied=False. The CLI must exit 3 and must
+        # NOT claim a swap that did not happen.
         layout = self._layout()
         calls = self._patch_solve_sequence(
             monkeypatch,
-            [
-                self._result("found", (layout,), (None,), unroutable=("fuji",)),
-                self._result("found", (layout,), (None,), unroutable=("fuji",)),
-            ],
+            [self._result("found", (layout,), (None,), unroutable=("fuji",))],
         )
         out = tmp_path / "p.png"
         rc = main(["solve", SMOKE_FIXTURE, "--render", str(out), "--render-paths", "--seed", "5"])
         assert rc == 3
-        assert len(calls) == 2  # the fallback was attempted
-        assert "re-solved" not in capsys.readouterr().err  # but not claimed
+        assert len(calls) == 1
+        assert "re-solved" not in capsys.readouterr().err  # not claimed
 
     def test_spread_routable_does_not_retry(self, tmp_path, monkeypatch, capsys):
         # Spread layout is already routable -> no fallback, no note, exit 0,
@@ -1041,15 +1042,13 @@ class TestSolveRenderPathsSpreadFallback:
     ):
         # #280 — non-interactive consumers must get a structured signal that the
         # tighter no-spread layout was substituted, not just the human stderr
-        # note. After a successful fallback swap, --json carries True.
+        # note. After a successful fallback swap, --json carries True (read
+        # straight off diagnostics since #402 / F5).
         layout = self._layout()
         plan = self._plan(layout)
         self._patch_solve_sequence(
             monkeypatch,
-            [
-                self._result("found", (layout,), (None,), unroutable=("fuji",)),
-                self._result("found", (layout,), (plan,)),
-            ],
+            [self._result("found", (layout,), (plan,), spread_fallback_applied=True)],
         )
         out = tmp_path / "p.png"
         rc = main(
@@ -1102,10 +1101,7 @@ class TestSolveRenderPathsSpreadFallback:
         plan = self._plan(layout)
         self._patch_solve_sequence(
             monkeypatch,
-            [
-                self._result("found", (layout,), (None,), unroutable=("fuji",)),
-                self._result("found", (layout,), (plan,)),
-            ],
+            [self._result("found", (layout,), (plan,), spread_fallback_applied=True)],
         )
         out_png = tmp_path / "p.png"
         out_yaml = tmp_path / "fallback.yaml"
@@ -1157,8 +1153,8 @@ class TestSolveRenderPathsSpreadFallback:
         assert "auto-fallback, see #280" not in out_yaml.read_text()
 
     def test_real_solve_spread_fallback_end_to_end(self, tmp_path, monkeypatch, capsys):
-        # Deterministic, CI-runnable integration of the #280 fallback against the
-        # REAL solver + REAL tow planner.
+        # Deterministic, CI-runnable integration of the #280 / #402 fallback
+        # against the REAL solver + REAL tow planner, end-to-end through the CLI.
         #
         # The *natural* trigger — a spread layout the bounded Hybrid-A* can't route
         # while no-spread can — is a narrow band that SHIFTS as towability improves.
@@ -1170,20 +1166,21 @@ class TestSolveRenderPathsSpreadFallback:
         # wall-clock-scoped, and the CLI's only knob is ``--budget``, so a real,
         # ``--budget``-driven trigger is inherently machine-dependent.
         #
-        # Fix: force ONLY the spread pass to report no plans, via a thin wrapper that
-        # otherwise delegates to the real ``solve()``. That reproduces the #280
-        # condition (all plans ``None`` on the spread layout) deterministically while
-        # keeping the real placement and — crucially — the real no-spread routing, so
-        # the live cli.py fallback wiring (re-solve with spread off → swap → stderr
-        # note → exit 0 → render) is exercised end-to-end without depending on the
-        # fragile trigger band. The fully-mocked sibling tests above cover the same
-        # control flow on synthetic data; this one proves it on a real solve+route,
-        # and is deliberately NOT ``@slow`` so CI actually runs it.
+        # Fix: force ONLY the spread pass to report no plans, via a thin wrapper on
+        # the library body ``_run_solve`` that otherwise delegates to the real one.
+        # Since #402 the spread-off re-solve lives inside ``solve()`` (which calls
+        # ``_run_solve`` twice), so wrapping ``_run_solve`` — NOT ``solve`` — lets
+        # the real LIBRARY fallback fire: the spread pass returns all-None, the
+        # no-spread pass routes for real, ``solve()`` swaps + sets
+        # ``spread_fallback_applied``, and the CLI surfaces it (stderr note → exit 0
+        # → render). The fully-mocked sibling tests above cover the control flow on
+        # synthetic data; this one proves it on a real solve+route, and is
+        # deliberately NOT ``@slow`` so CI actually runs it.
         #
         # Two choices make the outcome wall-clock-INDEPENDENT (so it cannot flake
         # under CPU contention the way the old budget-pinned version could):
         #   1. The trivial single-plane fixture — placement is the same control flow
-        #      regardless of plane count (this test exercises the cli FALLBACK wiring,
+        #      regardless of plane count (this test exercises the FALLBACK wiring,
         #      not multi-plane spread geometry, whose coverage #457 established is dead
         #      anyway), and a one-plane layout is found in the very first restart.
         #   2. The intercepted spread pass is re-bounded to a deterministic
@@ -1195,28 +1192,26 @@ class TestSolveRenderPathsSpreadFallback:
 
         import hangarfit.solver as solver_mod
 
-        real_solve = solver_mod.solve
+        real_run_solve = solver_mod._run_solve
 
         def spread_pass_unroutable(scenario, **kwargs):
             search = kwargs.get("search")
             if search is not None and search.spread and kwargs.get("plan_paths"):
                 # The bounded planner "routes nothing" for the spread arrangement —
-                # exactly the case #280's fallback exists to rescue. Run placement
-                # ONLY (skip the expensive Hybrid-A* routing whose result we would
-                # discard anyway — routing a hard spread layout floods the expansion
-                # budget, the very cost #280 sidesteps), bounded to a single
-                # deterministic restart so producing a valid layout is wall-clock-
-                # independent, then synthesize all-None plans (one per valid layout)
-                # so the fallback trigger (`result.layouts and all(plan is None …)`)
-                # holds.
+                # exactly the case the fallback exists to rescue. Run placement ONLY
+                # (skip the expensive Hybrid-A* routing whose result we would discard
+                # anyway), bounded to a single deterministic restart so producing a
+                # valid layout is wall-clock-independent, then synthesize all-None
+                # plans (one per valid layout) so the fallback trigger
+                # (``result.layouts and all(plan is None …)``) holds.
                 one_restart = dataclasses.replace(search, max_restarts=1)
-                result = real_solve(
+                result = real_run_solve(
                     scenario, **{**kwargs, "search": one_restart, "plan_paths": False}
                 )
                 return dataclasses.replace(result, plans=tuple(None for _ in result.layouts))
-            return real_solve(scenario, **kwargs)
+            return real_run_solve(scenario, **kwargs)
 
-        monkeypatch.setattr(solver_mod, "solve", spread_pass_unroutable)
+        monkeypatch.setattr(solver_mod, "_run_solve", spread_pass_unroutable)
 
         out = tmp_path / "real.png"
         rc = main(

--- a/tests/test_solver_tow_fallback.py
+++ b/tests/test_solver_tow_fallback.py
@@ -1,0 +1,201 @@
+"""Library-level spread-off tow fallback in :func:`hangarfit.solver.solve` (#402 / F5).
+
+The ADR-0016 spread-off re-solve was previously orchestrated in ``cli.py``, so a
+non-CLI caller of ``solve(plan_paths=True)`` bypassed it and could get a
+tow-hostile, spread-maximized layout. F5 promotes the fallback into the library
+``solve()`` so every caller gets the tow-routable arrangement.
+
+These tests pin the orchestration by stubbing the inner ``_run_solve`` body so
+the control flow runs on synthetic results, wall-clock-independently. The final
+test exercises the wiring on a *real* solve + route. The fallback is RNG-free
+re-selection: it changes *which* valid layout is returned, never *whether* it is
+valid (the ``(0, 0.0)`` gate is untouched).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import hangarfit.solver as solver_mod
+from hangarfit.loader import load_layout, load_scenario
+from hangarfit.models import SearchConfig, SolverDiagnostics, SolveResult
+from hangarfit.solver import solve
+from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+def _layout():
+    return load_layout(FIXTURES_DIR / "valid_two_separated.yaml")
+
+
+def _plan(layout):
+    start = Pose(x_m=2.0, y_m=0.0, heading_deg=0.0)
+    end = Pose(x_m=2.0, y_m=5.0, heading_deg=0.0)
+    arc = DubinsArc(start=start, end=end, turn_radius_m=1.0, segments=(Segment("S", 5.0),))
+    return MovesPlan(target_layout=layout, moves=(Move(plane_id="a", target_slot=end, path=arc),))
+
+
+def _result(layouts, plans):
+    diag = SolverDiagnostics(
+        restarts_attempted=1,
+        wall_time_s=0.1,
+        best_partial=None,
+        best_partial_layout=None,
+        seed=5,
+    )
+    return SolveResult(status="found", layouts=layouts, plans=plans, diagnostics=diag)
+
+
+def _patch_run_solve(monkeypatch, results):
+    """Stub ``_run_solve`` to return ``results[i]`` on the i-th call.
+
+    Records each call's kwargs so a test can assert which search config and
+    seed each pass used. More calls than results is a test-setup error.
+    """
+    calls: list[dict] = []
+    seq = list(results)
+
+    def fake_run_solve(scenario, **kwargs):
+        calls.append(kwargs)
+        if not seq:
+            raise AssertionError("_run_solve called more times than results provided")
+        return seq.pop(0)
+
+    monkeypatch.setattr(solver_mod, "_run_solve", fake_run_solve)
+    return calls
+
+
+def _scenario():
+    return load_scenario(str(FIXTURES_DIR / "solve_trivial_single_plane.yaml"))
+
+
+def test_plan_paths_falls_back_to_no_spread_when_spread_unroutable(monkeypatch):
+    layout = _layout()
+    plan = _plan(layout)
+    calls = _patch_run_solve(
+        monkeypatch,
+        [_result((layout,), (None,)), _result((layout,), (plan,))],
+    )
+
+    result = solve(_scenario(), seed=5, plan_paths=True, search=SearchConfig(spread=True))
+
+    # The routable (no-spread) arrangement is substituted.
+    assert result.plans == (plan,)
+    assert result.diagnostics.spread_fallback_applied is True
+    # Two passes: spread ON, then the fallback with spread OFF.
+    assert len(calls) == 2
+    assert calls[0]["search"].spread is True
+    assert calls[1]["search"].spread is False
+    # Determinism: the fallback pass reuses the same resolved seed.
+    assert calls[0]["seed"] == calls[1]["seed"] == 5
+
+
+def test_no_fallback_when_spread_layout_already_routes(monkeypatch):
+    layout = _layout()
+    plan = _plan(layout)
+    calls = _patch_run_solve(monkeypatch, [_result((layout,), (plan,))])
+
+    result = solve(_scenario(), seed=5, plan_paths=True, search=SearchConfig(spread=True))
+
+    assert result.plans == (plan,)
+    assert result.diagnostics.spread_fallback_applied is False
+    assert len(calls) == 1
+
+
+def test_explicit_no_spread_does_not_fall_back(monkeypatch):
+    # spread already off → nothing to fall back FROM; one pass, flag stays False
+    # even though the single result is un-routable.
+    layout = _layout()
+    calls = _patch_run_solve(monkeypatch, [_result((layout,), (None,))])
+
+    result = solve(_scenario(), seed=5, plan_paths=True, search=SearchConfig(spread=False))
+
+    assert result.plans == (None,)
+    assert result.diagnostics.spread_fallback_applied is False
+    assert len(calls) == 1
+    assert calls[0]["search"].spread is False
+
+
+def test_fallback_also_unroutable_keeps_original_spread_result(monkeypatch):
+    # Genuinely too tight: both spread and no-spread route nothing. The fallback
+    # ran but did not help, so keep the original spread result and DO NOT claim a
+    # swap that did not happen.
+    layout = _layout()
+    original = _result((layout,), (None,))
+    calls = _patch_run_solve(monkeypatch, [original, _result((layout,), (None,))])
+
+    result = solve(_scenario(), seed=5, plan_paths=True, search=SearchConfig(spread=True))
+
+    assert result is original
+    assert result.diagnostics.spread_fallback_applied is False
+    assert len(calls) == 2
+
+
+def test_no_fallback_when_plan_paths_false(monkeypatch):
+    # plan_paths=False means the caller never asked for tow plans; the fallback
+    # (a tow-routability rescue) must not fire.
+    layout = _layout()
+    calls = _patch_run_solve(monkeypatch, [_result((layout,), (None,))])
+
+    result = solve(_scenario(), seed=5, plan_paths=False, search=SearchConfig(spread=True))
+
+    assert result.diagnostics.spread_fallback_applied is False
+    assert len(calls) == 1
+
+
+def test_fallback_inherits_max_restarts_not_wall_clock(monkeypatch):
+    # The fallback pass must inherit the caller's max_restarts so the rescue is
+    # bound by a deterministic restart count (ADR-0003), NOT wall-clock — else a
+    # max_restarts-scoped determinism check on the fallback path could flake.
+    layout = _layout()
+    plan = _plan(layout)
+    calls = _patch_run_solve(
+        monkeypatch,
+        [_result((layout,), (None,)), _result((layout,), (plan,))],
+    )
+
+    solve(
+        _scenario(),
+        seed=5,
+        plan_paths=True,
+        search=SearchConfig(spread=True, max_restarts=7),
+    )
+
+    assert calls[1]["search"].spread is False
+    assert calls[1]["search"].max_restarts == 7
+
+
+def test_real_library_fallback_routes_single_plane(monkeypatch):
+    # End-to-end on the REAL solver + REAL planner, wall-clock-independently
+    # (mirrors the technique in tests/test_cli_solve.py's real fallback test):
+    # force ONLY the spread pass to report no plans via a thin wrapper that
+    # otherwise delegates to the real _run_solve, so the real no-spread routing
+    # actually runs. Single-plane fixture → found in restart 0; the spread pass
+    # is re-bounded to max_restarts=1 so producing a valid layout is a fixed
+    # amount of WORK, not a wall-clock race. Deliberately NOT @slow so CI runs it.
+    real_run_solve = solver_mod._run_solve
+
+    def spread_pass_unroutable(scenario, **kwargs):
+        search = kwargs.get("search")
+        if search is not None and search.spread and kwargs.get("plan_paths"):
+            one_restart = dataclasses.replace(search, max_restarts=1)
+            res = real_run_solve(scenario, **{**kwargs, "search": one_restart, "plan_paths": False})
+            return dataclasses.replace(res, plans=tuple(None for _ in res.layouts))
+        return real_run_solve(scenario, **kwargs)
+
+    monkeypatch.setattr(solver_mod, "_run_solve", spread_pass_unroutable)
+
+    result = solve(
+        _scenario(),
+        budget_s=30.0,
+        seed=5,
+        plan_paths=True,
+        search=SearchConfig(spread=True),
+    )
+
+    assert result.layouts
+    # The real no-spread fallback pass routed the single plane.
+    assert any(plan is not None for plan in result.plans)
+    assert result.diagnostics.spread_fallback_applied is True


### PR DESCRIPTION
## F5 — Promote the spread-off tow fallback into library `solve(plan_paths=True)`

Closes #402.

### Problem
The ADR-0016 / #280 spread-vs-towability fallback (and the #320 back-fill default) lived **only at the CLI**. A non-CLI caller of `solve(plan_paths=True)` bypassed them and got a tow-hostile, spread-maximized layout — so the *same scenario* was routable from the CLI but **un-routable from the library**. F5 fixes that inconsistency at the root.

### Change (pure plumbing of a proven mechanism)
- **`solver.solve()`** resolves the seed + search config once, runs the spread pass, and — when `plan_paths` is on, spread was kept on, and the valid layout(s) came back un-routable (every plan `None`) — re-solves **once** with spread disabled and prefers the routable (tighter) arrangement.
  - The re-solve inherits the caller's `SearchConfig` with only `spread` flipped off, so it keeps `max_restarts` (**deterministic, not wall-clock-bound**; the carried `back_bias_weight` is inert with spread off).
  - **RNG-free re-selection**: changes *which* valid layout is returned, never *whether* it is valid — the `(0, 0.0)` gate is untouched, so determinism holds end-to-end (ADR-0003).
- **`SolverDiagnostics.spread_fallback_applied`** (new field, default `False`): the swap is now a *solver fact* recorded on the result, available to **every** library caller — not just the CLI (#280's "machines need a durable signal", generalized).
- **`cli.py`** drops its own two-pass fallback and just *surfaces* the flag: the stderr note and the `--json` / `--write-yaml` provenance read straight off `diagnostics`. (The redundant CLI seed pre-resolution + `secrets` import are removed; the library owns seed-once.)

### Acceptance criteria
- [x] `solve(plan_paths=True)` from the library produces a tow-routable layout where the CLI already did (same-scenario parity) — `tests/test_solver_tow_fallback.py::test_real_library_fallback_routes_single_plane`.
- [x] Determinism preserved; validity gate `(0, 0.0)` unchanged (RNG-free re-selection; fallback inherits `max_restarts`).
- [x] Test covering the library-path parity with the CLI behavior.

### Tests
- New `tests/test_solver_tow_fallback.py` (7): library orchestration via stubbed `_run_solve` (swap on un-routable, no-swap when routable, no fallback under `--no-spread` / `plan_paths=False`, keep-original when fallback also un-routable, `max_restarts` inheritance) + a real single-plane e2e.
- `tests/test_cli_solve.py` `TestSolveRenderPathsSpreadFallback` migrated from *"CLI orchestrates two `solve()` calls"* to *"CLI surfaces `diagnostics.spread_fallback_applied`"* (the orchestration moved a layer down).
- Full suite: **1260 passed**, 8 deselected (`@slow`); ruff + mypy clean. Determinism canaries unaffected (they run `spread=False`).

### References
ADR-0016 (spread-towability fallback), ADR-0008 (spread post-pass), #320 (back-fill), #280. Part of the 2026-06-04 design-team roadmap (v0.11.0, milestone #31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)