### PR TITLE
feat(models): make Scenario picklable for ProcessPool parallel restarts

### DIFF
--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -799,6 +799,13 @@ class Scenario:
     maintenance_plane: str | None = None
     constraints: Mapping[str, PlaneConstraint] = field(default_factory=lambda: MappingProxyType({}))
 
+    # The mapping fields wrapped in MappingProxyType for immutability. This is
+    # the single source of truth for both the construction-time wrap (in
+    # __post_init__) and the pickle unwrap/re-wrap (in __getstate__/__setstate__,
+    # #545) — listing them once means the two cannot silently drift. (ClassVar so
+    # the dataclass excludes it from the field set and __slots__.)
+    _PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = ("fleet", "constraints")
+
     def __post_init__(self) -> None:
         # fleet_in must be non-empty (otherwise there's nothing to solve;
         # downstream helpers like the sum-of-areas infeasibility check
@@ -914,20 +921,22 @@ class Scenario:
                         f"{constraint.priority!r} must be >= 0.0 (a soft importance weight)"
                     )
 
-        object.__setattr__(self, "fleet", MappingProxyType(dict(self.fleet)))
-        # Always copy+wrap constraints — mirrors the unconditional pattern on
-        # fleet above (and on Layout.fleet). Skipping the copy when the caller
-        # passes a pre-wrapped MappingProxyType would let the caller leak
-        # mutations through their retained reference to the underlying dict.
-        object.__setattr__(self, "constraints", MappingProxyType(dict(self.constraints)))
+        # Wrap the mapping fields in MappingProxyType so a frozen Scenario can't
+        # be mutated through e.g. ``scenario.fleet["x"] = …``. Always copy+wrap
+        # (even an already-wrapped MappingProxyType arg): skipping the copy would
+        # let a caller leak mutations through their retained reference to the
+        # underlying dict. Driven off _PROXY_FIELDS so this wrap list and the
+        # pickle unwrap list stay a single source of truth.
+        for name in self._PROXY_FIELDS:
+            object.__setattr__(self, name, MappingProxyType(dict(getattr(self, name))))
 
     # ── Pickling (#545, enables #544 ProcessPool parallel restarts) ──────
     #
     # A Scenario must cross the process boundary so #544 can fan RR-MC
-    # restarts across a ProcessPoolExecutor. But ``fleet`` and ``constraints``
-    # are wrapped in MappingProxyType (above), and a mappingproxy is not
-    # picklable (``TypeError: cannot pickle 'mappingproxy' object``). So unwrap
-    # the proxies to plain dicts for the wire and re-wrap them on the far side,
+    # restarts across a ProcessPoolExecutor. But the _PROXY_FIELDS are wrapped
+    # in MappingProxyType (above), and a mappingproxy is not picklable
+    # (``TypeError: cannot pickle 'mappingproxy' object``). So unwrap the
+    # proxies to plain dicts for the wire and re-wrap them on the far side,
     # which keeps the immutability contract alive across the round-trip
     # (``slots=True`` ⇒ no ``__dict__``; the state lives in ``__slots__``).
     #
@@ -936,19 +945,23 @@ class Scenario:
     # on the wire — and if that future field is itself unpicklable it fails
     # *loudly* here (it won't be unwrapped) rather than corrupting a worker.
     #
-    # Security: this only round-trips a TRUSTED, in-process object across our
-    # own pool; it never unpickles external/untrusted data (see SECURITY.md).
-    _PICKLE_PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = ("fleet", "constraints")
+    # Security: this is an in-process trust boundary — it only round-trips a
+    # Scenario we built ourselves across our own pool, never deserializing
+    # external/untrusted data, so the usual pickle-RCE caveat does not apply.
+    #
+    # NOTE: Layout (the sibling type that may carry results *back* across the
+    # boundary) has the same MappingProxyType/pickle gap and no hooks yet —
+    # #544 must make whatever it returns from a worker picklable too.
 
     def __getstate__(self) -> dict[str, typing.Any]:
         state: dict[str, typing.Any] = {name: getattr(self, name) for name in self.__slots__}
-        for name in self._PICKLE_PROXY_FIELDS:
+        for name in self._PROXY_FIELDS:
             state[name] = dict(state[name])  # unwrap mappingproxy → plain dict
         return state
 
     def __setstate__(self, state: dict[str, typing.Any]) -> None:
         for name, value in state.items():
-            if name in self._PICKLE_PROXY_FIELDS:
+            if name in self._PROXY_FIELDS:
                 value = MappingProxyType(dict(value))  # re-wrap on the far side
             object.__setattr__(self, name, value)
 

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -921,6 +921,37 @@ class Scenario:
         # mutations through their retained reference to the underlying dict.
         object.__setattr__(self, "constraints", MappingProxyType(dict(self.constraints)))
 
+    # ── Pickling (#545, enables #544 ProcessPool parallel restarts) ──────
+    #
+    # A Scenario must cross the process boundary so #544 can fan RR-MC
+    # restarts across a ProcessPoolExecutor. But ``fleet`` and ``constraints``
+    # are wrapped in MappingProxyType (above), and a mappingproxy is not
+    # picklable (``TypeError: cannot pickle 'mappingproxy' object``). So unwrap
+    # the proxies to plain dicts for the wire and re-wrap them on the far side,
+    # which keeps the immutability contract alive across the round-trip
+    # (``slots=True`` ⇒ no ``__dict__``; the state lives in ``__slots__``).
+    #
+    # We iterate over ``__slots__`` rather than hand-listing the fields so a
+    # future field round-trips transparently instead of being silently dropped
+    # on the wire — and if that future field is itself unpicklable it fails
+    # *loudly* here (it won't be unwrapped) rather than corrupting a worker.
+    #
+    # Security: this only round-trips a TRUSTED, in-process object across our
+    # own pool; it never unpickles external/untrusted data (see SECURITY.md).
+    _PICKLE_PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = ("fleet", "constraints")
+
+    def __getstate__(self) -> dict[str, typing.Any]:
+        state: dict[str, typing.Any] = {name: getattr(self, name) for name in self.__slots__}
+        for name in self._PICKLE_PROXY_FIELDS:
+            state[name] = dict(state[name])  # unwrap mappingproxy → plain dict
+        return state
+
+    def __setstate__(self, state: dict[str, typing.Any]) -> None:
+        for name, value in state.items():
+            if name in self._PICKLE_PROXY_FIELDS:
+                value = MappingProxyType(dict(value))  # re-wrap on the far side
+            object.__setattr__(self, name, value)
+
 
 @dataclass(frozen=True, slots=True)
 class ApronShallowDrop:

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pickle
 from types import MappingProxyType
 
 import pytest
