### PR TITLE
feat(loader): strict top-level unknown-key allowlist for hangar/scenario/layout

### DIFF
--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -120,6 +120,26 @@ def _to_int(value: Any, field_name: str) -> int:
     return value
 
 
+def _reject_unknown_top_level_keys(
+    raw: Mapping[str, Any], allowed: frozenset[str], *, path: Path, block: str
+) -> None:
+    """Reject misspelled/unknown top-level keys in a hangar/layout/scenario file
+    (#516) — the same silent-failure class the ``aircraft:`` allowlist
+    (:data:`_ALLOWED_AIRCRAFT_KEYS`, #513) closes one layer down. Without it a
+    typo'd top-level key (e.g. ``apron_dpeth_m:``) is silently dropped to its
+    default. Raised with the ``{path}:`` prefix every top-level loader already uses.
+
+    Each ``allowed`` set is exactly the keys its loader reads — keep the two in
+    sync; the ``test_all_allowed_*_keys_load`` completeness guards fail loudly if
+    a real key is ever dropped from an allowlist (the too-strict direction).
+    """
+    unknown = set(raw) - allowed
+    if unknown:
+        raise LoaderError(
+            f"{path}: unknown {block} key(s) {sorted(unknown)}; allowed: {sorted(allowed)}"
+        )
+
+
 def load_fleet(path: Path | str) -> dict[str, Aircraft]:
     """Load ``fleet.yaml`` into a dict keyed by :attr:`Aircraft.id`.
 
@@ -175,6 +195,28 @@ def _resolve_apron_depth(
     return _to_float(value, field_name)
 
 
+# Strict top-level-key allowlist for a hangar.yaml (#516). Mirrors the `aircraft:`
+# (:data:`_ALLOWED_AIRCRAFT_KEYS`) guard, extended to the hangar file's top level.
+# The nested `door`/`maintenance_bay` blocks need no allowlist — all their keys are
+# required, so a typo there already fails loudly as "missing required field"; the
+# `structural_notches` rectangles carry their own per-entry allowlist (below). Keep
+# in sync with the keys read in :func:`load_hangar`; ``test_all_allowed_hangar_keys_load``
+# guards the too-strict direction.
+_ALLOWED_HANGAR_KEYS = frozenset(
+    {
+        "length_m",
+        "width_m",
+        "door",
+        "maintenance_bay",
+        "structural_notches",
+        "clearance_m",
+        "wing_layer_clearance_m",
+        "max_carts",
+        "apron_depth_m",
+    }
+)
+
+
 def load_hangar(path: Path | str, *, fleet: Mapping[str, Aircraft] | None = None) -> Hangar:
     """Load ``hangar.yaml`` into a :class:`Hangar`.
 
