### PR TITLE
feat(viewer): #530 render the L-shaped hangar footprint in 3D

### DIFF
--- a/docs/architecture/scene-v1-schema.md
+++ b/docs/architecture/scene-v1-schema.md
@@ -62,12 +62,22 @@ plane's group.
     "center_x_m": 13.5, "width_m": 9.0, "depth_m": 9.0,
     "closed": true,            // true iff layout.maintenance_plane is set
     "plane_id": "fk9_mkii"     // the absent occupant, or null
-  }
+  },
+  "structural_notches": [      // always emitted; empty for a rectangular hangar
+    { "x_min_m": 12.72, "y_min_m": 22.66, "x_max_m": 15.08, "y_max_m": 31.76 }
+  ]
 }
 ```
 
 The bay is back-anchored: it spans `y ∈ [length_m − depth_m, length_m]`. The viewer
 draws it as a translucent red box only when `closed`.
+
+`structural_notches` is the list of always-on rectangular floor keep-outs (ADR-0018)
+— corners/edges of the bounding rectangle that are **not** hangar floor (e.g. the
+Herrenteich office annex). Each is the axis-aligned rectangle
+`[x_min_m, x_max_m] × [y_min_m, y_max_m]`. The viewer cuts each from the floor
+(rendering the L-shaped footprint) and raises the notch's interior-facing walls.
+The list is always present and is empty for the common rectangular hangar.
 
 ## `planes[]`
 

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -74,15 +74,34 @@ import * as THREE2 from "three";
 var WALL_H = 3;
 function addHangar(scene2, H2, BRAND2, span2) {
   const wallMeshes2 = [];
-  const floor = new THREE2.Mesh(
-    new THREE2.PlaneGeometry(H2.width_m, H2.length_m),
-    new THREE2.MeshStandardMaterial({
-      color: new THREE2.Color(BRAND2.floor),
-      roughness: 1,
-      side: THREE2.DoubleSide
-    })
-  );
-  floor.position.set(H2.width_m / 2, H2.length_m / 2, 0);
+  const notches = H2.structural_notches ?? [];
+  const floorMat = new THREE2.MeshStandardMaterial({
+    color: new THREE2.Color(BRAND2.floor),
+    roughness: 1,
+    side: THREE2.DoubleSide
+  });
+  let floor;
+  if (notches.length === 0) {
+    floor = new THREE2.Mesh(new THREE2.PlaneGeometry(H2.width_m, H2.length_m), floorMat);
+    floor.position.set(H2.width_m / 2, H2.length_m / 2, 0);
+  } else {
+    const shape = new THREE2.Shape();
+    shape.moveTo(0, 0);
+    shape.lineTo(H2.width_m, 0);
+    shape.lineTo(H2.width_m, H2.length_m);
+    shape.lineTo(0, H2.length_m);
+    shape.closePath();
+    for (const n of notches) {
+      const hole = new THREE2.Path();
+      hole.moveTo(n.x_min_m, n.y_min_m);
+      hole.lineTo(n.x_max_m, n.y_min_m);
+      hole.lineTo(n.x_max_m, n.y_max_m);
+      hole.lineTo(n.x_min_m, n.y_max_m);
+      hole.closePath();
+      shape.holes.push(hole);
+    }
+    floor = new THREE2.Mesh(new THREE2.ShapeGeometry(shape), floorMat);
+  }
   floor.receiveShadow = true;
   scene2.add(floor);
   const grid = new THREE2.GridHelper(
@@ -114,6 +133,17 @@ function addHangar(scene2, H2, BRAND2, span2) {
   const dr = H2.door.center_x_m + H2.door.width_m / 2;
   if (dl > 1e-6) addWall(dl, t, dl / 2, 0);
   if (dr < H2.width_m - 1e-6) addWall(H2.width_m - dr, t, (dr + H2.width_m) / 2, 0);
+  const eps = 1e-6;
+  for (const n of notches) {
+    const cx = (n.x_min_m + n.x_max_m) / 2;
+    const cy = (n.y_min_m + n.y_max_m) / 2;
+    const w = n.x_max_m - n.x_min_m;
+    const l = n.y_max_m - n.y_min_m;
+    if (n.x_min_m > eps) addWall(t, l, n.x_min_m, cy);
+    if (n.x_max_m < H2.width_m - eps) addWall(t, l, n.x_max_m, cy);
+    if (n.y_min_m > eps) addWall(w, t, cx, n.y_min_m);
+    if (n.y_max_m < H2.length_m - eps) addWall(w, t, cx, n.y_max_m);
+  }
   const bay = H2.maintenance_bay;
   if (bay && bay.closed) {
     const bm = new THREE2.Mesh(

--- a/src/hangarfit/scene.py
+++ b/src/hangarfit/scene.py
@@ -62,6 +62,18 @@ def _hangar_block(layout: Layout) -> dict:
             "closed": layout.maintenance_plane is not None,
             "plane_id": layout.maintenance_plane,
         },
+        # Always-on floor keep-outs (ADR-0018). Always emitted (empty list for the
+        # common rectangular hangar); the viewer cuts each from the floor and
+        # raises interior walls, rendering the L-shaped footprint.
+        "structural_notches": [
+            {
+                "x_min_m": n.x_min_m,
+                "y_min_m": n.y_min_m,
+                "x_max_m": n.x_max_m,
+                "y_max_m": n.y_max_m,
+            }
+            for n in h.structural_notches
+        ],
     }
 
 

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -59,6 +59,23 @@ def test_hangar_block_shape():
         "width_m": lay.hangar.door.width_m,
     }
     assert h["maintenance_bay"]["closed"] is (lay.maintenance_plane is not None)
+    # structural_notches is always emitted; the default layout's hangar has none.
+    assert h["structural_notches"] == []
+
+
+def test_hangar_block_emits_structural_notches():
+    """A notched hangar emits each notch rectangle for the viewer (ADR-0018)."""
+    import dataclasses
+
+    from hangarfit.models import StructuralNotch
+
+    lay = load_layout(LAYOUT)  # 22 x 25 hangar
+    notch = StructuralNotch(x_min_m=18.0, y_min_m=20.0, x_max_m=22.0, y_max_m=25.0)
+    notched = dataclasses.replace(lay.hangar, structural_notches=(notch,))
+    h = scene._hangar_block(dataclasses.replace(lay, hangar=notched))
+    assert h["structural_notches"] == [
+        {"x_min_m": 18.0, "y_min_m": 20.0, "x_max_m": 22.0, "y_max_m": 25.0}
+    ]
 
 
 # ── Task 2: plane boxes ──────────────────────────────────────────────────────

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -423,3 +423,24 @@ def test_scene_contract_ts_nested_keys_match_scene_py():
     }
     for interface, obj in cases.items():
         assert _ts_interface_fields("scene-contract.ts", interface) == set(obj), interface
+
+    # StructuralNotchData: the animated scene uses a rectangular hangar, so its
+    # structural_notches list is empty — sample a notched hangar block to pin the
+    # nested notch field names against the TS mirror too (else a rename in scene.py
+    # could silently drift from scene-contract.ts).
+    import dataclasses
+
+    from hangarfit.models import StructuralNotch
+
+    lay = load_layout(LAYOUT)  # 22 x 25 hangar
+    notched = dataclasses.replace(
+        lay,
+        hangar=dataclasses.replace(
+            lay.hangar,
+            structural_notches=(
+                StructuralNotch(x_min_m=18.0, y_min_m=20.0, x_max_m=22.0, y_max_m=25.0),
+            ),
+        ),
+    )
+    notch_obj = scene._hangar_block(notched)["structural_notches"][0]
+    assert _ts_interface_fields("scene-contract.ts", "StructuralNotchData") == set(notch_obj)

--- a/viewer/src/hangar.ts
+++ b/viewer/src/hangar.ts
@@ -11,14 +11,36 @@ export function addHangar(
   scene: THREE.Scene, H: HangarData, BRAND: BrandTokens, span: number,
 ): THREE.Mesh[] {
   const wallMeshes: THREE.Mesh[] = [];
+  const notches = H.structural_notches ?? [];
 
-  const floor = new THREE.Mesh(
-    new THREE.PlaneGeometry(H.width_m, H.length_m),
-    new THREE.MeshStandardMaterial({
-      color: new THREE.Color(BRAND.floor), roughness: 1, side: THREE.DoubleSide,
-    }),
-  );
-  floor.position.set(H.width_m / 2, H.length_m / 2, 0); // PlaneGeometry lies in XY (normal +Z)
+  const floorMat = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(BRAND.floor), roughness: 1, side: THREE.DoubleSide,
+  });
+  let floor: THREE.Mesh;
+  if (notches.length === 0) {
+    floor = new THREE.Mesh(new THREE.PlaneGeometry(H.width_m, H.length_m), floorMat);
+    floor.position.set(H.width_m / 2, H.length_m / 2, 0); // PlaneGeometry lies in XY (normal +Z)
+  } else {
+    // L-shaped floor (ADR-0018): the bounding rectangle minus each notch, built
+    // as a ShapeGeometry hole. ShapeGeometry already lies in XY in absolute
+    // hangar coords, so no recentre is needed.
+    const shape = new THREE.Shape();
+    shape.moveTo(0, 0);
+    shape.lineTo(H.width_m, 0);
+    shape.lineTo(H.width_m, H.length_m);
+    shape.lineTo(0, H.length_m);
+    shape.closePath();
+    for (const n of notches) {
+      const hole = new THREE.Path();
+      hole.moveTo(n.x_min_m, n.y_min_m);
+      hole.lineTo(n.x_max_m, n.y_min_m);
+      hole.lineTo(n.x_max_m, n.y_max_m);
+      hole.lineTo(n.x_min_m, n.y_max_m);
+      hole.closePath();
+      shape.holes.push(hole);
+    }
+    floor = new THREE.Mesh(new THREE.ShapeGeometry(shape), floorMat);
+  }
   floor.receiveShadow = true; // catches the planes' contact shadows (#400)
   scene.add(floor);
 
@@ -47,6 +69,21 @@ export function addHangar(
   const dr = H.door.center_x_m + H.door.width_m / 2;
   if (dl > 1e-6) addWall(dl, t, dl / 2, 0);              // front, left of door
   if (dr < H.width_m - 1e-6) addWall(H.width_m - dr, t, (dr + H.width_m) / 2, 0); // front, right
+
+  // Interior notch walls (ADR-0018): the office-corner walls that face the
+  // hangar floor. Skip any notch edge flush with the outer boundary — that edge
+  // already has the outer wall (or is the building corner).
+  const eps = 1e-6;
+  for (const n of notches) {
+    const cx = (n.x_min_m + n.x_max_m) / 2;
+    const cy = (n.y_min_m + n.y_max_m) / 2;
+    const w = n.x_max_m - n.x_min_m;
+    const l = n.y_max_m - n.y_min_m;
+    if (n.x_min_m > eps) addWall(t, l, n.x_min_m, cy);                  // left face
+    if (n.x_max_m < H.width_m - eps) addWall(t, l, n.x_max_m, cy);      // right face
+    if (n.y_min_m > eps) addWall(w, t, cx, n.y_min_m);                  // front face
+    if (n.y_max_m < H.length_m - eps) addWall(w, t, cx, n.y_max_m);     // back face
+  }
 
   const bay = H.maintenance_bay;
   if (bay && bay.closed) {

--- a/viewer/src/scene-contract.ts
+++ b/viewer/src/scene-contract.ts
@@ -47,11 +47,21 @@ export interface MaintenanceBay {
   plane_id: string | null; // the absent occupant, or null
 }
 
+// An always-on rectangular floor keep-out (ADR-0018): a corner/edge of the
+// bounding rectangle that is NOT hangar floor (e.g. the Herrenteich office annex).
+export interface StructuralNotchData {
+  x_min_m: number;
+  y_min_m: number;
+  x_max_m: number;
+  y_max_m: number;
+}
+
 export interface HangarData {
   width_m: number;
   length_m: number;
   door: DoorData;
   maintenance_bay: MaintenanceBay; // always emitted (a dict; `closed` distinguishes occupied)
+  structural_notches: StructuralNotchData[]; // always emitted (empty for a rectangular hangar)
 }
 
 export interface SegmentData {

--- a/viewer/test/anchors.test.ts
+++ b/viewer/test/anchors.test.ts
@@ -36,6 +36,7 @@ function makeScene(aff: Affine, b: BoxData, wheel: [number, number]): SceneV1 {
       length_m: 10,
       door: { center_x_m: 5, width_m: 4 },
       maintenance_bay: { center_x_m: 5, width_m: 2, depth_m: 2, closed: false, plane_id: null },
+      structural_notches: [],
     },
     planes: [{ id: 'p', color: '#ffffff', boxes: [b], wheels: [wheel], on_carts: false }],
     conflicts: [],

--- a/viewer/test/paths.test.ts
+++ b/viewer/test/paths.test.ts
@@ -94,6 +94,7 @@ function makeScene(planes: PlaneData[], conflicts: string[], segments: SegmentDa
       length_m: 10,
       door: { center_x_m: 5, width_m: 4 },
       maintenance_bay: { center_x_m: 5, width_m: 2, depth_m: 2, closed: false, plane_id: null },
+      structural_notches: [],
     },
     planes,
     conflicts,


### PR DESCRIPTION
Closes #530. Part 3 of 3 of the ADR-0018 notch (umbrella #527). Builds on #528 (merged); independent of #529.

The 3D viewer renders the structural notch as a **true floor cutout + interior walls** — the L-shaped footprint, not just a marker.

## Changes
- **`scene.py`** — `_hangar_block` emits `structural_notches` (always, an empty list for a rectangular hangar) into `scene/v1` JSON.
- **`scene-contract.ts`** — `StructuralNotchData` + a required `HangarData.structural_notches` (the schema-faithful mirror `tests/test_scene.py` keeps in sync).
- **`hangar.ts`** — with notches, the floor becomes a `ShapeGeometry` (bounding rectangle minus each notch as a hole) and each notch's interior-facing edges (those *not* flush with the outer boundary) get a wall. **No notches ⇒ the original rectangular `PlaneGeometry`, unchanged.**
- **`scene-v1-schema.md`** — documents the field.
- Rebuilt the committed `viewer.js` (the `viewer-build-drift` guard rebuilds + diffs; verified locally `BUNDLE MATCHES`).

## Verification
- `npm run typecheck` + `eslint` + 21 node unit tests pass; 32 `test_scene.py` pass; mypy + ruff clean.
- The herrenteich layout renders headlessly (swiftshader) with **no transform-mismatch banner**.
- **Pixel-diff** of the same 1-plane layout in the notched vs a rectangular hangar: the change is **isolated to the back-right notch corner** (1039 px, region x∈[426,611] y∈[329,704]); the rest of the floor is pixel-identical — confirming the cutout renders and is inert for no-notch hangars.

> Based on `develop` (post-#528). The schema doc is the viewer's doc home; ADR-0018 is untouched here to avoid a stacked-PR conflict with #533's ADR note.
> Known minor: the reference `GridHelper` still spans the full bounding rectangle (it can't take holes); the solid floor + walls convey the L-shape. A grid-clip is a possible cosmetic follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)