### PR TITLE
viewer: draw each plane's tow path on the hangar floor (#505)

### DIFF
--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -308,14 +308,46 @@ function addPlanes(scene2, SCENE2, BRAND2) {
   return { groups: groups2, labelMeshes: labelMeshes2, noseMeshes: noseMeshes2 };
 }
 
+// src/paths.ts
+import * as THREE6 from "three";
+var TX = 2;
+var TY = 5;
+function pathPoints(seg) {
+  return seg.samples.map((s) => [s[TX], s[TY]]);
+}
+function addTowPaths(scene2, SCENE2, BRAND2) {
+  const Z_OFFSET = 0.02;
+  const segByPlane = {};
+  for (const s of SCENE2.timeline.segments) segByPlane[s.plane_id] = s;
+  const lines = [];
+  for (const p of SCENE2.planes) {
+    const seg = segByPlane[p.id];
+    if (!seg) continue;
+    const pts = pathPoints(seg);
+    if (pts.length < 2) continue;
+    const conflicted = SCENE2.conflicts.includes(p.id);
+    const colour = new THREE6.Color(conflicted ? BRAND2.conflict : p.color);
+    const geom = new THREE6.BufferGeometry().setFromPoints(
+      pts.map(([x, y]) => new THREE6.Vector3(x, y, Z_OFFSET))
+    );
+    const line = new THREE6.Line(geom, new THREE6.LineBasicMaterial({ color: colour }));
+    scene2.add(line);
+    lines.push(line);
+  }
+  const setVisible = (on) => {
+    for (const l of lines) l.visible = on;
+  };
+  return { lines, setVisible };
+}
+
 // src/anchors.ts
-import * as THREE7 from "three";
+import * as THREE8 from "three";
 
 // src/affine.ts
