### PR TITLE
docs(release): prep v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.11.0] — 2026-06-06
+
+### Added
+
+- **Soft per-plane `priority` weight in `constraints:` (#441).** A new
+  non-negative `priority` (float, `None` ≡ neutral) on `PlaneConstraint` lets a
+  scenario nudge the ADR-0008 spread post-pass to give a more important plane
+  more clearance: each plane-pair's repulsion energy is scaled by
+  `(1 + priority_i)·(1 + priority_j)`, while the maximin basin selection still
+  ranks on the raw geometric gap. It is the first *user-supplied soft*
+  preference (pins and `force_on_carts` stay the only HARD constraints); the
+  loader rejects negative, non-finite, or `bool` values. Determinism-safe and
+  inert by default — with every `priority` unset every weight is exactly `1.0`,
+  so the energy and the whole search stay byte-identical to before (ADR-0003).
 - **Opt-in spread-stagnation early-exit for `solve()` (#404 / F7).** Two new
   `SearchConfig` fields — `spread_stall_restarts: int | None` (default `None`)
   and `spread_stall_epsilon_m: float` (default `0.05` m) — let a spread-ON solve
@@ -39,9 +57,51 @@ All notable changes to this project are documented here. Format follows [Keep a 
   hangarfit brand (DocGerdSoft lineage + the 2D tokens + the 3D dark-surface
   section + the full token table), so the viewer's colours, banners, and
   typography trace to one document.
+- **Profile-first benchmarking — harness + always-on CI gate (#381, #403 / F6).**
+  A committed dev/CI-only `bench/` harness (`python -m bench.profile_pipeline`)
+  splits each regime's wall-clock into placement vs routing across trivial /
+  roomy-multi / tight-placeholder × spread on/off regimes, binding on
+  `max_restarts` (not wall-clock) so the numbers reproduce run-to-run; it lives
+  at the repo root outside `where=["src"]`, so `pip install`, the wheel build,
+  and pytest never touch it. Its headline finding
+  (`docs/spikes/solve-tow-profiling.md`) overturns the prior premise that
+  routing dominates: on the default spread-ON path placement is ~53× routing,
+  almost all of it the spread post-pass rebuilding part geometry on every
+  `collisions.check` — directly seeding the #453/#454 speedups below. F6 (#403)
+  then promotes the harness's correctness, path-validity, determinism, and speed
+  invariants into a dedicated `bench-gates.yml` that fails every `develop`/`main`
+  PR on a regression (the speed ceiling a generous catastrophic-regression
+  tripwire pinned to `ubuntu-24.04`, not a microbenchmark).
 
 ### Changed
 
+- **Spread-off tow fallback promoted into the library `solve()` (#402 / F5).**
+  The ADR-0016/#280 spread-vs-towability rescue used to live in `cli.py`, so any
+  non-CLI caller of `solve(plan_paths=True)` bypassed it and could get a
+  spread-maximized layout that was routable from the CLI but un-routable from the
+  library. `solve()` now resolves the seed and `SearchConfig` once above both
+  passes and, when spread stayed on and every returned layout came back
+  un-routable, re-solves once with `spread=False` (inheriting the caller's
+  `max_restarts`, so still deterministic, not wall-clock-bound). The swap is
+  recorded on a new always-present `SolverDiagnostics.spread_fallback_applied`
+  (default `False`, no schema bump); the CLI drops its own fallback and just
+  surfaces the flag on stderr and in `--json` / `--write-yaml`. The re-selection
+  is RNG-free and the `(0, 0.0)` validity gate is untouched, so the
+  byte-identical determinism contract holds (ADR-0003).
+- **Faster placement search — geometry memoization + a collision broad-phase
+  (#453, #454).** The #381 spike found placement dominates the pipeline (~53×
+  routing), bottlenecked on `aircraft_parts_world` rebuilding Shapely polygons on
+  every collision/clearance check. #453 adds a `ContextVar`-scoped per-`solve()`
+  cache keyed on `(plane_id, x, y, heading)` consulted at the hot call sites,
+  taking the canonical `roomy_three_spread_on` placement from 42.3 s to ~18.7 s
+  (~2.3×). #454 then adds a per-axis AABB broad-phase in
+  `collisions._pairwise_conflicts` that skips the exact Shapely predicate for
+  part-pairs whose bounding boxes are more than `clearance_m` apart — a provable
+  lower bound on true edge-to-edge distance, so no conflicting pair is ever
+  skipped — taking it a further 18.7 s → 15.7 s (−15.8 %). Both are pure-speed
+  levers verified byte-identical against `develop` at fixed `max_restarts` across
+  seeds; the conflict set, penetration accumulation order, and the determinism
+  contract are unchanged (ADR-0003).
 - **3D viewer renders on the DocGerdSoft dark-surface brand (#415).** `hangarfit
   view` now uses the dark-lifted fleet palette (`PLANES_DARK`, keyed by the same
   sorted id so 2D/3D plane identity is preserved), a unified scene shell
@@ -62,9 +122,45 @@ All notable changes to this project are documented here. Format follows [Keep a 
   is byte-identical across re-renders of a given scene, the CVD-safe palette
   (#326) values are unchanged, and the
   collision model / determinant-−1 transform are untouched (ADR-0019).
+- **2D maintenance-bay and placeholder banner aligned to the brand tokens
+  (#418).** Building on #419's centralization, the matplotlib 2D PNG drops two
+  off-system reds the 3D surface had already resolved: the closed maintenance-bay
+  fill now reads the `maint` violet the 3D bay uses (with an ink-dark edge/label
+  — the lighter violet needs dark ink for contrast), and the "PLACEHOLDER DATA"
+  honesty banner now uses the single-source `WARNING` amber, matching the 3D
+  banner for cross-surface parity. Render-only with no collision, determinism, or
+  `scene/v1` impact; the 3D banner value is unchanged, so the viewer HTML stays
+  byte-identical.
+- **Viewer ported to a typed, modular, dev/CI-only TypeScript toolchain (#436).**
+  The single hand-written `_viewer_assets/viewer.js` is now built by an esbuild +
+  `tsc` + eslint toolchain (top-level `viewer/`, ADR-0020) from typed modules
+  under `viewer/src/*.ts`; Node is a dev/CI concern only — `pip install`, the
+  wheel build, and pytest never invoke npm, and the wheel still ships the one
+  committed `viewer.js` bundle. The migration scaffolded the toolchain (#437),
+  atomically ported the renderer (#439), and added typed `scene-contract.ts` /
+  `brand-contract.ts` mirrors with Python key-set parity tests plus node-native
+  unit tests for the pure `affine` / `anchors` / `timeline` units (#440).
+  Equivalence is semantic, not byte-for-byte: the headless render is
+  pixel-identical (same screenshot hash) on a static and an animated fixture.
+  Render-only and determinism-neutral — the `scene/v1` schema is unchanged,
+  `scene.py` / `collisions.py` are untouched, Python still owns the
+  determinant-−1 transform, and a `viewer-build-drift` CI guard byte-pins the
+  committed bundle.
 
 ### Fixed
 
+- **Tow entry respects the door-jamb clearance instead of clipping the wall
+  (#411).** The #222 front-gap exemption dropped the entire front wall for a
+  mover in transit, so a plane straddling `y < 0` *outside* the door opening (an
+  off-centre or too-wide entry) clipped the solid wall/jamb with no rejection —
+  visible in the 3D viewer as a wing through the wall at tow `t=0`. The exemption
+  is now door-aware in the shared motion oracle: a vertex at `y < 0` is legal
+  only when `door_left ≤ x ≤ door_right`, otherwise it is a `hangar_bounds`
+  conflict. The door becomes a true motion gate for the whole tow, so off-centre
+  entries that would clip are filtered (the planner self-selects a centred/angled
+  entry) and a plane wider than the door at every orientation is reported
+  un-towable (best-effort `plans[i]=None`) rather than drawn clipping. RNG-free
+  and closed-form, so the ADR-0003 planner determinism contract holds.
 - **Solver no longer false-rejects glider fleets (#425).** The pre-search
   trivial-infeasibility gate (`solve` check #2) summed each plane's *bounding
   box* (`fuselage_length × wingspan`), which for a thin-winged glider is mostly
@@ -75,6 +171,27 @@ All notable changes to this project are documented here. Format follows [Keep a 
   glider-containing fleets reach the search; only genuinely-too-big fleets still
   short-circuit. RNG-free and pre-search, so the byte-identical determinism
   contract (ADR-0003) is unchanged.
+
+### Security
+
+- **Bumped pip 26.1.1 → 26.1.2 for PYSEC-2026-196 / CVE-2026-8643 (#460).** The
+  `requirements-pip-tools.txt` bootstrap lockfile pinned `pip==26.1.1` (an
+  `--allow-unsafe` transitive of pip-tools), which Scorecard code-scanning
+  flagged as vulnerable (all pip < 26.1.2). The lockfile was regenerated with the
+  canonical command plus `--upgrade-package pip`, bumping pip only to 26.1.2 with
+  fresh hashes — a byte-stable diff under the drift guard, so the lockfile-drift
+  CI jobs pass.
+- **CI supply-chain coverage extended to the viewer TypeScript toolchain (#461,
+  #462, #463).** The dev/CI-only `viewer/` codebase gained the monitoring the
+  Python tree already had: CodeQL became a per-language matrix adding a
+  `javascript-typescript` analysis scoped to `viewer/src` (vendored Three.js
+  excluded), preserving the existing required `Analyze (Python)` check (#461);
+  Dependabot got a weekly `npm` ecosystem entry for `/viewer`, with
+  `three` / `@types/three` ignored because they are pinned in lockstep with
+  vendored r160 (#462); and a PR-time `dependency-review` gate (fail-on high,
+  covering pip + npm) plus `ruff` over the dev-only `bench/` harness landed
+  (#463). All CI / supply-chain only — no runtime, collision, or determinism
+  impact; the actions stay SHA-pinned.
 
 ## [0.10.0] — 2026-06-04
 
@@ -308,7 +425,8 @@ First Phase 1 cut — substrate for arranging the flying club fleet in a stack-s
 - Apache-2.0 license, public-audience README, CI matrix (Python 3.11 + 3.12), branch protection on develop + main (#13, #14, #15, #16).
 - Strut-aware golden tests + all-9-planes fixture using larger test-only hangar to accommodate strut-bracing geometry on placeholder dimensions (#5).
 
-[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/DocGerd/hangarfit/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/DocGerd/hangarfit/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/DocGerd/hangarfit/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/DocGerd/hangarfit/compare/v0.7.2...v0.8.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ This file is the durable **operational** context for the project: how we work, w
 |---|---|
 | What `hangarfit` is and the quality goals it optimizes for | [§1 Introduction & Goals](docs/architecture/01-introduction-and-goals.md) |
 | What is in / out of scope, the external actors, exit-code semantics pointer | [§3 Context & Scope](docs/architecture/03-context-and-scope.md) |
-| Module map (`cli`, `loader`, `models`, `geometry`, `collisions`, `solver`, `towplanner`, `visualize`, `scene`, `viewer`, `metrics`) and per-module responsibilities | [§5 Building Block View](docs/architecture/05-building-block-view.md) |
+| Module map (`cli`, `loader`, `models`, `geometry`, `collisions`, `solver`, `towplanner`, `visualize`, `scene`, `viewer`, `metrics`, `brand`) and per-module responsibilities | [§5 Building Block View](docs/architecture/05-building-block-view.md) |
 | Runtime flow of `check` and `solve` invocations | [§6 Runtime View](docs/architecture/06-runtime-view.md) |
 | **The parts model** (collision rule, why parts not bbox, `struts:` block, the fuselage front/aft split — a wingtip may overhang a low-winger's *tail* but not its *cockpit*) | [§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md#the-parts-model) + [ADR-0001](docs/adr/0001-aircraft-parts-model.md) + [ADR-0012](docs/adr/0012-fuselage-front-aft-split.md) |
 | **The coordinate convention + the determinant-−1 transform trap** | [§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md#the-coordinate-convention) + [ADR-0002](docs/adr/0002-determinant-minus-one-transform.md) |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It also renders a top-down PNG so a human can sanity-check the result by eye.
 **Still explicitly out of scope:**
 
 - No tracking of hangar state across runs — each invocation is stateless.
-- No user-defined soft constraints or weighted objectives — user-supplied constraints are HARD only (pin, force_on_carts, maintenance plane). The solver does apply two built-in soft spatial preferences — inter-plane spread ([ADR-0008](docs/adr/0008-inter-plane-spread-soft-preference.md), default-on, toggleable with `--no-spread`) and a back-of-hangar fill bias that keeps the door-side approach corridors clear ([ADR-0008 §Amendments, #320](docs/adr/0008-inter-plane-spread-soft-preference.md), default-on, toggleable with `--no-back-fill`) — but neither ever overrides a hard constraint.
+- No general weighted / multi-objective optimization — the only *user-supplied* soft input is a per-plane `priority` weight ([#441](https://github.com/DocGerd/hangarfit/issues/441)) that biases the built-in inter-plane spread; pins, `force_on_carts`, and the maintenance-plane assignment remain the only inputs that can make a layout invalid. On top of `priority` the solver applies two built-in soft spatial preferences — inter-plane spread ([ADR-0008](docs/adr/0008-inter-plane-spread-soft-preference.md), default-on, toggleable with `--no-spread`) and a back-of-hangar fill bias that keeps the door-side approach corridors clear ([ADR-0008 §Amendments, #320](docs/adr/0008-inter-plane-spread-soft-preference.md), default-on, toggleable with `--no-back-fill`) — but none of these ever overrides a hard constraint.
 - No interactive editing GUI, server, or web app — the Phase 4 `hangarfit view` 3D viewer is a **read-only**, self-contained HTML *artifact* (like the PNG), not a live frontend you author layouts in.
 - No handling of late arrivals as a live event stream.
 - Multi-plane *rearrangement* (move planes around an already-occupied hangar). The tow planner only handles **empty-hangar fill** — every plane enters once. Rearrangement is planner v2+ territory.
@@ -117,7 +117,7 @@ hangarfit solve scenario.yaml --budget 5
 hangarfit solve scenario.yaml --render out.png --render-paths
 ```
 
-A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which planes are present), an optional `maintenance:` block (which plane is in the back bay), and an optional `constraints:` mapping (per-plane pins or `force_on_carts` locks). See `tests/fixtures/solve_*.yaml` for ready-to-read examples covering each constraint kind.
+A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which planes are present), an optional `maintenance:` block (which plane is in the back bay), and an optional `constraints:` mapping (per-plane pins, `force_on_carts` locks, or a soft `priority` weight). See `tests/fixtures/solve_*.yaml` for ready-to-read examples covering each constraint kind.
 
 ### Exit codes (`solve`)
 
@@ -128,7 +128,7 @@ A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which
 | 2 | Could not solve (file not found, bad YAML, invariant violation, IO error during render/write, or `--render-paths` without `--render`) |
 | 3 | `--render-paths` only: valid layout(s) found but the v1 tow planner could not route **any** of them. The layouts still render (without path overlays); each blocked layout gets a stderr warning naming the plane. Distinct from code 1 (no layout at all). |
 
-`--render-paths` overlays each plane's tow path on the `--render` PNG(s) (one colour per plane). It tow-plans every returned layout; a layout the planner cannot route is rendered without paths. If **at least one** candidate is routable the exit code is 0 (un-routable ones still warn); code 3 fires only when none are routable. Under default settings, if a spread layout is fully un-routable the CLI first re-solves with spread disabled and renders that tighter arrangement instead (reported on stderr and in `--json`), preferring a towable layout before code 3 is returned ([ADR-0016](docs/adr/0016-spread-towability-fallback.md)).
+`--render-paths` overlays each plane's tow path on the `--render` PNG(s) (one colour per plane). It tow-plans every returned layout; a layout the planner cannot route is rendered without paths. If **at least one** candidate is routable the exit code is 0 (un-routable ones still warn); code 3 fires only when none are routable. Under default settings, if a spread layout is fully un-routable `solve()` first re-solves once with spread disabled and prefers that tighter, routable arrangement (surfaced on stderr and in `--json` via `spread_fallback_applied`), choosing a towable layout before code 3 is returned ([ADR-0016](docs/adr/0016-spread-towability-fallback.md)).
 
 ### Interactive 3D viewer (Phase 4)
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ hangarfit solve scenario.yaml --budget 5
 hangarfit solve scenario.yaml --render out.png --render-paths
 ```
 
-A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which planes are present), an optional `maintenance:` block (which plane is in the back bay), and an optional `constraints:` mapping (per-plane pins, `force_on_carts` locks, or a soft `priority` weight). See `tests/fixtures/solve_*.yaml` for ready-to-read examples covering each constraint kind.
+A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which planes are present), an optional `maintenance:` block (which plane is in the back bay), and an optional `constraints:` mapping (per-plane pins, `force_on_carts` locks, or a soft `priority` weight). See `tests/fixtures/solve_*.yaml` for ready-to-read examples of the pin and `force_on_carts` kinds.
 
 ### Exit codes (`solve`)
 

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -19,6 +19,7 @@ flowchart TD
     scene["scene.py<br/>scene/v1 builder<br/>precomputed affines + timeline"]
     viewer["viewer.py<br/>self-contained 3D HTML<br/>inlined scene + vendored Three.js"]
     metrics["metrics.py<br/>read-only render annotations<br/>placeholder / gap / clearance / validity"]
+    brand["brand.py<br/>single source of brand tokens<br/>CVD-safe palette / opacity / fonts"]
 
     cli --> loader
     cli --> collisions
@@ -56,6 +57,10 @@ flowchart TD
     visualize --> metrics
     scene --> metrics
     viewer --> metrics
+
+    visualize --> brand
+    scene --> brand
+    viewer --> brand
 ```
 
 Edges point from caller to callee. `models.py` is the lowest-level
@@ -384,10 +389,13 @@ rationale: [ADR-0017](../adr/0017-3d-viewer-architecture.md).
 
 Assembles **one** offline HTML file: it inlines the `scene/v1` JSON plus a
 `data:`-URL import-map for the vendored Three.js (`_viewer_assets/three/`, shipped
-as package data) and the hand-written `_viewer_assets/viewer.js`. The `data:`
+as package data) and the committed `_viewer_assets/viewer.js` bundle — built from
+the typed TypeScript sources under the dev-only top-level `viewer/` by esbuild
+([ADR-0020](../adr/0020-viewer-typescript-architecture.md); the `pip` wheel ships
+the pre-built bundle and never invokes Node). The `data:`
 import-map sidesteps the ES-module `file://` CORS block so a double-clicked page
 loads with zero network. The embedded scene JSON escapes `<` to prevent a
-`</script>` breakout. The thin `viewer.js` consumer (Three.js vendored at r160) builds each plane as a
+`</script>` breakout. The compiled `viewer.js` consumer (Three.js vendored at r160) builds each plane as a
 Three.js `Group` driven per-frame by the affine as a `Matrix4` (`DoubleSide` for
 the reflected det-−1 matrix), with an orbit camera and a scrub/play/step timeline, and a
 load-time self-check of the affine path against the emitted `anchors` **and `gear_anchors`**.
@@ -423,6 +431,18 @@ verified-valid layout. A leaf consumer used by `visualize.py` (2D) and `scene.py
 (3D), with `viewer.py` consuming the shared `PLACEHOLDER_BANNER` string; it never
 enters the collision model, so it adds no determinism or correctness risk to the
 core.
+
+### `brand.py` — single source of brand tokens
+
+The one place every brand token is *defined* — the CVD-safe Okabe–Ito plane
+palette, opacities, darken factors and font stacks
+([ADR-0019](../adr/0019-brand-tokens-single-source.md), #419). The three render
+surfaces *reference* it: `visualize.py` (2D) re-exports the names it always
+exposed, `scene.py` reads `PLANES_DARK`, and `viewer.py` builds its CSS from the
+tokens and injects a canonical `BRAND` JSON blob (separate from the `scene/v1`
+blob) that the compiled `viewer.js` reads instead of hard-coded `0x` literals. A
+leaf of constants + small helpers with no project imports; it never enters the
+collision model, so it carries no determinism or correctness risk.
 
 ### `cli.py` — argparse dispatch + IO + exit codes
 


### PR DESCRIPTION
## Release prep for v0.11.0

Promotes the CHANGELOG `[Unreleased]` block to `## [0.11.0] — 2026-06-06` and refreshes stale docs ahead of the release cut, so the doc work gets a focused review surface separate from the release-state PR.

**Note — this prep did more than a verbatim promotion.** The `[Unreleased]` block was missing entries for most of the v0.11.0 headline work (no CI gate forces a per-PR CHANGELOG entry), so I reconciled the full v0.10.0→develop delta against the actual diffs and added the missing entries (each fact-checked, numbers quoted from the commit):

- **Added:** soft per-plane `priority` constraint (#441); profile-first bench harness + always-on CI gate (#381, #403/F6).
- **Changed:** spread-off tow fallback promoted into the library `solve()` (#402/F5); faster placement — parts-world memoize + AABB broad-phase, 42.3 s→15.7 s, byte-identical (#453, #454); 2D brand-token parity (#418); viewer ported to a dev/CI-only TypeScript toolchain (#436).
- **Fixed:** tow entry door-jamb clipping (#411).
- **Security:** pip 26.1.1→26.1.2 for CVE-2026-8643 (#460); viewer-toolchain CI supply-chain hardening — CodeQL JS/TS, Dependabot npm, dependency-review (#461/#462/#463).

(Already present and left as-is: #404/F7, #79 Herrenteich, #414/#415/#419 brand, #425 glider gate.)

### Doc-freshness fixes
- `README.md` — corrected the Scope claim "No user-defined soft constraints" (#441 added `priority`); updated the `constraints:` mapping description; re-attributed the spread fallback from the CLI to `solve()`.
- `docs/architecture/05-building-block-view.md` — `viewer.js` is a committed esbuild bundle from TypeScript now (ADR-0020), not "hand-written"; added the missing `brand.py` to the module map (node + edges + subsection).
- `CLAUDE.md` — added `brand` to the Quick Reference module-map list.

Docs-only; no source changed. After this PR merges into `develop`, run `/release-cut version=0.11.0` to create the release branch and the →main / →develop PRs.