### PR TITLE
test(towplanner): accept #480's realism-over-routability trade for the tight six-plane fill (#512)

### DIFF
--- a/docs/adr/0007-tow-path-planner-v1-scope.md
+++ b/docs/adr/0007-tow-path-planner-v1-scope.md
@@ -280,7 +280,9 @@ unjustified**, and the cheap planner levers that dig surfaced were adopted:
   (`plan_path`'s primitive default stays `euclidean`; callers choose). Euclidean
   ignores walls and floods the frontier in tight quarters (`aviat_husky`: ~13.5k
   expansions); the obstacle-aware grid geodesic threads the same maneuver in
-  ~6062. Pass `--tow-heuristic euclidean` to opt out.
+  ~6062 (pre-#480 cost — #480's cusp penalty later ~doubled it to ~12515; the
+  grid-beats-euclidean *relative* point still holds, see #512). Pass
+  `--tow-heuristic euclidean` to opt out.
 - **Per-plane `_MAX_EXPANSIONS` raised 2000 → 8000** — the budget grid needs to
   route the tight-but-feasible cases (the earlier "infeasible even at 4000" note
   was a euclidean-heuristic artifact, not geometry).

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1470,6 +1470,9 @@ _MAX_EXPANSIONS = 8000  # node-expansion budget per plane before bailing (#336).
 # an ACCEPTED realism-over-routability trade of #480 (ADR-0010), NOT a budget that
 # wants raising — see test_six_plane_fresh_fill_partial_routing_post_480 and #512.
 # The budgets are kept at 8000/16000 so an un-routable fill still disproves fast.
+# (The ~12515/~13000 figures are indicative, not asserted — re-measure after any
+# CUSP_PENALTY or fixture-geometry change; the binding contract is that test's
+# qualitative best-effort assertion, not these numbers.)
 #
 # Deterministic (machine-independent) bound on worst-case per-plane search cost.
 # Budget exhaustion can still report a genuinely-feasible-but-hard layout as

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1458,9 +1458,18 @@ _MAX_EXPANSIONS = 8000  # node-expansion budget per plane before bailing (#336).
 # seed=1) was "un-routable even at 4000 — genuine tight-geometry exhaustion."
 # That was a HEURISTIC artifact, NOT infeasibility: euclidean ignores walls and
 # floods the frontier, needing ~13.5k expansions, whereas the obstacle-aware grid
-# heuristic threads the same maneuver in ~6062. So with grid the routability knee
-# moves to ~6100, and 8000 gives headroom to route it (the seed=1 fill reaches
-# 5/5, ~8.4k total expansions).
+# heuristic threaded the same maneuver in ~6062 with grid-default + #336 budgets.
+#
+# #512 — the ~6062 figure is PRE-#480. #480's fewest-moves cost model (an additive
+# CUSP_PENALTY per direction reversal) roughly DOUBLED the per-plane expansion cost
+# of the deep, heading-hard slots: aviat_husky now needs ~12515 (measured), and
+# ctsl — cheap pre-#480 — exceeds even a 13000 cap. So the seed=1 spread=False
+# six-plane fill is NO LONGER fully tow-routable at these budgets; routing it would
+# need per-plane ~20k + global ~35k, pushing the un-routable-disprove wall-clock
+# (the very thing _MAX_FILL_EXPANSIONS bounds) past the ~400 s perf intent. That is
+# an ACCEPTED realism-over-routability trade of #480 (ADR-0010), NOT a budget that
+# wants raising — see test_six_plane_fresh_fill_partial_routing_post_480 and #512.
+# The budgets are kept at 8000/16000 so an un-routable fill still disproves fast.
 #
 # Deterministic (machine-independent) bound on worst-case per-plane search cost.
 # Budget exhaustion can still report a genuinely-feasible-but-hard layout as

--- a/tests/test_solver_towplanner.py
+++ b/tests/test_solver_towplanner.py
@@ -133,16 +133,29 @@ def test_solve_best_effort_real_planner_on_untowable_fill():
 
 
 @pytest.mark.slow
-def test_six_plane_fresh_fill_fully_routes_at_shipped_defaults():
-    """#336: a tow-friendly (spread=False) fill of ``solve_fresh_six_planes``
-    (seed=1) is **fully** tow-routable under the SHIPPED default planner — the
-    obstacle-aware grid heuristic + the raised per-plane budget. Previously
-    un-routable: euclidean@2000 capped out on ``aviat_husky`` (which needs
-    ~6062 grid expansions to thread its 10.82 m wing into the back corner).
+def test_six_plane_fresh_fill_partial_routing_post_480():
+    """#512: post-#480, the tow-friendly (spread=False) fill of
+    ``solve_fresh_six_planes`` (seed=1) is NO LONGER fully tow-routable at shipped
+    defaults — an ACCEPTED realism-over-routability trade, not a bug.
 
-    Scope: this asserts the *planner* improvement on a tow-friendly layout. The
-    default ``spread=True`` fill remaining hard is the separate #280 placement
-    tension (back-fill #320), not this issue. Slow (real per-plane search).
+    #336 originally shipped this as a *full*-routing guarantee: the obstacle-aware
+    grid heuristic threaded ``aviat_husky``'s 10.82 m wing into the back corner in
+    ~6062 expansions, and the seed=1 fill reached 5/5 at ~8.4 k total. #480's
+    fewest-moves cost model (an additive ``CUSP_PENALTY`` per direction reversal,
+    ADR-0010) roughly DOUBLED the per-plane cost of the deep, heading-hard slots:
+    ``aviat_husky`` now needs ~12515 (measured, > the 8000 per-plane cap) and
+    ``ctsl`` — cheap pre-#480 — exceeds even a 13000 cap. Routing the fill again
+    would need per-plane ~20 k + global ~35 k, pushing the un-routable-disprove
+    wall-clock past the ~400 s perf intent the 16000 global cap exists to hold (see
+    the ``_MAX_EXPANSIONS`` comment in towplanner.py). So the budgets stay at
+    8000/16000 and the solve is BEST-EFFORT here: it returns the valid static
+    layout with the over-budget plane's plan ``None`` and that plane named in
+    ``unroutable_planes``, rather than failing the whole solve.
+
+    (Was ``test_six_plane_fresh_fill_fully_routes_at_shipped_defaults``, which
+    asserted full routing under the pre-#480 ~6062-expansion path.) Slow (real
+    per-plane search to the budget). The separate ``spread=True`` placement tension
+    is #280 / back-fill #320, not this.
     """
     from hangarfit.loader import load_scenario
     from hangarfit.models import SearchConfig
@@ -152,13 +165,19 @@ def test_six_plane_fresh_fill_fully_routes_at_shipped_defaults():
     result = solve(
         scenario, budget_s=15.0, alternatives=1, seed=1, search=SearchConfig(spread=False)
     )
+    # The static layout is still found (a valid placement exists) — only its tow
+    # plan is best-effort.
     assert result.status in ("found", "found_partial")
     assert len(result.layouts) == 1
-    assert all(p is not None for p in result.plans), (
-        f"fill not fully routed at shipped defaults: "
-        f"unroutable={result.diagnostics.unroutable_planes}"
+    assert len(result.plans) == len(result.layouts)
+    # Best-effort: at least one plane exceeds the shipped tow budget post-#480, so
+    # its plan is None and it is named in unroutable_planes — the valid layout is
+    # preserved, the whole solve does not fail.
+    assert any(p is None for p in result.plans), (
+        f"expected best-effort partial routing post-#480; plans={result.plans}"
     )
-    assert result.diagnostics.unroutable_planes == ()
+    assert result.diagnostics.unroutable_planes  # non-empty: names the blocking plane(s)
+    assert len(result.diagnostics.unroutable_planes) == sum(1 for p in result.plans if p is None)
 
 
 def test_solve_k_gt_1_bundle_alignment_with_mixed_routability(monkeypatch):

--- a/tests/test_towplanner_grid_heuristic.py
+++ b/tests/test_towplanner_grid_heuristic.py
@@ -21,11 +21,17 @@ primitive default stays ``euclidean`` — callers choose). The earlier "grid is
 inert, so no 'grid beats euclidean' test can exist" conclusion was a budget-700/
 2000 artifact: at those budgets BOTH heuristics cap out on the tight cases, so
 grid bought no extra *routed count*. But grid roughly halves the *expansions*
-(aviat_husky ~13.5k euclidean → ~6062 grid), which converts to a routed plane once
-the per-plane budget clears ~6100 (#336 raised it to 8000). The end-to-end "grid
-routes a tight fill euclidean cannot, at the shipped default budget" proof now
-lives in ``tests/test_solver_towplanner.py::
-test_six_plane_fresh_fill_fully_routes_at_shipped_defaults``.
+(aviat_husky ~13.5k euclidean → ~6062 grid pre-#480), which converted to a routed
+plane once the per-plane budget cleared ~6100 (#336 raised it to 8000).
+
+#512: that ~6062 grid figure is PRE-#480. #480's fewest-moves cost model (an
+additive ``CUSP_PENALTY`` per direction reversal) ~doubled the per-plane cost of
+the deep, heading-hard slots (aviat_husky → ~12515, ctsl → > 13000), so the seed=1
+six-plane fill is no longer *fully* routable at the 8000/16000 budgets — an
+accepted realism-over-routability trade (raising the budgets enough would breach
+the un-routable-disprove perf intent). The grid-still-beats-euclidean property
+holds; the end-to-end behaviour is now pinned (as best-effort partial routing) by
+``tests/test_solver_towplanner.py::test_six_plane_fresh_fill_partial_routing_post_480``.
 """
 
 from __future__ import annotations

--- a/tests/test_towplanner_grid_heuristic.py
+++ b/tests/test_towplanner_grid_heuristic.py
@@ -26,12 +26,13 @@ plane once the per-plane budget cleared ~6100 (#336 raised it to 8000).
 
 #512: that ~6062 grid figure is PRE-#480. #480's fewest-moves cost model (an
 additive ``CUSP_PENALTY`` per direction reversal) ~doubled the per-plane cost of
-the deep, heading-hard slots (aviat_husky → ~12515, ctsl → > 13000), so the seed=1
-six-plane fill is no longer *fully* routable at the 8000/16000 budgets — an
-accepted realism-over-routability trade (raising the budgets enough would breach
-the un-routable-disprove perf intent). The grid-still-beats-euclidean property
-holds; the end-to-end behaviour is now pinned (as best-effort partial routing) by
-``tests/test_solver_towplanner.py::test_six_plane_fresh_fill_partial_routing_post_480``.
+the deep, heading-hard slots — aviat_husky → ~12515, and ctsl (cheap pre-#480) →
+> 13000 — so the seed=1 six-plane fill is no longer *fully* routable at the
+8000/16000 budgets — an accepted realism-over-routability trade (raising the
+budgets enough would breach the un-routable-disprove perf intent). The
+grid-still-beats-euclidean property holds; the end-to-end behaviour is now pinned
+(as best-effort partial routing) by ``tests/test_solver_towplanner.py::
+test_six_plane_fresh_fill_partial_routing_post_480``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

The `@slow` test `test_six_plane_fresh_fill_fully_routes_at_shipped_defaults` regressed on develop — the `spread=False` seed=1 fill of `solve_fresh_six_planes` is **no longer fully tow-routable** at shipped defaults. Bisected to **#480** (fewest-moves cost model). It was invisible to the merge gate (`@slow` is excluded from CI) and surfaced during the #263 review.

This PR resolves #512 by **accepting the trade** (your decision after the investigation below): keep the budgets, assert the honest best-effort behaviour, and document the cause.

## Root cause (measured, deterministic)

#480's additive `CUSP_PENALTY` per direction reversal roughly **doubled** the per-plane expansion cost of the deep, heading-hard slots:
- `aviat_husky`: **6062 → 12,515** (> the 8000 per-plane cap)
- `ctsl` (cheap pre-#480): now **exceeds even a 13,000** per-plane cap

The route still exists, but recovering full routability would need per-plane ~20k + global ~35k — pushing the un-routable-disprove wall-clock past the ~400 s perf intent the 16000 global cap exists to hold.

## Why not a planner fix or a cap bump

I investigated the principled heuristic fix first (the "planner fix" direction), measuring exhaustively:

| heuristic | aviat_husky expansions | verdict |
|---|---|---|
| 2D grid (current) | 12,515 | ❌ |
| exact free-space Reeds–Shepp distance | **7,249** | ✅ but obstacle-blind → breaks every *later* plane |
| max(grid, RS) / grid + (RS − euclidean) | ~12,200 | ❌ grid dominates the combination |
| 3D (x,y,θ) field, no cusp | 11,970 | ❌ |
| 3D (x,y,θ,gear) field, cusp-aware | 11,692 | ❌ too coarse to match exact RS |

No heuristic is simultaneously **obstacle-aware** (needed for later planes) and **as tight as exact RS** for the binding (obstacle-light, heading-hard) first plane. And the cap bump needs budgets that breach the perf intent — and may not route `ctsl` at any sane budget.

## Change

- **No production behaviour change.** `towplanner.py` edit is **comment-only** (budgets stay 8000/16000), so the ADR-0003 determinism contract is trivially preserved.
- Renamed the test to `test_six_plane_fresh_fill_partial_routing_post_480` and switched it to assert the honest **best-effort** outcome: the valid static layout is returned with the over-budget plane's plan `None` and that plane named in `unroutable_planes`.
- Documented the #480 cost increase in the test docstring, the `_MAX_EXPANSIONS` comment, and the grid-heuristic module docstring (which carried the now-stale full-routing claim).

## Note on the broader CI-visibility question

#512 also raised whether the `@slow` exclusion from CI should be revisited so planner-routability regressions are caught. This PR does **not** address that (it's a separate, broader question) — and for *this* test it's now moot (the behaviour is the accepted reality, not a regression to catch). Happy to file a follow-up if you want the broader concern tracked.

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)