### PR TITLE
ci(release): populate the Release description from the CHANGELOG section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,6 +246,42 @@ jobs:
 
           ls -la dist/
 
+      - name: Build release notes from the CHANGELOG section
+        # The published Release description should carry this version's
+        # CHANGELOG block, not the bare tag annotation (which `--notes-from-tag`
+        # would otherwise use — leaving the page showing only "Release vX.Y.Z").
+        # We run on the tag's checked-out commit, so CHANGELOG.md is the tagged
+        # version's. Extract `## [X.Y.Z]` up to the next `## [` heading via a
+        # literal-prefix match (so the dotted version needs no regex escaping),
+        # then append the compare-link footer. If the section is absent (a tag
+        # with no changelog entry), fall back to a minimal pointer so the
+        # release still publishes rather than failing on empty notes.
+        env:
+          TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+          awk -v h="## [${VERSION}] " '
+            index($0, h) == 1 { f = 1; next }
+            /^## \[/          { if (f) exit }
+            f                 { print }
+          ' CHANGELOG.md > "$NOTES_FILE"
+          # Drop the blank line(s) left under the consumed heading.
+          sed -i '/./,$!d' "$NOTES_FILE"
+          # Append the "Full changelog" compare link if CHANGELOG defines one.
+          link_line=$(grep -m1 -F "[${VERSION}]: http" CHANGELOG.md || true)
+          if [ -n "$link_line" ]; then
+            printf '\n---\n**Full changelog:** %s\n' "${link_line#*: }" >> "$NOTES_FILE"
+          fi
+          # Never publish empty notes — fall back to a pointer if absent.
+          if [ ! -s "$NOTES_FILE" ]; then
+            echo "WARNING: no CHANGELOG section for $VERSION; using minimal fallback notes." >&2
+            printf 'Release %s.\n\nSee [CHANGELOG.md](https://github.com/DocGerd/hangarfit/blob/%s/CHANGELOG.md) for details.\n' "$TAG" "$TAG" > "$NOTES_FILE"
+          fi
+          echo "NOTES_FILE=$NOTES_FILE" >> "$GITHUB_ENV"
+          { echo "--- release notes preview ---"; cat "$NOTES_FILE"; } >&2
+
       - name: Create or reuse a draft GitHub Release
         # Immutable-releases contract: a PUBLISHED release is sealed — its
         # assets can no longer be uploaded (the upload step would 422).
@@ -286,6 +322,8 @@ jobs:
             }
             if [ "$is_draft" = "true" ]; then
               echo "Draft release for $TAG already exists; reusing it."
+              # Refresh notes so a re-run picks up any CHANGELOG edits.
+              gh release edit "$TAG" --notes-file "$NOTES_FILE"
             else
               echo "A PUBLISHED (immutable) release for $TAG already exists;" >&2
               echo "its assets cannot be modified. Delete it first, then re-run" >&2
@@ -297,7 +335,7 @@ jobs:
             gh release create "$TAG" \
               --draft \
               --title "$TAG" \
-              --notes-from-tag
+              --notes-file "$NOTES_FILE"
           else
             echo "gh release view failed (rc=$view_rc) with unexpected output:" >&2
             echo "$view_out" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,32 +251,49 @@ jobs:
         # CHANGELOG block, not the bare tag annotation (which `--notes-from-tag`
         # would otherwise use — leaving the page showing only "Release vX.Y.Z").
         # We run on the tag's checked-out commit, so CHANGELOG.md is the tagged
-        # version's. Extract `## [X.Y.Z]` up to the next `## [` heading via a
-        # literal-prefix match (so the dotted version needs no regex escaping),
-        # then append the compare-link footer. If the section is absent (a tag
-        # with no changelog entry), fall back to a minimal pointer so the
-        # release still publishes rather than failing on empty notes.
+        # version's. Extract the `## [X.Y.Z]` block (details + edge cases inline
+        # below), append the compare-link footer, and — if the section is absent
+        # (a tag/CHANGELOG mismatch) — fall back to a minimal pointer with a loud
+        # warning so the release still publishes rather than failing on empty
+        # notes.
         env:
           TAG: ${{ steps.tag.outputs.name }}
         run: |
           set -euo pipefail
           VERSION="${TAG#v}"
           NOTES_FILE="$RUNNER_TEMP/release-notes.md"
