### PR TITLE
fix(collisions): catch edge-crossing bay intrusions via polygon overlap

### DIFF
--- a/src/hangarfit/collisions.py
+++ b/src/hangarfit/collisions.py
@@ -204,8 +204,9 @@ def _bay_intrusion_conflicts(
     "the occupant intrudes into its own bay" would otherwise be
     indistinguishable from a real intrusion.
 
-    Emits one ``bay_intrusion`` conflict per offending **part**, with
-    the first-violating vertex (matches the per-part granularity of
+    Emits one ``bay_intrusion`` conflict per offending **part** — citing the
+    first strictly-inside vertex when one exists, or ``edge crosses`` when only
+    the polygon overlaps (matches the per-part granularity of
     :func:`_hangar_bounds_conflicts`).
     """
     if layout.maintenance_plane is None:

--- a/src/hangarfit/collisions.py
+++ b/src/hangarfit/collisions.py
@@ -48,7 +48,13 @@ which plane is iterated first.
 
 from __future__ import annotations
 
-from .geometry import WorldPart, cached_parts_world, polygon_overlap, polygon_overlap_area
+from .geometry import (
+    WorldPart,
+    axis_aligned_rect,
+    cached_parts_world,
+    polygon_overlap,
+    polygon_overlap_area,
+)
 from .models import CheckResult, Conflict, Hangar, Layout
 
 
@@ -169,23 +175,26 @@ def _bay_intrusion_conflicts(
     world_parts: dict[str, list[WorldPart]], layout: Layout
 ) -> list[Conflict]:
     """When the bay is closed (``layout.maintenance_plane is not None``),
-    flag any non-occupant part with a vertex strictly inside the bay
-    rectangle.
+    flag any non-occupant part that either has a vertex strictly inside the bay
+    rectangle OR whose edge crosses it with no vertex inside.
 
     The bay is the axis-aligned rectangle anchored to the back wall:
 
     - ``x ∈ (center_x_m − width_m/2, center_x_m + width_m/2)``
     - ``y ∈ (length_m − depth_m, length_m]``
 
-    The three interior edges (left, right, front) use strict ``<``: a
-    vertex sitting on any of those edges counts as outside. The bay's
-    back edge coincides with the hangar's back wall, which is why
-    there is no separate ``y < length_m`` test — a vertex at
-    ``y = length_m`` sits on the hangar's outer wall (still inside the
-    hangar per :func:`_hangar_bounds_conflicts`) and is correctly
-    treated as inside the closed bay. This mirrors the convention in
-    :func:`_first_out_of_bounds_vertex` where the hangar boundary is
-    inclusive.
+    The per-vertex test (:func:`_first_vertex_in_bay`) is the primary gate —
+    strict ``<`` on the left/right/front edges, inclusive back edge (the hangar
+    wall, per :func:`_first_out_of_bounds_vertex`). To close the per-vertex test's
+    edge-crossing blind spot (a thin part skewering the bay with both endpoints
+    outside — the ADR-0018 ``floor.covers`` fix, mirrored here, #551), a
+    **polygon-level** :func:`polygon_overlap` test is consulted *additively* when
+    no vertex is inside. ``polygon_overlap`` (clearance 0) requires genuine
+    *interior* overlap, so a part merely flush with a bay edge (Shapely
+    ``touches``) is still outside. Keeping the per-vertex test as the gate (rather
+    than replacing it with the polygon test) keeps every existing verdict
+    byte-identical (ADR-0003): the polygon test only ever *adds* the edge-crossing
+    case, never removes a conflict the per-vertex test already raised.
 
     The maintenance occupant is absent from placements by Layout
     invariant, so it should not appear in ``world_parts``. A defensive
@@ -205,21 +214,36 @@ def _bay_intrusion_conflicts(
     x_min = bay.center_x_m - bay.width_m / 2
     x_max = bay.center_x_m + bay.width_m / 2
     y_min = layout.hangar.length_m - bay.depth_m
+    bay_rect = axis_aligned_rect(x_min, y_min, x_max, layout.hangar.length_m)
     out: list[Conflict] = []
     for plane_id, parts in world_parts.items():
         if plane_id == layout.maintenance_plane:
             continue
         for part in parts:
+            # The per-vertex test stays the PRIMARY gate so every existing verdict is
+            # byte-identical (ADR-0003). It intentionally counts a vertex beyond the
+            # back wall (y > length_m) — that candidate is out of bounds and already
+            # flagged by _hangar_bounds_conflicts, but the min-conflicts solver steers
+            # by conflict COUNT, so dropping that redundant conflict would shift the
+            # search trajectory. The polygon-overlap test is therefore an ADDITIVE
+            # catch, consulted only when NO vertex is inside: it flags the ADR-0018
+            # blind spot — a thin part whose EDGE crosses the bay with no vertex inside
+            # (#551). ``polygon_overlap`` (clearance 0) requires genuine *interior*
+            # overlap, so a part merely flush with a bay edge (Shapely ``touches``) is
+            # still outside, preserving the strict-``<`` boundary semantics.
             bad = _first_vertex_in_bay(part, x_min, x_max, y_min)
-            if bad is None:
+            if bad is not None:
+                where = f"vertex ({bad[0]:.3f}, {bad[1]:.3f}) inside"
+            elif polygon_overlap(bay_rect, part.polygon):
+                where = "edge crosses"
+            else:
                 continue
-            x, y = bad
             out.append(
                 Conflict.single(
                     kind="bay_intrusion",
                     plane=plane_id,
                     detail=(
-                        f"part {part.kind!r} vertex ({x:.3f}, {y:.3f}) inside "
+                        f"part {part.kind!r} {where} "
                         f"closed maintenance bay (x ∈ ({x_min:g}, {x_max:g}), "
                         f"y ∈ ({y_min:g}, {layout.hangar.length_m:g}); "
                         f"occupant={layout.maintenance_plane!r})"
@@ -235,7 +259,12 @@ def _first_vertex_in_bay(
     """Return ``(x, y)`` of the first vertex of ``part`` strictly inside
     the bay rectangle, or ``None`` if every vertex is outside. Strict
     ``<`` on left/right/front edges; no back-edge test (back edge is
-    the hangar's outer wall — see :func:`_bay_intrusion_conflicts`)."""
+    the hangar's outer wall — see :func:`_bay_intrusion_conflicts`).
+
+    This is the primary intrusion gate (#551 adds an additive polygon-overlap
+    catch for the edge-crossing case on top of it). When it returns a vertex,
+    the caller renders it in the detail; when it returns ``None`` but the polygon
+    still overlaps the bay, the caller renders "edge crosses" instead."""
     for x, y in list(part.polygon.exterior.coords)[:-1]:
         if x_min < x < x_max and y > y_min:
             return x, y

--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -27,7 +27,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 
-from shapely.geometry import Polygon
+from shapely.geometry import Polygon, box
 
 from .models import Aircraft, PartKind, Placement
 
@@ -78,6 +78,20 @@ def oriented_rect(
         (cx + x * cos_h - y * sin_h, cy + x * sin_h + y * cos_h) for x, y in corners_local
     ]
     return Polygon(corners_world)
+
+
+def axis_aligned_rect(x_min: float, y_min: float, x_max: float, y_max: float) -> Polygon:
+    """Build an axis-aligned rectangle ``Polygon`` from world-space bounds — e.g.
+    the maintenance-bay keep-out in
+    :func:`hangarfit.collisions._bay_intrusion_conflicts`.
+
+    Unlike :func:`oriented_rect` / :func:`aircraft_parts_world`, this applies NO
+    plane-local → world transform: the inputs are already world coordinates, so it
+    carries none of the determinant-−1 sign-flip concern (ADR-0002). A thin wrapper
+    over ``shapely.geometry.box`` kept here so polygon construction stays in one
+    module (the same ``box`` primitive ``models.Hangar`` uses for its floor/notches).
+    """
+    return box(x_min, y_min, x_max, y_max)
 
 
 def polygon_overlap(p1: Polygon, p2: Polygon, clearance: float = 0.0) -> bool:

--- a/tests/test_collisions.py
+++ b/tests/test_collisions.py
@@ -400,6 +400,58 @@ class TestBayIntrusion:
             f"part centered inside closed bay must fire bay_intrusion, got {result.conflicts!r}"
         )
 
+    def test_closed_bay_flags_edge_crossing_with_no_vertex_inside(self) -> None:
+        """The ADR-0018 blind spot, mirrored for the bay (#551): a thin part whose
+        EDGE skewers the bay with NO vertex strictly inside is missed by the
+        per-vertex test but caught by the polygon-overlap predicate.
+
+        Bay (from ``_build_layout``) is x ∈ (10, 18), y ∈ (16, 25]. This part spans
+        x ∈ [9, 19], y ∈ [19.9, 20.1]: all four vertices sit OUTSIDE the bay's
+        x-range (9 and 19 are both outside (10, 18)), so no vertex is inside — yet
+        its body clearly overlaps the bay interior. Built as an explicit WorldPart
+        (bypassing the placement transform) like ``TestStructuralNotch``'s analog."""
+        from shapely.geometry import Polygon
+
+        from hangarfit.collisions import _bay_intrusion_conflicts, _first_vertex_in_bay
+        from hangarfit.geometry import WorldPart
+
+        layout = self._build_layout(bay_open=False)  # bay closed (occupant inside)
+        skewer = WorldPart(
+            polygon=Polygon([(9.0, 19.9), (19.0, 19.9), (19.0, 20.1), (9.0, 20.1)]),
+            z_bottom_m=2.0,
+            z_top_m=2.3,
+            plane_id="probe",
+            kind="wing",
+        )
+        # Precondition: no vertex is strictly inside the bay (else we'd be exercising
+        # the old per-vertex path, not the new polygon-overlap one).
+        assert _first_vertex_in_bay(skewer, 10.0, 18.0, 16.0) is None
+        conflicts = _bay_intrusion_conflicts({"probe": [skewer]}, layout)
+        assert [c.kind for c in conflicts] == ["bay_intrusion"], conflicts
+        assert "edge crosses" in conflicts[0].detail, conflicts[0].detail
+
+    def test_closed_bay_edge_flush_part_does_not_fire(self) -> None:
+        """Byte-identity guard for the polygon predicate: a part whose edge is
+        FLUSH with the bay boundary (shares the x_min=10 edge, body entirely
+        outside at x ∈ [8, 10]) only *touches* the bay — no interior overlap — so
+        it must NOT fire, preserving the strict-``<`` semantics of the per-vertex
+        test (cf. ``valid_part_vertex_on_bay_edge`` / the sub-epsilon edge tests)."""
+        from shapely.geometry import Polygon
+
+        from hangarfit.collisions import _bay_intrusion_conflicts
+        from hangarfit.geometry import WorldPart
+
+        layout = self._build_layout(bay_open=False)
+        flush = WorldPart(
+            polygon=Polygon([(8.0, 19.0), (10.0, 19.0), (10.0, 21.0), (8.0, 21.0)]),
+            z_bottom_m=2.0,
+            z_top_m=2.3,
+            plane_id="probe",
+            kind="wing",
+        )
+        conflicts = _bay_intrusion_conflicts({"probe": [flush]}, layout)
+        assert conflicts == [], conflicts
+
     def test_left_edge_vertex_strictly_outside_passes(self) -> None:
         """Bay x_min=10. A 1×1 wing centered at (9.5, 20) has its
         right edge at x=10 exactly — on the boundary, not strictly

--- a/tests/test_solver_canaries.py
+++ b/tests/test_solver_canaries.py
@@ -182,10 +182,23 @@ def test_solve_deterministic_best_partial_under_max_restarts() -> None:
         trip before the cap. Re-calibration trigger unchanged: if a future
         change pushes ``seed=3`` natural success to ``<= 3``, re-probe and
         pick a higher-headroom seed.
+
+        Re-calibrated 2026-06-09 for #551 (bay edge-crossing intrusion):
+        adding the polygon-overlap catch for a part whose edge skewers the
+        *closed* bay with no vertex inside (this fixture has a maintenance
+        plane) re-bases this fixture's min-conflicts trajectory. Determinism is
+        unchanged — same seed still gives bit-identical output (the ``r2 == r1``
+        assertion below still holds); only *which* seed exhausts shifts. Under
+        the new logic ``seed=3`` finds within the cap, so the fixture was
+        re-probed: ``seed=44`` has by far the most headroom — first natural
+        success at restart **21**, an *18-restart* drift margin against the
+        fixed ``max_restarts=3``. Trigger unchanged: if a future change pushes
+        ``seed=44`` natural success to ``<= 3``, re-probe and pick a
+        higher-headroom seed.
     """
     fixture = "tests/fixtures/solve_canary_six_planes_tight.yaml"
     max_restarts = 3
-    seed = 3
+    seed = 44
 
     s1 = load_scenario(fixture)
     r1 = solve(


### PR DESCRIPTION
Closes #551.

## What

The maintenance-bay intrusion check (`_bay_intrusion_conflicts`) used a **per-vertex** containment test — the same thin-edge blind spot ADR-0018 fixed for the hangar floor via `floor.covers(part.polygon)`. A thin part whose **edge** skewers the closed bay with **no vertex strictly inside** was silently missed. This mirrors that fix at the polygon level.

## How

- **`geometry.axis_aligned_rect`** (new): builds the bay rectangle from world-space bounds. Applies **no** plane-local→world transform, so it carries none of the determinant-−1 sign-flip concern (ADR-0002); a thin wrapper over the same `shapely.box` `models.Hangar` uses for its floor/notches.
- **`collisions._bay_intrusion_conflicts`**: keeps the per-vertex test as the **primary gate** (byte-identical for every existing verdict — *including* its intentional uncapped back-wall count, which the min-conflicts solver's conflict count depends on) and consults `polygon_overlap` (clearance 0 = genuine *interior* overlap) **additively, only when no vertex is inside**. A part merely flush with a bay edge (Shapely `touches`) stays outside, preserving the strict-`<` boundary semantics.

## The determinism re-base (ratified)

The issue assumed this would be byte-identical-inert. That holds for `check` on existing fixtures, **but not for the solver**: a closed-bay fixture's search sees rotated wings genuinely skewer the narrow bay with no vertex inside, so the additive catch fires, re-basing that fixture's min-conflicts trajectory.

- **Determinism is preserved**: same seed → bit-identical output. Only *which* seed exhausts shifts.
- The fix is **not optional**: the solver evaluates candidates with this same code, so keeping the blind spot solver-side while `check` rejects it would let the solver *return* a layout `check` declares invalid.
- Re-calibrated the `exhausted_budget` canary **seed 3 → 44** (first natural success at restart **21**, an 18-restart margin vs `max_restarts=3`), following the canary's own documented re-calibration procedure (as #519/#520 and #544 did before).

## Verification

- Full fast suite **1460 passed**; serial canaries **7 passed**.
- **bench correctness** (required gate) **exit 0** — `det: ok` / `valid: ok` for all regimes, *including* the **closed-bay** ones (`full_nine_*` / `tight_six_*`, backed by `solve_all_nine_large_hangar.yaml` and `solve_fresh_six_planes.yaml`). Those regimes' search trajectories **do** see the new catch (same as the canary) — but the gate doesn't bind on the trajectory: its `det` verdict is a self-consistency double-solve and `valid` checks score-0, neither a frozen baseline, and the additive catch only ever *adds* conflicts, so it can't break either. (Corrected from an earlier draft that wrongly claimed no bench regime is closed-bay.)
- `mypy` + `ruff` + `ruff format --check` clean.
- New tests: `test_closed_bay_flags_edge_crossing_with_no_vertex_inside` (the skewer — fails pre-fix) and `test_closed_bay_edge_flush_part_does_not_fire` (byte-identity guard: flush-edge part still passes).

## Review arc

`geometry-invariant-guard` **PASS** (transform untouched; `axis_aligned_rect` transform-free; bounds + `box` arg order correct) · `determinism-guard` **PASS** (contract holds; change confirmed strictly additive incl. the adversarial back-wall case; seed-44 re-calibration sound) · `code-reviewer` **clean** (2 doc findings fixed: stale docstring tail + this body's bench rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)