### PR TITLE
feat(towplanner): warn when a too-shallow apron drops a plane to the door line

### DIFF
--- a/docs/adr/0021-tow-planner-staging-apron.md
+++ b/docs/adr/0021-tow-planner-staging-apron.md
@@ -219,6 +219,16 @@ rearrangement tier's extra needs named (spike Q7) so they are not foreclosed.
 - An optional additive `hangar.apron` `scene/v1` field (render-only apron ground) may be
   added later, mirroring the additive [#399/#400/#401](0017-3d-viewer-architecture.md)
   viewer fields; the contract stays backward-compatible.
+- **Apron engagement is per-plane FOOTPRINT-gated, not the `auto` formula.** A plane only
+  slides in if the apron is deep enough for *its* footprint to fit at an apron start pose;
+  the `auto` depth (`max plane length + max turn radius`) is a fleet-wide over-margin, so a
+  hand-set apron that "looks deep enough" can still leave the longest plane too deep to fit,
+  silently dropping it back to the `y = 0` door line (no slide-in). Since
+  [#503](https://github.com/DocGerd/hangarfit/issues/503) `plan_fill` emits an observational
+  **stderr** warning naming each such plane and the minimum depth (≈ its footprint extent) it
+  would need — output-only, so the `MovesPlan` stays byte-identical (ADR-0003). Prefer
+  `auto`, or raise `--apron-depth` past the warned value. Auto-deepening the apron to fit the
+  deepest plane (which *would* change the plan) is deferred (#503 Option 2).
 
 ## Compliance
 

--- a/docs/adr/0021-tow-planner-staging-apron.md
+++ b/docs/adr/0021-tow-planner-staging-apron.md
@@ -224,11 +224,20 @@ rearrangement tier's extra needs named (spike Q7) so they are not foreclosed.
   the `auto` depth (`max plane length + max turn radius`) is a fleet-wide over-margin, so a
   hand-set apron that "looks deep enough" can still leave the longest plane too deep to fit,
   silently dropping it back to the `y = 0` door line (no slide-in). Since
-  [#503](https://github.com/DocGerd/hangarfit/issues/503) `plan_fill` emits an observational
-  **stderr** warning naming each such plane and the minimum depth (≈ its footprint extent) it
-  would need — output-only, so the `MovesPlan` stays byte-identical (ADR-0003). Prefer
-  `auto`, or raise `--apron-depth` past the warned value. Auto-deepening the apron to fit the
-  deepest plane (which *would* change the plan) is deferred (#503 Option 2).
+  [#503](https://github.com/DocGerd/hangarfit/issues/503) this is surfaced as an observational
+  **stderr** warning naming each such plane and a suggested minimum depth. The warning is
+  **emitted once at the CLI boundary for the *returned* result**, deduped per plane (mirroring
+  `cli._warn_unroutable`): the library `plan_fill` no longer prints — it only *exposes* the
+  drops, plan-inert, via an optional `apron_dropped_out` out-param (and `solve()` folds those
+  into `SolverDiagnostics.apron_shallow_drops` for the layouts it actually returns). Keying on
+  the returned result means a discarded spread-fallback pass (#280 / F5) never warns about a
+  layout the user does not receive, and `--alternatives N` warns each plane once, not once per
+  layout × pass. The suggested depth is the plane's fore-aft footprint extent — a *conservative
+  (sufficient) upper bound*, not the exact minimum (the true engagement gate is
+  ≈ `2·min(fore, aft)` of the footprint about its reference), so a deeper-than-needed suggestion
+  is always safe. The `MovesPlan` stays byte-identical regardless (ADR-0003). Prefer `auto`, or
+  raise `--apron-depth` past the warned value. Auto-deepening the apron to fit the deepest plane
+  (which *would* change the plan) is deferred (#503 Option 2).
 
 ## Compliance
 

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -18,11 +18,19 @@ import argparse
 import json
 import math
 import sys
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Literal
 
 from hangarfit import __version__, collisions, visualize
 from hangarfit.loader import LoaderError, load_fleet, load_hangar, load_layout
-from hangarfit.models import CheckResult, Conflict, DiversityConfig, Layout, SolveResult
+from hangarfit.models import (
+    ApronShallowDrop,
+    CheckResult,
+    Conflict,
+    DiversityConfig,
+    Layout,
+    SolveResult,
+)
 
 if TYPE_CHECKING:
     # Annotation-only: avoids importing the solver/towplanner stack at module
@@ -655,8 +663,13 @@ def cmd_solve(args: argparse.Namespace) -> int:
     # Structured tow-path warnings: name the plane that blocked each layout the
     # tow planner could not route (best-effort — the layout is still valid and
     # is rendered, just without a path overlay; ADR-0007 + ADR-0010 / #197).
+    # Then warn (once per plane, deduped) about any plane that towed via the
+    # door line because the apron was too shallow for its footprint (#503) —
+    # keyed on the RETURNED result's diagnostics only, so the discarded
+    # spread-fallback pass's drops never surface.
     if args.render_paths:
         _warn_unroutable(result)
+        _warn_apron_shallow_drops(result.diagnostics.apron_shallow_drops)
 
     # Renders / YAML writes. Only run if we have layouts to write —
     # exhausted_budget / trivially_infeasible carry empty `layouts`.
@@ -748,6 +761,37 @@ def _warn_unroutable(result: SolveResult) -> None:
         print(
             f"warning: layout {layout_index}: no feasible tow path "
             f"(plane {plane!r} could not be routed); rendered without paths",
+            file=sys.stderr,
+        )
+
+
+def _warn_apron_shallow_drops(drops: Iterable[ApronShallowDrop]) -> None:
+    """Emit one stderr warning per plane that towed via the ``y = 0`` door line
+    because the site's apron was too shallow for its footprint (#503 / ADR-0021).
+
+    ``drops`` carries the too-shallow-apron drops across *every returned* layout
+    (one per dropped plane per layout — :attr:`SolverDiagnostics.apron_shallow_drops`
+    in the solve path, or the ``apron_dropped_out`` out-param of a single
+    :func:`~hangarfit.towplanner.plan_fill` in the view path). A plane may repeat
+    (once per layout it is dropped in), so we **dedup by plane id**, warning once
+    per plane and keeping the largest suggested depth seen for it. Emit order is
+    first-seen order — deterministic because the producer's order is (#503).
+
+    Each plane shows no slide-in: its footprint is too deep for the apron, so all
+    its apron start poses were filtered. The suggested minimum depth is the plane's
+    fore-aft FOOTPRINT extent — a conservative sufficient depth to engage the apron
+    (the true gate is ≈ ``2·min(fore, aft)``), NOT the fleet-wide ``auto``
+    over-margin. Purely observational: stderr only, never the plan."""
+    suggested: dict[str, float] = {}
+    for drop in drops:
+        prev = suggested.get(drop.plane_id)
+        if prev is None or drop.min_depth_m > prev:
+            suggested[drop.plane_id] = drop.min_depth_m
+    for plane_id, depth in suggested.items():
+        print(
+            f"warning: apron too shallow for plane {plane_id!r}: it tows in via the "
+            f"door line (no slide-in). Increase the apron depth to >= {depth:.1f} m "
+            f"(its footprint extent) so it engages the apron.",
             file=sys.stderr,
         )
 
@@ -925,6 +969,15 @@ def _emit_solve_json(
             # arrangement. Always present (False in the normal no-swap case) so
             # consumers can rely on it. Backward-compatible — no schema bump.
             "spread_fallback_applied": d.spread_fallback_applied,
+            # Additive (#503): planes that towed via the door line because the
+            # apron was too shallow for their footprint, with the suggested min
+            # depth (their footprint extent). One entry per dropped plane per
+            # returned layout; empty unless --render-paths ran the planner with an
+            # apron set. Backward-compatible — no schema bump.
+            "apron_shallow_drops": [
+                {"plane": drop.plane_id, "min_depth_m": drop.min_depth_m}
+                for drop in d.apron_shallow_drops
+            ],
         },
     }
     print(json.dumps(payload, indent=2))
@@ -991,6 +1044,12 @@ def cmd_view(args: argparse.Namespace) -> int:
                     "note: solution not tow-routable; rendering static 3D scene.",
                     file=sys.stderr,
                 )
+            # #503: warn (deduped) about any plane that towed via the door line
+            # because the apron was too shallow — the solve path carries the
+            # RETURNED result's drops on its diagnostics, so a discarded
+            # spread-fallback pass never contributes.
+            if args.animate:
+                _warn_apron_shallow_drops(result.diagnostics.apron_shallow_drops)
         else:
             layout = load_layout(
                 args.input,
@@ -1013,11 +1072,19 @@ def cmd_view(args: argparse.Namespace) -> int:
                         if args.tow_max_expansions is not None
                         else _VIEW_TOW_MAX_TOTAL_EXPANSIONS
                     )
+                    # #503: layout-mode view calls plan_fill directly (no
+                    # SolverDiagnostics), so collect the too-shallow-apron drops via
+                    # the plan-inert out-param and warn once each, deduped. Only a
+                    # plan that is actually built (no NoFeasiblePlanError) reaches
+                    # the warn call, so a discarded/failed plan never warns.
+                    apron_drops: list[ApronShallowDrop] = []
                     moves_plan = plan_fill(
                         layout,
                         max_expansions=args.tow_max_expansions,
                         max_total_expansions=view_total_cap,
+                        apron_dropped_out=apron_drops,
                     )
+                    _warn_apron_shallow_drops(apron_drops)
                 except NoFeasiblePlanError as e:
                     print(
                         f"note: layout not tow-routable (plane {e.plane_id!r} could not be "

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -788,6 +788,36 @@ class Scenario:
         object.__setattr__(self, "constraints", MappingProxyType(dict(self.constraints)))
 
 
+@dataclass(frozen=True, slots=True)
+class ApronShallowDrop:
+    """One plane that tows via the ``y = 0`` door line despite an apron being set,
+    because the apron is too shallow for its footprint (#503 / ADR-0021).
+
+    Plan-inert diagnostics produced by :func:`hangarfit.towplanner.plan_fill`:
+    when ``hangar.apron_depth_m > 0`` but every apron start pose was filtered for
+    a plane (its fore-aft footprint overflows the apron south bound), the plane
+    falls back to the door-line start and shows no slide-in — silent in the
+    :class:`~hangarfit.towplanner.MovesPlan`. This records that drop so the CLI
+    can warn at the boundary.
+
+    ``min_depth_m`` is the plane's fore-aft footprint extent — a *conservative
+    (sufficient) upper bound* on the apron depth needed to engage it, NOT the
+    exact minimum: the true per-plane engagement gate is ≈ ``2·min(fore, aft)``
+    of the footprint about its reference, so a deeper-than-necessary suggestion
+    is always safe. RNG-free, so it does not affect determinism (ADR-0003)."""
+
+    plane_id: str
+    min_depth_m: float
+
+    def __post_init__(self) -> None:
+        if not self.plane_id:
+            raise ValueError("ApronShallowDrop.plane_id must be non-empty")
+        if not math.isfinite(self.min_depth_m) or self.min_depth_m < 0.0:
+            raise ValueError(
+                f"ApronShallowDrop.min_depth_m must be finite and >= 0, got {self.min_depth_m!r}"
+            )
+
+
 SolveStatus = Literal[
     "found",
     "found_partial",
@@ -874,6 +904,20 @@ class SolverDiagnostics:
     selection exists, a ``True`` value always accompanies a ``found`` result.
     Advisory: it changes *when* the search stops, never *whether* the returned
     layout is valid — it does not affect ``status``.
+
+    ``apron_shallow_drops`` is a flat, advisory tuple of :class:`ApronShallowDrop`
+    for the planes that towed via the ``y = 0`` door line — showing no slide-in —
+    because the site's apron (``hangar.apron_depth_m > 0``) was too shallow for
+    their footprint (#503 / ADR-0021). It collects the drops of *every* returned
+    layout's tow plan, in returned-layout-then-move order; a plane may appear more
+    than once (once per layout it is dropped in), so the CLI dedups by plane id
+    before warning. Empty when no returned layout had a too-shallow drop, or when
+    tow-planning was not attempted (``solve(..., plan_paths=False)``) / no apron is
+    set. Crucially it carries only the *returned* result's drops: the discarded
+    spread-fallback pass (#280 / F5) never contributes, since its diagnostics are
+    not the ones returned. Advisory: the drop is observational — the layout is
+    still valid and the plan still routes (via the door line), so it does not
+    affect ``status``. RNG-free ⇒ ADR-0003-safe.
     """
 
     restarts_attempted: int
@@ -888,6 +932,7 @@ class SolverDiagnostics:
     valid_basins_found: int = 0
     spread_fallback_applied: bool = False
     spread_stall_applied: bool = False
+    apron_shallow_drops: tuple[ApronShallowDrop, ...] = ()
 
     def __post_init__(self) -> None:
         if (self.best_partial is None) != (self.best_partial_layout is None):

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -33,6 +33,7 @@ from hangarfit.collisions import check as check_layout
 from hangarfit.geometry import WorldPart, cached_parts_world, pose_cache_scope
 from hangarfit.models import (
     Aircraft,
+    ApronShallowDrop,
     CheckResult,
     Conflict,
     DiversityConfig,
@@ -489,46 +490,69 @@ def _tow_plan_layouts(
     plan_paths: bool,
     tow_heuristic: Literal["euclidean", "grid"],
     tow_max_expansions: int | None,
-) -> tuple[tuple[MovesPlan | None, ...], tuple[str, ...]]:
+) -> tuple[tuple[MovesPlan | None, ...], tuple[str, ...], tuple[ApronShallowDrop, ...]]:
     """Tow-plan every returned layout (best-effort enrichment, #197).
 
-    Returns ``(plans, unroutable)`` index-aligned with ``accepted_layouts``.
-    The v2 planner (Reeds–Shepp arcs + bounded Hybrid-A* — #222/#261 under
-    ADR-0007 + ADR-0010) cannot route dense multi-plane fills and has documented
-    false-negatives, so an un-routable layout is recorded as ``plans[i]=None``
-    rather than discarding the otherwise-valid static arrangement — the layout is
-    the headline answer; the tow plan is advisory (spike Risk #8). RNG-free, so
-    it preserves the ADR-0003 determinism contract.
+    Returns ``(plans, unroutable, apron_drops)``. ``plans`` is index-aligned with
+    ``accepted_layouts``. The v2 planner (Reeds–Shepp arcs + bounded Hybrid-A* —
+    #222/#261 under ADR-0007 + ADR-0010) cannot route dense multi-plane fills and
+    has documented false-negatives, so an un-routable layout is recorded as
+    ``plans[i]=None`` rather than discarding the otherwise-valid static arrangement
+    — the layout is the headline answer; the tow plan is advisory (spike Risk #8).
+    RNG-free, so it preserves the ADR-0003 determinism contract.
+
+    ``apron_drops`` is the flat, advisory list of every returned layout's
+    too-shallow-apron drops (#503): a plane that towed via the ``y = 0`` door line
+    despite an apron being set, because the apron was too shallow for its footprint
+    (one :class:`ApronShallowDrop` per dropped plane per layout, in
+    layout-then-move order). Because this collects only the layouts ACTUALLY
+    returned in the :class:`SolveResult`, a discarded spread-fallback pass's drops
+    never surface — only the chosen result's diagnostics are built (see
+    :func:`solve`). Empty when no returned layout had a too-shallow drop.
 
     With ``plan_paths=False`` no planning runs and ``plans`` is all-``None``
-    (still index-aligned), with no ``unroutable`` planes.
+    (still index-aligned), with no ``unroutable`` planes and no ``apron_drops``.
     """
     if not plan_paths:
-        return (None,) * len(accepted_layouts), ()
+        return (None,) * len(accepted_layouts), (), ()
 
     built: list[MovesPlan | None] = []
     unroutable: list[str] = []
+    apron_drops: list[ApronShallowDrop] = []
     for layout in accepted_layouts:
+        # Diagnostics-only out-param (#503): plan_fill populates this with the
+        # too-shallow-apron drops of THIS layout's tow plan, plan-inert — it is
+        # never read back into the MovesPlan, so the plan stays byte-identical
+        # whether or not the list is passed (ADR-0003). A fresh list per layout
+        # keeps the per-layout drops in their own scope; we extend the flat
+        # collection so a plane dropped across multiple layouts appears once per
+        # layout (the CLI dedups by plane id before warning).
+        layout_drops: list[ApronShallowDrop] = []
         try:
-            # Default path calls ``plan_fill(layout)`` with NO kwargs, so the
-            # ADR-0003 determinism canaries — and any test that stubs
-            # ``plan_fill`` with a target-only signature — stay untouched. Since
+            # Default path calls ``plan_fill(layout)`` with NO budget kwargs (only
+            # the plan-inert diagnostics out-param), so the ADR-0003 determinism
+            # canaries are unaffected (the out-param never changes the plan). Since
             # #336 the shipped default is grid + the module budgets, which is
             # exactly what a bare ``plan_fill(layout)`` applies; an explicit
             # euclidean / custom budget takes the kwargs path below.
             if tow_heuristic == "grid" and tow_max_expansions is None:
-                built.append(plan_fill(layout))
+                built.append(plan_fill(layout, apron_dropped_out=layout_drops))
             else:
                 built.append(
                     plan_fill(
                         layout,
                         heuristic=tow_heuristic,
                         max_expansions=tow_max_expansions,
+                        apron_dropped_out=layout_drops,
                     )
                 )
+            apron_drops.extend(layout_drops)
         except NoFeasiblePlanError as e:
             built.append(None)
             unroutable.append(e.plane_id)
+            # A NoFeasiblePlanError means this layout produced no plan at all, so
+            # any partial drops collected before the bail describe a plan the user
+            # never receives — discard them (don't extend apron_drops).
             # Log the conflict kind/detail too, not just the plane: it
             # distinguishes a genuinely-boxed-in plane from a Hybrid-A* budget
             # exhaustion (a known false-negative class), which call for different
@@ -540,7 +564,7 @@ def _tow_plan_layouts(
                 e.conflict.kind,
                 e.conflict.detail,
             )
-    return tuple(built), tuple(unroutable)
+    return tuple(built), tuple(unroutable), tuple(apron_drops)
 
 
 def _build_found_result(
@@ -568,7 +592,7 @@ def _build_found_result(
     accepted_layouts = [c.layout for c in selected]
     min_gaps = tuple(c.min_gap for c in selected)
     status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
-    plans, unroutable = _tow_plan_layouts(
+    plans, unroutable, apron_drops = _tow_plan_layouts(
         accepted_layouts,
         plan_paths=plan_paths,
         tow_heuristic=tow_heuristic,
@@ -590,6 +614,7 @@ def _build_found_result(
             min_pairwise_gap_m=min_gaps,
             valid_basins_found=valid_basins_found,
             spread_stall_applied=spread_stall_applied,
+            apron_shallow_drops=apron_drops,
         ),
     )
 

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import heapq
 import math
+import sys
 import typing
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
@@ -1264,10 +1265,17 @@ def plan_fill(
 
     placed: list[Placement] = []
     moves: list[Move] = []
+    # #503: planes that tow via the y=0 door-line fallback DESPITE an apron being
+    # set (their footprint is too deep for the apron, so every apron start pose was
+    # filtered). Collected in commit order and warned about once the fill is built,
+    # so the order is the deterministic move order (ADR-0003). Observational only —
+    # never read back into the plan.
+    apron_dropped: list[str] = []
 
     while ordered:
         chosen: int | None = None
         chosen_arc: DubinsArc | None = None
+        chosen_apron_fallback = False
         # The deepest unplaced plane is scanned first, so its conflict (if it
         # is rejected) is the one reported when the whole scan finds nothing.
         deepest_conflict: Conflict | None = None
@@ -1329,6 +1337,10 @@ def plan_fill(
             exp = stats.get("expansions", 0)
             total_used += exp if isinstance(exp, int) else 0
             chosen, chosen_arc = idx, arc
+            # Only the COMMITTED candidate's fallback matters: the rejected
+            # candidates of the scan are not in the plan, so their stats are
+            # irrelevant to what the user sees (#503).
+            chosen_apron_fallback = stats.get("apron_fallback") is True
             break
         if chosen is None:
             # Every remaining plane conflicts: greedy back-first is stuck. The
@@ -1340,8 +1352,34 @@ def plan_fill(
         assert chosen_arc is not None
         moves.append(Move(slot.plane_id, Pose.from_placement(slot), chosen_arc))
         placed.append(slot)
+        if chosen_apron_fallback:
+            apron_dropped.append(slot.plane_id)
 
+    _warn_apron_too_shallow(apron_dropped, fleet)
     return MovesPlan(target_layout=target, moves=tuple(moves))
+
+
+def _warn_apron_too_shallow(dropped_plane_ids: list[str], fleet: Mapping[str, Aircraft]) -> None:
+    """Emit one deterministic stderr warning per plane that tows via the ``y = 0``
+    door-line fallback despite an apron being set (#503).
+
+    Such a plane's footprint is too deep for the apron, so every apron start pose
+    was filtered and it shows no slide-in — silent in the :class:`MovesPlan`. The
+    suggested minimum depth is the plane's fore-aft footprint extent
+    (:func:`_plane_fore_aft_length_m`) — the per-plane FOOTPRINT depth the apron
+    must clear, NOT the fleet-wide ``auto`` over-margin (:func:`derive_apron_depth`).
+
+    Purely observational: writes to ``stderr`` (never the plan, never stdout), in
+    the caller-supplied (deterministic move) order. RNG-free ⇒ ADR-0003-safe.
+    """
+    for plane_id in dropped_plane_ids:
+        suggested = _plane_fore_aft_length_m(fleet[plane_id])
+        print(
+            f"warning: apron too shallow for plane {plane_id!r}: it tows in via the "
+            f"door line (no slide-in). Increase the apron depth to >= {suggested:.1f} m "
+            f"(its footprint extent) so it engages the apron.",
+            file=sys.stderr,
+        )
 
 
 # ── Hybrid-A* tow-path search (spike Q3 v2, #222) ───────────────────────────
@@ -1871,6 +1909,11 @@ def plan_path(
     ``found``, ``budget_exhausted`` (hit ``max_expansions``) vs ``space_exhausted``
     (open heap emptied first ⇒ genuine local infeasibility), ``start_poses``, and
     the ``heuristic`` used — the #332 routability characterisation harness reads it.
+    It additionally carries ``apron_fallback=True`` (#503) when the site has an
+    apron (``hangar.apron_depth_m > 0``) but every apron start pose was filtered,
+    so this plane fell back to the ``y = 0`` door line and shows no slide-in. The
+    key is set ONLY in that case (absent otherwise), and is purely observational —
+    it never affects the returned :class:`DubinsArc` or the plan (ADR-0003).
     """
     r = mover.effective_turn_radius_m()
     # Static obstacle set, computed once: placed planes don't move while this one
@@ -1929,6 +1972,15 @@ def plan_path(
             # start. It is NOT guaranteed feasible — a plane wider than the door
             # clips even here, and the search then finds no valid path (#411).
             start_poses = (Pose(x_m=hangar.door.center_x_m, y_m=0.0, heading_deg=0.0),)
+            # #503 signal (observational, plan-inert): when the site HAS an apron
+            # (apron_depth_m > 0) but every apron start pose was filtered, this
+            # plane tows via the y=0 door line and shows no slide-in — and that is
+            # silent in the MovesPlan. Record it in `stats` (a diagnostics-only
+            # out-param, never the plan) so the caller (:func:`plan_fill`) can warn,
+            # naming the plane. Suppressed at depth 0, where the door-line start is
+            # the correct pre-apron behaviour, not a dropped slide-in.
+            if stats is not None and hangar.apron_depth_m > 0.0:
+                stats["apron_fallback"] = True
 
     # ── Seed the open heap with all surviving start poses ───────────────────
     # Heuristic: ``_h`` — straight-line Euclidean distance by default (deliberately

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import heapq
 import math
-import sys
 import typing
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
@@ -36,7 +35,7 @@ from shapely.geometry import Point, Polygon
 from hangarfit.collisions import _parts_conflict
 from hangarfit.collisions import check as _check
 from hangarfit.geometry import WorldPart, cached_parts_world
-from hangarfit.models import Aircraft, Conflict, Hangar, Layout, Placement
+from hangarfit.models import Aircraft, ApronShallowDrop, Conflict, Hangar, Layout, Placement
 
 SegmentKind = Literal["L", "S", "R"]
 _VALID_SEGMENT_KINDS = frozenset(typing.get_args(SegmentKind))
@@ -1215,6 +1214,7 @@ def plan_fill(
     heuristic: Literal["euclidean", "grid"] = "grid",
     max_expansions: int | None = None,
     max_total_expansions: int | None = None,
+    apron_dropped_out: list[ApronShallowDrop] | None = None,
 ) -> MovesPlan:
     """Plan a collision-free entry order + per-plane path for an empty fill.
 
@@ -1233,6 +1233,19 @@ def plan_fill(
     (~per-plane × scan-retries); the global cap bounds that worst case so the
     planner bails in bounded time instead of running away, while a routable fill
     finishes well under it. RNG-free, so the cap is seed-deterministic (#336).
+
+    ``apron_dropped_out`` is an optional diagnostics-only **out-param** (#503,
+    mirroring how ``plan_path``'s ``stats`` out-dict works): when supplied, it is
+    populated — in committed-move order — with an :class:`ApronShallowDrop` for
+    each committed plane that towed via the ``y = 0`` door-line fallback despite an
+    apron being set (``hangar.apron_depth_m > 0``), i.e. whose footprint was too
+    deep for the apron so every apron start pose was filtered (it shows no
+    slide-in). Each drop's ``min_depth_m`` is the plane's fore-aft footprint extent
+    (:func:`_plane_fore_aft_length_m`) — a conservative sufficient depth to engage
+    it, NOT the exact minimum. Purely observational: it is **never** read back into
+    the :class:`MovesPlan`, so the plan stays byte-identical whether or not the
+    list is passed (ADR-0003). ``None`` (the default) collects nothing. The caller
+    (CLI / solver) emits the user-facing warning from this data, deduped.
 
     Walks :func:`back_first_order` (deepest slot first); for each plane searches
     for an in-bounds path from the door-cone entry poses (:func:`entry_poses`) to
@@ -1265,12 +1278,6 @@ def plan_fill(
 
     placed: list[Placement] = []
     moves: list[Move] = []
-    # #503: planes that tow via the y=0 door-line fallback DESPITE an apron being
-    # set (their footprint is too deep for the apron, so every apron start pose was
-    # filtered). Collected in commit order and warned about once the fill is built,
-    # so the order is the deterministic move order (ADR-0003). Observational only —
-    # never read back into the plan.
-    apron_dropped: list[str] = []
 
     while ordered:
         chosen: int | None = None
@@ -1352,34 +1359,22 @@ def plan_fill(
         assert chosen_arc is not None
         moves.append(Move(slot.plane_id, Pose.from_placement(slot), chosen_arc))
         placed.append(slot)
-        if chosen_apron_fallback:
-            apron_dropped.append(slot.plane_id)
+        # #503: record (plan-inert) the planes that towed via the y=0 door-line
+        # fallback DESPITE an apron being set — their footprint is too deep for the
+        # apron, so every apron start pose was filtered and they show no slide-in.
+        # Populated in committed-move order (the deterministic move order, ADR-0003)
+        # only when the caller passed `apron_dropped_out`; the suggested min depth
+        # is the per-plane FOOTPRINT extent, NOT the fleet-wide `auto` over-margin
+        # (derive_apron_depth). Never read back into the plan.
+        if chosen_apron_fallback and apron_dropped_out is not None:
+            apron_dropped_out.append(
+                ApronShallowDrop(
+                    plane_id=slot.plane_id,
+                    min_depth_m=_plane_fore_aft_length_m(fleet[slot.plane_id]),
+                )
+            )
 
-    _warn_apron_too_shallow(apron_dropped, fleet)
     return MovesPlan(target_layout=target, moves=tuple(moves))
-
-
-def _warn_apron_too_shallow(dropped_plane_ids: list[str], fleet: Mapping[str, Aircraft]) -> None:
-    """Emit one deterministic stderr warning per plane that tows via the ``y = 0``
-    door-line fallback despite an apron being set (#503).
-
-    Such a plane's footprint is too deep for the apron, so every apron start pose
-    was filtered and it shows no slide-in — silent in the :class:`MovesPlan`. The
-    suggested minimum depth is the plane's fore-aft footprint extent
-    (:func:`_plane_fore_aft_length_m`) — the per-plane FOOTPRINT depth the apron
-    must clear, NOT the fleet-wide ``auto`` over-margin (:func:`derive_apron_depth`).
-
-    Purely observational: writes to ``stderr`` (never the plan, never stdout), in
-    the caller-supplied (deterministic move) order. RNG-free ⇒ ADR-0003-safe.
-    """
-    for plane_id in dropped_plane_ids:
-        suggested = _plane_fore_aft_length_m(fleet[plane_id])
-        print(
-            f"warning: apron too shallow for plane {plane_id!r}: it tows in via the "
-            f"door line (no slide-in). Increase the apron depth to >= {suggested:.1f} m "
-            f"(its footprint extent) so it engages the apron.",
-            file=sys.stderr,
-        )
 
 
 # ── Hybrid-A* tow-path search (spike Q3 v2, #222) ───────────────────────────

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -644,7 +644,9 @@ class TestSolveRenderPaths:
         )
 
     @staticmethod
-    def _result(status, layouts, plans, unroutable=(), spread_fallback_applied=False):
+    def _result(
+        status, layouts, plans, unroutable=(), spread_fallback_applied=False, apron_drops=()
+    ):
         from hangarfit.models import SolverDiagnostics, SolveResult
 
         diag = SolverDiagnostics(
@@ -655,6 +657,7 @@ class TestSolveRenderPaths:
             seed=42,
             unroutable_planes=unroutable,
             spread_fallback_applied=spread_fallback_applied,
+            apron_shallow_drops=apron_drops,
         )
         return SolveResult(status=status, layouts=layouts, plans=plans, diagnostics=diag)
 
@@ -843,6 +846,135 @@ class TestSolveRenderPaths:
                     "42",
                 ]
             )
+
+    # ── #503: too-shallow-apron warning emitted ONCE at the CLI boundary ──────
+    # The warning is keyed on the RETURNED result's diagnostics
+    # (apron_shallow_drops) and deduped per plane, so --alternatives never
+    # multiplies it and a discarded spread-fallback pass never surfaces (its
+    # diagnostics are not the ones returned). These mirror _warn_unroutable's
+    # CLI-boundary tests.
+
+    @staticmethod
+    def _drop(plane_id, depth):
+        from hangarfit.models import ApronShallowDrop
+
+        return ApronShallowDrop(plane_id=plane_id, min_depth_m=depth)
+
+    def test_apron_shallow_warns_once_naming_plane_and_depth(self, tmp_path, monkeypatch, capsys):
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve(
+            monkeypatch,
+            self._result("found", (layout,), (plan,), apron_drops=(self._drop("husky", 8.0),)),
+        )
+        out = tmp_path / "p.png"
+        rc = main(["solve", SMOKE_FIXTURE, "--render", str(out), "--render-paths", "--seed", "42"])
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert err.count("apron too shallow") == 1
+        assert "'husky'" in err
+        assert "8.0 m" in err  # the suggested footprint-extent depth
+
+    def test_apron_shallow_not_multiplied_by_alternatives(self, tmp_path, monkeypatch, capsys):
+        # The SAME plane is dropped in BOTH returned layouts (--alternatives 2), so
+        # apron_shallow_drops carries two entries for 'husky'. The CLI dedups by
+        # plane id ⇒ exactly ONE warning, not one per alternative (the
+        # multiplicative-repetition bug the rework fixes).
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve(
+            monkeypatch,
+            self._result(
+                "found",
+                (layout, layout),
+                (plan, plan),
+                apron_drops=(self._drop("husky", 8.0), self._drop("husky", 8.0)),
+            ),
+        )
+        pattern = str(tmp_path / "p_{i}.png")
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--alternatives",
+                "2",
+                "--render",
+                pattern,
+                "--render-paths",
+                "--seed",
+                "42",
+            ]
+        )
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert err.count("apron too shallow") == 1  # deduped — not multiplied
+
+    def test_apron_shallow_dedup_keeps_largest_depth(self, tmp_path, monkeypatch, capsys):
+        # Same plane dropped in two layouts with DIFFERENT suggested depths: the
+        # one warning reports the LARGER (safe upper bound).
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve(
+            monkeypatch,
+            self._result(
+                "found",
+                (layout, layout),
+                (plan, plan),
+                apron_drops=(self._drop("husky", 6.0), self._drop("husky", 9.0)),
+            ),
+        )
+        pattern = str(tmp_path / "p_{i}.png")
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--alternatives",
+                "2",
+                "--render",
+                pattern,
+                "--render-paths",
+                "--seed",
+                "42",
+            ]
+        )
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert err.count("apron too shallow") == 1
+        assert "9.0 m" in err and "6.0 m" not in err
+
+    def test_no_apron_drops_no_warning(self, tmp_path, monkeypatch, capsys):
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve(monkeypatch, self._result("found", (layout,), (plan,)))
+        out = tmp_path / "p.png"
+        rc = main(["solve", SMOKE_FIXTURE, "--render", str(out), "--render-paths", "--seed", "42"])
+        assert rc == 0
+        assert "apron too shallow" not in capsys.readouterr().err
+
+    def test_apron_shallow_json_surfaces_drops(self, tmp_path, monkeypatch, capsys):
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve(
+            monkeypatch,
+            self._result("found", (layout,), (plan,), apron_drops=(self._drop("husky", 8.0),)),
+        )
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--render",
+                str(tmp_path / "p.png"),
+                "--render-paths",
+                "--json",
+                "--seed",
+                "42",
+            ]
+        )
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["diagnostics"]["apron_shallow_drops"] == [
+            {"plane": "husky", "min_depth_m": 8.0}
+        ]
 
     def test_empty_layouts_exits_1_not_3(self, tmp_path, monkeypatch):
         # No layouts (exhausted_budget): exit 1 wins over the exit-3 check even

--- a/tests/test_cli_view.py
+++ b/tests/test_cli_view.py
@@ -165,6 +165,56 @@ def test_view_tow_max_expansions_overrides_view_cap(tmp_path, monkeypatch):
     assert captured["max_expansions"] == 500
 
 
+def test_view_layout_mode_warns_apron_shallow_once(tmp_path, monkeypatch, capsys):
+    # #503: layout-mode view calls plan_fill directly (no SolverDiagnostics), so it
+    # collects the too-shallow-apron drops via the plan-inert out-param and warns
+    # once per plane at the CLI. Stub plan_fill to populate the out-param (the same
+    # plane TWICE, as if dropped across passes) and return a real MovesPlan; the
+    # CLI must dedup ⇒ exactly one warning naming the plane + suggested depth.
+    import hangarfit.towplanner as tp
+    from hangarfit.models import ApronShallowDrop
+    from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+
+    def fake_plan_fill(target, *, apron_dropped_out=None, **kwargs):
+        if apron_dropped_out is not None:
+            apron_dropped_out.append(ApronShallowDrop(plane_id="z", min_depth_m=8.0))
+            apron_dropped_out.append(ApronShallowDrop(plane_id="z", min_depth_m=8.0))
+        start = Pose(x_m=2.0, y_m=0.0, heading_deg=0.0)
+        end = Pose(x_m=2.0, y_m=5.0, heading_deg=0.0)
+        arc = DubinsArc(start=start, end=end, turn_radius_m=1.0, segments=(Segment("S", 5.0),))
+        return MovesPlan(
+            target_layout=target, moves=(Move(plane_id="z", target_slot=end, path=arc),)
+        )
+
+    monkeypatch.setattr(tp, "plan_fill", fake_plan_fill)
+    out = tmp_path / "v.html"
+    rc = main(["view", NESTING, "-o", str(out), "--apron-depth", "6"])
+    assert rc == 0 and out.exists()
+    err = capsys.readouterr().err
+    assert err.count("apron too shallow") == 1  # deduped — one warning per plane
+    assert "'z'" in err and "8.0 m" in err
+
+
+def test_view_layout_mode_no_apron_drop_no_warning(tmp_path, monkeypatch, capsys):
+    # No drop recorded (deep enough apron / no apron) ⇒ no warning.
+    import hangarfit.towplanner as tp
+    from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+
+    def fake_plan_fill(target, *, apron_dropped_out=None, **kwargs):
+        start = Pose(x_m=2.0, y_m=0.0, heading_deg=0.0)
+        end = Pose(x_m=2.0, y_m=5.0, heading_deg=0.0)
+        arc = DubinsArc(start=start, end=end, turn_radius_m=1.0, segments=(Segment("S", 5.0),))
+        return MovesPlan(
+            target_layout=target, moves=(Move(plane_id="z", target_slot=end, path=arc),)
+        )
+
+    monkeypatch.setattr(tp, "plan_fill", fake_plan_fill)
+    out = tmp_path / "v.html"
+    rc = main(["view", NESTING, "-o", str(out)])
+    assert rc == 0 and out.exists()
+    assert "apron too shallow" not in capsys.readouterr().err
+
+
 def test_view_check_overlay(tmp_path):
     # --no-animate: we are testing the conflict overlay, not the tow animation
     # (and tow-planning an invalid layout would just burn the search budget).

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ import pytest
 
 from hangarfit.models import (
     Aircraft,
+    ApronShallowDrop,
     CheckResult,
     Conflict,
     Door,
@@ -956,6 +957,27 @@ class TestLayout:
         layout = Layout(fleet={}, hangar=_ok_hangar(), placements=())
         assert layout.placements == ()
         assert len(layout.fleet) == 0
+
+
+class TestApronShallowDrop:
+    def test_valid_construction(self) -> None:
+        drop = ApronShallowDrop(plane_id="A", min_depth_m=8.0)
+        assert drop.plane_id == "A"
+        assert drop.min_depth_m == 8.0
+
+    def test_zero_min_depth_accepted(self) -> None:
+        # Non-negative is the gate (mirrors the module's other distance fields);
+        # a real footprint extent is always > 0, but 0 is not rejected.
+        assert ApronShallowDrop(plane_id="A", min_depth_m=0.0).min_depth_m == 0.0
+
+    def test_empty_plane_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="plane_id must be non-empty"):
+            ApronShallowDrop(plane_id="", min_depth_m=8.0)
+
+    @pytest.mark.parametrize("bad_depth", [-1.0, float("nan"), float("inf")])
+    def test_non_finite_or_negative_min_depth_rejected(self, bad_depth: float) -> None:
+        with pytest.raises(ValueError, match="min_depth_m must be finite and >= 0"):
+            ApronShallowDrop(plane_id="A", min_depth_m=bad_depth)
 
 
 class TestConflict:

--- a/tests/test_solver_canaries.py
+++ b/tests/test_solver_canaries.py
@@ -45,7 +45,7 @@ def _stub_towplanning(monkeypatch):
     from hangarfit.towplanner import MovesPlan
 
     monkeypatch.setattr(
-        solver_mod, "plan_fill", lambda target: MovesPlan(target_layout=target, moves=())
+        solver_mod, "plan_fill", lambda target, **kwargs: MovesPlan(target_layout=target, moves=())
     )
 
 

--- a/tests/test_solver_fixture_matrix.py
+++ b/tests/test_solver_fixture_matrix.py
@@ -36,7 +36,7 @@ def _stub_towplanning(monkeypatch):
     from hangarfit.towplanner import MovesPlan
 
     monkeypatch.setattr(
-        solver_mod, "plan_fill", lambda target: MovesPlan(target_layout=target, moves=())
+        solver_mod, "plan_fill", lambda target, **kwargs: MovesPlan(target_layout=target, moves=())
     )
 
 

--- a/tests/test_solver_infeasibility.py
+++ b/tests/test_solver_infeasibility.py
@@ -21,7 +21,7 @@ def _stub_towplanning(monkeypatch):
     from hangarfit.towplanner import MovesPlan
 
     monkeypatch.setattr(
-        solver_mod, "plan_fill", lambda target: MovesPlan(target_layout=target, moves=())
+        solver_mod, "plan_fill", lambda target, **kwargs: MovesPlan(target_layout=target, moves=())
     )
 
 

--- a/tests/test_solver_search.py
+++ b/tests/test_solver_search.py
@@ -29,7 +29,7 @@ def _stub_towplanning(monkeypatch):
     from hangarfit.towplanner import MovesPlan
 
     monkeypatch.setattr(
-        solver_mod, "plan_fill", lambda target: MovesPlan(target_layout=target, moves=())
+        solver_mod, "plan_fill", lambda target, **kwargs: MovesPlan(target_layout=target, moves=())
     )
 
 

--- a/tests/test_solver_spread.py
+++ b/tests/test_solver_spread.py
@@ -31,7 +31,7 @@ def _stub_towplanning(monkeypatch):
     from hangarfit.towplanner import MovesPlan
 
     monkeypatch.setattr(
-        solver_mod, "plan_fill", lambda target: MovesPlan(target_layout=target, moves=())
+        solver_mod, "plan_fill", lambda target, **kwargs: MovesPlan(target_layout=target, moves=())
     )
 
 

--- a/tests/test_solver_tow_fallback.py
+++ b/tests/test_solver_tow_fallback.py
@@ -37,13 +37,14 @@ def _plan(layout):
     return MovesPlan(target_layout=layout, moves=(Move(plane_id="a", target_slot=end, path=arc),))
 
 
-def _result(layouts, plans):
+def _result(layouts, plans, apron_drops=()):
     diag = SolverDiagnostics(
         restarts_attempted=1,
         wall_time_s=0.1,
         best_partial=None,
         best_partial_layout=None,
         seed=5,
+        apron_shallow_drops=apron_drops,
     )
     return SolveResult(status="found", layouts=layouts, plans=plans, diagnostics=diag)
 
@@ -165,6 +166,37 @@ def test_fallback_inherits_max_restarts_not_wall_clock(monkeypatch):
 
     assert calls[1]["search"].spread is False
     assert calls[1]["search"].max_restarts == 7
+
+
+def test_discarded_spread_pass_apron_drops_do_not_surface(monkeypatch):
+    # #503 phantom-layout guard: the spread pass is valid-but-unroutable (so it is
+    # DISCARDED) and reports an apron-shallow drop for a plane the user never gets;
+    # the returned fallback pass reports a DIFFERENT drop set. solve() returns the
+    # fallback result, so only ITS apron_shallow_drops surface — the discarded
+    # spread pass's drops must NOT appear (they describe a layout never returned).
+    from hangarfit.models import ApronShallowDrop
+
+    layout = _layout()
+    plan = _plan(layout)
+    spread_drop = ApronShallowDrop(plane_id="phantom", min_depth_m=9.0)
+    fallback_drop = ApronShallowDrop(plane_id="real", min_depth_m=7.0)
+    calls = _patch_run_solve(
+        monkeypatch,
+        [
+            _result((layout,), (None,), apron_drops=(spread_drop,)),
+            _result((layout,), (plan,), apron_drops=(fallback_drop,)),
+        ],
+    )
+
+    result = solve(_scenario(), seed=5, plan_paths=True, search=SearchConfig(spread=True))
+
+    assert len(calls) == 2  # both passes ran
+    assert result.diagnostics.spread_fallback_applied is True
+    # Only the RETURNED (fallback) layout's drop is present; the discarded spread
+    # pass's "phantom" drop is gone.
+    assert result.diagnostics.apron_shallow_drops == (fallback_drop,)
+    drop_ids = [d.plane_id for d in result.diagnostics.apron_shallow_drops]
+    assert "phantom" not in drop_ids
 
 
 def test_real_library_fallback_routes_single_plane(monkeypatch):

--- a/tests/test_solver_towplanner.py
+++ b/tests/test_solver_towplanner.py
@@ -73,7 +73,7 @@ def test_solve_best_effort_none_when_a_layout_is_untowable(solvable_scenario, mo
     from hangarfit.solver import solve
     from hangarfit.towplanner import NoFeasiblePlanError
 
-    def boom(target):
+    def boom(target, **kwargs):
         raise NoFeasiblePlanError("A", Conflict.single(kind="parts_overlap", plane="A", detail="x"))
 
     monkeypatch.setattr(solver_mod, "plan_fill", boom)
@@ -92,7 +92,7 @@ def test_solve_plan_paths_false_skips_planning(solvable_scenario, monkeypatch):
     import hangarfit.solver as solver_mod
     from hangarfit.solver import solve
 
-    def fail_if_called(target):
+    def fail_if_called(target, **kwargs):
         raise AssertionError("plan_fill must not be called when plan_paths=False")
 
     monkeypatch.setattr(solver_mod, "plan_fill", fail_if_called)
@@ -179,7 +179,7 @@ def test_solve_k_gt_1_bundle_alignment_with_mixed_routability(monkeypatch):
 
     calls = {"n": 0}
 
-    def fail_second_only(target):
+    def fail_second_only(target, **kwargs):
         calls["n"] += 1
         if calls["n"] == 2:
             pid = target.placements[0].plane_id

--- a/tests/test_towplanner_apron.py
+++ b/tests/test_towplanner_apron.py
@@ -19,7 +19,16 @@ from pathlib import Path
 
 import pytest
 
-from hangarfit.models import Aircraft, Door, Hangar, MaintenanceBay, Part, Placement, Wheels
+from hangarfit.models import (
+    Aircraft,
+    ApronShallowDrop,
+    Door,
+    Hangar,
+    MaintenanceBay,
+    Part,
+    Placement,
+    Wheels,
+)
 from hangarfit.towplanner import (
     Pose,
     _mover_motion_bounds_conflict,
@@ -426,77 +435,83 @@ def test_apron_movesplan_byte_identical_across_processes() -> None:
     assert h1 and h1 == h2, f"apron MovesPlan diverged across processes: {h1!r} != {h2!r}"
 
 
-# ── #503: too-shallow-apron warning (observational stderr; plan byte-identical) ─
+# ── #503: too-shallow-apron drops (plan-inert out-param; plan byte-identical) ──
 # When apron_depth_m > 0 but is too shallow for a given plane's footprint, ALL of
 # that plane's apron start poses are filtered and plan_path silently falls back to
-# the y=0 door-line pose (no slide-in). plan_fill emits a deterministic stderr
-# warning naming the plane + a suggested minimum depth. The warning is purely
-# observational: it never touches the MovesPlan (the apron byte-identity canaries
-# above remain the determinism proof).
+# the y=0 door-line pose (no slide-in). plan_fill records the drop into the
+# OPTIONAL `apron_dropped_out` list (plane id + suggested min depth) — it does NOT
+# print. The data is purely observational: it never touches the MovesPlan (the
+# apron byte-identity canaries above remain the determinism proof). The CLI emits
+# the user-facing warning from this data (see tests/test_cli_solve.py /
+# tests/test_cli_view.py).
 
 
-def test_shallow_apron_warns_naming_plane_and_min_depth(capsys) -> None:
+def test_shallow_apron_populates_drop_naming_plane_and_min_depth() -> None:
     """The fuji-at-6 m analogue (#503): an 8 m-long plane in a 6 m apron has all
-    apron start poses filtered → it tows via the y=0 door line. plan_fill warns on
-    stderr, names the plane, and suggests a minimum depth ≈ its 8 m footprint."""
+    apron start poses filtered → it tows via the y=0 door line. plan_fill records
+    one ApronShallowDrop naming the plane with a suggested depth ≈ its 8 m
+    footprint — and never prints."""
     h = _hangar(width_m=20.0, length_m=30.0, door_center=10.0, door_width=6.0, apron_depth_m=6.0)
     fleet = {"A": _long_box_plane("A", body_length_m=8.0)}
     target = _layout(fleet, h, _slot("A", 10.0, 12.0, 0.0))
-    plan = plan_fill(target)
+    drops: list[ApronShallowDrop] = []
+    plan = plan_fill(target, apron_dropped_out=drops)
     # The plane is still routed (best-effort) — via the door line, not the apron.
     first = list(plan.moves[0].path.sample(step_m=0.25, step_deg=5.0))[0]
     assert first.y_m == 0.0  # door-line fallback, NOT a slide-in
-    err = capsys.readouterr().err
-    assert "warning:" in err
-    assert "'A'" in err  # names the plane
-    assert "apron" in err
-    assert "8" in err  # suggests ~the 8 m footprint depth
+    assert len(drops) == 1
+    assert drops[0].plane_id == "A"
+    assert drops[0].min_depth_m == pytest.approx(8.0)  # the 8 m footprint extent
 
 
-def test_deep_apron_does_not_warn(capsys) -> None:
+def test_deep_apron_records_no_drop() -> None:
     """A 14 m apron clears the 8 m plane's footprint → it slides in from the apron,
-    so NO too-shallow warning fires."""
+    so NO drop is recorded."""
     h = _hangar(width_m=20.0, length_m=30.0, door_center=10.0, door_width=6.0, apron_depth_m=14.0)
     fleet = {"A": _long_box_plane("A", body_length_m=8.0)}
     target = _layout(fleet, h, _slot("A", 10.0, 12.0, 0.0))
-    plan = plan_fill(target)
+    drops: list[ApronShallowDrop] = []
+    plan = plan_fill(target, apron_dropped_out=drops)
     first = list(plan.moves[0].path.sample(step_m=0.25, step_deg=5.0))[0]
     assert first.y_m < 0.0  # slides in from the apron
-    assert "warning:" not in capsys.readouterr().err
+    assert drops == []
 
 
-def test_no_apron_never_warns(capsys) -> None:
+def test_no_apron_records_no_drop() -> None:
     """With no apron (depth 0) the y=0 door-line start is the CORRECT behaviour,
-    not a dropped slide-in — so the too-shallow warning must never fire."""
+    not a dropped slide-in — so no drop is recorded."""
     h = _hangar(width_m=20.0, length_m=30.0, door_center=10.0, door_width=6.0, apron_depth_m=0.0)
     fleet = {"A": _long_box_plane("A", body_length_m=8.0)}
     target = _layout(fleet, h, _slot("A", 10.0, 12.0, 0.0))
-    plan_fill(target)
-    assert "warning:" not in capsys.readouterr().err
+    drops: list[ApronShallowDrop] = []
+    plan_fill(target, apron_dropped_out=drops)
+    assert drops == []
 
 
-def test_shallow_apron_warning_only_for_the_dropped_plane(capsys) -> None:
+def test_shallow_apron_drop_only_for_the_dropped_plane() -> None:
     """Mixed fleet (the #499 §6 observation): the long plane drops to the door
-    line and warns; the short plane engages the apron and does not. Exactly one
-    warning, naming the long plane only."""
+    line; the short plane engages the apron. Exactly one drop, naming the long
+    plane only."""
     h = _hangar(width_m=20.0, length_m=30.0, door_center=10.0, door_width=6.0, apron_depth_m=6.0)
     fleet = {
         "LONG": _long_box_plane("LONG", body_length_m=8.0),
         "SHORT": _box_plane("SHORT"),
     }
     target = _layout(fleet, h, _slot("LONG", 6.0, 22.0, 0.0), _slot("SHORT", 14.0, 8.0, 0.0))
-    plan_fill(target)
-    err = capsys.readouterr().err
-    assert err.count("warning:") == 1
-    assert "'LONG'" in err
-    assert "'SHORT'" not in err
+    drops: list[ApronShallowDrop] = []
+    plan_fill(target, apron_dropped_out=drops)
+    assert [d.plane_id for d in drops] == ["LONG"]
 
 
-def test_shallow_apron_warning_does_not_change_the_plan() -> None:
-    """The warning is observational: the MovesPlan is identical whether or not the
-    warning path runs (it always runs at depth 6 here). Byte-identity across two
-    in-process calls — the warning is a side channel, never part of the plan."""
+def test_shallow_apron_out_param_does_not_change_the_plan() -> None:
+    """The out-param is observational: the MovesPlan is byte-identical whether or
+    not it is passed (it is plan-inert). Both branches — with and without the
+    out-param — yield the same plan, and equal to each other."""
     h = _hangar(width_m=20.0, length_m=30.0, door_center=10.0, door_width=6.0, apron_depth_m=6.0)
     fleet = {"A": _long_box_plane("A", body_length_m=8.0)}
     target = _layout(fleet, h, _slot("A", 10.0, 12.0, 0.0))
-    assert plan_fill(target) == plan_fill(target)
+    drops: list[ApronShallowDrop] = []
+    with_out = plan_fill(target, apron_dropped_out=drops)
+    without_out = plan_fill(target)
+    assert with_out == without_out == plan_fill(target)
+    assert len(drops) == 1  # the out-param was still populated

--- a/tests/test_towplanner_apron.py
+++ b/tests/test_towplanner_apron.py
@@ -78,6 +78,36 @@ def _always_cart_plane(plane_id: str) -> Aircraft:
     )
 
 
+def _long_box_plane(plane_id: str, *, body_length_m: float) -> Aircraft:
+    """A plane whose fuselage box is ``body_length_m`` long fore-aft and CENTRED on
+    the origin (``offset_x_m=0.0``), so at heading 0 the body spans world
+    y ∈ [ref_y − body_length_m/2, ref_y + body_length_m/2]. A long body cannot fit
+    an apron start pose in a shallow apron (its aft vertex overflows the south
+    bound) — the too-shallow-apron-drops-the-plane case (#503). Its fore-aft extent
+    is exactly ``body_length_m`` (one part centred on the origin)."""
+    part = Part(
+        kind="fuselage_aft",
+        length_m=body_length_m,
+        width_m=0.6,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=1.0,
+    )
+    return Aircraft(
+        id=plane_id,
+        name=f"Long {plane_id}",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=4.0,
+        measured=False,
+        parts=(part,),
+        wheels=_TAIL_WHEELS,
+    )
+
+
 def _wide_box_plane(plane_id: str, *, body_width_m: float) -> Aircraft:
     """A plane whose fuselage is ``body_width_m`` wide (lateral). At heading 0 the
     body spans world x ∈ [ref_x − body_width_m/2, ref_x + body_width_m/2]; used to
@@ -394,3 +424,79 @@ def test_apron_movesplan_byte_identical_across_processes() -> None:
     h1 = _run("111")
     h2 = _run("777")
     assert h1 and h1 == h2, f"apron MovesPlan diverged across processes: {h1!r} != {h2!r}"
+
+
+# ── #503: too-shallow-apron warning (observational stderr; plan byte-identical) ─
+# When apron_depth_m > 0 but is too shallow for a given plane's footprint, ALL of
+# that plane's apron start poses are filtered and plan_path silently falls back to
+# the y=0 door-line pose (no slide-in). plan_fill emits a deterministic stderr
+# warning naming the plane + a suggested minimum depth. The warning is purely
+# observational: it never touches the MovesPlan (the apron byte-identity canaries
+# above remain the determinism proof).
+
+
+def test_shallow_apron_warns_naming_plane_and_min_depth(capsys) -> None:
+    """The fuji-at-6 m analogue (#503): an 8 m-long plane in a 6 m apron has all
+    apron start poses filtered → it tows via the y=0 door line. plan_fill warns on
+    stderr, names the plane, and suggests a minimum depth ≈ its 8 m footprint."""
+    h = _hangar(width_m=20.0, length_m=30.0, door_center=10.0, door_width=6.0, apron_depth_m=6.0)
+    fleet = {"A": _long_box_plane("A", body_length_m=8.0)}
+    target = _layout(fleet, h, _slot("A", 10.0, 12.0, 0.0))
+    plan = plan_fill(target)
+    # The plane is still routed (best-effort) — via the door line, not the apron.
+    first = list(plan.moves[0].path.sample(step_m=0.25, step_deg=5.0))[0]
+    assert first.y_m == 0.0  # door-line fallback, NOT a slide-in
+    err = capsys.readouterr().err
+    assert "warning:" in err
+    assert "'A'" in err  # names the plane
+    assert "apron" in err
+    assert "8" in err  # suggests ~the 8 m footprint depth
+
+
+def test_deep_apron_does_not_warn(capsys) -> None:
+    """A 14 m apron clears the 8 m plane's footprint → it slides in from the apron,
+    so NO too-shallow warning fires."""
+    h = _hangar(width_m=20.0, length_m=30.0, door_center=10.0, door_width=6.0, apron_depth_m=14.0)
+    fleet = {"A": _long_box_plane("A", body_length_m=8.0)}
+    target = _layout(fleet, h, _slot("A", 10.0, 12.0, 0.0))
+    plan = plan_fill(target)
+    first = list(plan.moves[0].path.sample(step_m=0.25, step_deg=5.0))[0]
+    assert first.y_m < 0.0  # slides in from the apron
+    assert "warning:" not in capsys.readouterr().err
+
+
+def test_no_apron_never_warns(capsys) -> None:
+    """With no apron (depth 0) the y=0 door-line start is the CORRECT behaviour,
+    not a dropped slide-in — so the too-shallow warning must never fire."""
+    h = _hangar(width_m=20.0, length_m=30.0, door_center=10.0, door_width=6.0, apron_depth_m=0.0)
+    fleet = {"A": _long_box_plane("A", body_length_m=8.0)}
+    target = _layout(fleet, h, _slot("A", 10.0, 12.0, 0.0))
+    plan_fill(target)
+    assert "warning:" not in capsys.readouterr().err
+
+
+def test_shallow_apron_warning_only_for_the_dropped_plane(capsys) -> None:
+    """Mixed fleet (the #499 §6 observation): the long plane drops to the door
+    line and warns; the short plane engages the apron and does not. Exactly one
+    warning, naming the long plane only."""
+    h = _hangar(width_m=20.0, length_m=30.0, door_center=10.0, door_width=6.0, apron_depth_m=6.0)
+    fleet = {
+        "LONG": _long_box_plane("LONG", body_length_m=8.0),
+        "SHORT": _box_plane("SHORT"),
+    }
+    target = _layout(fleet, h, _slot("LONG", 6.0, 22.0, 0.0), _slot("SHORT", 14.0, 8.0, 0.0))
+    plan_fill(target)
+    err = capsys.readouterr().err
+    assert err.count("warning:") == 1
+    assert "'LONG'" in err
+    assert "'SHORT'" not in err
+
+
+def test_shallow_apron_warning_does_not_change_the_plan() -> None:
+    """The warning is observational: the MovesPlan is identical whether or not the
+    warning path runs (it always runs at depth 6 here). Byte-identity across two
+    in-process calls — the warning is a side channel, never part of the plan."""
+    h = _hangar(width_m=20.0, length_m=30.0, door_center=10.0, door_width=6.0, apron_depth_m=6.0)
+    fleet = {"A": _long_box_plane("A", body_length_m=8.0)}
+    target = _layout(fleet, h, _slot("A", 10.0, 12.0, 0.0))
+    assert plan_fill(target) == plan_fill(target)


### PR DESCRIPTION
Closes #503

## What & why
With a staging apron (`apron_depth_m > 0`), a plane only slides in if the apron is deep enough for *its* footprint at an apron start pose. When it's too shallow for a given plane, all its apron poses are filtered and `plan_path` silently falls back to the `y = 0` door line — that plane shows no slide-in, with zero signal. This adds an observability warning. **Output-only — the `MovesPlan`/`SolveResult` plan content is byte-identical** (determinism-guard PASS, cross-branch verified at apron 0/4/8).

## Design (CLI-boundary emission)
Detection lives in the planner; **emission lives at the CLI**, keyed on the *returned* plan only and deduped per plane (mirrors `cli._warn_unroutable`):
- `plan_path` sets a diagnostics-only `stats["apron_fallback"]` flag when the door-line fallback fires while `apron_depth_m > 0`.
- `plan_fill` exposes the committed drops via a plan-inert out-param `apron_dropped_out: list[ApronShallowDrop] | None`.
- `solver._tow_plan_layouts` collects each **returned** layout's drops into `SolverDiagnostics.apron_shallow_drops`; the **discarded** spread-fallback pass's drops never surface.
- `cli._warn_apron_shallow_drops` emits once to **stderr**, deduped (keeps the largest suggested depth), so `--alternatives N` doesn't multiply it. The `view` path emits from the out-param; `solve --json` carries `apron_shallow_drops` additively (no schema bump).

The suggested minimum depth is the plane's fore-aft footprint extent — a *conservative/sufficient* upper bound (the true engagement gate is approximately `2*min(fore, aft)`), documented in `ApronShallowDrop` and ADR-0021.

## Review arc
code-reviewer + silent-failure-hunter (first pass found the should-fix: library emission warned the discarded layout & multiplied by alternatives x passes -> reworked to CLI boundary), then on the rework: code-reviewer (clean), type-design-analyzer (clean), determinism-guard (PASS, plans byte-identical to develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
