### PR TITLE
docs(claude-md): subprocess coverage blind spot + det-rebase ceiling trigger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,10 +218,9 @@ pytest -m ""
 # GOTCHA: coverage.py does NOT measure ProcessPool/spawn WORKER subprocesses, so
 # code that only runs inside a worker (e.g. solver._run_restart_worker, #544)
 # reads as uncovered even when tests DO exercise it via the pool → `codecov/patch`
-# flags it (it is NOT a required check, so it won't block merge — see #561). To
-# actually cover such code, call the worker fn IN-PROCESS in a unit test (the
-# worker is usually a thin wrapper), or set coverage `concurrency = multiprocessing`
-# + COVERAGE_PROCESS_START.
+# flags it (non-blocking; #561 tracks closing the gap). Cover it by calling the
+# worker fn IN-PROCESS in a unit test (the worker is usually a thin wrapper; or
+# wire coverage `concurrency=multiprocessing` + COVERAGE_PROCESS_START).
 
 # Lint + format check (CI also runs these)
 ruff check src/ tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,8 +202,10 @@ pytest -m ""
 # solve_fresh_alternatives_three): `solve` sets rc=0 the instant the first valid
 # basin is found (sub-second), so the verdict no longer races the clock. The bench
 # `--gate` SPEED ceilings (bench/profile_pipeline.py) are wall-clock too and fail
-# on slower CI runners as the model gets heavier — re-baseline them (the empennage
-# pushed the apron regime past its ceiling, #524) rather than chase a phantom
+# on slower CI runners as the model gets heavier — OR when a deliberate determinism
+# re-base changes WHICH layout a regime selects (a different valid layout can
+# tow-route slower). Re-baseline them (empennage→apron ceiling #524; #544's
+# per-restart-index reseed→spread-off ceiling 20→45 s) rather than chase a phantom
 # regression; the bench's validity/path/determinism verdicts bind on max_restarts
 # and stay reproducible.
 
@@ -212,6 +214,14 @@ pytest -m ""
 # derives coverage from the COMBINED run, so marking a test @slow drops it from
 # coverage too. If a @slow test is the only one covering a new code path, the
 # `codecov/patch` PR check fails — keep >=1 non-slow test per new path.
+
+# GOTCHA: coverage.py does NOT measure ProcessPool/spawn WORKER subprocesses, so
+# code that only runs inside a worker (e.g. solver._run_restart_worker, #544)
+# reads as uncovered even when tests DO exercise it via the pool → `codecov/patch`
+# flags it (it is NOT a required check, so it won't block merge — see #561). To
+# actually cover such code, call the worker fn IN-PROCESS in a unit test (the
+# worker is usually a thin wrapper), or set coverage `concurrency = multiprocessing`
+# + COVERAGE_PROCESS_START.
 
 # Lint + format check (CI also runs these)
 ruff check src/ tests/


### PR DESCRIPTION
## What

Two operational gotchas that surfaced while building #544 (parallel restarts), added to CLAUDE.md's CI-gotchas block so future sessions don't re-discover them:

1. **`coverage.py` is blind to ProcessPool/spawn worker subprocesses.** Code that runs only inside a worker (`solver._run_restart_worker`) reads as uncovered even when tests exercise it via the pool → `codecov/patch` flags it. It's not a required check (won't block merge); cover such code by calling the worker fn **in-process** in a unit test, or set coverage `concurrency = multiprocessing`. (This cost a round-trip on #560 → tracked as #561.)
2. **bench `--gate` SPEED ceilings can need a re-baseline on a determinism *re-base*, not just model growth.** A deliberate reseed/algorithm change can shift *which* valid layout a regime selects, and a different layout may tow-route slower — #544's per-restart-index reseed pushed `roomy_three_spread_off` past its ceiling (20→45 s), same shape as the empennage→apron precedent (#524).

Docs-only — CLAUDE.md operational context, **no code impact** (CLAUDE.md isn't built or tested).

## Why a separate PR

Kept off #560 deliberately so that PR could merge immediately without a CI re-trigger; CLAUDE.md updates are the project's established standalone-PR pattern (#501/#525/#535).

Refs #544, #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)