### PR TITLE
feat(cli): wire --spread-stall-restarts N (opt-in), keep default off

### DIFF
--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -305,6 +305,22 @@ def build_parser() -> argparse.ArgumentParser:
             "spread-on fills with many restarts."
         ),
     )
+    solve.add_argument(
+        "--spread-stall-restarts",
+        type=int,
+        metavar="N",
+        default=None,
+        dest="spread_stall_restarts",
+        help=(
+            "Opt-in early-exit (F7/#404): stop the spread-ON restart loop after N "
+            "consecutive restarts fail to improve the selected layouts' maximin "
+            "plan-view gap (default: off = run to --budget/--max-restarts). The stop "
+            "is seed-deterministic (an integer counter, never wall-clock) and only "
+            "arms once a complete selection exists, so it just trims the "
+            "polish-the-incumbent tail; no-op under --no-spread. NOTE: setting it "
+            "makes the run ineligible for byte-identical --workers parallelism (#544)."
+        ),
+    )
     # ── Tow-planner knobs (grid heuristic default + global fill cap since #336;
     # spike #332). --tow-heuristic defaults to the shipped grid planner and
     # --tow-max-expansions widens the per-plane budget; both RNG-free (ADR-0003).
@@ -679,12 +695,20 @@ def cmd_solve(args: argparse.Namespace) -> int:
     # plan_paths=False: the library bundle (SolveResult.plans) is available to
     # callers, but the CLI would just pay the per-plane Hybrid-A* search cost
     # for output it never draws.
-    search_cfg = SearchConfig(
-        spread=args.spread,
-        nose_out=args.nose_out,
-        back_bias_weight=_BACK_FILL_DEFAULT_WEIGHT if args.back_fill else 0.0,
-        max_restarts=args.max_restarts,
-    )
+    try:
+        search_cfg = SearchConfig(
+            spread=args.spread,
+            nose_out=args.nose_out,
+            back_bias_weight=_BACK_FILL_DEFAULT_WEIGHT if args.back_fill else 0.0,
+            max_restarts=args.max_restarts,
+            spread_stall_restarts=args.spread_stall_restarts,
+        )
+    except ValueError as e:
+        # A bad restart-budget knob (e.g. --max-restarts 0 or --spread-stall-restarts
+        # 0; both must be >= 1 when set) surfaces as a clean exit-2 input error rather
+        # than an uncaught traceback — same contract as a LoaderError on malformed input.
+        print(f"error: {e}", file=sys.stderr)
+        return 2
     # Never silently ignore --workers (#544): if parallel restarts aren't
     # byte-identical-eligible for this config (no --max-restarts, or --no-spread),
     # solve() transparently runs serial — say so on stderr so the user isn't

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -69,6 +69,73 @@ class TestSolveSubparser:
         assert args.json is True
 
 
