### PR TITLE
feat: model the empennage tail surfaces (horizontal stabilizer + fin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,26 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- **BREAKING (collision model): the empennage is now modelled as explicit tail
+  surfaces (#518/#519/#520, ADR-0023).** Every aircraft gains a `tail` (horizontal
+  stabilizer — wide, ~2.5–3.5 m span) and a new `vertical_stabilizer` `PartKind`
+  (the fin + rudder — thin, on the centreline, rising to the published overall
+  height *into* the wing-nesting layer). The checker now rejects two cases it
+  silently passed before: a wing nested over a neighbour's tail that passes over
+  that plane's **fin** (#520 — the fin reaches into the wing layer), and a
+  wing/strut/fuselage clipping a realistic-width **tailplane** (#519). The
+  collision *predicate is unchanged* — honest z-extents alone produce the correct
+  verdict; a wing-over-tail nest stays legal exactly when it clears the centreline
+  fin laterally. Per-part z expresses conventional / cruciform / T-tail
+  configurations (the Stemme S10 is the fleet's one T-tail) with no per-type code.
+  Some previously-"valid" layouts flip to invalid: the canonical
+  `valid_wing_over_tail` fixtures were re-tuned to nest over the low tailplane
+  while clearing the fin (with a new paired `invalid_wing_over_fin`), the real
+  `examples/herrenteich/layout.yaml` all-eight arrangement was re-arranged to
+  clear every fin, and the packed 9-plane fill is now statically valid but no
+  longer tow-routable (wide tailplanes block the corridors). The placeholder
+  `data/hangar.yaml` was widened 18 → 22 m so the canonical demo keeps its full
+  plane set with the bulkier tail surfaces.
 - **Fewest-moves tow routing — nose-out slots are backed in (#480, ADR-0010
   amendment).** The tow planner now minimises **moves** (direction changes), not
   reverse distance: word/path cost is `length + CUSP_PENALTY × cusps` (a *cusp* is

--- a/data/fleet.yaml
+++ b/data/fleet.yaml
@@ -38,6 +38,14 @@
 #   towplanner substitutes 0 (pivot-in-place on the cart) via
 #   `Aircraft.effective_turn_radius_m()` rather than baking 0 into the data
 #   (ADR-0007, fork 4).
+# - Empennage (ADR-0023, #518/#519/#520): each aircraft carries a `tail` (the
+#   horizontal stabilizer / elevator — wide, held below the wing layer for
+#   conventional/cruciform tails so it stays overhangable) and a
+#   `vertical_stabilizer` (the fin + rudder — thin, on the centreline, rising
+#   from the fuselage top to the published overall height, into the wing layer).
+#   Spans/chords are published-spec-absent ESTIMATES; tail configs + overall
+#   heights are sourced. All measured: false. A wing nested over another plane's
+#   tail now conflicts with that plane's fin unless it clears it laterally.
 
 aircraft:
   # ----------------------------------------------------------------------------
@@ -66,6 +74,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.1
+      - kind: tail            # horizontal stabilizer (conventional low; ~2.6 m span est.)
+        length_m: 0.9
+        width_m: 2.6
+        offset_x_m: -3.35
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer  # fin+rudder to overall height 1.68 m
+        length_m: 1.1
+        width_m: 0.15
+        offset_x_m: -3.25
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 1.68
     wheels:
       main_offset_x_m: 0.0
 
@@ -95,6 +117,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 2.0
         z_top_m: 2.3
+      - kind: tail            # horizontal stabilizer (conventional low; ~3.0 m span est.)
+        length_m: 1.0
+        width_m: 3.0
+        offset_x_m: -4.66
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer  # fin+rudder to overall height 2.01 m (into the wing layer)
+        length_m: 1.3
+        width_m: 0.15
+        offset_x_m: -4.51
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 2.01
     struts:
       fuselage_attach_x_m: -1.22
       fuselage_attach_y_m: 0.425   # ~half fuselage width
@@ -132,6 +168,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 0.8
         z_top_m: 1.1
+      - kind: tail            # horizontal stabilizer (conventional low; ~3.2 m span est.)
+        length_m: 1.1
+        width_m: 3.2
+        offset_x_m: -3.84
+        offset_y_m: 0.0
+        z_bottom_m: 1.3
+        z_top_m: 1.6
+      - kind: vertical_stabilizer  # fin+rudder to overall height 2.02 m
+        length_m: 1.3
+        width_m: 0.15
+        offset_x_m: -3.74
+        offset_y_m: 0.0
+        z_bottom_m: 1.6
+        z_top_m: 2.02
     wheels:
       main_offset_x_m: -0.40
       track_m: 2.5
@@ -162,6 +212,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 2.0
         z_top_m: 2.2
+      - kind: tail            # horizontal stabilizer (conventional low; ~2.9 m span est.)
+        length_m: 0.9
+        width_m: 2.9
+        offset_x_m: -3.18
+        offset_y_m: 0.0
+        z_bottom_m: 1.1
+        z_top_m: 1.4
+      - kind: vertical_stabilizer  # fin+rudder to overall height ~1.9 m
+        length_m: 1.0
+        width_m: 0.15
+        offset_x_m: -3.13
+        offset_y_m: 0.0
+        z_bottom_m: 1.4
+        z_top_m: 1.9
     struts:
       fuselage_attach_x_m: 0.07
       fuselage_attach_y_m: 0.425
@@ -198,6 +262,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.2
+      - kind: tail            # horizontal stabilizer (conventional low; ~2.8 m span est.)
+        length_m: 0.9
+        width_m: 2.8
+        offset_x_m: -4.35
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer  # fin+rudder to overall height 2.03 m
+        length_m: 1.1
+        width_m: 0.15
+        offset_x_m: -4.25
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 2.03
     struts:
       fuselage_attach_x_m: -1.20
       fuselage_attach_y_m: 0.4
@@ -235,6 +313,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 2.0
         z_top_m: 2.3
+      - kind: tail            # horizontal stabilizer (conventional low; ~3.2 m span est.)
+        length_m: 1.1
+        width_m: 3.2
+        offset_x_m: -4.37
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer  # fin+rudder to overall height 1.91 m
+        length_m: 1.2
+        width_m: 0.15
+        offset_x_m: -4.32
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 1.91
     struts:
       fuselage_attach_x_m: -1.14
       fuselage_attach_y_m: 0.425
@@ -271,6 +363,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 2.0
         z_top_m: 2.3
+      - kind: tail            # horizontal stabilizer (conventional low; ~3.4 m span est.)
+        length_m: 1.1
+        width_m: 3.4
+        offset_x_m: -3.06
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer  # fin+rudder to overall height 2.11 m
+        length_m: 1.4
+        width_m: 0.15
+        offset_x_m: -2.91
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 2.11
     struts:
       fuselage_attach_x_m: 0.17
       fuselage_attach_y_m: 0.45
@@ -309,6 +415,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.2
+      - kind: tail            # CRUCIFORM tail — stabilator low/mid, kept below the wing layer (~2.6 m span est.)
+        length_m: 0.9
+        width_m: 2.6
+        offset_x_m: -3.18
+        offset_y_m: 0.0
+        z_bottom_m: 1.1
+        z_top_m: 1.4
+      - kind: vertical_stabilizer  # tall fin+rudder to overall height 2.34 m (well into the wing layer)
+        length_m: 1.2
+        width_m: 0.15
+        offset_x_m: -3.03
+        offset_y_m: 0.0
+        z_bottom_m: 1.4
+        z_top_m: 2.34
     wheels:
       main_offset_x_m: -0.10
       track_m: 1.7
@@ -340,6 +460,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.2
+      - kind: tail            # horizontal stabilizer (conventional low; ~3.2 m span est.)
+        length_m: 0.9
+        width_m: 3.2
+        offset_x_m: -2.77
+        offset_y_m: 0.0
+        z_bottom_m: 1.1
+        z_top_m: 1.4
+      - kind: vertical_stabilizer  # fin+rudder to overall height 2.15 m
+        length_m: 1.1
+        width_m: 0.15
+        offset_x_m: -2.67
+        offset_y_m: 0.0
+        z_bottom_m: 1.4
+        z_top_m: 2.15
     struts:
       fuselage_attach_x_m: 0.11
       fuselage_attach_y_m: 0.425

--- a/data/hangar.yaml
+++ b/data/hangar.yaml
@@ -9,18 +9,22 @@
 # "The coordinate convention" for the full convention.
 
 length_m: 25.0          # depth from front wall (door side) to back wall
-width_m: 18.0           # left-to-right span
+width_m: 22.0           # left-to-right span (widened from 18 m for #519/#520:
+                        # realistic ~3 m tailplanes + fins consume lateral room,
+                        # so the canonical demo needs ~4 m more width to keep its
+                        # full plane set valid. Placeholder — real survey resets it.)
 
 door:
   center_x_m: 9.0       # door center along the front wall (x axis)
   width_m: 12.0         # door opening width
 
 maintenance_bay:
-  # Partial-width, back-anchored rectangle. PLACEHOLDER values — real
-  # measurements will reset all three. Right-corner bay so the partial-width
-  # path is exercised by the canonical layout.
-  center_x_m: 13.5      # right side of the 18 m hangar (placeholder)
-  width_m: 9.0          # right half (placeholder)
+  # Partial-width, back-anchored keep-out rectangle spanning x ∈ [9, 18],
+  # y ∈ [16, 25]. PLACEHOLDER values — real measurements will reset all three.
+  # Kept at its original absolute x-range (center 13.5, width 9) after the hangar
+  # widened to 22 m, so it now leaves aisles on BOTH sides (still partial-width).
+  center_x_m: 13.5      # bay x ∈ [9, 18] (unchanged absolute position)
+  width_m: 9.0          # partial width (placeholder)
   depth_m: 9.0          # back nine meters (placeholder)
 
 clearance_m: 0.3        # minimum horizontal gap between any two aircraft parts

--- a/docs/adr/0012-fuselage-front-aft-split.md
+++ b/docs/adr/0012-fuselage-front-aft-split.md
@@ -162,6 +162,14 @@ at zero (only a header comment) and the break a single derived value.
   separate, currently-unused kind (the empennage folds into `fuselage_aft` —
   the aft *region* includes the tail, so a separate tail segment would add a
   kind with no distinct rule).
+  **Amended by [ADR-0023](0023-empennage-tail-surfaces.md):** this last claim no
+  longer holds. The empennage does *not* fully fold into `fuselage_aft` — its
+  lateral span and its fin's vertical extent are unmodelled there — so ADR-0023
+  makes the tail surfaces explicit (`tail` for the horizontal stabilizer, a new
+  `vertical_stabilizer` for the fin). The fin *does* exercise a distinct
+  outcome, though via the *uniform* two-clause predicate, not a new rule.
+  ADR-0012's front/aft split (D2) and the `wing × fuselage_front` cockpit rule
+  (D1) are unaffected and stay Accepted.
 - The visualizer tints `fuselage_front` a darker shade of the wing-position
   fill so the cockpit boundary reads at a glance. (At the time of this ADR
   `_draw_gear_glyph` reconstructed the full fuselage span from both segments to

--- a/docs/adr/0023-empennage-tail-surfaces.md
+++ b/docs/adr/0023-empennage-tail-surfaces.md
@@ -1,0 +1,298 @@
+# ADR-0023: Model the empennage as explicit tail surfaces so a vertical fin in the wing layer can block wing-over-tail nesting
+
+- **Status:** Proposed
+
+- **Date:** 2026-06-08
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+Every aircraft in [`data/fleet.yaml`](../../data/fleet.yaml) is modelled with two
+part kinds: `wing` and `fuselage` (the loader auto-splits the latter into
+`fuselage_front` + `fuselage_aft`, [ADR-0012](0012-fuselage-front-aft-split.md)).
+The empennage — the tail surfaces — is not represented at all; it is implicitly
+just the aft end of the fuselage rectangle: as wide as the fuselage tube and as
+tall as the fuselage's z-range. ADR-0012 recorded this deliberately ("the
+empennage folds into `fuselage_aft` … a separate tail segment would add a kind
+with no distinct rule", its Neutral consequence).
+
+That assumption is wrong in two independent, collision-relevant ways:
+
+- **Lateral span.** The real horizontal stabilizer / elevator spans ~2.5–3.5 m
+  tip-to-tip, against `aviat_husky`'s ~0.85 m fuselage tube. In plan view the
+  model sees free space on either side of the tail where a ~3 m tailplane is.
+- **Vertical extent (safety-critical).** The real vertical stabilizer (fin) +
+  rudder rises to roughly the aircraft's published overall height (~1.7–2.3 m
+  for this fleet) — *into* the wing-nesting layer. The modelled aft-fuselage box
+  tops out far lower (`aviat_husky`: 1.5 m). ADR-0012's wing-over-tail nesting —
+  the core space-saving trick — lets a high wing overhang another plane's
+  `fuselage_aft` because the two are z-disjoint (aft-fuselage top ≪ overhanging
+  wing bottom). A real fin sits *in the very z-band the nested wing occupies*, so
+  a layout the checker reports **valid** can **physically collide**, fin against
+  wing.
+
+This ADR records the model for the tail surfaces and, crucially, **how the
+vertical fin interacts with wing-over-tail nesting** — the part of ADR-0012's
+Neutral consequence it amends. It is a refinement *within* the parts model;
+[ADR-0001](0001-aircraft-parts-model.md) and ADR-0012's front/aft split and
+cockpit rule stay **Accepted**.
+
+## Decision Drivers
+
+- **The physical model must be sound.** A `valid` verdict must not hide a
+  fin-against-wing collision. This is the safety driver and it is
+  non-negotiable.
+- **Express the lateral-clearance nuance.** A wing whose tip passes *outboard*
+  of a narrow centreline fin genuinely clears it; a wing passing *over* it does
+  not. Keep the former legal (it is real, hard-won packing density) and reject
+  only the latter.
+- **One model, every tail config.** The fleet has conventional-low tails, one
+  cruciform (`ctsl`), and one T-tail (`stemme_s10`). The representation must
+  cover all three with no per-type special-casing.
+- **Robustness to placeholder measurements.** Every fleet dimension is a guess
+  (`measured: false`); the rule must not hinge on precise unmeasured numbers.
+- **Minimal blast radius on the guarded checker.** The collision predicate and
+  the det(−1) transform are the project's most safety-sensitive code. Prefer a
+  change that adds *data and parts*, not predicate branches.
+- **Consistency with existing idioms.** Closed `PartKind` literal, the
+  alphabetical conflict-kind taxonomy, the parts tuple as single source of
+  truth.
+
+## Considered Options
+
+### D1 — how to decompose the empennage
+
+1. **Two parts: a wide horizontal-stabilizer rectangle + a thin, tall
+   vertical-fin rectangle**, each with its own `[z_bottom_m, z_top_m]`
+   *(chosen)*.
+2. **One enlarged empennage bounding box** — a single part as wide as the
+   stabilizer *and* as tall as the fin.
+3. **Status quo** — keep the empennage folded into `fuselage_aft`, no separate
+   part. (The defect under repair; listed for completeness.)
+
+### D2 — the fin's `PartKind`
+
+1. **Add a `vertical_stabilizer` kind for the fin; reuse the existing `tail`
+   kind for the horizontal stabilizer** *(chosen)*.
+2. **Two `tail` parts** — model both surfaces as `kind: tail`, no new kind.
+3. **Two new kinds** (`horizontal_stabilizer` + `vertical_stabilizer`), retiring
+   bare `tail`.
+
+### D3 — how the fin interacts with wing-over-tail nesting (the ADR-0012 amendment)
+
+1. **Apply the existing two-clause predicate, unchanged, to
+   `wing × vertical_stabilizer`** — nesting stays legal iff the wing clears the
+   fin *laterally* (no plan-view overlap with the centreline fin); it conflicts
+   when the wing passes over the fin and their z-bands are within
+   `wing_layer_clearance_m` *(chosen)*.
+2. **Hard conflict, `z` ignored** — any wing overhanging a plane that has a fin
+   conflicts, mirroring the `wing × fuselage_front` cockpit rule.
+
+### D4 — how the tail surfaces are authored
+
+1. **Explicit `parts:` entries** per aircraft (`kind: tail`,
+   `kind: vertical_stabilizer`) *(chosen)*.
+2. **A new `empennage:` YAML block** the loader expands into the two parts, like
+   `struts:`.
+
+## Decision Outcome
+
+**Chosen: D1 = option 1 (two parts); D2 = option 1 (`tail` + new
+`vertical_stabilizer`); D3 = option 1 (unchanged predicate; legal iff laterally
+clear); D4 = option 1 (explicit parts).**
+
+The pivot is **D3**, and it is almost free. The collision predicate's z-clause is
+already `gap = max(z_bottom) − min(z_top); conflict iff gap <
+wing_layer_clearance_m` (`collisions._parts_conflict`). The reason it fails to
+catch a fin today is *not* a flaw in that math — it is that no part's z-range
+reaches the fin's true height. The moment a `vertical_stabilizer` part exists
+whose `z_top_m` enters the wing band, `wing × vertical_stabilizer` yields
+`gap ≤ 0` and the **unchanged** predicate returns a conflict — but only after its
+mandatory first gate, plan-view overlap, is met. A wingtip passing outboard of
+the thin centreline fin never overlaps it in plan view, so that nest stays
+legal. The predicate therefore expresses "legal iff the wing clears the fin
+laterally" with **zero new branches** — exactly the nuance D3 needs, and the
+most robust outcome to placeholder heights (the verdict flips only when the
+geometry genuinely intersects).
+
+**D1 two parts**, because the tail over-extends in two *independent* dimensions
+at two *different* heights: the stabilizer is wide and (usually) low; the fin is
+narrow and tall. A single box (D1.2) cannot hold both truths — it would be both
+stabilizer-wide and fin-tall, a solid no aircraft has, and would forbid every
+wing-over-tail nest even where the wing passes outboard of the centreline fin.
+Two parts each carry honest geometry.
+
+**The two-part model handles all three tail configurations through data alone**,
+with no per-type code, because the horizontal-stabilizer `tail` part carries its
+own z-band:
+
+- **Conventional-low** (`aviat_husky`, the Cessnas, `zlin_savage`, `fk9_mkii`,
+  `scheibe_falke`, `fuji`, `wild_thing`): the `tail` plane sits below the wing
+  layer → z-disjoint from an overhanging high wing → wing-over-tail nesting
+  stays legal over the *stabilizer*; the stabilizer newly conflicts only with a
+  neighbour's *low* parts (fuselage, strut, low wing) it now overlaps in plan
+  view.
+- **Cruciform** (`ctsl`): the stabilizer sits low-to-mid on the fin, still below
+  the wing layer — modelled like conventional-low.
+- **T-tail** (`stemme_s10`, the fleet's only one): the stabilizer sits at the
+  fin top, *inside* the wing layer → a neighbour's overhanging wing z-overlaps
+  it → conflict. Physically correct: you cannot tuck a wing over a T-tail.
+
+In every case it is the same uniform predicate reading the part's z-range; the
+configuration lives entirely in the data.
+
+**D2 reuse `tail` + add `vertical_stabilizer`**, because `tail` already means,
+throughout this codebase, "the overhangable low aft surface" — it is the kind in
+`metrics._OVERHANGABLE`, the kind `visualize.py` renders like the aft fuselage,
+and the subject of the "wing-over-tail clearance" readout. The horizontal
+stabilizer *is* that surface, so reuse keeps those consumers correct with no
+churn. The fin is the opposite — a hard obstacle that is *never* overhangable —
+so it earns a distinct kind, which makes "fin keeps the height clause; it is not
+a cockpit and not overhangable" structural rather than a comment.
+
+**D4 explicit parts**, because the loader already constructs any kind in
+`_VALID_PART_KINDS` via `_build_part`; authoring the two surfaces as plain
+`parts:` entries keeps this breaking-change PR free of new loader logic,
+allowlist surface, and expansion tests, and the per-part `z_bottom_m` /
+`z_top_m` already expresses every tail configuration directly.
+
+### Why not D1 option 2 (single empennage box)?
+
+It collapses the two independent over-extents into one solid that is
+simultaneously stabilizer-wide and fin-tall — a shape no aircraft has. Every
+wing-over-tail nest would then conflict, including the legitimate ones where the
+wingtip passes metres outboard of a ~0.15 m centreline fin. That throws away
+real packing density (the whole point of wing-over-tail nesting) to model a
+collision that is not there, and it cannot answer the epic's central question —
+"does the wing clear the fin laterally?" — because it has erased the lateral
+structure.
+
+### Why not D1 option 3 (status quo)?
+
+It is the defect. The model reports `valid` for a wing nested over a neighbour's
+tail when a real fin rises into that wing's layer, and it sees free space beside
+a ~3 m tailplane. ADR-0012's "the empennage folds into `fuselage_aft`, no
+distinct rule" was a reasonable Phase-1 simplification; this ADR is the additive
+upgrade ADR-0001 anticipated ("a later ADR can supersede … the upgrade path is
+additive").
+
+### Why not D2 option 2 (two `tail` parts)?
+
+`tail` is wired into `metrics._OVERHANGABLE` and rendered by `visualize.py` as a
+low aft surface. A fin tagged `tail` would be wrongly counted overhangable and
+mis-rendered, forcing a z-aware special-case in exactly the consumers a single
+kind was meant to keep simple — defeating the simplicity that motivated the
+option. A distinct kind makes the fin's "never overhangable, always keeps the
+height clause" nature structural.
+
+### Why not D2 option 3 (retire `tail` for two new kinds)?
+
+It renames a kind that is already correct. `tail` already denotes the
+overhangable low aft surface across `metrics`, `visualize`, the scene/viewer
+readout, and the "wing-over-tail clearance" terminology; retiring it churns all
+of those — and the user-facing readout name — for no behavioural gain over
+reusing it for the horizontal stabilizer.
+
+### Why not D3 option 2 (hard conflict, `z` ignored)?
+
+It is less faithful *and* more code. It would forbid a wing from nesting over the
+tail of any finned aircraft even when the wingtip passes outboard of a narrow
+centreline fin — a real, safe, dense arrangement — costing packing density for
+no safety gain. And unlike the chosen option it requires a *new* special-case
+branch in the predicate (a second `_is_wing_over_*` classifier), enlarging the
+guarded checker. The cockpit rule (ADR-0012 D1) earned its z-drop because
+wing-over-cockpit is *categorically* unacceptable at any height; wing-over-fin
+is not categorical — it depends on lateral clearance, which the unchanged
+predicate already measures.
+
+### Why not D4 option 2 (`empennage:` loader block)?
+
+It adds loader surface — an allowlist entry, an `_expand_empennage` expander, its
+validation, and its tests — to a PR that is already a breaking change across
+data, model, render, and tests. The per-part z fully expresses every
+configuration without it, so the block buys only reduced hand-authoring
+boilerplate (two parts per plane). If that authoring proves painful as the fleet
+grows, a later ADR can add the block additively, exactly as `struts:` was. YAGNI
+for now.
+
+## Consequences
+
+### Positive
+
+- The safety defect is fixed *structurally*: a fin reaching into the wing layer
+  now blocks the nest it would physically foul, via the existing predicate.
+- All three tail configurations (conventional, cruciform, T-tail) are handled by
+  data, with no per-type code branch.
+- The lateral-clearance nuance is preserved: a wing that genuinely passes
+  outboard of a centreline fin still nests.
+- Blast radius is small and avoids the most safety-sensitive code: **no change**
+  to the collision predicate's logic, the det(−1) transform, the solver, or the
+  tow-planner. The change is `+1 PartKind`, fleet data, rendering, and tests.
+
+### Negative
+
+- **Breaking change to the validity contract.** Currently-"valid" layouts where
+  a wing nests over a fin (or over a T-tail's high stabilizer), or where a
+  neighbour's low part overlaps a now-realistic ~3 m tailplane, flip to
+  **invalid**. This is intended — it is the defect surfacing — and the flipped
+  fixtures are enumerated in the PR.
+- Packing density drops wherever a fin or wide tailplane now blocks an
+  arrangement the old model allowed.
+- Each aircraft gains two placeholder tail parts to author and maintain
+  (`measured: false`), and the viewer bundle must be rebuilt (`viewer.js`) to
+  render them.
+
+### Neutral
+
+- **Amends ADR-0012's Neutral consequence.** ADR-0012 stated the empennage
+  "folds into `fuselage_aft` … a separate tail segment would add a kind with no
+  distinct rule." That is now false: the tail surfaces are separate parts, and
+  the fin *does* exercise a distinct outcome — though via the *uniform*
+  predicate, not a new rule. ADR-0012's front/aft split and the
+  `wing × fuselage_front` cockpit rule are unchanged and stay Accepted.
+- `fuselage_aft` still exists and still carries the aft fuselage tube; the legacy
+  `kind: fuselage` auto-split (ADR-0012 D2) is untouched. The tail surfaces are
+  *additional* parts alongside it.
+- `PartKind` stays a closed `Literal`, now six kinds; the alphabetical
+  conflict-kind taxonomy auto-derives `tail_wing_overlap`,
+  `vertical_stabilizer_wing_overlap`, `fuselage_aft_tail_overlap`, etc. with no
+  taxonomy code change.
+
+## Compliance
+
+- **`tests/test_collisions.py`** — three golden cases pin the model:
+  1. a wing nested over a neighbour's aft fuselage that passes *over* that
+     plane's fin → exactly one `vertical_stabilizer_wing_overlap` conflict (the
+     case silently accepted today);
+  2. the same nest with the wingtip *outboard* of the fin → still valid
+     (lateral-clearance pass-through);
+  3. a neighbour's low part (fuselage / strut / low wing) overlapping a
+     realistic-width horizontal stabilizer in plan view at a shared height →
+     conflict.
+- **The closed `PartKind` set** is asserted in the model tests; the new
+  `vertical_stabilizer` member is added there.
+- **`_is_wing_over_cockpit` stays pinned to `{wing, fuselage_front}`** — verified
+  by the existing cockpit tests continuing to pass and by the new fin retaining
+  the height clause; the predicate gains no branch.
+- **Fixture-flip audit.** The PR documents every fixture whose validity changes,
+  including whether the real [`examples/herrenteich/layout.yaml`](../../examples/herrenteich/layout.yaml)
+  all-eight arrangement flips.
+- No automated determinism / geometry guard is *triggered* (no `solver.py` /
+  `towplanner.py` / transform change), but the parts model is the subject, so the
+  relevant review subagents run at PR review.
+
+## More Information
+
+- Related ADRs: [ADR-0001](0001-aircraft-parts-model.md) (the parts model this
+  refines), [ADR-0012](0012-fuselage-front-aft-split.md) (front/aft split +
+  wing-over-tail nesting; its tail-fold-in Neutral consequence is amended here),
+  [ADR-0002](0002-determinant-minus-one-transform.md) (the transform left
+  untouched).
+- Related spec:
+  [`docs/superpowers/specs/2026-06-08-empennage-model-design.md`](../superpowers/specs/2026-06-08-empennage-model-design.md).
+- Related issues: epic [#518](https://github.com/DocGerd/hangarfit/issues/518),
+  [#519](https://github.com/DocGerd/hangarfit/issues/519) (horizontal
+  stabilizer), [#520](https://github.com/DocGerd/hangarfit/issues/520) (vertical
+  fin, safety-critical).
+- [§8 Crosscutting Concepts — "The parts model"](../architecture/08-crosscutting-concepts.md#the-parts-model)
+  — the operational statement, updated alongside this ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -89,7 +89,7 @@ manual workflow above is canonical.
 | 0009 | [Single supported Python — 3.12, anchored to the distro LTS](0009-single-supported-python-version.md) | Accepted |
 | 0010 | [Reeds–Shepp motion model — towplanner v2](0010-reeds-shepp-motion-model.md) | Accepted |
 | 0011 | [Linear history strategy under GitFlow — squash feature merges, accept release merge commits, target a clean first-parent mainline](0011-linear-history-strategy-under-gitflow.md) | Superseded by [ADR-0014](0014-merge-commit-only-history-strategy.md) |
-| 0012 | [Split the fuselage into front/aft so a wing may overhang a tail but not a cockpit](0012-fuselage-front-aft-split.md) | Accepted |
+| 0012 | [Split the fuselage into front/aft so a wing may overhang a tail but not a cockpit](0012-fuselage-front-aft-split.md) | Accepted (tail-fold-in neutral consequence amended by [ADR-0023](0023-empennage-tail-surfaces.md)) |
 | 0013 | [Wheel positions are canonical per-aircraft data; turn_radius_m stays empirical, cross-checked at load](0013-wheels-canonical-data.md) | Accepted |
 | 0014 | [Merge-commit-only history under GitFlow — squash/rebase disabled as a release-safety guardrail](0014-merge-commit-only-history-strategy.md) | Accepted |
 | 0015 | [Wheels do not participate in the static collision model (gear stays render/motion data)](0015-wheels-not-in-collision-model.md) | Accepted |
@@ -100,3 +100,4 @@ manual workflow above is canonical.
 | 0020 | [The viewer is a typed, modular TypeScript application built by a dev-only toolchain; the Python-owned transform is retained](0020-viewer-typescript-architecture.md) | Proposed |
 | 0021 | [Tow-planner staging apron — a bounded entry-staging start-region in front of the door; rearrangement holding-area deferred](0021-tow-planner-staging-apron.md) | Proposed |
 | 0022 | [Nose-out parked heading — RNG-free 180° flip post-pass (default on), plus the `tow_pivotable` towing-motion flag](0022-nose-out-parked-heading.md) | Accepted |
+| 0023 | [Model the empennage as explicit tail surfaces so a vertical fin in the wing layer can block wing-over-tail nesting](0023-empennage-tail-surfaces.md) | Proposed |

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -23,10 +23,13 @@ of the *same* aircraft are never checked against each other — a
 Husky's wing and its own strut share a plan-view column by design.
 
 **The fuselage front/aft exception.** The fuselage is split into two
-kinds, `fuselage_front` (cockpit / nose) and `fuselage_aft` (cabin-aft
-+ tail), so the rule can tell a wing-over-cockpit from a wing-over-tail.
+kinds, `fuselage_front` (cockpit / nose) and `fuselage_aft` (the
+cabin-aft tube), so the rule can tell a wing-over-cockpit from a
+wing-over-tail. (The tail *surfaces* are now explicit `tail` +
+`vertical_stabilizer` parts, no longer folded into `fuselage_aft` — see
+"The empennage" below and [ADR-0023](../adr/0023-empennage-tail-surfaces.md).)
 `wing × fuselage_aft` keeps the two-clause rule above (a wing may
-overhang another plane's tail when the heights are disjoint). But
+overhang another plane's aft fuselage when the heights are disjoint). But
 `wing × fuselage_front` is a **hard conflict on plan-view overlap
 alone — the height clause (2) is dropped**: a wing over a cockpit blocks
 the canopy / prop arc / pilot ingress at *any* nesting height. This is
@@ -69,22 +72,39 @@ gap is irrelevant -- the cockpit rule drops clause (2) entirely (ADR-0012, D1).
                         | z-gap >= wing_layer_clearance_m
          B fuselage  [############]   (lower layer)
 ```
-*A wingtip may overhang a parked plane's aft fuselage / tail (Case A: legal when heights are disjoint, the two-clause `wing × fuselage_aft` rule) but never its cockpit / front fuselage (Case B: a hard `fuselage_front_wing_overlap` conflict at any nesting height). The loader auto-splits a `fuselage` part at the wing trailing edge `x_break`; front is the nose side, aft the tail side.*
+*A wingtip may overhang a parked plane's aft fuselage / low tailplane (Case A: legal when heights are disjoint, the two-clause `wing × fuselage_aft` rule) but never its cockpit / front fuselage (Case B: a hard `fuselage_front_wing_overlap` conflict at any nesting height). The loader auto-splits a `fuselage` part at the wing trailing edge `x_break`; front is the nose side, aft the tail side. Since [ADR-0023](../adr/0023-empennage-tail-surfaces.md) Case A also requires the wing to clear the plane's centreline `vertical_stabilizer` (fin), which rises into the wing layer — see "The empennage" below.*
 
 The closed set of `PartKind` values is `{"fuselage_front",
-"fuselage_aft", "wing", "strut", "tail"}`. The legacy `"fuselage"` is
-**not** a constructed kind — it survives only as a transient YAML keyword
-the loader auto-splits at the wing trailing-edge station
-(`wing.offset_x_m − wing.length_m/2`, the #282 wing-spar precedent),
-emitting an area-conserving `fuselage_front` + `fuselage_aft` pair whose
-union is the original box. An aircraft with a `fuselage` part but no
-`wing` part is a load error (nothing to derive the break from); explicit
-`fuselage_front`/`fuselage_aft` parts in YAML are a valid override the
-loader does not split. Adding a new structural element (engine nacelle,
-ventral fin) is a code change in `src/hangarfit/models.py`, not just a
-YAML edit — see [ADR-0001](../adr/0001-aircraft-parts-model.md) for the
+"fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer"}`. The
+legacy `"fuselage"` is **not** a constructed kind — it survives only as a
+transient YAML keyword the loader auto-splits at the wing trailing-edge
+station (`wing.offset_x_m − wing.length_m/2`, the #282 wing-spar
+precedent), emitting an area-conserving `fuselage_front` + `fuselage_aft`
+pair whose union is the original box. An aircraft with a `fuselage` part
+but no `wing` part is a load error (nothing to derive the break from);
+explicit `fuselage_front`/`fuselage_aft` parts in YAML are a valid
+override the loader does not split. Adding a new structural element (e.g.
+an engine nacelle) is a code change in `src/hangarfit/models.py`, not just
+a YAML edit — see [ADR-0001](../adr/0001-aircraft-parts-model.md) for the
 parts-not-bbox rationale and [ADR-0012](../adr/0012-fuselage-front-aft-split.md)
 for the front/aft refinement.
+
+**The empennage** ([ADR-0023](../adr/0023-empennage-tail-surfaces.md)).
+Each aircraft carries two explicit tail surfaces: `tail` (the horizontal
+stabilizer — wide, ~2.5–3.5 m span, at a per-aircraft height) and
+`vertical_stabilizer` (the fin + rudder — thin, on the centreline, rising
+from the fuselage top to the published overall height, *into* the wing
+layer). No collision-rule change is needed: the same two-clause predicate
+makes a wing nested over a neighbour's tail conflict with that plane's fin
+**only when the wing also overlaps the thin centreline fin in plan view** —
+i.e. wing-over-tail nesting stays legal exactly when the wing clears the
+fin laterally. Per-part z expresses every tail configuration with no
+per-type code: conventional / cruciform tails sit the horizontal
+stabilizer *below* the wing layer (z-disjoint from an overhanging high
+wing, so it stays overhangable); a T-tail (the Stemme S10) sits it at the
+fin top *inside* the wing layer (so an overhanging wing conflicts).
+The fin is never overhangable; `metrics._OVERHANGABLE` keeps only `tail`
+and `fuselage_aft`.
 
 **Fleet composition relevant to the parts model.** Of the nine
 aircraft in `data/fleet.yaml`, six are **strut-braced** (the Aviat
@@ -96,10 +116,11 @@ which plane is low-wing — drive the operationally interesting cases
 of the collision rule: strut-braced planes block another plane's
 wing from nesting through their wing volume, and the only low-wing
 allows a high-wing's wingtip to legally project over its **aft
-fuselage / tail** in plan view (the height-disjoint pass-through case)
-— but *not* over its **cockpit / front fuselage**, which is a hard
-conflict regardless of height (the front/aft split, ADR-0012).
-Per-plane dimensions, gear types, and movement modes live in
+fuselage / low tailplane** in plan view (the height-disjoint pass-through
+case) — but *not* over its **cockpit / front fuselage**, which is a hard
+conflict regardless of height (the front/aft split, ADR-0012), and *not*
+over its **fin** (`vertical_stabilizer`), which rises into the wing layer
+(ADR-0023). Per-plane dimensions, gear types, and movement modes live in
 `data/fleet.yaml` as the source of truth.
 
 ### The maintenance bay rule
@@ -425,12 +446,15 @@ amendment).
 The two-clause predicate is symmetric in the two clearances: a
 collision requires *both* the plan-view and the height-gap thresholds
 to be violated simultaneously. This is what lets a high-wing's
-wingtip legally project over a low-wing's **aft fuselage / tail**
+wingtip legally project over a low-wing's **aft fuselage / low tailplane**
 (close in plan view, far in height) — see ADR-0001. The **one
 exception** is `wing × fuselage_front`: a wing over a cockpit is a hard
 conflict on plan-view overlap alone, with the height clause dropped
 (ADR-0012). `wing_layer_clearance_m` therefore governs every pair
-*except* wing-over-cockpit.
+*except* wing-over-cockpit — including `wing × vertical_stabilizer`, where
+the fin's reach *into* the wing layer is exactly what makes the height
+gap small enough to bite when a wing passes over the centreline fin
+(ADR-0023).
 
 ## Data integrity: frozen dataclasses + `__post_init__` invariants
 

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -52,7 +52,7 @@ Split station x_break = wing.offset_x_m - wing.length_m/2  (the wing TRAILING ed
               |   tail (-y, near door)                      |   tail (-y, near door)
         +-----------+                                 +-----------+
         |           |                                 |:::::::::::|
-        |           |  ... fuselage_aft (TAIL)        |::::: A :::|
+        |           |  ... fuselage_aft (CABIN-AFT)    |::::: A :::|
    - - -|:::::::::::|- - - x_break (wing TE) - - - - -|           |- - - x_break - - -
         |::::: A :::|                                 |           |
         +-----------+  ... fuselage_front (COCKPIT)   +-----------+

--- a/docs/superpowers/plans/2026-06-08-empennage-model.md
+++ b/docs/superpowers/plans/2026-06-08-empennage-model.md
@@ -1,0 +1,562 @@
+# Empennage Tail-Surface Model — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task (inline execution recommended — the fallout phase, Task 8, is observe-and-re-pin and needs live test output). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model each aircraft's empennage as two explicit oriented-rectangle `Part`s — a wide horizontal stabilizer (reusing the existing `tail` kind) and a thin, tall vertical fin (new `vertical_stabilizer` kind) — so the existing two-clause collision predicate catches a fin rising into the wing-nesting layer (#520) and a tailplane wider than the fuselage tube (#519), with no predicate change.
+
+**Architecture:** Per ADR-0023. The collision predicate (`collisions._parts_conflict`) is unchanged; correctness falls out of the existing plan-view-overlap-then-z-gap rule once the parts carry honest z-extents. Per-part z expresses conventional / cruciform / T-tail configs. Blast radius: `+1 PartKind`, fleet data ×2, 2D render branch, tests, docs. **Not touched:** the predicate logic, the det(−1) transform, `geometry.py`, `solver.py`, `towplanner.py`, the loader, `scene.py`, and the viewer TypeScript (the new parts render in the 3D viewer for free via `scene.py`'s kind-pass-through + `boxMaterial`'s opaque-body fall-through — so **no `viewer.js` rebuild**).
+
+**Tech Stack:** Python 3.12, pytest, ruff, mypy. Geometry via shapely (already wired). YAML fleet data.
+
+**Spec:** [`docs/superpowers/specs/2026-06-08-empennage-model-design.md`](../specs/2026-06-08-empennage-model-design.md). **ADR:** [`docs/adr/0023-empennage-tail-surfaces.md`](../../adr/0023-empennage-tail-surfaces.md) (committed `02df1c1`).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/hangarfit/models.py` | `PartKind` closed set | add `"vertical_stabilizer"` to the `Literal` (line 28) |
+| `src/hangarfit/visualize.py` | 2D part render switch | add a `vertical_stabilizer` branch to `_draw_part` (the `else` fails loud) |
+| `src/hangarfit/collisions.py` | the predicate | **no logic**; one clarifying comment in `_is_wing_over_cockpit` |
+| `src/hangarfit/metrics.py` | overhang metric | **no logic**; one comment why the fin is excluded from `_OVERHANGABLE` |
+| `data/fleet.yaml` | synthetic fleet | add `tail` + `vertical_stabilizer` parts to all 9 aircraft |
+| `examples/herrenteich/fleet.yaml` | real-spec fleet | add the two parts to all 8 (incl. the `stemme_s10` T-tail) |
+| `tests/test_models.py` | closed-set assertion | add `"vertical_stabilizer"` to the parametrize list (line 96) |
+| `tests/fuzz/geometry_strategies.py` | fuzz kind list | add `"vertical_stabilizer"` (line 54) |
+| `tests/test_visualize.py` | render coverage | add a `vertical_stabilizer`-renders test |
+| `tests/test_collisions.py` | golden tests | new `TestEmpennage` class (3 cases) |
+| `tests/fixtures/*.yaml` | new + re-pinned fixtures | 3 new goldens; re-tune/re-pin flipped existing ones |
+| `docs/architecture/08-crosscutting-concepts.md` | operational statement | 6th kind + tail-surface prose |
+| `CHANGELOG.md` | breaking-change entry | list flipped fixtures |
+| `examples/herrenteich/AUDIT-518.md` *(or PR body)* | fixture-flip audit record | which fixtures flipped & why |
+
+---
+
+## Task 1: Add the `vertical_stabilizer` PartKind
+
+**Files:**
+- Modify: `src/hangarfit/models.py:28`
+- Modify: `tests/test_models.py:96`
+- Modify: `tests/fuzz/geometry_strategies.py:54`
+
+- [ ] **Step 1: Add the new kind to the closed-set test (failing first)**
+
+In `tests/test_models.py`, change the parametrize list at line 96 from:
+```python
+    @pytest.mark.parametrize("kind", ["fuselage_front", "fuselage_aft", "wing", "strut", "tail"])
+```
+to:
+```python
+    @pytest.mark.parametrize(
+        "kind", ["fuselage_front", "fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer"]
+    )
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pytest tests/test_models.py -k test_all_valid_kinds_accepted -q`
+Expected: FAIL on `kind="vertical_stabilizer"` — `ValueError: Part.kind must be one of [...]` (the kind isn't valid yet).
+
+- [ ] **Step 3: Add the kind to the `PartKind` Literal**
+
+In `src/hangarfit/models.py:28`, change:
+```python
+PartKind = Literal["fuselage_front", "fuselage_aft", "wing", "strut", "tail"]
+```
+to:
+```python
+PartKind = Literal["fuselage_front", "fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer"]
+```
+(`_VALID_PART_KINDS` at line 30 auto-derives via `get_args`; no other models.py change.)
+
+- [ ] **Step 4: Keep the fuzz strategy in sync**
+
+In `tests/fuzz/geometry_strategies.py:54`, change:
+```python
+_PART_KINDS = ["fuselage_front", "fuselage_aft", "wing", "strut", "tail"]
+```
+to:
+```python
+_PART_KINDS = ["fuselage_front", "fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer"]
+```
+
+- [ ] **Step 5: Run to confirm green**
+
+Run: `pytest tests/test_models.py -q`
+Expected: PASS (all kinds, incl. `vertical_stabilizer`, accepted; the invalid-kind test still rejects `"fuselage"`/bogus kinds).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_models.py tests/fuzz/geometry_strategies.py
+git commit -m "feat(models): #520 add vertical_stabilizer PartKind (fin)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Render `vertical_stabilizer` in the 2D visualizer
+
+The `_draw_part` switch (`visualize.py:371-434`) raises `ValueError` on any unhandled kind (closed-type fail-loud). The fin needs a branch. Render it as an **opaque, ink-edged thin polygon at `zorder=3`** (above wings) — it is a solid obstacle that pokes up into/above the wing layer, so drawing it on top is the height cue.
+
+**Files:**
+- Modify: `src/hangarfit/visualize.py` (`_draw_part`, the `elif` chain)
+- Modify: `tests/test_visualize.py` (mirror the existing `test_tail_kind_renders_without_exception`)
+
+- [ ] **Step 1: Write the failing render test**
+
+In `tests/test_visualize.py`, next to `TestDrawPartHandlesTailKind` (≈ line 458), add:
+```python
+    def test_vertical_stabilizer_kind_renders_without_exception(self) -> None:
+        """A vertical_stabilizer (fin) part renders via its own branch, not
+        the fail-loud else (#520)."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        from hangarfit.geometry import WorldPart
+        from shapely.geometry import Polygon
+
+        fig, ax = plt.subplots()
+        fin = WorldPart(
+            polygon=Polygon([(0, 0), (0.15, 0), (0.15, 1.2), (0, 1.2)]),
+            z_bottom_m=1.5,
+            z_top_m=2.4,
+            plane_id="p",
+            kind="vertical_stabilizer",
+        )
+        _draw_part(ax, fin, "#0079B5")  # must not raise
+        plt.close(fig)
+```
+> Adjust the imports/`_draw_part` reference to match the file's existing test idiom (the tail test next to it shows the exact pattern — mirror it, including how `_draw_part` is imported and how `WorldPart` is built).
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pytest tests/test_visualize.py -k vertical_stabilizer -q`
+Expected: FAIL — `ValueError: _draw_part: unhandled part kind 'vertical_stabilizer'`.
+
+- [ ] **Step 3: Add the render branch**
+
+In `src/hangarfit/visualize.py` `_draw_part`, add an `elif` **before** the `else:` (after the `strut` branch):
+```python
+    elif part.kind == "vertical_stabilizer":
+        # The fin: a thin centreline surface that rises into / above the wing
+        # layer (ADR-0023). Drawn opaque and ink-edged on top (zorder above the
+        # wing) so its height — invisible in a top-down view — reads as "this
+        # pokes up through the wing band."
+        patch = MplPolygon(
+            coords,
+            closed=True,
+            facecolor=color,
+            edgecolor=_INK_EDGE,
+            alpha=_FUSELAGE_ALPHA,
+            lw=0.5,
+            zorder=4,
+        )
+```
+Also update the `_draw_part` docstring's part-by-part list to mention the fin (one clause).
+
+- [ ] **Step 4: Run to confirm green**
+
+Run: `pytest tests/test_visualize.py -q`
+Expected: PASS (incl. the existing `test_unknown_part_kind_raises`, which uses a *bogus* kind and still raises).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/visualize.py tests/test_visualize.py
+git commit -m "feat(visualize): #520 render vertical_stabilizer (fin) as opaque top-layer cue
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Golden collision tests (inline-constructed, predicate-unchanged proof)
+
+Three goldens built from **synthetic inline aircraft** (the `TestBayIntrusion._build_layout` pattern, `test_collisions.py:275-371`) so the geometry is fully controlled and independent of placeholder fleet data. All use `heading_deg=0.0` and axis-aligned parts so world coords are easy to reason about; **verify** each lands as intended by running `check` and inspecting `result.conflicts`, nudging offsets until exact.
+
+These tests **pass as soon as `vertical_stabilizer` exists (Task 1)** with no predicate change — that passing IS the proof that ADR-0023 D3 needs no new branch.
+
+**Files:**
+- Modify: `tests/test_collisions.py` (new `TestEmpennage` class + a module-level `_empennage_layout` helper)
+
+- [ ] **Step 1: Add the helper + the three tests**
+
+Append to `tests/test_collisions.py`:
+```python
+class TestEmpennage:
+    """ADR-0023: the empennage as explicit tail surfaces. The predicate is
+    unchanged — these lock that honest tail z-extents produce the physically
+    correct verdict (fin in the wing layer blocks a nest that passes over it;
+    a wing that clears the fin laterally still nests; a wide tailplane clips a
+    neighbour's low part)."""
+
+    def _layout(self, *, nester_offset_y_m: float, nester_kind: str = "wing",
+                nester_z: tuple[float, float] = (2.0, 2.3)):
+        from hangarfit.models import (
+            Aircraft, Door, Hangar, Layout, Part, Placement, Wheels,
+        )
+
+        # HOST: a parked plane with a low aft fuselage (z 0..1.5), a low wide
+        # tailplane (`tail`, z 1.2..1.5), and a tall thin centreline fin
+        # (`vertical_stabilizer`, z 1.5..2.4 — into the 2.0..2.3 wing band).
+        host = Aircraft(
+            id="host", name="Host", wing_position="high", gear="tailwheel",
+            movement_mode="always_own_gear", turn_radius_m=5.0, measured=False,
+            parts=(
+                Part(kind="fuselage_aft", length_m=3.0, width_m=0.85,
+                     offset_x_m=-1.5, offset_y_m=0.0, angle_deg=0.0,
+                     z_bottom_m=0.0, z_top_m=1.5),
+                Part(kind="tail", length_m=1.0, width_m=3.0,
+                     offset_x_m=-2.8, offset_y_m=0.0, angle_deg=0.0,
+                     z_bottom_m=1.2, z_top_m=1.5),
+                Part(kind="vertical_stabilizer", length_m=1.2, width_m=0.15,
+                     offset_x_m=-2.8, offset_y_m=0.0, angle_deg=0.0,
+                     z_bottom_m=1.5, z_top_m=2.4),
+            ),
+            wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-3.0),
+        )
+        # NESTER: a single part whose footprint sits over the host's tail region.
+        nester = Aircraft(
+            id="nester", name="Nester", wing_position="high", gear="tailwheel",
+            movement_mode="always_own_gear", turn_radius_m=5.0, measured=False,
+            parts=(
+                Part(kind=nester_kind, length_m=4.0, width_m=4.0,
+                     offset_x_m=0.0, offset_y_m=0.0, angle_deg=0.0,
+                     z_bottom_m=nester_z[0], z_top_m=nester_z[1]),
+            ),
+            wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-3.0),
+        )
+        hangar = Hangar(
+            length_m=40.0, width_m=20.0, door=Door(center_x_m=10.0, width_m=12.0),
+            maintenance_bay=None, clearance_m=0.3, wing_layer_clearance_m=0.2,
+        )
+        return Layout(
+            fleet={"host": host, "nester": nester}, hangar=hangar,
+            placements=(
+                Placement(plane_id="host", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False),
+                Placement(plane_id="nester", x_m=10.0, y_m=10.0 + nester_offset_y_m,
+                          heading_deg=0.0, on_carts=False),
+            ),
+            maintenance_plane=None,
+        )
+
+    def test_fin_blocks_wing_nesting(self) -> None:
+        """#520 safety case: a wing footprint passing OVER the host's centreline
+        fin (fin z_top 2.4 in the wing band) conflicts — silently valid today."""
+        # nester directly over host (offset 0): its wing covers the fin.
+        result = check(self._layout(nester_offset_y_m=0.0))
+        assert not result.valid
+        assert "vertical_stabilizer_wing_overlap" in _conflict_kinds(result), result.conflicts
+
+    def test_wing_clears_fin_laterally_is_valid(self) -> None:
+        """#520 nuance: shift the nester wing so its footprint passes OUTBOARD
+        of the thin centreline fin (no plan-view overlap with the fin) -> still
+        valid (the lateral-clearance pass-through)."""
+        # Tune offset so the wing footprint clears the fin in plan view but not
+        # the (low, z-disjoint) tail/aft fuselage. Verify by inspecting conflicts.
+        result = check(self._layout(nester_offset_y_m=6.0))
+        assert result.valid, result.conflicts
+
+    def test_wide_tailplane_clips_neighbour_low_part(self) -> None:
+        """#519: a neighbour's low part (here a fuselage_aft at z 0..1.5) that
+        overlaps the host's now-realistic ~3 m tailplane in plan view at a
+        shared z-band conflicts (free space under the old narrow model)."""
+        result = check(self._layout(
+            nester_offset_y_m=2.5, nester_kind="fuselage_aft", nester_z=(0.0, 1.5)))
+        assert not result.valid
+        assert any(k.endswith("_tail_overlap") for k in _conflict_kinds(result)), result.conflicts
+```
+
+- [ ] **Step 2: Run the three tests and TUNE offsets to land exactly**
+
+Run: `pytest tests/test_collisions.py::TestEmpennage -q`
+Expected after tuning: PASS. If a case doesn't land:
+- Print `[(c.kind, c.detail) for c in check(...).conflicts]` to see what overlapped.
+- For `test_fin_blocks...`: the nester wing (4×4 at offset 0) must cover the host fin at host-local `offset_x=-2.8`. If the world overlap misses, adjust `nester_offset_y_m` toward the host tail.
+- For `test_wing_clears_fin_laterally...`: increase `nester_offset_y_m` until the wing footprint no longer overlaps the fin **and** check reports `valid` (no tail/fin conflict). The fin is thin (0.15 m on centreline), so a lateral shift clears it while the low tail stays z-disjoint from the high wing.
+- For `test_wide_tailplane...`: the neighbour `fuselage_aft` (z 0..1.5) must overlap the host `tail` (z 1.2..1.5 → z-overlap) in plan view.
+> These offsets are tuned by observation exactly as the existing wing-over-tail fixtures were; the det(−1) transform makes hand-prediction error-prone, so iterate against `check` output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_collisions.py
+git commit -m "test(collisions): #518 empennage goldens — fin blocks nest, lateral clear, wide tailplane
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Add tail surfaces to `data/fleet.yaml` (all 9 aircraft)
+
+Insert the two parts **after the `wing` part** in each aircraft's `parts:` list (before `struts:` where present). Values below are derived from each plane's real fuselage/wing geometry: `tail`/`vertical_stabilizer` `offset_x_m` ≈ aft-fuselage end + chord/2; tailplane z held below `wing.z_bottom_m − 0.2` (stays overhangable); fin z from the fuselage top up to the published overall height. All `measured: false` (placeholders).
+
+**Files:**
+- Modify: `data/fleet.yaml`
+
+- [ ] **Step 1: Add a header comment** near the top of `data/fleet.yaml` documenting the addition:
+```yaml
+# Empennage (ADR-0023, #518/#519/#520): each aircraft carries a `tail` (horizontal
+# stabilizer/elevator — wide, low for conventional/cruciform tails) and a
+# `vertical_stabilizer` (fin+rudder — thin, tall, rising to the published overall
+# height into the wing layer). Spans/chords are published-spec-absent estimates;
+# tail configs + overall heights are sourced. All measured: false.
+```
+
+- [ ] **Step 2: Insert the two parts per aircraft** (exact blocks):
+
+`scheibe_falke`:
+```yaml
+      - kind: tail
+        length_m: 0.9
+        width_m: 2.6
+        offset_x_m: -3.35
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer
+        length_m: 1.1
+        width_m: 0.15
+        offset_x_m: -3.25
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 1.68
+```
+`aviat_husky`: tail `0.9?`→ `length_m: 1.0, width_m: 3.0, offset_x_m: -4.66, z 1.2..1.5`; fin `length_m: 1.3, width_m: 0.15, offset_x_m: -4.51, z 1.5..2.01`.
+`fuji`: tail `length_m: 1.1, width_m: 3.2, offset_x_m: -3.84, z 1.3..1.6`; fin `length_m: 1.3, width_m: 0.15, offset_x_m: -3.74, z 1.6..2.02`.
+`wild_thing`: tail `length_m: 0.9, width_m: 2.9, offset_x_m: -3.18, z 1.1..1.4`; fin `length_m: 1.0, width_m: 0.15, offset_x_m: -3.13, z 1.4..1.9`.
+`zlin_savage`: tail `length_m: 0.9, width_m: 2.8, offset_x_m: -4.35, z 1.2..1.5`; fin `length_m: 1.1, width_m: 0.15, offset_x_m: -4.25, z 1.5..2.03`.
+`cessna_140`: tail `length_m: 1.1, width_m: 3.2, offset_x_m: -4.37, z 1.2..1.5`; fin `length_m: 1.2, width_m: 0.15, offset_x_m: -4.32, z 1.5..1.91`.
+`cessna_150`: tail `length_m: 1.1, width_m: 3.4, offset_x_m: -3.06, z 1.2..1.5`; fin `length_m: 1.4, width_m: 0.15, offset_x_m: -2.91, z 1.5..2.11`.
+`ctsl` (cruciform — tailplane low/mid, kept below wing layer): tail `length_m: 0.9, width_m: 2.6, offset_x_m: -3.18, z 1.1..1.4`; fin (tall, 2.34) `length_m: 1.2, width_m: 0.15, offset_x_m: -3.03, z 1.4..2.34`.
+`fk9_mkii`: tail `length_m: 0.9, width_m: 3.2, offset_x_m: -2.77, z 1.1..1.4`; fin `length_m: 1.1, width_m: 0.15, offset_x_m: -2.67, z 1.4..2.15`.
+
+> Use the same YAML shape as the `scheibe_falke` block for every aircraft, substituting the values above. `offset_y_m: 0.0` and (implicit) `angle_deg: 0` for all.
+
+- [ ] **Step 3: Confirm the fleet loads**
+
+Run: `python -c "from hangarfit.loader import load_fleet; f = load_fleet('data/fleet.yaml'); [print(k, [p.kind for p in a.parts]) for k,a in f.items()]"`
+> (Use the actual loader entry point — check `loader.py` for `load_fleet`/`_load_fleet`; if the only public path is `load_layout`, load a fixture instead.)
+Expected: each aircraft now lists `... wing, tail, vertical_stabilizer (, strut, strut)`. No `LoaderError`.
+
+- [ ] **Step 4: Do NOT commit yet** — committing happens after Task 8 re-pins the fallout, so the data + the fixed expectations land together. Proceed to Task 5.
+
+---
+
+## Task 5: Add tail surfaces to `examples/herrenteich/fleet.yaml` (all 8, incl. the T-tail)
+
+Same shape. Aircraft shared with `data/` (`aviat_husky`, `zlin_savage`, `cessna_140`, `ctsl`, `fk9_mkii`) use the **same** values as Task 4. Herrenteich-specific:
+
+**Files:**
+- Modify: `examples/herrenteich/fleet.yaml`
+
+- [ ] **Step 1: Insert per aircraft.** Shared five → Task 4 values. Herrenteich-specific:
+
+`scheibe_falke` (fuselage 7.58×1.1): tail `length_m: 0.9, width_m: 2.6, offset_x_m: -3.34, z 1.2..1.5`; fin `length_m: 1.1, width_m: 0.15, offset_x_m: -3.24, z 1.5..1.68`.
+`wild_thing` (fuselage 6.49): tail `length_m: 0.9, width_m: 2.9, offset_x_m: -3.13, z 1.1..1.4`; fin `length_m: 1.0, width_m: 0.15, offset_x_m: -3.08, z 1.4..1.9`.
+`stemme_s10` (**T-tail** — tailplane at the fin top, in/near the wing band; fuselage 8.42×1.18, overall height 1.80):
+```yaml
+      - kind: tail
+        # T-tail: horizontal stabilizer sits HIGH, at the fin top (ADR-0023).
+        length_m: 0.8
+        width_m: 2.8
+        offset_x_m: -5.31
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 1.8
+      - kind: vertical_stabilizer
+        length_m: 1.0
+        width_m: 0.15
+        offset_x_m: -5.21
+        offset_y_m: 0.0
+        z_bottom_m: 1.4
+        z_top_m: 1.8
+```
+> The folded Stemme's published height (1.80 m) is below the 2.0 m wing layer, so its real tail does not actually block a neighbour's high wing — that is honest. The T-tail *conflict* is demonstrated by the synthetic golden (Task 3), not this real plane.
+
+- [ ] **Step 2: Confirm it loads** (same command as Task 4 Step 3, on `examples/herrenteich/fleet.yaml`). No commit yet.
+
+---
+
+## Task 6: Audit the collisions predicate + metrics (comments only)
+
+- [ ] **Step 1: Add a clarifying comment in `collisions.py`** at `_is_wing_over_cockpit` (line 315) confirming the fin is deliberately *not* in the cockpit exception:
+```python
+    # NB: only fuselage_front (cockpit) drops the height clause. A
+    # vertical_stabilizer (fin) is NOT here on purpose (ADR-0023): it keeps the
+    # uniform two-clause rule, so a wing conflicts with a fin only when it both
+    # overlaps the thin centreline fin in plan view AND their z-bands meet —
+    # i.e. wing-over-tail stays legal iff the wing clears the fin laterally.
+```
+
+- [ ] **Step 2: Add a comment in `metrics.py`** at `_OVERHANGABLE` (line 20) noting the fin's exclusion:
+```python
+# (vertical_stabilizer is deliberately absent: a wing over a fin is a conflict,
+# not an overhang — ADR-0023.)
+```
+
+- [ ] **Step 3: Run the metrics + collisions suites** to confirm no logic regressed:
+
+Run: `pytest tests/test_metrics.py tests/test_collisions.py -q`
+Expected: `TestEmpennage` green; **other failures here are the intended fallout** addressed in Task 8 (the inline metrics tests use their own fixtures — note any that flip).
+
+---
+
+## Task 7: Update arc42 §8 "The parts model"
+
+**Files:**
+- Modify: `docs/architecture/08-crosscutting-concepts.md`
+
+- [ ] **Step 1: The PartKind set statement (line 74-75).** Change:
+```
+The closed set of `PartKind` values is `{"fuselage_front",
+"fuselage_aft", "wing", "strut", "tail"}`.
+```
+to:
+```
+The closed set of `PartKind` values is `{"fuselage_front",
+"fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer"}`.
+The empennage is now two explicit surfaces (ADR-0023): `tail` (the
+horizontal stabilizer — wide, usually low) and `vertical_stabilizer`
+(the fin + rudder — thin, tall, rising into the wing layer), no longer
+folded into `fuselage_aft`.
+```
+
+- [ ] **Step 2: The front/aft prose (lines 26-27).** Change `fuselage_aft` (cabin-aft + tail)` to `fuselage_aft` (cabin-aft tube)` and add one sentence: "The tail *surfaces* are now separate `tail` + `vertical_stabilizer` parts (ADR-0023), not part of `fuselage_aft`."
+
+- [ ] **Step 3: Add a short empennage paragraph** after the PartKind-set paragraph explaining the fin's role in nesting (legal iff the wing clears the fin laterally; conventional/cruciform/T-tail expressed by per-part z). Keep it ≤ 6 lines; link ADR-0023.
+
+- [ ] **Step 4: Touch the "aft fuselage / tail" mentions** (caption ~line 72, fleet note ~line 98-99, symmetry note ~line 428) so they don't imply the tail is *inside* `fuselage_aft` — re-word to "aft fuselage (and the low `tail` surface)" where the height-disjoint pass-through is described, and note the fin is the exception that can block it.
+
+- [ ] **Step 5: Commit the docs** (with Tasks 1-3 already committed; this can be its own commit):
+```bash
+git add docs/architecture/08-crosscutting-concepts.md src/hangarfit/collisions.py src/hangarfit/metrics.py
+git commit -m "docs(arc42): #518 empennage tail surfaces in the parts model + predicate/metric notes
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Run the full suite, triage the fallout, re-pin (the breaking change)
+
+This is the iterative heart. Adding tail surfaces to `data/fleet.yaml` changes the geometry of every fixture's planes; existing collision goldens pin exact penetration areas / conflict-kind sets / counts and will move.
+
+**Triage criterion for each failing test/fixture:**
+- **A new conflict that is physically real** (a wing over a fin; a wide tailplane over a neighbour's low part) → the flip is the feature. Re-pin the expectation (or rename `valid_*` → `invalid_*`) and record it in the audit.
+- **A `valid_*` fixture that should stay a positive control** (e.g. wing-over-tail that should still demonstrate legal nesting) → re-tune its placement so the wing clears the fin **laterally** (preserving a valid wing-over-tail-but-clears-fin control), rather than deleting the case.
+- **A changed penetration `m²` / conflict count** in an `invalid_*` golden → recompute and re-pin the exact number; add the new tail-related kinds to the expected set.
+- **Never** tune fin/tailplane *dimensions* to make a test pass — dimensions are fixed by Tasks 4-5; only placements/expectations move.
+
+- [ ] **Step 1: Run the whole suite and capture failures**
+
+Run: `pytest -q -m "" 2>&1 | tee /tmp/empennage-fallout.txt | tail -40`
+(`-m ""` runs slow+serial too, so the audit sees everything.)
+
+- [ ] **Step 2: Triage the known-likely flips first.** For each, decide per the criterion and apply:
+  - `valid_wing_over_tail.yaml` / `valid_high_over_low_aft_z_disjoint.yaml`: the `ctsl` wing overhangs `fuji`'s aft — now likely covers `fuji`'s fin (z 1.6..2.02 ∩ ctsl wing 1.9..2.2) → flips invalid. **Action:** keep one as the *lateral-clearance positive control* by nudging `ctsl`'s `x_m`/`fuji`'s heading so the wing tip passes outboard of `fuji`'s centreline fin (re-verify `valid`); convert the other to `invalid_wing_over_fin.yaml` asserting `vertical_stabilizer_wing_overlap` (the #520 case on real data). Update `test_collisions.py` accordingly.
+  - `invalid_wing_wing_same_height.yaml` (golden 5.54045 m²), `invalid_strut_blocks_nesting.yaml` (2.85 m²), `invalid_fuselage_*`, `invalid_wing_over_cockpit.yaml`: recompute penetration/kind-set/count with the new parts; re-pin.
+  - `valid_left_side_nesting.yaml`, `valid_right_side_nesting.yaml`, `valid_all_nine_planes.yaml`: re-run; if they flip, re-tune placements to restore validity where the intent is a *valid* nest, else re-pin.
+  - `examples/layouts/example.yaml`: re-run `hangarfit check examples/layouts/example.yaml`; if invalid, re-nudge placements (as #50 did) so it stays a valid demo, OR document it now requires more spacing.
+
+- [ ] **Step 3: The Herrenteich real-layout check (spec step 4).**
+
+Run: `hangarfit check examples/herrenteich/layout.yaml`
+Record the verdict. If it flips to invalid, **do not** adjust fin heights — report it as a finding (real tight clearance vs. placeholder aggressiveness) and, if it's a real-data concern, file a follow-up issue. Note the conflict kinds in the audit.
+
+- [ ] **Step 4: Iterate** Steps 1-2 until `pytest -q -m ""` is green, re-pinning each golden with the recomputed exact values.
+
+- [ ] **Step 5: Write the fixture-flip audit.** Create `examples/herrenteich/AUDIT-518.md` *(or a section in the PR body)* listing every fixture/example whose validity or golden changed, the new verdict/value, and why. This satisfies the epic's "Document which currently-'valid' fixtures flip to invalid."
+
+- [ ] **Step 6: Lint, format, type-check.**
+
+```bash
+ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/
+```
+Expected: clean. Fix any issues.
+
+- [ ] **Step 7: Visual smoke (2D + 3D render the tail surfaces).**
+
+```bash
+hangarfit check examples/layouts/example.yaml --render /tmp/empennage-2d.png   # tail + fin drawn
+hangarfit view tests/fixtures/valid_left_side_nesting.yaml -o /tmp/empennage-3d.html
+```
+Confirm the 2D PNG shows the thin centreline fins + wide tailplanes, and the viewer HTML builds (the fin/tail render as boxes via scene.py pass-through — no viewer rebuild needed). Surface both to the user with `SendUserFile`.
+
+- [ ] **Step 8: Commit the data + re-pinned fixtures + audit.**
+
+```bash
+git add data/fleet.yaml examples/herrenteich/fleet.yaml tests/fixtures/ tests/test_collisions.py examples/herrenteich/AUDIT-518.md
+git commit -m "feat(fleet): #519 #520 empennage tail surfaces + re-pin flipped fixtures
+
+Adds tail (horizontal stab) + vertical_stabilizer (fin) parts to every aircraft
+in data/ and examples/herrenteich/. Breaking change to the validity contract:
+re-pins/renames the fixtures whose verdict or golden moved (see AUDIT-518).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: CHANGELOG + open the PR + review arc
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: CHANGELOG entry** under `## [Unreleased]`:
+```markdown
+### Changed
+- **BREAKING (collision model): the empennage is now modelled as explicit tail
+  surfaces (#518/#519/#520, ADR-0023).** Each aircraft carries a `tail`
+  (horizontal stabilizer) and a new `vertical_stabilizer` (fin) part with honest
+  z-extent, so the checker now rejects a wing nested over a neighbour's fin and a
+  wing/strut/fuselage clipping a realistic-width tailplane — cases silently
+  reported valid before. Some previously-"valid" layouts flip to invalid; see the
+  PR's fixture-flip audit. The collision predicate itself is unchanged.
+```
+
+- [ ] **Step 2: Push + open the draft PR.**
+
+```bash
+git push -u origin feature/518-empennage-model
+gh pr create --draft --base develop \
+  --title "feat: model the empennage tail surfaces (horizontal stab + fin)" \
+  --body "$(cat <<'EOF'
+Closes #519
+Closes #520
+Refs #518
+
+Models the empennage as two explicit oriented-rectangle Parts per ADR-0023: a
+wide `tail` (horizontal stabilizer) and a thin tall `vertical_stabilizer` (fin).
+The existing two-clause collision predicate is unchanged — honest z-extents make
+it catch a fin in the wing layer (#520) and a tailplane wider than the fuselage
+(#519). Per-part z expresses conventional / cruciform / T-tail (Stemme S10).
+
+**Breaking change:** previously-"valid" wing-over-tail nestings that pass over a
+fin, and side-by-side layouts overlapping a realistic tailplane, flip to invalid.
+Fixture-flip audit: see AUDIT-518 / below.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+> `#518` is the epic — use `Refs #518` (it closes when both subs land), `Closes #519`/`Closes #520` in the body.
+
+- [ ] **Step 3: Run the review arc** (per CLAUDE.md, every PR): `pr-review-toolkit:code-reviewer` (main pass) + `pr-review-toolkit:type-design-analyzer` (models.py changed) + `pr-review-toolkit:silent-failure-hunter` is **not** required (loader untouched) but `geometry-invariant-guard` should confirm `geometry.py`/`collisions.py` logic is untouched. Convert findings to diff threads, fix or reply+resolve, re-run if non-trivial.
+
+- [ ] **Step 4: When the arc is clean**, `gh pr ready <n>` and tell the user it's clean and ready for final review. Do **not** merge.
+
+---
+
+## Self-Review (against the spec)
+
+- **Spec coverage:** model (Task 1) ✓; data both files incl. T-tail (Tasks 4-5) ✓; predicate audited not changed (Task 6) ✓; 2D render (Task 2) + 3D via pass-through (Task 8 Step 7) ✓; metrics `_OVERHANGABLE` unchanged (Task 6) ✓; 3 golden cases (Task 3) ✓; closed-set test (Task 1) ✓; fixture-flip audit incl. Herrenteich (Task 8) ✓; §8 + ADR-0012 amendment (Task 7 / done in `02df1c1`) ✓; CHANGELOG (Task 9) ✓.
+- **No-placeholder check:** all fleet values are concrete; code edits show full snippets; the only "observe-and-tune" steps (golden offsets, re-pinned penetration numbers) are inherently runtime-derived and specify the exact command + criterion, not a vague "fix it."
+- **Type consistency:** `vertical_stabilizer` spelled identically in models, fuzz, visualize, tests, fleet YAML, docs. Conflict kind auto-derives `vertical_stabilizer_wing_overlap` (alphabetical: `vertical_stabilizer` < `wing`) and `..._tail_overlap` — matches the assertions in Task 3.
+- **Open risk:** Task 8's blast radius is the real unknown (how many fixtures flip). Mitigated by the explicit triage criterion and inline execution with the user in the loop.

--- a/docs/superpowers/specs/2026-06-08-empennage-model-design.md
+++ b/docs/superpowers/specs/2026-06-08-empennage-model-design.md
@@ -1,0 +1,187 @@
+# Empennage model — design spec (epic #518 / #519 + #520)
+
+- **Date:** 2026-06-08
+- **Status:** Proposed (pending review)
+- **ADR:** [ADR-0023](../../adr/0023-empennage-tail-surfaces.md) records the
+  decision + rejected alternatives. This spec is the implementation companion:
+  the data plan, the file-by-file change set, the test matrix, and the
+  breaking-change audit.
+
+## Problem
+
+The collision model has no representation of the tail surfaces. The empennage is
+implicitly the aft end of the fuselage rectangle — fuselage-tube-wide and
+fuselage-tall. Two independent consequences (see ADR-0023 for the full framing):
+
+- **#519 (lateral):** the real horizontal stabilizer spans ~2.5–3.5 m vs a
+  ~0.85 m fuselage tube; the checker sees free space beside a ~3 m tailplane.
+- **#520 (vertical, safety-critical):** the real fin rises to the aircraft's
+  overall height (~1.7–2.3 m) — into the wing-nesting layer — while the aft box
+  tops out at ~1.5 m, so a wing nested "valid" over a neighbour's tail can
+  physically foul that plane's fin.
+
+## Goal
+
+Model both tail surfaces as honest oriented-rectangle `Part`s with real
+z-extents, so the **existing** two-clause collision predicate produces the
+physically correct verdict — including the lateral-clearance nuance (a wing
+passing *outboard* of a centreline fin still nests; a wing passing *over* it does
+not) and all three tail configurations (conventional, cruciform, T-tail), with
+no per-type code.
+
+## The model (per ADR-0023)
+
+Two new parts per aircraft, both oriented rectangles with their own
+`[z_bottom_m, z_top_m]`:
+
+| Surface | `PartKind` | plan-view footprint | z-band | overhangable? |
+|---|---|---|---|---|
+| Horizontal stabilizer / elevator | `tail` *(existing kind, reused)* | `length = h_stab_chord` (fore-aft) × `width = h_stab_span` (lateral) | per config (below) | yes for low/cruciform (z-disjoint from overhanging wings); structurally a `tail` so it stays in `metrics._OVERHANGABLE` |
+| Vertical stabilizer (fin) + rudder | `vertical_stabilizer` *(new kind)* | `length = fin_chord` (fore-aft) × `width ≈ 0.15` (thin, centreline) | fuselage-top → overall height (into the wing layer) | **never** — distinct kind, not in `_OVERHANGABLE` |
+
+**Why it just works (no predicate change):** `collisions._parts_conflict`
+already gates on plan-view overlap **then** the z-gap
+`max(z_bottom) − min(z_top) < wing_layer_clearance_m`. A fin whose `z_top_m`
+enters the wing band makes `wing × vertical_stabilizer` conflict *only when the
+wing also overlaps the thin centreline fin in plan view*. Pass outboard → no
+plan-view overlap → still legal. That is the lateral-clearance rule, for free.
+
+## Geometry derivation rules (per aircraft)
+
+The exact numbers are finalized at implementation by reading each plane's
+existing `fuselage` and `wing` parts; the placement is mechanical:
+
+- **Station (both surfaces).** Centre near the aft fuselage end:
+  `offset_x_m ≈ (fuselage.offset_x_m − fuselage.length_m/2) + chord/2`. (Sanity
+  check against the tailwheel station where present — e.g. `aviat_husky`'s third
+  wheel sits at `offset_x_m = −4.80`, beside its tail.) `offset_y_m = 0`,
+  `angle_deg = 0`.
+- **Horizontal stabilizer (`tail`) z-band:**
+  - *conventional-low / cruciform:* a thin band at/just below the aft-fuselage
+    top, kept clearly below `wing.z_bottom_m − wing_layer_clearance_m` so it
+    stays z-disjoint from overhanging high wings (remains overhangable). E.g.
+    `aviat_husky` (fuselage top 1.5, wing bottom 2.0): `z ≈ [1.2, 1.5]` — gap to
+    a 2.0 m wing is 0.5 m ≥ 0.2.
+  - *T-tail (`stemme_s10`):* a thin band at the **fin top** (`z_top ≈ overall
+    height`), i.e. inside the wing layer → an overhanging neighbour wing
+    z-overlaps it → conflict.
+- **Vertical stabilizer (`vertical_stabilizer`) z-band:** `z_bottom_m ≈
+  fuselage.z_top_m` (fin root atop the aft fuselage), `z_top_m = published
+  overall height`. E.g. `aviat_husky`: `z ≈ [1.5, 2.01]` — `z_top` reaches into
+  the 2.0–2.3 m wing layer, so a neighbour wing nested over the centreline
+  conflicts (gap ≈ −0.01).
+
+All values are placeholders (`measured: false`), consistent with the rest of
+`data/`. The fin `z_top` honestly equals the published overall height — even
+where that yields a thin (~cm) overlap with the wing layer; we do not pad it to
+manufacture a larger margin.
+
+## Per-aircraft empennage data (researched; spans/chords are estimates)
+
+`tail_config` and `overall_height_m` are sourced; `h_stab_span_m`,
+`h_stab_chord_m`, `fin_chord_m` are published-spec-absent estimates
+(h-stab span ≈ 33–40 % of wingspan for powered types; gliders sized absolutely).
+
+| id | tail_config | h_stab_span_m | h_stab_chord_m | overall_height_m (→ fin top) | fin_chord_m |
+|---|---|---|---|---|---|
+| `aviat_husky` | conventional_low | ~3.0 | ~1.0 | 2.01 | ~1.3 |
+| `scheibe_falke` | conventional_low | ~2.6 | ~0.9 | 1.68 | ~1.1 |
+| `stemme_s10` *(herrenteich)* | **t_tail** | ~2.8 | ~0.8 | 1.80 | ~1.0 |
+| `fuji` | conventional_low | ~3.2 | ~1.1 | 2.02 | ~1.3 |
+| `wild_thing` | conventional_low | ~2.9 | ~0.9 | ~1.9 | ~1.0 |
+| `zlin_savage` | conventional_low | ~2.8 | ~0.9 | 2.03 | ~1.1 |
+| `cessna_140` | conventional_low | ~3.2 | ~1.1 | 1.91 | ~1.2 |
+| `cessna_150` *(data only)* | conventional_low | ~3.4 | ~1.1 | 2.11 | ~1.4 |
+| `ctsl` | **cruciform** (low/mid stabilator; NOT a T-tail) | ~2.6 | ~0.9 | 2.34 | ~1.2 |
+| `fk9_mkii` | conventional_low | ~3.2 | ~0.9 | 2.15 | ~1.1 |
+
+> **Research correction:** the Flight Design CTSL is **cruciform**, not a T-tail
+> (low/mid all-flying stabilator + rudder over a small ventral fin). The fleet's
+> only true T-tail is the **Stemme S10**. The CTSL is modelled like
+> conventional-low (stabilizer below the wing layer); the Stemme's stabilizer
+> sits at the fin top.
+
+`stemme_s10` lives only in `examples/herrenteich/fleet.yaml`; `cessna_150` and
+`fuji` live only in `data/fleet.yaml`. Both files get the tail surfaces.
+
+## Change set (file by file)
+
+| File | Change | Notes |
+|---|---|---|
+| `src/hangarfit/models.py` | add `"vertical_stabilizer"` to the `PartKind` `Literal` | `_VALID_PART_KINDS` auto-derives; docstring note |
+| `data/fleet.yaml` | add `tail` + `vertical_stabilizer` parts to each aircraft | per the derivation rules + table; header comment |
+| `examples/herrenteich/fleet.yaml` | same, incl. the `stemme_s10` T-tail | published-spec |
+| `src/hangarfit/collisions.py` | **logic unchanged**; add a clarifying comment that `vertical_stabilizer` keeps the height clause and is not in the cockpit exception | audit only |
+| `src/hangarfit/metrics.py` | confirm `_OVERHANGABLE` stays `{tail, fuselage_aft}` (do **not** add the fin) | likely no change |
+| `src/hangarfit/visualize.py` | render the `tail` (already aft-fuselage-like) + a height cue for `vertical_stabilizer` | 2D |
+| `src/hangarfit/scene.py` | emit the new parts into `scene/v1` JSON | by `kind` |
+| `viewer/src/*.ts` → rebuild `src/hangarfit/_viewer_assets/viewer.js` | render `vertical_stabilizer` (+ `tail` if not already) | **must** rebuild bundle or `viewer-build-drift` CI fails |
+| `tests/test_collisions.py` | the 3 golden cases (below) | — |
+| `tests/test_models.py` / wherever the closed `PartKind` set is asserted | add `vertical_stabilizer` | — |
+| `docs/architecture/08-crosscutting-concepts.md` | update "The parts model" (6 kinds; tail surfaces) | operational statement |
+| `docs/adr/0012-...md` | amend the tail-fold-in Neutral consequence to point at ADR-0023 | + index entry for 0023 |
+| `CHANGELOG.md` | breaking-change entry | list flipped fixtures |
+
+**Not touched:** the collision predicate logic, the det(−1) transform,
+`geometry.py` (`aircraft_parts_world` passes parts through unchanged),
+`solver.py`, `towplanner.py`, the loader's expansion logic.
+
+## Test matrix (`tests/test_collisions.py`)
+
+Synthetic fixtures with clear numbers (not the real fleet) so the assertions are
+unambiguous:
+
+1. **Fin blocks nesting (the #520 safety case).** Plane B's wing nested over
+   plane A's aft fuselage, the wing's footprint passing *over* A's centreline fin
+   (fin `z_top` in the wing band) → exactly one `vertical_stabilizer_wing_overlap`
+   conflict. This layout is silently `valid` today.
+2. **Lateral clearance still valid (the #520 nuance).** Same nest, but B's
+   wingtip passes *outboard* of A's thin centreline fin → no plan-view overlap
+   with the fin → **valid**.
+3. **Wide tailplane conflict (the #519 case).** A neighbour's low part
+   (fuselage / strut / low wing) overlapping A's realistic-width `tail` in plan
+   view at a shared z-band → `..._tail_overlap` conflict (free space under the
+   old narrow model).
+4. *(regression)* existing cockpit tests (`_is_wing_over_cockpit`) and the
+   wing-over-`fuselage_aft` positive control still pass — the predicate gained no
+   branch.
+5. *(model)* the closed `PartKind` set now includes `vertical_stabilizer`.
+
+Each new path needs ≥1 **non-slow** test (the `codecov/patch` gotcha in
+CLAUDE.md).
+
+## Breaking-change / fixture-flip audit
+
+A required deliverable. Procedure:
+
+1. Enumerate every fixture and example layout under `tests/fixtures/`,
+   `examples/`, and `data/` that is currently `valid` and involves a
+   wing-over-tail nest or a near-tail side-by-side arrangement.
+2. After adding the tail surfaces, re-run `hangarfit check` on each; record which
+   flip `valid → invalid` and the conflict kind.
+3. **Expected to flip:** the canonical `valid_wing_over_tail` /
+   `valid_high_over_low_aft_z_disjoint` positive control (that *is* the safety
+   fix). Re-pin or rename those fixtures to reflect the new reality, with a note.
+4. **Investigate, don't paper over:** check whether the real
+   `examples/herrenteich/layout.yaml` all-eight arrangement flips. If it does,
+   report it as a genuine finding (real tight fin/wing clearance vs. too-aggressive
+   placeholder fin height) — do **not** tune fin heights to keep it green.
+5. List every flipped fixture in the PR body + CHANGELOG.
+
+## Out of scope / non-goals
+
+- No 3D mesh (ADR-0001 stands); parts remain oriented rectangles with z-bands.
+- No `empennage:` loader block — explicit `parts:` entries (ADR-0023 D4). A block
+  can be added additively later if hand-authoring proves painful.
+- No new clearance knob; the fin uses the existing `wing_layer_clearance_m`.
+- T-tail vs cruciform vs conventional is expressed purely by per-part z; the
+  model does **not** gain a `tail_config` field.
+
+## Open questions
+
+- **Horizontal-stabilizer thickness/z-band fidelity.** A thin band at the
+  aft-fuselage top is the placeholder; if a real low-set tailplane should sit a
+  little higher/lower per type, that is a measurement refinement, not a model
+  change.
+- **Herrenteich `layout.yaml` outcome** — resolved during the audit (step 4);
+  may surface a follow-up issue if the real layout flips for a real reason.

--- a/examples/herrenteich/fleet.yaml
+++ b/examples/herrenteich/fleet.yaml
@@ -131,7 +131,7 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.5
         z_top_m: 1.8
-      - kind: vertical_stabilizer  # fin to overall height 1.80 m (folded config; below the 2.0 m wing layer)
+      - kind: vertical_stabilizer  # fin to overall height 1.80 m (folded config; tops 0.1 m below a 1.9 m wing — within the 0.2 m clearance band, so a wing nested over it still conflicts)
         length_m: 1.0
         width_m: 0.15
         offset_x_m: -5.21

--- a/examples/herrenteich/fleet.yaml
+++ b/examples/herrenteich/fleet.yaml
@@ -44,6 +44,12 @@
 # - stemme_s10 is modelled in its WINGS-FOLDED hangar configuration: the
 #   wing part width is the folded 11.40 m span (unfolded 23 m would not enter
 #   the 13.46 m door). Folded outer panels raise the effective height.
+# - Empennage (ADR-0023, #518/#519/#520): each aircraft carries a `tail` (the
+#   horizontal stabilizer) + a `vertical_stabilizer` (fin+rudder rising to the
+#   published height column above, into the wing layer). stemme_s10 is the one
+#   T-tail (stabilizer at the fin top); ctsl is cruciform (stabilizer kept below
+#   the wing layer); all others are conventional-low. Spans/chords are estimates;
+#   tail configs + heights are sourced. All measured: false.
 
 aircraft:
   # ----------------------------------------------------------------------------
@@ -74,6 +80,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.1
+      - kind: tail            # horizontal stabilizer (conventional low; ~2.6 m span est.)
+        length_m: 0.9
+        width_m: 2.6
+        offset_x_m: -3.34
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer  # fin+rudder to overall height 1.85 m (Super Falke)
+        length_m: 1.1
+        width_m: 0.15
+        offset_x_m: -3.24
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 1.85
     wheels:
       main_offset_x_m: 0.0
 
@@ -104,6 +124,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.1
+      - kind: tail            # T-TAIL: horizontal stabilizer HIGH, at the fin top (~2.8 m span est.)
+        length_m: 0.8
+        width_m: 2.8
+        offset_x_m: -5.31
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 1.8
+      - kind: vertical_stabilizer  # fin to overall height 1.80 m (folded config; below the 2.0 m wing layer)
+        length_m: 1.0
+        width_m: 0.15
+        offset_x_m: -5.21
+        offset_y_m: 0.0
+        z_bottom_m: 1.4
+        z_top_m: 1.8
     wheels:
       main_offset_x_m: 0.0
 
@@ -132,6 +166,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 2.0
         z_top_m: 2.3
+      - kind: tail            # horizontal stabilizer (conventional low; ~3.0 m span est.)
+        length_m: 1.0
+        width_m: 3.0
+        offset_x_m: -4.66
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer  # fin+rudder to overall height 2.26 m (A-1C; into the wing layer)
+        length_m: 1.3
+        width_m: 0.15
+        offset_x_m: -4.51
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 2.26
     struts:
       fuselage_attach_x_m: -1.22
       fuselage_attach_y_m: 0.425
@@ -168,6 +216,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 2.0
         z_top_m: 2.2
+      - kind: tail            # horizontal stabilizer (conventional low; ~2.9 m span est.)
+        length_m: 0.9
+        width_m: 2.9
+        offset_x_m: -3.13
+        offset_y_m: 0.0
+        z_bottom_m: 1.1
+        z_top_m: 1.4
+      - kind: vertical_stabilizer  # fin+rudder to overall height 1.90 m
+        length_m: 1.0
+        width_m: 0.15
+        offset_x_m: -3.08
+        offset_y_m: 0.0
+        z_bottom_m: 1.4
+        z_top_m: 1.9
     struts:
       fuselage_attach_x_m: 0.07
       fuselage_attach_y_m: 0.425
@@ -204,6 +266,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.2
+      - kind: tail            # horizontal stabilizer (conventional low; ~2.8 m span est.)
+        length_m: 0.9
+        width_m: 2.8
+        offset_x_m: -4.35
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer  # fin+rudder to overall height 2.03 m
+        length_m: 1.1
+        width_m: 0.15
+        offset_x_m: -4.25
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 2.03
     struts:
       fuselage_attach_x_m: -1.20
       fuselage_attach_y_m: 0.4
@@ -241,6 +317,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 2.0
         z_top_m: 2.3
+      - kind: tail            # horizontal stabilizer (conventional low; ~3.2 m span est.)
+        length_m: 1.1
+        width_m: 3.2
+        offset_x_m: -4.37
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer  # fin+rudder to overall height 1.91 m
+        length_m: 1.2
+        width_m: 0.15
+        offset_x_m: -4.32
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 1.91
     struts:
       fuselage_attach_x_m: -1.14
       fuselage_attach_y_m: 0.425
@@ -278,6 +368,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.2
+      - kind: tail            # CRUCIFORM tail — stabilator low/mid, kept below the wing layer (~2.6 m span est.)
+        length_m: 0.9
+        width_m: 2.6
+        offset_x_m: -3.18
+        offset_y_m: 0.0
+        z_bottom_m: 1.1
+        z_top_m: 1.4
+      - kind: vertical_stabilizer  # tall fin+rudder to overall height 2.34 m (well into the wing layer)
+        length_m: 1.2
+        width_m: 0.15
+        offset_x_m: -3.03
+        offset_y_m: 0.0
+        z_bottom_m: 1.4
+        z_top_m: 2.34
     wheels:
       main_offset_x_m: -0.10
       track_m: 1.7
@@ -308,6 +412,20 @@ aircraft:
         offset_y_m: 0.0
         z_bottom_m: 1.9
         z_top_m: 2.2
+      - kind: tail            # horizontal stabilizer (conventional low; ~3.2 m span est.)
+        length_m: 0.9
+        width_m: 3.2
+        offset_x_m: -2.77
+        offset_y_m: 0.0
+        z_bottom_m: 1.1
+        z_top_m: 1.4
+      - kind: vertical_stabilizer  # fin+rudder to overall height 2.15 m
+        length_m: 1.1
+        width_m: 0.15
+        offset_x_m: -2.67
+        offset_y_m: 0.0
+        z_bottom_m: 1.4
+        z_top_m: 2.15
     struts:
       fuselage_attach_x_m: 0.11
       fuselage_attach_y_m: 0.425

--- a/examples/herrenteich/layout.yaml
+++ b/examples/herrenteich/layout.yaml
@@ -1,70 +1,74 @@
 # Airfield Herrenteich — "everyone home": all eight usual occupants parked
 # in the real hangar at once. Passes `hangarfit check` (exit 0).
 #
-# HOW THIS WAS PRODUCED. The product solver (`hangarfit solve`) cannot
-# generate this layout. (#425 — fixed — once made its fast trivial-
-# infeasibility gate sum each plane's bounding-box area, Σ ≈ 606 m² > the
-# 479 m² rectangular floor, and bail, because an 18 m-span motor glider is a
-# 136 m² bounding box of mostly empty air; the gate now sums actual part
-# footprints — Σ ≈ 160 m² « 479 — and no longer bails.) Two reasons solve
-# still won't reproduce this layout: the rectangular hangar model does not
-# represent the back-right office NOTCH that this layout keeps every plane
-# clear of (see hangar.yaml + spike #424), and finding an all-eight nested
-# arrangement within budget is a separate search-feasibility question. The
-# REAL, part-based collision checker (thin wing rectangles, z-disjoint
-# wing-over-fuselage nesting) accepts a nested arrangement, so this layout was
-# found by a search that drives that real checker directly.
+# RE-ARRANGED for the empennage model (#518/#519/#520, ADR-0023). The previous
+# arrangement was built before the tail surfaces were modelled; once each
+# aircraft gained a wide horizontal stabilizer (`tail`) and a fin
+# (`vertical_stabilizer`) that rises into the wing-nesting layer, six of its
+# nestings turned out to physically foul a neighbour's fin or tailplane (a
+# wing tucked over a plane's tail now collides with that plane's fin). The
+# placements below are a fresh nested arrangement that clears every fin
+# (min wing-over-tail clearance ~0.40 m), stays in bounds, and keeps clear of
+# the back-right office NOTCH (x ∈ [12.72, 15.08], y ∈ [22.66, 31.76]) by hand
+# — the rectangular model still does not represent that notch (spike #424).
 #
-# So: this file is a VALID nested layout, but it is the tool's arrangement,
-# not a record of where the club actually parks each aircraft. Replace the
-# placements with the real parking positions when known.
+# HOW THIS WAS PRODUCED. The product solver (`hangarfit solve`) cannot generate
+# this layout (it won't reproduce an all-eight nested arrangement within budget,
+# and it does not model the notch). The REAL, part-based collision checker (thin
+# wing rectangles, z-disjoint wing-over-fuselage nesting, fins in the wing layer)
+# accepts a nested arrangement, so this layout was found by a search that drives
+# that real checker directly.
 #
-# Coordinate convention (see hangar.yaml): world (0,0) front-left, +x right
-# along the door wall, +y deeper in; heading 0 = nose deep (+y), 90 = nose
-# toward +x. scheibe_falke (18 m span) cannot sit nose-in under the 15.08 m
-# width, so it parks lengthwise (heading 90).
+# So: this file is a VALID nested layout, but it is the tool's arrangement, not a
+# record of where the club actually parks each aircraft. Replace the placements
+# with the real parking positions when known.
+#
+# Coordinate convention (see hangar.yaml): world (0,0) front-left, +x right along
+# the door wall, +y deeper in; heading 0 = nose deep (+y), 90 = nose toward +x.
+# scheibe_falke (18 m span) cannot sit nose-in under the 15.08 m width, so it
+# parks lengthwise (heading 90).
 
 fleet: fleet.yaml
 hangar: hangar.yaml
 
 placements:
   - plane: scheibe_falke
-    x_m: 7.5
-    y_m: 22.5
+    x_m: 8.60
+    y_m: 22.50
     heading_deg: 90.0
     on_carts: true          # always_cart
   - plane: stemme_s10
-    x_m: 3.5
-    y_m: 13.5
+    x_m: 3.50
+    y_m: 13.65
     heading_deg: 270.0
     on_carts: false         # always_own_gear
   - plane: aviat_husky
-    x_m: 5.5
-    y_m: 19.5
+    x_m: 5.60
+    y_m: 16.40
     heading_deg: 90.0
     on_carts: false         # always_own_gear
   - plane: cessna_140
-    x_m: 10.5
-    y_m: 6.5
+    x_m: 12.80
+    y_m: 5.35
     heading_deg: 90.0
     on_carts: false         # cart_eligible, on own gear
   - plane: fk9_mkii
-    x_m: 7.5
-    y_m: 10.5
+    x_m: 7.60
+    y_m: 10.00
     heading_deg: 270.0
     on_carts: false         # cart_eligible, on own gear
   - plane: zlin_savage
-    x_m: 6.5
-    y_m: 26.5
+    x_m: 2.70
+    y_m: 24.90
     heading_deg: 270.0
     on_carts: true          # always_cart
   - plane: wild_thing
-    x_m: 10.5
-    y_m: 16.5
+    x_m: 11.45
+    y_m: 16.95
     heading_deg: 90.0
     on_carts: true          # always_cart
   - plane: ctsl
-    x_m: 4.5
-    y_m: 4.5
+    x_m: 4.50
+    y_m: 4.50
     heading_deg: 180.0
     on_carts: false         # cart_eligible, on own gear

--- a/examples/layouts/example.yaml
+++ b/examples/layouts/example.yaml
@@ -15,15 +15,21 @@
 # of the visualiser, use ``examples/layouts/example_invalid.yaml`` (a deliberately
 # bad layout shipped alongside this file for that purpose).
 #
-# Hangar: 18 m wide × 25 m deep (data/hangar.yaml). Maintenance bay
-# is the right-rear corner: x ∈ (9, 18), y > 16 (a 9 × 9 m walled
-# keep-out while scheibe_falke is in maintenance). Coordinate
-# convention (CLAUDE.md): world (0, 0) at front-left, +x right along
-# door wall, +y deeper into hangar. heading 0 = nose into hangar.
+# Hangar: 22 m wide × 25 m deep (data/hangar.yaml). Maintenance bay
+# spans x ∈ (9, 18), y > 16 (a 9 × 9 m walled keep-out while
+# scheibe_falke is in maintenance). Coordinate convention (CLAUDE.md):
+# world (0, 0) at front-left, +x right along door wall, +y deeper into
+# hangar. heading 0 = nose into hangar.
 #
-# Cart usage: only the three ``always_cart`` planes (scheibe, zlin,
-# wild_thing) are on carts; CTSL is ``cart_eligible`` but parked on its
-# own gear (the "no cart swapping unless necessary" operational rule).
+# Cart usage: only the two ``always_cart`` planes here (zlin, wild_thing)
+# are on carts; CTSL is ``cart_eligible`` but parked on its own gear (the
+# "no cart swapping unless necessary" operational rule).
+#
+# Empennage (#518/#519/#520, ADR-0023): every aircraft now carries a wide
+# horizontal stabilizer (`tail`) and a fin (`vertical_stabilizer`) that rises
+# into the wing-nesting layer. Those realistic tail surfaces consume lateral
+# room, so the planes are spread across the (widened) 22 m hall — a wing may
+# no longer nest directly over a neighbour's tail unless it clears the fin.
 #
 # Planes not in this layout (out flying):
 #   - cessna_140  (training flight)
@@ -36,53 +42,37 @@ hangar: ../../data/hangar.yaml
 maintenance:
   plane: scheibe_falke
 
-# Front/aft nudge (#50 / ADR-0012): the fuselage split makes a wing over
-# another plane's COCKPIT (fuselage_front) a hard conflict at any height,
-# where the pre-split layout let high-wing wingtips legally overhang a
-# neighbour's fuselage. Two placements were adjusted so every overhang now
-# lands on an aft fuselage / tail (still valid) rather than a cockpit:
-#   - ctsl shifted right (x 9 → 11) so zlin's wingtip no longer reaches its
-#     cockpit;
-#   - wild_thing rotated to heading 180 (nose toward the door) so the husky
-#     wing crossing it overhangs its aft fuselage, not its cockpit.
-
 placements:
-  # Front-right: small cantilever near the door, easy to roll out first.
-  # Sits at x=11 so the Zlin's wingtip (to its left) clears its cockpit.
+  # Front row, left + right (clear of each other's wide wings + tails).
+  - plane: zlin_savage
+    x_m: 5.0
+    y_m: 6.0
+    heading_deg: 0.0
+    on_carts: true         # always_cart
   - plane: ctsl
-    x_m: 11.0
+    x_m: 16.5
     y_m: 4.0
     heading_deg: 0.0
     on_carts: false        # cart_eligible but on own gear
 
-  # Front lane (y = 8): one strut-braced on the left, fuji
-  # parked sideways on the right
-  - plane: zlin_savage
-    x_m: 5.0
-    y_m: 8.0
-    heading_deg: 0.0
-    on_carts: true         # always_cart
+  # Mid: the low-wing Fuji parked sideways (heading 90), its low wing
+  # threading between the high-wing neighbours (z-disjoint).
   - plane: fuji
-    x_m: 13.0
-    y_m: 8.0
-    heading_deg: 90.0      # nose pointing right; low wing threads under
-                           # neighbouring high wings (z-disjoint nesting)
+    x_m: 10.5
+    y_m: 9.5
+    heading_deg: 90.0
     on_carts: false        # always_own_gear
 
-  # Mid-center: wild_thing at heading 180 (nose toward the door) so the
-  # husky wing behind it overhangs its AFT fuselage / tail, not its
-  # cockpit (front/aft split — ADR-0012)
+  # Back row (forward of the maintenance bay at y = 16): wild_thing nose
+  # toward the door (heading 180) on the left, husky on the right.
   - plane: wild_thing
-    x_m: 9.0
-    y_m: 12.0
+    x_m: 5.0
+    y_m: 13.5
     heading_deg: 180.0
     on_carts: true         # always_cart
-
-  # Just forward of the maintenance bay: husky tucked left of centre
-  # with its 10.82 m wing fully clear of the bay's front edge at y=16
   - plane: aviat_husky
-    x_m: 6.0
-    y_m: 15.0
+    x_m: 16.5
+    y_m: 14.0
     heading_deg: 0.0
     on_carts: false        # always_own_gear
 

--- a/src/hangarfit/collisions.py
+++ b/src/hangarfit/collisions.py
@@ -319,6 +319,13 @@ def _is_wing_over_cockpit(pa: WorldPart, pb: WorldPart) -> bool:
     pairwise loop iterates one ordering only, but a symmetric helper is
     robust to a future reorder). This is the one pair whose height clause is
     dropped — see :func:`_parts_conflict` and ADR-0012 (D1).
+
+    NB ``vertical_stabilizer`` (the fin) is deliberately NOT here (ADR-0023):
+    it keeps the uniform two-clause rule, so a wing conflicts with a fin only
+    when it both overlaps the thin centreline fin in plan view AND their
+    z-bands meet — i.e. wing-over-tail nesting stays legal iff the wing clears
+    the fin laterally. The fin earns no z-drop because, unlike a cockpit, the
+    obstruction is geometric (lateral clearance), not categorical.
     """
     kinds = {pa.kind, pb.kind}
     return kinds == {"wing", "fuselage_front"}

--- a/src/hangarfit/metrics.py
+++ b/src/hangarfit/metrics.py
@@ -17,9 +17,11 @@ from hangarfit import collisions
 from hangarfit.geometry import WorldPart, aircraft_parts_world
 from hangarfit.models import CheckResult, Layout
 
-# Parts a wing may legally overhang: a wingtip may overhang a low-winger's tail or
-# aft fuselage, never its cockpit (ADR-0012). The vertical clearance there is the
-# actionable "how close did that overhang come" number an operator should eyeball.
+# Parts a wing may legally overhang: a wingtip may overhang a low-winger's tail
+# (the horizontal stabilizer) or aft fuselage, never its cockpit (ADR-0012). The
+# vertical clearance there is the actionable "how close did that overhang come"
+# number an operator should eyeball. vertical_stabilizer (the fin) is deliberately
+# absent: a wing over a fin is a conflict, not an overhang (ADR-0023).
 _OVERHANGABLE = frozenset({"tail", "fuselage_aft"})
 
 # The single source of the honesty-banner wording, shared by the 2D PNG

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 WingPosition = Literal["high", "mid", "low"]
 Gear = Literal["tailwheel", "nosewheel", "monowheel"]
 MovementMode = Literal["always_cart", "always_own_gear", "cart_eligible"]
-PartKind = Literal["fuselage_front", "fuselage_aft", "wing", "strut", "tail"]
+PartKind = Literal["fuselage_front", "fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer"]
 
 _VALID_PART_KINDS = frozenset(typing.get_args(PartKind))
 _VALID_WING_POSITIONS = frozenset(typing.get_args(WingPosition))
@@ -43,10 +43,14 @@ class Part:
     convention" for plane-local coordinates (``+x`` forward, ``+y`` right).
 
     ``kind`` is closed: ``"fuselage_front" | "fuselage_aft" | "wing" |
-    "strut" | "tail"``. The fuselage is split front/aft so the collision
-    rule can distinguish a wing over a cockpit (``fuselage_front`` — always
-    a conflict in plan view, height ignored) from a wing over a tail
-    (``fuselage_aft`` — today's two-clause z-gap rule); see ADR-0012 and
+    "strut" | "tail" | "vertical_stabilizer"``. The fuselage is split
+    front/aft so the collision rule can distinguish a wing over a cockpit
+    (``fuselage_front`` — always a conflict in plan view, height ignored)
+    from a wing over a tail (``fuselage_aft`` — today's two-clause z-gap
+    rule); see ADR-0012. The empennage is two explicit surfaces (ADR-0023):
+    ``tail`` (the horizontal stabilizer — wide, usually low) and
+    ``vertical_stabilizer`` (the fin + rudder — thin, tall, rising into the
+    wing layer so a wing nested over the centreline conflicts with it). See
     ``docs/architecture/08-crosscutting-concepts.md`` "The parts model".
     The legacy ``"fuselage"`` keyword is **not** a constructed kind: it
     survives only as a transient YAML keyword the loader auto-splits at the

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
 WingPosition = Literal["high", "mid", "low"]
 Gear = Literal["tailwheel", "nosewheel", "monowheel"]
 MovementMode = Literal["always_cart", "always_own_gear", "cart_eligible"]
+# `tail` denotes the horizontal stabilizer specifically (a wide, usually-low
+# overhangable surface — see metrics._OVERHANGABLE); `vertical_stabilizer` is the
+# fin (thin, tall, never overhangable). Empennage split per ADR-0023.
 PartKind = Literal["fuselage_front", "fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer"]
 
 _VALID_PART_KINDS = frozenset(typing.get_args(PartKind))

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -372,10 +372,12 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
     """Render a single world part. Fuselage segments are near-opaque (two
     fuselages overlapping is always a conflict; no value in seeing through) —
     ``fuselage_front`` (cockpit) a darker tint of the plane's brand fill,
-    ``fuselage_aft`` (tail) the plain fill — wing translucent (so stacked
+    ``fuselage_aft`` (cabin-aft) the plain fill — wing translucent (so stacked
     wings show their plan-view overlap visually), strut as a thin outlined
     polygon (struts are physically thin, a fill would be near-invisible), tail
-    rendered like a small fuselage (same z-tier, same conflict semantics).
+    (the horizontal stabilizer) rendered like a small fuselage (same z-tier,
+    same conflict semantics), and ``vertical_stabilizer`` (the fin) opaque on
+    the top z-tier as a cue that it rises through the wing layer (ADR-0023).
 
     Solid parts are stroked in ``_INK_EDGE`` (#14161A), the brand "never hue
     alone" outline — so a plane's silhouette reads even in greyscale or under
@@ -425,6 +427,20 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
             edgecolor=_INK_EDGE,
             lw=_STRUT_LINEWIDTH,
             zorder=3,
+        )
+    elif part.kind == "vertical_stabilizer":
+        # The fin (ADR-0023): a thin centreline surface that rises into / above
+        # the wing layer. Drawn opaque and ink-edged on top (zorder above the
+        # wing) so its height — invisible in a top-down view — reads as "this
+        # pokes up through the wing band."
+        patch = MplPolygon(
+            coords,
+            closed=True,
+            facecolor=color,
+            edgecolor=_INK_EDGE,
+            alpha=_FUSELAGE_ALPHA,
+            lw=0.5,
+            zorder=4,
         )
     else:
         raise ValueError(

--- a/tests/fixtures/canary_hangar_tight_18m.yaml
+++ b/tests/fixtures/canary_hangar_tight_18m.yaml
@@ -1,0 +1,19 @@
+# Tight 18 m-wide hangar for the max_restarts exhausted-budget determinism
+# canary (tests/test_solver_canaries.py). These are the pre-#519/#520
+# placeholder dimensions: data/hangar.yaml was widened 18 -> 22 m so the demo
+# keeps its full plane set with the bulkier tail surfaces, which made the
+# 6-plane fresh fill *solvable* within a tiny max_restarts and broke the
+# canary. This fixture pins a tight hangar so the canary keeps exercising the
+# exhausted-budget (best-partial) branch, decoupled from data/hangar.yaml.
+length_m: 25.0
+width_m: 18.0
+door:
+  center_x_m: 9.0
+  width_m: 12.0
+maintenance_bay:
+  center_x_m: 13.5
+  width_m: 9.0
+  depth_m: 9.0
+clearance_m: 0.3
+wing_layer_clearance_m: 0.2
+max_carts: 1

--- a/tests/fixtures/invalid_fuselage_fuselage.yaml
+++ b/tests/fixtures/invalid_fuselage_fuselage.yaml
@@ -1,22 +1,17 @@
-# Case 5 — two fuselages overlap (single isolated conflict).
+# Case 5 — two deeply-overlapping planes (rich segment-pair conflict set).
 #
-# ctsl at (9, 5, 0, false) — fuselage x [8.5, 9.5], y [1.85, 8.15], z [0, 1.4];
-#                            wing x [4.7, 13.3], y [5.3, 6.7], z [1.9, 2.2].
-# fuji at (9, 9, 0, false)  — fuselage x [8.5, 9.5], y [5, 13],   z [0, 1.6];
-#                            wing x [4.3, 13.7], y [8.75, 10.25], z [0.8, 1.1].
+# ctsl at (9, 5, 0) and fuji at (9, 9, 0): their fuselages share x [8.5, 9.5]
+# and overlap in y → the front/aft split (#50/ADR-0012) yields the
+# fuselage_aft × fuselage_{front,aft} segment-pair kinds. With the empennage
+# modelled (ADR-0023) the dense overlap also catches fuji's wide horizontal
+# stabilizer (`tail`, z 1.3-1.6) against ctsl's fuselage segments, and the ctsl
+# wing (z 1.9-2.2) over fuji's fin (`vertical_stabilizer`, z 1.6-2.02).
 #
-# Fuselages share x [8.5, 9.5] and overlap y [5, 8.15] → fuselage_fuselage_overlap.
-#
-# Crucially, no other pair conflicts:
-#   - ctsl wing y [5.3, 6.7] vs fuji fuselage y [5, 13]: plan overlap, but
-#     z-gap = 1.9 − 1.6 = 0.3 m > 0.2 m clearance.
-#   - fuji wing y [8.75, 10.25] vs ctsl fuselage y [1.85, 8.15]: y-gap 0.6 m
-#     (no plan overlap at all).
-#   - ctsl wing y [5.3, 6.7] vs fuji wing y [8.75, 10.25]: y-gap 2.05 m.
-#
-# This makes case 5 a *single-conflict* fixture suitable for asserting
-# the conflict list has exactly one entry — guarding against future
-# regressions that might emit phantom extra conflicts.
+# The fixture's value is the TAXONOMY invariant, not a clean count: every
+# conflict kind is the two part kinds sorted alphabetically + `_overlap`, and
+# the retired un-split `fuselage_fuselage_overlap` kind must never reappear.
+# See `tests/test_collisions.py::TestPairwiseOverlap::test_case_5_fuselage_fuselage_overlap`
+# for the exact re-pinned kind set.
 
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml

--- a/tests/fixtures/invalid_wing_over_cockpit.yaml
+++ b/tests/fixtures/invalid_wing_over_cockpit.yaml
@@ -1,35 +1,19 @@
 # #50 / ADR-0012 (D1) — a wing over another plane's `fuselage_front`
-# (cockpit) is a HARD conflict EVEN at a z-disjoint height. This is the
-# canary that the new rule actually bites: under the OLD (pre-split) rule
-# this exact geometry was VALID (z-gap 0.3 m > 0.2 m clearance); the split
-# makes it `fuselage_front_wing_overlap` because a wing over a cockpit is
-# unacceptable at any nesting height (canopy / prop arc / pilot ingress).
+# (cockpit) is a HARD conflict EVEN at a z-disjoint height. Under the OLD
+# (pre-split) rule this geometry was VALID (z-gap 0.3 m > 0.2 m clearance);
+# the split makes it `fuselage_front_wing_overlap` because a wing over a
+# cockpit is unacceptable at any nesting height (canopy / prop arc / ingress).
 #
-# Paired with `valid_wing_over_tail.yaml`: the two fixtures use the same
-# two aircraft at the same z-disjoint height and differ only in Fuji's
-# heading (which flips its `fuselage_front` vs `fuselage_aft` to the
-# deeper-y end the ctsl wing crosses) — the cleanest possible
-# demonstration of the front/aft distinction (mirrors the case-7/8
-# left/right-symmetry idiom).
+# Paired with `valid_wing_over_tail.yaml`: same two aircraft, same ctsl
+# placement (x 5.5), differ ONLY in Fuji's heading. Heading 0 puts fuji's
+# cockpit (`fuselage_front`) at the deeper-y end the ctsl wing crosses → hard
+# conflict; heading 180 puts the tail there and the wing clears the fin → valid.
 #
-# Fuji's fuselage split: plane-local fuselage spans x ∈ [-4.39, 3.59];
-# wing trailing edge x_break = 0.10 - 1.5/2 = -0.65 ⇒
-# `fuselage_front` = plane-local x ∈ [-0.65, 3.59] (cockpit / nose).
-#
-# Layout (Fuji at heading 0 ⇒ nose points DEEPER / +y, so `fuselage_front`
-# is at the high-y end where the ctsl wing crosses):
-#   fuji at (5, 9, 0, false):
-#       fuselage_front world x ∈ [4.50, 5.50], y ∈ [8.35, 12.59], z [0, 1.6]
-#       fuselage_aft   world x ∈ [4.50, 5.50], y ∈ [4.61,  8.35], z [0, 1.6]
-#   ctsl at (4, 13.5, 90, false):
-#       wing world x ∈ [3.97, 5.37], y ∈ [9.21, 17.79], z [1.9, 2.2]
-#
-# Plan-view overlap of ctsl wing × fuji `fuselage_front`: x ∈ [4.50, 5.37],
-# y ∈ [9.21, 12.59]. z-gap = 1.9 - 1.6 = 0.3 m (> 0.2 m clearance, so the
-# OLD rule would PASS) — but D1 IGNORES the z-gap for wing × fuselage_front,
-# so this is a conflict. The ctsl wing clears fuji's `fuselage_aft`
-# (y ≤ 8.35) by 0.36 m in plan view (> 0.3 m clearance), so exactly ONE
-# conflict fires: `fuselage_front_wing_overlap` (alphabetical kind order).
+# fuji at (5, 9, 0): nose deeper (+y), cockpit at the high-y end; the fin /
+#   horizontal stab are at the LOW-y (door) end, away from the crossing — so the
+#   only conflict is the cockpit one (the fin does not participate here).
+# ctsl at (5.5, 13.5, 90): wing crosses fuji's `fuselage_front`; D1 ignores the
+#   z-gap → exactly one `fuselage_front_wing_overlap` (alphabetical kind order).
 
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
@@ -41,7 +25,7 @@ placements:
     heading_deg: 0.0
     on_carts: false
   - plane: ctsl
-    x_m: 4.0
+    x_m: 5.5
     y_m: 13.5
     heading_deg: 90.0
     on_carts: false

--- a/tests/fixtures/invalid_wing_over_fin.yaml
+++ b/tests/fixtures/invalid_wing_over_fin.yaml
@@ -1,0 +1,28 @@
+# ADR-0023 (#520) — the safety case on real-fleet data. A high wing nested
+# over a low-wing's tail conflicts with that plane's VERTICAL STABILIZER (fin)
+# when the wing passes OVER the centreline fin, because the fin rises into the
+# wing-nesting layer. This layout was reported VALID before the empennage model
+# (the wing cleared the flat aft-fuselage box in z); the fin makes it invalid.
+#
+# Same two aircraft and same Fuji heading as `valid_wing_over_tail.yaml`; the
+# ONLY difference is ctsl's x (5.5 -> 4.0), which slides the wing from outboard
+# of fuji's fin onto it. The thin centreline fin (`vertical_stabilizer`,
+# z 1.6-2.02) overlaps the ctsl wing (z 1.9-2.2) → `vertical_stabilizer_wing_overlap`.
+#
+# fuji at (5, 9, 180): fin on the centreline (~world x 5.0) at the high-y tail.
+# ctsl at (4, 14.5, 90): wing world x ~3.97-5.37 covers the fin's x → conflict.
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+
+placements:
+  - plane: fuji
+    x_m: 5.0
+    y_m: 9.0
+    heading_deg: 180.0
+    on_carts: false
+  - plane: ctsl
+    x_m: 4.0
+    y_m: 14.5
+    heading_deg: 90.0
+    on_carts: false

--- a/tests/fixtures/solve_canary_six_planes_tight.yaml
+++ b/tests/fixtures/solve_canary_six_planes_tight.yaml
@@ -1,0 +1,13 @@
+# Six-plane fresh fill in a TIGHT 18 m hangar — the exhausted-budget
+# determinism canary (tests/test_solver_canaries.py). Same fleet subset as
+# solve_fresh_six_planes.yaml, but pinned to canary_hangar_tight_18m.yaml
+# (the pre-#519/#520 placeholder width) so the fill does NOT fully solve
+# within a tiny max_restarts, exercising the best-partial branch whose
+# byte-identical determinism the canary guards. (The shared
+# solve_fresh_six_planes.yaml now uses the widened 22 m data/hangar.yaml and
+# solves within max_restarts, so it can no longer drive this canary.)
+fleet: ../../data/fleet.yaml
+hangar: canary_hangar_tight_18m.yaml
+fleet_in: [aviat_husky, fuji, ctsl, wild_thing, fk9_mkii, cessna_140]
+maintenance:
+  plane: wild_thing

--- a/tests/fixtures/valid_high_over_low_aft_z_disjoint.yaml
+++ b/tests/fixtures/valid_high_over_low_aft_z_disjoint.yaml
@@ -1,40 +1,19 @@
-# Case 3 (reframed for #50 / ADR-0012) — a high-wing's wingtip over the
-# AFT fuselage / tail of the low-wing Fuji is VALID because the heights are
-# disjoint enough to clear the 0.2 m vertical clearance.
+# Case 3 (reframed for #50 / ADR-0012 + ADR-0023) — a high-wing's wingtip over
+# the low-wing Fuji's tail surfaces is VALID when the heights are z-disjoint AND
+# the wing clears the centreline fin laterally.
 #
-# The fuselage front/aft split (ADR-0012) makes *where* over the fuselage
-# matter: a wing over `fuselage_front` (cockpit) is a HARD conflict (z
-# ignored, D1); a wing over `fuselage_aft` (tail) keeps today's z-gap rule.
-# This fixture is the headline POSITIVE control for the new rule — the
-# overlap deliberately lands on the AFT segment, well clear of the cockpit,
-# so it stays valid (its z-disjoint cousin `invalid_wing_over_cockpit.yaml`
-# lands on the front and is rejected).
+# The headline POSITIVE control. The ctsl high wing (z 1.9-2.2) overhangs fuji's
+# wide horizontal stabilizer (`tail`, z 1.3-1.6) — a real ~1.24 m² nest that
+# PASSES because the z-gap (0.3 m) exceeds the 0.2 m clearance. ctsl is placed
+# (x 5.5) so the wing passes OUTBOARD of fuji's thin centreline fin
+# (`vertical_stabilizer`, z 1.6-2.02 reaching into the wing layer, ~world x 5.0),
+# so the fin does not bite. A wing crossing directly over the fin would conflict
+# (see `invalid_wing_over_fin.yaml`); clearing it laterally keeps the nest legal.
 #
-# Fuji's fuselage split: plane-local fuselage spans x ∈ [-4.39, 3.59];
-# the wing trailing edge x_break = 0.10 - 1.5/2 = -0.65, so
-# `fuselage_front` = plane-local x ∈ [-0.65, 3.59] (cockpit / nose),
-# `fuselage_aft` = plane-local x ∈ [-4.39, -0.65] (cabin-aft + tail).
-#
-# Layout (Fuji at heading 180 so its NOSE points toward the door / -y,
-# putting the aft/tail at the DEEPER-y end where the ctsl wing crosses):
-#   fuji at (5, 5, 180, false):
-#       fuselage_front world x ∈ [4.50, 5.50], y ∈ [1.41, 5.65], z [0, 1.6]
-#       fuselage_aft   world x ∈ [4.50, 5.50], y ∈ [5.65, 9.39], z [0, 1.6]
-#       wing           world x ∈ [0.29, 9.71], y ∈ [4.15, 5.65], z [0.8, 1.1]
-#   ctsl at (4, 10.5, 90, false):
-#       wing world x ∈ [3.97, 5.37], y ∈ [6.21, 14.79], z [1.9, 2.2]
-#
-# Plan-view overlap of ctsl wing × fuji `fuselage_aft`: x ∈ [4.50, 5.37],
-# y ∈ [6.21, 9.39] — a real "in 2D this looks like a collision" zone.
-# z-gap = 1.9 - 1.6 = 0.3 m > 0.2 m clearance ⇒ NOT a conflict.
-#
-# Crucially the ctsl wing clears fuji's `fuselage_front` by 0.555 m in plan
-# view (> 0.3 m horizontal clearance), so the hard cockpit rule does NOT
-# fire — this is genuinely a wing-over-tail, not a wing-over-cockpit.
-#
-# Counterpart non-conflicts that must also be clean here:
-#   - ctsl fuselage (centred near world x ≈ 4) doesn't enter fuji's footprint.
-#   - ctsl wing × fuji wing: any plan overlap is z-disjoint by 0.8 m.
+# fuji at (5, 5, 180): nose toward the door (-y), tail surfaces at the deeper-y
+#   end; fin centreline ~x 5.0; horizontal stab spans ~x 3.4-6.6, low (z 1.3-1.6).
+# ctsl at (5.5, 10.5, 90): wing world x ~5.07-6.47, clearing the fin by > 0.3 m,
+#   overlapping the low horizontal stab z-disjointly; clears the cockpit too.
 #
 # A bbox-style implementation that ignores z would mark this invalid.
 
@@ -48,7 +27,7 @@ placements:
     heading_deg: 180.0
     on_carts: false
   - plane: ctsl
-    x_m: 4.0
+    x_m: 5.5
     y_m: 10.5
     heading_deg: 90.0
     on_carts: false

--- a/tests/fixtures/valid_high_over_low_aft_z_disjoint.yaml
+++ b/tests/fixtures/valid_high_over_low_aft_z_disjoint.yaml
@@ -12,7 +12,7 @@
 #
 # fuji at (5, 5, 180): nose toward the door (-y), tail surfaces at the deeper-y
 #   end; fin centreline ~x 5.0; horizontal stab spans ~x 3.4-6.6, low (z 1.3-1.6).
-# ctsl at (5.5, 10.5, 90): wing world x ~5.07-6.47, clearing the fin by > 0.3 m,
+# ctsl at (5.5, 10.5, 90): wing world x ~5.47-6.87, clearing the fin by ~0.40 m,
 #   overlapping the low horizontal stab z-disjointly; clears the cockpit too.
 #
 # A bbox-style implementation that ignores z would mark this invalid.

--- a/tests/fixtures/valid_wing_over_tail.yaml
+++ b/tests/fixtures/valid_wing_over_tail.yaml
@@ -1,32 +1,22 @@
-# #50 / ADR-0012 — a wing over another plane's `fuselage_aft` (tail) at a
-# z-disjoint height is VALID: the aft region is empty / walkable, so the
-# uniform two-clause z-gap rule still governs (z-gap 0.3 m > 0.2 m clearance
-# ⇒ no conflict). This is the VALID half of the front/aft pair.
+# #50 / ADR-0012 + ADR-0023 — a wing over another plane's tail surfaces at a
+# z-disjoint height is VALID *when it clears the centreline fin laterally*.
 #
-# Paired with `invalid_wing_over_cockpit.yaml`: the two fixtures use the
-# same two aircraft at the same z-disjoint height and differ only in Fuji's
-# heading (which flips its `fuselage_front` vs `fuselage_aft` to the
-# deeper-y end the ctsl wing crosses). Over the COCKPIT it is a hard
-# conflict; over the TAIL it is valid — the cleanest demonstration of the
-# split (mirrors the case-7/8 left/right-symmetry idiom).
+# The ctsl high wing (z 1.9-2.2) overhangs fuji's wide horizontal stabilizer
+# (`tail`, z 1.3-1.6) — a genuine ~1.24 m² nest that PASSES because the heights
+# are disjoint (z-gap 0.3 m > 0.2 m clearance). It is positioned (ctsl x = 5.5)
+# so its footprint passes OUTBOARD of fuji's thin centreline fin
+# (`vertical_stabilizer`, z 1.6-2.02, on fuji's centreline ~world x 5.0), so the
+# fin's height into the wing layer does not bite. This is the VALID half of the
+# front/aft pair AND the lateral-clearance half of the fin rule (ADR-0023).
 #
-# Fuji's fuselage split: plane-local fuselage spans x ∈ [-4.39, 3.59];
-# wing trailing edge x_break = 0.10 - 1.5/2 = -0.65 ⇒
-# `fuselage_aft` = plane-local x ∈ [-4.39, -0.65] (cabin-aft + tail).
+# Paired with `invalid_wing_over_cockpit.yaml` (same two aircraft, same ctsl
+# placement, differ only in Fuji's heading) and `invalid_wing_over_fin.yaml`
+# (same Fuji heading, ctsl shifted ONTO the centreline fin → conflict).
 #
-# Layout (Fuji at heading 180 ⇒ nose points toward the door / -y, so
-# `fuselage_aft` is at the high-y end where the ctsl wing crosses):
-#   fuji at (5, 9, 180, false):
-#       fuselage_front world x ∈ [4.50, 5.50], y ∈ [5.41,  9.65], z [0, 1.6]
-#       fuselage_aft   world x ∈ [4.50, 5.50], y ∈ [9.65, 13.39], z [0, 1.6]
-#   ctsl at (4, 14.5, 90, false):
-#       wing world x ∈ [3.97, 5.37], y ∈ [10.21, 18.79], z [1.9, 2.2]
-#
-# Plan-view overlap of ctsl wing × fuji `fuselage_aft`: x ∈ [4.50, 5.37],
-# y ∈ [10.21, 13.39]. z-gap = 1.9 - 1.6 = 0.3 m > 0.2 m clearance ⇒ NOT a
-# conflict. The ctsl wing clears fuji's `fuselage_front` (y ≤ 9.65) by
-# 0.555 m in plan view (> 0.3 m clearance), so the hard cockpit rule does
-# NOT fire — zero conflicts.
+# fuji at (5, 9, 180): nose toward the door (-y), so tail surfaces are at the
+#   high-y end; fin on the centreline ~x 5.0; horizontal stab spans ~x 3.4-6.6.
+# ctsl at (5.5, 14.5, 90): wing world x ~5.07-6.47 (clears the fin's x ~4.93-5.07
+#   by > 0.3 m), overlapping fuji's horizontal stab z-disjointly. Zero conflicts.
 
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml
@@ -38,7 +28,7 @@ placements:
     heading_deg: 180.0
     on_carts: false
   - plane: ctsl
-    x_m: 4.0
+    x_m: 5.5
     y_m: 14.5
     heading_deg: 90.0
     on_carts: false

--- a/tests/fixtures/valid_wing_over_tail.yaml
+++ b/tests/fixtures/valid_wing_over_tail.yaml
@@ -15,8 +15,8 @@
 #
 # fuji at (5, 9, 180): nose toward the door (-y), so tail surfaces are at the
 #   high-y end; fin on the centreline ~x 5.0; horizontal stab spans ~x 3.4-6.6.
-# ctsl at (5.5, 14.5, 90): wing world x ~5.07-6.47 (clears the fin's x ~4.93-5.07
-#   by > 0.3 m), overlapping fuji's horizontal stab z-disjointly. Zero conflicts.
+# ctsl at (5.5, 14.5, 90): wing world x ~5.47-6.87 (clears the fin's x ~4.93-5.07
+#   by ~0.40 m), overlapping fuji's horizontal stab z-disjointly. Zero conflicts.
 
 fleet: ../../data/fleet.yaml
 hangar: ../../data/hangar.yaml

--- a/tests/fuzz/geometry_strategies.py
+++ b/tests/fuzz/geometry_strategies.py
@@ -51,7 +51,7 @@ from hangarfit.models import (
 # transform/checker logic, not probing how GEOS handles ±inf coordinates (a
 # shapely concern, not ours — and a source of false findings). Headings range
 # well outside [0, 360) to exercise the sin/cos wrap.
-_PART_KINDS = ["fuselage_front", "fuselage_aft", "wing", "strut", "tail"]
+_PART_KINDS = ["fuselage_front", "fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer"]
 _coord = st.floats(min_value=-60.0, max_value=60.0, allow_nan=False, allow_infinity=False)
 _dim = st.floats(min_value=0.05, max_value=25.0, allow_nan=False, allow_infinity=False)
 _heading = st.floats(min_value=-1080.0, max_value=1080.0, allow_nan=False, allow_infinity=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -305,8 +305,19 @@ class TestFleetHangarOverrides:
 def test_solve_human_output_shows_min_gap(capsys):
     from hangarfit.cli import main
 
+    # An EASY 3-plane fixture: rc==0 is set the moment the first valid basin is
+    # found (sub-second), so this can't flake under heavy parallel CI load — the
+    # budget only governs spread-pool collection, not the verdict. (A hard 6/9-plane
+    # fill flaked here once #519/#520 tail surfaces slowed each restart.)
     rc = main(
-        ["solve", "tests/fixtures/solve_fresh_six_planes.yaml", "--seed", "7", "--budget", "5"]
+        [
+            "solve",
+            "tests/fixtures/solve_fresh_alternatives_three.yaml",
+            "--seed",
+            "7",
+            "--budget",
+            "5",
+        ]
     )
     out = capsys.readouterr().out
     assert rc == 0
@@ -318,10 +329,12 @@ def test_solve_json_output_has_spread_diagnostics(capsys):
 
     from hangarfit.cli import main
 
+    # Easy 3-plane fixture — load-robust (see test_solve_human_output_shows_min_gap):
+    # rc==0 once the first valid basin is found, regardless of wall-clock budget.
     rc = main(
         [
             "solve",
-            "tests/fixtures/solve_fresh_six_planes.yaml",
+            "tests/fixtures/solve_fresh_alternatives_three.yaml",
             "--seed",
             "7",
             "--budget",

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -568,11 +568,14 @@ def test_solve_no_spread_flag_accepted_and_runs(tmp_path):
     """`--no-spread` is accepted on `solve` and drives a successful no-spread run."""
     from hangarfit.cli import main
 
+    # Easy 2-plane fixture so rc==0 is load-robust: it finds a valid layout
+    # immediately rather than risking budget exhaustion under heavy parallel CI
+    # load (which #519/#520 tail surfaces made worse on the old 9-plane fill).
     out = tmp_path / "layout.yaml"
     rc = main(
         [
             "solve",
-            "tests/fixtures/solve_all_nine_large_hangar.yaml",
+            "tests/fixtures/scenario_minimal.yaml",
             "--seed",
             "42",
             "--budget",
@@ -629,11 +632,14 @@ def test_solve_no_back_fill_flag_accepted_and_runs(tmp_path):
     """`--no-back-fill` is accepted on `solve` and drives a successful run."""
     from hangarfit.cli import main
 
+    # Easy 2-plane fixture so rc==0 is load-robust (finds a valid layout at once,
+    # rather than risking budget exhaustion under heavy parallel CI load that
+    # #519/#520 tail surfaces aggravated on the old 9-plane fill).
     out = tmp_path / "layout.yaml"
     rc = main(
         [
             "solve",
-            "tests/fixtures/solve_all_nine_large_hangar.yaml",
+            "tests/fixtures/scenario_minimal.yaml",
             "--seed",
             "42",
             "--budget",

--- a/tests/test_collisions.py
+++ b/tests/test_collisions.py
@@ -834,3 +834,152 @@ class TestBroadPhaseEquivalence:
                 had_conflict += 1
         assert loaded >= 5, f"expected to sweep several layout fixtures, loaded {loaded}"
         assert had_conflict >= 1, "sweep never exercised a conflicting pair — net is too weak"
+
+
+class TestEmpennage:
+    """ADR-0023 / #518: the empennage as explicit tail surfaces.
+
+    The collision predicate is unchanged — these lock that honest tail
+    z-extents produce the physically correct verdict: a fin in the wing layer
+    blocks a nest that passes over it; a wing that clears the fin still nests;
+    a realistic-width tailplane clips a neighbour's low part. Built from
+    synthetic inline aircraft (not the placeholder fleet) so the geometry is
+    fully controlled. Heading 0 maps plane-local +x -> world +y and plane-local
+    +y -> world +x (det(-1), ADR-0002); offsets below are chosen against that.
+    """
+
+    def _layout(
+        self,
+        *,
+        nester_xy: tuple[float, float],
+        nester_kind: str = "wing",
+        nester_z: tuple[float, float] = (2.0, 2.3),
+        nester_size: tuple[float, float] = (4.0, 4.0),
+    ):
+        from hangarfit.models import (
+            Aircraft,
+            Door,
+            Hangar,
+            Layout,
+            MaintenanceBay,
+            Part,
+            Placement,
+            Wheels,
+        )
+
+        # HOST parked at world (10, 10): low aft fuselage (z 0..1.5), a low wide
+        # tailplane (`tail`, z 1.2..1.5, world x 8.5..11.5 / y 6.7..7.7), and a
+        # tall thin centreline fin (`vertical_stabilizer`, z 1.5..2.4 reaching
+        # into the 2.0..2.3 wing band, world x ~9.93..10.08 / y 6.6..7.8).
+        host = Aircraft(
+            id="host",
+            name="Host",
+            wing_position="high",
+            gear="tailwheel",
+            movement_mode="always_own_gear",
+            turn_radius_m=5.0,
+            measured=False,
+            parts=(
+                Part(
+                    kind="fuselage_aft",
+                    length_m=3.0,
+                    width_m=0.85,
+                    offset_x_m=-1.5,
+                    offset_y_m=0.0,
+                    angle_deg=0.0,
+                    z_bottom_m=0.0,
+                    z_top_m=1.5,
+                ),
+                Part(
+                    kind="tail",
+                    length_m=1.0,
+                    width_m=3.0,
+                    offset_x_m=-2.8,
+                    offset_y_m=0.0,
+                    angle_deg=0.0,
+                    z_bottom_m=1.2,
+                    z_top_m=1.5,
+                ),
+                Part(
+                    kind="vertical_stabilizer",
+                    length_m=1.2,
+                    width_m=0.15,
+                    offset_x_m=-2.8,
+                    offset_y_m=0.0,
+                    angle_deg=0.0,
+                    z_bottom_m=1.5,
+                    z_top_m=2.4,
+                ),
+            ),
+            wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-3.0),
+        )
+        nx, ny = nester_xy
+        nl, nw = nester_size
+        nester = Aircraft(
+            id="nester",
+            name="Nester",
+            wing_position="high",
+            gear="tailwheel",
+            movement_mode="always_own_gear",
+            turn_radius_m=5.0,
+            measured=False,
+            parts=(
+                Part(
+                    kind=nester_kind,  # type: ignore[arg-type]
+                    length_m=nl,
+                    width_m=nw,
+                    offset_x_m=0.0,
+                    offset_y_m=0.0,
+                    angle_deg=0.0,
+                    z_bottom_m=nester_z[0],
+                    z_top_m=nester_z[1],
+                ),
+            ),
+            wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-3.0),
+        )
+        hangar = Hangar(
+            length_m=40.0,
+            width_m=20.0,
+            door=Door(center_x_m=10.0, width_m=12.0),
+            maintenance_bay=MaintenanceBay(center_x_m=10.0, width_m=8.0, depth_m=9.0),
+            clearance_m=0.3,
+            wing_layer_clearance_m=0.2,
+        )
+        return Layout(
+            fleet={"host": host, "nester": nester},
+            hangar=hangar,
+            placements=(
+                Placement(plane_id="host", x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False),
+                Placement(plane_id="nester", x_m=nx, y_m=ny, heading_deg=0.0, on_carts=False),
+            ),
+            maintenance_plane=None,
+        )
+
+    def test_fin_blocks_wing_nesting(self) -> None:
+        """#520 safety case: a wing footprint passing OVER the host's centreline
+        fin (fin z_top 2.4 in the wing band) conflicts — silently valid today."""
+        result = check(self._layout(nester_xy=(10.0, 7.0)))
+        assert not result.valid
+        assert _conflict_kinds(result) == {"vertical_stabilizer_wing_overlap"}, result.conflicts
+
+    def test_wing_clears_fin_laterally_is_valid(self) -> None:
+        """#520 nuance: a wing whose footprint passes OUTBOARD of the thin
+        centreline fin (no plan-view overlap with it) still nests over the
+        host's low tailplane at a disjoint height -> valid."""
+        result = check(self._layout(nester_xy=(13.0, 7.0)))
+        assert result.valid, result.conflicts
+
+    def test_wide_tailplane_clips_neighbour_low_part(self) -> None:
+        """#519: a neighbour's low part (fuselage_aft at z 0..1.5) overlapping
+        the host's realistic ~3 m tailplane in plan view at a shared z-band
+        conflicts — free space under the old fuselage-tube-width model."""
+        result = check(
+            self._layout(
+                nester_xy=(8.3, 7.2),
+                nester_kind="fuselage_aft",
+                nester_z=(0.0, 1.5),
+                nester_size=(1.5, 1.5),
+            )
+        )
+        assert not result.valid
+        assert "fuselage_aft_tail_overlap" in _conflict_kinds(result), result.conflicts

--- a/tests/test_collisions.py
+++ b/tests/test_collisions.py
@@ -113,27 +113,27 @@ class TestPairwiseOverlap:
         )
 
     def test_case_5_fuselage_fuselage_overlap(self) -> None:
-        """Two fuselages overlapping → still invalid, but the kind set + count
-        change with the front/aft split.
+        """Two deeply-overlapping planes → invalid, with a rich set of
+        correctly-taxonomized segment-pair conflicts.
 
-        Re-pinned for #50 / ADR-0012: ctsl and fuji fuselages overlap. The
-        single legacy ``fuselage_fuselage_overlap`` splits into the
-        segment-pair kinds — here the overlap zone spans ctsl's aft × fuji's
-        front and ctsl's aft × fuji's aft, so two conflicts fire
-        (``fuselage_aft_fuselage_aft_overlap`` and
-        ``fuselage_aft_fuselage_front_overlap``). The *verdict* is unchanged
-        (two overlapping fuselages is a conflict regardless of segment, since
-        they share a z-band); only the taxonomy + count move. The retired
-        un-split kind must never reappear."""
+        Re-pinned for #50 / ADR-0012 (front/aft split) and ADR-0023 (the tail
+        surfaces). ctsl and fuji are parked so their fuselages overlap; with the
+        empennage now modelled, the dense overlap also catches fuji's wide
+        horizontal stabilizer (``tail``) and the ctsl wing over fuji's fin
+        (``vertical_stabilizer``). The *verdict* is unchanged; the taxonomy is
+        richer. The invariants that matter: the retired un-split
+        ``fuselage_fuselage_overlap`` kind never reappears, the fuselage
+        segment-pair kinds are present, and every kind is the two part kinds
+        sorted alphabetically + ``_overlap``."""
         result = check(_load("invalid_fuselage_fuselage"))
         assert not result.valid
         assert _conflict_kinds(result) == {
             "fuselage_aft_fuselage_aft_overlap",
             "fuselage_aft_fuselage_front_overlap",
-        }, f"expected segment-pair fuselage kinds, got {result.conflicts!r}"
-        assert len(result.conflicts) == 2, (
-            f"expected exactly 2 conflicts, got {len(result.conflicts)}: {result.conflicts!r}"
-        )
+            "fuselage_aft_tail_overlap",
+            "fuselage_front_tail_overlap",
+            "vertical_stabilizer_wing_overlap",
+        }, f"expected the re-pinned segment-pair kind set, got {result.conflicts!r}"
         assert "fuselage_fuselage_overlap" not in _conflict_kinds(result), (
             f"retired un-split kind leaked into conflicts: {result.conflicts!r}"
         )
@@ -163,12 +163,26 @@ class TestWingOverFuselageSegment:
         )
 
     def test_wing_over_tail_at_same_height_is_valid(self) -> None:
-        """The same wing over ``fuselage_aft`` at the same z-disjoint height
-        is valid — the aft region keeps the z-gap rule."""
+        """A wing over another plane's tail surfaces at a z-disjoint height is
+        valid WHEN it clears the centreline fin laterally — the ctsl wing nests
+        over fuji's low horizontal stabilizer (z-disjoint) and passes outboard
+        of fuji's fin (#50/ADR-0012 tail rule + ADR-0023 lateral clearance)."""
         result = check(_load("valid_wing_over_tail"))
         assert result.valid, (
-            f"wing over fuselage_aft at z-disjoint height must be valid, "
+            f"wing over the tail clearing the fin must be valid, "
             f"got conflicts: {result.conflicts!r}"
+        )
+
+    def test_wing_over_fin_conflicts_on_real_fleet(self) -> None:
+        """ADR-0023 (#520): the same wing-over-tail as ``valid_wing_over_tail``,
+        but with the overhanging ctsl wing slid ONTO fuji's centreline fin. The
+        fin rises into the wing layer, so this flips to a
+        ``vertical_stabilizer_wing_overlap`` conflict — silently valid before
+        the empennage was modelled."""
+        result = check(_load("invalid_wing_over_fin"))
+        assert not result.valid
+        assert "vertical_stabilizer_wing_overlap" in _conflict_kinds(result), (
+            f"expected the fin conflict, got {result.conflicts!r}"
         )
 
     def test_fuselage_front_wing_kind_is_alphabetical(self) -> None:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -158,7 +158,7 @@ class TestRealDataFiles:
     def test_load_hangar(self) -> None:
         hangar = load_hangar(HANGAR_YAML)
         assert hangar.length_m == 25.0
-        assert hangar.width_m == 18.0
+        assert hangar.width_m == 22.0  # widened for #519/#520 (realistic tail surfaces)
         assert hangar.door.center_x_m == 9.0
         assert hangar.maintenance_bay.center_x_m == 13.5
         assert hangar.maintenance_bay.width_m == 9.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -93,7 +93,9 @@ class TestPart:
         with pytest.raises(ValueError, match="Part.kind must be one of"):
             _ok_part(kind=kind)  # type: ignore[arg-type]
 
-    @pytest.mark.parametrize("kind", ["fuselage_front", "fuselage_aft", "wing", "strut", "tail"])
+    @pytest.mark.parametrize(
+        "kind", ["fuselage_front", "fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer"]
+    )
     def test_all_valid_kinds_accepted(self, kind: str) -> None:
         p = _ok_part(kind=kind)  # type: ignore[arg-type]
         assert p.kind == kind

--- a/tests/test_solver_canaries.py
+++ b/tests/test_solver_canaries.py
@@ -159,8 +159,18 @@ def test_solve_deterministic_best_partial_under_max_restarts() -> None:
         ``1 < 2`` (the predicate is strictly ``<``, not ``<=``), so
         the canary keeps working — but headroom drops to one restart
         and is one regression away from breaking.
+
+        Re-calibrated 2026-06-08 for #519/#520 (ADR-0023): widening
+        ``data/hangar.yaml`` 18 -> 22 m (so the demo keeps its full plane
+        set with the bulkier tail surfaces) made the shared
+        ``solve_fresh_six_planes.yaml`` *solvable* within ``max_restarts=1``,
+        flipping this canary to ``status=found``. It now uses a dedicated
+        tight 18 m hangar fixture (``solve_canary_six_planes_tight.yaml`` ->
+        ``canary_hangar_tight_18m.yaml``) so the fill stays un-fully-solvable
+        within the cap — decoupling the canary from ``data/hangar.yaml``'s
+        width so future demo-hangar tweaks cannot re-break it.
     """
-    fixture = "tests/fixtures/solve_fresh_six_planes.yaml"
+    fixture = "tests/fixtures/solve_canary_six_planes_tight.yaml"
     max_restarts = 1
     seed = 256
 

--- a/tests/test_towplanner_grid_heuristic.py
+++ b/tests/test_towplanner_grid_heuristic.py
@@ -170,8 +170,14 @@ def test_default_heuristic_and_stats_do_not_change_the_path() -> None:
 
 
 def test_grid_heuristic_is_deterministic() -> None:
-    """``heuristic="grid"`` is RNG-free ⇒ byte-identical across repeat runs."""
-    layout = load_layout("tests/fixtures/valid_all_nine_planes.yaml")
+    """``heuristic="grid"`` is RNG-free ⇒ byte-identical across repeat runs.
+
+    Uses a sparse 2-plane nesting fixture: since ADR-0023 added realistic tail
+    surfaces (#519/#520), the packed 9-plane ``valid_all_nine_planes`` fill is
+    statically valid but no longer tow-routable (the wide tailplanes block every
+    corridor). This test only needs *a* routable plane to exercise the grid
+    heuristic's determinism."""
+    layout = load_layout("tests/fixtures/valid_left_side_nesting.yaml")
     mover = min(layout.placements, key=lambda p: p.y_m).plane_id  # a shallow, routable plane
     stats: dict[str, object] = {}
     a = _route_one(layout, mover, heuristic="grid", stats=stats)
@@ -191,7 +197,9 @@ def test_grid_heuristic_is_deterministic() -> None:
 
 
 def test_grid_path_is_oracle_clean() -> None:
-    layout = load_layout("tests/fixtures/valid_all_nine_planes.yaml")
+    # Sparse 2-plane fixture: the packed 9-plane fill is no longer tow-routable
+    # once the empennage is modelled (ADR-0023); a routable plane suffices here.
+    layout = load_layout("tests/fixtures/valid_left_side_nesting.yaml")
     mover = min(layout.placements, key=lambda p: p.y_m).plane_id
     others = tuple(p for p in layout.placements if p.plane_id != mover)
     placed = Layout(
@@ -352,9 +360,11 @@ def test_plan_fill_global_cap_bails_in_bounded_total_expansions() -> None:
     """``max_total_expansions`` caps the SUM of expansions across the whole fill
     (#336). A tiny global cap forces a fast, bounded bail with the cap-exhausted
     conflict — instead of paying per-plane-budget × scan-retries on a fill the
-    bounded planner cannot route. ``valid_two_separated`` leads with the 18 m-wing
-    scheibe_falke, which cannot route in 10 expansions, so the global cap trips."""
-    layout = load_layout("tests/fixtures/valid_two_separated.yaml")
+    bounded planner cannot route. Uses the packed 9-plane fill, which since
+    ADR-0023 added realistic tail surfaces (#519/#520) is no longer tow-routable
+    (the wide tailplanes block every corridor): the planes consume expansions
+    until the global SUM cap trips."""
+    layout = load_layout("tests/fixtures/valid_all_nine_planes.yaml")
     with pytest.raises(NoFeasiblePlanError) as ei:
         plan_fill(layout, max_total_expansions=10)
     assert "global fill expansion budget" in ei.value.conflict.detail

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -505,6 +505,36 @@ class TestDrawPartHandlesVerticalStabilizer:
         ax.add_patch.assert_called_once()
 
 
+class TestDrawPartExhaustiveOverClosedKinds:
+    """Every member of the closed ``PartKind`` set must reach a real
+    ``_draw_part`` branch — not the fail-loud ``else``. This converts the
+    "PartKind grew; the renderer didn't" footgun into a test failure the day a
+    seventh kind is added without a render branch (the membership-set analogue
+    of the ``else: raise`` guard; ADR-0023 review)."""
+
+    def test_every_part_kind_renders_without_raising(self) -> None:
+        from unittest.mock import MagicMock
+
+        from shapely.geometry import Polygon
+
+        from hangarfit.geometry import WorldPart
+        from hangarfit.models import _VALID_PART_KINDS
+        from hangarfit.visualize import _draw_part
+
+        square = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        for kind in sorted(_VALID_PART_KINDS):
+            part = WorldPart(
+                polygon=square,
+                z_bottom_m=0.0,
+                z_top_m=1.0,
+                plane_id="probe",
+                kind=kind,  # type: ignore[arg-type]
+            )
+            ax = MagicMock()
+            _draw_part(ax, part, "#0079B5")  # must not raise for any closed kind
+            ax.add_patch.assert_called_once()
+
+
 class TestDrawTowPaths:
     """`_draw_tow_paths` overlays each plane's tow path as a polyline, one
     colour per plane, at the conflict-overlay z-tier (#192). Companion to

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -480,6 +480,31 @@ class TestDrawPartHandlesTailKind:
         ax.add_patch.assert_called_once()
 
 
+class TestDrawPartHandlesVerticalStabilizer:
+    """``vertical_stabilizer`` (the fin, #520/ADR-0023) renders via its own
+    branch in ``_draw_part``, not the fail-loud ``else``. The fin rises into /
+    above the wing layer, so it is drawn opaque on top as a height cue."""
+
+    def test_vertical_stabilizer_kind_renders_without_exception(self) -> None:
+        from unittest.mock import MagicMock
+
+        from shapely.geometry import Polygon
+
+        from hangarfit.geometry import WorldPart
+        from hangarfit.visualize import _draw_part
+
+        fin_part = WorldPart(
+            polygon=Polygon([(0, 0), (0.15, 0), (0.15, 1.2), (0, 1.2)]),
+            z_bottom_m=1.5,
+            z_top_m=2.4,
+            plane_id="probe",
+            kind="vertical_stabilizer",
+        )
+        ax = MagicMock()
+        _draw_part(ax, fin_part, "#0079B5")
+        ax.add_patch.assert_called_once()
+
+
 class TestDrawTowPaths:
     """`_draw_tow_paths` overlays each plane's tow path as a polyline, one
     colour per plane, at the conflict-overlay z-tier (#192). Companion to


### PR DESCRIPTION
Closes #519
Closes #520
Refs #518

Models the empennage as two explicit oriented-rectangle `Part`s per **[ADR-0023](https://github.com/DocGerd/hangarfit/blob/feature/518-empennage-model/docs/adr/0023-empennage-tail-surfaces.md)**: a wide `tail` (horizontal stabilizer, reusing the existing kind) and a thin, tall **`vertical_stabilizer`** (new `PartKind`, the fin). The collision **predicate is unchanged** — honest z-extents make the existing two-clause rule catch a fin in the wing layer (#520) and a tailplane wider than the fuselage tube (#519). Per-part z expresses conventional / cruciform / T-tail (the Stemme S10 is the fleet's one T-tail) with no per-type code.

`★` Why no predicate change: the z-clause is already `max(z_bottom) − min(z_top) < clearance`; a `vertical_stabilizer` whose `z_top` enters the wing band conflicts with an overhanging wing **only after** the mandatory plan-view-overlap gate — so wing-over-tail nesting stays legal exactly when the wing clears the thin centreline fin laterally. The 3 inline goldens in `TestEmpennage` pass with zero predicate edits, which is the proof.

## Breaking change — validity contract

Previously-"valid" layouts where a wing nests over a fin (or a wide tailplane overlaps a neighbour's low part) now correctly conflict. **Fixture-flip audit:**

| Fixture / artifact | Before | After / resolution |
|---|---|---|
| `valid_wing_over_tail`, `valid_high_over_low_aft_z_disjoint` | valid (wing over aft fuselage) | **re-tuned** — ctsl wing now nests over fuji's low tailplane (z-disjoint, ~1.24 m²) clearing the centreline fin; still valid |
| `invalid_wing_over_fin` (new) | — | the #520 flip on real data: same nest slid onto the fin → `vertical_stabilizer_wing_overlap` |
| `invalid_fuselage_fuselage` (case 5) | 2 conflicts | re-pinned to its richer 5-kind set (tail/fin now participate); taxonomy invariants kept |
| `examples/layouts/example.yaml` | valid (6-plane demo, 18 m hangar) | **re-laid-out valid** in a widened 22 m `data/hangar.yaml` (realistic tails consume lateral room); keeps its full plane set |
| `examples/herrenteich/layout.yaml` (real all-8) | valid | **re-arranged** (placements only; published dims/fins untouched) to a valid, notch-clear all-8 with ~0.40 m fin clearance |
| `valid_all_nine_planes` (packed fill) | tow-routable | statically valid but **no longer tow-routable** (wide tailplanes block corridors) — towplanner grid tests repointed to a sparse routable fixture; the global-cap canary now uses this fill (its ideal trigger) |
| `data/hangar.yaml` | 25 × **18** m | widened to 25 × **22** m (placeholder); bay rect + left/back walls unchanged |
| max_restarts determinism canary | exhausted on `solve_fresh_six_planes` @ 18 m | decoupled onto a dedicated tight 18 m hangar fixture so the widening can't re-break it |

## Scope
`+1 PartKind`, fleet data (×2), 2D render branch, fixtures, tests, docs. **Not touched:** the collision predicate logic, the det(−1) transform, `geometry.py`, `solver.py`, `towplanner.py`, the loader, `scene.py`, the viewer TypeScript (the new parts render in 3D for free via scene pass-through + `boxMaterial` fall-through). ADR-0023 + a design spec + an ADR-0012 amendment + arc42 §8 update are included.

## Verify
- `pytest` — full suite green (1421 passed locally incl. slow + serial).
- `hangarfit check examples/layouts/example.yaml --render out.png` → valid; tail surfaces + fins render.
- `hangarfit check examples/herrenteich/layout.yaml` → valid (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)