@@ -623,3 +624,54 @@ def test_scenario_priority_coexists_with_pin_and_force_on_carts(fleet, hangar):
     )
     c = s.constraints["ctsl"]
     assert c.priority == 4.0 and c.pin == pin and c.force_on_carts is True
+
+
+# ── Scenario picklability (#545 — enables #544 ProcessPool parallel restarts) ──
+
+
+def test_scenario_pickle_round_trips_all_fields(fleet, hangar):
+    """Scenario must survive a pickle round-trip so #544's ProcessPool
+    parallel restarts can ship it across the process boundary. The
+    MappingProxyType wraps on ``fleet``/``constraints`` make the default
+    pickle raise ``TypeError: cannot pickle 'mappingproxy' object``; the
+    __getstate__/__setstate__ hooks unwrap then re-wrap them. Round-trips a
+    scenario that exercises every field (multi-plane fleet_in, a
+    maintenance_plane, and a fully-populated constraint)."""
+    pin = Placement(plane_id="ctsl", x_m=2.0, y_m=10.0, heading_deg=0.0, on_carts=True)
+    s = Scenario(
+        fleet=fleet,
+        hangar=hangar,
+        fleet_in=("ctsl", "aviat_husky"),
+        maintenance_plane="aviat_husky",
+        constraints={"ctsl": PlaneConstraint(pin=pin, force_on_carts=True, priority=4.0)},
+    )
+
+    restored = pickle.loads(pickle.dumps(s))
+
+    assert dict(restored.fleet) == dict(s.fleet)
+    assert restored.hangar == s.hangar
+    assert restored.fleet_in == s.fleet_in
+    assert restored.maintenance_plane == s.maintenance_plane
+    assert dict(restored.constraints) == dict(s.constraints)
+
+
+def test_scenario_pickle_preserves_immutability_wraps(fleet, hangar):
+    """The round-trip must restore the MappingProxyType immutability
+    contract, not just the data — otherwise an unpickled Scenario would
+    silently become mutable, regressing the same guarantee
+    test_scenario_fleet_is_mapping_proxy pins for the constructed form."""
+    s = Scenario(
+        fleet=fleet,
+        hangar=hangar,
+        fleet_in=("aviat_husky",),
+        constraints={"aviat_husky": PlaneConstraint()},
+    )
+
+    restored = pickle.loads(pickle.dumps(s))
+
+    assert isinstance(restored.fleet, MappingProxyType)
+    assert isinstance(restored.constraints, MappingProxyType)
+    with pytest.raises(TypeError):
+        restored.fleet["x"] = None  # type: ignore[index]
+    with pytest.raises(TypeError):
+        restored.constraints["x"] = PlaneConstraint()  # type: ignore[index]


### PR DESCRIPTION
## What

`Scenario` wraps `fleet` and `constraints` in `MappingProxyType` for immutability (mirroring `Layout`). But a `mappingproxy` is **not picklable**, so `pickle.dumps(scenario)` raised `TypeError: cannot pickle 'mappingproxy' object`. That is the hard blocker for #544's ProcessPool parallel restarts: each worker must receive the `Scenario` across the process boundary.

## How

Add `__getstate__` / `__setstate__` to `Scenario`:
- `__getstate__` unwraps the two proxy fields to plain `dict`s for the wire (`slots=True` ⇒ state lives in `__slots__`, no `__dict__`).
- `__setstate__` re-wraps them in `MappingProxyType` on the far side, so the **immutability contract survives the round-trip** — an unpickled `Scenario` is still mutation-proof.

The hooks iterate over `__slots__` rather than hand-listing fields, so:
- a future plain field round-trips transparently instead of being **silently dropped** on the wire (the silent-data-loss failure mode #513/#516 guard against elsewhere), and
- a future *unpicklable* field fails **loudly** here (it won't be in `_PICKLE_PROXY_FIELDS`, so it won't be unwrapped) rather than corrupting a worker.

## Determinism

Pure addition — construction behaviour is unchanged, so solver output stays byte-identical. **No ADR-0003 impact** (that re-base is #544's concern, not this enabler's).

## Verification

- New tests `test_scenario_pickle_round_trips_all_fields` (every field, incl. a maintenance plane + a fully-populated constraint) and `test_scenario_pickle_preserves_immutability_wraps` (proxies restored, still immutable). Both watched fail RED with the documented `TypeError`, then GREEN.
- Verified the `Scenario` survives the **exact** `multiprocessing.reduction.ForkingPickler` that `ProcessPoolExecutor` uses on its queues (not just `pickle.dumps`).
- Full non-slow suite: **1440 passed**, 0 regressions. ruff + mypy clean.

## Security

The pickle path round-trips only a **trusted, in-process** object across our own pool; it never deserializes external/untrusted data (noted in the code + consistent with SECURITY.md).

Closes #545
Refs #544, #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)