### PR TITLE
docs(claude-md): arming auto-merge counts as merging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ If you find yourself about to write a domain assertion in this file, **don't** �
 4. Convert each finding into a **review thread on the diff** (via `gh pr review` line comments / `gh api .../pulls/<n>/comments`). Findings never live only in chat.
 5. Resolve every thread: fix the code (preferred) or reply with rationale, then mark resolved.
 6. If the changes were non-trivial, re-run the review.
-7. When the review arc is clean, flip the PR out of draft (`gh pr ready <n>`) and tell the user it is **clean and ready for final review**. You may mark it ready **even before CI finishes** — readiness tracks the review arc, not the CI run (the user still cannot merge until the required checks pass, so an early ready flip never risks a premature merge). The user approves and merges. **Never `gh pr merge` from Claude.**
+7. When the review arc is clean, flip the PR out of draft (`gh pr ready <n>`) and tell the user it is **clean and ready for final review**. You may mark it ready **even before CI finishes** — readiness tracks the review arc, not the CI run (the user still cannot merge until the required checks pass, so an early ready flip never risks a premature merge). The user approves and merges. **Never `gh pr merge` from Claude — this includes `--auto`/enabling auto-merge, which counts as merging. Never arm it without the user's explicit go-ahead on that specific PR, every time (`gh pr merge <n> --disable-auto` undoes a stray arm).**
 
 **Stacking PRs (shared-file features).** When a feature splits into PRs that touch
 the same files (parallel branches would conflict), build a linear stack but **base


### PR DESCRIPTION
## Summary

Extends the per-PR-process step-7 rule so it explicitly covers **auto-merge**.
Previously it said *"Never `gh pr merge` from Claude"* but did not name `--auto`,
which sessions had been arming on clean plumbing PRs as a convenience — silently
bypassing the user's per-PR merge gate. Now the rule states that arming
auto-merge counts as merging and needs the user's explicit go-ahead on that
specific PR, every time, with the `gh pr merge <n> --disable-auto` undo noted.

One-line change to the existing rule; no other content touched.

Closes #557