+class TestSpreadStallRestartsFlag:
+    """#546: the opt-in ``--spread-stall-restarts N`` flag exposes F7 (#404)'s
+    spread-stagnation early-exit from the CLI. The default stays opt-in (``None``),
+    so omitting the flag is byte-identical to before (no #544 ``--workers``
+    regression, no bench re-baseline).
+    """
+
+    def test_default_is_none(self):
+        parser = build_parser()
+        args = parser.parse_args(["solve", SMOKE_FIXTURE])
+        assert args.spread_stall_restarts is None
+
+    def test_parsed(self):
+        parser = build_parser()
+        args = parser.parse_args(["solve", SMOKE_FIXTURE, "--spread-stall-restarts", "5"])
+        assert args.spread_stall_restarts == 5
+
+    def test_threads_into_searchconfig(self, monkeypatch):
+        """The flag value reaches the ``SearchConfig`` the solver receives."""
+        import hangarfit.solver as solver_mod
+
+        captured: dict = {}
+        real_solve = solver_mod.solve
+
+        def spy(scenario, **kwargs):
+            captured["search"] = kwargs.get("search")
+            return real_solve(scenario, **kwargs)
+
+        # --no-spread keeps the solve sub-second (single-plane first-valid exit); the
+        # flag still threads into SearchConfig regardless of spread, which is what we
+        # assert. Running the real spread loop here would burn the wall-clock --budget
+        # and risk the documented -n auto flake (docs/dev/test-flakes-and-ci-gotchas.md).
+        monkeypatch.setattr(solver_mod, "solve", spy)
+        rc = main(["solve", SMOKE_FIXTURE, "--no-spread", "--spread-stall-restarts", "7"])
+        assert rc == 0
+        assert captured["search"] is not None
+        assert captured["search"].spread_stall_restarts == 7
+
+    def test_zero_exits_2(self, capsys):
+        """``--spread-stall-restarts 0`` is invalid (must be >= 1): the CLI surfaces
+        the SearchConfig ValueError as a clean exit 2, not an uncaught traceback.
+        (The same wrap also closes the latent ``--max-restarts 0`` crash.)"""
+        rc = main(["solve", SMOKE_FIXTURE, "--spread-stall-restarts", "0"])
+        assert rc == 2
+        assert "spread_stall_restarts" in capsys.readouterr().err
+
+    def test_with_workers_surfaces_serial_note(self, capsys):
+        """The #544 interaction made visible: setting --spread-stall-restarts makes
+        an otherwise parallel-eligible config (--max-restarts + spread) ineligible
+        (the stall counter is completion-order-dependent), so --workers prints the
+        'ignored (runs serial)' note rather than silently degrading the speedup."""
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--max-restarts",
+                "1",
+                "--workers",
+                "4",
+                "--spread-stall-restarts",
+                "5",
+            ]
+        )
+        assert rc == 0
+        assert "--workers 4 ignored (runs serial)" in capsys.readouterr().err
+
+
 class TestSolveParallelFlags:
     """#544/#561: the ``--workers`` / ``--max-restarts`` argparse surface, the
     serial-fallback ``note:`` branch, and eligible-regime byte-identity surfaced

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -157,6 +157,14 @@ class TestSolveParallelFlags:
         assert args.workers == 4
         assert args.max_restarts == 8
 
+    def test_max_restarts_zero_exits_2(self, capsys):
+        """``--max-restarts 0`` is invalid (must be >= 1). It previously crashed with
+        an uncaught ValueError traceback; the #546 SearchConfig try/except wrap now
+        surfaces it as a clean exit 2 (regression lock for that latent gap)."""
+        rc = main(["solve", SMOKE_FIXTURE, "--max-restarts", "0"])
+        assert rc == 2
+        assert "max_restarts" in capsys.readouterr().err
+
     def test_eligible_parallel_no_note_and_byte_identical(self, capsys):
         """Eligible regime (``--max-restarts`` + spread on): ``--workers >1``
         prints NO note and yields byte-identical ``--json`` output to


### PR DESCRIPTION
Closes #546.

## What

F7 (#404) shipped `SearchConfig.spread_stall_restarts` — the spread-stagnation early-exit that stops the spread-ON restart loop once N consecutive restarts fail to improve the selected layouts' maximin gap — but it was **opt-in and unreachable from the CLI**. This wires a `--spread-stall-restarts N` flag so users can opt into the ~4×-fewer-restarts spread speedup per invocation.

## The default decision (you gave "no preference"; here's the call + why)

The issue's literal ask was "flip the default ON". I'm **keeping it opt-in** (model default stays `None`) and only adding the CLI flag, because the issue was filed from spike #540 *before* #544 landed, and a default-ON value regresses two things shipped since:

1. **#544 `--workers`.** `_parallel_eligible` requires `spread_stall_restarts is None` (the stall counter is completion-order-dependent, so it can't be byte-identical across a process fan-out). A default of 5 would silently downgrade the documented `solve --max-restarts 64 --workers 8` recipe to serial.
2. **The `bench correctness` gate (#564).** The bench harness inherits the model default, so flipping it would re-baseline a *freshly-required* check the same day it landed.

Omitting the flag is **byte-identical to develop**. Flipping the default later is a one-line change if you decide the latency win is worth reconciling #544 (the Option-C auto-reconcile from our earlier discussion).

## How

- `cli.py`: add `--spread-stall-restarts` (`type=int`, `default=None`) and thread it into the solve `SearchConfig`. Both the flag help and the existing `--workers` serial-`note:` make the #544 trade-off **visible, not silent** — setting it makes the run `--workers`-ineligible, and the existing note fires.
- `cli.py`: wrap the `SearchConfig` construction in `try/except ValueError → exit 2`, so `--spread-stall-restarts 0` (must be ≥ 1) reports a clean input error. This also closes a **latent gap**: `--max-restarts 0` (same ≥ 1 constraint, models.py:1433) previously crashed with an uncaught traceback.

## Tests

`TestSpreadStallRestartsFlag`: default-is-None, parsed, **threads-into-SearchConfig** (spy on `solver.solve` captures the `search` kwarg), **0-exits-2**, and the **#544 `--workers` serial-note interaction**. The spy test uses `--no-spread` to stay sub-second (the flag threads regardless of spread) — avoiding the wall-clock `-n auto` flake documented in `docs/dev/test-flakes-and-ci-gotchas.md`.

## Verification

- Full fast suite **1480 passed**; determinism canaries pass (byte-identical default path); `bench` unaffected (the harness never sets the field, so the default stays `None`); `mypy` + `ruff` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)