-import * as THREE6 from "three";
+import * as THREE7 from "three";
 function affineMatrix(aff) {
   const [a, b, tx, c, d, ty] = aff;
-  const m = new THREE6.Matrix4();
+  const m = new THREE7.Matrix4();
   m.set(
     a,
     b,
@@ -343,7 +375,7 @@ function applyAffine(aff, u, v) {
 
 // src/anchors.ts
 function boxCornersLocal(b) {
-  const h = THREE7.MathUtils.degToRad(b.angle_deg);
+  const h = THREE8.MathUtils.degToRad(b.angle_deg);
   const cs = Math.cos(h), sn = Math.sin(h);
   const hl = b.length_m / 2, hw = b.width_m / 2;
   const corners = [[hl, -hw], [hl, hw], [-hl, hw], [-hl, -hw]];
@@ -519,6 +551,9 @@ labelsToggle.addEventListener("change", () => {
   for (const m of labelMeshes) m.visible = on;
   for (const m of noseMeshes) m.visible = on;
 });
+var { setVisible: setPathsVisible } = addTowPaths(scene, SCENE, BRAND);
+var pathsToggle = byId("paths");
+pathsToggle.addEventListener("change", () => setPathsVisible(pathsToggle.checked));
 try {
   const { structural, maxErr } = checkAnchors(SCENE);
   if (structural) {

--- a/src/hangarfit/viewer.py
+++ b/src/hangarfit/viewer.py
@@ -143,6 +143,10 @@ _HUD = (
     '<button id="reset">reset view</button>'
     '<label><input id="walls" type="checkbox" checked> walls</label>'
     '<label><input id="labels" type="checkbox" checked> labels</label>'
+    # #505 floor tow-path overlay toggle. Default ON: the 3D analogue of the 2D
+    # `solve --render-paths` overlay; drawing the route makes the apron slide-in
+    # (ty<0) and the in-hangar maneuvering legible. Inert on a static scene.
+    '<label><input id="paths" type="checkbox" checked> paths</label>'
     '<span id="readouts"></span>'
     '<span id="legend"></span>'
 )

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -95,6 +95,16 @@ def test_html_embeds_polish_features(tmp_path):
     assert 'id="labels"' in html  # the HUD toggle for labels + nose arrows
 
 
+def test_html_embeds_floor_tow_paths(tmp_path):
+    # #505: the floor tow-path overlay (3D analogue of `solve --render-paths`)
+    # must reach the artifact — the HUD `paths` toggle (default ON) and the
+    # bundled line-builder. Pixels are checked by the headless screenshot; this
+    # is the string-presence guard that the toggle + builder ship in the HTML.
+    html = _html(tmp_path)
+    assert 'id="paths" type="checkbox" checked' in html  # toggle, default ON
+    assert "addTowPaths" in html  # the bundled floor-line builder reaches viewer.js
+
+
 def test_html_embeds_honesty_banner_and_readouts(tmp_path):
     # #401: the placeholder banner + readouts wiring must reach the artifact, and
     # the scene JSON must carry the placeholder flag (shipped fleet is unmeasured).

--- a/viewer/src/main.ts
+++ b/viewer/src/main.ts
@@ -14,6 +14,7 @@ import { banner, byId } from './dom.ts';
 import { createRenderer } from './renderer.ts';
 import { addHangar } from './hangar.ts';
 import { addPlanes } from './planes.ts';
+import { addTowPaths } from './paths.ts';
 import { checkAnchors } from './anchors.ts';
 import { createTimeline } from './timeline.ts';
 import { startHud } from './hud.ts';
@@ -56,6 +57,14 @@ labelsToggle.addEventListener('change', () => {
   for (const m of labelMeshes) m.visible = on;
   for (const m of noseMeshes) m.visible = on;
 });
+
+// floor tow paths (#505) + paths toggle. One coloured floor line per plane's
+// tow route (the 3D analogue of `solve --render-paths`), default ON so the route
+// — and the apron slide-in (ty<0) — is legible at a glance. A static / un-routed
+// scene draws no lines; the toggle stays harmlessly inert in that case.
+const { setVisible: setPathsVisible } = addTowPaths(scene, SCENE, BRAND);
+const pathsToggle = byId<HTMLInputElement>('paths');
+pathsToggle.addEventListener('change', () => setPathsVisible(pathsToggle.checked));
 
 // ── load-time anchor self-check ──────────────────────────────────────────────
 // Must FAIL LOUD (banner), never throw — a throw here aborts module evaluation

--- a/viewer/src/paths.ts
+++ b/viewer/src/paths.ts
@@ -1,0 +1,67 @@
+// ── floor tow-path polylines (#505): the 3D analogue of the 2D --render-paths ─
+//
+// Draw each placed plane's full tow route as a coloured line on the hangar floor
+// (z ≈ 0), one colour per plane — the 3D counterpart of `solve --render-paths`
+// (#192/#193). NO scene/v1 change (ADR-0017): the polyline is already implicit
+// in the timeline. Each `segments[].samples` entry is a `[a,b,tx,c,d,ty]` affine
+// whose translation `(tx, ty) = (sample[2], sample[5])` is exactly the
+// plane-local origin's ground track, door (or apron, ty<0) → parked slot. So we
+// derive the floor line straight from the samples Python already emits.
+//
+// The line uses the plane's own `p.color` — the same hue as its boxes, its nose
+// cone, and its legend swatch (PLANES_DARK, the dark-surface expression of the
+// 2D PLANES fill, brand-parity by sorted-id index, ADR-0017/#415) — so the
+// "blue plane has a blue route" reading is self-consistent in the viewer.
+import * as THREE from 'three';
+import type { BrandTokens } from './brand-contract.ts';
+import type { SceneV1, SegmentData } from './scene-contract.ts';
+
+const TX = 2; // index of tx in a [a,b,tx,c,d,ty] affine
+const TY = 5; // index of ty
+
+/** The floor ground track of one tow segment: `(tx, ty)` of each sample, in
+ * order (door/apron → slot). PURE — no THREE, no DOM (node-tested in #505). A
+ * segment with an apron lead-in carries its `ty < 0` sample(s) verbatim, so the
+ * slide-in from outside the door is part of the drawn line (#412 / ADR-0021). */
+export function pathPoints(seg: SegmentData): [number, number][] {
+  return seg.samples.map((s) => [s[TX], s[TY]]);
+}
+
+export interface TowPaths {
+  /** The Line objects, so the caller can dispose / inspect them if needed. */
+  lines: THREE.Line[];
+  /** Show/hide every floor path at once (the HUD `paths` toggle). */
+  setVisible: (on: boolean) => void;
+}
+
+/** Build one floor polyline per tow segment, coloured by the plane's own hue,
+ * and add them to `scene`. A plane with no segment (static / un-routable scene)
+ * gets no line — there is no route to draw. Lines sit a hair above the floor
+ * (z = `Z_OFFSET`) so they don't z-fight the floor plane or the grid, and below
+ * the parked planes' bellies. Returns the lines + a visibility toggle. */
+export function addTowPaths(scene: THREE.Scene, SCENE: SceneV1, BRAND: BrandTokens): TowPaths {
+  const Z_OFFSET = 0.02; // just above the floor (grid sits at 0.003); under any belly
+  const segByPlane: Record<string, SegmentData> = {};
+  for (const s of SCENE.timeline.segments) segByPlane[s.plane_id] = s;
+
+  const lines: THREE.Line[] = [];
+  for (const p of SCENE.planes) {
+    const seg = segByPlane[p.id];
+    if (!seg) continue; // static plane: no tow route to draw
+    const pts = pathPoints(seg);
+    if (pts.length < 2) continue; // a single point is not a line
+    const conflicted = SCENE.conflicts.includes(p.id);
+    const colour = new THREE.Color(conflicted ? BRAND.conflict : p.color);
+    const geom = new THREE.BufferGeometry().setFromPoints(
+      pts.map(([x, y]) => new THREE.Vector3(x, y, Z_OFFSET)),
+    );
+    const line = new THREE.Line(geom, new THREE.LineBasicMaterial({ color: colour }));
+    scene.add(line);
+    lines.push(line);
+  }
+
+  const setVisible = (on: boolean): void => {
+    for (const l of lines) l.visible = on;
+  };
+  return { lines, setVisible };
+}

--- a/viewer/test/paths.test.ts
+++ b/viewer/test/paths.test.ts
@@ -6,8 +6,10 @@
 // derives the floor line from those samples with NO scene/v1 change (ADR-0017).
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { pathPoints } from '../src/paths.ts';
-import type { Affine, SegmentData } from '../src/scene-contract.ts';
+import * as THREE from 'three';
+import { addTowPaths, pathPoints } from '../src/paths.ts';
+import type { Affine, PlaneData, SceneV1, SegmentData } from '../src/scene-contract.ts';
+import type { BrandTokens } from '../src/brand-contract.ts';
 
 // Three samples whose translations trace door (y=0) → mid → slot. The linear
 // part is irrelevant to the ground track — only (tx, ty) at indices 2 and 5 are.
@@ -40,4 +42,111 @@ test('pathPoints: a single-sample segment yields a single point (no line drawn b
 
 test('pathPoints: an empty-samples segment yields no points', () => {
   assert.deepEqual(pathPoints({ plane_id: 'p', start_s: 0, end_s: 1, samples: [] }), []);
+});
+
+// ── addTowPaths: the impure THREE-backed builder (one Line per routable plane).
+// Mirrors anchors.test.ts: build a minimal SceneV1 + BRAND blob, run the builder
+// against a real THREE.Scene (the test-only `three` devDep), and inspect the
+// returned Line objects. Only `conflict` of BRAND is read by addTowPaths, but
+// the full BrandTokens shape is supplied so the literal type-checks.
+const BRAND: BrandTokens = {
+  sceneBg: '#000000',
+  hemisphereSky: '#000000',
+  hemisphereGround: '#000000',
+  hemisphereIntensity: 1,
+  sun: '#000000',
+  sunIntensity: 1,
+  fill: '#000000',
+  fillIntensity: 1,
+  floor: '#000000',
+  gridMajor: '#000000',
+  gridMinor: '#000000',
+  walls: '#000000',
+  wallsOpacity: 1,
+  bay: '#000000',
+  bayOpacity: 1,
+  wheel: '#000000',
+  cartDeck: '#000000',
+  conflict: '#e6194b',
+  labelConflictChip: '#000000',
+  labelChipBg: '#000000',
+  labelText: '#000000',
+};
+
+function plane(over: Partial<PlaneData> = {}): PlaneData {
+  return { id: 'x', color: '#112233', boxes: [], wheels: [], on_carts: false, ...over };
+}
+
+// A two-sample (drawable) tow segment for `plane_id`; the linear part is inert.
+function towSeg(plane_id: string): SegmentData {
+  return { plane_id, start_s: 0, end_s: 2, samples: [[1, 0, 5, 0, 1, 0], [1, 0, 5, 0, 1, 6]] };
+}
+
+// Minimal SceneV1 for the builder: it only reads planes[], conflicts[] and
+// timeline.segments[]. Everything else is filled with valid-shape placeholders.
+function makeScene(planes: PlaneData[], conflicts: string[], segments: SegmentData[]): SceneV1 {
+  return {
+    schema: 'hangarfit.scene/v1',
+    units: 'm',
+    coordinate_note: '',
+    hangar: {
+      width_m: 10,
+      length_m: 10,
+      door: { center_x_m: 5, width_m: 4 },
+      maintenance_bay: { center_x_m: 5, width_m: 2, depth_m: 2, closed: false, plane_id: null },
+    },
+    planes,
+    conflicts,
+    final_poses: {},
+    anchors: {},
+    gear_anchors: {},
+    timeline: { segments, total_s: 0 },
+    placeholder: false,
+    readouts: null,
+  };
+}
+
+test('addTowPaths: one line per routable plane; conflicted line uses BRAND.conflict, others p.color; segment-less / single-sample planes skipped', () => {
+  const clean = plane({ id: 'clean', color: '#1f77b4' }); // drawable, not conflicted
+  const bad = plane({ id: 'bad', color: '#2ca02c' }); // drawable AND in conflicts[]
+  const onePt = plane({ id: 'onept', color: '#ff7f0e' }); // single-sample → no line
+  const static_ = plane({ id: 'static', color: '#9467bd' }); // no segment → no line
+  const SCENE = makeScene(
+    [clean, bad, onePt, static_],
+    ['bad'],
+    [
+      towSeg('clean'),
+      towSeg('bad'),
+      { plane_id: 'onept', start_s: 0, end_s: 1, samples: [[1, 0, 5, 0, 1, 0]] },
+      // 'static' has no segment at all
+    ],
+  );
+
+  const scene = new THREE.Scene();
+  const { lines, setVisible } = addTowPaths(scene, SCENE, BRAND);
+
+  // Exactly the two drawable planes produce a line; the single-point and the
+  // segment-less plane are skipped.
+  assert.equal(lines.length, 2, 'only the two ≥2-sample planes get a line');
+  assert.equal(scene.children.length, 2, 'each line is added to the scene');
+
+  // The two lines come out in planes[] order: clean (index 0), bad (index 1).
+  const cleanLine = lines[0];
+  const badLine = lines[1];
+  const colourOf = (l: THREE.Line): string =>
+    '#' + (l.material as THREE.LineBasicMaterial).color.getHexString();
+
+  // Conflicted plane → conflict ink, NOT its own colour.
+  assert.equal(colourOf(badLine), BRAND.conflict.toLowerCase(), 'conflicted line uses BRAND.conflict');
+  assert.notEqual(colourOf(badLine), bad.color.toLowerCase(), 'conflicted line is NOT the plane colour');
+
+  // Non-conflicted plane → its own hue.
+  assert.equal(colourOf(cleanLine), clean.color.toLowerCase(), 'non-conflicted line uses the plane colour');
+
+  // The visibility toggle flips every line at once.
+  assert.ok(lines.every((l) => l.visible), 'lines start visible');
+  setVisible(false);
+  assert.ok(lines.every((l) => l.visible === false), 'setVisible(false) hides every line');
+  setVisible(true);
+  assert.ok(lines.every((l) => l.visible === true), 'setVisible(true) shows every line again');
 });

--- a/viewer/test/paths.test.ts
+++ b/viewer/test/paths.test.ts
@@ -1,0 +1,43 @@
+// node --test units for the floor tow-path polyline derivation (#505). The
+// 3D analogue of the 2D `solve --render-paths` overlay (#192/#193). The path is
+// ALREADY implicit in the scene: each `timeline.segments[].samples` entry is a
+// `[a,b,tx,c,d,ty]` affine whose translation `(tx, ty)` = `(sample[2],
+// sample[5])` is exactly the plane-local origin's ground track. `pathPoints`
+// derives the floor line from those samples with NO scene/v1 change (ADR-0017).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { pathPoints } from '../src/paths.ts';
+import type { Affine, SegmentData } from '../src/scene-contract.ts';
+
+// Three samples whose translations trace door (y=0) → mid → slot. The linear
+// part is irrelevant to the ground track — only (tx, ty) at indices 2 and 5 are.
+const A0: Affine = [1, 0, 9.0, 0, 1, 0.0];
+const A1: Affine = [0, 1, 8.5, 1, 0, 6.2];
+const A2: Affine = [-1, 0, 8.6, 0, -1, 12.4];
+const seg: SegmentData = { plane_id: 'p', start_s: 0, end_s: 4, samples: [A0, A1, A2] };
+
+test('pathPoints: one floor point per sample, taking (tx, ty) = (sample[2], sample[5])', () => {
+  assert.deepEqual(pathPoints(seg), [[9.0, 0.0], [8.5, 6.2], [8.6, 12.4]]);
+});
+
+test('pathPoints: an apron lead-in (first sample ty < 0) is preserved verbatim', () => {
+  // With an apron the planner seeds the path OUTSIDE the door (y<0); the floor
+  // line must extend to ty<0 so the slide-in is visible (#412 / ADR-0021).
+  const apronSeg: SegmentData = {
+    plane_id: 'q',
+    start_s: 0,
+    end_s: 4,
+    samples: [[1, 0, 8.5, 0, 1, -7.49], [1, 0, 8.5, 0, 1, 0], [1, 0, 8.5, 0, 1, 6.0]],
+  };
+  const pts = pathPoints(apronSeg);
+  assert.deepEqual(pts[0], [8.5, -7.49]);
+  assert.ok(pts[0][1] < 0, 'lead-in point is outside the door (ty<0)');
+});
+
+test('pathPoints: a single-sample segment yields a single point (no line drawn by caller)', () => {
+  assert.deepEqual(pathPoints({ plane_id: 'p', start_s: 0, end_s: 1, samples: [A0] }), [[9.0, 0.0]]);
+});
+
+test('pathPoints: an empty-samples segment yields no points', () => {
+  assert.deepEqual(pathPoints({ plane_id: 'p', start_s: 0, end_s: 1, samples: [] }), []);
+});


### PR DESCRIPTION
Closes #505

## What

Adds the 3D analogue of the 2D `solve --render-paths` overlay (#192/#193):
each placed plane's full tow route is drawn as a coloured line on the hangar
floor (z ≈ 0), one colour per plane.

| Before | After |
|---|---|
| viewer animates the tow but draws no route | one coloured floor line per plane, door (or apron) → slot |

The route makes the apron slide-in, the in-hangar maneuvering, and the tow
order legible at a glance — and exposes path quality (e.g. a forward-then-reverse cusp) that a bare animation hides.

## How

**No `scene/v1` schema change** (ADR-0017 seam stays stable). The polyline is
already implicit in the timeline: each `segments[].samples` entry is a
`[a,b,tx,c,d,ty]` affine whose translation `(sample[2], sample[5])` is exactly
the plane-local origin's ground track. A new **pure** `pathPoints(seg)` derives
the floor line from those samples; `addTowPaths()` builds one `THREE.Line` per
segment.

- **Colour:** the plane's own `p.color` (`PLANES_DARK`) — the same hue as its
  boxes, nose cone, and legend swatch, so "the blue plane has a blue route" is
  self-consistent in the viewer. (`PLANES_DARK` is the dark-surface expression
  of the 2D `PLANES` fill by the same sorted-id index — brand-parity per
  `scene._color_map`/ADR-0017.) A conflicted plane's line uses the conflict ink,
  mirroring its boxes. See the open-question note below on the 2D `TOW_PATH_COLORS` palette.
- **Apron lead-in:** the first sample's `ty < 0` (outside the door, #412/ADR-0021)
  is carried verbatim, so the slide-in is part of the drawn line. Verified the
  apron line reaches `y = -3.0` at `--apron-depth 6`; at depth 0 it starts at `y = 0`.
- **Static / un-routed scene:** no segment ⇒ no line drawn; the toggle stays inert.

## Toggle default

A `paths` HUD checkbox (next to `walls` / `labels`), **default ON**. Drawing the
route is the whole point of the issue, so it ships visible; the toggle lets a
user hide it to inspect the static parking. Mirrors the existing toggle wiring
end-to-end (HUD checkbox in `viewer.py` → listener in `main.ts` → `setVisible`).

## Files

- `viewer/src/paths.ts` (new) — pure `pathPoints` + impure `addTowPaths` builder.
- `viewer/test/paths.test.ts` (new) — node `--test` units: ground track, apron
  lead-in preserved, single-point / empty-segment edges (TDD: written failing first).
- `viewer/src/main.ts` — build the paths + wire the `paths` toggle.
- `src/hangarfit/viewer.py` — `paths` checkbox in the HUD (default checked).
- `src/hangarfit/_viewer_assets/viewer.js` — rebuilt committed bundle (reproducible; `viewer-build-drift` safe).
- `tests/test_viewer.py` — assert the toggle + builder reach the emitted HTML (non-slow patch coverage).

## Verification

- `npm run typecheck` ✅ · `npm run lint` ✅ · `npm run test` ✅ (20 node tests)
- `pytest tests/test_viewer.py tests/test_scene.py tests/test_visualize.py` ✅ (112 passed)
- `ruff check` / `ruff format --check` ✅
- Bundle rebuild reproducible (scratch build == committed bundle).
- Headless swiftshader screenshots show the floor lines, no transform banner:
  - no-apron (`valid_left_side_nesting.yaml`): orange `fuji` + blue `cessna_150` lines, starting at the door (`y=0`).
  - apron (`--apron-depth 6`): same colours, line extends to `y = -3.0` outside the door.

## Open question / deviation

The issue says "matching the existing 2D palette AND the viewer's legend swatches."
In the current code those are two different things: the 2D `--render-paths` overlay
uses `brand.TOW_PATH_COLORS` (Okabe–Ito, chosen to not blur into the 2D conflict
highlight on white), while the viewer's legend/boxes use `PLANES_DARK`. I chose
`PLANES_DARK` so the 3D route matches the legend swatch + the plane it belongs to
(the stronger in-viewer constraint, and brand-parity-equivalent to the 2D fill).
Happy to switch to `TOW_PATH_COLORS` for strict 2D-overlay parity if the reviewer prefers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)