### PR TITLE
fix(loader): strict unknown-key allowlist on aircraft entries (#513)

### DIFF
--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -818,9 +818,43 @@ def _validate_wheels_vs_turn_radius(aircraft: Aircraft) -> None:
         )
 
 
+# Strict unknown-key allowlist for an `aircraft:` entry (#513). Mirrors the
+# `wheels:` (:func:`_parse_wheels`) and constraint-key (:data:`_ALLOWED_CONSTRAINT_KEYS`)
+# guards. These are the YAML *schema* keys — note `struts` is a YAML-only convenience
+# block (expanded into `parts` below), NOT an Aircraft field, so the allowlist is the
+# accepted-input set, not the dataclass fields. Without it a misspelled key is silently
+# dropped to its default: e.g. `tow_pivot: true` (the #511/#263 widening) parses as
+# `tow_pivotable=False`, silently denying the pivot capability the author tried to grant.
+_ALLOWED_AIRCRAFT_KEYS = frozenset(
+    {
+        "id",
+        "name",
+        "wing_position",
+        "gear",
+        "movement_mode",
+        "turn_radius_m",
+        "measured",
+        "parts",
+        "wheels",
+        "notes",
+        "struts",
+        "tow_pivotable",
+    }
+)
+
+
 def _build_aircraft(entry: Any) -> Aircraft:
     if not isinstance(entry, dict):
         raise LoaderError(f"aircraft entry must be a mapping, got {type(entry).__name__}")
+
+    # Reject unknown/misspelled keys loudly (#513) before any field is read, so a
+    # typo'd required key (e.g. `nam:`) surfaces as the offending key rather than a
+    # downstream "missing required field" for the key the author thought they spelled.
+    unknown = set(entry) - _ALLOWED_AIRCRAFT_KEYS
+    if unknown:
+        raise LoaderError(
+            f"unknown aircraft key(s) {sorted(unknown)}; allowed: {sorted(_ALLOWED_AIRCRAFT_KEYS)}"
+        )
 
     required = ("id", "name", "wing_position", "gear", "movement_mode")
     for key in required:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -974,7 +974,7 @@ def _build_struts_spec(data: dict[str, Any]) -> StrutsSpec:
     # Reject unknown/misspelled nested keys (#513), mirroring the `wheels:` block
     # (:func:`_parse_wheels`). All struts keys are required, so a typo of one fails
     # loudly above as "missing"; this additionally catches a misspelled near-duplicate
-    # (e.g. `wing_attach_ym:` alongside a correct key) that would otherwise be dropped.
+    # (e.g. `wing_atttach_y_m:` alongside a correct key) that would otherwise be dropped.
     unknown = set(data) - set(required)
     if unknown:
         raise LoaderError(f"'struts' block has unknown key(s): {sorted(unknown)}")

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -821,10 +821,12 @@ def _validate_wheels_vs_turn_radius(aircraft: Aircraft) -> None:
 # Strict unknown-key allowlist for an `aircraft:` entry (#513). Mirrors the
 # `wheels:` (:func:`_parse_wheels`) and constraint-key (:data:`_ALLOWED_CONSTRAINT_KEYS`)
 # guards. These are the YAML *schema* keys — note `struts` is a YAML-only convenience
