### PR TITLE
ci(bench): full_nine_placement regime + required-candidate correctness gate

### DIFF
--- a/.github/workflows/bench-gates.yml
+++ b/.github/workflows/bench-gates.yml
@@ -12,9 +12,25 @@ name: bench gates
 #
 # Deliberately a SEPARATE workflow from ci.yml (the Python test/lint matrix): a
 # bench regression is a distinct signal from a unit-test failure, and a separate
-# file keeps each concern independently editable. This job is NOT yet a *required*
-# status check — it runs on every develop/main PR, but the repo owner adds it to
-# branch protection's required set when ready.
+# file keeps each concern independently editable.
+#
+# TWO jobs split the gate by what is safe to block a merge on (#564):
+#
+#   * `bench-correctness` runs `python -m bench.profile_pipeline` WITHOUT `--gate`,
+#     so it exits non-zero ONLY on the byte-reproducible VALIDITY / PATH-VALIDITY /
+#     DETERMINISM invariants and merely reports timing. Those invariants are machine-
+#     and load-independent (the harness binds on `max_restarts`), so this job is
+#     safe to make a REQUIRED status check — a determinism regression then BLOCKS a
+#     merge instead of only reporting red (closing the gap where a direct push also
+#     bypasses the in-session determinism-guard subagent). The repo owner adds the
+#     `bench correctness ...` check to branch protection's required set (it is not
+#     timing-sensitive, so it runs on the floating `ubuntu-latest`).
+#   * `bench-gates` runs `--gate`, which additionally enforces the per-regime SPEED
+#     ceilings. Those are runner-sensitive and periodically re-baselined (CLAUDE.md),
+#     so this job stays a NON-required reporting check: a speed regression reports
+#     red but is never allowed to block a merge on CI-runner jitter.
+#
+# Both jobs run on every develop/main PR.
 
 on:
   pull_request:
@@ -75,3 +91,43 @@ jobs:
         # speed-ceiling breach. `bench/` lives outside src/ and ships in no wheel,
         # so it is invoked as a module, not via the installed console script.
         run: python -m bench.profile_pipeline --gate
+
+  bench-correctness:
+    name: bench correctness (validity + path-validity + determinism)
+    # The REQUIRED-candidate gate (#564): correctness ONLY, no speed ceiling.
+    # NOT timing-sensitive — the harness binds on `max_restarts`, so VALIDITY /
+    # PATH-VALIDITY / DETERMINISM are byte-reproducible regardless of runner speed.
+    # So this job runs on the floating `ubuntu-latest` (no calibration pin needed,
+    # unlike the speed job above), and is the one the repo owner adds to branch
+    # protection's required set so a determinism regression blocks merge.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Set up Python 3.12
+        # The single supported Python (ADR-0009).
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-dev.txt
+            requirements-build.txt
+
+      - name: Install dev deps (hash-pinned)
+        run: pip install --require-hashes -r requirements-dev.txt
+
+      - name: Install build toolchain (hash-pinned)
+        run: pip install --require-hashes -r requirements-build.txt
+
+      - name: Install project (editable, no deps)
+        # MUST run after the build-toolchain install (see the speed job's note).
+        run: pip install -e . --no-deps --no-build-isolation
+
+      - name: Run bench correctness (fast regimes — no speed ceiling)
+        # No `--gate`: exit non-zero ONLY on a VALIDITY / PATH-VALIDITY /
+        # DETERMINISM failure; speed is reported in the table but never enforced
+        # (profile_pipeline.py main()'s default-path return). This is the
+        # merge-blocking signal once added to the required set.
+        run: python -m bench.profile_pipeline

--- a/bench/profile_pipeline.py
+++ b/bench/profile_pipeline.py
@@ -97,14 +97,13 @@ _SPEED_CEILING_S: dict[str, float] = {
     # ~170 s pre-empennage). Tripwire, not a microbenchmark (#499 / #263 / #524).
     "roomy_three_apron": 380.0,
     # 2026-06-09 (#547): parts²-scaling guard. PLACEMENT-dominated 9-plane fill
-    # (spread ON, 8 restarts; tiny tow cap ⇒ routing bails fast). Local total ~47 s
-    # (placement ~37 s + routing ~10 s). PROVISIONAL ceiling pending the first
-    # `bench gates` CI observation — like every ceiling above, the binding value is
-    # ~1.7x the CI median, but CI runs 2–4x slower than local and is not yet
-    # measured for this regime, so 300 s is a safe first-run headroom that still
-    # trips on a parts²-blowup or a #453-memoization revert (both multi-x). Tighten
-    # to ~1.7x the observed CI total once the workflow reports it.
-    "full_nine_placement": 300.0,
+    # (spread ON, 8 restarts; a tiny tow cap ⇒ routing bails fast, so placement is
+    # ~80% of the total). Measured 110.2 s on the bench-gates CI runner (placement
+    # 88.4 s + routing 21.8 s; ~2.3x the ~47 s local). 190 s is ~1.7x that CI median
+    # — matching the spread_off/apron headroom — and still trips on a parts²-blowup
+    # or a #453 memoization revert (both multi-x placement growth). Tripwire, not a
+    # microbenchmark.
+    "full_nine_placement": 190.0,
 }
 
 

