### PR TITLE
chore(release): add dedicated 'release' label + lean taxonomy (#387)

### DIFF
--- a/.claude/skills/release-cut/SKILL.md
+++ b/.claude/skills/release-cut/SKILL.md
@@ -139,7 +139,7 @@ The following steps will be executed in order. No changes have been made yet.
            --title "release: v<version>" \
            --body "..." \
            --assignee DocGerd \
-           --label enhancement \
+           --label release \
            --milestone <MILESTONE_NUMBER>
 [ ] 6. Open back-merge PR into develop:
          gh pr create \
@@ -148,14 +148,13 @@ The following steps will be executed in order. No changes have been made yet.
            --title "chore: back-merge v<version> into develop" \
            --body "..." \
            --assignee DocGerd \
-           --label enhancement \
+           --label release \
            --milestone <MILESTONE_NUMBER>
 [ ] 7. Print both PR URLs.
 [ ] 8. Remind you to tag v<version> AFTER the main PR merges.
 
 NOTE: 'main' is protected — the skill never pushes to main directly.
-NOTE: No 'release' label exists in this repo. Using 'enhancement' for both PRs.
-      TODO: create a dedicated 'release' label in a future PR.
+NOTE: Both the release PR and the back-merge PR use the dedicated 'release' label.
 ```
 
 Where `<current_version>` is the version currently in `pyproject.toml` (read it now if not already known), and `<MILESTONE_NUMBER>` is the resolved integer from Step 3 (or the warning text if unresolved).
@@ -250,7 +249,7 @@ After merging, tag the release:
 PREOF
 )" \
   --assignee DocGerd \
-  --label enhancement \
+  --label release \
   --milestone <MILESTONE_NUMBER>
 ```
 
@@ -286,7 +285,7 @@ This PR should be merged AFTER the main release PR is merged.
 PREOF
 )" \
   --assignee DocGerd \
-  --label enhancement \
+  --label release \
   --milestone <MILESTONE_NUMBER>
 ```
 

--- a/.claude/skills/release-prep/SKILL.md
+++ b/.claude/skills/release-prep/SKILL.md
@@ -330,9 +330,12 @@ create the actual release branch and PRs.
 PREOF
 )" \
   --assignee DocGerd \
+  --label release \
   --label documentation \
   --milestone <MILESTONE_NUMBER>
 ```
+The prep PR is release-process work that happens to touch docs, so it carries
+both `release` (process) and `documentation` (content).
 If `MILESTONE_NUMBER` is `<unresolved>`, omit the `--milestone` flag and note in
 the PR body that the milestone must be set by hand.
 


### PR DESCRIPTION
## Summary

Closes #387.

Adds the dedicated `release` label and wires it into the release skills, replacing the `enhancement` fallback and dropping the skill's "no release label exists" TODO. Also completes the lean §2 taxonomy review.

### Part 1 — `release` label (the immediate need)

- New `release` label created (`Release / back-merge PRs and release-process work`, colour `#006B75`).
- **`/release-cut`**: both the release PR (→ `main`) and the back-merge PR (→ `develop`) now use `--label release` (was `enhancement`) — in **both** the plan-preview block and the real `gh pr create` commands. The "No 'release' label exists … TODO" note is removed.
- **`/release-prep`**: the `docs(release): prep` PR now carries `--label release --label documentation` (release-process work that also touches docs).

### Part 2 — taxonomy decision (recorded)

`gh label list` was already ahead of the issue's stale snapshot: `dependencies` and `ci` already existed, plus `area:backend` / `area:viewer` / `area:docs` were added earlier today. Decision (lean, single-maintainer repo):

| Label | Action | Rationale |
|---|---|---|
| `release` | **added** | item 1 — the core ask |
| `chore` | **added** | housekeeping that's neither feature nor fix; matches the `chore(...)` commit style |
| `breaking-change` | **added** | pre-1.0 breaks (e.g. #322 `Aircraft.wheels`) for CHANGELOG / release-note visibility |
| `spike` | **added** | complements the perpetual Spikes milestone #15 (e.g. #476) |
| `dependencies` | already exists | no-op |
| `ci` | already exists | no-op |
| `build` | **declined** | redundant with `ci` for this repo |
| priority / extra status labels | **declined** | overkill for a single maintainer |

### Optional clean-up

The open/merged v0.9.0 release PRs #384 / #385 were relabelled from `enhancement` to `release` to model the new convention (cosmetic, on already-merged PRs).

### Scope / safety

Markdown-only change to two skill instruction files; no `src/` or test changes, no CI-config changes. Developed in an isolated worktree off `origin/develop` (a sibling instance is active on `feature/404` in the shared checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