-          awk -v h="## [${VERSION}] " '
-            index($0, h) == 1 { f = 1; next }
-            /^## \[/          { if (f) exit }
-            f                 { print }
-          ' CHANGELOG.md > "$NOTES_FILE"
-          # Drop the blank line(s) left under the consumed heading.
-          sed -i '/./,$!d' "$NOTES_FILE"
-          # Append the "Full changelog" compare link if CHANGELOG defines one.
-          link_line=$(grep -m1 -F "[${VERSION}]: http" CHANGELOG.md || true)
-          if [ -n "$link_line" ]; then
-            printf '\n---\n**Full changelog:** %s\n' "${link_line#*: }" >> "$NOTES_FILE"
-          fi
-          # Never publish empty notes — fall back to a pointer if absent.
-          if [ ! -s "$NOTES_FILE" ]; then
-            echo "WARNING: no CHANGELOG section for $VERSION; using minimal fallback notes." >&2
+          # Extract the section body up to the next version heading OR the bottom
+          # `[x.y.z]: …` link-reference block — so the file's LAST section does
+          # not sweep in the link list. Literal-prefix match → the dotted version
+          # needs no regex escaping; the trailing space pins it to
+          # `## [X.Y.Z] — DATE` and stops `0.1.0` matching `0.10.0`.
+          section="$(awk -v h="## [${VERSION}] " '
+            index($0, h) == 1            { f = 1; next }
+            /^## \[/ || /^\[[^]]+\]: /   { if (f) exit }
+            f                            { print }
+          ' CHANGELOG.md)"
+          # $() already strips trailing blank lines; drop the leading ones too.
+          section="$(printf '%s\n' "$section" | sed '/./,$!d')"
+          if [ -n "$section" ]; then
+            printf '%s\n' "$section" > "$NOTES_FILE"
+            # Append the "Full changelog" compare link if CHANGELOG defines one.
+            # `|| true` only softens grep's rc=1 (link not defined yet); a real
+            # read error can't reach here — the awk above already read the file.
+            link_line=$(grep -m1 -F "[${VERSION}]: http" CHANGELOG.md || true)
+            if [ -n "$link_line" ]; then
+              printf '\n---\n**Full changelog:** %s\n' "${link_line#*: }" >> "$NOTES_FILE"
+            fi
+          else
+            # No usable section. Publish a minimal pointer rather than blocking a
+            # signed release — but make the degraded path LOUD (a stderr line on
+            # a green job is too easy to miss) and say WHICH failure it was.
+            if grep -qF "## [${VERSION}]" CHANGELOG.md; then
+              msg="found a '## [${VERSION}]' heading but no body — check the heading format ('## [${VERSION}] — DATE') or an empty section"
+            else
+              msg="no '## [${VERSION}]' section in CHANGELOG.md"
+            fi
+            echo "::warning title=Release notes::${msg}; published ${TAG} with minimal fallback notes."
+            echo "⚠️ Release ${TAG} published with FALLBACK notes — ${msg}." >> "$GITHUB_STEP_SUMMARY"
             printf 'Release %s.\n\nSee [CHANGELOG.md](https://github.com/DocGerd/hangarfit/blob/%s/CHANGELOG.md) for details.\n' "$TAG" "$TAG" > "$NOTES_FILE"
           fi
           echo "NOTES_FILE=$NOTES_FILE" >> "$GITHUB_ENV"


### PR DESCRIPTION
Closes #486

## Problem

`release.yml` created the GitHub Release with `gh release create --draft --notes-from-tag`, so the published Release **description** was whatever the annotated tag said. The `release-cut` flow tags with a minimal `-m "Release vX.Y.Z"`, so every Release page showed only "Release vX.Y.Z" with no notes (seen on v0.11.0, fixed by hand post-publish).

## Change

A new **Build release notes from the CHANGELOG section** step (runs on the already-checked-out tag commit, so `CHANGELOG.md` is the tagged version's):
- Extracts the `## [X.Y.Z]` block (`VERSION = TAG` minus leading `v`) up to the next `## [` heading, using a literal-prefix `index($0, "## [VERSION] ") == 1` match so the dotted version needs **no** regex escaping; strips the leading blank line.
- Appends the `[X.Y.Z]: …/compare/…` link as a **Full changelog** footer.
- Falls back to a minimal pointer (with a warning) if no section exists, so the release **never** fails on empty notes.

Then `gh release create … --notes-file "$NOTES_FILE"` replaces `--notes-from-tag`, and the **reuse-draft path** gains `gh release edit … --notes-file` so a `workflow_dispatch` re-run refreshes the notes.

## Safety

- CI-only. No change to the artifact build, `SOURCE_DATE_EPOCH` reproducibility, Sigstore signing, or the immutable draft→upload→publish sequence.
- No injection surface: the step reads `TAG` via `env:` (the workflow's existing pattern) and `$TAG` is maintainer-controlled tag input, not untrusted event data; no `${{ }}` is interpolated into a `run:` block.
- Extraction prototyped locally against the current CHANGELOG → produces the exact `### Added/Changed/Fixed/Security` body + footer, no neighbouring-version leakage.

## Verification note

The build-notes logic only exercises on a real `v*` tag push, so it can't be covered by a develop-base CI run. Validated by local prototype (see issue #486); the next release cut will exercise it end-to-end.