--- a/bench/profile_pipeline.py
+++ b/bench/profile_pipeline.py
@@ -96,6 +96,15 @@ _SPEED_CEILING_S: dict[str, float] = {
     # CI (the pre-fix run that tripped the old 240 s ceiling peaked at ~269 s; was
     # ~170 s pre-empennage). Tripwire, not a microbenchmark (#499 / #263 / #524).
     "roomy_three_apron": 380.0,
+    # 2026-06-09 (#547): parts²-scaling guard. PLACEMENT-dominated 9-plane fill
+    # (spread ON, 8 restarts; tiny tow cap ⇒ routing bails fast). Local total ~47 s
+    # (placement ~37 s + routing ~10 s). PROVISIONAL ceiling pending the first
+    # `bench gates` CI observation — like every ceiling above, the binding value is
+    # ~1.7x the CI median, but CI runs 2–4x slower than local and is not yet
+    # measured for this regime, so 300 s is a safe first-run headroom that still
+    # trips on a parts²-blowup or a #453-memoization revert (both multi-x). Tighten
+    # to ~1.7x the observed CI total once the workflow reports it.
+    "full_nine_placement": 300.0,
 }
 
 

--- a/bench/regimes.py
+++ b/bench/regimes.py
@@ -103,6 +103,24 @@ REGIMES: tuple[Regime, ...] = (
         heavy=True,
     ),
     Regime(
+        # parts²-scaling guard (#547, from spike #540). The all-nine fill maximizes
+        # part-pairs, so the O(planes²·parts²) collision sweep is heaviest here as
+        # the parts model grows (the empennage #518–#520 already added 2 parts per
+        # aircraft). Unlike full_nine_spread_on (heavy, characterises 9-plane
+        # ROUTING), this is a FAST regime that characterises 9-plane PLACEMENT: a
+        # tiny global tow cap makes routing bail fast (NoFeasiblePlanError ⇒ no
+        # committed arc ⇒ paths vacuously valid + deterministic) so placement
+        # dominates the measured wall-clock. Binds on max_restarts (8).
+        key="full_nine_placement",
+        description="9 planes, large hangar, spread ON — placement parts²-scaling guard",
+        scenario=FIXTURES / "solve_all_nine_large_hangar.yaml",
+        seed=1,
+        max_restarts=8,
+        spread=True,
+        n_planes=9,
+        tow_max_total_expansions=300,
+    ),
+    Regime(
         key="tight_six_placeholder",
         description="6 planes, 25x18 m placeholder — tight, routing likely bails",
         scenario=FIXTURES / "solve_fresh_six_planes.yaml",


### PR DESCRIPTION
Closes #547
Closes #564

## What

Two related bench/CI loose ends from the 2026-06-09 audit (#547) and spike #540.

### #547 — `full_nine_placement` parts²-scaling guard
A new **FAST** regime (`bench/regimes.py`) that characterises 9-plane *placement*: `solve_all_nine_large_hangar.yaml`, spread ON, 8 restarts, with a **tiny global tow cap (300)** so routing bails fast and placement dominates the measured wall-clock. The all-nine fill maximizes part-pairs, so it is the most sensitive guard against the `O(planes²·parts²)` collision sweep growing as the parts model does (the empennage #518–#520 already added 2 parts/aircraft).

`heavy=False` ⇒ it joins `FAST_REGIMES`, so both gate jobs run it. An un-routable fill bails with `NoFeasiblePlanError` (`plan=None`) ⇒ no committed arc ⇒ paths vacuously valid + deterministic. Local: `valid=ok paths=ok det=ok`, total ~47 s (placement ~37 s + routing ~10 s).

The `_SPEED_CEILING_S` entry is **provisional at 300 s** (the gate refuses to run a regime with no ceiling). CI runs 2–4× slower than local and this regime has no CI measurement yet, so 300 s is a safe first-run headroom that still trips on a parts²-blowup. **I will tighten it to ~1.7× once this PR's `bench gates` run reports the real CI total** — exactly how every existing ceiling was calibrated (from the workflow itself).

### #564 — required-candidate correctness gate
Split `bench-gates.yml` into two jobs:

| Job | Runs | Enforces | Required? |
|---|---|---|---|
| **`bench-correctness`** (new) | `profile_pipeline` (no `--gate`) | validity + path-validity + **determinism** only | **candidate** — safe to require (machine-independent) |
| `bench-gates` (existing) | `profile_pipeline --gate` | the above **+ speed ceilings** | stays non-required (ceilings are runner-sensitive) |

This closes the gap where a determinism regression only *reported* red and a direct push also bypasses the in-session `determinism-guard` subagent.

## ⚠️ Owner action (not done in this PR)
Per #564's acceptance, **you** add the `bench correctness (validity + path-validity + determinism)` check to `develop`'s (and `main`'s) branch-protection required set once it's green across a few runs:
```
gh api -X PUT repos/DocGerd/hangarfit/branches/develop/protection/required_status_checks/contexts \
  -f 'contexts[]=bench correctness (validity + path-validity + determinism)'
```
(Do **not** enable `required_linear_history` — it breaks the GitFlow release flow.)

## Verification
- `python -m bench.profile_pipeline --regime full_nine_placement --gate` → GATE PASSED (valid/paths/det ok).
- `bench-gates.yml` parses as valid YAML; `ruff` clean on `bench/`.
- Provisional ceiling will be tightened from this PR's CI `total_s` before I mark it ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)