### PR TITLE
feat(solver): opt-in spread-stagnation early-exit on the spread-ON path (#404 / F7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Opt-in spread-stagnation early-exit for `solve()` (#404 / F7).** Two new
+  `SearchConfig` fields — `spread_stall_restarts: int | None` (default `None`)
+  and `spread_stall_epsilon_m: float` (default `0.05` m) — let a spread-ON solve
+  stop the restart loop once N consecutive restarts fail to improve the selected
+  layout's maximin plan-view gap by epsilon, instead of always running the full
+  budget. The counter arms only after a complete (`≥ alternatives`) selection
+  exists, so hard scenarios still get the full budget to find their first answer.
+  Default (`None`) preserves today's run-to-budget behaviour byte-for-byte (the
+  determinism canaries are untouched); when enabled, the stop depends only on the
+  seed-fixed restart sequence + an integer counter (never wall-clock), so the
+  result is identical per-seed across machines — *narrowing* the #267 timing
+  scope rather than widening it. Calibrated from the F6 benchmark
+  (`bench.profile_pipeline`): `spread_stall_restarts=5` cuts the canonical
+  `roomy_three_spread_on` regime from 30 restarts to 7 (~4×) while keeping 96 %
+  of the achievable separation. New advisory
+  `SolverDiagnostics.spread_stall_applied` reports when the early-exit fired. See
+  ADR-0008 / ADR-0003 (2026-06-06 amendments).
 - **Real Airfield Herrenteich dataset (`herrenteich/`, refs #79).** A
   self-contained real-world dataset kept separate from the synthetic `data/`
   placeholders: the DWG-measured hangar (15.08 m × 31.76 m, 13.46 m door), the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
   `SearchConfig` fields — `spread_stall_restarts: int | None` (default `None`)
   and `spread_stall_epsilon_m: float` (default `0.05` m) — let a spread-ON solve
   stop the restart loop once N consecutive restarts fail to improve the selected
-  layout's maximin plan-view gap by epsilon, instead of always running the full
+  set's maximin plan-view gap by epsilon, instead of always running the full
   budget. The counter arms only after a complete (`≥ alternatives`) selection
   exists, so hard scenarios still get the full budget to find their first answer.
   Default (`None`) preserves today's run-to-budget behaviour byte-for-byte (the

--- a/docs/adr/0003-rr-mc-solver-algorithm.md
+++ b/docs/adr/0003-rr-mc-solver-algorithm.md
@@ -357,6 +357,31 @@ bound it is timing-scoped as described above.
 
 ---
 
+### 2026-06-06 — opt-in spread-stagnation early-exit narrows the timing scope (issue #404 / F7)
+
+The opt-in `SearchConfig.spread_stall_restarts` (see the ADR-0008 amendment
+dated 2026-06-06) terminates the spread-ON restart loop once N consecutive
+restarts fail to improve the selected set's maximin gap by an absolute epsilon.
+This **narrows** — never widens — the wall-clock timing-dependence scoped above:
+
+- The stop condition reads only the seed-fixed restart sequence, the
+  fully-ordered `_select_spread_diverse` pool, and an integer counter. It adds no
+  RNG draws and no wall-clock reads, so under a `max_restarts` bound a run with
+  `spread_stall_restarts` set is **still fully reproducible across machines** —
+  the counter trips at the same restart everywhere.
+- It cannot make a previously-reproducible (`max_restarts`-bounded) run
+  non-reproducible: it only changes the *restart at which the loop stops*, and it
+  stops at a seed-deterministic point. For the wall-clock-bounded spread-ON path
+  it can only cause the loop to stop *earlier* than `budget_s` would — turning a
+  timing-variable tail into a seed-fixed one.
+
+The default (`spread_stall_restarts=None`) preserves the pre-F7 behaviour
+byte-for-byte, so the `tests/test_solver_canaries.py` determinism canaries (which
+run `spread=False`) and the `determinism-guard` contract are unaffected. No
+change to the RR-MC algorithm itself.
+
+---
+
 ### 2026-05-23 — maintenance-plane handling, post-milestone-#9
 
 Two passages in the body above describe how RR-MC handles the

--- a/docs/adr/0008-inter-plane-spread-soft-preference.md
+++ b/docs/adr/0008-inter-plane-spread-soft-preference.md
@@ -239,3 +239,53 @@ and does not change the draw count or order (candidate generation is unchanged),
 so same-seed output stays byte-identical (`tests/test_solver_search.py::
 test_spread_back_fill_is_deterministic_for_same_seed`). No `determinism-guard`
 amendment is required.
+
+### 2026-06-06 — opt-in spread-stagnation early-exit (issue #404 / F7)
+
+**Background.** The #267 best-of-all-basins change (above) runs *every* restart
+within budget even after an excellent basin appears early, so a default-spread
+single-alternative solve is "always ~30 s". The F6 profile
+(`bench.profile_pipeline`) made the waste concrete on the canonical
+`roomy_three_spread_on` regime: the selected maximin gap reaches ~96 % of its
+30-restart value by restart 3 (10.09 → 12.05 → 12.06 m) and then sits on a
+~17-restart plateau before two negligible late nudges (+0.048 m at restart 21,
++0.396 m at restart 30). Most of the budget buys nothing.
+
+**Change.** A new **opt-in** `SearchConfig.spread_stall_restarts: int | None`
+(default `None` ≡ today's run-to-budget behaviour) lets the spread-ON restart
+loop stop once `spread_stall_restarts` *consecutive* restarts fail to improve the
+selected set's maximin gap by at least `spread_stall_epsilon_m` (default
+`0.05 m`). The metric is `min(min_gap)` over the `_select_spread_diverse`
+selection — for `alternatives == 1` that is the pool's best gap. The counter is
+armed **only after a complete (`≥ alternatives`) selection exists**, so a hard
+scenario still gets the full budget to find its first answer; the early-exit only
+trims the polish-the-incumbent tail. The improvement test uses Keras-style
+`min_delta` semantics: a restart resets the counter only if it beats the running
+best by `≥ epsilon`, so steady sub-epsilon accumulation eventually crosses the
+threshold and resets rather than triggering a premature exit. No effect when
+`spread=False` (that path already first-valid early-exits per #267).
+
+**Calibration.** `spread_stall_restarts=5` with the default `0.05 m` epsilon
+stops `roomy_three_spread_on` at restart 7 — ~4× fewer restarts while keeping
+12.058 m of the 12.502 m final gap (96 %). `0.05 m` (5 cm) treats the +0.048 m
+plateau bump as noise (operationally negligible for wingtip clearance) while a
+genuinely better-separated basin (the +0.396 m late jump) would reset the
+counter. These are the *recommended* values documented on the fields; the
+shipped default leaves the feature **off** (`None`). The `trivial_single` regime
+(1 plane, `min_gap = math.inf`) confirms the degenerate inf case never stagnates
+and so never early-exits — harmless, since single-plane solves are not the slow
+ones.
+
+**Observability.** `SolverDiagnostics.spread_stall_applied` is `True` when the
+loop stopped on stagnation rather than budget / `max_restarts`. Because the
+early-exit arms only after a complete selection, a `True` value always
+accompanies a `found` result. Advisory — it changes *when* the search stops,
+never *whether* the returned layout is valid.
+
+**Determinism.** The stop depends only on the seed-fixed restart sequence + an
+integer counter (and the existing fully-ordered `_select_spread_diverse` sort) —
+never wall-clock. So under a `max_restarts` bound the selected layout is
+identical for a given seed across machines, which *narrows* the #267 wall-clock
+timing scope rather than widening it (see the ADR-0003 amendment dated
+2026-06-06). The default `None` path is byte-identical to pre-F7, so the
+`spread=False` determinism canaries and `determinism-guard` are untouched.

--- a/docs/architecture/06-runtime-view.md
+++ b/docs/architecture/06-runtime-view.md
@@ -80,7 +80,7 @@ sequenceDiagram
     alt trivially infeasible
         Solver-->>CLI: SolveResult(status=trivially_infeasible)
     else feasible
-        loop restart until budget_s / max_restarts
+        loop restart until budget_s / max_restarts / spread-stall (opt-in, #404)
             Note over Solver: Random initial placement
             loop descent (min-conflicts)
                 Solver->>Coll: check(candidate)

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1017,12 +1017,14 @@ class SearchConfig:
     Useful for cross-machine-deterministic exhaustion canaries that
     can't rely on wall-clock budget cutoffs.
 
-    ``None`` is the only *kind* of "opt out" sentinel in
+    ``None`` is the only kind of **opt-out** sentinel in
     :class:`SearchConfig` / :class:`DiversityConfig` /
-    :class:`SolverDiagnostics` — used here and by ``spread_stall_restarts``;
-    all other numeric fields require a concrete positive value. Pass ``None``
-    explicitly to disable the cap; passing ``0`` is rejected (it would
-    skip the search loop entirely)."""
+    :class:`SolverDiagnostics`: it means "disabled" on ``max_restarts`` and on
+    ``spread_stall_restarts``. (``spread_scale_m``'s ``None`` is *not* an
+    opt-out — it selects the adaptive default scale rather than disabling
+    anything.) Every other numeric field requires a concrete positive value.
+    Pass ``None`` explicitly to disable the cap; passing ``0`` is rejected (it
+    would skip the search loop entirely)."""
 
     spread: bool = True
     """When True (default), ``solve()`` runs a post-pass spread phase on each
@@ -1062,8 +1064,9 @@ class SearchConfig:
     CLI never builds one). Modeled as ``float = 0.0`` rather than ``float |
     None`` deliberately: ``0.0`` is the exact identity of ``weight · B``
     (contributes nothing), not a degenerate value, so no distinct opt-out
-    sentinel is warranted — ``None`` stays the only *kind* of sentinel in this
-    dataclass (used by ``max_restarts`` and ``spread_stall_restarts``)."""
+    sentinel is warranted — ``None``-means-disabled (on ``max_restarts`` and
+    ``spread_stall_restarts``) stays the only kind of opt-out sentinel in this
+    dataclass; see ``max_restarts``."""
 
     spread_stall_restarts: int | None = None
     """(F7 / #404) Opt-in early-exit for the spread-ON restart loop. ``None``
@@ -1079,7 +1082,8 @@ class SearchConfig:
     wall-clock), so the selected layout is identical for a given seed across
     machines: this *narrows* the #267 timing scope rather than widening it
     (ADR-0003). No effect when ``spread=False`` (that path already first-valid
-    early-exits).
+    early-exits) — a ``spread=False`` config with this set is a silent no-op by
+    design, *not* an error, mirroring ``back_bias_weight``.
 
     Calibrated from the F6 benchmark (``bench.profile_pipeline``): on the
     canonical ``roomy_three_spread_on`` regime the maximin gap reaches ~96 % of
@@ -1090,9 +1094,9 @@ class SearchConfig:
 
     spread_stall_epsilon_m: float = 0.05
     """(F7 / #404) Minimum maximin-gap improvement (metres) that counts as
-    progress for ``spread_stall_restarts``. A concrete positive value, not a
-    sentinel — ``None`` stays the only *kind* of opt-out sentinel in this
-    dataclass (``max_restarts`` / ``spread_stall_restarts``). Default ``0.05`` m
+    progress for ``spread_stall_restarts``. A concrete positive value, never an
+    opt-out sentinel (that role is reserved for ``None`` on ``max_restarts`` /
+    ``spread_stall_restarts`` — see ``max_restarts``). Default ``0.05`` m
     (5 cm): on the F6 ``roomy_three_spread_on`` regime the only post-plateau gains
     are a negligible +0.048 m bump and a real +0.396 m late basin, so 5 cm treats
     the former as noise while a genuinely better-separated basin still resets the

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -851,6 +851,17 @@ class SolverDiagnostics:
     in the normal no-swap case) so non-interactive consumers can rely on it.
     Advisory: the swap changes *which* valid layout is returned, never *whether*
     it is valid — it does not affect ``status``.
+
+    ``spread_stall_applied`` is ``True`` when the spread-ON restart loop stopped
+    early on pool stagnation rather than running to ``budget_s`` /
+    ``search.max_restarts`` — i.e. ``search.spread_stall_restarts`` consecutive
+    restarts failed to improve the selected set's maximin gap by
+    ``search.spread_stall_epsilon_m`` (the opt-in F7 / #404 early-exit). Always
+    ``False`` under the default ``spread_stall_restarts=None`` and on the
+    ``spread=False`` fast path. Because the early-exit arms only after a complete
+    selection exists, a ``True`` value always accompanies a ``found`` result.
+    Advisory: it changes *when* the search stops, never *whether* the returned
+    layout is valid — it does not affect ``status``.
     """
 
     restarts_attempted: int
@@ -864,6 +875,7 @@ class SolverDiagnostics:
     min_pairwise_gap_m: tuple[float, ...] = ()
     valid_basins_found: int = 0
     spread_fallback_applied: bool = False
+    spread_stall_applied: bool = False
 
     def __post_init__(self) -> None:
         if (self.best_partial is None) != (self.best_partial_layout is None):
@@ -1005,9 +1017,10 @@ class SearchConfig:
     Useful for cross-machine-deterministic exhaustion canaries that
     can't rely on wall-clock budget cutoffs.
 
-    ``None`` is the only "opt out" sentinel in :class:`SearchConfig` /
-    :class:`DiversityConfig` / :class:`SolverDiagnostics`; all other
-    numeric fields require a concrete positive value. Pass ``None``
+    ``None`` is the only *kind* of "opt out" sentinel in
+    :class:`SearchConfig` / :class:`DiversityConfig` /
+    :class:`SolverDiagnostics` — used here and by ``spread_stall_restarts``;
+    all other numeric fields require a concrete positive value. Pass ``None``
     explicitly to disable the cap; passing ``0`` is rejected (it would
     skip the search loop entirely)."""
 
@@ -1049,8 +1062,42 @@ class SearchConfig:
     CLI never builds one). Modeled as ``float = 0.0`` rather than ``float |
     None`` deliberately: ``0.0`` is the exact identity of ``weight · B``
     (contributes nothing), not a degenerate value, so no distinct opt-out
-    sentinel is warranted — ``None`` stays the *only* sentinel in this dataclass
-    (on ``max_restarts``)."""
+    sentinel is warranted — ``None`` stays the only *kind* of sentinel in this
+    dataclass (used by ``max_restarts`` and ``spread_stall_restarts``)."""
+
+    spread_stall_restarts: int | None = None
+    """(F7 / #404) Opt-in early-exit for the spread-ON restart loop. ``None``
+    (default) preserves the run-to-budget collect-every-basin behaviour, so the
+    determinism canaries (which run ``spread=False``) and the byte-identical
+    default are untouched. When set (must be ``>= 1``), ``solve()`` stops the
+    spread-ON loop once this many *consecutive* restarts fail to improve the
+    selected set's maximin plan-view gap by at least ``spread_stall_epsilon_m``.
+    The counter is armed only *after* a complete (``>= alternatives``) selection
+    exists — so a hard scenario still gets the full budget to find its first
+    answer and the early-exit only trims the polish-the-incumbent tail. The stop
+    depends solely on the seed-fixed restart sequence + an integer counter (never
+    wall-clock), so the selected layout is identical for a given seed across
+    machines: this *narrows* the #267 timing scope rather than widening it
+    (ADR-0003). No effect when ``spread=False`` (that path already first-valid
+    early-exits).
+
+    Calibrated from the F6 benchmark (``bench.profile_pipeline``): on the
+    canonical ``roomy_three_spread_on`` regime the maximin gap reaches ~96 % of
+    its 30-restart value by restart 3 then plateaus for ~17 restarts, so
+    ``spread_stall_restarts=5`` with the default epsilon stops at restart 7
+    (~4x fewer restarts) while keeping the near-best separation. See ADR-0008's
+    F7 amendment."""
+
+    spread_stall_epsilon_m: float = 0.05
+    """(F7 / #404) Minimum maximin-gap improvement (metres) that counts as
+    progress for ``spread_stall_restarts``. A concrete positive value, not a
+    sentinel — ``None`` stays the only *kind* of opt-out sentinel in this
+    dataclass (``max_restarts`` / ``spread_stall_restarts``). Default ``0.05`` m
+    (5 cm): on the F6 ``roomy_three_spread_on`` regime the only post-plateau gains
+    are a negligible +0.048 m bump and a real +0.396 m late basin, so 5 cm treats
+    the former as noise while a genuinely better-separated basin still resets the
+    counter. Inert unless ``spread_stall_restarts`` is set; validated ``> 0``
+    regardless so the field is always a usable threshold."""
 
     def __post_init__(self) -> None:
         if self.candidates_per_iter < 1:
@@ -1087,4 +1134,16 @@ class SearchConfig:
             raise ValueError(
                 f"SearchConfig.back_bias_weight must be >= 0 "
                 f"(0 disables the back-of-hangar fill bias), got {self.back_bias_weight}"
+            )
+        if self.spread_stall_restarts is not None and self.spread_stall_restarts < 1:
+            raise ValueError(
+                f"SearchConfig.spread_stall_restarts must be >= 1 when set "
+                f"(pass ``None`` to disable the spread-stagnation early-exit; "
+                f"``0`` would break before any restart), got {self.spread_stall_restarts}"
+            )
+        if self.spread_stall_epsilon_m <= 0.0:
+            raise ValueError(
+                f"SearchConfig.spread_stall_epsilon_m must be positive "
+                f"(metres of maximin-gap improvement that counts as progress), "
+                f"got {self.spread_stall_epsilon_m}"
             )

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -234,6 +234,14 @@ def _run_solve(
     restart_index = 0
     spread_scale = _resolve_spread_scale(scenario, search)
 
+    # F7 (#404) spread-stagnation early-exit state. Inert unless
+    # ``search.spread_stall_restarts`` is set (see the loop tail): tracks the
+    # best selected-set maximin gap seen so far and how many consecutive
+    # restarts have failed to beat it by ``spread_stall_epsilon_m``.
+    best_stall_gap = float("-inf")
+    stall_count = 0
+    spread_stalled = False
+
     # Outer restart loop. Two independent termination gates; first to
     # trip wins:
     #   1. Wall-clock budget (`budget_s`) — always present.
@@ -353,6 +361,29 @@ def _run_solve(
             selected_so_far, _ = _select_spread_diverse(pool, alternatives, diversity)
             if len(selected_so_far) >= alternatives:
                 break
+        elif search.spread_stall_restarts is not None:
+            # F7 (#404): opt-in spread-stagnation early-exit. Reached only when
+            # ``search.spread`` is True (the ``if not search.spread`` arm was
+            # False). Arms only once a COMPLETE selected set exists, so a hard
+            # scenario still gets the full budget to find its first answer and
+            # this only trims the polish-the-incumbent tail. Thereafter, stop
+            # once ``spread_stall_restarts`` consecutive restarts fail to improve
+            # the set's maximin gap by ``spread_stall_epsilon_m``. The metric is
+            # ``min(min_gap)`` over the selected basins (the maximin objective,
+            # ADR-0008) — for ``alternatives == 1`` that is the pool's best gap.
+            # Seed-fixed restart sequence + an integer counter ⇒ identical
+            # per-seed across machines, narrowing the #267 timing scope (ADR-0003).
+            selected_so_far, _ = _select_spread_diverse(pool, alternatives, diversity)
+            if len(selected_so_far) >= alternatives:
+                current_stall_gap = min(c.min_gap for c in selected_so_far)
+                if current_stall_gap >= best_stall_gap + search.spread_stall_epsilon_m:
+                    best_stall_gap = current_stall_gap
+                    stall_count = 0
+                else:
+                    stall_count += 1
+                    if stall_count >= search.spread_stall_restarts:
+                        spread_stalled = True
+                        break
 
     elapsed = time.monotonic() - start
 
@@ -371,7 +402,11 @@ def _run_solve(
             diversity_impossible=diversity_impossible,
             diversity_rejected_count=diversity_rejected_count,
             valid_basins_found=len(pool),
+            spread_stall_applied=spread_stalled,
         )
+    # ``spread_stalled`` can only be True alongside a complete (non-empty)
+    # selection, so the exhausted branch always leaves the flag at its default
+    # False (the early-exit never fires before the first complete answer).
     return _build_exhausted_result(
         best_partial_layout,
         restart_index=restart_index,
@@ -517,6 +552,7 @@ def _build_found_result(
     diversity_impossible: bool,
     diversity_rejected_count: int,
     valid_basins_found: int,
+    spread_stall_applied: bool = False,
 ) -> SolveResult:
     """Build the ``found`` / ``found_partial`` :class:`SolveResult`.
 
@@ -549,6 +585,7 @@ def _build_found_result(
             unroutable_planes=unroutable,
             min_pairwise_gap_m=min_gaps,
             valid_basins_found=valid_basins_found,
+            spread_stall_applied=spread_stall_applied,
         ),
     )
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -370,8 +370,12 @@ def _run_solve(
             # once ``spread_stall_restarts`` consecutive restarts fail to improve
             # the set's maximin gap by ``spread_stall_epsilon_m``. The metric is
             # ``min(min_gap)`` over the selected basins (the maximin objective,
-            # ADR-0008) — for ``alternatives == 1`` that is the pool's best gap.
-            # Seed-fixed restart sequence + an integer counter ⇒ identical
+            # ADR-0008) — for ``alternatives == 1`` that is the pool's best gap
+            # and strictly monotonic; for ``alternatives > 1`` it need not be
+            # monotonic (the diversity gate can re-pick the set), but
+            # ``best_stall_gap`` tracks the running max, so the stop stays a sound,
+            # deterministic "no improvement in the last N restarts" signal either
+            # way. Seed-fixed restart sequence + an integer counter ⇒ identical
             # per-seed across machines, narrowing the #267 timing scope (ADR-0003).
             selected_so_far, _ = _select_spread_diverse(pool, alternatives, diversity)
             if len(selected_so_far) >= alternatives:
@@ -552,7 +556,7 @@ def _build_found_result(
     diversity_impossible: bool,
     diversity_rejected_count: int,
     valid_basins_found: int,
-    spread_stall_applied: bool = False,
+    spread_stall_applied: bool,
 ) -> SolveResult:
     """Build the ``found`` / ``found_partial`` :class:`SolveResult`.
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1115,6 +1115,38 @@ class TestSearchConfig:
         assert SearchConfig(back_bias_weight=0.0).back_bias_weight == 0.0
         assert SearchConfig(back_bias_weight=2.5).back_bias_weight == 2.5
 
+    # ── F7 (#404): opt-in spread-stagnation early-exit ──────────────────────
+    def test_spread_stall_restarts_default_is_none(self) -> None:
+        # Opt-in: None preserves the run-to-budget spread-ON behavior, so the
+        # determinism canaries and byte-identical default are untouched.
+        assert SearchConfig().spread_stall_restarts is None
+
+    def test_spread_stall_restarts_positive_accepted(self) -> None:
+        assert SearchConfig(spread_stall_restarts=1).spread_stall_restarts == 1
+        assert SearchConfig(spread_stall_restarts=8).spread_stall_restarts == 8
+
+    def test_spread_stall_restarts_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match="spread_stall_restarts"):
+            SearchConfig(spread_stall_restarts=0)
+
+    def test_spread_stall_restarts_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match="spread_stall_restarts"):
+            SearchConfig(spread_stall_restarts=-1)
+
+    def test_spread_stall_epsilon_default_is_positive(self) -> None:
+        # A concrete positive metres value (not a sentinel): None stays the only
+        # opt-out sentinel in this dataclass (max_restarts / spread_stall_restarts).
+        eps = SearchConfig().spread_stall_epsilon_m
+        assert eps == 0.05
+        assert eps > 0.0
+
+    def test_spread_stall_epsilon_rejects_non_positive(self) -> None:
+        with pytest.raises(ValueError, match="spread_stall_epsilon_m"):
+            SearchConfig(spread_stall_epsilon_m=0.0)
+        with pytest.raises(ValueError, match="spread_stall_epsilon_m"):
+            SearchConfig(spread_stall_epsilon_m=-0.1)
+        assert SearchConfig(spread_stall_epsilon_m=0.25).spread_stall_epsilon_m == 0.25
+
 
 # ---------------------------------------------------------------------------
 # SolveResult.plans — best-effort tow-plan bundle (#197)

--- a/tests/test_solver_stall.py
+++ b/tests/test_solver_stall.py
@@ -1,0 +1,96 @@
+"""Opt-in spread-stagnation early-exit on the spread-ON path (#404 / F7).
+
+When :class:`~hangarfit.models.SearchConfig.spread_stall_restarts` is set,
+``solve()``'s spread-ON restart loop stops once N consecutive restarts fail to
+improve the selected set's maximin plan-view gap by ``spread_stall_epsilon_m``.
+The stop depends only on the seed-fixed restart sequence + an integer counter
+(never wall-clock), so the selected layout is identical for a given seed across
+machines — this *narrows* the #267 timing scope rather than widening it
+(ADR-0003). The default (``None``) preserves run-to-budget behavior, so the
+determinism canaries (which run ``spread=False``) and the byte-identical contract
+are untouched.
+
+These run the real solver on a 3-plane fixture (single-plane gaps are
+``math.inf`` — nothing to stagnate on), kept cheap via a large epsilon so the
+loop exits after a couple of restarts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hangarfit.collisions import check as check_layout
+from hangarfit.loader import load_scenario
+from hangarfit.models import SearchConfig
+from hangarfit.solver import solve
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+# 3 free planes in the 30x25 test hangar: spread ON yields finite, improvable
+# inter-plane gaps and restart 0 already finds a valid basin.
+_THREE_PLANE = FIXTURES / "solve_fresh_alternatives_three.yaml"
+
+
+def _scenario():
+    return load_scenario(str(_THREE_PLANE))
+
+
+def test_spread_stall_early_exits_and_flags_it() -> None:
+    """A large epsilon means no further restart can improve the first complete
+    basin's gap, so N=2 stops the spread-ON loop after a few restarts — far
+    short of max_restarts — and records ``spread_stall_applied``."""
+    result = solve(
+        _scenario(),
+        budget_s=600.0,  # huge: stagnation / max_restarts are the only gates
+        seed=1,
+        plan_paths=False,
+        search=SearchConfig(
+            spread=True,
+            max_restarts=20,
+            spread_stall_restarts=2,
+            spread_stall_epsilon_m=1000.0,
+        ),
+    )
+
+    assert result.status == "found"
+    assert check_layout(result.layouts[0]).valid  # the basin really scores (0, 0.0)
+    assert result.diagnostics.spread_stall_applied is True
+    # Stopped well before the cap (the whole point of the feature).
+    assert result.diagnostics.restarts_attempted < 20
+
+
+def test_opt_out_default_runs_to_max_restarts() -> None:
+    """Default ``spread_stall_restarts=None`` preserves run-to-budget behavior:
+    every restart runs and the stall is never flagged (the new code path is fully
+    gated behind the opt-in, so the byte-identical default is untouched)."""
+    result = solve(
+        _scenario(),
+        budget_s=600.0,
+        seed=1,
+        plan_paths=False,
+        search=SearchConfig(spread=True, max_restarts=4),  # None stall (default)
+    )
+
+    assert result.diagnostics.restarts_attempted == 4
+    assert result.diagnostics.spread_stall_applied is False
+
+
+def test_spread_stall_exit_is_deterministic_across_runs() -> None:
+    """The early-exit depends only on the seed-fixed restart sequence + an
+    integer counter (never wall-clock), so two same-seed runs are identical —
+    the cross-machine reproducibility the issue promises (ADR-0003)."""
+    cfg = SearchConfig(
+        spread=True,
+        max_restarts=20,
+        spread_stall_restarts=1,
+        spread_stall_epsilon_m=1000.0,
+    )
+    r1 = solve(_scenario(), budget_s=600.0, seed=1, plan_paths=False, search=cfg)
+    r2 = solve(_scenario(), budget_s=600.0, seed=1, plan_paths=False, search=cfg)
+
+    assert r1.status == r2.status
+    assert r1.diagnostics.restarts_attempted == r2.diagnostics.restarts_attempted
+    assert r1.diagnostics.spread_stall_applied is True
+    assert r2.diagnostics.spread_stall_applied is True
+    assert r1.diagnostics.min_pairwise_gap_m == r2.diagnostics.min_pairwise_gap_m
+    for la, lb in zip(r1.layouts, r2.layouts, strict=True):
+        assert la.placements == lb.placements

--- a/tests/test_solver_stall.py
+++ b/tests/test_solver_stall.py
@@ -94,3 +94,28 @@ def test_spread_stall_exit_is_deterministic_across_runs() -> None:
     assert r1.diagnostics.min_pairwise_gap_m == r2.diagnostics.min_pairwise_gap_m
     for la, lb in zip(r1.layouts, r2.layouts, strict=True):
         assert la.placements == lb.placements
+
+
+def test_spread_stall_with_multiple_alternatives() -> None:
+    """For ``alternatives > 1`` the stagnation metric is ``min(min_gap)`` over the
+    *selected set* (not just the single best basin), so this exercises the
+    multi-element path. A large epsilon forces the early-exit once two diverse
+    basins exist, deterministically, while still returning the full set."""
+    cfg = SearchConfig(
+        spread=True,
+        max_restarts=20,
+        spread_stall_restarts=2,
+        spread_stall_epsilon_m=1000.0,
+    )
+    r1 = solve(_scenario(), budget_s=600.0, alternatives=2, seed=1, plan_paths=False, search=cfg)
+    r2 = solve(_scenario(), budget_s=600.0, alternatives=2, seed=1, plan_paths=False, search=cfg)
+
+    assert r1.status == "found"
+    assert len(r1.layouts) == 2
+    assert r1.diagnostics.spread_stall_applied is True
+    assert r1.diagnostics.restarts_attempted < 20
+    # Same seed + config ⇒ byte-identical, on the multi-alternative metric path.
+    assert r1.diagnostics.restarts_attempted == r2.diagnostics.restarts_attempted
+    assert r1.diagnostics.min_pairwise_gap_m == r2.diagnostics.min_pairwise_gap_m
+    for la, lb in zip(r1.layouts, r2.layouts, strict=True):
+        assert la.placements == lb.placements


### PR DESCRIPTION
Closes #404

## F7 — Opt-in deterministic spread-stagnation early-exit

Promotes the v0.11.0 roadmap's last placement-side lever: a spread-ON `solve()`
no longer has to run the **full** restart budget collecting every basin once a
clearly-best one has appeared. New **opt-in** `SearchConfig` fields let the
restart loop stop on pool stagnation, deterministically.

### What changed

- **`SearchConfig.spread_stall_restarts: int | None` (default `None`)** — when
  set (`>= 1`), the spread-ON restart loop stops once that many *consecutive*
  restarts fail to improve the selected set's maximin plan-view gap by
  `spread_stall_epsilon_m`.
- **`SearchConfig.spread_stall_epsilon_m: float` (default `0.05` m)** — the
  minimum gap improvement (metres) that counts as progress. A concrete positive
  value, never a sentinel (`None` stays the only opt-out sentinel, now on
  `max_restarts` *and* `spread_stall_restarts`).
- **`SolverDiagnostics.spread_stall_applied: bool` (default `False`)** — advisory
  flag, `True` when the loop stopped on stagnation rather than budget /
  `max_restarts`.

### Design decisions

- **Arms only after a complete (`>= alternatives`) selection exists.** A hard
  scenario still gets the full budget to find its first answer; the early-exit
  only trims the polish-the-incumbent tail. Consequence: `spread_stall_applied=True`
  always accompanies a `found` result.
- **Keras-style `min_delta` early stopping.** A restart resets the counter only
  if it beats the running best by `>= epsilon`, so steady sub-epsilon
  accumulation eventually crosses the threshold and resets — no premature exit on
  slow-but-real improvement.
- **Default `None` is fully gated** — the new code path never executes, so the
  byte-identical default and the `spread=False` determinism canaries are
  untouched.
- **No CLI flag (deliberate).** F7 is a library `solve()`/`SearchConfig`
  capability per the issue; the CLI keeps `spread_stall_restarts=None`, so CLI
  behaviour is unchanged. CLI exposure can follow later.

### Determinism (ADR-0003)

The stop reads only the seed-fixed restart sequence, the fully-ordered
`_select_spread_diverse` pool, and an integer counter — never wall-clock. So
under a `max_restarts` bound the selected layout is identical per-seed across
machines: this **narrows** the #267 timing scope rather than widening it. ADR-0003
gets a 2026-06-06 cross-reference amendment spelling this out.

### Calibration (F6 / `bench.profile_pipeline`)

Thresholds are **measured, not guessed** (acceptance criterion). On the canonical
`roomy_three_spread_on` regime the selected maximin gap reaches ~96 % of its
30-restart value by restart 3, then plateaus for ~17 restarts before two
negligible late nudges:

| restart | gap (m) | Δ |
|--------:|--------:|---|
| 1 | 10.085 | — |
| 2 | 12.045 | +1.960 |
| 3 | 12.058 | +0.013 |
| 4–20 | 12.058 | +0.000 (17-restart plateau) |
| 21 | 12.106 | +0.048 |
| 30 | 12.502 | +0.396 |

`spread_stall_restarts=5` + default `0.05 m` epsilon stops at **restart 7**
(~4× fewer restarts) while keeping 12.058 m of the 12.502 m final gap (96 %).
`0.05 m` treats the +0.048 m plateau bump as noise while a genuine +0.396 m basin
would reset the counter. The `trivial_single` regime (gap=inf) confirms the
degenerate single-plane case never stagnates — harmless, since it is not the slow
path.

### Tests

- `tests/test_solver_stall.py` (real solver, 3-plane fixture, **not** `@slow`):
  early-exit fires + flags before `max_restarts`; default `None` runs to budget
  and never flags; same-seed runs are byte-identical (cross-machine reproducibility).
- `tests/test_models.py::TestSearchConfig`: field defaults + `__post_init__`
  validation for both new fields.

### Docs

- ADR-0008 amendment (2026-06-06) — the early-exit + calibration.
- ADR-0003 amendment (2026-06-06) — why this narrows the timing scope.
- arc42 §6 runtime-view restart-loop note; CHANGELOG `[Unreleased]`.

### Verification

- `pytest -m ''` green · `ruff check`/`format` clean · `mypy` clean ·
  determinism-guard PASS (see review).
