### PR TITLE
docs: theme-aware README hero (light/dark <picture>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Theme-aware README hero (#514).** The README banner now serves two
+  brand-tuned SVG variants via an HTML `<picture>` element with
+  `prefers-color-scheme` media queries — `docs/assets/banner-light.svg` (light
+  theme / safe fallback) and `docs/assets/banner-dark.svg` (dark theme) — so
+  GitHub picks the on-brand variant for each viewer's color scheme. Same
+  composition, theme-appropriate BRAND.md tokens (recolour, not redesign); the
+  original `docs/assets/banner.svg` is retained. Pure docs, no code impact.
 - **Nose-out parked heading preference (#263, ADR-0022).** The solver now prefers
   to park each plane pointing **out** (nose toward the door) for an easy
   straight-out exit: an RNG-free `_nose_out` post-pass flips a plane's parked

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-![hangarfit](docs/assets/banner.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)"  srcset="docs/assets/banner-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/banner-light.svg">
+  <img alt="hangarfit" src="docs/assets/banner-light.svg">
+</picture>
 
 # hangarfit
 

--- a/docs/assets/banner-dark.svg
+++ b/docs/assets/banner-dark.svg
@@ -10,8 +10,9 @@
       wall+datum #3B4046 / maint #7B63A3 / valid #0F7C72 (status inks fixed across
       surfaces) / plane tiles = PLANES_DARK fills with an #ECEEF1 ink edge (the
       "never hue alone" outline, lifted to read on dark paper).
-    On-brand vector stopgap; wordmark falls back to system-ui (Geist not installed
-    locally) so this is NOT pixel-identical to the design comp. Canvas 1280x400.
+    On-brand vector stopgap (the pixel-accurate PNG is the deferred canonical
+    deliverable); wordmark falls back to system-ui (Geist not installed locally)
+    so this is NOT pixel-identical to the design comp. Canvas 1280x400.
     No (R)/(TM); DocGerdSoft is a personal brand, not a company.
   -->
   <defs>
@@ -41,7 +42,7 @@
   <g transform="translate(760,60)" opacity="0.9">
     <!-- floor (the surface token; the raised plane the fleet sits on) -->
     <rect x="0" y="0" width="560" height="280" fill="#15171A" stroke="none"/>
-    <!-- back-strip maintenance bay (maint violet; opacity lifted to read on dark floor, per BRAND.md §4 bay 0.32) -->
+    <!-- back-strip maintenance bay (maint violet; opacity lifted to read on the dark floor) -->
     <rect x="0" y="0" width="560" height="46" fill="#7B63A3" opacity="0.30"/>
     <!-- back wall -->
     <line x1="0" y1="0" x2="560" y2="0" stroke="#3B4046" stroke-width="3"/>

--- a/docs/assets/banner-dark.svg
+++ b/docs/assets/banner-dark.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 400" width="1280" height="400" role="img" aria-label="hangarfit — validate, solve, and render a flying club's hangar-parking layouts, from above">
+  <!--
+    hangarfit README banner — DARK-THEME variant (DocGerdSoft brand, BRAND.md dark
+    neutral core + PLANES_DARK fills). Tuned for GitHub's dark theme. SAME
+    composition as the light variant; only background/foreground are recoloured to
+    the theme-appropriate tokens (a recolour, NOT a redesign):
+      paper #0D0E10 / surface #15171A / hairline-2 #202428 (grid) /
+      ink #ECEEF1 (wordmark) / graphite-strong #C2C7CD (tagline) /
+      graphite #969CA4 (mono + door threshold) / accent (dark) #3FA3D6 /
+      wall+datum #3B4046 / maint #7B63A3 / valid #0F7C72 (status inks fixed across
+      surfaces) / plane tiles = PLANES_DARK fills with an #ECEEF1 ink edge (the
+      "never hue alone" outline, lifted to read on dark paper).
+    On-brand vector stopgap; wordmark falls back to system-ui (Geist not installed
+    locally) so this is NOT pixel-identical to the design comp. Canvas 1280x400.
+    No (R)/(TM); DocGerdSoft is a personal brand, not a company.
+  -->
+  <defs>
+    <linearGradient id="horizonRule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#3FA3D6"/>
+      <stop offset="1" stop-color="#3FA3D6" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="gridMask" cx="78%" cy="30%" r="72%">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="1"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid40" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0 L0 0 L0 40" fill="none" stroke="#202428" stroke-width="1"/>
+    </pattern>
+    <mask id="gridFade">
+      <rect width="1280" height="400" fill="url(#gridMask)"/>
+    </mask>
+  </defs>
+
+  <!-- Background: dark Paper + faint 40px grid masked by a radial fade toward the right. -->
+  <rect width="1280" height="400" fill="#0D0E10"/>
+  <rect width="1280" height="400" fill="url(#grid40)" mask="url(#gridFade)"/>
+
+  <!-- Right column: abstract top-down hangar schematic, bleeding off the right edge.
+       Three solid walls + a front wall with a central door gap, plus a faint
+       back-strip maintenance bay. Schematic only — never the brand mark. -->
+  <g transform="translate(760,60)" opacity="0.9">
+    <!-- floor (the surface token; the raised plane the fleet sits on) -->
+    <rect x="0" y="0" width="560" height="280" fill="#15171A" stroke="none"/>
+    <!-- back-strip maintenance bay (maint violet; opacity lifted to read on dark floor, per BRAND.md §4 bay 0.32) -->
+    <rect x="0" y="0" width="560" height="46" fill="#7B63A3" opacity="0.30"/>
+    <!-- back wall -->
+    <line x1="0" y1="0" x2="560" y2="0" stroke="#3B4046" stroke-width="3"/>
+    <!-- left + right walls -->
+    <line x1="0" y1="0" x2="0" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="560" y1="0" x2="560" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <!-- front wall split around a central door gap -->
+    <line x1="0" y1="280" x2="210" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="350" y1="280" x2="560" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="210" y1="280" x2="350" y2="280" stroke="#969CA4" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <!-- a few abstract plane-slot tiles, PLANES_DARK fills, ink edge (never hue alone) -->
+    <rect x="60"  y="70"  width="120" height="40" rx="6" fill="#3FA3D6" stroke="#ECEEF1" stroke-width="1.5"/>
+    <rect x="220" y="120" width="120" height="40" rx="6" fill="#E8794A" stroke="#ECEEF1" stroke-width="1.5"/>
+    <rect x="380" y="80"  width="120" height="40" rx="6" fill="#33B894" stroke="#ECEEF1" stroke-width="1.5"/>
+    <rect x="110" y="180" width="120" height="40" rx="6" fill="#CE7EC0" stroke="#ECEEF1" stroke-width="1.5"/>
+    <rect x="330" y="200" width="120" height="40" rx="6" fill="#8585C9" stroke="#ECEEF1" stroke-width="1.5"/>
+  </g>
+
+  <!-- Left column (fixed 560px), padding 56 48, vertically centered. -->
+  <g transform="translate(48,118)">
+    <!-- Lockup: delta mark 54x54 (dark accent #3FA3D6) + wordmark. -->
+    <g transform="translate(0,0)">
+      <g transform="scale(0.54)" fill="#3FA3D6">
+        <path d="M50 17.09 L69.87 51.5 L30.13 51.5 Z"/>
+        <path d="M26.96 57 L73.04 57 L88 82.91 L12 82.91 Z"/>
+      </g>
+      <text x="70" y="48" font-family="Geist, system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
+            font-size="52" font-weight="600" letter-spacing="-1.5">
+        <tspan fill="#ECEEF1">hangar</tspan><tspan fill="#3FA3D6">fit</tspan>
+      </text>
+    </g>
+
+    <!-- Horizon rule: 120x2 gradient (dark accent). -->
+    <rect x="2" y="78" width="120" height="2" fill="url(#horizonRule)"/>
+
+    <!-- Tagline, ~23px, graphite-strong (dark). -->
+    <text x="0" y="120" font-family="Geist, system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
+          font-size="23" font-weight="400" fill="#C2C7CD">
+      <tspan x="0" dy="0">Validate, solve, and render a flying club's</tspan>
+      <tspan x="0" dy="32">hangar-parking layouts — from above.</tspan>
+    </text>
+
+    <!-- Mono command block, ~16px, graphite (dark). $ in accent, verdict in valid green (status ink fixed across surfaces). -->
+    <text x="0" y="206" font-family="'Geist Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace"
+          font-size="16" fill="#969CA4">
+      <tspan fill="#3FA3D6">$</tspan><tspan> hangarfit check examples/layouts/example.yaml</tspan>
+    </text>
+    <text x="0" y="232" font-family="'Geist Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace"
+          font-size="16" fill="#969CA4">
+      <tspan fill="#0F7C72">-</tspan><tspan> valid  // 9 planes . 0 conflicts</tspan>
+    </text>
+  </g>
+</svg>

--- a/docs/assets/banner-light.svg
+++ b/docs/assets/banner-light.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 400" width="1280" height="400" role="img" aria-label="hangarfit — validate, solve, and render a flying club's hangar-parking layouts, from above">
+  <!--
+    hangarfit README banner — LIGHT-THEME variant (DocGerdSoft brand, BRAND.md
+    light tokens). Tuned for GitHub's light theme and the safe default / <picture>
+    fallback. SAME composition as the dark variant; only background/foreground use
+    the light neutral core + the light PLANES fills. This is the on-brand vector
+    stopgap (the pixel-accurate PNG is the deferred canonical deliverable); the
+    wordmark falls back to system-ui because Geist is not installed locally, so
+    this is NOT pixel-identical to the design comp. Canvas 1280x400. No (R)/(TM);
+    DocGerdSoft is a personal brand, not a company.
+  -->
+  <defs>
+    <linearGradient id="horizonRule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#0079B5"/>
+      <stop offset="1" stop-color="#0079B5" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="gridMask" cx="78%" cy="30%" r="72%">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="1"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid40" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0 L0 0 L0 40" fill="none" stroke="#E6E9EC" stroke-width="1"/>
+    </pattern>
+    <mask id="gridFade">
+      <rect width="1280" height="400" fill="url(#gridMask)"/>
+    </mask>
+  </defs>
+
+  <!-- Background: Paper + faint 40px grid masked by a radial fade toward the right. -->
+  <rect width="1280" height="400" fill="#FBFBFC"/>
+  <rect width="1280" height="400" fill="url(#grid40)" mask="url(#gridFade)"/>
+
+  <!-- Right column: abstract top-down hangar schematic, bleeding off the right edge.
+       Three solid walls + a front wall with a central door gap, plus a faint
+       back-strip maintenance bay. Schematic only — never the brand mark. -->
+  <g transform="translate(760,60)" opacity="0.9">
+    <!-- floor -->
+    <rect x="0" y="0" width="560" height="280" fill="#FFFFFF" stroke="none"/>
+    <!-- back-strip maintenance bay (~13% opacity maint colour) -->
+    <rect x="0" y="0" width="560" height="46" fill="#7B63A3" opacity="0.13"/>
+    <!-- back wall -->
+    <line x1="0" y1="0" x2="560" y2="0" stroke="#3B4046" stroke-width="3"/>
+    <!-- left + right walls -->
+    <line x1="0" y1="0" x2="0" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="560" y1="0" x2="560" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <!-- front wall split around a central door gap -->
+    <line x1="0" y1="280" x2="210" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="350" y1="280" x2="560" y2="280" stroke="#3B4046" stroke-width="3"/>
+    <line x1="210" y1="280" x2="350" y2="280" stroke="#bdc3c7" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <!-- a few abstract plane-slot tiles, brand palette, ink outline (never hue alone) -->
+    <rect x="60"  y="70"  width="120" height="40" rx="6" fill="#0079B5" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="220" y="120" width="120" height="40" rx="6" fill="#D55E00" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="380" y="80"  width="120" height="40" rx="6" fill="#009E73" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="110" y="180" width="120" height="40" rx="6" fill="#B45CA6" stroke="#14161A" stroke-width="1.5"/>
+    <rect x="330" y="200" width="120" height="40" rx="6" fill="#4C4C9E" stroke="#14161A" stroke-width="1.5"/>
+  </g>
+
+  <!-- Left column (fixed 560px), padding 56 48, vertically centered. -->
+  <g transform="translate(48,118)">
+    <!-- Lockup: delta mark 54x54 (#0079B5) + wordmark. -->
+    <g transform="translate(0,0)">
+      <g transform="scale(0.54)" fill="#0079B5">
+        <path d="M50 17.09 L69.87 51.5 L30.13 51.5 Z"/>
+        <path d="M26.96 57 L73.04 57 L88 82.91 L12 82.91 Z"/>
+      </g>
+      <text x="70" y="48" font-family="Geist, system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
+            font-size="52" font-weight="600" letter-spacing="-1.5">
+        <tspan fill="#14161A">hangar</tspan><tspan fill="#0079B5">fit</tspan>
+      </text>
+    </g>
+
+    <!-- Horizon rule: 120x2 gradient. -->
+    <rect x="2" y="78" width="120" height="2" fill="url(#horizonRule)"/>
+
+    <!-- Tagline, ~23px, graphite-strong. -->
+    <text x="0" y="120" font-family="Geist, system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
+          font-size="23" font-weight="400" fill="#3B4046">
+      <tspan x="0" dy="0">Validate, solve, and render a flying club's</tspan>
+      <tspan x="0" dy="32">hangar-parking layouts — from above.</tspan>
+    </text>
+
+    <!-- Mono command block, ~16px, graphite. $ in accent, check + verdict in valid green. -->
+    <text x="0" y="206" font-family="'Geist Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace"
+          font-size="16" fill="#5E646B">
+      <tspan fill="#0079B5">$</tspan><tspan> hangarfit check examples/layouts/example.yaml</tspan>
+    </text>
+    <text x="0" y="232" font-family="'Geist Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace"
+          font-size="16" fill="#5E646B">
+      <tspan fill="#0F7C72">-</tspan><tspan> valid  // 9 planes . 0 conflicts</tspan>
+    </text>
+  </g>
+</svg>

--- a/docs/assets/banner-light.svg
+++ b/docs/assets/banner-light.svg
@@ -79,7 +79,7 @@
       <tspan x="0" dy="32">hangar-parking layouts — from above.</tspan>
     </text>
 
-    <!-- Mono command block, ~16px, graphite. $ in accent, check + verdict in valid green. -->
+    <!-- Mono command block, ~16px, graphite. $ in accent, verdict in valid green. -->
     <text x="0" y="206" font-family="'Geist Mono', ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, monospace"
           font-size="16" fill="#5E646B">
       <tspan fill="#0079B5">$</tspan><tspan> hangarfit check examples/layouts/example.yaml</tspan>


### PR DESCRIPTION
Closes #514

## Summary

Replaces the single theme-agnostic README hero with two brand-tuned SVG variants served via an HTML `<picture>` element, so GitHub picks the on-brand banner for each viewer's color scheme.

- **`docs/assets/banner-light.svg`** — light theme + the safe `<picture>` fallback (the existing banner's composition + light tokens).
- **`docs/assets/banner-dark.svg`** — dark theme: same composition, recoloured to BRAND.md dark tokens — dark neutral core (`#0D0E10` paper / `#15171A` surface / `#202428` grid), `#ECEEF1` wordmark ink, dark accent `#3FA3D6` (mark + `fit` + `$`), `PLANES_DARK` plane fills with an `#ECEEF1` "never hue alone" edge. Status inks stay fixed across surfaces (`wall #3B4046`, `maint #7B63A3`, `valid #0F7C72`), door threshold lifts to graphite `#969CA4`.
- **`README.md:1`** → the `<picture>` block with `prefers-color-scheme` sources and a light-variant `<img alt="hangarfit">` fallback.
- The original `docs/assets/banner.svg` is **retained** (still referenced by `BRAND.md`); the two variants are additions, not a rename.
- CHANGELOG: one-line Unreleased/Added entry.

Recolour, not redesign — composition is byte-for-byte the same geometry as `banner.svg`. Pure docs; no code, no determinism impact.

## How to verify

- View `README.md` on GitHub in **both** the light and dark themes (Settings → Appearance, or the theme toggle) — the hero should swap to the matching variant and read on-brand against each background.
- Confirm the fallback `<img>` (light variant) resolves on renderers without `<picture>` support.
- Both SVGs validate as well-formed XML: `python -c "import xml.dom.minidom; xml.dom.minidom.parse('docs/assets/banner-dark.svg')"` (and `-light`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)