-# block (expanded into `parts` below), NOT an Aircraft field, so the allowlist is the
-# accepted-input set, not the dataclass fields. Without it a misspelled key is silently
-# dropped to its default: e.g. `tow_pivot: true` (the #511/#263 widening) parses as
-# `tow_pivotable=False`, silently denying the pivot capability the author tried to grant.
+# block (expanded into `parts` by :func:`_expand_struts`), NOT an Aircraft field, so the
+# allowlist is the accepted-input set, not the dataclass fields. Without it a misspelled
+# key is silently dropped to its default: e.g. `tow_pivot: true` (the #511/#263 widening)
+# parses as `tow_pivotable=False`, silently denying the pivot capability the author tried
+# to grant. Keep in sync with the keys read in :func:`_build_aircraft`;
+# ``test_all_allowed_aircraft_keys_load`` guards the too-strict direction.
 _ALLOWED_AIRCRAFT_KEYS = frozenset(
     {
         "id",
@@ -969,6 +971,13 @@ def _build_struts_spec(data: dict[str, Any]) -> StrutsSpec:
     for key in required:
         if key not in data:
             raise LoaderError(f"'struts' missing required field {key!r}")
+    # Reject unknown/misspelled nested keys (#513), mirroring the `wheels:` block
+    # (:func:`_parse_wheels`). All struts keys are required, so a typo of one fails
+    # loudly above as "missing"; this additionally catches a misspelled near-duplicate
+    # (e.g. `wing_attach_ym:` alongside a correct key) that would otherwise be dropped.
+    unknown = set(data) - set(required)
+    if unknown:
+        raise LoaderError(f"'struts' block has unknown key(s): {sorted(unknown)}")
     return StrutsSpec(
         fuselage_attach_x_m=_to_float(data["fuselage_attach_x_m"], "struts.fuselage_attach_x_m"),
         fuselage_attach_y_m=_to_float(data["fuselage_attach_y_m"], "struts.fuselage_attach_y_m"),

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 
 from hangarfit.loader import (
+    _ALLOWED_AIRCRAFT_KEYS,
     LoaderError,
     _resolve_known_plane_id,
     _suggest_plane_id,
@@ -533,14 +535,35 @@ aircraft:
         ["tow_pivot", "towpivotable", "tow-pivotable", "turn_radius", "note", "bogus_field"],
     )
     def test_unknown_aircraft_key_rejected(self, tmp_path: Path, typo: str) -> None:
-        """A misspelled aircraft field key must be REJECTED, not silently dropped
-        to its default. PR #511 (#263) widened this gap with ``tow_pivotable``:
-        ``tow_pivot: true`` silently parsed as ``tow_pivotable=False``, denying
-        the pivot capability the author tried to grant. Mirrors the strict
-        ``wheels:`` and constraint-key allowlists (#513)."""
+        """A misspelled aircraft field key must be REJECTED (#513), not silently
+        dropped to its default. PR #511 (#263) added a new field (``tow_pivotable``)
+        that newly exposed this pre-existing gap: ``tow_pivot: true`` silently parsed
+        as ``tow_pivotable=False``, denying the pivot capability the author tried to
+        grant. Mirrors the strict ``wheels:`` and constraint-key allowlists. The
+        ``match`` also pins the ``aircraft '<id>':`` attribution prefix so a refactor
+        can't silently drop the file/id context while keeping the 'unknown key' text."""
         path = _write(tmp_path / "f.yaml", self._pivot_fleet(f"    {typo}: true\n"))
-        with pytest.raises(LoaderError, match="unknown aircraft key"):
+        with pytest.raises(LoaderError, match=r"aircraft 'foo': unknown aircraft key"):
             load_fleet(path)
+
+    def test_unknown_struts_key_rejected(self, tmp_path: Path) -> None:
+        """The nested ``struts:`` block also rejects unknown keys (#513), mirroring
+        ``wheels:``. All struts keys are required, so a typo of one fails loudly as
+        'missing'; this catches a misspelled near-duplicate alongside the correct key
+        (e.g. ``wing_atttach_y_m:``) that would otherwise be silently dropped."""
+        body = self._pivot_fleet("    tow_pivotable: false\n").replace(
+            "    wheels:\n",
+            "    struts:\n"
+            "      fuselage_attach_x_m: -1.22\n"
+            "      fuselage_attach_y_m: 0.425\n"
+            "      fuselage_attach_z_m: 0.5\n"
+            "      wing_attach_y_m: 1.8\n"
+            "      width_m: 0.05\n"
+            "      wing_atttach_y_m: 1.8\n"  # typo'd near-duplicate
+            "    wheels:\n",
+        )
+        with pytest.raises(LoaderError, match=r"'struts' block has unknown key\(s\)"):
+            load_fleet(_write(tmp_path / "f.yaml", body))
 
     def test_all_allowed_aircraft_keys_load(self, tmp_path: Path) -> None:
         """Completeness guard for the allowlist: an aircraft declaring EVERY
@@ -580,6 +603,15 @@ aircraft:
       track_m: 1.8
       third_wheel_offset_x_m: -2.0
 """
+        # Self-enforcing: the fixture must exercise EVERY allowed key, so adding a
+        # new key to _ALLOWED_AIRCRAFT_KEYS without extending this fixture fails here
+        # (closing the "forgot the fixture line" hole that a hand-maintained guard has).
+        entry_keys = set(yaml.safe_load(body)["aircraft"][0])
+        assert entry_keys == _ALLOWED_AIRCRAFT_KEYS, (
+            f"fixture must cover the full allowlist; "
+            f"missing={sorted(_ALLOWED_AIRCRAFT_KEYS - entry_keys)} "
+            f"extra={sorted(entry_keys - _ALLOWED_AIRCRAFT_KEYS)}"
+        )
         fleet = load_fleet(_write(tmp_path / "f.yaml", body))
         assert fleet["foo"].tow_pivotable is True
         assert fleet["foo"].notes == "a strut-braced high-winger"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -528,6 +528,64 @@ aircraft:
         with pytest.raises(LoaderError, match="'tow_pivotable': expected boolean"):
             load_fleet(path)
 
+    @pytest.mark.parametrize(
+        "typo",
+        ["tow_pivot", "towpivotable", "tow-pivotable", "turn_radius", "note", "bogus_field"],
+    )
+    def test_unknown_aircraft_key_rejected(self, tmp_path: Path, typo: str) -> None:
+        """A misspelled aircraft field key must be REJECTED, not silently dropped
+        to its default. PR #511 (#263) widened this gap with ``tow_pivotable``:
+        ``tow_pivot: true`` silently parsed as ``tow_pivotable=False``, denying
+        the pivot capability the author tried to grant. Mirrors the strict
+        ``wheels:`` and constraint-key allowlists (#513)."""
+        path = _write(tmp_path / "f.yaml", self._pivot_fleet(f"    {typo}: true\n"))
+        with pytest.raises(LoaderError, match="unknown aircraft key"):
+            load_fleet(path)
+
+    def test_all_allowed_aircraft_keys_load(self, tmp_path: Path) -> None:
+        """Completeness guard for the allowlist: an aircraft declaring EVERY
+        valid key (including the YAML-only ``struts:`` block, which is expanded
+        into ``parts`` and is *not* an ``Aircraft`` field, plus ``notes``) loads
+        without error — so the allowlist can never be too strict."""
+        body = """
+aircraft:
+  - id: foo
+    name: Foo
+    notes: a strut-braced high-winger
+    wing_position: high
+    gear: tailwheel
+    movement_mode: always_own_gear
+    turn_radius_m: 5.0
+    measured: false
+    tow_pivotable: true
+    parts:
+      - kind: fuselage
+        length_m: 7.0
+        width_m: 0.8
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.4
+        width_m: 9.0
+        z_bottom_m: 2.0
+        z_top_m: 2.3
+    struts:
+      fuselage_attach_x_m: -1.22
+      fuselage_attach_y_m: 0.425
+      fuselage_attach_z_m: 0.5
+      wing_attach_y_m: 1.8
+      width_m: 0.05
+    wheels:
+      main_offset_x_m: 0.20
+      track_m: 1.8
+      third_wheel_offset_x_m: -2.0
+"""
+        fleet = load_fleet(_write(tmp_path / "f.yaml", body))
+        assert fleet["foo"].tow_pivotable is True
+        assert fleet["foo"].notes == "a strut-braced high-winger"
+        # struts expanded into parts (no `struts` Aircraft field).
+        assert any(p.kind == "strut" for p in fleet["foo"].parts)
+
     def test_invalid_movement_mode_caught(self, tmp_path: Path) -> None:
         """Typo in movement_mode used to leak silently past the Layout cart
         rule (Aircraft.__post_init__ now validates the Literal set)."""


### PR DESCRIPTION
## Summary

Fleet `aircraft:` entries had **no unknown-key allowlist**, so a misspelled field key was **silently dropped** to its default. PR #511 (#263) widened this gap with `tow_pivotable`: `tow_pivot: true` / `towpivotable: true` / `tow-pivotable: true` all parsed as `tow_pivotable=False`, silently denying the aircraft the pivot capability the author tried to grant. The same applied to `measured`, `notes`, `turn_radius_m`, etc.

## Change

- Add `_ALLOWED_AIRCRAFT_KEYS` and reject unknown keys in `_build_aircraft` with an attributed `LoaderError` (the `aircraft '<id>':` wrapper at the `load_fleet` call site already exists). Mirrors the strict `wheels:` (`_parse_wheels`) and constraint-key (`_ALLOWED_CONSTRAINT_KEYS`, added in #511) guards — the only existing precedents that take a position.
- The check runs **before any field is read**, so a typo'd *required* key (e.g. `nam:`) surfaces as the offending key rather than a downstream "missing required field" for the key the author thought they spelled.
- The allowlist is the **YAML schema key set** — note `struts:` is a YAML-only convenience block (expanded into `parts`), *not* an `Aircraft` dataclass field, so it is the accepted-input set, not the dataclass fields.

## Tests

- `test_unknown_aircraft_key_rejected` — parametrized typo-rejection incl. the three `tow_pivotable` typos from the issue (`tow_pivot`, `towpivotable`, `tow-pivotable`) plus `turn_radius`, `note`, `bogus_field`.
- `test_all_allowed_aircraft_keys_load` — positive completeness guard loading an aircraft that declares **every** allowed key (`struts`, `notes`, `tow_pivotable`, …), so the allowlist can never be too strict. Full fast suite (1399 tests) + the real `data/fleet.yaml` / `examples/herrenteich/` fixtures still load green.

## Scope note

This PR covers the `aircraft:` block (the issue's titled ask). The issue also says *"Consider the same for the hangar/scenario top-level blocks for consistency"* — deliberately left out to keep the change tight and reviewable; easy follow-up if wanted.

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)