### PR TITLE
feat(towplanner): #529 keep tow paths out of the structural notch

### DIFF
--- a/docs/adr/0018-non-rectangular-hangar-footprint.md
+++ b/docs/adr/0018-non-rectangular-hangar-footprint.md
@@ -11,10 +11,10 @@
 - **Date:** 2026-06-04 (accepted 2026-06-08)
 - **Deciders:** Patrick Kuhn (DocGerd)
 
-## Implementation note (2026-06-08, #527/#528)
+## Implementation note (2026-06-08, #527/#528/#529)
 
-The implementation deviates from this ADR's "generalize `maintenance_bay` into a
-tagged keep-out list" sketch in one deliberate way, decided during build:
+The implementation deviates from this ADR's sketch in two deliberate ways,
+decided during build:
 
 - **Orthogonal field, not a generalized list.** `Hangar` gains a new, separate
   `structural_notches: tuple[StructuralNotch, ...]` field; `maintenance_bay` is
@@ -33,6 +33,18 @@ tagged keep-out list" sketch in one deliberate way, decided during build:
 - **Distinct conflict kind.** A notch overhang is reported as `structural_notch`
   (not `hangar_bounds`), so the tow planner's mover-bounds exemption can never
   silently swallow it (#529) and the taxonomy stays self-documenting.
+- **Tow: a separate keep-out, not "route the in-transit bounds through the floor
+  polygon" (#529).** This ADR sketched routing the mover's in-transit bounds
+  through the derived floor polygon. Implementation deviates: a moving plane is
+  allowed to protrude the front door at `y < 0` during entry (#411/#412), but the
+  floor polygon excludes `y < 0`, so `floor.covers(mover)` would wrongly reject
+  every legitimate door/apron protrusion. Instead the notch is carried as an
+  always-on keep-out alongside the maintenance bay — checked in `_motion_clear`
+  (polygon overlap, so an edge crossing the notch is caught) and the grid
+  heuristic — which preserves the door-gap exemption. The final-path oracle
+  (`path_first_conflict`) still enforces the notch for the mover for free: it
+  skips only the oracle's `hangar_bounds` verdict, so the distinct
+  `structural_notch` conflict surfaces.
 
 ## Context & Problem Statement
 

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -27,7 +27,7 @@ from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from typing import Literal
 
-from shapely import union_all
+from shapely import box, union_all
 from shapely.geometry import Point, Polygon
 
 # `_parts_conflict` is the exact oracle's per-pair predicate (collisions.py). The
@@ -36,7 +36,7 @@ from shapely.geometry import Point, Polygon
 # Importing a sibling-module private is the same pattern as `check as _check`.
 from hangarfit.collisions import _parts_conflict
 from hangarfit.collisions import check as _check
-from hangarfit.geometry import WorldPart, cached_parts_world
+from hangarfit.geometry import WorldPart, cached_parts_world, polygon_overlap
 from hangarfit.models import Aircraft, ApronShallowDrop, Conflict, Hangar, Layout, Placement
 
 SegmentKind = Literal["L", "S", "R"]
@@ -1683,7 +1683,8 @@ def _root_pose(node: _SearchNode) -> Pose:
 @dataclass(frozen=True, slots=True)
 class _Obstacles:
     """Precomputed static geometry for one plane-search: placed planes' world
-    parts and the (optional) maintenance-bay keep-out rectangle.
+    parts, the (optional) maintenance-bay keep-out rectangle, and the always-on
+    structural notch keep-outs (ADR-0018).
 
     Placed planes do not move while a single plane is routed, so this is built
     once per :func:`plan_path` invocation and reused for every sampled pose.
@@ -1699,6 +1700,11 @@ class _Obstacles:
     bay_xmax: float
     bay_ymin: float
     bay_active: bool
+    # Structural notch keep-out boxes (Shapely), built once from
+    # ``hangar.structural_notches``. Empty for the common rectangular hangar, in
+    # which case every notch check below is a no-op (byte-identical to pre-notch
+    # routing). Unlike the bay these are ALWAYS on — there is no state gate.
+    notch_boxes: tuple[Polygon, ...] = ()
 
     def __post_init__(self) -> None:
         # The parallel-array pairing is load-bearing: _motion_clear zips
@@ -1720,6 +1726,10 @@ def _build_obstacles(placed: Layout, *, mover_id: str) -> _Obstacles:
     the thing being moved, not an obstacle. The maintenance occupant is absent
     from ``placed.placements`` by Layout invariant, so the mover is correctly
     subject to the bay keep-out (it is never the occupant).
+
+    The structural notch keep-outs (ADR-0018) are built here too, once, from
+    ``hangar.structural_notches`` — always on (no state gate), and empty (a no-op
+    downstream) for the common rectangular hangar.
     """
     parts: list[WorldPart] = []
     for placement in placed.placements:
@@ -1734,6 +1744,10 @@ def _build_obstacles(placed: Layout, *, mover_id: str) -> _Obstacles:
         bay_xmax=bay.center_x_m + bay.width_m / 2,
         bay_ymin=placed.hangar.length_m - bay.depth_m,
         bay_active=placed.maintenance_plane is not None,
+        notch_boxes=tuple(
+            box(n.x_min_m, n.y_min_m, n.x_max_m, n.y_max_m)
+            for n in placed.hangar.structural_notches
+        ),
     )
 
 
@@ -1767,6 +1781,12 @@ def _motion_clear(mover: Aircraft, pose: Pose, obstacles: _Obstacles, hangar: Ha
         exactly (strict ``<`` on left/right/front edges; no upper-``y`` test —
         the back edge is the hangar wall) when the bay is closed.
 
+    (D) **Structural notch** — the mover may not overhang an always-on floor
+        keep-out (ADR-0018). Polygon overlap (not per-vertex) so an edge crossing
+        a notch with no vertex inside is caught, matching the static
+        :func:`collisions._hangar_bounds_conflicts` ``floor.covers`` test. No-op
+        when ``hangar.structural_notches`` is empty.
+
     ``on_carts`` is fixed to ``False`` here: :func:`~hangarfit.geometry.aircraft_parts_world`
     derives part geometry from pose only (``x``/``y``/``heading``) and the parts,
     NOT from ``on_carts``, so the part polygons are identical to the oracle's
@@ -1790,6 +1810,15 @@ def _motion_clear(mover: Aircraft, pose: Pose, obstacles: _Obstacles, hangar: Ha
             for x, y in list(mp.polygon.exterior.coords)[:-1]:
                 if obstacles.bay_xmin < x < obstacles.bay_xmax and y > obstacles.bay_ymin:
                     return False
+
+        # (D) Structural notch (always-on floor keep-out, ADR-0018): the mover
+        # may not overhang a notch. Polygon overlap (intersects-and-not-touches —
+        # the same boundary-inclusive predicate the static floor uses) so a part
+        # EDGE crossing a notch with no vertex inside is caught too, and a part
+        # flush against a notch wall stays clear. No-op when there are no notches.
+        for nb in obstacles.notch_boxes:
+            if polygon_overlap(mp.polygon, nb):
+                return False
 
         # (B) Pairwise overlap against each placed-plane part.
         if obstacles.world_parts:
@@ -1869,9 +1898,10 @@ def _build_grid_heuristic(
     heuristic there, so the field only ever RE-PRIORITISES the frontier, it
     never makes a pose un-expandable.
 
-    Obstacles are the placed planes' footprints (un-inflated, point-robot) plus
-    the closed maintenance bay; the side/back walls bound the grid (the front
-    ``y < 0`` apron is open during tow). RNG-free and pure ⇒ ADR-0003-safe.
+    Obstacles are the placed planes' footprints (un-inflated, point-robot), the
+    closed maintenance bay, and the always-on structural notch(es) (ADR-0018);
+    the side/back walls bound the grid (the front ``y < 0`` apron is open during
+    tow). RNG-free and pure ⇒ ADR-0003-safe.
 
     The southward extent reconciles the historic fixed ``_GRID_H_Y_PAD_M = 6 m``
     pad with the site's staging apron (``hangar.apron_depth_m``, #412/ADR-0021):
@@ -1900,6 +1930,12 @@ def _build_grid_heuristic(
         if obstacles.bay_active and (
             obstacles.bay_xmin < cx < obstacles.bay_xmax and cy > obstacles.bay_ymin
         ):
+            return False
+        # Structural notch keep-out (always on, ADR-0018): route the geodesic
+        # around the dead pocket. A cell whose centre is in a notch interior is
+        # blocked (boundary cells stay free — the notch edge is floor). No-op
+        # when there are no notches.
+        if any(nb.contains(Point(cx, cy)) for nb in obstacles.notch_boxes):
             return False
         return blocked_geom is None or not blocked_geom.contains(Point(cx, cy))
 

--- a/tests/test_towplanner_notch.py
+++ b/tests/test_towplanner_notch.py
@@ -1,0 +1,166 @@
+"""Tow-path planner honours the structural notch (ADR-0018, #529).
+
+A plane being towed may not pass through (or overhang) an always-on
+structural notch — the same office-corner keep-out the static checker enforces
+(#528). The planner honours it in three places, mirroring the maintenance bay:
+
+- the final-path oracle (:func:`path_first_conflict`) inherits it for the mover
+  via the merged ``collisions.check`` — the mover-bounds skip is
+  ``hangar_bounds``-only, so a distinct ``structural_notch`` conflict surfaces;
+- the fast in-search check (:func:`_motion_clear`, rule D) rejects a pose whose
+  footprint overlaps a notch (polygon overlap, so an *edge* crossing the notch
+  with no vertex inside is caught too);
+- the geodesic heuristic (:func:`_build_grid_heuristic`) routes around notch
+  cells.
+
+A hangar with no notch is unaffected (empty ``notch_boxes`` ⇒ every check is a
+no-op), pinned by :func:`test_no_notch_is_inert`.
+"""
+
+from __future__ import annotations
+
+from hangarfit.models import (
+    Aircraft,
+    Door,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    StructuralNotch,
+    Wheels,
+)
+from hangarfit.towplanner import (
+    _GRID_XY_M,
+    Pose,
+    _build_grid_heuristic,
+    _build_obstacles,
+    _motion_clear,
+    path_first_conflict,
+    plan_dubins,
+)
+
+_TAIL_WHEELS = Wheels(main_offset_x_m=0.20, track_m=1.8, third_wheel_offset_x_m=-2.0)
+
+# Back-right notch in a 20x20 hangar: x in [14, 20], y in [14, 20].
+_NOTCH = (14.0, 14.0, 20.0, 20.0)
+
+
+def _box_plane(plane_id: str = "B") -> Aircraft:
+    """A minimal own-gear plane: one 1.0 x 0.6 m fuselage box mounted forward
+    (``offset_x_m = 0.5``) so a ``y = 0`` entry pose keeps every vertex at
+    ``y >= 0`` (no spurious front-wall ``hangar_bounds``)."""
+    return Aircraft(
+        id=plane_id,
+        name=f"Plane {plane_id}",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=4.0,
+        measured=False,
+        parts=(
+            Part(
+                kind="fuselage_aft",
+                length_m=1.0,
+                width_m=0.6,
+                offset_x_m=0.5,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.0,
+            ),
+        ),
+        wheels=_TAIL_WHEELS,
+    )
+
+
+def _hangar(*, with_notch: bool) -> Hangar:
+    notches = (StructuralNotch(*_NOTCH),) if with_notch else ()
+    return Hangar(
+        length_m=20.0,
+        width_m=20.0,
+        door=Door(center_x_m=10.0, width_m=6.0),
+        maintenance_bay=MaintenanceBay(center_x_m=10.0, width_m=4.0, depth_m=2.0),
+        clearance_m=0.5,
+        wing_layer_clearance_m=0.5,
+        structural_notches=notches,
+    )
+
+
+def _placed(hangar: Hangar, mover: Aircraft) -> Layout:
+    """Empty placed layout (only the mover in the fleet) so the only possible
+    conflicts are hangar bounds (skipped for the mover) and the notch."""
+    return Layout(fleet={mover.id: mover}, hangar=hangar, placements=())
+
+
+# ── final-path oracle (path_first_conflict) ──────────────────────────────────
+
+
+def test_tow_path_into_notch_is_blamed_on_mover() -> None:
+    """A tow ending with the footprint inside the office notch returns a
+    ``structural_notch`` conflict naming the mover (the mover-bounds skip is
+    ``hangar_bounds``-only, so this distinct kind is not swallowed)."""
+    mover = _box_plane()
+    placed = _placed(_hangar(with_notch=True), mover)
+    # Goal (17, 17, 0): box world footprint x in [16.7, 17.3], y in [17, 18] —
+    # squarely inside the notch [14,20] x [14,20].
+    arc = plan_dubins(Pose(8.0, 0.0, 0.0), Pose(17.0, 17.0, 0.0), turn_radius_m=4.0)
+    conflict = path_first_conflict(arc, mover, mover_on_carts=False, placed=placed)
+    assert conflict is not None
+    assert conflict.kind == "structural_notch"
+    assert mover.id in conflict.planes
+
+
+def test_tow_path_clear_of_notch_is_none() -> None:
+    """The same hangar, a tow straight up the clear x = 8 corridor (far from the
+    back-right notch) returns no conflict."""
+    mover = _box_plane()
+    placed = _placed(_hangar(with_notch=True), mover)
+    arc = plan_dubins(Pose(8.0, 0.0, 0.0), Pose(8.0, 12.0, 0.0), turn_radius_m=4.0)
+    assert path_first_conflict(arc, mover, mover_on_carts=False, placed=placed) is None
+
+
+# ── fast in-search check (_motion_clear, rule D) ─────────────────────────────
+
+
+def test_motion_clear_rejects_pose_overhanging_notch() -> None:
+    mover = _box_plane()
+    hangar = _hangar(with_notch=True)
+    obstacles = _build_obstacles(_placed(hangar, mover), mover_id=mover.id)
+    assert len(obstacles.notch_boxes) == 1
+    in_notch = Pose(17.0, 17.0, 0.0)  # footprint inside the notch
+    clear = Pose(8.0, 8.0, 0.0)  # mid-floor, no notch, no other planes
+    assert _motion_clear(mover, in_notch, obstacles, hangar) is False
+    assert _motion_clear(mover, clear, obstacles, hangar) is True
+
+
+# ── geodesic heuristic (_build_grid_heuristic) ───────────────────────────────
+
+
+def test_grid_heuristic_blocks_notch_cells() -> None:
+    mover = _box_plane()
+    hangar = _hangar(with_notch=True)
+    obstacles = _build_obstacles(_placed(hangar, mover), mover_id=mover.id)
+    field = _build_grid_heuristic(Pose(8.0, 2.0, 0.0), obstacles, hangar)
+    # A cell whose centre is deep inside the notch is blocked (absent from the
+    # reachable cost-to-go field).
+    notch_cell = (round(17.0 / _GRID_XY_M), round(17.0 / _GRID_XY_M))
+    assert notch_cell not in field
+    # A clear floor cell is reachable.
+    clear_cell = (round(8.0 / _GRID_XY_M), round(8.0 / _GRID_XY_M))
+    assert clear_cell in field
+
+
+# ── inert when no notch (byte-identical pre-notch routing) ───────────────────
+
+
+def test_no_notch_is_inert() -> None:
+    mover = _box_plane()
+    hangar = _hangar(with_notch=False)
+    obstacles = _build_obstacles(_placed(hangar, mover), mover_id=mover.id)
+    assert obstacles.notch_boxes == ()
+    # The same pose the notch rejects is clear when no notch is configured.
+    assert _motion_clear(mover, Pose(17.0, 17.0, 0.0), obstacles, hangar) is True
+    arc = plan_dubins(Pose(8.0, 0.0, 0.0), Pose(17.0, 17.0, 0.0), turn_radius_m=4.0)
+    assert (
+        path_first_conflict(arc, mover, mover_on_carts=False, placed=_placed(hangar, mover)) is None
+    )


### PR DESCRIPTION
Closes #529. Part 2 of 3 of the ADR-0018 notch (umbrella #527). Builds on #528 (merged).

An in-transit plane may not pass through (or overhang) an always-on structural notch — the same office-corner keep-out the static checker enforces (#528). Mirrors the maintenance-bay handling, but the notch is **always on** (no state gate).

## Where it's honoured (mirrors the bay)
- **`_Obstacles` / `_build_obstacles`** — carry the notch boxes (Shapely), built once from `hangar.structural_notches`. Empty for the common rectangular hangar.
- **`_motion_clear` rule (D)** — reject a pose whose footprint overlaps a notch. **Polygon overlap** (`intersects`-and-not-`touches`, the boundary-inclusive predicate the static floor uses) so an *edge* crossing a notch with no vertex inside is caught, and a part flush against a notch wall stays clear.
- **`_build_grid_heuristic._cell_free`** — block notch cells so the geodesic routes around the dead pocket.
- **`path_first_conflict` — UNCHANGED.** Its mover-bounds skip is `hangar_bounds`-only, so the distinct `structural_notch` conflict from the merged `collisions.check` surfaces for the mover automatically (final-path enforcement for free, the reason #528 used a distinct kind).

## Determinism
Empty `structural_notches` ⇒ every notch check is a no-op ⇒ **byte-identical pre-notch routing**. The determinism canaries + bench (all no-notch) are unaffected (ADR-0003). Note: this is a small, deliberate deviation from ADR-0018's "route the in-transit bounds through the floor polygon" sketch — routing the mover through `floor.covers` would wrongly reject the legitimate `y<0` door/apron protrusion (the floor excludes `y<0`). Treating the notch as a separate keep-out (like the bay) sidesteps that and preserves the #411/#412 door-gap exemption.

## Tests (`tests/test_towplanner_notch.py`)
Tow into the notch blamed on the mover (`structural_notch`) · tow clear of it is `None` · `_motion_clear` rejects an overhanging pose · grid heuristic blocks notch cells · no-notch case inert. Full suite green (1443 passed); mypy + ruff clean.

> Based on `develop` (post-#528 merge), so the diff is just the towplanner change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)