### PR TITLE
towplanner: fewest-moves tow routing — back nose-out slots in (#480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
   headings whenever the *target* parked heading is nose-out — independent of the
   staging apron — and a cost-aware start-seed analytic expansion returns the
   cheapest collision-clean approach, so a nose-out slot is **backed in** (in-hangar
-  reorientation drops from ~160° to a near-straight slide-in) instead of
+  reorientation drops from ~162° to a near-straight slide-in) instead of
   pirouetting in the back corner. Determinism (ADR-0003) is preserved; this
   re-baselines the depth-0 tow grid for **nose-out** targets only, superseding the
   #412 depth-0 cross-version byte-identity for that case (the same-input contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- **Fewest-moves tow routing — nose-out slots are backed in (#480, ADR-0010
+  amendment).** The tow planner now minimises **moves** (direction changes), not
+  reverse distance: word/path cost is `length + CUSP_PENALTY × cusps` (a *cusp* is
+  a forward↔reverse change), replacing the old `_REVERSE_COST_FACTOR = 1.5`
+  reverse-length penalty; forward motion is now preferred only as the
+  deterministic tie-break. The door entry cone emits its rear-entry (nose-out)
+  headings whenever the *target* parked heading is nose-out — independent of the
+  staging apron — and a cost-aware start-seed analytic expansion returns the
+  cheapest collision-clean approach, so a nose-out slot is **backed in** (in-hangar
+  reorientation drops from ~160° to a near-straight slide-in) instead of
+  pirouetting in the back corner. Determinism (ADR-0003) is preserved; this
+  re-baselines the depth-0 tow grid for **nose-out** targets only, superseding the
+  #412 depth-0 cross-version byte-identity for that case (the same-input contract
+  is unchanged). Obstructed nose-out approaches that need mid-search maneuvering
+  remain best-effort.
+
 ### Fixed
 
 ## [0.12.0] — 2026-06-07

--- a/docs/adr/0010-reeds-shepp-motion-model.md
+++ b/docs/adr/0010-reeds-shepp-motion-model.md
@@ -90,7 +90,11 @@ This **supersedes [ADR-0007](0007-tow-path-planner-v1-scope.md) fork 2
 own-gear with `turn_radius_m = 0`, the `effective_turn_radius_m()` accessor,
 the door-as-motion-gate, the bounded greedy-order retry) stands.
 
-### Why `_REVERSE_COST_FACTOR = 1.5`?
+### Why `_REVERSE_COST_FACTOR = 1.5`? (Superseded — see the [2026-06-07 #480 amendment](#amendment-2026-06-07--480-fewest-moves-cost-model--nose-out-back-in))
+
+> **Superseded.** The multiplicative reverse-length factor was replaced by an
+> additive **cusp** penalty in the #480 amendment below; this section is kept for
+> the historical rationale.
 
 A measured nose-out case is **18 m reverse vs 32 m forward**. At **1.5×** the
 reverse weighs 27 m, still beating the 32 m forward loop, so the reverse win is
@@ -210,8 +214,83 @@ word algebra, not a bolt-on. One vocabulary, one cost model, one integrator.
   ([ADR-0002](0002-determinant-minus-one-transform.md)) is the hazard the reverse
   legs add a fresh sign to.
 
