### PR TITLE
perf(#455): incremental single-plane gap cache in the spread post-pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
   candidates) and recomputes only the moved plane's pairs — an O(n²)→O(n)
   reduction in pairwise distances per candidate. The energy is still summed over
   all pairs in canonical order, so the result is **byte-for-byte identical** to
-  before (ADR-0003): verified by diffing solve output across 3 fixtures × 5 seeds
-  against the prior `develop`, the determinism canaries, and the bench
-  run-twice check. It is a distance memo, never the bit-divergent delta-update.
-  Measured `roomy_three_spread_on` placement 15.04 s → 14.08 s median (~6 %) at
-  n = 3; the saving grows with fleet size.
+  before (ADR-0003): verified by diffing solve output against the prior `develop`
+  across the two spread-active fixtures (3- and 6-plane) over 5 seeds each, the
+  determinism canaries, and the bench run-twice check. It is a distance memo,
+  never the bit-divergent delta-update. Measured `roomy_three_spread_on`
+  placement 15.04 s → 14.08 s median (~6 %) at n = 3 (baseline itself down from
+  the spike's 40.6 s after #453/#454); the saving grows with fleet size.
 
 - **Consolidated example artifacts under a top-level `examples/` umbrella
   (#448).** The root `layouts/` (hand-authored demo layouts) and `herrenteich/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- **Incremental single-plane gap cache in the spread post-pass (#455).** The
+  ADR-0008 spread hill-climb perturbs one plane per iteration and scores several
+  candidate positions for it; the repulsion energy (`_inter_plane_energy`) now
+  memoizes the expensive shapely edge-to-edge distance for the plane pairs that
+  do *not* involve the moved plane (their gap is invariant across those
+  candidates) and recomputes only the moved plane's pairs — an O(n²)→O(n)
+  reduction in pairwise distances per candidate. The energy is still summed over
+  all pairs in canonical order, so the result is **byte-for-byte identical** to
+  before (ADR-0003): verified by diffing solve output across 3 fixtures × 5 seeds
+  against the prior `develop`, the determinism canaries, and the bench
+  run-twice check. It is a distance memo, never the bit-divergent delta-update.
+  Measured `roomy_three_spread_on` placement 15.04 s → 14.08 s median (~6 %) at
+  n = 3; the saving grows with fleet size.
+
 - **Consolidated example artifacts under a top-level `examples/` umbrella
   (#448).** The root `layouts/` (hand-authored demo layouts) and `herrenteich/`
   (the real DWG-measured Airfield Herrenteich dataset) directories moved to

--- a/docs/adr/0008-inter-plane-spread-soft-preference.md
+++ b/docs/adr/0008-inter-plane-spread-soft-preference.md
@@ -289,3 +289,37 @@ identical for a given seed across machines, which *narrows* the #267 wall-clock
 timing scope rather than widening it (see the ADR-0003 amendment dated
 2026-06-06). The default `None` path is byte-identical to pre-F7, so the
 `spread=False` determinism canaries and `determinism-guard` are untouched.
+
+### 2026-06-07 — incremental single-plane gap cache (issue #455)
+
+**Background.** The F6 profile (`bench.profile_pipeline`) confirmed the spread
+post-pass is ~99 % of placement on the canonical `roomy_three_spread_on` regime,
+and that within it the repulsion energy (`_inter_plane_energy`) is ~25 % (the rest
+is the per-candidate validity `collisions.check`, which #453's geometry
+memoization already attacks). Each `_spread` iteration perturbs **one** plane and
+scores several candidate positions for it, yet the energy recomputed the
+(expensive) shapely `polygon.distance` for *all* O(n²) pairs on every candidate —
+even the pairs whose gap cannot have changed because neither endpoint moved.
+
+**Change.** `_inter_plane_energy` takes an optional `gap_cache` + `moved` plane.
+For every pair **not** touching `moved` it memoizes the edge-to-edge distance and
+reuses it across the candidates that share the cache (one per `_spread`
+iteration); the `moved` plane's pairs are always recomputed. This turns the
+per-candidate energy cost from O(n²) to O(n) pairwise shapely distances. Every
+caller outside `_spread` passes `gap_cache=None` and gets the original full sweep.
+
+**Determinism — the safe form, NOT a delta-update.** The energy is still summed
+over **all** pairs in canonical `sorted`-id order; only the *source* of each
+pair's gap changes (cache vs. fresh), and a cached gap is the identical float
+(same unchanged poses, deterministic shapely). So the sum is **byte-for-byte
+identical** to the cache-free recompute (ADR-0003) — verified empirically by
+diffing solve output for 3 fixtures × 5 seeds against the pre-change `develop`
+(all identical), plus the two `test_gap_cache_*` unit assertions and the bench
+run-twice determinism check. **Do not** convert this to a delta-update
+("subtract the moved plane's old pair energies, add the new"): the #455 review
+measured that form diverging ~1e-15 in ~29 % of moves, which — because energy is
+the primary acceptance key — flips candidate acceptance and breaks the contract.
+The `back_bias` term (#320) is a per-plane sum with no pairs, so it is always
+re-summed in full. Measured: `roomy_three_spread_on` placement 15.04 s → 14.08 s
+median (~6 %) at n = 3; the saving is O(n²)→O(n) in plane count, so it grows with
+fleet size.

--- a/docs/adr/0008-inter-plane-spread-soft-preference.md
+++ b/docs/adr/0008-inter-plane-spread-soft-preference.md
@@ -292,14 +292,21 @@ timing scope rather than widening it (see the ADR-0003 amendment dated
 
 ### 2026-06-07 — incremental single-plane gap cache (issue #455)
 
-**Background.** The F6 profile (`bench.profile_pipeline`) confirmed the spread
-post-pass is ~99 % of placement on the canonical `roomy_three_spread_on` regime,
-and that within it the repulsion energy (`_inter_plane_energy`) is ~25 % (the rest
-is the per-candidate validity `collisions.check`, which #453's geometry
-memoization already attacks). Each `_spread` iteration perturbs **one** plane and
-scores several candidate positions for it, yet the energy recomputed the
-(expensive) shapely `polygon.distance` for *all* O(n²) pairs on every candidate —
-even the pairs whose gap cannot have changed because neither endpoint moved.
+**Background.** A **fresh** profile taken *after* #453 (parts-world memo) and #454
+(AABB broad-phase) had landed —
+`python -m bench.profile_pipeline --regime roomy_three_spread_on --profile` —
+confirms the spread post-pass is still ~99 % of placement on the canonical
+`roomy_three_spread_on` regime, with the per-candidate split now **collisions.check
+~72 % / `_inter_plane_energy` ~25 %** (cumulative cProfile buckets). That inverts
+the pre-#453 spike's 57 % / 41 % split (`solve-tow-profiling.md`): #453's geometry
+memo turned the energy term's repeated world-part rebuilds into cache hits, so its
+*share* shrank while `collisions.check` stayed the dominant placement cost. The
+upshot is that the energy term this amendment optimizes is the **secondary** lever
+(the validity `collisions.check` is the bigger slice, attacked cross-cuttingly by
+#453). Each `_spread` iteration perturbs **one** plane and scores several candidate
+positions for it, yet the energy recomputed the (expensive) shapely
+`polygon.distance` for *all* O(n²) pairs on every candidate — even the pairs whose
+gap cannot have changed because neither endpoint moved.
 
 **Change.** `_inter_plane_energy` takes an optional `gap_cache` + `moved` plane.
 For every pair **not** touching `moved` it memoizes the edge-to-edge distance and
@@ -313,13 +320,17 @@ over **all** pairs in canonical `sorted`-id order; only the *source* of each
 pair's gap changes (cache vs. fresh), and a cached gap is the identical float
 (same unchanged poses, deterministic shapely). So the sum is **byte-for-byte
 identical** to the cache-free recompute (ADR-0003) — verified empirically by
-diffing solve output for 3 fixtures × 5 seeds against the pre-change `develop`
-(all identical), plus the two `test_gap_cache_*` unit assertions and the bench
-run-twice determinism check. **Do not** convert this to a delta-update
-("subtract the moved plane's old pair energies, add the new"): the #455 review
-measured that form diverging ~1e-15 in ~29 % of moves, which — because energy is
-the primary acceptance key — flips candidate acceptance and breaks the contract.
+diffing solve output against the pre-change `develop` across the two
+**spread-active** fixtures (`solve_fresh_alternatives_three`, 3 planes, and
+`solve_fresh_six_planes`, 6 planes) over 5 seeds each — the cache path runs only
+under spread — all identical, plus the two `test_gap_cache_*` unit assertions and
+the bench run-twice determinism check. **Do not** convert this to a delta-update
+("subtract the moved plane's old pair energies, add the new"): the #455 issue's
+adversarial review measured that form diverging at the float-ULP level (~1e-15) on
+a substantial fraction of moves (~29 %), which — because energy is the primary
+acceptance key — flips candidate acceptance and breaks the contract.
 The `back_bias` term (#320) is a per-plane sum with no pairs, so it is always
 re-summed in full. Measured: `roomy_three_spread_on` placement 15.04 s → 14.08 s
-median (~6 %) at n = 3; the saving is O(n²)→O(n) in plane count, so it grows with
-fleet size.
+median (~6 %) at n = 3 — baseline ~15 s, itself down from the spike's 40.6 s after
+#453/#454 landed. The saving is O(n²)→O(n) in plane count, so it grows with fleet
+size.

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -945,6 +945,9 @@ def _inter_plane_energy(
     placements: dict[str, Placement],
     scenario: Scenario,
     scale: float,
+    *,
+    gap_cache: dict[tuple[str, str], float] | None = None,
+    moved: str | None = None,
 ) -> float:
     """Smooth repulsion energy ``E = Σ_{i<j} w_i·w_j·exp(−gap_ij / scale)`` (spec §4).
 
@@ -957,6 +960,19 @@ def _inter_plane_energy(
     unweighted ``Σ exp(−gap/scale)`` byte-for-byte (ADR-0003). Returns ``0.0``
     when fewer than two planes are present. Ignores z (plan-view only) — see
     ADR-0008 for the nesting limitation.
+
+    Incremental single-plane re-scoring (#455): the :func:`_spread` hill-climb
+    perturbs ONE plane (``moved``) per iteration and scores several candidate
+    positions for it. Every pair that does *not* involve ``moved`` is identical
+    across those candidates, so when ``gap_cache`` is supplied this memoizes the
+    expensive ``gap_ij`` (the shapely distance) for exactly those pairs and
+    reuses it. The energy is still accumulated over **all** pairs in canonical
+    ``sorted``-id order, so a cached gap (the same float, recomputed from the same
+    unchanged poses) makes the result **byte-for-byte identical** to the cache-free
+    full recompute (ADR-0003) — this is a distance memo, never the bit-divergent
+    delta-update (#455). Pairs touching ``moved`` are always recomputed and never
+    cached (``moved`` moves between calls). With ``gap_cache=None`` (every caller
+    outside ``_spread``) this is exactly the original full pairwise sweep.
     """
     ids = sorted(placements)
     if len(ids) < 2:
@@ -968,10 +984,17 @@ def _inter_plane_energy(
     energy = 0.0
     for i in range(len(ids)):
         for j in range(i + 1, len(ids)):
-            gap = min(
-                pa.polygon.distance(pb.polygon) for pa in world[ids[i]] for pb in world[ids[j]]
-            )
-            energy += w[ids[i]] * w[ids[j]] * math.exp(-gap / scale)
+            a, b = ids[i], ids[j]
+            # A pair is cacheable iff neither endpoint is the perturbed plane:
+            # only then is its gap invariant across the candidates sharing the cache.
+            cache = gap_cache if (moved != a and moved != b) else None
+            if cache is not None and (a, b) in cache:
+                gap = cache[(a, b)]
+            else:
+                gap = min(pa.polygon.distance(pb.polygon) for pa in world[a] for pb in world[b])
+                if cache is not None:
+                    cache[(a, b)] = gap
+            energy += w[a] * w[b] * math.exp(-gap / scale)
     return energy
 
 
@@ -1070,11 +1093,18 @@ def _spread(
         # lone plane is still pulled to the back wall, so we do NOT bail there.
         return placements
 
-    def _energy(trial: dict[str, Placement]) -> float:
+    def _energy(
+        trial: dict[str, Placement],
+        *,
+        gap_cache: dict[tuple[str, str], float] | None = None,
+        moved: str | None = None,
+    ) -> float:
         # Spread repulsion, plus the #320 back-of-hangar bias when active. The
         # back-bias re-ranks candidates *within* this hill-climb; basin selection
-        # stays min-gap-primary (ADR-0008 amended).
-        e = _inter_plane_energy(trial, scenario, scale)
+        # stays min-gap-primary (ADR-0008 amended). gap_cache/moved memoize the
+        # unchanged-pair distances within one iteration (#455, byte-identical);
+        # the back-bias is a per-plane sum (no pairs) so it is always re-summed.
+        e = _inter_plane_energy(trial, scenario, scale, gap_cache=gap_cache, moved=moved)
         if back_fill:
             e += search.back_bias_weight * _back_bias_energy(trial, scenario)
         return e
@@ -1100,6 +1130,10 @@ def _spread(
         # Pick the lowest-(energy, displacement) VALID candidate. Adopt it
         # only if its energy is strictly below current (so the stall counter
         # advances on non-improving iterations — no plateau-wander livelock).
+        # Per-iteration distance memo (#455): only `target` moves across these
+        # candidates, so the pairs not touching it have an invariant gap — compute
+        # each once and reuse. Re-summed in canonical order ⇒ byte-identical.
+        gap_cache: dict[tuple[str, str], float] = {}
         best_key: tuple[float, float] | None = None
         best_placements = placements
         for cand in candidates:
@@ -1124,7 +1158,7 @@ def _spread(
                 continue
             if _score(trial_layout) != (0, 0.0):
                 continue  # must STAY valid
-            e = _energy(trial)
+            e = _energy(trial, gap_cache=gap_cache, moved=target)
             disp = (
                 (cand.x_m - placements[target].x_m) ** 2 + (cand.y_m - placements[target].y_m) ** 2
             ) ** 0.5

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -428,6 +428,71 @@ def test_inter_plane_energy_strictly_increases_with_priority():
     assert _inter_plane_energy(placements, hi, scale) > base
 
 
+# ---------------------------------------------------------------------------
+# Incremental single-plane gap cache in _inter_plane_energy (#455)
+#
+# The spread hill-climb moves ONE plane per iteration and evaluates several
+# candidates for it. Pairs that do NOT involve the moved plane are identical
+# across all candidates, so their (expensive) shapely edge-to-edge distance can
+# be computed once and reused. The SAFE form re-sums ALL pairs in canonical
+# sorted order using cached distances for the unchanged pairs — bit-identical to
+# the full recompute (ADR-0003), unlike a delta-update which drifts ~1e-15 and
+# flips acceptance (#455).
+# ---------------------------------------------------------------------------
+
+
+def _three_plane_placements(scenario):
+    """A valid 3-plane layout's placements dict (plane_id -> Placement)."""
+    res = solve(scenario, seed=0, search=SearchConfig(max_restarts=3), plan_paths=False)
+    return {p.plane_id: p for p in res.layouts[0].placements}
+
+
+def test_gap_cache_byte_identical_to_full_recompute():
+    """A populated gap cache yields the EXACT same energy as the cache-free full
+    recompute — including after moving ONLY the cached ``moved`` plane, where the
+    unchanged pairs stay valid. Bit-identical (``==``), not approximate."""
+    from hangarfit.solver import _inter_plane_energy, _resolve_spread_scale
+
+    s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    placements = _three_plane_placements(s)
+    scale = _resolve_spread_scale(s, SearchConfig())
+    moved = sorted(placements)[0]
+
+    cache: dict = {}
+    e1 = _inter_plane_energy(placements, s, scale, gap_cache=cache, moved=moved)
+    assert e1 == _inter_plane_energy(placements, s, scale)  # exact, not approx
+
+    # Perturb ONLY ``moved``; the other pair(s) are unchanged, so the cache from
+    # the first call stays valid and the reused result must equal a fresh full
+    # sum (the moved plane's own pairs are always recomputed).
+    shifted = dataclasses.replace(placements[moved], x_m=placements[moved].x_m + 1.0)
+    moved_layout = {**placements, moved: shifted}
+    e2 = _inter_plane_energy(moved_layout, s, scale, gap_cache=cache, moved=moved)
+    assert e2 == _inter_plane_energy(moved_layout, s, scale)  # exact, not approx
+
+
+def test_gap_cache_is_consulted_for_unchanged_pairs():
+    """The cache is actually READ, not accepted-and-ignored: poisoning the cached
+    unchanged-pair distance changes the computed energy. Only the non-``moved``
+    pairs are cached (n=3 with one moved plane => exactly one cacheable pair); the
+    ``moved`` plane's pairs are always recomputed fresh."""
+    from hangarfit.solver import _inter_plane_energy, _resolve_spread_scale
+
+    s = load_scenario("tests/fixtures/solve_fresh_alternatives_three.yaml")
+    placements = _three_plane_placements(s)
+    scale = _resolve_spread_scale(s, SearchConfig())
+    moved = sorted(placements)[0]
+
+    cache: dict = {}
+    e_clean = _inter_plane_energy(placements, s, scale, gap_cache=cache, moved=moved)
+    assert len(cache) == 1  # only the single unchanged (non-moved) pair is cached
+
+    for key in list(cache):
+        cache[key] = 1.0e9  # poison: a huge gap => ~0 repulsion contribution
+    e_poisoned = _inter_plane_energy(placements, s, scale, gap_cache=cache, moved=moved)
+    assert e_poisoned < e_clean  # the cached unchanged pair was consulted
+
+
 def test_solve_priority_zero_byte_identical_to_no_constraints():
     """Inert-by-default at solve() level: all-zero priority selects the SAME
     layout as no priority, same seed (ADR-0003, max_restarts-scoped)."""


### PR DESCRIPTION
Closes #455

## What

The ADR-0008 spread hill-climb (`_spread`) perturbs **one** plane per iteration and scores several candidate positions for it. Every plane pair that does *not* involve the moved plane has an invariant edge-to-edge gap across those candidates, yet the old `_inter_plane_energy` recomputed the (expensive) shapely `polygon.distance` for **all** O(n²) pairs on every candidate.

This adds an optional per-iteration `gap_cache` + `moved` plane to `_inter_plane_energy`: it memoizes the shapely distance for pairs **not** touching the moved plane and reuses it; the moved plane's pairs are always recomputed. O(n²)→O(n) pairwise shapely distances per candidate. Every caller outside `_spread` passes `gap_cache=None` and gets the original full sweep.

## Determinism — byte-identical, the *safe* form (ADR-0003)

The energy is still summed over **all** pairs in canonical `sorted`-id order; only the *source* of each pair's gap changes (cache vs. fresh), and a cached gap is the identical float (same unchanged poses, deterministic shapely). It is a **distance memo, never a delta-update** — the #455 review measured the delta form diverging ~1e-15 in ~29 % of moves, flipping the energy-keyed candidate acceptance and breaking the contract. The `back_bias` term (per-plane sum, no pairs) is always re-summed.

**Evidence:**
- **Cross-branch byte-identity:** solve output diffed across **3 fixtures × 5 seeds** (incl. spread-active 3- and 6-plane) against pre-change `develop` — **all identical**.
- Two new unit tests: `test_gap_cache_byte_identical_to_full_recompute` (exact `==`) and `test_gap_cache_is_consulted_for_unchanged_pairs` (poison test — proves the cache is actually read, not a no-op).
- `bench` run-twice determinism (`det=True`) + the `spread=False` solver canaries (unchanged).

## Measured

`roomy_three_spread_on` placement **15.04 s → 14.08 s median (~6 %)** at n = 3 (3-run medians, `max_restarts`-bound so reproducible). The saving is O(n²)→O(n) in plane count, so it **grows with fleet size**; at n = 3 it is modest because the dominant placement cost is the per-candidate `collisions.check` (~72 %), not the energy term (~25 %).

## Docs

ADR-0008 amendment (the safe-form rationale + the do-not-delta-update warning) and CHANGELOG `[Unreleased]/Changed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)