### PR TITLE
perf(#499): apron regimes in the solve→tow profiling harness

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -54,6 +54,15 @@ re-check.
   layouts, `placement_s + routing_s` is a faithful decomposition of the
   end-to-end wall-clock.
 
+* **Apron regimes (#499/ADR-0021).** `Regime.apron_depth` applies a staging
+  apron to the scenario's hangar (`0` ⇒ no apron, the load path stays
+  byte-identical; a number or `"auto"` ⇒ apron on). It enlarges the per-plane tow
+  start set and lengthens each path, so it characterises the apron's
+  routing-cost effect. Finding: the apron is planner-only (placement unchanged),
+  feasible fills route at the default budgets, and the un-routable disprove rises
+  only modestly — no budget re-tune needed. See the
+  [profiling spike §6](../docs/spikes/solve-tow-profiling.md).
+
 The regimes themselves are defined in [`regimes.py`](regimes.py); they reference
 committed `tests/fixtures/*.yaml` scenarios so the harness has no private data.
 

--- a/bench/harness.py
+++ b/bench/harness.py
@@ -121,8 +121,14 @@ class RegimeResult:
 
 
 def load_regime_scenario(regime: Regime) -> Scenario:
-    """Load a regime's scenario (relative fleet/hangar refs resolve correctly)."""
-    return load_scenario(regime.scenario)
+    """Load a regime's scenario (relative fleet/hangar refs resolve correctly).
+
+    A non-zero ``apron_depth`` (#499/ADR-0021) is applied to the resolved hangar;
+    ``0`` passes ``apron_depth=None`` so the no-apron regimes keep the original
+    load path (and their numbers) byte-identical.
+    """
+    apron = regime.apron_depth if regime.apron_depth else None
+    return load_scenario(regime.scenario, apron_depth=apron)
 
 
 def _search_config(regime: Regime) -> SearchConfig:

--- a/bench/profile_pipeline.py
+++ b/bench/profile_pipeline.py
@@ -60,6 +60,10 @@ _SPEED_CEILING_S: dict[str, float] = {
     "trivial_single": 10.0,
     "roomy_three_spread_on": 100.0,
     "roomy_three_spread_off": 20.0,
+    # Same placement as roomy_three_spread_on (apron is planner-only) plus the
+    # apron's heavier routing (~5 s dev / ~15-20 s CI for the 14 m deep fill), so
+    # a touch above the spread-on ceiling. Tripwire, not a microbenchmark (#499).
+    "roomy_three_apron": 120.0,
 }
 
 

--- a/bench/regimes.py
+++ b/bench/regimes.py
@@ -37,6 +37,12 @@ class Regime:
     (``plan_fill``'s ``max_total_expansions``). ``None`` on either means the
     ``towplanner`` module default. ``heavy`` regimes are excluded from the
     default fast set (they do substantial — sometimes un-routable — routing).
+
+    ``apron_depth`` (#412/ADR-0021) sets the staging-apron depth applied to the
+    scenario's hangar (``0`` ⇒ no apron, the pre-apron path, byte-identical;
+    ``"auto"`` ⇒ fleet-derived). It enlarges the per-plane tow start set (forward
+    + reverse cones × the apron y-samples) and lengthens each path, so it is the
+    knob that characterises the apron's routing-cost effect (#499).
     """
 
     key: str
@@ -51,6 +57,7 @@ class Regime:
     tow_max_expansions: int | None = None
     tow_max_total_expansions: int | None = None
     heavy: bool = False
+    apron_depth: float | Literal["auto"] = 0.0
 
 
 REGIMES: tuple[Regime, ...] = (
@@ -104,6 +111,37 @@ REGIMES: tuple[Regime, ...] = (
         spread=True,
         n_planes=6,
         tow_max_total_expansions=4000,
+        heavy=True,
+    ),
+    Regime(
+        # Apron routing-cost characterisation (#499/ADR-0021). Same placement as
+        # roomy_three_spread_on (apron is planner-only ⇒ placement unchanged); the
+        # apron enlarges the tow start set (forward+reverse cones × y-samples) and
+        # lengthens each path. 14 m ≈ derive_apron_depth(fleet)=14.98 m here, deep
+        # enough that ALL three planes engage the apron (a shallower apron silently
+        # falls back to the door line for the longer planes — see the #499 spike).
+        key="roomy_three_apron",
+        description="3 planes, 30x25 m hangar, 14 m staging apron — slide-in routing cost",
+        scenario=FIXTURES / "solve_fresh_alternatives_three.yaml",
+        seed=1,
+        max_restarts=30,
+        spread=True,
+        n_planes=3,
+        apron_depth=14.0,
+    ),
+    Regime(
+        # The apron's effect on the un-routable disprove (the expensive failure
+        # mode): the tight 6-plane placeholder fill with a 10 m apron. The global
+        # cap bounds the bail; heavy ⇒ excluded from the gated fast set.
+        key="tight_six_apron",
+        description="6 planes, 25x18 m placeholder, 10 m apron — un-routable disprove cost",
+        scenario=FIXTURES / "solve_fresh_six_planes.yaml",
+        seed=1,
+        max_restarts=6,
+        spread=True,
+        n_planes=6,
+        tow_max_total_expansions=4000,
+        apron_depth=10.0,
         heavy=True,
     ),
 )

--- a/bench/regimes.py
+++ b/bench/regimes.py
@@ -117,9 +117,10 @@ REGIMES: tuple[Regime, ...] = (
         # Apron routing-cost characterisation (#499/ADR-0021). Same placement as
         # roomy_three_spread_on (apron is planner-only ⇒ placement unchanged); the
         # apron enlarges the tow start set (forward+reverse cones × y-samples) and
-        # lengthens each path. 14 m ≈ derive_apron_depth(fleet)=14.98 m here, deep
-        # enough that ALL three planes engage the apron (a shallower apron silently
-        # falls back to the door line for the longer planes — see the #499 spike).
+        # lengthens each path. 14 m matches the opt-in derive_apron_depth(fleet)=
+        # 14.98 m over-margin and clears every plane's per-plane footprint gate with
+        # room to spare, so ALL three engage the apron (the longer planes fall back
+        # to the door line at a too-shallow depth like 6 m — see the #499 spike).
         key="roomy_three_apron",
         description="3 planes, 30x25 m hangar, 14 m staging apron — slide-in routing cost",
         scenario=FIXTURES / "solve_fresh_alternatives_three.yaml",

--- a/docs/spikes/solve-tow-profiling.md
+++ b/docs/spikes/solve-tow-profiling.md
@@ -84,13 +84,15 @@ at 0.05 m / 1° against the faithful back-first obstacle context), and
 
 ### Regimes
 
-| Regime | Scenario | Planes | Hangar | Spread | Restarts |
-|---|---|---:|---|---|---:|
-| `trivial_single` | `solve_trivial_single_plane` | 1 | 30×25 | on | 20 |
-| `roomy_three_spread_on` | `solve_fresh_alternatives_three` | 3 | 30×25 | on | 30 |
-| `roomy_three_spread_off` | `solve_fresh_alternatives_three` | 3 | 30×25 | off | 30 |
-| `full_nine_spread_on` | `solve_all_nine_large_hangar` | 9 | 30×25 | on | 4 |
-| `tight_six_placeholder` | `solve_fresh_six_planes` | 6 | 25×18 | on | 6 |
+| Regime | Scenario | Planes | Hangar | Spread | Restarts | Apron |
+|---|---|---:|---|---|---:|---:|
+| `trivial_single` | `solve_trivial_single_plane` | 1 | 30×25 | on | 20 | — |
+| `roomy_three_spread_on` | `solve_fresh_alternatives_three` | 3 | 30×25 | on | 30 | — |
+| `roomy_three_spread_off` | `solve_fresh_alternatives_three` | 3 | 30×25 | off | 30 | — |
+| `full_nine_spread_on` | `solve_all_nine_large_hangar` | 9 | 30×25 | on | 4 | — |
+| `tight_six_placeholder` | `solve_fresh_six_planes` | 6 | 25×18 | on | 6 | — |
+| `roomy_three_apron` (#499) | `solve_fresh_alternatives_three` | 3 | 30×25 | on | 30 | 14 m |
+| `tight_six_apron` (#499, heavy) | `solve_fresh_six_planes` | 6 | 25×18 | on | 6 | 10 m |
 
 ---
 
@@ -192,6 +194,46 @@ parts constant within a `plan_path`, but everything else — every placement-sid
 `_motion_clear` — rebuilds parts from scratch with **no memoization and no
 broad-phase**. A single un-routable 9-plane fill still constructs **8.6 million**
 shapely polygons. That one function is the lever.
+
+### 6. The staging apron (#412 / ADR-0021) — routing-cost characterisation (#499)
+
+The apron enlarges the per-plane tow start set (forward **and** reverse cones ×
+the apron y-samples) and lengthens each path, so #499 added two regimes to track
+its cost. Measured (dev machine, 2026-06-07):
+
+| Regime | place_s | route_s | total_s | routed | det |
+|---|---:|---:|---:|---|---|
+| `roomy_three_spread_on` (no apron) | 14.05 | 0.76 | 14.81 | 1/1 | ok |
+| `roomy_three_apron` (14 m) | 13.94 | **4.97** | 18.91 | 1/1 | ok |
+| `tight_six_placeholder` (no apron) | 5.73 | 67.39 | 73.11 | 0/1 | ok |
+| `tight_six_apron` (10 m) | 5.80 | **73.42** | 79.22 | 0/1 | ok |
+
+- **Apron is planner-only — placement is unchanged** (14.05↔13.94, 5.73↔5.80; the
+  solver never reads `apron_depth_m`). This is the empirical proof of the
+  ADR-0021 gating claim.
+- **Feasible fills route at the default budgets.** `roomy_three_apron` is 1/1
+  routed at the shipped `_MAX_EXPANSIONS`/`_MAX_FILL_EXPANSIONS`; routing rises
+  0.76 → 4.97 s (~6.5×) for the fully-engaged 14 m apron, but the absolute cost
+  is small and well under the gate. No feasible apron fill bailed from budget.
+- **The un-routable disprove rises only modestly and stays bounded:** tight-6
+  67.4 → 73.4 s (+9 %), capped by the global expansion cap. Determinism holds
+  (`det=ok`) for both apron regimes.
+- **Slide-in engagement is depth-gated, per-plane.** An apron only engages a
+  plane when its depth ≳ that plane's (fore-aft length + turn radius): at 6 m,
+  `fuji` (7.98 m) has *all* its apron start poses filtered (footprint overflows
+  the apron south bound) and **silently falls back to the `y = 0` door line** (the
+  `plan_path` fallback), while the two shorter planes slide in. At ≈14 m (or
+  `auto` = 14.98 m here) all three engage. **`auto` is the safe default; a
+  too-shallow hand-set apron is the footgun** — a candidate follow-up is to warn
+  (or auto-deepen) when every apron pose for a plane filters out.
+
+**Budget decision (the #499 question): keep `_MAX_EXPANSIONS` /
+`_MAX_FILL_EXPANSIONS` as-is.** The apron's routing cost is modest, bounded by
+the global cap, and feasible fills route at the defaults; raising the budgets
+would buy nothing here and risks shifting the non-apron routability knee (a
+byte-divergence hazard for existing outputs — see the determinism section). A
+hard apron fill is bounded per-run with `--tow-max-expansions`, exactly as
+ADR-0021 anticipated.
 
 ---
 

--- a/docs/spikes/solve-tow-profiling.md
+++ b/docs/spikes/solve-tow-profiling.md
@@ -219,12 +219,18 @@ its cost. Measured (dev machine, 2026-06-07):
   67.4 → 73.4 s (+9 %), capped by the global expansion cap. Determinism holds
   (`det=ok`) for both apron regimes.
 - **Slide-in engagement is depth-gated, per-plane.** An apron only engages a
-  plane when its depth ≳ that plane's (fore-aft length + turn radius): at 6 m,
-  `fuji` (7.98 m) has *all* its apron start poses filtered (footprint overflows
-  the apron south bound) and **silently falls back to the `y = 0` door line** (the
-  `plan_path` fallback), while the two shorter planes slide in. At ≈14 m (or
-  `auto` = 14.98 m here) all three engage. **`auto` is the safe default; a
-  too-shallow hand-set apron is the footgun** — a candidate follow-up is to warn
+  plane when it is deep enough for that plane's footprint to fit *inside* the
+  apron at a start pose — i.e. a function of the plane's **footprint depth**
+  (driven by its fore-aft extent and where the reference origin sits), **not** its
+  turn radius (the radius does not enter the per-plane `_mover_motion_bounds_conflict`
+  south-bound filter). At 6 m, `fuji` (7.98 m long) has *all* its apron start poses
+  filtered (footprint overflows the apron south bound) and **silently falls back
+  to the `y = 0` door line** (the `plan_path` fallback), while the two shorter
+  planes slide in; measured, all three roomy-3 planes engage by ~7 m. The opt-in
+  `auto` depth (`≈ max plane length + max turn radius` = 14.98 m here) is a
+  deliberate *over-margin* that clears every plane's gate comfortably — not the
+  minimum. **`auto` is the safe default; a too-shallow hand-set apron is the
+  footgun** — a candidate follow-up is to warn
   (or auto-deepen) when every apron pose for a plane filters out.
 
 **Budget decision (the #499 question): keep `_MAX_EXPANSIONS` /


### PR DESCRIPTION
Closes #499. The ADR-0021-named follow-up: characterise the staging apron's effect on tow-routing cost, and decide whether the expansion budgets need re-tuning. **Dev-only `bench/` change — never shipped in the wheel; CI does not mypy/build it.**

## What changed
- `bench/regimes.py`: `Regime.apron_depth: float | Literal["auto"] = 0.0`; two new regimes — `roomy_three_apron` (14 m, fast/gated) and `tight_six_apron` (10 m, heavy).
- `bench/harness.py`: `load_regime_scenario` threads `apron_depth` (0 ⇒ `None`, so the existing no-apron regimes keep their exact load path + numbers).
- `bench/profile_pipeline.py`: gate ceiling for the fast apron regime (120 s tripwire).
- `docs/spikes/solve-tow-profiling.md` §6 + `bench/README.md`: findings + the budget decision.

## Measured (dev machine)
| Regime | place_s | route_s | total_s | routed | det |
|---|---:|---:|---:|---|---|
| `roomy_three_spread_on` (no apron) | 14.05 | 0.76 | 14.81 | 1/1 | ok |
| `roomy_three_apron` (14 m) | 13.94 | **4.97** | 18.91 | 1/1 | ok |
| `tight_six_placeholder` (no apron) | 5.73 | 67.39 | 73.11 | 0/1 | ok |
| `tight_six_apron` (10 m) | 5.80 | **73.42** | 79.22 | 0/1 | ok |

`--gate` passes: `roomy_three_apron valid=ok paths=ok det=ok speed[18.82s / 120s]`.

## Findings
- **Apron is planner-only** — placement unchanged (14.05↔13.94, 5.73↔5.80), the empirical proof of ADR-0021's gating claim.
- **Feasible fills route at default budgets** (`roomy_three_apron` 1/1); routing 0.76 → 4.97 s for the deep apron, small in absolute terms.
- **Un-routable disprove rises modestly** (+9%) and stays bounded by the global cap; **det=ok** for both apron regimes.
- **Slide-in is depth-gated per plane:** an apron engages a plane only when depth ≳ (plane length + turn radius). At 6 m the longest plane (`fuji`, 7.98 m) silently falls back to the `y=0` door line; at ≈14 m / `auto` all engage. `auto` is the safe default; a too-shallow hand-set apron is the footgun (candidate follow-up: warn/auto-deepen when all of a plane's apron poses filter out).

## Decision
**Keep `_MAX_EXPANSIONS` / `_MAX_FILL_EXPANSIONS` as-is.** The apron's cost is modest and bounded; re-tuning buys nothing here and risks shifting the non-apron routability knee (a byte-divergence hazard, ADR-0003). `--tow-max-expansions` bounds a hard apron fill per-run.

## Test plan
- [x] `python -m bench.profile_pipeline --heavy` — full table (above), all regimes valid/paths/det ok
- [x] `python -m bench.profile_pipeline --gate` — GATE PASSED
- [x] `ruff check bench/` / `ruff format --check bench/` clean
- [x] No `src/` change → solver/towplanner determinism contract untouched (the harness's `det=ok` independently re-confirms apron determinism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)