+## Amendment (2026-06-07) — #480: fewest-moves cost model + nose-out back-in
+
+**Status:** Accepted. **Context:** a UAT/Herrenteich observation — a plane whose
+*parked* heading is nose-out (toward the door) was towed nose-first deep into the
+hangar and spun ~160° in the cramped back corner, because the door entry cone was
+inward-only and the cost model penalised reverse *distance*. The paths were valid
+but low-quality (and pessimistic for routability). [#480](https://github.com/DocGerd/hangarfit/issues/480).
+
+Three coordinated changes, all RNG-free — the ADR-0003 determinism contract holds
+(verified: serial canaries + the `bench` `det` verdict). Cross-version
+byte-identity is intentionally re-baselined where noted.
+
+1. **Cost model: cusp penalty replaces the reverse-length factor.** Word /
+   path selection now minimises **`Σ|leg| + CUSP_PENALTY × cusps`** — gear-agnostic
+   length plus a fixed additive penalty per **cusp** (a forward↔reverse
+   *travel-direction* change between consecutive *translating* legs; in-place cart
+   pivots don't translate and are excluded). This makes the objective **fewest
+   moves** (`moves = cusps + 1`), not least-reverse-distance. `_REVERSE_COST_FACTOR`
+   is removed; it applied at three sites (`_rs_solve_normalised`, `_cart_seg_weight`,
+   `_seg_cost`) — all three now use the cusp model (the search charges the cusp
+   incrementally in the expansion loop via a `_SearchNode.last_drive_gear`). The
+   normalised RS solver gets `CUSP_PENALTY / r` so its choice agrees with the
+   metre-space objective. **Forward preference is now purely the
+   enumeration-order tie-break** (forward primitives/words enumerated first →
+   equal cost keeps forward), not a per-metre tax.
+
+   **Why `CUSP_PENALTY = 10.0` m?** It must (a) keep a genuine nose-out win — a
+   rear-entry back-in is 0 cusps and wins on length alone, and where a 1-cusp
+   back-in (~18 m) replaces a forward loop (~32 m) we need `CUSP_PENALTY < 14`
+   m — and (b) dominate the small length differences between equal-move
+   alternatives so the planner doesn't trade a direction change for a couple of
+   saved metres. 10 m (order of a plane length / the hangar's short dimension)
+   satisfies both; pinned by `test_cusp_penalty_value`.
+
+2. **Rear-entry cone is nose-out-gated, apron-independent.** `entry_poses` emits
+   the rear cone `{150°,165°,180°,195°,210°}` iff the *target* parked heading is
+   nose-out (`|wrap180(target.heading − 180)| ≤ _REAR_CONE_HALF_ANGLE_DEG ≈ 45°`),
+   with or without an apron (previously it was emitted only when an apron existed).
+   A nose-out slot can therefore be **backed in** through the door; a nose-in slot
+   keeps the 5-heading forward cone only (no wasted seeds). This changes the
+   depth-0 grid for **nose-out** targets, **superseding the [#412](https://github.com/DocGerd/hangarfit/issues/412)/[ADR-0021](0021-tow-planner-staging-apron.md)
+   depth-0 cross-version byte-identity for that case** (the ADR-0003 same-input
+   contract is intact; only the historical depth-0≡pre-apron equality is given up,
+   and only for nose-out targets).
+
+3. **Cost-aware start-seed analytic expansion.** The rear cone + cusp cost alone
+   did *not* fix nose-out: the Hybrid-A\* analytic expansion returned the **first**
+   collision-clean shot in pop order, and the forward cone is enumerated first, so
+   a forward entry that pirouettes inside was returned before the cheaper back-in
+   was evaluated. The fix evaluates **every surviving start seed's** closed-form
+   completion up front and returns the **cheapest collision-clean** one (the back-in
+   is a start-seed shot, so it now wins); if no seed closes cleanly (an obstructed
+   approach) it falls through to the unchanged greedy node-level search.
+   - *Considered and rejected:* making the **whole** search cost-aware (keep the
+     cheapest analytic completion across all popped nodes, admissible f-cutoff).
+     It is more general (optimises obstructed nose-out too) but, with the loose
+     default euclidean heuristic, explores to ~`max_expansions` before the cutoff
+     fires — **13–26 s per `plan_path`** (vs milliseconds), impractical for
+     `solve` and the bench perf gate. The bounded start-seed variant fixes the
+     measured open-hangar/clear-approach cases at ~unchanged speed; **obstructed
+     nose-out needing mid-search maneuvering stays best-effort** (greedy), which is
+     an accepted limitation.
+
+**Acceptance:** a nose-out slot's in-hangar swept turning drops from ~162° to a
+back-in (<45°), verified by `tests/test_towplanner_nose_out.py`; no validity /
+path-validity / determinism regression (`bench`; serial canaries); design spec
+`docs/superpowers/specs/2026-06-07-480-fewest-moves-tow-routing-design.md`.
+
+**Relationship to [#263](https://github.com/DocGerd/hangarfit/issues/263)** (prefer
+a nose-out *parked heading*): this amendment makes a nose-out slot **cheap to
+reach** when the solver picks one; #263 (separate) makes the solver *prefer* to
+pick them.
+
 ## More Information
 
+- Amended by #480 (2026-06-07): cusp-penalty cost model, nose-out-gated rear cone,
+  cost-aware start-seed analytic expansion (see the amendment section above).
 - Supersedes: [ADR-0007](0007-tow-path-planner-v1-scope.md) fork 2 ("Dubins-only").
   The rest of ADR-0007 stands.
 - Related ADRs:

--- a/docs/superpowers/plans/2026-06-07-480-fewest-moves-tow-routing.md
+++ b/docs/superpowers/plans/2026-06-07-480-fewest-moves-tow-routing.md
@@ -1,0 +1,295 @@
+# #480 Fewest-moves tow routing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans (inline, supervised — this is determinism-sensitive solver/planner code). Steps use `- [ ]` checkboxes.
+
+**Goal:** Replace the multiplicative reverse-length penalty (`_REVERSE_COST_FACTOR=1.5`) with an additive cusp penalty (`cost = length + CUSP_PENALTY·cusps`) and emit the rear-entry cone for nose-out targets independent of apron, so nose-out slots are *backed in* instead of pirouetted in the back corner.
+
+**Architecture:** Single module — `src/hangarfit/towplanner.py`. The cost objective changes at three sites that must agree: the Hybrid-A\* search g-cost (`_seg_cost` + expansion loop), the analytic Reeds–Shepp word selection (`_rs_solve_normalised`), and the cart planner (`_plan_cart`/`_cart_seg_weight`). The entry grid (`entry_poses`) gains a nose-out-gated rear cone. Determinism contract (ADR-0003) preserved; cross-version byte-identity (incl. #412 depth-0) intentionally re-baselined.
+
+**Tech stack:** Python 3.12, pytest (incl. `serial`/`slow` markers), `determinism-guard`, `bench`.
+
+**Design source:** `docs/superpowers/specs/2026-06-07-480-fewest-moves-tow-routing-design.md`.
+
+**Reality note on sequencing:** this is a cross-cutting cost change. New behavior gets new unit tests (red→green per task). Existing *behavioral* tests that encode the old ×1.5 weighting (RS word choice, specific costs, the apron rear-cone test) and any path-shape assertions will go RED when the model flips — they are deliberately re-baselined together in **Task 8** with inspected, justified new expectations, NOT silently. The double-solve **determinism canaries are self-comparison (two runs, same version)**, so they stay GREEN throughout as long as determinism holds.
+
+---
+
+### Task 0: `_wrap180` heading helper
+
+**Files:** Modify `src/hangarfit/towplanner.py` (near the heading utilities ~line 240); Test `tests/test_towplanner.py` (or `test_towplanner_reeds_shepp.py`).
+
+- [ ] **Step 1 — failing test**
+```python
+def test_wrap180_folds_to_half_open_interval():
+    from hangarfit.towplanner import _wrap180
+    assert _wrap180(0.0) == 0.0
+    assert _wrap180(180.0) == 180.0
+    assert _wrap180(181.0) == -179.0
+    assert _wrap180(-180.0) == 180.0       # canonical: (-180,180]
+    assert _wrap180(360.0) == 0.0
+    assert _wrap180(540.0) == 180.0
+```
+- [ ] **Step 2 — run, expect ImportError/fail:** `pytest tests/test_towplanner_reeds_shepp.py -k wrap180 -q`
+- [ ] **Step 3 — implement** (beside the other heading helpers):
+```python
+def _wrap180(deg: float) -> float:
+    """Fold an angle (degrees) into the half-open interval ``(-180, 180]``."""
+    return (deg + 180.0) % 360.0 - 180.0
+```
+Note `(-180,180]`: `(-180+180)%360-180 = -180`? → `0%360-180=-180`; adjust: use `180.0 - (180.0 - deg) % 360.0` form OR accept the standard `((deg + 180) % 360) - 180` which yields `[-180,180)` and special-case. **Verify the exact boundary against the test**; pick the formula that passes (`180.0` maps to `180.0`, `-180.0` maps to `180.0`). The robust form:
+```python
+def _wrap180(deg: float) -> float:
+    w = (deg + 180.0) % 360.0 - 180.0
+    return 180.0 if w == -180.0 else w
+```
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — commit:** `feat(towplanner): add _wrap180 heading helper (#480)`
+
+---
+
+### Task 1: nose-out-gated rear-entry cone in `entry_poses`
+
+**Files:** Modify `src/hangarfit/towplanner.py:906-995` (`entry_poses`) + add `_REAR_CONE_HALF_ANGLE_DEG` near `_REVERSE_CONE_HEADINGS:903`; Test `tests/test_towplanner_apron.py` (+ `tests/test_towplanner.py`).
+
+- [ ] **Step 1 — failing tests** (new): nose-out target ⇒ rear headings present (apron or not); nose-in target ⇒ forward cone only.
+```python
+def test_entry_poses_rear_cone_for_nose_out_target_no_apron(small_hangar_no_apron):
+    target = _placement(heading_deg=180.0)   # nose-out
+    headings = {p.heading_deg for p in entry_poses(target, small_hangar_no_apron)}
+    assert {150.0, 165.0, 180.0, 195.0, 210.0} <= headings        # rear cone present
+    assert {330.0, 345.0, 0.0, 15.0, 30.0} <= headings            # forward cone too
+
+def test_entry_poses_no_rear_cone_for_nose_in_target_no_apron(small_hangar_no_apron):
+    target = _placement(heading_deg=0.0)      # nose-in
+    headings = {p.heading_deg for p in entry_poses(target, small_hangar_no_apron)}
+    assert headings == {330.0, 345.0, 0.0, 15.0, 30.0}            # forward cone ONLY
+
+def test_entry_poses_no_rear_cone_for_nose_in_target_with_apron(small_hangar_apron):
+    target = _placement(heading_deg=0.0)
+    headings = {p.heading_deg for p in entry_poses(target, small_hangar_apron)}
+    assert not ({150.0,165.0,180.0,195.0,210.0} & headings)        # nose-in keeps fwd-only even with apron
+```
+(Use/define `_placement(heading_deg)` and the hangar fixtures to match existing test conventions — read `tests/test_towplanner_apron.py` for the existing helpers, e.g. how a `Placement`/`Hangar(apron_depth_m=...)` is built.)
+- [ ] **Step 2 — run, expect fail** (rear cone currently apron-gated): `pytest tests/test_towplanner_apron.py -k "rear_cone or nose_in" -q`
+- [ ] **Step 3 — implement.** Replace the depth branch in `entry_poses`:
+```python
+    depth = hangar.apron_depth_m
+    nose_out = abs(_wrap180(target.heading_deg - 180.0)) <= _REAR_CONE_HALF_ANGLE_DEG
+    headings = _CONE_HEADINGS + (_REVERSE_CONE_HEADINGS if nose_out else ())
+    y_samples = (-depth / 2.0, -depth) if depth > 0.0 else (0.0,)
+```
+Add near `_REVERSE_CONE_HEADINGS`:
+```python
+# Rear cone is emitted iff the target parked heading is nose-out-ish (#480):
+# |wrap180(h-180)| <= this. The rear cone's own +/-30 span plus margin -> ~45.
+_REAR_CONE_HALF_ANGLE_DEG = 45.0
+```
+Update the `entry_poses` docstring (Headings section) to state the new nose-out gate (apron no longer gates the rear cone; it gates only the y-samples).
+- [ ] **Step 4 — update the existing apron test** `tests/test_towplanner_apron.py:186` (currently asserts the rear cone appears with an apron): give its target a nose-out heading so the assertion still holds under the new gate (and add a sibling asserting a nose-in target with the same apron has NO rear cone). Justify in the commit.
+- [ ] **Step 5 — run apron + new tests, expect PASS:** `pytest tests/test_towplanner_apron.py -q`
+- [ ] **Step 6 — commit:** `feat(towplanner): emit rear-entry cone for nose-out targets, apron-independent (#480)`
+
+---
+
+### Task 2: `CUSP_PENALTY` constant + `_count_cusps` helper
+
+**Files:** Modify `src/hangarfit/towplanner.py` (replace the `_REVERSE_COST_FACTOR` block ~513-519 region — but keep `_REVERSE_COST_FACTOR` defined until Task 6 to avoid breaking the other two sites mid-sequence); Test `tests/test_towplanner_reeds_shepp.py`.
+
+- [ ] **Step 1 — failing unit tests for cusp counting** over a sequence of `(gear, translates)` legs:
+```python
+def test_count_cusps_pure_forward_is_zero():
+    assert _count_cusps([(1, True), (1, True), (1, True)]) == 0
+def test_count_cusps_pure_reverse_is_zero():
+    assert _count_cusps([(-1, True), (-1, True)]) == 0
+def test_count_cusps_one_reversal():
+    assert _count_cusps([(1, True), (-1, True)]) == 1
+def test_count_cusps_forward_reverse_forward_is_two():
+    assert _count_cusps([(1, True), (-1, True), (1, True)]) == 2
+def test_count_cusps_excludes_nontranslating_pivots():
+    # cart: pivot(non-translating), reverse straight, pivot -> 0 cusps (single reverse drive)
+    assert _count_cusps([(1, False), (-1, True), (1, False)]) == 0
+```
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement** `_count_cusps` (counts gear sign-changes between consecutive *translating* legs) + add the constant:
+```python
+# Additive per-cusp penalty (metres). A "cusp" is a travel-direction reversal
+# (forward<->reverse) between consecutive TRANSLATING legs; moves = cusps + 1.
+# Replaces the old multiplicative _REVERSE_COST_FACTOR: reverse is no longer
+# taxed per-metre; instead each direction change costs a fixed, large-but-finite
+# amount, so the planner minimises *moves*. Forward preference survives as the
+# enumeration-order tie-break (forward primitives/words enumerated first).
+# Pinned by test_cusp_penalty_value; changing it requires an ADR-0010 update.
+CUSP_PENALTY = 10.0  # PROVISIONAL — finalise empirically in Task 8 (spec §6)
+
+def _count_cusps(legs: "list[tuple[int, bool]]") -> int:
+    """Number of travel-direction reversals among the TRANSLATING legs.
+
+    ``legs`` is ``(gear, translates)`` in travel order. Non-translating legs
+    (in-place cart pivots) are skipped — they are free reorientations, not moves.
+    """
+    cusps = 0
+    prev: int | None = None
+    for gear, translates in legs:
+        if not translates:
+            continue
+        if prev is not None and gear != prev:
+            cusps += 1
+        prev = gear
+    return cusps
+```
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — commit:** `feat(towplanner): add CUSP_PENALTY + _count_cusps (#480)`
+
+---
+
+### Task 3: cusp-weighted Reeds–Shepp word selection
+
+**Files:** Modify `src/hangarfit/towplanner.py:731-769` (`_rs_solve_normalised`) + `:799-835` (`plan_reeds_shepp`); Test `tests/test_towplanner_reeds_shepp.py`.
+
+- [ ] **Step 1 — failing test:** a goal reachable by a 0-cusp reverse word vs a longer forward word — assert the planner now picks the (possibly longer-in-old-metric) fewer-cusp word; and assert a unit-consistency property (passing `cusp_penalty_normalised=0` reproduces shortest-length selection).
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement.** `_rs_solve_normalised(x, y, phi, *, cusp_penalty_normalised: float)`:
+```python
+            word_cusps = _count_cusps([(e.gear, True) for e in word])  # RS legs all translate
+            cost = math.fsum(e.t for e in word) + cusp_penalty_normalised * word_cusps
+            if best is None or cost < best[0]:
+                best = (cost, word)
+```
+`plan_reeds_shepp` computes and passes it (delegates carts to `_plan_cart` before this, so `r > 0`):
+```python
+    word = _rs_solve_normalised(x, y, phi, cusp_penalty_normalised=CUSP_PENALTY / r)
+```
+- [ ] **Step 4 — update existing RS tests** that referenced the ×1.5 weighting (`test_towplanner_reeds_shepp.py:169` comment + any cost assertion; line 212 docstring) with the new metric. Leave `test_reverse_cost_factor_value` for Task 6.
+- [ ] **Step 5 — run, expect PASS:** `pytest tests/test_towplanner_reeds_shepp.py -q` (some path-choice tests may need re-baselining → defer to Task 8 if they encode old behavior; note which.)
+- [ ] **Step 6 — commit:** `feat(towplanner): cusp-weighted Reeds–Shepp word selection (#480)`
+
+---
+
+### Task 4: drop the reverse tax from the cart planner
+
+**Files:** Modify `src/hangarfit/towplanner.py:479-485` (`_cart_seg_weight`); Test `tests/test_towplanner*.py`.
+
+- [ ] **Step 1 — failing/locking test:** a cart back-in that is *equal length* to a forward alternative is now chosen by length+tie-break (not suppressed by ×1.5); a strictly-shorter reverse is chosen.
+- [ ] **Step 2 — run, expect fail** (old ×1.5 suppresses the equal-length reverse).
+- [ ] **Step 3 — implement** — drop the factor:
+```python
+def _cart_seg_weight(seg: Segment) -> float:
+    """Unweighted cart segment cost: a pivot's radians (gear-agnostic) or a
+    straight's metres. Reverse is no longer taxed per-metre (#480); both the
+    forward and reverse pivot-straight-pivot candidates are single drives
+    (0 cusps), so _plan_cart's choice reduces to length with forward as the
+    deterministic tie-break (forward enumerated first)."""
+    if seg.kind != "S":
+        return seg.length_m  # pivot: length_m is radians
+    return seg.length_m
+```
+(`min(forward, reverse)` in `_plan_cart` already keeps forward on a tie.)
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — commit:** `feat(towplanner): drop reverse per-metre tax from cart planner (#480)`
+
+---
+
+### Task 5: cusp-aware Hybrid-A\* search g-cost
+
+**Files:** Modify `src/hangarfit/towplanner.py` — `_seg_cost:1450-1470`, `_SearchNode:1486-1501`, start node `:1944`, expansion/child `:2013-2031`; Test `tests/test_towplanner.py` / `test_towplanner_grid_heuristic.py`.
+
+- [ ] **Step 1 — failing test:** drive the search on a nose-out fixture and assert the returned path backs in (reverse legs reaching the slot) rather than a long forward in-hangar turn; assert determinism (two calls identical).
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement.**
+  - `_seg_cost`: drop the `factor`; return the unweighted cost.
+```python
+def _seg_cost(seg: Segment, turn_radius_m: float) -> float:
+    if seg.kind == "S":
+        return seg.length_m
+    if turn_radius_m > 0.0:
+        return seg.length_m + _TURN_PENALTY * (seg.length_m / turn_radius_m)
+    return _TURN_PENALTY * seg.length_m  # cart pivot: length_m is radians
+```
+  - `_SearchNode`: add `last_drive_gear: int` (0 = none yet).
+```python
+@dataclass(frozen=True, slots=True)
+class _SearchNode:
+    pose: Pose
+    g: float
+    seg: Segment | None
+    parent: "_SearchNode | None"
+    last_drive_gear: int  # 1/-1 of the last TRANSLATING leg; 0 at the root
+```
+  - Start node `:1944`: `_SearchNode(start_pose, 0.0, None, None, 0)`.
+  - Child construction `:2031` (compute cusp + carry gear). Around the expansion where `seg`/`child_pose`/`child_g` are formed:
+```python
+            translates = not (r == 0.0 and seg.kind in ("L", "R"))
+            cusp = 1 if (translates and node.last_drive_gear != 0 and node.last_drive_gear != seg.gear) else 0
+            child_drive_gear = seg.gear if translates else node.last_drive_gear
+            child_g = node.g + _seg_cost(seg, r) + (CUSP_PENALTY if cusp else 0.0)
+            ...
+            (child_g + h, counter, _SearchNode(child_pose, child_g, seg, node, child_drive_gear)),
+```
+  (Confirm the exact local var names in the loop — `r`, `seg`, `child_pose`, `child_g`, `h` — and adapt.)
+- [ ] **Step 4 — run, expect PASS** (incl. determinism: `pytest tests/test_towplanner.py -q`).
+- [ ] **Step 5 — note the deliberate approximation** in a comment: the cell key `(x,y,heading)` does NOT include `last_drive_gear`, so the domination check may occasionally prune a higher-g node whose gear would avoid a downstream cusp — an accepted Hybrid-A\* approximation (same spirit as pose-binning), kept to bound the state space / expansions; the dominant nose-out win comes from the rear-entry seed (0-cusp reverse), not mid-search gear switches.
+- [ ] **Step 6 — commit:** `feat(towplanner): cusp-aware Hybrid-A* g-cost + last_drive_gear node state (#480)`
+
+---
+
+### Task 6: remove `_REVERSE_COST_FACTOR`; pin `CUSP_PENALTY`
+
+**Files:** Modify `src/hangarfit/towplanner.py` (delete `:519` + docstring refs at `:11`, `:426`, `:480`-ish, `:513-518`, `:736`, `:805`, `:1457-1463`); `tests/test_towplanner_reeds_shepp.py` (replace `test_reverse_cost_factor_value` + import).
+
+- [ ] **Step 1 — grep:** `grep -rn _REVERSE_COST_FACTOR src/ tests/` — every hit must be removed/replaced.
+- [ ] **Step 2 — replace the value test:**
+```python
+def test_cusp_penalty_value() -> None:
+    """CUSP_PENALTY is pinned; changing it requires an ADR-0010 update (spec §6)."""
+    assert CUSP_PENALTY == 10.0   # or the Task-8-calibrated value
+```
+- [ ] **Step 3 — delete the constant + scrub docstrings** (replace "reverse legs cost 1.5×…" prose with the cusp model; update the module header docstring at `:11-12`).
+- [ ] **Step 4 — run:** `pytest tests/test_towplanner_reeds_shepp.py -q` + `grep` clean.
+- [ ] **Step 5 — commit:** `refactor(towplanner): remove _REVERSE_COST_FACTOR, pin CUSP_PENALTY (#480)`
+
+---
+
+### Task 7: swept-turning acceptance metric (the issue's own measure)
+
+**Files:** Test `tests/test_towplanner.py` (or a new `tests/test_towplanner_nose_out.py`).
+
+- [ ] **Step 1 — helper + test:** `Σ|Δheading|` sampled along the path while `y_m > 0`, on a nose-out fixture; assert it is small (backs in) — snapshot the number with a tolerance, and assert it's far below the pre-change value (document the before/after in the test docstring).
+```python
+def _swept_turning_inside(arc) -> float:
+    samples = list(arc.sample(step_m=0.25, step_deg=5.0))
+    total = 0.0
+    for a, b in zip(samples, samples[1:]):
+        if a.y_m > 0.0 and b.y_m > 0.0:
+            total += abs(_wrap180(b.heading_deg - a.heading_deg))
+    return total
+```
+- [ ] **Step 2 — run, expect PASS** (this is the real acceptance check — keep it non-`slow` for codecov).
+- [ ] **Step 3 — commit:** `test(towplanner): swept-in-hangar-turning acceptance metric for nose-out (#480)`
+
+---
+
+### Task 8: re-baseline, determinism, calibration, bench
+
+**Files:** whatever the full suite flags; `src/hangarfit/towplanner.py` (finalise `CUSP_PENALTY`).
+
+- [ ] **Step 1 — full suite:** `pytest -m "not slow and not serial" -q` then `pytest -m "serial and not slow" -q`. Triage every failure: is the new behavior *better/equal* (less swept turning, fewer moves)? If yes, update the expectation with a one-line justification in the test. If a path got *worse* or a fixture hit `budget_exhausted`, STOP — that's a real regression, investigate (don't paper over by raising the cap).
+- [ ] **Step 2 — calibrate `CUSP_PENALTY`:** with the Herrenteich nose-out fixtures (`zlin_savage`, `fk9_mkii`) + the synthetic regression fixture, confirm the chosen value keeps the genuine back-in win and doesn't over-trade length for cusps (spec §6: lower bound `< 14 m`). Update the constant + `test_cusp_penalty_value` if the empirics move it off 10.0; record the justification.
+- [ ] **Step 3 — determinism:** run `determinism-guard` (double-solve byte-identity on a fixed seed; the max_restarts-scoped check). Must PASS.
+- [ ] **Step 4 — bench:** `python -m bench.profile_pipeline` — validity / path-validity / determinism verdicts green per regime; note any expansion-budget movement.
+- [ ] **Step 5 — commit:** `test(towplanner): re-baseline tow goldens for cusp cost model (#480)` with the inspected-diff summary in the body.
+
+---
+
+### Task 9: ADR-0010 amendment + spec close-out
+
+**Files:** Modify `docs/adr/0010-reeds-shepp-motion-model.md`; mark the spec status done.
+
+- [ ] **Step 1 — amend ADR-0010:** add a dated amendment section: the cost model is now `length + CUSP_PENALTY·cusps` (was Σ|leg|×1.5^reverse); "prefer forward" is now an enumeration-order tie-break; the rear cone is nose-out-gated (apron-independent); **this supersedes the #412 depth-0 cross-version byte-identity** (the ADR-0003 *contract* is intact). Replace the "Why `_REVERSE_COST_FACTOR = 1.5`?" section with "Why `CUSP_PENALTY = <value>`?" carrying the §6 justification.
+- [ ] **Step 2 — CHANGELOG** entry under Unreleased (Changed): fewest-moves tow routing / nose-out back-in.
+- [ ] **Step 3 — commit:** `docs(adr): ADR-0010 amendment — cusp-penalty cost model (#480)`
+
+---
+
+### Final: open the PR
+- [ ] Push `feature/480-fewest-moves-tow-routing`; `gh pr create --draft --base develop --body "Closes #480 …"` calling out the determinism re-baseline + the superseded #412 depth-0 byte-identity.
+- [ ] Review arc: `code-reviewer` + **`determinism-guard`** (mandated) + `geometry-invariant-guard` only if geometry helpers were touched (they weren't → skip) + `comment-analyzer` (ADR/docstrings).

--- a/docs/superpowers/specs/2026-06-07-480-fewest-moves-tow-routing-design.md
+++ b/docs/superpowers/specs/2026-06-07-480-fewest-moves-tow-routing-design.md
@@ -1,0 +1,314 @@
+# Design spec — #480: fewest-moves tow routing (cusp-penalty cost + nose-out-gated rear cone)
+
+- **Issue:** [#480](https://github.com/DocGerd/hangarfit/issues/480) — *towplanner v2: nose-out slots force a large in-hangar reorientation (entry cone is inward-only) — allow rear/reverse entry or apron-side pre-rotation*
+- **Date:** 2026-06-07
+- **Status:** Approved (design fork settled 2026-06-07: cusp cost + nose-out-gated rear cone)
+- **Deciders:** Patrick Kuhn (DocGerd)
+- **Touches:** `src/hangarfit/towplanner.py` (determinism-sensitive — ADR-0003 contract, `determinism-guard`)
+- **Amends:** [ADR-0010](../../adr/0010-reeds-shepp-motion-model.md) (the reverse-cost model)
+- **Supersedes (cross-version byte-identity only):** the [#412](https://github.com/DocGerd/hangarfit/issues/412) / [ADR-0021](../../adr/0021-tow-planner-staging-apron.md) **depth-0 byte-identical** guarantee
+- **Related / downstream:** #263 (prefer nose-out parked heading — separate PR2), #505 (3D floor path — makes this visible), #412 (apron)
+
+---
+
+## 1. Problem
+
+A plane whose **parked (final) heading is nose-out** (heading ≈ 180°, nose toward
+the door) is currently reached by **driving deep into the hangar nose-first and
+spinning ~180° in the cramped back corner**. Measured on a Herrenteich subset
+(#480): `zlin_savage` sweeps **161°** and `fk9_mkii` **132°** of reorientation
+*inside* the hangar; the nose-in plane sweeps ~0°.
+
+Two independent code facts cause it:
+
+1. **The entry cone is inward-only without an apron.** `entry_poses`
+   (`towplanner.py:906`) seeds the rear-entry cone `_REVERSE_CONE_HEADINGS =
+   {150,165,180,195,210}` **only when `apron_depth_m > 0`** (`:977`). With no
+   apron, every plane must enter nose-pointing-inward (`_CONE_HEADINGS =
+   {330,345,0,15,30}`), so a nose-out slot is reachable **only** by doing the
+   whole reorientation inside.
+2. **Reverse motion is taxed per-meter.** `_REVERSE_COST_FACTOR = 1.5`
+   (`:519`) multiplies the *length* of every reverse leg in all three cost
+   sites, so the planner prefers a **long forward loop** over a **short
+   back-in**.
+
+The paths are valid — this is a planner **quality** issue (awkward, and
+pessimistic for routability because an in-hangar 160° turn needs swept clearance
+a nicer approach would not).
+
+## 2. Decision
+
+Reframe the planner objective from "shortest, with reverse penalised" to
+**"fewest moves"** — minimise direction changes, not reverse distance — and let
+nose-out slots be **backed in** through the door without requiring an apron.
+
+Two coordinated changes:
+
+1. **Cost model:** replace the multiplicative reverse-length penalty
+   (`_REVERSE_COST_FACTOR`, applied at three sites) with an **additive cusp
+   penalty**:
+
+   ```
+   cost = total_length + CUSP_PENALTY · num_cusps
+   ```
+
+   - `total_length` = Σ|leg length| — the true metric length, **gear-agnostic**
+     (a reverse metre costs the same as a forward metre).
+   - `num_cusps` = number of **travel-direction reversals** along the path
+     (`moves = cusps + 1`).
+   - `CUSP_PENALTY` is **large-but-finite** (§6) — a single deterministic
+     scalar, *not* a lexicographic `(cusps, length)` order, so an absurdly long
+     detour to save one cusp still loses.
+   - **Forward preference is retained as a deterministic enumeration-order
+     tie-break** (forward primitives / words are enumerated first, so an exact
+     cost tie keeps forward), replacing the old per-meter bias.
+
+2. **Entry cone:** emit the rear-entry cone **iff the target slot's parked
+   heading is nose-out-ish** — `|wrap180(target.heading_deg − 180°)| ≤
+   _REAR_CONE_HALF_ANGLE_DEG` (≈ 45°) — **independent of apron depth**. Nose-in
+   slots keep today's 5-heading forward grid byte-for-byte (no wasted
+   expansions); only nose-out slots gain the 5 rear headings.
+
+### Definition: cusp
+
+A **cusp** is a reversal of travel direction (forward ↔ reverse, i.e. a `gear`
+sign change) **between consecutive *translating* legs**. **In-place cart pivots**
+(`r == 0` turns `L`/`R`, which rotate without translating) **do not translate and
+are excluded** from cusp counting — they are free reorientations the cart model
+already treats as cheap. For own-gear motion (`r > 0`) every leg translates, so
+cusps are simply gear sign-changes between adjacent legs.
+
+## 3. Changes by site
+
+All three cost sites must score by the **same** `length + CUSP_PENALTY·cusps`
+objective so the search g-cost, the analytic RS shot, and the cart choice agree.
+
+### 3a. `entry_poses` (`:906`) — nose-out-gated rear cone
+
+Today:
+
+```python
+if depth > 0.0:
+    y_samples = (-depth / 2.0, -depth)
+    headings  = _CONE_HEADINGS + _REVERSE_CONE_HEADINGS
+else:
+    y_samples = (0.0,)
+    headings  = _CONE_HEADINGS
+```
+
+New rule — the rear cone is gated on **target nose-out**, the apron still gates
+only the **y-samples**:
+
+```python
+nose_out = abs(_wrap180(target.heading_deg - 180.0)) <= _REAR_CONE_HALF_ANGLE_DEG
+headings = _CONE_HEADINGS + (_REVERSE_CONE_HEADINGS if nose_out else ())
+y_samples = (-depth / 2.0, -depth) if depth > 0.0 else (0.0,)
+```
+
+- Keeps the fixed, deterministic grid (emit order unchanged: x-outer, y-middle,
+  heading-inner, dedup by exact-float key).
+- **Migration note:** with an apron present today, the rear cone is emitted for
+  *all* planes; under the new rule a nose-**in** plane with an apron loses its
+  (useless) rear headings → its apron `MovesPlan` changes. Accepted (re-baseline,
+  §7) — a nose-in plane never wins a rear-entry seed anyway.
+- `_REAR_CONE_HALF_ANGLE_DEG` is a pinned module constant (≈ 45°, so the rear
+  cone's own ±30° span plus a margin is covered). Document the choice.
+
+### 3b. Hybrid-A* search g-cost (`_seg_cost:1450` + expansion loop `:2013+`)
+
+- `_seg_cost` drops the `_REVERSE_COST_FACTOR` factor → returns the unweighted
+  metric cost (straight metres / arc length + turn penalty / cart-pivot
+  penalty), gear-agnostic.
+- The **cusp charge is incremental, in the expansion step**, not inside
+  `_seg_cost` (a single segment has no cusp): when expanding parent node `n`
+  with primitive `p`, add `CUSP_PENALTY` to the child g iff `p` reverses travel
+  direction relative to the **last translating leg** on `n`'s branch.
+  - **Own-gear (`r > 0`):** every primitive translates ⇒ the predecessor is
+    `n.seg`; charge iff `n.seg is not None and n.seg.gear != p.gear`.
+  - **Cart (`r == 0`):** only straights translate; `n.seg` may be an in-place
+    pivot. The child must compare against the **last translating gear** on the
+    branch. Carry a `last_drive_gear: int` (or `Literal[1,-1] | None`) on
+    `_SearchNode` so the comparison is O(1) and does not walk the parent chain.
+    A pivot child inherits the parent's `last_drive_gear` unchanged; a straight
+    child charges a cusp iff `last_drive_gear` is set and differs, then becomes
+    the new `last_drive_gear`. (Own-gear sets `last_drive_gear = p.gear` on every
+    child — uniform.)
+  - `_SearchNode` stays `frozen=True`; add the field to the dataclass.
+- **Heuristic:** `_build_grid_heuristic` is a free-space geodesic *lower bound*.
+  Adding a non-negative cusp term only *raises* actual g, so the existing
+  heuristic stays admissible (it may be looser, costing a few more expansions —
+  acceptable, watch the budget §7). **No heuristic change required.**
+- Determinism: expansion order is unchanged (fixed primitive fan order +
+  `(f, counter)` heap tie-break). The cusp term is a deterministic function of
+  the branch, so the contract holds.
+
+### 3c. `_rs_solve_normalised` (`:731`) — cusp-weighted RS word selection
+
+The analytic shot `plan_reeds_shepp(node.pose, goal, turn_radius_m=r)` (`:1968`)
+selects the best Reeds–Shepp **word** for the remaining leg.
+
+- Replace `cost = Σ e.t · 1.5^[reverse]` with
+  `cost = Σ e.t + cusp_penalty_normalised · cusps(word)`, where `cusps(word)` =
+  gear sign-changes between adjacent `_RSElement`s (every RS leg translates, so
+  no pivot exclusion here).
+- **Unit consistency (critical):** word cost is in **normalised** units
+  (radius = 1); the chosen word is later scaled by `r` to metres. To make the
+  RS choice agree with the metre-space objective, pass
+  `cusp_penalty_normalised = CUSP_PENALTY / r` from `plan_reeds_shepp` (which
+  knows `r`) into `_rs_solve_normalised`. Then minimising
+  `Σ e.t + (CUSP_PENALTY/r)·cusps` is `argmin` of
+  `(Σ e.t·r + CUSP_PENALTY·cusps)/r` = the metre objective. (`plan_reeds_shepp`
+  delegates carts to `_plan_cart` *before* this point, so `r > 0` here.)
+- Keep the strict-`<` tie-break so an exact tie deterministically keeps the
+  earliest-enumerated word (forward-first).
+
+### 3d. `_plan_cart` (`:420`) + `_cart_seg_weight` (`:479`) — drop the reverse tax
+
+`_plan_cart` chooses between a forward and a reverse pivot-straight-pivot.
+
+- Drop `_REVERSE_COST_FACTOR` from `_cart_seg_weight`; weight a straight by its
+  metres (gear-agnostic) and a pivot by its radians (as today).
+- **Both candidates are single-drive ⇒ 0 cusps** under the *translating-legs-
+  only* rule: the lone straight is the only translating leg, so the
+  pivot-straight-pivot has no *internal* travel-direction reversal whether the
+  straight is forward or reverse. The cusp term is therefore **inert inside
+  `_plan_cart`** (0 for both), and the choice **reduces to an unweighted length
+  comparison** with `min(forward, reverse)` keeping forward on an exact tie
+  (forward first → determinism). No explicit cusp term is needed here; this is
+  the desired effect — backing a cart straight in is "one move," exactly like
+  pulling it forward, and is chosen iff genuinely shorter (no per-meter reverse
+  tax). The old ×1.5 was the only thing biasing against an equal-length back-in.
+
+### 3e (note). The analytic-expansion boundary cusp is not separately charged
+
+The returned path is `reconstructed search prefix + analytic suffix`. Cusps
+*within* the prefix are charged in the search g-cost (§3b); cusps *within* the
+analytic word in `_rs_solve_normalised` (§3c). The single **boundary** cusp
+(last prefix translating gear vs first analytic leg gear) is **not** separately
+charged — consistent with Hybrid-A*'s greedy analytic expansion, which returns
+the analytic completion from the first low-`f` node with a collision-clean shot
+rather than globally minimising total cost. This matches the current code's
+accounting granularity (the old ×1.5 likewise never charged a boundary term); we
+are not regressing it. The dominant path shaping comes from the search g-cost and
+the analytic word choice, which the §8.1 swept-turning metric verifies end-to-end.
+
+### 3f. Remove `_REVERSE_COST_FACTOR`
+
+Delete the constant (`:519`) and all three usages. Replace
+`test_reverse_cost_factor_value` (`tests/test_towplanner_reeds_shepp.py:142`)
+with `test_cusp_penalty_value` pinning the new constant; keep its "changing this
+requires an ADR-0010 update" docstring intent.
+
+## 4. New module constants
+
+| Constant | Purpose | Pinned by |
+|---|---|---|
+| `CUSP_PENALTY` (metres) | additive per-cusp cost (§6) | `test_cusp_penalty_value` + ADR-0010 amendment |
+| `_REAR_CONE_HALF_ANGLE_DEG` (≈ 45°) | nose-out gate half-angle for the rear cone | a unit test on `entry_poses` heading set vs target heading |
+
+(`_wrap180(deg)` — a small helper folding an angle to `(−180, 180]`; reuse an
+existing helper if one exists, else add one beside the heading utilities.)
+
+## 5. Why this design (vs the rejected forks)
+
+- **Unconditional rear cone** (always 10 headings): simplest, but ~2× entry
+  poses for *every* plane → more expansions per plane (the `_MAX_EXPANSIONS =
+  8000` / global-cap budget tightens) even for nose-in slots that never use rear
+  entry. Rejected: pay the cost only where it helps.
+- **Cost change only, keep cone apron-gated:** smallest blast radius, but the
+  no-apron nose-out case the issue *measured* stays broken. Rejected: under-
+  delivers the issue.
+- **Lexicographic `(cusps, length)`:** would let one saved cusp justify an
+  unbounded detour. Rejected for the bounded `length + CUSP_PENALTY·cusps`
+  scalar (also keeps a single deterministic comparison key).
+
+## 6. Calibrating `CUSP_PENALTY`
+
+Method (mirrors ADR-0010's `_REVERSE_COST_FACTOR = 1.5` justification):
+
+- **Lower bound** — a genuine nose-out win must survive: the measured case is
+  ~18 m back-in vs ~32 m forward loop. The back-in via a rear-entry seed is
+  typically **0 cusps** (single reverse leg) ⇒ it already wins on length alone;
+  where a back-in costs **1 cusp** (back in, then a short forward nudge), we need
+  `18 + 1·CUSP_PENALTY < 32` ⇒ `CUSP_PENALTY < 14 m`.
+- **Upper-bound intent** — `CUSP_PENALTY` should dominate the *typical* small
+  length differences between equal-direction-change alternatives, so the planner
+  doesn't trade an extra direction change for a couple of saved metres.
+- **Proposed starting value:** `CUSP_PENALTY = 10.0` m (order of a plane length /
+  the hangar's short dimension); **finalise empirically** against the Herrenteich
+  nose-out fixtures (zlin_savage, fk9_mkii) and a synthetic regression fixture,
+  then pin it with `test_cusp_penalty_value` and justify the number in the
+  ADR-0010 amendment (same prose pattern as the old 1.5 paragraph).
+
+## 7. Determinism & migration
+
+- **The ADR-0003 contract holds.** Same scenario + same seed → byte-identical
+  `SolveResult` / `MovesPlan`. The new cost is a deterministic, RNG-free function
+  of the (fixed) inputs; expansion order, the fixed entry grid, and the
+  `(f, counter)` / strict-`<` tie-breaks are unchanged. **`determinism-guard`
+  must pass** (double-solve diff on a fixed seed).
+- **Cross-version byte-identity is intentionally broken.** Changing the scoring
+  metric re-selects RS words and entry poses, so **all tow goldens re-baseline**.
+  This **supersedes the #412 / ADR-0021 depth-0 byte-identical guarantee** (the
+  promise that an apron-depth-0 plan equals the pre-apron plan byte-for-byte) —
+  call this out explicitly in the ADR-0010 amendment and the PR body. The
+  *contract* (determinism within a version) is untouched; only the *historical
+  stability* across this change is.
+- **Goldens / tests to update:** `tests/test_towplanner*.py`,
+  `tests/test_solver_towplanner.py`, the `serial`-marked determinism canaries,
+  and any committed path goldens. Re-baseline by regenerating, then **inspect the
+  diffs** to confirm the new paths are *better* (less in-hangar swept turning),
+  not merely different.
+- **Expansion budget:** nose-out slots now seed ~2× headings and the heuristic is
+  slightly looser; verify no nose-out fixture regresses to `budget_exhausted`
+  under the default `_MAX_EXPANSIONS = 8000`. If one does, that's a measured
+  signal — surface it, don't silently raise the cap.
+
+## 8. Test plan & acceptance
+
+Acceptance (from the issue):
+
+- [ ] A nose-out slot routes with **substantially reduced in-hangar swept
+      turning** (backs in / pre-rotates), verified on the Herrenteich subset
+      (`zlin_savage`, `fk9_mkii`) **and** a synthetic regression fixture.
+- [ ] **No regression** in validity / path-validity / determinism (`bench`
+      verdicts; `determinism-guard`).
+- [ ] Decision recorded — ADR-0010 amendment.
+
+Tests to add / change:
+
+1. **Swept-turning metric** — a helper that sums `Σ|Δheading|` along a path while
+   `y_m > 0` (the issue's own metric); assert it drops markedly for a nose-out
+   fixture vs the pre-change baseline (snapshot the number).
+2. **Cusp counting unit tests** — own-gear word with a reversal (1 cusp), pure
+   reverse leg (0 cusps), forward-reverse-forward (2 cusps), cart
+   pivot-straight⁻-pivot (1 cusp, pivots excluded).
+3. **`entry_poses` gate** — nose-out target ⇒ rear headings present; nose-in
+   target ⇒ exactly the 5 forward headings (no apron) / forward headings only
+   (with apron); boundary at `_REAR_CONE_HALF_ANGLE_DEG`.
+4. **`test_cusp_penalty_value`** + **remove `test_reverse_cost_factor_value`**.
+5. **Determinism canaries** stay green (double-solve byte-identity) — run the
+   `serial` set; run `determinism-guard`.
+6. **Regenerated goldens** committed with an inspected, justified diff.
+7. **`bench`** (`python -m bench.profile_pipeline`) validity/path-validity/
+   determinism verdicts stay green for every regime.
+
+## 9. Out of scope (this PR)
+
+- **#263** (solver *prefers* a nose-out parked heading) — separate PR2. This PR
+  makes a nose-out slot *cheap to reach when the solver happens to pick one*;
+  #263 makes the solver pick more of them. Doing #263 here would conflate two
+  determinism-sensitive changes.
+- **#505** (draw the path on the 3D floor) — independent viewer PR; it *visualises*
+  this improvement but doesn't depend on it.
+- **Apron auto-deepen** (#503 Option 2) — unrelated; #503's warn cut is separate.
+
+## 10. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Cart cusp bookkeeping subtly wrong (pivot exclusion) | Dedicated cusp unit tests (§8.2); carts rarely hit the nose-out case (they pivot in place) so blast radius is small |
+| `CUSP_PENALTY` mis-calibrated → reverse over/under-used | Empirical calibration against fixtures (§6); pinned + ADR-justified |
+| Looser heuristic → a hard nose-out fixture blows the expansion budget | §7 check; surface, don't silently raise the cap |
+| Golden churn hides a real regression | Inspect every golden diff; the swept-turning metric (§8.1) is the objective check, not just "different bytes" |
+| Reviewer surprise at lost #412 depth-0 byte-identity | Called out explicitly in ADR-0010 amendment + PR body |

--- a/docs/superpowers/specs/2026-06-07-480-fewest-moves-tow-routing-design.md
+++ b/docs/superpowers/specs/2026-06-07-480-fewest-moves-tow-routing-design.md
@@ -179,6 +179,17 @@ selects the best Reeds–Shepp **word** for the remaining leg.
   pulling it forward, and is chosen iff genuinely shorter (no per-meter reverse
   tax). The old ×1.5 was the only thing biasing against an equal-length back-in.
 
+> **Implementation outcome (2026-06-07):** the greedy analytic expansion this
+> §3e note assumed was *insufficient* — it returned the first collision-clean
+> shot (a forward-enumerated seed) before the cheaper back-in was evaluated, so
+> nose-out slots still pirouetted. The shipped fix is a **cost-aware start-seed
+> analytic expansion**: evaluate every surviving start seed's completion up front
+> and return the cheapest collision-clean one (the back-in is a start-seed shot),
+> else fall through to the greedy node-level search. A full cost-aware search
+> (every node) was prototyped and rejected on perf (13–26 s/`plan_path` under the
+> loose euclidean heuristic). Obstructed nose-out is best-effort. See the
+> [ADR-0010 #480 amendment](../../adr/0010-reeds-shepp-motion-model.md).
+
 ### 3e (note). The analytic-expansion boundary cusp is not separately charged
 
 The returned path is `reconstructed search prefix + analytic suffix`. Cusps

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -245,6 +245,15 @@ def math_rad_to_compass(theta_rad: float) -> float:
     return (90.0 - math.degrees(theta_rad)) % 360.0
 
 
+def _wrap180(deg: float) -> float:
+    """Fold an angle (degrees) into the half-open interval ``(-180, 180]``.
+
+    Canonical at the boundary: ``+180`` stays ``+180`` and ``-180`` maps to
+    ``+180`` (used by the #480 nose-out gate, which measures distance from 180°)."""
+    w = (deg + 180.0) % 360.0 - 180.0
+    return 180.0 if w == -180.0 else w
+
+
 def _mod2pi(theta: float) -> float:
     """Normalise an angle (radians) to ``[0, 2π)``."""
     two_pi = 2.0 * math.pi

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1556,8 +1556,9 @@ def _cell(pose: Pose) -> tuple[int, int, int]:
     whose gear would have avoided a downstream cusp — an accepted Hybrid-A\\*
     approximation (same spirit as the pose-binning), kept to bound the state
     space / expansion budget. The dominant nose-out win comes from the
-    rear-entry seed (a near-0-cusp reverse approach), not mid-search gear
-    switches, so this rarely bites in practice."""
+    rear-entry seed (a near-0-cusp reverse approach handled by the cost-aware
+    start-seed pre-pass in :func:`plan_path`), not mid-search gear switches, so
+    the measured nose-out cases do not exercise this approximation."""
     return (
         round(pose.x_m / _GRID_XY_M),
         round(pose.y_m / _GRID_XY_M),

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1534,6 +1534,19 @@ def _seg_cost(seg: Segment, turn_radius_m: float) -> float:
     return _TURN_PENALTY * seg.length_m  # cart pivot: length_m is radians
 
 
+def _segments_cost(segs: tuple[Segment, ...], turn_radius_m: float) -> float:
+    """Fewest-moves cost of a complete segment run (#480): Σ ``_seg_cost`` +
+    ``CUSP_PENALTY`` per cusp. Used to rank start-seed analytic completions so the
+    cheapest collision-clean one wins — e.g. a nose-out slot's reverse back-in
+    (short, 0 cusps) beats a forward entry that pirouettes inside. A standalone
+    run has no prior travel, so there is no boundary cusp to charge."""
+    legs: list[tuple[int, bool]] = [
+        (seg.gear, not (turn_radius_m == 0.0 and seg.kind in ("L", "R"))) for seg in segs
+    ]
+    seg_sum = math.fsum(_seg_cost(seg, turn_radius_m) for seg in segs)
+    return seg_sum + CUSP_PENALTY * _count_cusps(legs)
+
+
 def _cell(pose: Pose) -> tuple[int, int, int]:
     """Bin a pose into the search grid: ``(x, y)`` rounded to ``_GRID_XY_M`` and
     heading rounded to ``_GRID_DEG`` (wrapped into ``_HEADING_BINS``).
@@ -2009,6 +2022,47 @@ def plan_path(
             # start. It is NOT guaranteed feasible — a plane wider than the door
             # clips even here, and the search then finds no valid path (#411).
             start_poses = (Pose(x_m=hangar.door.center_x_m, y_m=0.0, heading_deg=0.0),)
+
+    # ── Cost-aware start-seed analytic expansion (#480) ──────────────────────
+    # A nose-out slot's cheap fix is a START-SEED analytic shot: back in from the
+    # rear-entry cone rather than entering forward and pirouetting in the back
+    # corner. Evaluate every surviving start seed's closed-form completion up front
+    # and take the cheapest collision-clean one, so the back-in beats an
+    # earlier-enumerated forward entry. Bounded work (≤ the cone size): the
+    # closed-form cost is computed first and the expensive screen + EXACT oracle
+    # are paid only when a seed could beat the best found. Forward preference is the
+    # strict-< tie-break (entry_poses enumerates the forward cone first). If no seed
+    # closes cleanly (an obstructed approach), fall through to the greedy node-level
+    # Hybrid-A* search below — that case stays best-effort, not cost-optimised, and
+    # keeps the pre-#480 routing speed (returns at the first clean shot).
+    best_seed: tuple[float, DubinsArc] | None = None
+    for start_pose in start_poses:
+        seed_arc = plan_reeds_shepp(start_pose, goal, turn_radius_m=r)
+        seed_cost = _segments_cost(seed_arc.segments, r)
+        if best_seed is not None and seed_cost >= best_seed[0]:
+            continue  # can't beat the best clean seed — skip the costly checks
+        if not all(
+            _motion_clear(mover, p, obstacles, hangar)
+            for p in seed_arc.sample(step_m=_SEARCH_STEP_M, step_deg=_SEARCH_STEP_DEG)
+        ):
+            continue
+        candidate = DubinsArc(start_pose, goal, r, seed_arc.segments)
+        if (
+            path_first_conflict(candidate, mover, mover_on_carts=mover_on_carts, placed=placed)
+            is None
+        ):
+            best_seed = (seed_cost, candidate)
+    if best_seed is not None:
+        if stats is not None:
+            stats.update(
+                expansions=0,
+                found=True,
+                budget_exhausted=False,
+                space_exhausted=False,
+                start_poses=len(start_poses),
+                heuristic=heuristic,
+            )
+        return best_seed[1]
 
     # ── Seed the open heap with all surviving start poses ───────────────────
     # Heuristic: ``_h`` — straight-line Euclidean distance by default (deliberately

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -768,17 +768,21 @@ _RS_BASE_SOLVERS: tuple[Callable[[float, float, float], _RSWord | None], ...] = 
 )
 
 
-def _rs_solve_normalised(x: float, y: float, phi: float) -> _RSWord:
-    """Shortest feasible Reeds–Shepp word for a normalised goal ``(x, y, phi)``.
+def _rs_solve_normalised(
+    x: float, y: float, phi: float, *, cusp_penalty_normalised: float
+) -> _RSWord:
+    """Fewest-moves feasible Reeds–Shepp word for a normalised goal ``(x, y, phi)``.
 
     Enumerates :data:`_RS_BASE_SOLVERS` under the timeflip / reflect goal
     symmetries (the standard mechanical generation of the classical word
-    family), scoring each feasible word by weighted normalised length (reverse
-    legs ×:data:`_REVERSE_COST_FACTOR`) and returning the minimum with a
-    strict-``<`` tie-break so an exact tie deterministically keeps the
-    earliest-enumerated word (determinism, ADR-0003). A Reeds–Shepp path always
-    exists between any two poses, so some word is always feasible — proven
-    exhaustively by ``test_reeds_shepp_roundtrip_grid``.
+    family), scoring each feasible word by ``Σ|leg| + cusp_penalty_normalised ×
+    cusps`` (#480) — gear-agnostic length plus a fixed per-cusp penalty — and
+    returning the minimum with a strict-``<`` tie-break so an exact tie
+    deterministically keeps the earliest-enumerated word (determinism, ADR-0003).
+    ``cusp_penalty_normalised`` is :data:`CUSP_PENALTY` ``/ r`` (the caller's turn
+    radius), so the normalised choice agrees with the metre-space objective. A
+    Reeds–Shepp path always exists between any two poses, so some word is always
+    feasible — proven exhaustively by ``test_reeds_shepp_roundtrip_grid``.
 
     Every generated word is gated by :func:`_rs_word_reaches` (an independent
     re-integration) before it can be chosen: a base-formula sign error then
@@ -801,7 +805,8 @@ def _rs_solve_normalised(x: float, y: float, phi: float) -> _RSWord:
         for word in _candidates_for(base):
             if not _rs_word_reaches(word, x, y, phi):
                 continue
-            cost = math.fsum(e.t * (_REVERSE_COST_FACTOR if e.gear == -1 else 1.0) for e in word)
+            cusps = _count_cusps([(e.gear, True) for e in word])  # every RS leg translates
+            cost = math.fsum(e.t for e in word) + cusp_penalty_normalised * cusps
             if best is None or cost < best[0]:
                 best = (cost, word)
     if best is None:  # pragma: no cover - a Reeds–Shepp path always exists
@@ -837,15 +842,16 @@ def _rs_word_reaches(word: _RSWord, x: float, y: float, phi: float) -> bool:
 
 
 def plan_reeds_shepp(start: Pose, end: Pose, *, turn_radius_m: float) -> DubinsArc:
-    """Closed-form shortest Reeds–Shepp path from ``start`` to ``end`` (ADR-0010).
+    """Closed-form fewest-moves Reeds–Shepp path from ``start`` to ``end`` (ADR-0010).
 
     Reeds–Shepp extends Dubins with reverse arcs and straights, so a plane can
     back up to reorient rather than driving a full turning-circle loop. Word
-    selection minimises Σ(``|leg|`` × factor) with reverse legs weighted by
-    :data:`_REVERSE_COST_FACTOR` (prefer forward). Still closed-form and RNG-free,
-    so the ADR-0003 byte-identical-plan contract holds. ``turn_radius_m == 0`` is
-    the cart case and delegates to :func:`_plan_cart` with reverse enabled (a
-    carted plane may back straight out of a slot).
+    selection minimises ``Σ|leg| + CUSP_PENALTY × cusps`` (#480): gear-agnostic
+    length plus a fixed per-cusp (direction-change) penalty, so reverse is not
+    taxed per-metre and forward is preferred only as the tie-break. Still
+    closed-form and RNG-free, so the ADR-0003 byte-identical-plan contract holds.
+    ``turn_radius_m == 0`` is the cart case and delegates to :func:`_plan_cart`
+    with reverse enabled (a carted plane may back straight out of a slot).
 
     Works in the standard math frame: positions pass through unchanged; headings
     convert via :func:`compass_to_math_rad`. The integrated endpoint
@@ -871,7 +877,10 @@ def plan_reeds_shepp(start: Pose, end: Pose, *, turn_radius_m: float) -> DubinsA
     y = -s * dx + c * dy
     phi = _rs_mod2pi(theta1 - theta0)
 
-    word = _rs_solve_normalised(x, y, phi)
+    # CUSP_PENALTY is in metres; the word is scored in normalised units (×r to
+    # metres), so the normalised per-cusp penalty is CUSP_PENALTY / r — making the
+    # word choice agree with the metre-space fewest-moves objective (#480).
+    word = _rs_solve_normalised(x, y, phi, cusp_penalty_normalised=CUSP_PENALTY / r)
     raw = tuple(Segment(e.steering, e.t * r, gear=e.gear) for e in word)
     # Collapse zero-length legs (a collinear same-heading path degenerates to a
     # single straight); keep at least one segment.

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -486,12 +486,15 @@ def _plan_cart(start: Pose, end: Pose, *, allow_reverse: bool) -> DubinsArc:
 
 
 def _cart_seg_weight(seg: Segment) -> float:
-    """Weighted cost of one cart segment for the forward-vs-reverse choice: a
-    pivot's radians (cheap, gear-agnostic) or a straight's metres scaled by the
-    reverse factor when backing."""
+    """Unweighted cost of one cart segment for the forward-vs-reverse choice: a
+    pivot's radians (cheap, gear-agnostic) or a straight's metres. Reverse is no
+    longer taxed per-metre (#480) — both the forward and reverse
+    pivot-straight-pivot candidates are single drives (0 cusps under the
+    translating-legs-only rule), so :func:`_plan_cart`'s ``min`` reduces to a
+    pure length comparison with forward kept on an exact tie (forward first)."""
     if seg.kind != "S":
         return seg.length_m  # pivot: length_m is radians
-    return seg.length_m * (_REVERSE_COST_FACTOR if seg.gear == -1 else 1.0)
+    return seg.length_m
 
 
 # ---------------------------------------------------------------------------

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -8,11 +8,13 @@ found by a deterministic Hybrid-A* search (:func:`plan_path`, #222) over
 unobstructed plane finishes in one closed-form Reeds–Shepp shot (the search's
 analytic expansion). Reeds–Shepp = Dubins (forward arc-line-arc) **plus reverse
 arcs/straights** (:func:`plan_reeds_shepp`, #261), so a plane can back up to
-reorient instead of driving a full turning-circle loop; reverse legs cost
-:data:`_REVERSE_COST_FACTOR`× their length so forward motion is preferred. The
-closed form is still deterministic, preserving the ADR-0003 byte-identical-plan
-contract. See ADR-0002 (heading convention), ADR-0010 (Reeds–Shepp motion model,
-supersedes ADR-0007 fork-2 "Dubins-only"), ADR-0007 (cart = own-gear, r=0), and
+reorient instead of driving a full turning-circle loop. The planner minimises
+*moves*: cost is ``length + CUSP_PENALTY × cusps`` (#480), so a direction change
+is what's penalised, not reverse distance — forward is preferred only as the
+deterministic tie-break. The closed form is still deterministic, preserving the
+ADR-0003 byte-identical-plan contract. See ADR-0002 (heading convention),
+ADR-0010 (Reeds–Shepp motion model, supersedes ADR-0007 fork-2 "Dubins-only";
+amended for the #480 cusp-cost model), ADR-0007 (cart = own-gear, r=0), and
 docs/spikes/tow-path-planning.md.
 """
 
@@ -431,10 +433,11 @@ def _plan_cart(start: Pose, end: Pose, *, allow_reverse: bool) -> DubinsArc:
 
     With ``allow_reverse`` (Reeds–Shepp), the straight leg may be driven in
     reverse — pivot to the *reverse* bearing, back straight, pivot to the final
-    heading — and the cheaper of the forward/reverse option is returned under
-    the reverse cost weighting (:data:`_REVERSE_COST_FACTOR`). Without it
-    (Dubins) only the forward option is considered, preserving the exact
-    forward-only behaviour ``plan_dubins`` shipped.
+    heading — and the cheaper of the forward/reverse option is returned by
+    unweighted length (#480: no per-metre reverse tax; both options are single
+    0-cusp drives, so forward wins only on an exact tie). Without it (Dubins)
+    only the forward option is considered, preserving the exact forward-only
+    behaviour ``plan_dubins`` shipped.
     """
     dx = end.x_m - start.x_m
     dy = end.y_m - start.y_m
@@ -522,24 +525,22 @@ def _cart_seg_weight(seg: Segment) -> float:
 # ---------------------------------------------------------------------------
 
 
-# Reverse legs cost 1.5× their length. Justification (a measured nose-out case):
-# 18 m reverse vs 32 m forward. At 1.5× the reverse weighs 27 m, still beating
-# the 32 m forward loop, so the reverse win is kept — while a gratuitous short
-# reverse is discouraged. At 2.0× the reverse would weigh 36 m and be SUPPRESSED
-# in favour of the longer forward path, defeating the whole point of Reeds–Shepp.
-# Pinned by test_reverse_cost_factor_value; changing it requires an ADR-0010 update.
-_REVERSE_COST_FACTOR = 1.5
-
-
-# Additive per-cusp penalty (metres) — the #480 "fewest-moves" cost model.
-# A "cusp" is a travel-direction reversal (forward<->reverse) between consecutive
-# TRANSLATING legs; moves = cusps + 1. Cost is `length + CUSP_PENALTY * cusps` at
-# all three sites (search g-cost, Reeds–Shepp word selection, cart choice),
-# replacing the multiplicative _REVERSE_COST_FACTOR above (removed once every
-# site has migrated — #480 Task 6). Reverse is no longer taxed per-metre; instead
+# Additive per-cusp penalty (metres) — the #480 "fewest-moves" cost model
+# (supersedes the old multiplicative reverse-length factor, ADR-0010 #480
+# amendment). A "cusp" is a travel-direction reversal (forward<->reverse) between
+# consecutive TRANSLATING legs; moves = cusps + 1. Cost is
+# `length + CUSP_PENALTY * cusps` at all three sites (search g-cost, Reeds–Shepp
+# word selection, cart choice). Reverse is no longer taxed per-metre; instead
 # each direction change costs a fixed, large-but-finite amount, so the planner
-# minimises *moves* and forward preference survives only as the
-# enumeration-order tie-break (forward primitives/words enumerated first).
+# minimises *moves* and forward preference survives only as the enumeration-order
+# tie-break (forward primitives/words enumerated first).
+#
+# Why 10.0 m? It must (a) keep a genuine nose-out win — a back-in via a
+# rear-entry seed is 0 cusps and wins on length alone, and where a 1-cusp back-in
+# (~18 m) replaces a forward loop (~32 m) we need CUSP_PENALTY < 14 m — and
+# (b) dominate the small length differences between equal-move alternatives so
+# the planner doesn't trade a direction change for a couple of saved metres.
+# 10 m (order of a plane length / the hangar's short dimension) satisfies both.
 # Pinned by test_cusp_penalty_value; changing it requires an ADR-0010 update.
 CUSP_PENALTY = 10.0
 

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -528,6 +528,37 @@ def _cart_seg_weight(seg: Segment) -> float:
 _REVERSE_COST_FACTOR = 1.5
 
 
+# Additive per-cusp penalty (metres) — the #480 "fewest-moves" cost model.
+# A "cusp" is a travel-direction reversal (forward<->reverse) between consecutive
+# TRANSLATING legs; moves = cusps + 1. Cost is `length + CUSP_PENALTY * cusps` at
+# all three sites (search g-cost, Reeds–Shepp word selection, cart choice),
+# replacing the multiplicative _REVERSE_COST_FACTOR above (removed once every
+# site has migrated — #480 Task 6). Reverse is no longer taxed per-metre; instead
+# each direction change costs a fixed, large-but-finite amount, so the planner
+# minimises *moves* and forward preference survives only as the
+# enumeration-order tie-break (forward primitives/words enumerated first).
+# Pinned by test_cusp_penalty_value; changing it requires an ADR-0010 update.
+CUSP_PENALTY = 10.0
+
+
+def _count_cusps(legs: list[tuple[int, bool]]) -> int:
+    """Number of travel-direction reversals among the TRANSLATING legs (#480).
+
+    ``legs`` is ``(gear, translates)`` in travel order. Non-translating legs
+    (in-place cart pivots — ``r == 0`` turns) are skipped: they are free
+    reorientations, not moves. The result is the count of ``gear`` sign-changes
+    between consecutive *translating* legs."""
+    cusps = 0
+    prev: int | None = None
+    for gear, translates in legs:
+        if not translates:
+            continue
+        if prev is not None and gear != prev:
+            cusps += 1
+        prev = gear
+    return cusps
+
+
 @dataclass(frozen=True, slots=True)
 class _RSElement:
     """One normalised Reeds–Shepp leg: steering ``L``/``S``/``R``, ``gear``

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -904,12 +904,21 @@ def derive_apron_depth(fleet: Mapping[str, Aircraft]) -> float:
 _CONE_HEADINGS: tuple[float, ...] = (330.0, 345.0, 0.0, 15.0, 30.0)
 
 # The five rear-entry (nose-out / back-in) headings: 180° ± 30° in 15° steps.
-# Emitted ONLY when an apron exists (apron_depth_m > 0): backing a plane in
-# tail-first needs the apron run-up room (#263, unblocked by the apron — ADR-0021).
-# Gating on depth > 0 keeps the no-apron pose set — and thus the MovesPlan —
-# byte-identical (ADR-0003); they are additional deterministic seed poses the
-# search chooses among on cost, never a forced orientation.
+# Emitted iff the TARGET parked heading is nose-out-ish (#480), independent of
+# the apron: a nose-out slot can then be backed in tail-first rather than
+# pirouetting in the back corner. A nose-in slot never wins a rear-entry seed,
+# so it keeps the forward cone only (no wasted expansions). These remain
+# additional deterministic seed poses the search chooses among on cost, never a
+# forced orientation. Un-gating from the apron deliberately changes the depth-0
+# grid for nose-out targets, superseding the #412 depth-0 cross-version
+# byte-identity for that case (the ADR-0003 same-input determinism contract is
+# intact). See ADR-0010 (#480 amendment).
 _REVERSE_CONE_HEADINGS: tuple[float, ...] = (150.0, 165.0, 180.0, 195.0, 210.0)
+
+# Nose-out gate half-angle (#480): the rear cone is emitted iff
+# |_wrap180(target.heading_deg - 180)| <= this. ~45° covers the rear cone's own
+# ±30° span plus margin (so headings in [135, 225] qualify).
+_REAR_CONE_HALF_ANGLE_DEG = 45.0
 
 
 def entry_poses(target: Placement, hangar: Hangar) -> tuple[Pose, ...]:
@@ -941,13 +950,17 @@ def entry_poses(target: Placement, hangar: Hangar) -> tuple[Pose, ...]:
       decision 2026-06-07). Were ``y = 0`` kept, the shortest path would always
       pick the door-line start and show no slide-in.
 
-    **Headings**:
+    **Headings** (independent of the apron — #480):
 
-    - **No apron**: the 5-heading forward-admissible cone
+    - **Nose-in target**: the 5-heading forward-admissible cone
       ``{330°, 345°, 0°, 15°, 30°}`` only (straight-in ±30°).
-    - **With an apron**: the forward cone **followed by** the rear-entry cone
-      ``{150°, 165°, 180°, 195°, 210°}`` (180° ± 30°), so the search may choose
-      to back a plane in tail-first from the apron (#263, never forced).
+    - **Nose-out target** (``|wrap180(target.heading − 180)| ≤
+      _REAR_CONE_HALF_ANGLE_DEG``): the forward cone **followed by** the
+      rear-entry cone ``{150°, 165°, 180°, 195°, 210°}`` (180° ± 30°), so the
+      search may choose to back the plane in tail-first (#263/#480, never
+      forced). This applies with or without an apron, and so changes the depth-0
+      grid for nose-out targets (superseding the #412 depth-0 byte-identity for
+      that case; the ADR-0003 same-input contract is intact).
 
     **Emit order** (fixed for ADR-0003 determinism): x-outer, y-middle,
     heading-inner; duplicate ``(x, y, heading)`` triples (exact float equality)
@@ -977,18 +990,20 @@ def entry_poses(target: Placement, hangar: Hangar) -> tuple[Pose, ...]:
 
     x_samples = (x_centre, x_target, x_mid)
 
-    # Apron extension (ADR-0021). depth == 0 ⇒ the single y = 0 sample + the
-    # forward cone only ⇒ byte-identical to the pre-apron grid. depth > 0 ⇒ the
-    # start is forced ONTO the apron (the y = 0 door line is excluded) so every
-    # plane originates outside and slides in (#412 viewer motivation; user
+    # Y-samples — apron only (ADR-0021). depth == 0 ⇒ the single y = 0 door-line
+    # sample (byte-identical to the pre-apron grid for a nose-in target). depth >
+    # 0 ⇒ the start is forced ONTO the apron (the y = 0 door line is excluded) so
+    # every plane originates outside and slides in (#412 viewer motivation; user
     # decision 2026-06-07) — otherwise the shortest path keeps picking y = 0.
     depth = hangar.apron_depth_m
-    if depth > 0.0:
-        y_samples: tuple[float, ...] = (-depth / 2.0, -depth)
-        headings: tuple[float, ...] = _CONE_HEADINGS + _REVERSE_CONE_HEADINGS
-    else:
-        y_samples = (0.0,)
-        headings = _CONE_HEADINGS
+    y_samples: tuple[float, ...] = (-depth / 2.0, -depth) if depth > 0.0 else (0.0,)
+
+    # Headings — forward cone always; rear-entry cone iff the target parked
+    # heading is nose-out-ish (#480), independent of the apron. A nose-out slot
+    # can then be backed in (cheap under the cusp cost, ADR-0010 #480 amendment)
+    # instead of pirouetting inside; a nose-in slot keeps the forward cone only.
+    nose_out = abs(_wrap180(target.heading_deg - 180.0)) <= _REAR_CONE_HALF_ANGLE_DEG
+    headings: tuple[float, ...] = _CONE_HEADINGS + (_REVERSE_CONE_HEADINGS if nose_out else ())
 
     seen: set[tuple[float, float, float]] = set()
     poses: list[Pose] = []

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1521,25 +1521,29 @@ def _seg_cost(seg: Segment, turn_radius_m: float) -> float:
     ``length_m`` metres plus penalty over ``length_m / r`` radians. Pivot
     ``r == 0``: no translation, penalty over ``length_m`` radians.
 
-    A **reverse** leg (``gear == -1``) multiplies the cost by
-    :data:`_REVERSE_COST_FACTOR` (ADR-0010), so the search prefers forward
-    motion and only backs up when it is genuinely cheaper (the nose-out win).
-    The factor scales the whole leg cost — translation and turn penalty alike —
-    so a reverse arc is penalised consistently with a reverse straight. (The
-    cart fan no longer emits reverse pivots — see :func:`_primitives` — so for
-    ``r == 0`` the factor only ever applies to the reverse straight.)
-    """
-    factor = _REVERSE_COST_FACTOR if seg.gear == -1 else 1.0
+    Gear-agnostic (#480): a reverse leg costs the same per-metre as a forward
+    leg — reverse is no longer taxed here. Direction changes are charged once, as
+    an additive :data:`CUSP_PENALTY` per cusp, in the expansion loop (which knows
+    the parent's travel direction); a single segment has no cusp. Forward
+    preference survives as the fixed primitive-order tie-break."""
     if seg.kind == "S":
-        return factor * seg.length_m
+        return seg.length_m
     if turn_radius_m > 0.0:
-        return factor * (seg.length_m + _TURN_PENALTY * (seg.length_m / turn_radius_m))
-    return factor * _TURN_PENALTY * seg.length_m  # cart pivot: length_m is radians
+        return seg.length_m + _TURN_PENALTY * (seg.length_m / turn_radius_m)
+    return _TURN_PENALTY * seg.length_m  # cart pivot: length_m is radians
 
 
 def _cell(pose: Pose) -> tuple[int, int, int]:
     """Bin a pose into the search grid: ``(x, y)`` rounded to ``_GRID_XY_M`` and
-    heading rounded to ``_GRID_DEG`` (wrapped into ``_HEADING_BINS``)."""
+    heading rounded to ``_GRID_DEG`` (wrapped into ``_HEADING_BINS``).
+
+    Deliberately does NOT include the travel direction (#480 ``last_drive_gear``),
+    so the ``best_g`` domination check may occasionally prune a higher-g node
+    whose gear would have avoided a downstream cusp — an accepted Hybrid-A\\*
+    approximation (same spirit as the pose-binning), kept to bound the state
+    space / expansion budget. The dominant nose-out win comes from the
+    rear-entry seed (a near-0-cusp reverse approach), not mid-search gear
+    switches, so this rarely bites in practice."""
     return (
         round(pose.x_m / _GRID_XY_M),
         round(pose.y_m / _GRID_XY_M),
@@ -1560,12 +1564,20 @@ class _SearchNode:
     bug of mutating ``g`` in place after a node is on the heap, which would
     silently corrupt the ``best_g`` stale-entry check. **Invariant:** ``seg`` is
     ``None`` iff ``parent`` is ``None`` (the start node); every child carries
-    both — :func:`_reconstruct_segments` relies on this to stop at the root."""
+    both — :func:`_reconstruct_segments` relies on this to stop at the root.
+
+    ``last_drive_gear`` (#480) is the gear (+1/−1) of the most recent TRANSLATING
+    leg on this node's branch, or ``0`` at the root (no travel yet). The
+    expansion loop reads it to charge a :data:`CUSP_PENALTY` when the next
+    translating primitive reverses direction — counting cusps incrementally
+    without walking the parent chain. A non-translating cart pivot inherits the
+    parent's value unchanged."""
 
     pose: Pose
     g: float
     seg: Segment | None
     parent: _SearchNode | None
+    last_drive_gear: int
 
 
 def _reconstruct_segments(node: _SearchNode) -> list[Segment]:
@@ -2008,7 +2020,7 @@ def plan_path(
     open_heap: list[tuple[float, int, _SearchNode]] = []
     best_g: dict[tuple[int, int, int], float] = {}
     for start_pose in start_poses:
-        start_node = _SearchNode(start_pose, 0.0, None, None)
+        start_node = _SearchNode(start_pose, 0.0, None, None, 0)
         start_key = _cell(start_pose)
         h_start = _h(start_pose)
         # Only seed if not already dominated by a cheaper start in the same cell.
@@ -2087,7 +2099,15 @@ def plan_path(
                 for p in edge.sample(step_m=_SEARCH_STEP_M, step_deg=_SEARCH_STEP_DEG)
             ):
                 continue
-            child_g = node.g + _seg_cost(seg, r)
+            # Cusp charge (#480): a primitive that TRANSLATES and reverses the
+            # branch's last travel direction costs one CUSP_PENALTY. In-place cart
+            # pivots (r == 0 turns) don't translate — they inherit the parent's
+            # last_drive_gear and never charge a cusp. Own-gear (r > 0) primitives
+            # all translate, so this is just parent-gear vs this-gear.
+            translates = not (r == 0.0 and seg.kind in ("L", "R"))
+            is_cusp = translates and node.last_drive_gear != 0 and node.last_drive_gear != seg.gear
+            child_drive_gear = seg.gear if translates else node.last_drive_gear
+            child_g = node.g + _seg_cost(seg, r) + (CUSP_PENALTY if is_cusp else 0.0)
             child_key = _cell(child_pose)
             if child_g < best_g.get(child_key, math.inf) - 1e-9:
                 best_g[child_key] = child_g
@@ -2095,7 +2115,11 @@ def plan_path(
                 h = _h(child_pose)
                 heapq.heappush(
                     open_heap,
-                    (child_g + h, counter, _SearchNode(child_pose, child_g, seg, node)),
+                    (
+                        child_g + h,
+                        counter,
+                        _SearchNode(child_pose, child_g, seg, node, child_drive_gear),
+                    ),
                 )
 
     # The per-edge / analytic validity checks use the fast `_motion_clear`, which

--- a/tests/test_towplanner_apron.py
+++ b/tests/test_towplanner_apron.py
@@ -175,15 +175,17 @@ def test_entry_poses_depth_zero_exact_order_unchanged() -> None:
 
 
 def test_entry_poses_with_apron_forces_start_onto_apron_and_adds_reverse_headings() -> None:
+    # Nose-out target (h=180): the apron forces the start onto the apron AND, since
+    # the target is nose-out, the rear cone is emitted (#480 gates it on nose-out).
     h = _hangar(door_center=10.0, door_width=6.0, apron_depth_m=6.0)
-    slot = _slot("A", x=10.0, y=12.0, h=0.0)
+    slot = _slot("A", x=10.0, y=12.0, h=180.0)
     poses = entry_poses(slot, h)
     # y=0 (door line) is excluded — every start is ON the apron (#412 slide-in).
     assert {p.y_m for p in poses} == {-3.0, -6.0}  # {-d/2, -d}
     assert all(p.y_m < 0.0 for p in poses)
     headings = {p.heading_deg for p in poses}
     assert {330.0, 345.0, 0.0, 15.0, 30.0} <= headings  # forward cone retained
-    assert {150.0, 165.0, 180.0, 195.0, 210.0} <= headings  # reverse cone added
+    assert {150.0, 165.0, 180.0, 195.0, 210.0} <= headings  # rear cone (nose-out target)
 
 
 def test_entry_poses_with_apron_is_deterministic() -> None:
@@ -193,13 +195,59 @@ def test_entry_poses_with_apron_is_deterministic() -> None:
 
 
 def test_entry_poses_apron_emit_order_x_outer_y_middle_heading_inner() -> None:
-    """The fixed emit order is x-outer, y-middle, heading-inner (ADR-0003)."""
+    """The fixed emit order is x-outer, y-middle, heading-inner (ADR-0003).
+
+    Uses a nose-out target (h=180) so the rear cone is emitted (#480 gates the
+    rear cone on a nose-out target, not on the apron)."""
     h = _hangar(door_center=10.0, door_width=6.0, apron_depth_m=4.0)
-    slot = _slot("A", x=10.0, y=12.0, h=0.0)  # x_centre == x_target == x_mid == 10 ⇒ 1 x-sample
+    slot = _slot("A", x=10.0, y=12.0, h=180.0)  # x_centre == x_target == x_mid == 10 ⇒ 1 x-sample
     poses = list(entry_poses(slot, h))
     headings = (330.0, 345.0, 0.0, 15.0, 30.0, 150.0, 165.0, 180.0, 195.0, 210.0)
     expected = [Pose(x_m=10.0, y_m=y, heading_deg=hd) for y in (-2.0, -4.0) for hd in headings]
     assert poses == expected
+
+
+# ── #480: rear-entry cone is gated on a NOSE-OUT target, not on the apron ──────
+
+
+def test_entry_poses_rear_cone_for_nose_out_target_without_apron() -> None:
+    """#480: a nose-out target (heading ~180) gets the rear-entry cone even with
+    NO apron — so the plane can be backed in rather than pirouetting inside.
+    This deliberately changes the depth-0 grid for nose-out targets (superseding
+    the #412 depth-0 cross-version byte-identity for that case)."""
+    h = _hangar(door_center=10.0, door_width=6.0)  # no apron
+    slot = _slot("A", x=10.0, y=12.0, h=180.0)  # nose-out
+    poses = entry_poses(slot, h)
+    assert {p.y_m for p in poses} == {0.0}  # still the door line (no apron)
+    headings = {p.heading_deg for p in poses}
+    assert {330.0, 345.0, 0.0, 15.0, 30.0} <= headings  # forward cone
+    assert {150.0, 165.0, 180.0, 195.0, 210.0} <= headings  # rear cone, no apron needed
+
+
+def test_entry_poses_no_rear_cone_for_nose_in_target_even_with_apron() -> None:
+    """#480: a nose-in target (heading ~0) keeps the forward cone only, even with
+    an apron — a nose-in slot never wins a rear-entry seed, so don't waste it."""
+    h = _hangar(door_center=10.0, door_width=6.0, apron_depth_m=6.0)
+    slot = _slot("A", x=10.0, y=12.0, h=0.0)  # nose-in
+    poses = entry_poses(slot, h)
+    assert all(p.y_m < 0.0 for p in poses)  # apron still forces the start onto the apron
+    headings = {p.heading_deg for p in poses}
+    assert headings == {330.0, 345.0, 0.0, 15.0, 30.0}  # forward cone ONLY, no rear cone
+
+
+def test_entry_poses_nose_out_gate_boundary() -> None:
+    """#480: the rear cone is emitted iff |wrap180(h-180)| <= 45 (covers the rear
+    cone's own +/-30 span plus margin). h=135 and h=225 are in; h=134/226 are out."""
+    h = _hangar(door_center=10.0, door_width=6.0)
+    rear = {150.0, 165.0, 180.0, 195.0, 210.0}
+
+    def _headings(target_h: float) -> set[float]:
+        return {p.heading_deg for p in entry_poses(_slot("A", x=10.0, y=12.0, h=target_h), h)}
+
+    assert rear <= _headings(135.0)  # boundary in
+    assert rear <= _headings(225.0)  # boundary in (symmetric)
+    assert not (rear & _headings(134.0))  # just outside
+    assert not (rear & _headings(226.0))  # just outside
 
 
 # ── Task 4: apron-aware front-wall rule (#411 jamb retained) ─────────────────

--- a/tests/test_towplanner_nose_out.py
+++ b/tests/test_towplanner_nose_out.py
@@ -1,0 +1,112 @@
+"""#480: nose-out slots are backed in, not pirouetted inside the hangar.
+
+The acceptance metric mirrors the issue's own measure — the heading swept while
+the mover is INSIDE the hangar (``y_m > 0``). A nose-out slot used to force a
+~160° reorientation in the cramped back corner because the door entry cone was
+inward-only and the greedy analytic expansion returned the first (forward) clean
+shot. With the #480 rear-entry cone + cusp cost + cost-aware analytic expansion,
+the planner backs the plane in instead, sweeping little inside.
+"""
+
+from __future__ import annotations
+
+from hangarfit.models import (
+    Aircraft,
+    Door,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    Placement,
+    Wheels,
+)
+from hangarfit.towplanner import Pose, _wrap180, entry_poses, plan_path
+
+
+def _hangar() -> Hangar:
+    return Hangar(
+        length_m=30.0,
+        width_m=20.0,
+        door=Door(center_x_m=10.0, width_m=6.0),
+        maintenance_bay=MaintenanceBay(center_x_m=10.0, width_m=2.0, depth_m=2.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.2,
+    )
+
+
+def _plane(pid: str = "A") -> Aircraft:
+    return Aircraft(
+        id=pid,
+        name=pid,
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=4.0,
+        measured=False,
+        parts=(
+            Part(
+                kind="fuselage_aft",
+                length_m=1.0,
+                width_m=0.6,
+                offset_x_m=0.5,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.0,
+            ),
+        ),
+        wheels=Wheels(main_offset_x_m=0.2, track_m=1.8, third_wheel_offset_x_m=-2.0),
+    )
+
+
+def _swept_inside(arc: object) -> float:
+    """Σ|Δheading| sampled along the path while inside the hangar (y > 0)."""
+    samples = list(arc.sample(step_m=0.25, step_deg=5.0))  # type: ignore[attr-defined]
+    return sum(
+        abs(_wrap180(b.heading_deg - a.heading_deg))
+        for a, b in zip(samples, samples[1:], strict=False)
+        if a.y_m > 0.0 and b.y_m > 0.0
+    )
+
+
+def _route(target_heading: float) -> object:
+    h = _hangar()
+    plane = _plane()
+    placed = Layout(fleet={"A": plane}, hangar=h, placements=())
+    slot = Placement(plane_id="A", x_m=10.0, y_m=20.0, heading_deg=target_heading, on_carts=False)
+    cone = entry_poses(slot, h)
+    goal = Pose(slot.x_m, slot.y_m, slot.heading_deg)
+    return plan_path(
+        plane,
+        cone[0],
+        goal,
+        hangar=h,
+        placed=placed,
+        mover_on_carts=False,
+        entries=cone,
+        heuristic="grid",
+    )
+
+
+def test_nose_out_slot_is_backed_in_not_pirouetted() -> None:
+    """A nose-out slot (heading 180) is reached by backing in (reverse legs) with
+    little in-hangar reorientation — NOT a ~160° pirouette in the back corner.
+    Pre-#480 this swept ~162° (the greedy forward-entry return); the cost-aware
+    analytic expansion picks the cheaper back-in instead."""
+    arc = _route(180.0)
+    assert any(s.gear == -1 for s in arc.segments), "nose-out slot should be backed in"
+    assert _swept_inside(arc) < 45.0  # ~162° before the fix
+
+
+def test_nose_in_slot_enters_forward_with_little_sweep() -> None:
+    """A nose-in slot still enters forward with little in-hangar reorientation."""
+    arc = _route(0.0)
+    assert _swept_inside(arc) < 45.0
+
+
+def test_plan_path_nose_out_is_deterministic() -> None:
+    a = _route(180.0)
+    b = _route(180.0)
+    fa = [(s.kind, s.gear, s.length_m) for s in a.segments]  # type: ignore[attr-defined]
+    fb = [(s.kind, s.gear, s.length_m) for s in b.segments]  # type: ignore[attr-defined]
+    assert fa == fb

--- a/tests/test_towplanner_reeds_shepp.py
+++ b/tests/test_towplanner_reeds_shepp.py
@@ -215,6 +215,19 @@ def test_rs_solve_normalised_cusp_penalty_never_increases_cusps() -> None:
         assert _cusps(high) <= _cusps(zero), f"goal {(x, y, phi)}: high-penalty word added cusps"
 
 
+def test_cart_seg_weight_reverse_straight_not_taxed_per_metre() -> None:
+    """#480: a cart's reverse straight is no longer ×1.5 — both forward and
+    reverse pivot-straight-pivot are single 0-cusp drives, so the choice reduces
+    to length with forward as the tie-break. A pivot stays its radians."""
+    from hangarfit.towplanner import _cart_seg_weight
+
+    fwd_straight = Segment("S", 4.0, gear=1)
+    rev_straight = Segment("S", 4.0, gear=-1)
+    assert _cart_seg_weight(rev_straight) == _cart_seg_weight(fwd_straight) == 4.0
+    pivot = Segment("L", 1.0)  # length_m is radians for a cart pivot
+    assert _cart_seg_weight(pivot) == 1.0
+
+
 def test_collinear_forward_goal_stays_pure_forward_straight() -> None:
     """When the goal is straight ahead on the same heading, RS must NOT pick a
     reverse maneuver — a forward "S" is both shortest (0 cusps, same length) and

--- a/tests/test_towplanner_reeds_shepp.py
+++ b/tests/test_towplanner_reeds_shepp.py
@@ -194,10 +194,31 @@ def test_reverse_cost_factor_value() -> None:
     assert _REVERSE_COST_FACTOR == 1.5
 
 
+def test_rs_solve_normalised_cusp_penalty_never_increases_cusps() -> None:
+    """#480 fewest-moves invariant: scoring is ``Σt + cusp_penalty_normalised *
+    cusps``, so raising the cusp penalty must never INCREASE the chosen word's
+    cusp count vs a zero penalty. Pins the new signature + the objective."""
+    from hangarfit.towplanner import _rs_solve_normalised
+
+    def _cusps(word: object) -> int:
+        return _count_cusps([(e.gear, True) for e in word])  # type: ignore[attr-defined]
+
+    goals = [
+        (1.5, 0.8, math.radians(200.0)),
+        (-1.2, 0.5, math.radians(160.0)),
+        (0.5, -0.9, math.radians(170.0)),
+        (2.0, -1.3, math.radians(135.0)),
+    ]
+    for x, y, phi in goals:
+        zero = _rs_solve_normalised(x, y, phi, cusp_penalty_normalised=0.0)
+        high = _rs_solve_normalised(x, y, phi, cusp_penalty_normalised=100.0)
+        assert _cusps(high) <= _cusps(zero), f"goal {(x, y, phi)}: high-penalty word added cusps"
+
+
 def test_collinear_forward_goal_stays_pure_forward_straight() -> None:
     """When the goal is straight ahead on the same heading, RS must NOT pick a
-    reverse maneuver — a forward "S" is both shortest and cheapest. Guards that
-    the reverse-cost weighting actually biases toward forward."""
+    reverse maneuver — a forward "S" is both shortest (0 cusps, same length) and
+    wins the forward-first tie-break (#480 cusp cost)."""
     arc = plan_reeds_shepp(Pose(0.0, 0.0, 0.0), Pose(0.0, 8.0, 0.0), turn_radius_m=4.0)
     assert all(s.gear == 1 for s in arc.segments)
     assert [s.kind for s in arc.segments] == ["S"]
@@ -215,8 +236,8 @@ def test_reverse_beats_forward_loop_for_short_backup() -> None:
     rs = plan_reeds_shepp(start, end, turn_radius_m=2.0)
     dubins = plan_dubins(start, end, turn_radius_m=2.0)
     assert any(s.gear == -1 for s in rs.segments)
-    # Weighted RS length (6 m reverse × 1.5 = 9 m) still crushes the forward
-    # loop (≳ 4πr ≈ 25 m for a same-heading reversal at r = 2).
+    # The straight back-up is 6 m, 0 cusps (#480: no per-metre reverse tax), so it
+    # crushes the forward loop (≳ 4πr ≈ 25 m for a same-heading reversal at r = 2).
     assert rs.length_m < dubins.length_m
 
 

--- a/tests/test_towplanner_reeds_shepp.py
+++ b/tests/test_towplanner_reeds_shepp.py
@@ -22,7 +22,6 @@ import math
 import pytest
 
 from hangarfit.towplanner import (
-    _REVERSE_COST_FACTOR,
     CUSP_PENALTY,
     Pose,
     Segment,
@@ -188,10 +187,11 @@ def test_reeds_shepp_roundtrip_grid(start_heading, goal, end_heading, radius) ->
 # --- cost model: prefer forward --------------------------------------------
 
 
-def test_reverse_cost_factor_value() -> None:
-    # Pinned so a casual retune to 2.0 (which would suppress the measured
-    # nose-out reverse win) trips this and forces an ADR update.
-    assert _REVERSE_COST_FACTOR == 1.5
+def test_cusp_penalty_value() -> None:
+    # Pinned so a casual retune trips this and forces an ADR-0010 update. Must
+    # stay < 14 m to keep the measured 1-cusp nose-out back-in (~18 m) beating
+    # the forward loop (~32 m); large enough to dominate small length ties (#480).
+    assert CUSP_PENALTY == 10.0
 
 
 def test_rs_solve_normalised_cusp_penalty_never_increases_cusps() -> None:
@@ -307,10 +307,11 @@ def test_cart_reverse_straight_backs_out() -> None:
 def test_cart_prefers_forward_when_not_cheaper_to_reverse() -> None:
     """Mirror of :func:`test_cart_reverse_straight_backs_out`: a goal directly
     AHEAD (same heading) is a single FORWARD "S" leg. Backing in would cost a
-    180° pivot + a reverse straight (×_REVERSE_COST_FACTOR) + a 180° pivot, so
-    the forward option is strictly cheaper and `_plan_cart`'s `min((forward,
-    reverse), …)` must keep it — pinning the prefer-forward tie-break (ADR-0003
-    determinism: no gratuitous reverse)."""
+    180° pivot + a reverse straight + a 180° pivot (the extra pivots make it
+    strictly longer, #480: reverse itself is no longer taxed), so the forward
+    option is cheaper and `_plan_cart`'s `min((forward, reverse), …)` must keep
+    it — pinning the prefer-forward tie-break (ADR-0003 determinism: no
+    gratuitous reverse)."""
     start = Pose(5.0, 3.0, 0.0)
     end = Pose(5.0, 8.0, 0.0)  # 5 m straight ahead (heading 0 ⇒ +y)
     arc = plan_reeds_shepp(start, end, turn_radius_m=0.0)

--- a/tests/test_towplanner_reeds_shepp.py
+++ b/tests/test_towplanner_reeds_shepp.py
@@ -215,6 +215,21 @@ def test_rs_solve_normalised_cusp_penalty_never_increases_cusps() -> None:
         assert _cusps(high) <= _cusps(zero), f"goal {(x, y, phi)}: high-penalty word added cusps"
 
 
+def test_seg_cost_reverse_not_taxed_per_metre() -> None:
+    """#480: the Hybrid-A* search g-cost is gear-agnostic — a reverse leg costs
+    the same per-metre as forward (direction changes are charged once as
+    CUSP_PENALTY in the expansion loop, not per-metre here)."""
+    from hangarfit.towplanner import _seg_cost
+
+    fwd = Segment("S", 4.0, gear=1)
+    rev = Segment("S", 4.0, gear=-1)
+    assert _seg_cost(rev, 2.0) == _seg_cost(fwd, 2.0) == 4.0
+    # A reverse arc costs the same as the forward arc (length + turn penalty).
+    fwd_arc = Segment("L", 3.0, gear=1)
+    rev_arc = Segment("L", 3.0, gear=-1)
+    assert _seg_cost(rev_arc, 2.0) == _seg_cost(fwd_arc, 2.0)
+
+
 def test_cart_seg_weight_reverse_straight_not_taxed_per_metre() -> None:
     """#480: a cart's reverse straight is no longer ×1.5 — both forward and
     reverse pivot-straight-pivot are single 0-cusp drives, so the choice reduces

--- a/tests/test_towplanner_reeds_shepp.py
+++ b/tests/test_towplanner_reeds_shepp.py
@@ -25,6 +25,7 @@ from hangarfit.towplanner import (
     _REVERSE_COST_FACTOR,
     Pose,
     Segment,
+    _wrap180,
     plan_reeds_shepp,
 )
 
@@ -32,6 +33,17 @@ from hangarfit.towplanner import (
 def _heading_close(a: float, b: float, tol: float = 0.5) -> bool:
     d = (a - b + 180.0) % 360.0 - 180.0
     return abs(d) <= tol
+
+
+def test_wrap180_folds_to_half_open_interval() -> None:
+    # Canonical interval is (-180, 180]: +180 stays +180, -180 maps to +180.
+    assert _wrap180(0.0) == 0.0
+    assert _wrap180(180.0) == 180.0
+    assert _wrap180(181.0) == -179.0
+    assert _wrap180(-180.0) == 180.0
+    assert _wrap180(360.0) == 0.0
+    assert _wrap180(540.0) == 180.0
+    assert _wrap180(-90.0) == -90.0
 
 
 # --- Segment gear field -----------------------------------------------------

--- a/tests/test_towplanner_reeds_shepp.py
+++ b/tests/test_towplanner_reeds_shepp.py
@@ -23,8 +23,10 @@ import pytest
 
 from hangarfit.towplanner import (
     _REVERSE_COST_FACTOR,
+    CUSP_PENALTY,
     Pose,
     Segment,
+    _count_cusps,
     _wrap180,
     plan_reeds_shepp,
 )
@@ -44,6 +46,41 @@ def test_wrap180_folds_to_half_open_interval() -> None:
     assert _wrap180(360.0) == 0.0
     assert _wrap180(540.0) == 180.0
     assert _wrap180(-90.0) == -90.0
+
+
+# --- cusp counting (#480): travel-direction reversals among translating legs ---
+
+
+def test_count_cusps_pure_forward_is_zero() -> None:
+    assert _count_cusps([(1, True), (1, True), (1, True)]) == 0
+
+
+def test_count_cusps_pure_reverse_is_zero() -> None:
+    # A single-direction reverse drive is "one move", zero cusps.
+    assert _count_cusps([(-1, True), (-1, True)]) == 0
+
+
+def test_count_cusps_one_reversal() -> None:
+    assert _count_cusps([(1, True), (-1, True)]) == 1
+
+
+def test_count_cusps_forward_reverse_forward_is_two() -> None:
+    assert _count_cusps([(1, True), (-1, True), (1, True)]) == 2
+
+
+def test_count_cusps_excludes_nontranslating_pivots() -> None:
+    # Cart: pivot (non-translating), reverse straight, pivot -> a single reverse
+    # drive, 0 cusps. In-place pivots are free reorientations, not moves.
+    assert _count_cusps([(1, False), (-1, True), (1, False)]) == 0
+
+
+def test_count_cusps_empty_is_zero() -> None:
+    assert _count_cusps([]) == 0
+
+
+def test_cusp_penalty_is_positive_finite() -> None:
+    # Large-but-finite (not lexicographic): a deterministic scalar (#480).
+    assert 0.0 < CUSP_PENALTY < float("inf")
 
 
 # --- Segment gear field -----------------------------------------------------


### PR DESCRIPTION
Closes #480

## Problem
A plane whose *parked* heading is nose-out (toward the door) was towed nose-first deep into the hangar and spun ~160° in the cramped back corner (measured: `zlin_savage` 161°, `fk9_mkii` 132° swept *inside*). Valid but low-quality paths, and pessimistic for routability — the door entry cone was inward-only and the cost model penalised reverse *distance*.

## Fix — "fewest moves" (ADR-0010 #480 amendment)
1. **Cusp-penalty cost model.** Word/path cost is `length + CUSP_PENALTY × cusps` (a *cusp* = a forward↔reverse travel-direction change between translating legs; in-place cart pivots excluded), replacing `_REVERSE_COST_FACTOR = 1.5` at all three sites (`_rs_solve_normalised`, `_cart_seg_weight`, `_seg_cost` + an incremental cusp charge in the search via `_SearchNode.last_drive_gear`). Reverse is no longer taxed per-metre; **forward preference is now the enumeration-order tie-break**. The normalised RS solver gets `CUSP_PENALTY / r` for metre-space consistency. `CUSP_PENALTY = 10.0` m (pinned; `< 14` m keeps the measured nose-out win, large enough to dominate small length ties).
2. **Nose-out-gated rear cone.** `entry_poses` emits the rear-entry cone iff the *target* heading is nose-out (`|wrap180(h−180)| ≤ 45°`), apron-independent. Nose-in slots keep the forward cone only.
3. **Cost-aware start-seed analytic expansion.** The greedy "first clean analytic shot" return picked the forward-enumerated seed before the cheaper back-in; now every surviving start seed's closed-form completion is evaluated up front and the **cheapest collision-clean** one is returned (the back-in is a start-seed shot). If none closes cleanly (obstructed), it falls through to the unchanged greedy node-level search.

## Result
Nose-out in-hangar swept turning drops **~162° → backs in (<45°)** (`tests/test_towplanner_nose_out.py`), at ~unchanged routing speed.

## Determinism & scope
- **ADR-0003 contract preserved** — RNG-free; serial canaries (6) + `bench` `det` verdict green.
- **Re-baselines the depth-0 tow grid for nose-out targets only**, superseding the #412 depth-0 cross-version byte-identity *for that case* (the same-input contract is intact). No golden churn elsewhere (existing fixtures are nose-in): full non-slow suite **1338 passed**, towplanner+solver **397 passed**, bench all regimes ok.
- **Rejected:** a full cost-aware search (every node) — more general but 13–26 s/`plan_path` under the loose euclidean heuristic; impractical. Bounded start-seed variant fixes the measured cases fast; obstructed nose-out stays best-effort.
- **Not** #263 (prefer a nose-out *parked heading*) — separate; this makes nose-out *cheap to reach* when the solver picks it.

Design spec: `docs/superpowers/specs/2026-06-07-480-fewest-moves-tow-routing-design.md`. Plan: `docs/superpowers/plans/2026-06-07-480-fewest-moves-tow-routing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
