### PR TITLE
docs(claude-md): runnable solve --workers/--max-restarts example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,17 @@ hangarfit check examples/layouts/example.yaml --render out.png
 # exit 3 only if NO candidate layout is tow-routable.
 hangarfit solve tests/fixtures/scenario_minimal.yaml --render out.png --render-paths
 
+# #544/#560 parallel restarts. --max-restarts N bounds the search by a FIXED
+# restart count (cross-machine reproducible, NOT wall-clock); --workers N fans
+# those restarts across worker processes. The speedup is BYTE-IDENTICAL to serial
+# ONLY in the --max-restarts + spread-on regime (`_parallel_eligible`): for any
+# other config (no --max-restarts, or --no-spread) --workers is silently
+# downgraded to serial and prints a `note: --workers N ignored (runs serial)` on
+# stderr. Speedup is sub-linear and placement-only — most useful on roomy spread-on
+# fills with many restarts. Determinism stays max_restarts-scoped (ADR-0003 #544
+# amendment); see tests/test_solver_parallel.py for the byte-identity contract.
+hangarfit solve tests/fixtures/scenario_minimal.yaml --max-restarts 64 --workers 8
+
 # Phase 4: 3D viewer (self-contained offline HTML). examples/layouts/example.yaml is NOT
 # tow-routable → it falls back to a static 3D render. Since #398 (F1), layout-mode
 # `view` passes a small deterministic GLOBAL tow-expansion cap


### PR DESCRIPTION
Closes #566

## What
Every shipped CLI surface in CLAUDE.md's `## Useful commands` block had a runnable example **except** the most recent one (#544/#560 `--workers` / `--max-restarts`). Add it, with the non-obvious eligibility rule inline:

```bash
hangarfit solve tests/fixtures/scenario_minimal.yaml --max-restarts 64 --workers 8
```

The comment explains: `--workers >1` is byte-identical to serial **only** in the `--max-restarts` + spread-on regime (`_parallel_eligible`); for any other config it's silently downgraded to serial with a `note: --workers N ignored (runs serial)` on stderr. Points at `tests/test_solver_parallel.py` for the byte-identity contract.

## Verification
- The recipe parses and runs (`build_parser` accepts `--max-restarts 64 --workers 8` on `scenario_minimal.yaml`).

## Note
#567 (the larger CLAUDE.md restructure) edits the same block and is `blocked_by` this — it should rebase on it once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)