### PR TITLE
docs(release): prep v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.13.0] — 2026-06-09
+
+### Added
+
+- **L-shaped hangar / structural-notch support (#528/#529/#530, epic #527,
+  ADR-0018).** A hangar may now declare an optional `structural_notches:` list of
+  always-on rectangular floor keep-outs in `hangar.yaml`, modelling a
+  non-rectangular footprint (the real Airfield Herrenteich back-right office notch
+  — `x ∈ [12.72, 15.08]`, `y ∈ [22.66, 31.76]` — is now recorded as data instead
+  of avoided by hand). End to end: (1) **static containment (#528)** —
+  `collisions.check` derives a Shapely floor polygon (bounding rectangle − notches)
+  and rejects any part that parks in *or overhangs* a notch, reported as a distinct
+  `structural_notch` conflict (escaping the outer wall stays `hangar_bounds`);
+  (2) **tow keep-out (#529)** — the tow planner honours the notch for the plane
+  *in transit* (polygon-overlap pose rejection + grid-heuristic cells blocked so a
+  route bends around the dead pocket; a tow ending in the notch surfaces as a
+  `structural_notch` conflict on the mover), treating the notch as a separate
+  keep-out so the #411/#412 `y < 0` door/apron protrusion exemption is preserved;
+  (3) **3D viewer (#530)** — `hangarfit view` renders the footprint as a true floor
+  cutout (`ShapeGeometry`) plus interior walls, and `scene/v1` gains an
+  always-emitted `structural_notches` array on the hangar block (empty for a
+  rectangular hangar, documented in `scene-v1-schema.md`). The 2D PNG draws each
+  notch as a cross-hatched keep-out overlay, and the same `covers` containment
+  closes a latent vertex-only edge-crossing bug. **Inert and byte-identical when no
+  notch is configured** (ADR-0003): the fast per-vertex bounds path and the
+  original rectangular floor/render are retained for every synthetic `data/`
+  hangar, test fixture, determinism canary, and the bench — only a notched hangar
+  pays the `covers` cost.
 - **Theme-aware README hero (#514).** The README banner now serves two
   brand-tuned SVG variants via an HTML `<picture>` element with
   `prefers-color-scheme` media queries — `docs/assets/banner-light.svg` (light
@@ -29,6 +61,33 @@ All notable changes to this project are documented here. Format follows [Keep a 
   fan — no new motion primitive). Set for `aviat_husky`, `ctsl`, `fk9_mkii`. A
   realism flag (these types genuinely pivot when towed), orthogonal to
   `movement_mode`.
+- **Tow paths on the 3D viewer floor (#505).** `hangarfit view` now draws each
+  placed plane's full tow route as a coloured line on the hangar floor (`z ≈ 0`),
+  one colour per plane — the 3D analogue of the 2D `solve --render-paths` overlay
+  (#192/#193). Each line uses the plane's own viewer hue (`PLANES_DARK`, the same
+  swatch as its boxes, nose cone, and legend entry; conflicted planes use the
+  conflict ink), so the apron slide-in, in-hangar maneuvering, and tow order are
+  legible at a glance — and path quality (e.g. a forward-then-reverse cusp) that a
+  bare animation hides becomes visible. The apron lead-in is drawn verbatim: with
+  `--apron-depth > 0` the line extends to `ty < 0` outside the door, and at depth 0
+  it starts at the door (`y = 0`); a static / un-routed scene draws no line. A new
+  `paths` HUD checkbox (next to `walls` / `labels`), **default ON**, shows or hides
+  the routes. The route is derived from the existing `timeline.segments[].samples`
+  affines with **no `scene/v1` schema change** (the ADR-0017 seam stays stable).
+- **Too-shallow-apron observability warning (#503, ADR-0021).** With a staging
+  apron (`apron_depth_m > 0`), a plane only slides in if the apron is deep enough
+  for *its* footprint at an apron start pose; a plane too deep to fit was silently
+  routed via the `y = 0` door line (no slide-in) with zero signal. The tow path now
+  emits a deterministic, deduped **stderr** warning naming each such plane and a
+  suggested minimum depth (its fore-aft footprint extent — a conservative
+  sufficient bound, not the `auto` over-margin), on `solve --render-paths` and
+  `view --animate`; `solve --json` additionally carries an additive
+  `apron_shallow_drops` list (no schema bump). Emission lives at the CLI boundary
+  keyed on the *returned* result and deduped per plane, so a discarded
+  spread-fallback pass never warns and `--alternatives N` warns each plane once.
+  **Output-only — the `MovesPlan` is byte-identical** (ADR-0003); raise
+  `--apron-depth` past the warned value (or prefer `auto`) to engage the apron.
+  Auto-deepening the apron is deferred (#503 Option 2).
 
 ### Changed
 
@@ -67,8 +126,42 @@ All notable changes to this project are documented here. Format follows [Keep a 
   #412 depth-0 cross-version byte-identity for that case (the same-input contract
   is unchanged). Obstructed nose-out approaches that need mid-search maneuvering
   remain best-effort.
+- **Herrenteich fleet refreshed to TCDS / 3-view-sourced dimensions + a working
+  demo scenario (#536, refs ADR-0023 / ADR-0018).** The eight real-data occupants
+  in `examples/herrenteich/fleet.yaml` move from estimated part dimensions to
+  figures **sourced** from EASA/FAA TCDS + manufacturer manuals where published
+  (wing chord, fuselage/cabin width, horizontal-stabilizer span, gear track +
+  wheelbase; per-field provenance recorded inline). Two configurations are
+  corrected against primary sources: the **Stemme S10 → taildragger** (twin
+  retractable mains + tailwheel; EASA TCDS A.054), and the **CTSL tail →
+  conventional-low** all-moving stabilator (was the secondary-source "cruciform"
+  label; geometry unchanged). The Scheibe SF-25E's real **low** wing stays modelled
+  **high** as the deliberate monowheel-tilt abstraction (a flat 18 m low wing is
+  unclearable for any all-eight arrangement — search-verified across 40+ seeds;
+  dimensions are real, only the z-layer is the modelling choice). The hand-built
+  all-eight `examples/herrenteich/layout.yaml` stays **valid** (0 conflicts) under
+  the refreshed dimensions, and a new **`examples/herrenteich/scenario_demo.yaml`**
+  — a 3-aircraft subset — **solves and fully tow-routes** end-to-end
+  (`solve --render-paths`, spread-off fallback ADR-0016) around the office notch,
+  with the commands shown in the dataset README. Part fore-aft stations, most tail
+  chords, all fin chords, and strut attach points remain honestly derived /
+  estimated (unpublished for these light types); `measured: false` is retained
+  (sourced, not on-site surveyed). Real-data only — `data/fleet.yaml` stays the
+  synthetic placeholder and no `src/` behaviour changes.
 
 ### Fixed
+
+- **Strict unknown-key allowlist on fleet aircraft entries (#513).** A misspelled
+  field key in an `aircraft:` entry — e.g. `tow_pivot:` / `towpivotable:` /
+  `tow-pivotable:` for the new `tow_pivotable` flag, or `turn_radius:` for
+  `turn_radius_m:` — used to be **silently dropped to its default**, denying the
+  capability the author tried to grant. `_build_aircraft` now validates each entry
+  against a strict key allowlist *before any field is read* and raises an
+  attributed `LoaderError` (`aircraft '<id>': unknown aircraft key(s) …`), so a
+  typo of a *required* key surfaces as the offending key rather than a downstream
+  "missing field". The nested `struts:` block gets the same guard, catching a
+  misspelled near-duplicate alongside a correct key. Mirrors the existing strict
+  `wheels:` and constraint-key allowlists.
 
 ## [0.12.0] — 2026-06-07
 
@@ -534,7 +627,8 @@ First Phase 1 cut — substrate for arranging the flying club fleet in a stack-s
 - Apache-2.0 license, public-audience README, CI matrix (Python 3.11 + 3.12), branch protection on develop + main (#13, #14, #15, #16).
 - Strut-aware golden tests + all-9-planes fixture using larger test-only hangar to accommodate strut-bracing geometry on placeholder dimensions (#5).
 
-[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/DocGerd/hangarfit/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/DocGerd/hangarfit/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/DocGerd/hangarfit/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/DocGerd/hangarfit/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/DocGerd/hangarfit/compare/v0.9.0...v0.10.0

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ hangarfit --version
 hangarfit check examples/layouts/example.yaml
 ```
 
-> Note: `examples/layouts/example.yaml` is a deliberate 6-plane subset that fits inside the current placeholder hangar — running `check` on it returns `valid` (exit code 0). To see a conflict diagnosis (red overlay in the PNG render, exit code 1), point at one of the `tests/fixtures/invalid_*.yaml` fixtures. All dimensions in `data/` remain placeholders pending real measurement (see Status), so any verdict on the current data is illustrative.
+> Note: `examples/layouts/example.yaml` is a deliberate 5-plane subset (plus the Scheibe in the maintenance bay) that fits inside the current placeholder hangar — running `check` on it returns `valid` (exit code 0). To see a conflict diagnosis (red overlay in the PNG render, exit code 1), point at one of the `tests/fixtures/invalid_*.yaml` fixtures. All dimensions in `data/` remain placeholders pending real measurement (see Status), so any verdict on the current data is illustrative.
 
 ```bash
 # Render the layout (works on invalid layouts too — conflicts highlighted in red)

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -105,8 +105,9 @@ maintenance-plane-is-in-fleet rule, the
 maintenance-plane-is-not-in-placements rule. A constructed instance is
 guaranteed structurally valid; nothing downstream re-checks.
 
-`PartKind` is a closed `Literal` set (`"fuselage"`, `"wing"`,
-`"strut"`, `"tail"`). The `Conflict.kind` taxonomy is also closed —
+`PartKind` is a closed `Literal` set (`"fuselage_front"`,
+`"fuselage_aft"`, `"wing"`, `"strut"`, `"tail"`,
+`"vertical_stabilizer"`). The `Conflict.kind` taxonomy is also closed —
 adding a new conflict kind is a code change here, not just a string
 constant elsewhere.
 

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -144,8 +144,10 @@ Top-down, with the placeholder `data/hangar.yaml` values made concrete
 ```text
  TOP-DOWN.  +x along the door; +y runs deeper into the hangar, drawn DOWNWARD
  (door at top) to match the §8 convention box and the renderer.  Placeholder
- data/hangar.yaml: length_m=25, width_m=18; bay center_x_m=13.5, width_m=9,
- depth_m=9  ->  x in (9.0, 18.0),  y in (16.0, 25.0].
+ data/hangar.yaml: length_m=25, width_m=22; bay center_x_m=13.5, width_m=9,
+ depth_m=9  ->  x in (9.0, 18.0),  y in (16.0, 25.0].  (Schematic, not to scale:
+ the box below draws the bay flush to its right edge x=18; the right wall is now
+ x=22 — a ~4 m aisle, x in (18, 22), is elided.)
  x=0          door center_x=9.0, width=12.0  (x in [3, 15])               x=18
   +=========================[  door  ]=======================================+   y = 0.0   front wall
   |        +x runs right along the door --->        +y runs into hangar      |
@@ -156,8 +158,8 @@ Top-down, with the placeholder `data/hangar.yaml` values made concrete
   |                                          |#  MAINTENANCE BAY (closed)  #|   a vertex ON x=9 or
   |          normal hangar floor             |#  back-anchored, partial-w  #|   y=16 is OUTSIDE the bay)
   |                                          |#  x in (9.0, 18.0)          #|
-  |                                          |#  y in (16.0, 25.0]         #|   right edge x=18
-  |                                          |#  any non-occupant vertex   #|   == hangar wall
+  |                                          |#  y in (16.0, 25.0]         #|   bay right edge x=18
+  |                                          |#  any non-occupant vertex   #|   (~4 m aisle to x=22 wall)
   |                                          |#  STRICTLY inside  =>  one   #|
   |                                          |#  bay_intrusion per part    #|
   +==========================================+#############################+   y = 25.0  [INSIDE]
@@ -168,7 +170,7 @@ Top-down, with the placeholder `data/hangar.yaml` values made concrete
    strict < on the left / right / front edges; inclusive <= on the back edge
    (inherited from _hangar_bounds_conflicts, so y = 25 is not re-tested here)
 ```
-*Maintenance-bay geometry on the placeholder hangar (`length_m`=25, `width_m`=18; bay `center_x_m`=13.5, `width_m`=9, `depth_m`=9): the back-right 9×9 m corner, `x ∈ (9.0, 18.0)`, `y ∈ (16.0, 25.0]`. The left/right/front edges are strict `<` (a vertex on the edge is in the aisle, not the bay); the back-`y` edge is inclusive because it coincides with the hangar back wall and is inherited from `_hangar_bounds_conflicts`. When a maintenance occupant is set, any non-occupant part vertex strictly inside fires one `bay_intrusion` conflict per offending part.*
+*Maintenance-bay geometry on the placeholder hangar (`length_m`=25, `width_m`=22; bay `center_x_m`=13.5, `width_m`=9, `depth_m`=9): the back-right 9×9 m corner, `x ∈ (9.0, 18.0)`, `y ∈ (16.0, 25.0]` (the bay's x=18 right edge now sits ~4 m inside the widened x=22 wall — that aisle is elided from the schematic above). The left/right/front edges are strict `<` (a vertex on the edge is in the aisle, not the bay); the back-`y` edge is inclusive because it coincides with the hangar back wall and is inherited from `_hangar_bounds_conflicts`. When a maintenance occupant is set, any non-occupant part vertex strictly inside fires one `bay_intrusion` conflict per offending part.*
 
 This rule replaced the earlier "fuselage centroid in the back strip"
 rule during the bay-walling work that completed in
@@ -634,7 +636,7 @@ otherwise the default-fast invariant erodes.
 ### Test-only fixtures live alongside the production ones
 
 Files like `tests/fixtures/test_hangar_large.yaml` (30 × 25 m) exist
-because the placeholder production hangar (25 × 18 m in
+because the placeholder production hangar (25 × 22 m in
 `data/hangar.yaml`) cannot fit all nine aircraft simultaneously
 under the placeholder clearance budget. The fixture header explains
 the reason; the all-nine-planes test uses this larger hangar. When


### PR DESCRIPTION
## Release prep for v0.13.0

Promotes the CHANGELOG `[Unreleased]` block to `## [0.13.0] — 2026-06-09` and
refreshes stale docs ahead of the release cut, so the doc work gets a focused
review surface separate from the release-state PR.

### CHANGELOG backfill (audited every PR merged since v0.12.0)

The `[Unreleased]` block was missing five **user-facing** change groups; they were
backfilled (and then promoted) alongside the four already-present entries (#514,
#263, #518/#519/#520, #480):

**Added**
- **L-shaped hangar / structural-notch support** (#528/#529/#530, epic #527, ADR-0018) — headline; static containment + tow keep-out + 3D viewer; inert/byte-identical when no notch is configured.
- **Tow paths on the 3D viewer floor** (#505).
- **Too-shallow-apron observability warning** (#503, ADR-0021).

**Changed**
- **Herrenteich fleet refreshed to TCDS / 3-view-sourced dimensions + working demo** (#536).

**Fixed**
- **Strict unknown-key allowlist on fleet aircraft entries** (#513).

Seven PRs were deliberately **excluded** as internal/non-user-facing (test-only #512/#538, CI/bench #524/#531, dev-doc #525/#535, spike docs #540/#541).

### Doc-freshness audit

- `README.md` — `example.yaml` "6-plane subset" → "5-plane subset (+ Scheibe in the maintenance bay)".
- `docs/architecture/05-building-block-view.md` — `PartKind` set corrected for the ADR-0012 fuselage front/aft split **and** the ADR-0023 `vertical_stabilizer`.
- `docs/architecture/08-crosscutting-concepts.md` — maintenance-bay diagram + caption + the `25 × 18 m` reference corrected to the empennage-widened `25 × 22 m` (bay coordinates/predicate unchanged; the box is now labelled schematic, with the ~4 m right aisle to the x=22 wall noted as elided).
- `SECURITY.md` and `CLAUDE.md` audited — already fresh, no changes.

After this PR merges into `develop`, the release cut runs `release-cut version=0.13.0`
to create the `release/0.13.0` branch, bump `pyproject.toml`, and open the PRs into
`main` + back into `develop`.

Closes nothing — this is release plumbing tracked under milestone v0.13.0.