@@ -188,6 +230,7 @@ def load_hangar(path: Path | str, *, fleet: Mapping[str, Aircraft] | None = None
     raw = _read_yaml(path)
     if not isinstance(raw, dict):
         raise LoaderError(f"{path}: top-level must be a mapping")
+    _reject_unknown_top_level_keys(raw, _ALLOWED_HANGAR_KEYS, path=path, block="hangar")
 
     door_data = raw.get("door")
     if not isinstance(door_data, dict):
@@ -271,6 +314,13 @@ def load_hangar(path: Path | str, *, fleet: Mapping[str, Aircraft] | None = None
         raise LoaderError(f"{path}: {e}") from e
 
 
+# Strict top-level-key allowlist for a layout.yaml (#516). Keep in sync with the
+# keys read in :func:`load_layout`; ``test_all_allowed_layout_keys_load`` guards the
+# too-strict direction. ``fleet``/``hangar`` are optional in the file (they may arrive
+# as kwargs instead); the file-vs-kwarg conflict is handled separately, below.
+_ALLOWED_LAYOUT_KEYS = frozenset({"fleet", "hangar", "placements", "maintenance"})
+
+
 def load_layout(
     path: Path | str,
     *,
@@ -297,6 +347,7 @@ def load_layout(
     raw = _read_yaml(path)
     if not isinstance(raw, dict):
         raise LoaderError(f"{path}: top-level must be a mapping")
+    _reject_unknown_top_level_keys(raw, _ALLOWED_LAYOUT_KEYS, path=path, block="layout")
 
     if fleet is None:
         fleet_ref = raw.get("fleet")
@@ -393,6 +444,13 @@ def load_layout(
         raise LoaderError(f"{path}: {e}") from e
 
 
+# Strict top-level-key allowlist for a scenario.yaml (#516). Keep in sync with the
+# keys read in :func:`load_scenario`; ``test_all_allowed_scenario_keys_load`` guards
+# the too-strict direction. Per-plane ``constraints`` entries carry their own
+# allowlist (:data:`_ALLOWED_CONSTRAINT_KEYS`).
+_ALLOWED_SCENARIO_KEYS = frozenset({"fleet_in", "fleet", "hangar", "maintenance", "constraints"})
+
+
 def load_scenario(
     path: Path | str,
     *,
@@ -424,6 +482,7 @@ def load_scenario(
     raw = _read_yaml(path)
     if not isinstance(raw, dict):
         raise LoaderError(f"{path}: top-level must be a mapping")
+    _reject_unknown_top_level_keys(raw, _ALLOWED_SCENARIO_KEYS, path=path, block="scenario")
 
     # fleet_in (required) — checked before fleet/hangar are loaded so that
     # a missing required field is reported as such, rather than as a

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -14,6 +14,8 @@ import yaml
 
 from hangarfit.loader import (
     _ALLOWED_AIRCRAFT_KEYS,
+    _ALLOWED_HANGAR_KEYS,
+    _ALLOWED_LAYOUT_KEYS,
     LoaderError,
     _resolve_known_plane_id,
     _suggest_plane_id,
@@ -1313,6 +1315,47 @@ maintenance_bay: {center_x_m: 13.5, width_m: 9, depth_m: 9}
         assert h.clearance_m == 0.3
         assert h.wing_layer_clearance_m == 0.2
 
+    @pytest.mark.parametrize(
+        "typo",
+        ["lenght_m", "appron_depth_m", "max_cart", "wing_clearance_m", "bogus_field"],
+    )
+    def test_unknown_hangar_key_rejected(self, tmp_path: Path, typo: str) -> None:
+        """A misspelled TOP-LEVEL hangar key must be REJECTED (#516), not silently
+        dropped to its default — the same silent-failure class #513 closed for
+        ``aircraft:`` entries. The nastiest case is ``apron_depth_m`` (#503): a
+        typo (``appron_depth_m:``) silently falls back to depth 0, compounding the
+        already-silent too-shallow-apron fallback. Mirrors ``_ALLOWED_AIRCRAFT_KEYS``."""
+        path = _write(tmp_path / "h.yaml", _MIN_HANGAR + f"{typo}: 1.0\n")
+        with pytest.raises(LoaderError, match=r"unknown hangar key\(s\)"):
+            load_hangar(path)
+
+    def test_all_allowed_hangar_keys_load(self, tmp_path: Path) -> None:
+        """Completeness guard for the allowlist: a hangar declaring EVERY allowed
+        top-level key (including the optional ``structural_notches`` + ``apron_depth_m``)
+        loads without error — so the allowlist can never be too strict. Self-enforcing:
+        adding a key to ``_ALLOWED_HANGAR_KEYS`` without extending this fixture fails here."""
+        body = """
+length_m: 30.0
+width_m: 25.0
+door: {center_x_m: 12.5, width_m: 12.0}
+maintenance_bay: {center_x_m: 21.0, width_m: 6.0, depth_m: 6.0}
+clearance_m: 0.3
+wing_layer_clearance_m: 0.2
+max_carts: 2
+apron_depth_m: 6.0
+structural_notches:
+  - {x_min_m: 0.0, y_min_m: 27.0, x_max_m: 2.0, y_max_m: 30.0}
+"""
+        file_keys = set(yaml.safe_load(body))
+        assert file_keys == _ALLOWED_HANGAR_KEYS, (
+            f"fixture must cover the full allowlist; "
+            f"missing={sorted(_ALLOWED_HANGAR_KEYS - file_keys)} "
+            f"extra={sorted(file_keys - _ALLOWED_HANGAR_KEYS)}"
+        )
+        h = load_hangar(_write(tmp_path / "h.yaml", body))
+        assert h.apron_depth_m == 6.0
+        assert len(h.structural_notches) == 1
+
 
 # ----------------------------------------------------------------------------
 # Layout loader: path resolution + cross-reference errors.
@@ -1354,6 +1397,45 @@ placements:
         layout = load_layout(layout_path)
         assert len(layout.placements) == 1
         assert layout.placements[0].plane_id == "foo"
+
+    @pytest.mark.parametrize(
+        "typo",
+        ["placments", "maintenence", "hangarr", "bogus_field"],
+    )
+    def test_unknown_layout_key_rejected(self, tmp_path: Path, typo: str) -> None:
+        """A misspelled TOP-LEVEL layout key must be REJECTED (#516), not silently
+        dropped — the silent-failure class #513 closed for ``aircraft:`` entries,
+        extended to the layout file's top level. Mirrors ``_ALLOWED_AIRCRAFT_KEYS``."""
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            "fleet: fleet.yaml\n"
+            "hangar: hangar.yaml\n"
+            "placements:\n"
+            "  - {plane: foo, x_m: 5.0, y_m: 5.0, heading_deg: 0, on_carts: false}\n"
+            f"{typo}: 1\n",
+        )
+        with pytest.raises(LoaderError, match=r"unknown layout key\(s\)"):
+            load_layout(layout_path)
+
+    def test_all_allowed_layout_keys_load(self, tmp_path: Path) -> None:
+        """Completeness guard: a layout declaring EVERY allowed top-level key
+        (``maintenance`` + ``placements`` alongside the ``fleet``/``hangar`` refs)
+        loads — so the allowlist can never be too strict. Self-enforcing against
+        ``_ALLOWED_LAYOUT_KEYS``."""
+        self._minimal_fleet_and_hangar(tmp_path)
+        body = (
+            "fleet: fleet.yaml\nhangar: hangar.yaml\nmaintenance:\n  plane: foo\nplacements: []\n"
+        )
+        file_keys = set(yaml.safe_load(body))
+        assert file_keys == _ALLOWED_LAYOUT_KEYS, (
+            f"fixture must cover the full allowlist; "
+            f"missing={sorted(_ALLOWED_LAYOUT_KEYS - file_keys)} "
+            f"extra={sorted(file_keys - _ALLOWED_LAYOUT_KEYS)}"
+        )
+        layout = load_layout(_write(tmp_path / "layout.yaml", body))
+        assert layout.maintenance_plane == "foo"
+        assert layout.placements == ()
 
     def test_unknown_plane_reference_propagates(self, tmp_path: Path) -> None:
         self._minimal_fleet_and_hangar(tmp_path)

--- a/tests/test_loader_scenario.py
+++ b/tests/test_loader_scenario.py
@@ -326,6 +326,48 @@ def test_load_scenario_rejects_unknown_constraint_key(tmp_path, typo):
         load_scenario(p)
 
 
+@pytest.mark.parametrize("typo", ["fleet_inn", "constraint", "maintenace", "bogus_field"])
+def test_load_scenario_rejects_unknown_top_level_key(tmp_path, typo):
+    """A misspelled TOP-LEVEL scenario key must be REJECTED (#516), not silently
+    dropped to its default — the silent-failure class #513 closed for the
+    ``aircraft:`` block, extended to the scenario file's top level. Mirrors
+    ``_ALLOWED_CONSTRAINT_KEYS`` / ``_ALLOWED_AIRCRAFT_KEYS``."""
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(tmp_path, f"fleet_in: [aviat_husky]\n{typo}: 1\n")
+    with pytest.raises(LoaderError, match=r"unknown scenario key\(s\)"):
+        load_scenario(p)
+
+
+def test_load_scenario_all_allowed_top_level_keys_load(tmp_path):
+    """Completeness guard: a scenario declaring EVERY allowed top-level key
+    (``maintenance`` + ``constraints`` alongside ``fleet_in``/``fleet``/``hangar``)
+    loads — so the allowlist can never be too strict. Self-enforcing against
+    ``_ALLOWED_SCENARIO_KEYS``."""
+    import yaml
+
+    from hangarfit.loader import _ALLOWED_SCENARIO_KEYS, load_scenario
+
+    p = _stage_scenario(
+        tmp_path,
+        "fleet_in: [aviat_husky, ctsl]\n"
+        "maintenance:\n"
+        "  plane: ctsl\n"
+        "constraints:\n"
+        "  aviat_husky:\n"
+        "    priority: 1.0\n",
+    )
+    file_keys = set(yaml.safe_load(p.read_text()))
+    assert file_keys == _ALLOWED_SCENARIO_KEYS, (
+        f"fixture must cover the full allowlist; "
+        f"missing={sorted(_ALLOWED_SCENARIO_KEYS - file_keys)} "
+        f"extra={sorted(file_keys - _ALLOWED_SCENARIO_KEYS)}"
+    )
+    s = load_scenario(p)
+    assert s.maintenance_plane == "ctsl"
+    assert "aviat_husky" in s.constraints
+
+
 def test_load_scenario_rejects_quoted_bool_nose_out(tmp_path):
     """`nose_out: "true"` (quoted) would silently be truthy via bool(); rejected
     by the strict _to_bool, like force_on_carts/measured."""

--- a/tests/test_loader_scenario.py
+++ b/tests/test_loader_scenario.py
@@ -368,6 +368,19 @@ def test_load_scenario_all_allowed_top_level_keys_load(tmp_path):
     assert "aviat_husky" in s.constraints
 
 
+def test_load_scenario_unknown_key_wins_over_missing_required(tmp_path):
+    """Ordering contract (#516): with BOTH an unknown top-level key AND a missing
+    required field, the unknown key (the author's actual typo) surfaces first — not
+    a confusing 'missing fleet_in'. `fleet_inn` IS the typo'd `fleet_in`, so the
+    required key is absent; the unknown-key check must still win. Pins the
+    check-order so a future reorder can't silently regress it."""
+    from hangarfit.loader import load_scenario
+
+    p = _stage_scenario(tmp_path, "fleet_inn: [aviat_husky]\n")
+    with pytest.raises(LoaderError, match=r"unknown scenario key\(s\)"):
+        load_scenario(p)
+
+
 def test_load_scenario_rejects_quoted_bool_nose_out(tmp_path):
     """`nose_out: "true"` (quoted) would silently be truthy via bool(); rejected
     by the strict _to_bool, like force_on_carts/measured."""


### PR DESCRIPTION
Closes #516.

## What

Extends the #513 aircraft-entry unknown-key allowlist to the **top-level** blocks of `hangar.yaml` and the scenario/layout files. Before this, a typo'd top-level key was silently dropped to its default — the same silent-failure class #513 closed one layer down.

The motivating case is the apron (#503): `apron_dpeth_m:` silently falls back to depth 0, compounding the already-silent too-shallow-apron → door-line fallback. A user who internalised "hangarfit rejects my typos" from the fleet loader (#513) reasonably assumes the same protection on the hangar file and gets burned.

## How

- New `_reject_unknown_top_level_keys` helper + `_ALLOWED_HANGAR_KEYS` / `_ALLOWED_LAYOUT_KEYS` / `_ALLOWED_SCENARIO_KEYS` frozensets, each placed beside its loader (mirroring the `_ALLOWED_AIRCRAFT_KEYS` / `_ALLOWED_CONSTRAINT_KEYS` convention) and kept in sync with the keys that loader actually reads.
- The check runs **before** the required-field checks, so a typo'd *required* key surfaces as the offending key rather than a confusing downstream "missing required field" (same ordering rationale as `_build_aircraft`).
- **Out of scope by design:** the nested `door` / `maintenance_bay` blocks need no allowlist — all their keys are required, so a typo there already fails loudly as "missing required field". `structural_notches` keeps its existing per-entry allowlist (loader.py).

## Tests

- Parametrized typo-rejection tests per block (`test_unknown_hangar_key_rejected`, `test_unknown_layout_key_rejected`, `test_load_scenario_rejects_unknown_top_level_key`) — written test-first; verified they fail with "DID NOT RAISE" before the fix.
- Self-enforcing **completeness guards** (`test_all_allowed_*_keys_load`) that assert a file declaring *every* allowed key loads, and that the fixture covers the full allowlist — so the allowlist can never drift too strict, and adding a key without extending the fixture fails loudly.

## Verification

- Allowlists cross-checked against **every committed** hangar/scenario/layout YAML — no valid key is rejected.
- Full fast suite green (1474 passed); `mypy src/hangarfit/loader.py` clean; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)