### PR TITLE
chore: gitignore the .claude/scheduled_tasks.lock runtime lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,11 @@ out*.png
 # committed (issue #148).
 .claude/worktrees/
 
+# Transient runtime lock written by Claude Code's scheduled-tasks / `/loop`
+# machinery (holds the owning sessionId + pid); a pure runtime artifact, never
+# meant to be committed (issue #555).
+.claude/scheduled_tasks.lock
+
 # Viewer TypeScript toolchain (top-level `viewer/`, ADR-0020 / issue #437). The
 # dev/CI-only Node deps are installed via `npm --prefix viewer/ ci` and must never
 # be committed or shipped; the committed bundle is src/hangarfit/_viewer_assets/


### PR DESCRIPTION
## Summary

Adds `.claude/scheduled_tasks.lock` to `.gitignore`. It is a transient runtime
lock written by Claude Code's scheduled-tasks / `/loop` machinery (holds the
owning `sessionId` + `pid`) and was surfacing as an untracked file in every
working tree that ran a scheduled/looped task — `git status` noise, and a trip
hazard for the clean-tree guards in the release skills (it had to be
staged-around during the v0.13.0 cut).

Placed alongside the existing `.claude/settings.local.json` and
`.claude/worktrees/` entries, each of which carries the same one-line rationale +
issue ref. Verified `git check-ignore` now matches the file and it no longer
appears in `git status`.

Closes #555