### PR TITLE
docs(release): prep v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.12.0] — 2026-06-07
+
+### Added
+
 - **Tow-planner staging apron (#412, ADR-0021).** New optional `Hangar`
   scalar `apron_depth_m` (in `hangar.yaml`; default `0`) models a bounded
   staging apron in the `y ∈ [−apron_depth_m, 0)` region in front of the door.
@@ -466,7 +474,8 @@ First Phase 1 cut — substrate for arranging the flying club fleet in a stack-s
 - Apache-2.0 license, public-audience README, CI matrix (Python 3.11 + 3.12), branch protection on develop + main (#13, #14, #15, #16).
 - Strut-aware golden tests + all-9-planes fixture using larger test-only hangar to accommodate strut-bracing geometry on placeholder dimensions (#5).
 
-[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/DocGerd/hangarfit/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/DocGerd/hangarfit/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/DocGerd/hangarfit/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/DocGerd/hangarfit/compare/v0.8.0...v0.9.0


### PR DESCRIPTION
## Release prep for v0.12.0

Promotes the CHANGELOG `[Unreleased]` block to `## [0.12.0] — 2026-06-07` and
rebuilds the compare links, so the doc work gets a focused review surface
separate from the release-state PR.

### What's in v0.12.0 (user-facing, from the promoted block)
- **Added** — Tow-planner staging apron (#412, ADR-0021): `apron_depth_m` /
  `--apron-depth N|auto`, slide-in from outside the door, depth-0 byte-identical.
- **Changed** — Incremental single-plane gap cache in the spread post-pass
  (#455, ~6% placement, byte-identical); examples reorg under `examples/` (#448).
- **Fixed** — none this cycle.

### CHANGELOG-completeness audit
The remaining merged work since v0.11.0 is CI / dev-tooling / spikes /
release-infra with no user-facing surface, deliberately **not** changelogged
(matching the [0.11.0] granularity bar): #492 (pytest-xdist CI), #431
(entry-cone strict-win regression guard — *test-only*), #494 (apron design
spike), #499 (apron bench regimes), #475/#433/#476 (viewer/CI dev-tooling),
#486 (release-notes-from-CHANGELOG workflow), #500 (CLAUDE.md notes).

### Doc-freshness audit
README / SECURITY.md / CLAUDE.md / `docs/architecture/` reviewed — nothing
stale. The docs are phase-based; the staging apron lands within the
already-shipped Phase 3b/4 surface and is already in the CLAUDE.md Quick
Reference. No doc edits required.

After this PR merges into `develop`, run `/release-cut version=0.12.0` to create
the actual release branch and PRs.