### PR TITLE
feat(geometry): #528 model the L-shaped hangar notch (static containment)

### DIFF
--- a/docs/adr/0018-non-rectangular-hangar-footprint.md
+++ b/docs/adr/0018-non-rectangular-hangar-footprint.md
@@ -1,13 +1,38 @@
 # ADR-0018: Model the non-rectangular hangar footprint — a list of keep-out rects + a derived Shapely floor polygon for containment
 
-- **Status:** Proposed
-  <!-- This is a design-note SPIKE (#424). The deliverable is the decision
-       record only; no `src/` code ships in the PR that introduces this ADR.
-       Implementation is a separate follow-up issue. The status flips to
-       Accepted when the *implementing* PR merges, not when this note lands. -->
+- **Status:** Accepted
+  <!-- Originated as a design-note SPIKE (#424); flipped Proposed → Accepted
+       when the implementing PR (#528, static containment) landed. The full
+       roll-out is umbrella #527 in three stacked PRs: #528 static containment
+       (model + loader + checker + 2D viz + data), #529 tow routing, #530 the
+       3D viewer L-shape. See the Implementation note below for the one
+       deviation from the sketch (orthogonal field, not a generalized list). -->
 
-- **Date:** 2026-06-04
+- **Date:** 2026-06-04 (accepted 2026-06-08)
 - **Deciders:** Patrick Kuhn (DocGerd)
+
+## Implementation note (2026-06-08, #527/#528)
+
+The implementation deviates from this ADR's "generalize `maintenance_bay` into a
+tagged keep-out list" sketch in one deliberate way, decided during build:
+
+- **Orthogonal field, not a generalized list.** `Hangar` gains a new, separate
+  `structural_notches: tuple[StructuralNotch, ...]` field; `maintenance_bay` is
+  left **untouched**. The two stay orthogonal (different activation: the notch is
+  always-on and defines the floor; the bay is state-gated and never subtracted
+  from the floor), so folding the bay into a tagged list would have added
+  backward-compat surface and bay-test churn for **no behavioural gain** — the
+  bay was never going to be subtracted from `floor_polygon` anyway. The keep-out
+  *representation* is still a list of rectangles, exactly as the decision below
+  intends; only the bay is not retrofitted into it.
+- **Inert when empty.** `floor_polygon` is `None` (and the checker keeps its fast
+  per-vertex rectangle path) whenever `structural_notches` is empty — so every
+  no-notch hangar (all `data/` + test fixtures, the determinism canaries, the
+  bench) is **byte-identical and zero-cost**. Only a hangar that configures a
+  notch pays the `covers` cost.
+- **Distinct conflict kind.** A notch overhang is reported as `structural_notch`
+  (not `hangar_bounds`), so the tow planner's mover-bounds exemption can never
+  silently swallow it (#529) and the taxonomy stays self-documenting.
 
 ## Context & Problem Statement
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -95,7 +95,7 @@ manual workflow above is canonical.
 | 0015 | [Wheels do not participate in the static collision model (gear stays render/motion data)](0015-wheels-not-in-collision-model.md) | Accepted |
 | 0016 | [Spread-vs-towability — CLI re-solves spread-off as a backstop when a default-spread layout is un-routable](0016-spread-towability-fallback.md) | Proposed |
 | 0017 | [3D viewer — `scene/v1` JSON seam → self-contained offline Three.js HTML, transform owned by Python](0017-3d-viewer-architecture.md) | Accepted (build-toolchain / thin-renderer decision superseded by [ADR-0020](0020-viewer-typescript-architecture.md)) |
-| 0018 | [Model the non-rectangular hangar footprint — list of keep-out rects + derived Shapely floor polygon for containment](0018-non-rectangular-hangar-footprint.md) | Proposed |
+| 0018 | [Model the non-rectangular hangar footprint — list of keep-out rects + derived Shapely floor polygon for containment](0018-non-rectangular-hangar-footprint.md) | Accepted |
 | 0019 | [Brand tokens live in one Python module (`brand.py`), injected into the viewer as a canonical BRAND blob](0019-brand-tokens-single-source.md) | Proposed |
 | 0020 | [The viewer is a typed, modular TypeScript application built by a dev-only toolchain; the Python-owned transform is retained](0020-viewer-typescript-architecture.md) | Proposed |
 | 0021 | [Tow-planner staging apron — a bounded entry-staging start-region in front of the door; rearrangement holding-area deferred](0021-tow-planner-staging-apron.md) | Proposed |

--- a/examples/herrenteich/README.md
+++ b/examples/herrenteich/README.md
@@ -24,24 +24,25 @@ hangarfit view examples/herrenteich/layout.yaml -o herrenteich.html
 
 ## Two things this dataset is honest about
 
-**1. The hangar is L-shaped; the model is a rectangle.** The real back-right
-corner is notched out (~2.36 m × 9.10 m) — that's office/annex space, not
-hangar floor. The model only has a rectangle, so `hangar.yaml` records the
-bounding rectangle and the files keep planes clear of the notch by hand.
-Teaching the model the notch is spike **#424**.
+**1. The hangar is L-shaped, and since ADR-0018 (#527) the model knows it.**
+The real back-right corner is notched out (~2.36 m × 9.10 m) — that's
+office/annex space, not hangar floor. `hangar.yaml`'s `structural_notches` block
+carves it out of the floor, so `hangarfit check` (and the solver / tow planner)
+now reject any layout that parks — or even overhangs — a plane in it. The
+earlier rectangular model kept planes clear of the notch only by hand; spike
+**#424** designed the fix and **#528** shipped it.
 
 **2. `layout.yaml` is the tool's arrangement, not the club's real parking.**
 The product solver (`hangarfit solve`) cannot produce this layout. (**#425**
 — fixed — once made its trivial-infeasibility gate sum *bounding boxes*, Σ ≈
 606 m² > the 479 m² rectangular floor, and bail, because an 18 m-span motor
 glider is mostly empty air; the gate now sums actual part footprints, Σ ≈
-160 m² « 479, and no longer bails.) It still won't reproduce this layout: the
-rectangular model ignores the office **notch** (#424) the layout keeps clear
-by hand, and finding an all-eight nested arrangement within budget is a
-separate search-feasibility question. The real, part-based collision checker
-accepts a nested layout, so this one was found by driving that checker
-directly. Replace the placements with the club's real parking positions when
-known.
+160 m² « 479, and no longer bails.) It still won't reproduce this layout: even
+though the checker now enforces the office **notch** (#528), finding an
+all-eight nested arrangement within budget is a separate search-feasibility
+question. The real, part-based collision checker accepts a nested layout, so
+this one was found by driving that checker directly. Replace the placements with
+the club's real parking positions when known.
 
 ## Notable aircraft
 

--- a/examples/herrenteich/hangar.yaml
+++ b/examples/herrenteich/hangar.yaml
@@ -7,17 +7,16 @@
 # architect's DWG of the main building (distances annotated on the floor
 # plan, read to the millimetre and rounded here to the centimetre).
 #
-# ⚠ NON-RECTANGULAR FOOTPRINT IS NOT YET MODELLED. The real hangar is an
-# L-shape: one back corner is notched out by ~2.36 m (x) × ~9.10 m (y) —
-# that corner is office/annex space, NOT hangar floor. The model here is
-# the full BOUNDING RECTANGLE (15.08 × 31.76), so a layout that parks a
-# plane in that back corner is NOT yet rejected even though there is no
-# floor there. Representing the notch in the data model + the containment /
-# solver / tow algorithms is deferred to spike #424. In the coordinate
-# frame below the notch is the back-right corner: x ∈ [12.72, 15.08],
-# y ∈ [22.66, 31.76]. These coords are DERIVED from the rectangle dims —
-# back-right = [width-2.36, width] × [length-9.10, length] — so if length_m /
-# width_m are ever re-surveyed, recompute this box (nothing enforces it).
+# NON-RECTANGULAR FOOTPRINT (L-shape). The real hangar's back-right corner is
+# notched out by ~2.36 m (x) × ~9.10 m (y) — that corner is office/annex space,
+# NOT hangar floor. Since ADR-0018 (#527) this is MODELLED: the
+# `structural_notches` block below subtracts the corner from the hangar floor,
+# so `hangarfit check` (and the solver / tow planner) now reject any layout that
+# parks — or even overhangs — a plane in it. width_m / length_m below stay the
+# full BOUNDING RECTANGLE (15.08 × 31.76); the notch is carved out of it. The
+# notch box is DERIVED from the rectangle dims — back-right =
+# [width-2.36, width] × [length-9.10, length] — so if length_m / width_m are
+# ever re-surveyed, recompute it (the loader validates only that it fits).
 #
 # ⚠ NO MAINTENANCE BAY. The real hangar has no modelled curtained bay; the
 # block below is an inert placeholder that only satisfies the schema (the
@@ -48,6 +47,16 @@ maintenance_bay:
   center_x_m: 2.0
   width_m: 3.0
   depth_m: 2.0
+
+structural_notches:
+  # Back-right office/annex corner — a permanent absence of floor (ADR-0018)
+  # that makes the building L-shaped. DERIVED from the rectangle:
+  # x ∈ [width-2.36, width] = [12.72, 15.08],
+  # y ∈ [length-9.10, length] = [22.66, 31.76]. Recompute if the dims change.
+  - x_min_m: 12.72
+    y_min_m: 22.66
+    x_max_m: 15.08
+    y_max_m: 31.76
 
 clearance_m: 0.3        # minimum horizontal gap between any two aircraft parts
 wing_layer_clearance_m: 0.2  # minimum vertical gap between two parts at the same XY

--- a/src/hangarfit/collisions.py
+++ b/src/hangarfit/collisions.py
@@ -71,37 +71,65 @@ def check(layout: Layout) -> CheckResult:
 def _hangar_bounds_conflicts(
     world_parts: dict[str, list[WorldPart]], hangar: Hangar
 ) -> list[Conflict]:
-    """Flag any world part with a vertex outside the hangar rectangle
-    ``[0, width_m] × [0, length_m]``.
+    """Flag any world part that is not fully inside the hangar floor.
 
-    Uses **per-vertex bounds**, not ``polygon.contains(...)``. The Shapely
-    contains check has touching-vs-overlap subtleties at the boundary that
-    would either over- or under-report walls flush with the hangar edge.
-    Per-vertex bounds give "every corner inside" with no surprise semantics
-    — a vertex exactly at ``x = 0`` or ``x = hangar.width_m`` counts as inside.
+    Two regimes, selected by whether the hangar has a structural notch:
+
+    * **No notch (the common case)** — the floor is the plain rectangle
+      ``[0, width_m] × [0, length_m]`` and a part is in-bounds iff every
+      vertex lies inside it. Uses **per-vertex bounds**, not
+      ``polygon.contains(...)``: the Shapely contains check has
+      touching-vs-overlap subtleties at the boundary that would over- or
+      under-report walls flush with the hangar edge; per-vertex bounds give
+      "every corner inside", with a vertex exactly at ``x = 0`` or
+      ``x = hangar.width_m`` counting as inside. This path is byte-identical
+      to the pre-notch checker.
+
+    * **With one or more** :class:`~hangarfit.models.StructuralNotch` — the
+      floor is the L-shaped :attr:`~hangarfit.models.Hangar.floor_polygon`
+      (outer rectangle minus the notches) and a part is in-bounds iff
+      ``floor.covers(part.polygon)``. ``covers`` (not ``contains``) keeps the
+      same boundary-inclusive semantics — a part flush with an outer wall
+      *or* with a notch edge is inside — while correctly rejecting a part that
+      overhangs a notch, **including a thin part whose edge crosses a notch
+      with neither endpoint inside it** (the per-vertex test's blind spot,
+      ADR-0018). A notch overhang is reported as a ``structural_notch``
+      conflict; escaping the outer rectangle stays ``hangar_bounds``.
 
     Emits one conflict per offending **part** (not per plane), with the
     first out-of-bounds vertex of that part. Reporting per-part means a
     plane whose wing sticks out the front *and* tail sticks out the back
     surfaces both, instead of having one masked behind the other.
     """
+    floor = hangar.floor_polygon
     out: list[Conflict] = []
     for plane_id, parts in world_parts.items():
         for part in parts:
             bad = _first_out_of_bounds_vertex(part, hangar)
-            if bad is None:
-                continue
-            x, y = bad
-            out.append(
-                Conflict.single(
-                    kind="hangar_bounds",
-                    plane=plane_id,
-                    detail=(
-                        f"part {part.kind!r} vertex ({x:.3f}, {y:.3f}) outside hangar "
-                        f"0..{hangar.width_m:g} x 0..{hangar.length_m:g}"
-                    ),
+            if bad is not None:
+                x, y = bad
+                out.append(
+                    Conflict.single(
+                        kind="hangar_bounds",
+                        plane=plane_id,
+                        detail=(
+                            f"part {part.kind!r} vertex ({x:.3f}, {y:.3f}) outside hangar "
+                            f"0..{hangar.width_m:g} x 0..{hangar.length_m:g}"
+                        ),
+                    )
                 )
-            )
+                continue
+            # Inside the outer rectangle but possibly overhanging a notch. Only
+            # reached when the hangar has notches (``floor`` is then non-None);
+            # the ``covers`` test also catches edge-crossings with no vertex inside.
+            if floor is not None and not floor.covers(part.polygon):
+                out.append(
+                    Conflict.single(
+                        kind="structural_notch",
+                        plane=plane_id,
+                        detail=_notch_intrusion_detail(part, hangar),
+                    )
+                )
     return out
 
 
@@ -112,6 +140,25 @@ def _first_out_of_bounds_vertex(part: WorldPart, hangar: Hangar) -> tuple[float,
         if not (0.0 <= x <= hangar.width_m and 0.0 <= y <= hangar.length_m):
             return x, y
     return None
+
+
+def _notch_intrusion_detail(part: WorldPart, hangar: Hangar) -> str:
+    """Human-readable detail for a ``structural_notch`` conflict, naming the
+    first notch whose rectangle the part's bounding box overlaps.
+
+    The part has already failed ``floor.covers`` while sitting inside the outer
+    rectangle, so it must overhang *some* notch; the AABB scan just identifies
+    which one for the message (a fallback covers the rare AABB-overlap-only
+    case)."""
+    pxmin, pymin, pxmax, pymax = _part_aabb(part)
+    for n in hangar.structural_notches:
+        if pxmin < n.x_max_m and pxmax > n.x_min_m and pymin < n.y_max_m and pymax > n.y_min_m:
+            return (
+                f"part {part.kind!r} overhangs structural notch "
+                f"(no floor at x ∈ [{n.x_min_m:g}, {n.x_max_m:g}], "
+                f"y ∈ [{n.y_min_m:g}, {n.y_max_m:g}])"
+            )
+    return f"part {part.kind!r} overhangs a structural notch"
 
 
 def _bay_intrusion_conflicts(

--- a/src/hangarfit/collisions.py
+++ b/src/hangarfit/collisions.py
@@ -96,10 +96,12 @@ def _hangar_bounds_conflicts(
       ADR-0018). A notch overhang is reported as a ``structural_notch``
       conflict; escaping the outer rectangle stays ``hangar_bounds``.
 
-    Emits one conflict per offending **part** (not per plane), with the
-    first out-of-bounds vertex of that part. Reporting per-part means a
-    plane whose wing sticks out the front *and* tail sticks out the back
-    surfaces both, instead of having one masked behind the other.
+    Emits one conflict per offending **part** (not per plane): a
+    ``hangar_bounds`` conflict names the first out-of-bounds vertex; a
+    ``structural_notch`` conflict names the overhung notch (the edge-crossing
+    case has no vertex inside to name). Reporting per-part means a plane whose
+    wing sticks out the front *and* tail sticks out the back surfaces both,
+    instead of having one masked behind the other.
     """
     floor = hangar.floor_polygon
     out: list[Conflict] = []
@@ -147,9 +149,11 @@ def _notch_intrusion_detail(part: WorldPart, hangar: Hangar) -> str:
     first notch whose rectangle the part's bounding box overlaps.
 
     The part has already failed ``floor.covers`` while sitting inside the outer
-    rectangle, so it must overhang *some* notch; the AABB scan just identifies
-    which one for the message (a fallback covers the rare AABB-overlap-only
-    case)."""
+    rectangle, so it must overhang *some* notch — and a true overhang always
+    overlaps that notch's AABB, so the scan finds it. The trailing generic
+    ``return`` is an unreachable defensive default. (With multiple notches whose
+    boxes overlap the part, the broad-phase names the first match, which is fine
+    for a human-readable message.)"""
     pxmin, pymin, pxmax, pymax = _part_aabb(part)
     for n in hangar.structural_notches:
         if pxmin < n.x_max_m and pxmax > n.x_min_m and pymin < n.y_max_m and pymax > n.y_min_m:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -210,16 +210,29 @@ def load_hangar(path: Path | str, *, fleet: Mapping[str, Aircraft] | None = None
         if key not in bay_data:
             raise LoaderError(f"{path}: missing required field 'maintenance_bay.{key}'")
 
-    # Optional always-on floor keep-outs (ADR-0018). Absent ⇒ rectangular hangar,
-    # unchanged behaviour. Each entry is an axis-aligned rectangle in hangar coords.
-    notches_data = raw.get("structural_notches", [])
+    # Optional always-on floor keep-outs (ADR-0018). Absent — or an explicit
+    # null (`structural_notches:` with no value) — ⇒ rectangular hangar, unchanged
+    # behaviour (mirrors load_scenario's None→{} handling for `constraints:`).
+    # Each entry is an axis-aligned rectangle in hangar coords.
+    notches_data = raw.get("structural_notches")
+    if notches_data is None:
+        notches_data = []
     if not isinstance(notches_data, list):
         raise LoaderError(f"{path}: 'structural_notches' must be a list of rectangles")
     _notch_keys = ("x_min_m", "y_min_m", "x_max_m", "y_max_m")
+    _allowed_notch_keys = frozenset(_notch_keys)
     for i, notch in enumerate(notches_data):
         if not isinstance(notch, dict):
             raise LoaderError(
                 f"{path}: structural_notches[{i}] must be a mapping with {', '.join(_notch_keys)}"
+            )
+        # Reject unknown keys loudly — a misspelled coord must not be silently
+        # dropped (same discipline as _ALLOWED_AIRCRAFT_KEYS / _parse_wheels).
+        unknown = set(notch) - _allowed_notch_keys
+        if unknown:
+            raise LoaderError(
+                f"{path}: structural_notches[{i}] has unknown key(s) {sorted(unknown)}; "
+                f"allowed: {list(_notch_keys)}"
             )
         for key in _notch_keys:
             if key not in notch:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -52,6 +52,7 @@ from .models import (
     Placement,
     PlaneConstraint,
     Scenario,
+    StructuralNotch,
     StrutsSpec,
     Wheels,
 )
@@ -209,6 +210,21 @@ def load_hangar(path: Path | str, *, fleet: Mapping[str, Aircraft] | None = None
         if key not in bay_data:
             raise LoaderError(f"{path}: missing required field 'maintenance_bay.{key}'")
 
+    # Optional always-on floor keep-outs (ADR-0018). Absent ⇒ rectangular hangar,
+    # unchanged behaviour. Each entry is an axis-aligned rectangle in hangar coords.
+    notches_data = raw.get("structural_notches", [])
+    if not isinstance(notches_data, list):
+        raise LoaderError(f"{path}: 'structural_notches' must be a list of rectangles")
+    _notch_keys = ("x_min_m", "y_min_m", "x_max_m", "y_max_m")
+    for i, notch in enumerate(notches_data):
+        if not isinstance(notch, dict):
+            raise LoaderError(
+                f"{path}: structural_notches[{i}] must be a mapping with {', '.join(_notch_keys)}"
+            )
+        for key in _notch_keys:
+            if key not in notch:
+                raise LoaderError(f"{path}: missing required field 'structural_notches[{i}].{key}'")
+
     try:
         return Hangar(
             length_m=_to_float(raw["length_m"], "length_m"),
@@ -228,6 +244,15 @@ def load_hangar(path: Path | str, *, fleet: Mapping[str, Aircraft] | None = None
             ),
             max_carts=_to_int(raw.get("max_carts", 1), "max_carts"),
             apron_depth_m=_resolve_apron_depth(raw.get("apron_depth_m", 0.0), fleet),
+            structural_notches=tuple(
+                StructuralNotch(
+                    x_min_m=_to_float(notch["x_min_m"], f"structural_notches[{i}].x_min_m"),
+                    y_min_m=_to_float(notch["y_min_m"], f"structural_notches[{i}].y_min_m"),
+                    x_max_m=_to_float(notch["x_max_m"], f"structural_notches[{i}].x_max_m"),
+                    y_max_m=_to_float(notch["y_max_m"], f"structural_notches[{i}].y_max_m"),
+                )
+                for i, notch in enumerate(notches_data)
+            ),
         )
     except (ValueError, TypeError) as e:
         raise LoaderError(f"{path}: {e}") from e

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -452,7 +452,11 @@ class Hangar:
     the collision checker uses for containment. Defaults to empty, in which
     case ``floor_polygon`` is ``None`` and the checker keeps its fast,
     byte-identical per-vertex rectangle test — so a hangar with no notch
-    behaves exactly as before.
+    behaves exactly as before. Each notch is validated to fit inside the
+    rectangle and to leave some floor; coherence *between* keep-outs (a notch
+    overlapping the door opening, the maintenance bay, or another notch) is the
+    author's responsibility and is **not** validated — overlaps are geometrically
+    harmless (the floor is a set difference) but may indicate a data error.
     """
 
     length_m: float
@@ -528,6 +532,14 @@ class Hangar:
                     ]
                 )
             )
+            # A notch (or union) covering the whole floor would otherwise leave an
+            # empty polygon that ``covers`` rejects for *every* part — a baffling
+            # "all planes out of bounds" instead of a clear construction error.
+            if floor.is_empty:
+                raise ValueError(
+                    "structural_notches leave no usable hangar floor "
+                    f"(outer {self.width_m:g} x {self.length_m:g} fully covered)"
+                )
         object.__setattr__(self, "_floor_polygon", floor)
 
     @property

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -19,6 +19,9 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal, cast
 
+from shapely import box, union_all
+from shapely.geometry.base import BaseGeometry
+
 if TYPE_CHECKING:
     from hangarfit.towplanner import MovesPlan
 
@@ -375,6 +378,49 @@ class MaintenanceBay:
 
 
 @dataclass(frozen=True, slots=True)
+class StructuralNotch:
+    """An always-on rectangular keep-out cut from the hangar floor.
+
+    Unlike :class:`MaintenanceBay` — a *state-gated* operational
+    reservation that only bites when a plane occupies it — a structural
+    notch is a **permanent absence of floor**: e.g. the Airfield
+    Herrenteich hangar's back-right office annex, which makes the real
+    building L-shaped rather than rectangular (ADR-0018). It is subtracted
+    from the hangar's derived :attr:`Hangar.floor_polygon`, so the
+    collision checker rejects any part that overhangs it — including a thin
+    part whose *edge* crosses the notch with neither endpoint inside it (a
+    case the legacy per-vertex bounds test missed).
+
+    Axis-aligned, in hangar coordinates: the rectangle
+    ``[x_min_m, x_max_m] × [y_min_m, y_max_m]``. The notch-fits-in-hangar
+    check (``x_max_m ≤ width_m``, ``y_max_m ≤ length_m``) lives on
+    :class:`Hangar` because it needs the hangar dimensions.
+    """
+
+    x_min_m: float
+    y_min_m: float
+    x_max_m: float
+    y_max_m: float
+
+    def __post_init__(self) -> None:
+        if self.x_min_m < 0 or self.y_min_m < 0:
+            raise ValueError(
+                f"StructuralNotch corners must be non-negative, got "
+                f"min=({self.x_min_m}, {self.y_min_m})"
+            )
+        if self.x_max_m <= self.x_min_m:
+            raise ValueError(
+                f"StructuralNotch.x_max_m ({self.x_max_m}) must be greater than "
+                f"x_min_m ({self.x_min_m})"
+            )
+        if self.y_max_m <= self.y_min_m:
+            raise ValueError(
+                f"StructuralNotch.y_max_m ({self.y_max_m}) must be greater than "
+                f"y_min_m ({self.y_min_m})"
+            )
+
+
+@dataclass(frozen=True, slots=True)
 class Hangar:
     """The hangar floor plan.
 
@@ -398,6 +444,15 @@ class Hangar:
     it is positive. The loader resolves the opt-in ``auto`` keyword to a
     fleet-derived depth before construction, so this field is always a plain
     resolved float.
+
+    ``structural_notches`` is an optional tuple of always-on rectangular
+    keep-outs cut from the floor (ADR-0018) — e.g. the real Herrenteich
+    hangar's back-right office annex, which makes the building L-shaped. When
+    present, they are subtracted from the derived :attr:`floor_polygon`, which
+    the collision checker uses for containment. Defaults to empty, in which
+    case ``floor_polygon`` is ``None`` and the checker keeps its fast,
+    byte-identical per-vertex rectangle test — so a hangar with no notch
+    behaves exactly as before.
     """
 
     length_m: float
@@ -408,6 +463,13 @@ class Hangar:
     wing_layer_clearance_m: float
     max_carts: int = 1
     apron_depth_m: float = 0.0
+    structural_notches: tuple[StructuralNotch, ...] = ()
+    # Derived L-shaped floor outline (outer rectangle minus the notches),
+    # computed once in __post_init__ and cached here. ``None`` when there are
+    # no notches (the common case) so the checker stays on its rectangle path.
+    # Excluded from equality/hash/repr (a Shapely geometry is not hashable and
+    # is fully determined by the other fields).
+    _floor_polygon: BaseGeometry | None = field(init=False, compare=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.length_m <= 0:
@@ -446,6 +508,38 @@ class Hangar:
                 f"must be strictly less than Hangar.length_m={self.length_m} "
                 f"(otherwise no non-bay parking area remains)"
             )
+        for notch in self.structural_notches:
+            if notch.x_max_m > self.width_m or notch.y_max_m > self.length_m:
+                raise ValueError(
+                    f"StructuralNotch (x ∈ [{notch.x_min_m:g}, {notch.x_max_m:g}], "
+                    f"y ∈ [{notch.y_min_m:g}, {notch.y_max_m:g}]) doesn't fit in hangar "
+                    f"{self.width_m:g} x {self.length_m:g}"
+                )
+        # Derive the floor outline once. Only build the (more expensive) polygon
+        # when there is something to subtract; otherwise leave it ``None`` and
+        # let the checker stay on the fast rectangle path.
+        floor: BaseGeometry | None = None
+        if self.structural_notches:
+            floor = box(0.0, 0.0, self.width_m, self.length_m).difference(
+                union_all(
+                    [
+                        box(n.x_min_m, n.y_min_m, n.x_max_m, n.y_max_m)
+                        for n in self.structural_notches
+                    ]
+                )
+            )
+        object.__setattr__(self, "_floor_polygon", floor)
+
+    @property
+    def floor_polygon(self) -> BaseGeometry | None:
+        """The hangar floor as a Shapely polygon (outer rectangle minus any
+        :class:`StructuralNotch`), or ``None`` when there are no notches.
+
+        ``None`` is the signal to the collision checker that the floor is a
+        plain rectangle and the fast per-vertex bounds test applies; a non-None
+        value is the L-shaped outline against which parts are tested with
+        ``covers`` (ADR-0018)."""
+        return self._floor_polygon
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -243,14 +243,16 @@ def nose_direction(heading_deg: float) -> tuple[float, float]:
 
 
 def _draw_hangar(ax: Any, layout: Layout) -> None:
-    """Hangar rectangle with a gap in the front wall for the door and a
-    conditional maintenance-bay overlay (closed-bay only)."""
+    """Hangar rectangle with a gap in the front wall for the door, a
+    conditional maintenance-bay overlay (closed-bay only), and an always-on
+    hatched overlay for any structural notch (ADR-0018)."""
     hangar = layout.hangar
     door_left = hangar.door.center_x_m - hangar.door.width_m / 2
     door_right = hangar.door.center_x_m + hangar.door.width_m / 2
 
-    # Bay overlay first (zorder=0) so walls and aircraft layer on top.
+    # Keep-out overlays first (zorder=0) so walls and aircraft layer on top.
     _draw_maintenance_bay(ax, layout)
+    _draw_structural_notches(ax, layout)
 
     # Back, left, right walls — solid.
     ax.plot(
@@ -318,6 +320,30 @@ def _draw_maintenance_bay(ax: Any, layout: Layout) -> None:
         color=_BAY_LABEL_COLOR,
         zorder=4,
     )
+
+
+def _draw_structural_notches(ax: Any, layout: Layout) -> None:
+    """Overlay each always-on structural notch (ADR-0018) as a cross-hatched
+    keep-out — the slice of the bounding rectangle that is *not* floor (e.g. the
+    Herrenteich back-right office annex). Drawn unconditionally whenever notches
+    are present, unlike the state-gated maintenance bay, and rendered in the
+    wall ink (no fill) so it reads as "structure, not parkable floor"."""
+    for notch in layout.hangar.structural_notches:
+        patch = MplPolygon(
+            [
+                (notch.x_min_m, notch.y_min_m),
+                (notch.x_max_m, notch.y_min_m),
+                (notch.x_max_m, notch.y_max_m),
+                (notch.x_min_m, notch.y_max_m),
+            ],
+            closed=True,
+            facecolor="none",
+            edgecolor=_HANGAR_EDGE,
+            hatch="xx",
+            lw=1.5,
+            zorder=0,
+        )
+        ax.add_patch(patch)
 
 
 def _draw_aircraft(ax: Any, layout: Layout) -> None:

--- a/tests/test_collisions.py
+++ b/tests/test_collisions.py
@@ -997,3 +997,129 @@ class TestEmpennage:
         )
         assert not result.valid
         assert "fuselage_aft_tail_overlap" in _conflict_kinds(result), result.conflicts
+
+
+class TestStructuralNotch:
+    """The ``structural_notch`` rule (ADR-0018): an always-on rectangular
+    keep-out cut from the floor. A part overhanging a notch is rejected with a
+    ``structural_notch`` conflict — *including* a thin part whose edge crosses
+    the notch with neither endpoint inside it (the blind spot of the legacy
+    per-vertex bounds test). A hangar with no notch keeps the byte-identical
+    rectangle path.
+    """
+
+    # Herrenteich-shaped notch: back-right corner of a 15.08 x 31.76 hangar.
+    _NOTCH = (12.72, 22.66, 15.08, 31.76)
+
+    def _hangar(self, *, with_notch: bool):
+        from hangarfit.models import Door, Hangar, MaintenanceBay, StructuralNotch
+
+        notches = (StructuralNotch(*self._NOTCH),) if with_notch else ()
+        return Hangar(
+            length_m=31.76,
+            width_m=15.08,
+            door=Door(center_x_m=7.28, width_m=13.46),
+            maintenance_bay=MaintenanceBay(center_x_m=2.0, width_m=3.0, depth_m=2.0),
+            clearance_m=0.3,
+            wing_layer_clearance_m=0.2,
+            structural_notches=notches,
+        )
+
+    def _layout(self, *, probe_xy, with_notch: bool):
+        """Minimal 1-plane layout: a 1x1 m wing centered on the part origin, so
+        at heading 0 its world footprint centers on the placement coords."""
+        from hangarfit.models import Aircraft, Layout, Part, Placement, Wheels
+
+        probe = Aircraft(
+            id="probe",
+            name="Probe",
+            wing_position="high",
+            gear="tailwheel",
+            movement_mode="always_own_gear",
+            turn_radius_m=5.0,
+            measured=False,
+            parts=(
+                Part(
+                    kind="wing",
+                    length_m=1.0,
+                    width_m=1.0,
+                    offset_x_m=0.0,
+                    offset_y_m=0.0,
+                    angle_deg=0.0,
+                    z_bottom_m=2.0,
+                    z_top_m=2.3,
+                ),
+            ),
+            wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
+        )
+        x, y = probe_xy
+        return Layout(
+            fleet={"probe": probe},
+            hangar=self._hangar(with_notch=with_notch),
+            placements=(
+                Placement(plane_id="probe", x_m=x, y_m=y, heading_deg=0.0, on_carts=False),
+            ),
+            maintenance_plane=None,
+        )
+
+    def test_part_in_notch_rejected(self) -> None:
+        """A wing parked inside the office corner overhangs the notch."""
+        result = check(self._layout(probe_xy=(13.8, 27.0), with_notch=True))
+        assert "structural_notch" in _conflict_kinds(result), result.conflicts
+
+    def test_back_left_strip_accepted(self) -> None:
+        """Deep in the back of the hangar but well left of the notch
+        (x < 12.72) is real floor -> valid."""
+        result = check(self._layout(probe_xy=(3.0, 27.0), with_notch=True))
+        assert result.valid, result.conflicts
+
+    def test_no_notch_accepts_same_region(self) -> None:
+        """Byte-identical legacy path: with no notch configured, the same
+        in-corner placement the notch rejects is accepted (plain rectangle),
+        and ``floor_polygon`` stays ``None``."""
+        layout = self._layout(probe_xy=(13.8, 27.0), with_notch=False)
+        assert layout.hangar.floor_polygon is None
+        assert check(layout).valid
+
+    def test_edge_crossing_with_no_vertex_inside_rejected(self) -> None:
+        """The bug ADR-0018 fixes: a thin part whose two endpoints both lie
+        OUTSIDE the notch but whose body slices through it has no vertex inside,
+        so the per-vertex test passed it. ``floor.covers`` rejects it."""
+        from shapely.geometry import Polygon
+
+        from hangarfit.collisions import _hangar_bounds_conflicts
+        from hangarfit.geometry import WorldPart
+
+        hangar = self._hangar(with_notch=True)
+        crossing = WorldPart(
+            polygon=Polygon([(12.0, 31.0), (14.5, 20.0), (14.6, 20.1), (12.1, 31.1)]),
+            z_bottom_m=2.0,
+            z_top_m=2.3,
+            plane_id="p",
+            kind="wing",
+        )
+        x0, y0, x1, y1 = self._NOTCH
+        assert not any(
+            x0 <= vx <= x1 and y0 <= vy <= y1 for vx, vy in crossing.polygon.exterior.coords
+        ), "test setup: no vertex should lie inside the notch"
+        conflicts = _hangar_bounds_conflicts({"p": [crossing]}, hangar)
+        assert [c.kind for c in conflicts] == ["structural_notch"], conflicts
+
+    def test_part_flush_against_notch_edge_accepted(self) -> None:
+        """A part touching the notch's left wall from outside is on floor and
+        accepted (boundary-inclusive ``covers``), mirroring the flush-with-
+        outer-wall convention."""
+        from shapely.geometry import box
+
+        from hangarfit.collisions import _hangar_bounds_conflicts
+        from hangarfit.geometry import WorldPart
+
+        hangar = self._hangar(with_notch=True)
+        flush = WorldPart(
+            polygon=box(11.5, 24.0, 12.72, 25.0),
+            z_bottom_m=2.0,
+            z_top_m=2.3,
+            plane_id="p",
+            kind="wing",
+        )
+        assert _hangar_bounds_conflicts({"p": [flush]}, hangar) == []

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -17,9 +17,10 @@ from hangarfit.loader import load_fleet, load_hangar, load_layout
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HERRENTEICH = REPO_ROOT / "examples" / "herrenteich"
 
-# Real office NOTCH (back-right corner): non-floor space the rectangular hangar
-# model does NOT enforce (hangar.yaml + spike #424). Derived from the rectangle
-# dims: [width-2.36, width] x [length-9.10, length].
+# Real office NOTCH (back-right corner): non-floor space. Since ADR-0018 (#527)
+# it is MODELLED in hangar.yaml (`structural_notches`) and enforced by
+# collisions.check. Derived from the rectangle dims:
+# [width-2.36, width] x [length-9.10, length].
 NOTCH = (12.72, 22.66, 15.08, 31.76)  # x_min, y_min, x_max, y_max
 
 USUAL_OCCUPANTS = {
@@ -63,13 +64,13 @@ def test_everyone_home_layout_is_valid() -> None:
     )
 
 
-def test_layout_clears_unmodelled_office_notch() -> None:
-    """No plane may sit in the back-right office notch.
+def test_layout_clears_office_notch() -> None:
+    """No plane sits in the back-right office notch.
 
-    ``collisions.check`` only validates the bounding rectangle, so a layout
-    edit could drift a plane into the (real, non-floor) office corner and the
-    validity test above would stay green. Pin the clearance the rectangular
-    model cannot see (#424).
+    The notch is now modelled and ``collisions.check`` enforces it (ADR-0018),
+    but this independent, model-free vertex scan double-checks the *shipped*
+    layout — so a future layout edit that drifts a plane into the (real,
+    non-floor) office corner trips here too, with a geometry-level message.
     """
     layout = load_layout(HERRENTEICH / "layout.yaml")
     x0, y0, x1, y1 = NOTCH
@@ -79,5 +80,50 @@ def test_layout_clears_unmodelled_office_notch() -> None:
             for x, y in part.polygon.exterior.coords:
                 assert not (x0 <= x <= x1 and y0 <= y <= y1), (
                     f"{placement.plane_id} {part.kind} vertex ({x:.2f}, {y:.2f}) "
-                    f"is inside the unmodelled office notch — non-floor space"
+                    f"is inside the office notch — non-floor space"
                 )
+
+
+def test_real_hangar_notch_is_enforced() -> None:
+    """The real hangar.yaml carries a modelled notch (ADR-0018), and
+    ``collisions.check`` rejects a part parked in the office corner — a layout
+    the old rectangular model accepted. Exercises the loader → model → checker
+    path on the actual data file.
+    """
+    from hangarfit.models import Aircraft, Layout, Part, Placement, Wheels
+
+    hangar = load_hangar(HERRENTEICH / "hangar.yaml")
+    assert hangar.floor_polygon is not None, "notch should be modelled"
+    # 1x1 m wing centered at (13.9, 27.0) — wholly inside the office corner.
+    probe = Aircraft(
+        id="probe",
+        name="Probe",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=5.0,
+        measured=False,
+        parts=(
+            Part(
+                kind="wing",
+                length_m=1.0,
+                width_m=1.0,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=2.0,
+                z_top_m=2.3,
+            ),
+        ),
+        wheels=Wheels(main_offset_x_m=0.0, track_m=1.8, third_wheel_offset_x_m=-2.0),
+    )
+    layout = Layout(
+        fleet={"probe": probe},
+        hangar=hangar,
+        placements=(
+            Placement(plane_id="probe", x_m=13.9, y_m=27.0, heading_deg=0.0, on_carts=False),
+        ),
+        maintenance_plane=None,
+    )
+    kinds = {c.kind for c in collisions.check(layout).conflicts}
+    assert "structural_notch" in kinds, kinds

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2023,3 +2023,58 @@ def test_load_fleet_rejects_non_utf8_file(tmp_path: Path) -> None:
     bad.write_bytes(b"\xff\xfe\x00bad bytes not utf-8")
     with pytest.raises(LoaderError, match="UTF-8"):
         load_fleet(bad)
+
+
+class TestStructuralNotchesLoading:
+    """`load_hangar` parses the optional `structural_notches:` list (ADR-0018).
+    Absent ⇒ rectangular hangar, byte-identical behaviour."""
+
+    def test_absent_defaults_to_empty(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "h.yaml", _MIN_HANGAR)
+        hangar = load_hangar(path)
+        assert hangar.structural_notches == ()
+        assert hangar.floor_polygon is None
+
+    def test_single_notch_parsed(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "h.yaml",
+            _MIN_HANGAR + "structural_notches: "
+            "[{x_min_m: 14.0, y_min_m: 20.0, x_max_m: 18.0, y_max_m: 25.0}]\n",
+        )
+        hangar = load_hangar(path)
+        assert len(hangar.structural_notches) == 1
+        n = hangar.structural_notches[0]
+        assert (n.x_min_m, n.y_min_m, n.x_max_m, n.y_max_m) == (14.0, 20.0, 18.0, 25.0)
+        assert hangar.floor_polygon is not None
+
+    def test_missing_key_rejected(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "h.yaml",
+            _MIN_HANGAR + "structural_notches: [{x_min_m: 14.0, y_min_m: 20.0, x_max_m: 18.0}]\n",
+        )
+        with pytest.raises(LoaderError, match=r"structural_notches\[0\].y_max_m"):
+            load_hangar(path)
+
+    def test_non_list_rejected(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "h.yaml", _MIN_HANGAR + "structural_notches: {x_min_m: 1.0}\n")
+        with pytest.raises(LoaderError, match="must be a list"):
+            load_hangar(path)
+
+    def test_notch_outside_hangar_rejected(self, tmp_path: Path) -> None:
+        # x_max 20.0 exceeds width 18.0 — a model error wrapped as LoaderError.
+        path = _write(
+            tmp_path / "h.yaml",
+            _MIN_HANGAR + "structural_notches: "
+            "[{x_min_m: 14.0, y_min_m: 20.0, x_max_m: 20.0, y_max_m: 25.0}]\n",
+        )
+        with pytest.raises(LoaderError, match="doesn't fit in hangar"):
+            load_hangar(path)
+
+    def test_degenerate_notch_rejected(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "h.yaml",
+            _MIN_HANGAR + "structural_notches: "
+            "[{x_min_m: 14.0, y_min_m: 20.0, x_max_m: 14.0, y_max_m: 25.0}]\n",
+        )
+        with pytest.raises(LoaderError, match="must be greater than"):
+            load_hangar(path)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2035,6 +2035,20 @@ class TestStructuralNotchesLoading:
         assert hangar.structural_notches == ()
         assert hangar.floor_polygon is None
 
+    def test_explicit_null_treated_as_empty(self, tmp_path: Path) -> None:
+        # A bare `structural_notches:` (YAML null) means "none", like constraints:.
+        path = _write(tmp_path / "h.yaml", _MIN_HANGAR + "structural_notches:\n")
+        assert load_hangar(path).structural_notches == ()
+
+    def test_unknown_notch_key_rejected(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "h.yaml",
+            _MIN_HANGAR + "structural_notches: "
+            "[{x_min_m: 14.0, y_min_m: 20.0, x_max_m: 18.0, y_max_m: 25.0, x_mn_m: 9.0}]\n",
+        )
+        with pytest.raises(LoaderError, match="unknown key"):
+            load_hangar(path)
+
     def test_single_notch_parsed(self, tmp_path: Path) -> None:
         path = _write(
             tmp_path / "h.yaml",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,6 +20,7 @@ from hangarfit.models import (
     SearchConfig,
     SolverDiagnostics,
     SolveResult,
+    StructuralNotch,
     StrutsSpec,
     Wheels,
 )
@@ -589,6 +590,65 @@ class TestHangar:
             wing_layer_clearance_m=0.2,
         )
         assert h.maintenance_bay.center_x_m == 14.0
+
+
+class TestStructuralNotch:
+    """The always-on floor keep-out (ADR-0018): a rectangle validated for
+    sane corners on its own, and for fit-in-hangar by :class:`Hangar`."""
+
+    def test_valid_construction(self) -> None:
+        n = StructuralNotch(x_min_m=12.72, y_min_m=22.66, x_max_m=15.08, y_max_m=31.76)
+        assert (n.x_min_m, n.y_min_m, n.x_max_m, n.y_max_m) == (12.72, 22.66, 15.08, 31.76)
+
+    @pytest.mark.parametrize("x_min,y_min", [(-1.0, 0.0), (0.0, -2.0)])
+    def test_negative_corner_rejected(self, x_min: float, y_min: float) -> None:
+        with pytest.raises(ValueError, match="must be non-negative"):
+            StructuralNotch(x_min_m=x_min, y_min_m=y_min, x_max_m=5.0, y_max_m=5.0)
+
+    def test_non_increasing_x_rejected(self) -> None:
+        with pytest.raises(ValueError, match="x_max_m .* must be greater than"):
+            StructuralNotch(x_min_m=5.0, y_min_m=0.0, x_max_m=5.0, y_max_m=5.0)
+
+    def test_non_increasing_y_rejected(self) -> None:
+        with pytest.raises(ValueError, match="y_max_m .* must be greater than"):
+            StructuralNotch(x_min_m=0.0, y_min_m=5.0, x_max_m=5.0, y_max_m=4.0)
+
+
+class TestHangarFloorPolygon:
+    """The derived :attr:`Hangar.floor_polygon` (ADR-0018) — ``None`` without a
+    notch (fast rectangle path), an L-shape with one, and a fit guard."""
+
+    def _hangar(self, notches: tuple[StructuralNotch, ...]) -> Hangar:
+        return Hangar(
+            length_m=31.76,
+            width_m=15.08,
+            door=Door(center_x_m=7.28, width_m=13.46),
+            maintenance_bay=MaintenanceBay(center_x_m=2.0, width_m=3.0, depth_m=2.0),
+            clearance_m=0.3,
+            wing_layer_clearance_m=0.2,
+            structural_notches=notches,
+        )
+
+    def test_floor_polygon_none_without_notch(self) -> None:
+        assert self._hangar(()).floor_polygon is None
+
+    def test_floor_polygon_area_reduced_by_notch(self) -> None:
+        notch = StructuralNotch(x_min_m=12.72, y_min_m=22.66, x_max_m=15.08, y_max_m=31.76)
+        floor = self._hangar((notch,)).floor_polygon
+        assert floor is not None
+        expected = 15.08 * 31.76 - (15.08 - 12.72) * (31.76 - 22.66)
+        assert floor.area == pytest.approx(expected)
+
+    def test_notch_outside_hangar_rejected(self) -> None:
+        with pytest.raises(ValueError, match="doesn't fit in hangar"):
+            # x_max 16.0 exceeds width 15.08
+            self._hangar((StructuralNotch(x_min_m=12.0, y_min_m=22.0, x_max_m=16.0, y_max_m=31.0),))
+
+    def test_floor_polygon_excluded_from_equality_and_hash(self) -> None:
+        notch = StructuralNotch(x_min_m=12.72, y_min_m=22.66, x_max_m=15.08, y_max_m=31.76)
+        h1, h2 = self._hangar((notch,)), self._hangar((notch,))
+        assert h1 == h2
+        assert hash(h1) == hash(h2)
 
 
 class TestPlacement:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -644,6 +644,12 @@ class TestHangarFloorPolygon:
             # x_max 16.0 exceeds width 15.08
             self._hangar((StructuralNotch(x_min_m=12.0, y_min_m=22.0, x_max_m=16.0, y_max_m=31.0),))
 
+    def test_full_floor_notch_rejected(self) -> None:
+        # A notch covering the whole floor would leave an empty polygon that
+        # `covers` rejects for every part — caught at construction instead.
+        with pytest.raises(ValueError, match="no usable hangar floor"):
+            self._hangar((StructuralNotch(x_min_m=0.0, y_min_m=0.0, x_max_m=15.08, y_max_m=31.76),))
+
     def test_floor_polygon_excluded_from_equality_and_hash(self) -> None:
         notch = StructuralNotch(x_min_m=12.72, y_min_m=22.66, x_max_m=15.08, y_max_m=31.76)
         h1, h2 = self._hangar((notch,)), self._hangar((notch,))


### PR DESCRIPTION
Closes #528. Part 1 of 3 of the ADR-0018 notch (umbrella #527). Refs #424.

Teaches the model, loader, collision checker, and 2D renderer about **always-on rectangular floor keep-outs** (`structural_notches`), and applies it to the real Herrenteich hangar's back-right office notch (`x∈[12.72,15.08], y∈[22.66,31.76]`). Until now a plane parked in the office was a false-valid.

## Design (per ADR-0018, with one recorded deviation)
- **Orthogonal field, not a generalized keep-out list.** New `Hangar.structural_notches` tuple; `maintenance_bay` untouched (the bay is state-gated and never subtracted from the floor, so folding it into a tagged list buys no behaviour). ADR-0018 updated to record this.
- **Inert when empty.** `floor_polygon` is `None` and the checker keeps its fast per-vertex rectangle path whenever there are no notches → every `data/` + test fixture, the determinism canaries, and the bench stay **byte-identical and zero-cost**. Only a notched hangar pays the `covers` cost.
- **Fixes a latent bug.** With a notch, a part is in-bounds iff `floor.covers(part.polygon)` — which rejects a thin part whose *edge* crosses the notch with neither endpoint inside it (the per-vertex test's blind spot). Reported as a distinct `structural_notch` conflict kind.

## Changes
- `models.py` — `StructuralNotch` value object, `structural_notches` field, cached `floor_polygon` (frozen+slots-safe via `object.__setattr__`), fit-validation.
- `loader.py` — parse optional `structural_notches:` list.
- `collisions.py` — `covers`-based containment when notches present; docstring rewritten (it previously argued *against* `polygon.contains`).
- `visualize.py` — hatched 2D keep-out overlay.
- `examples/herrenteich/` — notch block + updated comments; the hand-built all-8 layout still validates.
- ADR-0018 + ADR index → Accepted.

## Tests
ADR-0018 regression class (notch rejected · edge-crossing-no-vertex rejected · back-left strip accepted · no-notch byte-identical · flush-against-notch accepted) + model/loader validation + real-hangar enforcement. Full suite green locally (1435 passed); mypy + ruff clean.

> Note: based on `develop`; the required `test (Python 3.12)` check shares the #531 budget-flake until #526 (which fixes #531) merges and this branch rebases — tracked, not a regression in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)