### PR TITLE
feat: optional polygon part footprints + collision build-path (#548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- Optional polygon part footprints: a `Part` may carry a load-time-canonicalized
+  `local_vertices` polygon (authored via a parametrized `planform: {root_chord_m,
+  tip_chord_m}` wing block), used by the collision build-path while `length_m`/
+  `width_m` stay the bounding box. Scalar fleets are byte-identical; the 3D viewer
+  still renders boxes until the scene/v2 work. (#548, ADR-0024)
+
 ### Changed
 
 ### Fixed

--- a/docs/adr/0024-optional-polygon-parts.md
+++ b/docs/adr/0024-optional-polygon-parts.md
@@ -99,11 +99,14 @@ decouples the invariant from the build-path and makes the contract
 directly verifiable.
 
 `_canonicalize_ring` applies four steps: (1) reject non-finite
-coordinates, fewer than 3 vertices, self-intersecting (non-simple) rings,
-and degenerate / collinear rings (signed area ≈ 0); (2) force CCW by
-signed-area sign; (3) rotate to a lex-min start vertex; (4) drop the
-closing duplicate (store an open ring). Two equivalent input orderings of
-the same shape produce a byte-identical `Part`.
+coordinates and fewer than 3 vertices; reject collinear / degenerate rings
+via the **maximum-cross-product collinearity gate** (max |cross-product|
+over consecutive triples ≈ 0); reject self-intersecting (non-simple) rings;
+the **shoelace signed area is used for the CCW winding decision** (step 2),
+with a defense-in-depth |area| guard that is unreachable after the earlier
+gates; (2) force CCW by signed-area sign; (3) rotate to a lex-min start
+vertex; (4) drop the closing duplicate (store an open ring). Two equivalent
+input orderings of the same shape produce a byte-identical `Part`.
 
 **P1 tuple-of-tuples field**, because `Part` is `frozen=True, slots=True`
 (hashable dataclass); Shapely objects are not hashable and cannot live in a
@@ -251,8 +254,9 @@ configuration. That is a provenance violation, not a fidelity gain.
   degenerate rings; two equivalent input orderings → identical `Part`) plus
   the `Part.local_vertices` field and bbox-subset tests.
 - **`tests/test_geometry.py`** — per-vertex det(−1) transform at a
-  non-axis-aligned heading (geometry-invariant-guard requirement); confirms
-  no centroid shortcut is taken.
+  non-axis-aligned heading (geometry-invariant-guard requirement); exercises
+  every vertex through the transform (a centroid shortcut would fail the
+  rectangle-equivalence assertion).
 - **`tests/test_loader_planform.py`** — `planform:` parse, `tip > root`
   rejection, unknown-key rejection, root-exceeds-bbox rejection.
 - **`tests/test_solver_canaries.py::test_solve_deterministic_polygon_taper_fleet`**

--- a/docs/adr/0024-optional-polygon-parts.md
+++ b/docs/adr/0024-optional-polygon-parts.md
@@ -1,0 +1,286 @@
+# ADR-0024: Optional polygon footprints on `Part` — load-time-canonicalized, authored via `planform:`
+
+- **Status:** Accepted
+
+- **Date:** 2026-06-10
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+Every `Part` in the collision model is an oriented rectangle in plan view
+([ADR-0001](0001-aircraft-parts-model.md)). Subsequent refinements
+([ADR-0012](0012-fuselage-front-aft-split.md), [ADR-0023](0023-empennage-tail-surfaces.md))
+improved realism only by *adding* rectangles. A tapered glider wing (e.g.
+the Scheibe SF-25E) fits in the plan-view footprint of its bounding
+rectangle, yet the bounding rectangle extends past the wingtip into
+space that is genuinely free. The spike (#541,
+`docs/spikes/polygon-part-geometry-feasibility.md`) measured a robust
+**0.10–0.30 m verdict-flip window** on the real Herrenteich layout:
+a tapered Scheibe wingtip nests safely against the Stemme empennage where
+the bounding-rectangle model falsely reports a conflict. The collision
+build-path (`geometry.aircraft_parts_world`) is already polygon-generic
+(Shapely `Polygon`); the only thing missing is a vertex sequence on `Part`
+and a loader schema to author it honestly.
+
+This ADR records the polygon extension of [ADR-0001](0001-aircraft-parts-model.md).
+The parts model's founding design — closed `PartKind` set, scalar
+`length_m`/`width_m`/`offset_x_m`/`offset_y_m`, part-own height band
+`[z_bottom_m, z_top_m]` — is unchanged and stays Accepted. ADR-0012's
+front/aft split and ADR-0023's empennage surfaces are likewise untouched.
+
+## Decision Drivers
+
+- **Verdict accuracy.** A `valid` report on a layout whose bounding
+  rectangles falsely conflict (when the real polygon does not) is a
+  spuriously rejected arrangement — lost packing density for no safety
+  reason. The measured flip window is 0.10–0.30 m, large enough to
+  matter for a tight hangar.
+- **Determinism contract (ADR-0003).** The geometry layer must never
+  re-orient polygon rings at solve time. Identical shapes in any author
+  order must produce a byte-identical `Part`, or the seeded random-restart
+  solver's byte-identity contract is broken.
+- **No honest raw-outline data source.** 0/8 fleet aircraft expose a
+  dimensioned plan-view outline in any TCDS; raw vertices would look
+  surveyed while being fabricated. The authoring primitive must be
+  parametrized (not free-form) so that every polygon traces back to a
+  published scalar.
+- **Scalar fleets must stay byte-identical.** Existing placements and
+  solver runs must be unaffected by this change; `None` vertices must
+  be a genuine no-op.
+- **Forward-compat for tilt and meshes.** The transform pipeline and
+  `[z_bottom, z_top]` bands must remain self-contained per part so a
+  future wing-tilt/roll DoF and true-3D meshes (ADR-0001's deferred
+  upgrade path) can extend without rewriting consumers.
+
+## Considered Options
+
+### P1 — How to store the polygon on `Part`
+
+1. **Optional `local_vertices: tuple[tuple[float, float], ...] | None`
+   field, defaulting to `None`, load-time-canonicalized in
+   `__post_init__`** *(chosen)*.
+2. **Optional `local_polygon: shapely.Polygon | None`** — store the
+   Shapely object directly on the model.
+3. **A subclass `PolygonPart(Part)`** — separate type for parts with
+   polygon footprints.
+
+### P2 — Canonicalization site and contract
+
+1. **Load-time only: `Part.__post_init__` calls a module-level
+   `_canonicalize_ring(verts)` helper that is unit-testable in
+   isolation; the geometry layer never re-orders** *(chosen)*.
+2. **Lazy: canonicalize on first call to `aircraft_parts_world`.**
+3. **No canonicalization: caller is responsible for vertex order.**
+
+### P3 — The bounding-box / area trade
+
+1. **Polygon must be a strict subset of the `length_m × width_m` bbox;
+   wing area is intentionally under-conserved** *(chosen)*.
+2. **Grow `length_m` to the root chord** — polygon is area-conserving
+   but the scalar `length_m` changes.
+
+### P4 — Loader authoring primitive
+
+1. **Parametrized `planform: {root_chord_m, tip_chord_m}` block only;
+   no raw `vertices:` field** *(chosen)*.
+2. **Both `planform:` and a raw `vertices:` field, with the same
+   canonicalization applied.**
+
+## Decision Outcome
+
+**Chosen: P1 = option 1; P2 = option 1; P3 = option 1; P4 = option 1.**
+
+The pivot is **P2**: canonicalization at `Part.__post_init__` is the
+ADR-0003 determinism crux. The geometry layer calls `Shapely.Polygon()`
+with the stored vertices verbatim — Shapely preserves vertex order, so
+canonical storage is the only safe place to enforce byte-identity across
+equivalent author orderings. A unit-testable `_canonicalize_ring` helper
+decouples the invariant from the build-path and makes the contract
+directly verifiable.
+
+`_canonicalize_ring` applies four steps: (1) reject non-finite
+coordinates, fewer than 3 vertices, self-intersecting (non-simple) rings,
+and degenerate / collinear rings (signed area ≈ 0); (2) force CCW by
+signed-area sign; (3) rotate to a lex-min start vertex; (4) drop the
+closing duplicate (store an open ring). Two equivalent input orderings of
+the same shape produce a byte-identical `Part`.
+
+**P1 tuple-of-tuples field**, because `Part` is `frozen=True, slots=True`
+(hashable dataclass); Shapely objects are not hashable and cannot live in a
+frozen slot. `None` is a genuine no-op: the `aircraft_parts_world`
+build-path's `oriented_rect` branch is reached unchanged; no scalar
+consumer sees any change; the solver's byte-identity over the entire
+existing fleet is preserved.
+
+The `aircraft_parts_world` branch for a non-None `local_vertices` routes
+every canonical vertex through `local_to_world` directly (the det(−1)
+affine from [ADR-0002](0002-determinant-minus-one-transform.md)), skipping
+`oriented_rect`. No centroid or bbox shortcut is taken — every declared
+vertex rides the same transform, so the geometry-invariant-guard's
+per-vertex non-axis-aligned canary passes.
+
+### Why not P1 option 2 (Shapely object on `Part`)?
+
+`shapely.Polygon` is not hashable, which breaks `frozen=True` and the
+model's use of `Part` in sets and as dict keys throughout the codebase.
+Storing the raw vertex tuple and letting the geometry layer construct the
+Shapely object at call time is the clean separation — the model owns the
+geometry data, the geometry module owns the Shapely construction.
+
+### Why not P1 option 3 (subclass `PolygonPart`)?
+
+It fractures every `isinstance(part, Part)` check, every pattern-match
+on `PartKind`, and the closed-type guarantees throughout `models.py`,
+`collisions.py`, and `visualize.py`. The optional field is strictly
+additive — scalar and polygon parts are the same kind of thing, just
+with different footprint precision.
+
+### Why not P2 option 2 (lazy canonicalization)?
+
+Lazy canonicalization means the `Part` object's internal state depends on
+when `aircraft_parts_world` is first called. Two `Part` instances built
+from the same vertices but never yet passed to the geometry layer would
+compare unequal — breaking the frozen-dataclass equality semantics and
+making the ADR-0003 byte-identity contract impossible to reason about
+without tracing call order.
+
+### Why not P2 option 3 (no canonicalization)?
+
+Author vertex order becomes load-bearing. The same tapered wing authored
+with the lex-first corner starting or the lex-second corner starting would
+produce different `Part`s, different solver states, and a broken
+byte-identity contract. The canonicalization step exists precisely to close
+that gap.
+
+### Why not P3 option 2 (grow `length_m` to root chord)?
+
+Setting `length_m` equal to the root chord (longer than the published mean
+chord) changes the scalar `length_m` that drives `metrics`, scene box
+sizing, `towplanner` apron calculations, and the trivial-infeasibility area
+gate. Every consumer that reads the scalar would get a different number,
+forcing a golden-value re-pin across tests and potentially changing solver
+and tow-planner outputs. The verdict-flip value — the entire reason this
+ADR exists — is reproduced equally well by a polygon that sits strictly
+inside the existing `length_m` bbox, because the flip is driven by the
+polygon's *reduced* footprint, not by its root chord. Keeping
+`root_chord_m = existing length_m` means no scalar changes anywhere.
+
+**The bbox / area trade (from spec §5.1, important):** `length_m × width_m`
+remains the bounding box for all scalar consumers (`metrics`, scene box,
+`towplanner` apron). The loader asserts the canonical polygon ring is a
+strict subset of that bbox. Wing area is intentionally **under-conserved**:
+the bounding box over-claims the true footprint, and the polygon sits safely
+inside it. This is the *conservative* footprint direction — it never
+creates a false "valid" verdict (the box can only over-reject, never
+under-reject). The trivial-infeasibility area gate reads
+`length_m × width_m`, so it stays a sound lower bound.
+
+### Why not P4 option 2 (also a raw `vertices:` field)?
+
+0/8 fleet aircraft expose a dimensioned plan-view outline in any TCDS
+(spike Q2, unanimous panel verdict). A raw `vertices:` field would ship
+with zero honest data, *look* surveyed (which `measured: false` understates
+on a per-vertex basis), and turn every canonicalization branch into a
+load-bearing gate against adversarially-authored rings with no validation
+payoff. `Part.local_vertices` is the shared internal store, so a raw
+authoring primitive is a strictly additive future branch behind the same
+invariant if a surveyed outline ever becomes available. YAGNI.
+
+**The `planform:` schema.** `loader._build_part` gains a `planform:
+{root_chord_m, tip_chord_m}` block, mirroring the `struts:` idiom exactly.
+The block expands into `local_vertices` via a symmetric double-taper with
+**no sweep and a root kink at y=0**, producing a **hexagon** (both leading
+and trailing edges recede toward each tip; not a simple 4-vertex trapezoid).
+Validation: `0 < tip_chord_m ≤ root_chord_m` (a glider wing does not
+taper outward). Unknown keys are rejected; required keys are checked.
+
+The folded Stemme wing deliberately stays a rectangle. Folding swings the
+outer panels — it is not a taper, and a linear-taper polygon would fabricate
+a planform that does not physically exist in the hangared (folded)
+configuration. That is a provenance violation, not a fidelity gain.
+
+## Consequences
+
+### Positive
+
+- The measured 0.10–0.30 m verdict-flip window on the Herrenteich layout
+  is resolved: a tapered glider wingtip that genuinely clears a neighbour
+  is no longer falsely rejected.
+- The determinism contract (ADR-0003) is preserved end-to-end: canonical
+  storage means two equivalent author orderings produce byte-identical
+  solver runs.
+- Scalar fleets are byte-identical — no existing placement, solver output,
+  or test golden value changes.
+- The bbox-subset invariant keeps the area gate and all scalar consumers
+  (`metrics`, scene box, `towplanner` apron) sound and unchanged.
+- The transform pipeline (`local_to_world` per vertex, no shortcuts)
+  leaves the seam open for a future wing-tilt/roll DoF and true-3D meshes
+  without rewriting any consumer (ADR-0001's mesh deferral stands; see §6
+  of the design spec).
+
+### Negative
+
+- The 3D viewer (`hangarfit view`) renders bounding-box prisms until the
+  `scene/v2` work (#549); during this transitional period the collision
+  model uses the polygon while the viewer displays the enclosing rectangle.
+- Each `planform:`-authored part gains a canonicalization cost at load
+  time (negligible in practice; the geometry layer constructs Shapely
+  objects at solve time regardless).
+- A `planform:` block ported to an aircraft whose `length_m` differs from
+  the expected bbox fails at load time (the bbox-subset assertion), which
+  is the intended behaviour but requires a data update alongside any
+  `length_m` change.
+
+### Neutral
+
+- **Refines ADR-0001's mesh deferral.** ADR-0001 stated "rectangles now,
+  meshes later via a superseding ADR." This ADR is the first step: optional
+  polygon footprints at 2.5D. The full mesh deferral — true-3D curved
+  geometry — remains deferred; ADR-0001 stays Accepted.
+- `PartKind` and the collision predicate are unchanged. The polygon is a
+  footprint refinement, not a new kind of part or a new collision rule.
+- The `local_vertices` field is `None` for every part in `data/fleet.yaml`
+  until explicit `planform:` blocks are authored; the feature is invisible
+  to all existing callers.
+
+## Compliance
+
+- **`tests/test_part_polygon.py`** — unit matrix for `_canonicalize_ring`
+  (CCW forcing, lex-min-start rotation, closing-duplicate drop, rejection of
+  non-finite coordinates / fewer-than-3 vertices / self-intersecting rings /
+  degenerate rings; two equivalent input orderings → identical `Part`) plus
+  the `Part.local_vertices` field and bbox-subset tests.
+- **`tests/test_geometry.py`** — per-vertex det(−1) transform at a
+  non-axis-aligned heading (geometry-invariant-guard requirement); confirms
+  no centroid shortcut is taken.
+- **`tests/test_loader_planform.py`** — `planform:` parse, `tip > root`
+  rejection, unknown-key rejection, root-exceeds-bbox rejection.
+- **`tests/test_solver_canaries.py::test_solve_deterministic_polygon_taper_fleet`**
+  — a placed-taper scenario fed to a `solve()` double-run asserts
+  byte-identity; necessary because existing canaries exclude the Scheibe or
+  park it as the maintenance occupant (geometrically absent from
+  `placements`).
+- **`tests/test_fleet_polygon_optin.py`** — guards that every shipped-fleet
+  `Part` keeps `local_vertices is None`, proving no regression and the
+  byte-identity guarantee for this PR.
+- No automated check guards the bbox-subset invariant at merge time beyond
+  the loader test; breakage is caught at load time with a `ValueError`.
+
+## More Information
+
+- Related ADRs: [ADR-0001](0001-aircraft-parts-model.md) (the mesh-deferral
+  ADR this refines), [ADR-0002](0002-determinant-minus-one-transform.md)
+  (the det(−1) transform applied per vertex), [ADR-0003](0003-rr-mc-solver-algorithm.md)
+  (the byte-identity contract the canonicalization protects),
+  [ADR-0012](0012-fuselage-front-aft-split.md) and
+  [ADR-0023](0023-empennage-tail-surfaces.md) (the prior rectangle-based
+  refinements that motivated a more accurate footprint).
+- Related spec:
+  [`docs/superpowers/specs/2026-06-10-realistic-polygon-plane-geometry-design.md`](../superpowers/specs/2026-06-10-realistic-polygon-plane-geometry-design.md).
+- Related spike:
+  [`docs/spikes/polygon-part-geometry-feasibility.md`](../spikes/polygon-part-geometry-feasibility.md).
+- Related issues / PRs: [#548](https://github.com/DocGerd/hangarfit/issues/548)
+  (polygon parts Phase 1), [#541](https://github.com/DocGerd/hangarfit/issues/541)
+  (feasibility spike).
+- [§8 Crosscutting Concepts — "The parts model"](../architecture/08-crosscutting-concepts.md#the-parts-model)
+  — the operational statement, updated alongside this ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -101,3 +101,4 @@ manual workflow above is canonical.
 | 0021 | [Tow-planner staging apron — a bounded entry-staging start-region in front of the door; rearrangement holding-area deferred](0021-tow-planner-staging-apron.md) | Proposed |
 | 0022 | [Nose-out parked heading — RNG-free 180° flip post-pass (default on), plus the `tow_pivotable` towing-motion flag](0022-nose-out-parked-heading.md) | Accepted |
 | 0023 | [Model the empennage as explicit tail surfaces so a vertical fin in the wing layer can block wing-over-tail nesting](0023-empennage-tail-surfaces.md) | Accepted |
+| 0024 | [Optional polygon footprints on `Part` — load-time-canonicalized, authored via `planform:` (refines [ADR-0001](0001-aircraft-parts-model.md))](0024-optional-polygon-parts.md) | Accepted |

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -106,6 +106,23 @@ fin top *inside* the wing layer (so an overhanging wing conflicts).
 The fin is never overhangable; `metrics._OVERHANGABLE` keeps only `tail`
 and `fuselage_aft`.
 
+**Optional polygon footprints** ([ADR-0024](../adr/0024-optional-polygon-parts.md)).
+A part is an oriented rectangle by default, but a `Part` may carry an
+optional polygon footprint — `local_vertices`, a load-time-canonicalized
+vertex ring authored via a parametrized `planform: {root_chord_m,
+tip_chord_m}` wing block (a symmetric double-taper hexagon). When present,
+the collision build-path (`geometry.aircraft_parts_world`) routes every
+vertex through the det(−1) transform and uses the polygon for the plan-view
+overlap test; when absent (`None`), today's bounding-rectangle path is
+unchanged. `length_m`/`width_m` always remain the bounding box for every
+scalar consumer (`metrics`, scene box, `towplanner` apron, the
+trivial-infeasibility area gate), and the polygon is constrained to be a
+subset of that box — so wing area is intentionally under-conserved in the
+conservative direction. Canonicalization at load time (force CCW, lex-min
+start, drop the closing duplicate) is the determinism crux: equivalent
+author orderings yield a byte-identical `Part`, protecting the ADR-0003
+solver contract.
+
 **Fleet composition relevant to the parts model.** Of the nine
 aircraft in `data/fleet.yaml`, six are **strut-braced** (the Aviat
 Husky, Wild Thing, Zlin Savage, Cessna 140, Cessna 150, and FK9 Mk II)

--- a/docs/superpowers/plans/2026-06-10-polygon-parts-pr1-collision.md
+++ b/docs/superpowers/plans/2026-06-10-polygon-parts-pr1-collision.md
@@ -1,0 +1,895 @@
+# Polygon Parts — PR1 (model & collision) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional polygon footprint to `Part` (load-time-canonicalized for determinism) plus the collision build-path and a parametrized `planform:` loader schema — keeping every shipped fleet byte-identical, with the viewer untouched.
+
+**Architecture:** A new trailing `Part.local_vertices` field (part-own frame, `+x`=length axis, `+y`=width axis) is canonicalized in `__post_init__` (force-CCW, lex-min start, drop closing dup, reject degenerate/non-finite/self-intersecting) and constrained to its `length_m × width_m` bbox. `geometry.aircraft_parts_world` grows a branch that routes those vertices through the same det(−1) `local_to_world` as the scalar `oriented_rect` path. `loader._build_part` grows a `planform: {root_chord_m, tip_chord_m}` block (mirroring `struts:`) that expands into the canonical hexagon. No real fleet data is authored as a polygon in this PR — the determinism contract is exercised by a new test-only taper scenario.
+
+**Tech Stack:** Python 3.12, `dataclasses` (frozen+slots), `shapely` (`LinearRing`/`Polygon`), `pytest`. Lint/format `ruff`, types `mypy`.
+
+**Scope note:** This is PR1 of a 3-PR stack (design: `docs/superpowers/specs/2026-06-10-realistic-polygon-plane-geometry-design.md`). PR2 (#549 viewer scene/v2) and PR3 (glider taper data + flip regression) get their own plans. Closes the re-scoped #548.
+
+**Conventions for every task:**
+- Run tests with bare `pytest` (the editable install resolves `src/`). The `.claude` PostToolUse hook auto-runs `ruff` + `pytest` after edits under `src/hangarfit/` or `tests/`.
+- Commit messages use Conventional Commits and end with the trailer
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- Work on the existing branch `feature/polygon-parts-realistic-geometry`.
+
+---
+
+### Task 1: `_canonicalize_ring` — the determinism crux (lands first)
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (imports near line 13–23; add helper + constants after the `_VALID_*` block ~line 39)
+- Test: `tests/test_part_polygon.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_part_polygon.py`:
+
+```python
+"""Polygon-part canonicalization + Part.local_vertices tests (issue #548).
+
+The canonicalization invariant is the determinism crux (ADR-0003): two
+orderings of the same ring MUST produce a byte-identical canonical tuple.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from hangarfit.models import Part, _canonicalize_ring
+
+
+# A simple CCW unit square, vertices listed from a non-lex-min start.
+_SQUARE_CCW = [(1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)]
+# Same square wound CW.
+_SQUARE_CW = [(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)]
+
+
+def test_canonicalize_forces_ccw_and_lexmin_start() -> None:
+    canon = _canonicalize_ring(_SQUARE_CCW)
+    # Lex-min vertex (0,0) is first.
+    assert canon[0] == (0.0, 0.0)
+    # Wound CCW: signed area positive.
+    n = len(canon)
+    area2 = sum(
+        canon[i][0] * canon[(i + 1) % n][1] - canon[(i + 1) % n][0] * canon[i][1]
+        for i in range(n)
+    )
+    assert area2 > 0
+
+
+def test_canonicalize_equivalent_orderings_are_identical() -> None:
+    """CCW, CW, and rotated inputs of the same shape canonicalize identically."""
+    rotated = _SQUARE_CCW[2:] + _SQUARE_CCW[:2]
+    assert _canonicalize_ring(_SQUARE_CCW) == _canonicalize_ring(_SQUARE_CW)
+    assert _canonicalize_ring(_SQUARE_CCW) == _canonicalize_ring(rotated)
+
+
+def test_canonicalize_drops_closing_duplicate() -> None:
+    closed = [*_SQUARE_CCW, _SQUARE_CCW[0]]
+    assert _canonicalize_ring(closed) == _canonicalize_ring(_SQUARE_CCW)
+
+
+def test_canonicalize_rejects_too_few_vertices() -> None:
+    with pytest.raises(ValueError, match="3"):
+        _canonicalize_ring([(0.0, 0.0), (1.0, 1.0)])
+
+
+def test_canonicalize_rejects_non_finite() -> None:
+    with pytest.raises(ValueError, match="non-finite"):
+        _canonicalize_ring([(0.0, 0.0), (1.0, 0.0), (math.inf, 1.0)])
+
+
+def test_canonicalize_rejects_degenerate_collinear() -> None:
+    with pytest.raises(ValueError, match="degenerate"):
+        _canonicalize_ring([(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)])
+
+
+def test_canonicalize_rejects_self_intersecting_bowtie() -> None:
+    with pytest.raises(ValueError, match="self-intersect"):
+        _canonicalize_ring([(0.0, 0.0), (1.0, 1.0), (1.0, 0.0), (0.0, 1.0)])
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_part_polygon.py -q`
+Expected: FAIL — `ImportError: cannot import name '_canonicalize_ring'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/hangarfit/models.py`, extend the shapely import (line 22) and add `Sequence`:
+
+```python
+from collections.abc import Mapping, Sequence
+```
+```python
+from shapely import box, union_all
+from shapely.geometry import LinearRing
+from shapely.geometry.base import BaseGeometry
+```
+
+After the `_VALID_MOVEMENT_MODES = ...` line (~39) add:
+
+```python
+# Below this absolute |2·signed-area| a ring is treated as degenerate
+# (zero-area / collinear). 1e-9 m² is far tighter than any real part.
+_RING_MIN_ABS_SIGNED_AREA = 1e-9
+# Float slack for the local_vertices-within-bbox containment check.
+_PART_BBOX_TOL_M = 1e-9
+
+
+def _canonicalize_ring(
+    vertices: Sequence[tuple[float, float]],
+) -> tuple[tuple[float, float], ...]:
+    """Canonicalize an author-supplied polygon ring to a deterministic form.
+
+    Returns the ring OPEN (no closing duplicate), wound counter-clockwise,
+    rotated so the lexicographically-smallest vertex is first. Two orderings
+    of the SAME shape therefore produce a byte-identical tuple — the
+    determinism contract (ADR-0003) for polygon parts, since the geometry
+    layer never re-orients at solve time (Shapely preserves vertex order
+    verbatim). Rejects non-finite, fewer-than-3-vertex, degenerate
+    (zero-area / collinear), and self-intersecting rings.
+    """
+    pts = [(float(x), float(y)) for x, y in vertices]
+    # Drop an explicit closing duplicate if the author supplied one.
+    if len(pts) >= 2 and pts[0] == pts[-1]:
+        pts = pts[:-1]
+    if len(pts) < 3:
+        raise ValueError(f"polygon ring needs >= 3 distinct vertices, got {len(pts)}")
+    if not all(math.isfinite(x) and math.isfinite(y) for x, y in pts):
+        raise ValueError(f"polygon ring has a non-finite vertex: {pts}")
+    # Signed area (shoelace) gives BOTH the winding sign and a degeneracy check.
+    n = len(pts)
+    signed_area2 = sum(
+        pts[i][0] * pts[(i + 1) % n][1] - pts[(i + 1) % n][0] * pts[i][1] for i in range(n)
+    )
+    if abs(signed_area2) < _RING_MIN_ABS_SIGNED_AREA:
+        raise ValueError(f"polygon ring is degenerate (near-zero area): {pts}")
+    # Reject self-intersection (bow-ties) — shapely is the well-tested oracle.
+    if not LinearRing([*pts, pts[0]]).is_simple:
+        raise ValueError(f"polygon ring self-intersects: {pts}")
+    # Force counter-clockwise (positive signed area).
+    if signed_area2 < 0:
+        pts = list(reversed(pts))
+    # Rotate to the lexicographically-minimum start vertex.
+    start = min(range(len(pts)), key=lambda i: pts[i])
+    pts = pts[start:] + pts[:start]
+    return tuple(pts)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/test_part_polygon.py -q`
+Expected: PASS (7 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_part_polygon.py
+git commit -m "feat(models): add _canonicalize_ring polygon canonicalization helper (#548)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `Part.local_vertices` field + canonicalization + bbox-subset invariant
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (`Part` dataclass ~line 42–95)
+- Test: `tests/test_part_polygon.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_part_polygon.py`:
+
+```python
+def _wing(**kw):
+    base = dict(
+        kind="wing",
+        length_m=2.0,
+        width_m=10.0,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=1.9,
+        z_top_m=2.1,
+    )
+    base.update(kw)
+    return Part(**base)
+
+
+def test_part_defaults_local_vertices_none() -> None:
+    assert _wing().local_vertices is None
+
+
+def test_part_canonicalizes_local_vertices_on_construction() -> None:
+    # A hexagon taper, listed CW from a non-lex-min start; must come back canonical.
+    verts = [(1.0, 0.0), (0.4, -5.0), (-0.4, -5.0), (-1.0, 0.0), (-0.4, 5.0), (0.4, 5.0)]
+    p = _wing(local_vertices=verts)
+    assert p.local_vertices == _canonicalize_ring(verts)
+    # Canonical: lex-min start, CCW.
+    assert p.local_vertices[0] == min(p.local_vertices)
+
+
+def test_part_rejects_local_vertices_outside_bbox() -> None:
+    # Vertex x=1.5 exceeds half-length (length_m/2 = 1.0).
+    verts = [(1.5, 0.0), (0.4, 5.0), (-0.4, 5.0), (-1.0, 0.0), (-0.4, -5.0), (0.4, -5.0)]
+    with pytest.raises(ValueError, match="bbox"):
+        _wing(local_vertices=verts)
+
+
+def test_part_local_vertices_within_bbox_ok() -> None:
+    # Tip/root within the 2.0 x 10.0 box; touching the boundary is allowed.
+    verts = [(1.0, 0.0), (0.4, 5.0), (-0.4, 5.0), (-1.0, 0.0), (-0.4, -5.0), (0.4, -5.0)]
+    p = _wing(local_vertices=verts)
+    assert len(p.local_vertices) == 6
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_part_polygon.py -q`
+Expected: FAIL — `TypeError: Part.__init__() got an unexpected keyword argument 'local_vertices'`.
+
+- [ ] **Step 3: Implement the field + validation**
+
+In `src/hangarfit/models.py`, add the field to `Part` after `z_top_m` (line 76):
+
+```python
+    z_top_m: float
+    local_vertices: tuple[tuple[float, float], ...] | None = None
+```
+
+At the END of `Part.__post_init__` (after the existing `z_top_m` check ~line 95) add:
+
+```python
+        if self.local_vertices is not None:
+            canonical = _canonicalize_ring(self.local_vertices)
+            half_l = self.length_m / 2.0
+            half_w = self.width_m / 2.0
+            for x, y in canonical:
+                if abs(x) > half_l + _PART_BBOX_TOL_M or abs(y) > half_w + _PART_BBOX_TOL_M:
+                    raise ValueError(
+                        f"Part {self.kind!r}: local_vertices vertex ({x}, {y}) lies outside "
+                        f"the length_m x width_m bbox (+/-{half_l} x +/-{half_w}); the polygon "
+                        f"footprint must be a subset of the bounding box"
+                    )
+            object.__setattr__(self, "local_vertices", canonical)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/test_part_polygon.py -q`
+Expected: PASS (11 passed).
+
+- [ ] **Step 5: Run the full model + loader suites to confirm no back-compat break**
+
+Run: `pytest tests/test_models.py tests/test_loader.py -q`
+Expected: PASS (the trailing defaulted field leaves all keyword construction valid).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_part_polygon.py
+git commit -m "feat(models): optional Part.local_vertices with canonicalization + bbox invariant (#548)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `aircraft_parts_world` polygon build-path
+
+**Files:**
+- Modify: `src/hangarfit/geometry.py` (`aircraft_parts_world` loop ~line 198–216)
+- Test: `tests/test_geometry.py` (append a class)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_geometry.py` (the helpers `_aircraft_with_one_part`, `Placement`, `aircraft_parts_world` are already imported/defined in this file):
+
+```python
+class TestAircraftPartsWorldPolygon:
+    def test_rectangle_vertices_match_scalar_path_at_45deg(self) -> None:
+        """A part whose local_vertices ARE its rectangle corners must transform
+        to the SAME world polygon as the scalar oriented_rect path — proving the
+        polygon branch routes every vertex through the det(-1) transform."""
+        hl, hw = 1.0, 5.0  # length_m=2, width_m=10
+        rect_corners = [(hl, -hw), (hl, hw), (-hl, hw), (-hl, -hw)]
+        scalar = _aircraft_with_one_part(
+            Part(kind="wing", length_m=2.0, width_m=10.0, offset_x_m=0.3,
+                 offset_y_m=-0.2, angle_deg=0.0, z_bottom_m=1.9, z_top_m=2.1)
+        )
+        poly = _aircraft_with_one_part(
+            Part(kind="wing", length_m=2.0, width_m=10.0, offset_x_m=0.3,
+                 offset_y_m=-0.2, angle_deg=0.0, z_bottom_m=1.9, z_top_m=2.1,
+                 local_vertices=rect_corners)
+        )
+        pl = Placement(plane_id="probe", x_m=4.0, y_m=7.0, heading_deg=45.0, on_carts=False)
+        [ws] = aircraft_parts_world(scalar, pl)
+        [wp] = aircraft_parts_world(poly, pl)
+        assert wp.polygon.equals(ws.polygon)
+
+    def test_taper_polygon_is_strict_subset_area_of_bbox(self) -> None:
+        """A tapered hexagon transforms to a world polygon with LESS area than
+        the bounding rectangle (the conservative footprint direction)."""
+        taper = [(1.0, 0.0), (0.4, 5.0), (-0.4, 5.0), (-1.0, 0.0), (-0.4, -5.0), (0.4, -5.0)]
+        scalar = _aircraft_with_one_part(
+            Part(kind="wing", length_m=2.0, width_m=10.0, offset_x_m=0.0,
+                 offset_y_m=0.0, angle_deg=0.0, z_bottom_m=1.9, z_top_m=2.1)
+        )
+        poly = _aircraft_with_one_part(
+            Part(kind="wing", length_m=2.0, width_m=10.0, offset_x_m=0.0,
+                 offset_y_m=0.0, angle_deg=0.0, z_bottom_m=1.9, z_top_m=2.1,
+                 local_vertices=taper)
+        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False)
+        [ws] = aircraft_parts_world(scalar, pl)
+        [wp] = aircraft_parts_world(poly, pl)
+        assert wp.polygon.area < ws.polygon.area
+        assert wp.polygon.within(ws.polygon.buffer(1e-9))
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_geometry.py::TestAircraftPartsWorldPolygon -q`
+Expected: FAIL — the polygon and scalar polygons differ (the branch is not yet implemented, so `local_vertices` is ignored and both build the rectangle... the first test PASSES trivially but the second FAILS because `wp.area == ws.area`). Confirm at least `test_taper_polygon_is_strict_subset_area_of_bbox` fails with `assert <equal areas>`.
+
+- [ ] **Step 3: Implement the branch**
+
+In `src/hangarfit/geometry.py`, replace the body of the `for part in aircraft.parts:` loop (the `oriented_rect` + `world_coords` construction, lines ~200–216) with:
+
+```python
+    for part in aircraft.parts:
+        if part.local_vertices is not None:
+            # Polygon footprint: rotate each author vertex from the part's own
+            # frame into plane-local by the part's angle+offset (mirroring
+            # oriented_rect's per-corner affine), then route EVERY vertex through
+            # the det(-1) local_to_world transform — no centroid shortcut (ADR-0002).
+            h = math.radians(part.angle_deg)
+            cos_h = math.cos(h)
+            sin_h = math.sin(h)
+            cx = part.offset_x_m
+            cy = part.offset_y_m
+            local_coords = [
+                (cx + x * cos_h - y * sin_h, cy + x * sin_h + y * cos_h)
+                for x, y in part.local_vertices
+            ]
+        else:
+            # Scalar oriented rectangle (back-compat path). ``angle_deg`` rotates
+            # the part within plane-local (standard CCW).
+            local_poly = oriented_rect(
+                cx=part.offset_x_m,
+                cy=part.offset_y_m,
+                length=part.length_m,
+                width=part.width_m,
+                angle_deg=part.angle_deg,
+            )
+            # exterior.coords includes the closing-point duplicate; slice it off.
+            local_coords = list(local_poly.exterior.coords)[:-1]
+        # Apply the plane-local-to-world transform to each vertex.
+        world_coords = [local_to_world(u, v, placement) for u, v in local_coords]
+        world_poly = Polygon(world_coords)
+        world_parts.append(
+            WorldPart(
+                polygon=world_poly,
+                z_bottom_m=part.z_bottom_m,
+                z_top_m=part.z_top_m,
+                plane_id=placement.plane_id,
+                kind=part.kind,
+            )
+        )
+    return world_parts
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/test_geometry.py -q`
+Expected: PASS (existing geometry tests + the two new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/geometry.py tests/test_geometry.py
+git commit -m "feat(geometry): polygon build-path in aircraft_parts_world (#548)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: loader `planform:` schema + part-key allowlist
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (`_build_part` ~line 1041; add `_ALLOWED_PART_KEYS` + `_build_planform`)
+- Test: `tests/test_loader_planform.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_loader_planform.py`:
+
+```python
+"""Loader tests for the parametrized `planform:` wing block (#548)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.loader import LoaderError, _build_part
+
+
+def _wing_data(**planform):
+    return {
+        "kind": "wing",
+        "length_m": 2.0,
+        "width_m": 10.0,
+        "offset_x_m": 1.5,
+        "z_bottom_m": 1.9,
+        "z_top_m": 2.1,
+        "planform": {"root_chord_m": 2.0, "tip_chord_m": 0.9, **planform},
+    }
+
+
+def test_planform_expands_to_canonical_hexagon() -> None:
+    part = _build_part(_wing_data(), 0)
+    assert part.local_vertices is not None
+    assert len(part.local_vertices) == 6
+    # Within the 2.0 x 10.0 bbox.
+    for x, y in part.local_vertices:
+        assert abs(x) <= 1.0 + 1e-9
+        assert abs(y) <= 5.0 + 1e-9
+
+
+def test_planform_absent_leaves_local_vertices_none() -> None:
+    data = {"kind": "wing", "length_m": 2.0, "width_m": 10.0,
+            "z_bottom_m": 1.9, "z_top_m": 2.1}
+    assert _build_part(data, 0).local_vertices is None
+
+
+def test_planform_rejects_tip_exceeding_root() -> None:
+    with pytest.raises(LoaderError, match="taper outward"):
+        _build_part(_wing_data(root_chord_m=1.0, tip_chord_m=1.5), 0)
+
+
+def test_planform_rejects_root_exceeding_length_bbox() -> None:
+    # root_chord 3.0 > length_m 2.0 -> a vertex pokes outside the bbox.
+    with pytest.raises((LoaderError, ValueError), match="bbox"):
+        _build_part(_wing_data(root_chord_m=3.0, tip_chord_m=0.9), 0)
+
+
+def test_planform_rejects_unknown_nested_key() -> None:
+    with pytest.raises(LoaderError, match="unknown key"):
+        _build_part(_wing_data(sweep_deg=3.0), 0)
+
+
+def test_build_part_rejects_unknown_part_key() -> None:
+    data = {"kind": "wing", "length_m": 2.0, "width_m": 10.0,
+            "z_bottom_m": 1.9, "z_top_m": 2.1, "planfrm": {}}
+    with pytest.raises(LoaderError, match="unknown key"):
+        _build_part(data, 0)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_loader_planform.py -q`
+Expected: FAIL — `_build_part` ignores `planform` (so `local_vertices is None`), and there is no part-key allowlist yet.
+
+- [ ] **Step 3: Implement the schema**
+
+In `src/hangarfit/loader.py`, immediately before `def _build_part` (~line 1041) add:
+
+```python
+# Strict unknown-key allowlist for a `parts[i]` entry, mirroring
+# _ALLOWED_AIRCRAFT_KEYS. `planform` is a YAML-only convenience block expanded
+# into Part.local_vertices by _build_planform (NOT a Part field). Without this,
+# a typo like `planfrm:` would be silently dropped and the wing would stay a
+# rectangle with no error.
+_ALLOWED_PART_KEYS = frozenset(
+    {
+        "kind",
+        "length_m",
+        "width_m",
+        "offset_x_m",
+        "offset_y_m",
+        "angle_deg",
+        "z_bottom_m",
+        "z_top_m",
+        "planform",
+    }
+)
+
+
+def _build_planform(data: Any, span_m: float, index: int) -> tuple[tuple[float, float], ...]:
+    """Expand a parametrized symmetric double-taper wing into part-own vertices.
+
+    Convention (ADR-0024): no sweep, root kink at y=0. In the part's own frame
+    ``+x`` is the chord (forward = leading edge), and ``width_m`` is the span
+    running along ``+-y``. Produces a 6-vertex hexagon; the chord at the root
+    (y=0) is ``root_chord_m`` and at each tip (y=+-span/2) is ``tip_chord_m``.
+    Part.__post_init__ canonicalizes the ring and enforces the bbox subset.
+    """
+    if not isinstance(data, dict):
+        raise LoaderError(f"parts[{index}].planform must be a mapping")
+    required = ("root_chord_m", "tip_chord_m")
+    for key in required:
+        if key not in data:
+            raise LoaderError(f"parts[{index}].planform missing required field {key!r}")
+    unknown = set(data) - set(required)
+    if unknown:
+        raise LoaderError(f"parts[{index}].planform has unknown key(s) {sorted(unknown)}")
+    root = _to_float(data["root_chord_m"], f"parts[{index}].planform.root_chord_m")
+    tip = _to_float(data["tip_chord_m"], f"parts[{index}].planform.tip_chord_m")
+    if root <= 0 or tip <= 0:
+        raise LoaderError(
+            f"parts[{index}].planform chords must be positive, got root={root}, tip={tip}"
+        )
+    if tip > root:
+        raise LoaderError(
+            f"parts[{index}].planform tip_chord_m ({tip}) must not exceed root_chord_m "
+            f"({root}) — a wing does not taper outward"
+        )
+    half_span = span_m / 2.0
+    hr = root / 2.0
+    ht = tip / 2.0
+    return (
+        (hr, 0.0),
+        (ht, half_span),
+        (-ht, half_span),
+        (-hr, 0.0),
+        (-ht, -half_span),
+        (ht, -half_span),
+    )
+```
+
+Replace the body of `_build_part` (lines ~1041–1057) with:
+
+```python
+def _build_part(data: Any, index: int) -> Part:
+    if not isinstance(data, dict):
+        raise LoaderError(f"parts[{index}] must be a mapping")
+    unknown = set(data) - _ALLOWED_PART_KEYS
+    if unknown:
+        raise LoaderError(
+            f"parts[{index}] has unknown key(s) {sorted(unknown)}; "
+            f"allowed: {sorted(_ALLOWED_PART_KEYS)}"
+        )
+    required = ("kind", "length_m", "width_m", "z_bottom_m", "z_top_m")
+    for key in required:
+        if key not in data:
+            raise LoaderError(f"parts[{index}] missing required field {key!r}")
+    width_m = _to_float(data["width_m"], f"parts[{index}].width_m")
+    local_vertices = None
+    if "planform" in data:
+        local_vertices = _build_planform(data["planform"], width_m, index)
+    return Part(
+        kind=data["kind"],
+        length_m=_to_float(data["length_m"], f"parts[{index}].length_m"),
+        width_m=width_m,
+        offset_x_m=_to_float(data.get("offset_x_m", 0.0), f"parts[{index}].offset_x_m"),
+        offset_y_m=_to_float(data.get("offset_y_m", 0.0), f"parts[{index}].offset_y_m"),
+        angle_deg=_to_float(data.get("angle_deg", 0.0), f"parts[{index}].angle_deg"),
+        z_bottom_m=_to_float(data["z_bottom_m"], f"parts[{index}].z_bottom_m"),
+        z_top_m=_to_float(data["z_top_m"], f"parts[{index}].z_top_m"),
+        local_vertices=local_vertices,
+    )
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `pytest tests/test_loader_planform.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Run the FULL loader + fleet suites (the part-key allowlist is a behavior change)**
+
+Run: `pytest tests/test_loader.py tests/test_scenario.py tests/test_herrenteich_dataset.py -q`
+Expected: PASS. If any shipped fixture/data carries a part key outside `_ALLOWED_PART_KEYS`, this surfaces it — add the missing key to the allowlist (do NOT silently widen past the real schema).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader_planform.py
+git commit -m "feat(loader): parametrized planform: wing block + part-key allowlist (#548)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: determinism scenario fixtures + canary
+
+**Files:**
+- Create: `tests/fixtures/hangar_taper.yaml`, `tests/fixtures/fleet_taper.yaml`, `tests/fixtures/solve_taper_determinism.yaml`
+- Test: `tests/test_solver_canaries.py` (append one function)
+
+- [ ] **Step 1: Create the hangar fixture**
+
+`tests/fixtures/hangar_taper.yaml`:
+
+```yaml
+# Roomy test hangar for the polygon-taper determinism canary (#548). Large
+# enough for one 18 m-span tapered glider. Synthetic placeholder dimensions.
+length_m: 25.0
+width_m: 22.0
+door:
+  center_x_m: 11.0
+  width_m: 12.0
+clearance_m: 0.3
+wing_layer_clearance_m: 0.2
+```
+
+- [ ] **Step 2: Create the test-only fleet fixture (with a polygon wing)**
+
+`tests/fixtures/fleet_taper.yaml`:
+
+```yaml
+# TEST-ONLY fleet for the polygon-parts determinism canary (#548). One tapered
+# glider authored via a `planform:` block so the polygon build-path + load-time
+# canonicalization are exercised through solve(). NOT shipped data.
+aircraft:
+  - id: taper_glider
+    name: "Taper Glider (test)"
+    wing_position: high
+    gear: monowheel
+    movement_mode: always_cart
+    turn_radius_m: null
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 7.6
+        width_m: 0.7
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.2
+        width_m: 18.0
+        offset_x_m: 1.5
+        offset_y_m: 0.0
+        z_bottom_m: 1.9
+        z_top_m: 2.1
+        planform:
+          root_chord_m: 1.2
+          tip_chord_m: 0.54
+      - kind: tail
+        length_m: 0.9
+        width_m: 2.6
+        offset_x_m: -3.35
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer
+        length_m: 1.1
+        width_m: 0.15
+        offset_x_m: -3.25
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 1.68
+    wheels:
+      main_offset_x_m: 0.0
+```
+
+- [ ] **Step 3: Create the scenario fixture**
+
+`tests/fixtures/solve_taper_determinism.yaml`:
+
+```yaml
+# Determinism canary scenario (#548): place the tapered glider so the polygon
+# build-path runs inside solve()'s seeded restart loop.
+fleet: fleet_taper.yaml
+hangar: hangar_taper.yaml
+fleet_in: [taper_glider]
+```
+
+- [ ] **Step 4: Append the canary test**
+
+Append to `tests/test_solver_canaries.py`:
+
+```python
+def test_solve_deterministic_polygon_taper_fleet() -> None:
+    """A fleet whose wing is a polygon (tapered hexagon) solves bit-identically
+    across two runs under a fixed max_restarts cap — proving the polygon
+    build-path + load-time vertex canonicalization are determinism-safe
+    (ADR-0003). max_restarts (not wall-clock) makes this load-independent, so
+    it stays in the parallel pool (no `serial` mark)."""
+    fixture = "tests/fixtures/solve_taper_determinism.yaml"
+    cfg = SearchConfig(max_restarts=8, spread=False, nose_out=False)
+
+    s1 = load_scenario(fixture)
+    r1 = solve(s1, budget_s=30.0, alternatives=1, seed=42, search=cfg)
+    s2 = load_scenario(fixture)
+    r2 = solve(s2, budget_s=30.0, alternatives=1, seed=42, search=cfg)
+
+    assert r1.status == r2.status
+    assert len(r1.layouts) == len(r2.layouts)
+    for la, lb in zip(r1.layouts, r2.layouts, strict=True):
+        assert la.placements == lb.placements
+        assert la.maintenance_plane == lb.maintenance_plane
+
+    bp1 = r1.diagnostics.best_partial_layout
+    bp2 = r2.diagnostics.best_partial_layout
+    if bp1 is not None:
+        assert bp2 is not None
+        assert bp1.placements == bp2.placements
+```
+
+- [ ] **Step 5: Run the canary**
+
+Run: `pytest tests/test_solver_canaries.py::test_solve_deterministic_polygon_taper_fleet -q`
+Expected: PASS. (If `status` is unexpectedly `exhausted_budget` for a single roomy-hangar plane, the byte-identity assertions still hold — the test is direction-agnostic. If the scenario fails to load, re-check the relative `fleet:`/`hangar:` paths resolve from `tests/fixtures/`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/hangar_taper.yaml tests/fixtures/fleet_taper.yaml \
+        tests/fixtures/solve_taper_determinism.yaml tests/test_solver_canaries.py
+git commit -m "test(solver): polygon-taper determinism canary fixture + double-solve (#548)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: opt-in byte-identity guard (shipped fleets stay rectangles)
+
+**Files:**
+- Test: `tests/test_fleet_polygon_optin.py` (create)
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/test_fleet_polygon_optin.py`:
+
+```python
+"""PR1 guarantee: the polygon-parts feature ships PLUMBING only. No shipped
+fleet aircraft is authored as a polygon yet, so every shipped Part keeps
+local_vertices=None and the real fleets stay byte-identical. The Scheibe taper
+lands in a later PR once the viewer renders N-gon (#548 stack)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.loader import load_fleet
+
+_SHIPPED_FLEETS = ["data/fleet.yaml", "examples/herrenteich/fleet.yaml"]
+
+
+@pytest.mark.parametrize("path", _SHIPPED_FLEETS)
+def test_shipped_fleet_has_no_polygon_parts(path: str) -> None:
+    fleet = load_fleet(path)
+    for ac in fleet.values():
+        for part in ac.parts:
+            assert part.local_vertices is None, (
+                f"{path}:{ac.id} part {part.kind!r} unexpectedly carries a polygon "
+                f"footprint; PR1 must keep shipped fleets byte-identical"
+            )
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pytest tests/test_fleet_polygon_optin.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_fleet_polygon_optin.py
+git commit -m "test(fleet): guard that shipped fleets stay rectangles in PR1 (#548)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: docs — ADR-0024 + arc42 note + CHANGELOG
+
+**Files:**
+- Create: `docs/adr/0024-optional-polygon-parts.md`
+- Modify: `docs/adr/README.md` (ADR index), `docs/architecture/08-crosscutting-concepts.md` ("The parts model"), `CHANGELOG.md`
+
+- [ ] **Step 1: Write ADR-0024**
+
+Create `docs/adr/0024-optional-polygon-parts.md` (follow `docs/adr/template.md`'s structure). Required content:
+- **Status:** Accepted. **Refines:** ADR-0001 (mesh deferral).
+- **Context:** every `Part` is an oriented rectangle (ADR-0001); ADR-0012/0023 added realism only by adding rectangles. The spike (#541) measured a 0.10–0.30 m verdict-flip window where a tapered glider wingtip nests but its bounding rectangle falsely conflicts.
+- **Decision:** add an optional `Part.local_vertices` (part-own frame), load-time-canonicalized (force-CCW, lex-min start, drop closing dup, reject degenerate/non-finite/self-intersecting — the ADR-0003 determinism crux), constrained to the `length_m × width_m` bbox. `aircraft_parts_world` routes every vertex through the det(−1) `local_to_world` (ADR-0002). Author via a parametrized `planform: {root_chord_m, tip_chord_m}` block (symmetric double-taper, no sweep, root kink at y=0 → a hexagon). No raw `vertices:` primitive (no honest data source; spike Q2).
+- **The bbox / area trade:** `length_m × width_m` stays the bounding box for all scalar consumers; the polygon is a strict subset, so wing **area is intentionally under-conserved** (the conservative footprint direction — the box over-claims). The area-gate reads scalars, so it stays a sound lower bound.
+- **Consequences:** scalar fleets byte-identical; the viewer continues to render boxes until #549 (scene/v2); the folded Stemme wing stays a rectangle (folding ≠ taper).
+- **Forward-compat:** the vertex-routed transform + explicit per-part height band leave room for a future wing-tilt DoF and true-3D meshes (both deferred).
+
+- [ ] **Step 2: Add the ADR to the index**
+
+In `docs/adr/README.md`, add a row/line for ADR-0024 in the same format as the surrounding entries (link + one-line summary, marked as refining ADR-0001).
+
+- [ ] **Step 3: Note polygon parts in arc42 §8**
+
+In `docs/architecture/08-crosscutting-concepts.md`, in "The parts model" section, add a short paragraph: parts are oriented rectangles by default, but a `Part` may carry an optional canonicalized polygon footprint (`local_vertices`, authored via `planform:`) that the collision build-path uses while `length_m`/`width_m` remain the bounding box; link to ADR-0024.
+
+- [ ] **Step 4: Add the CHANGELOG entry**
+
+In `CHANGELOG.md`, under `## [Unreleased]` → `### Added`, add:
+
+```markdown
+- Optional polygon part footprints: a `Part` may carry a load-time-canonicalized
+  `local_vertices` polygon (authored via a parametrized `planform: {root_chord_m,
+  tip_chord_m}` wing block), used by the collision build-path while `length_m`/
+  `width_m` stay the bounding box. Scalar fleets are byte-identical; the 3D viewer
+  still renders boxes until the scene/v2 work. (#548, ADR-0024)
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/adr/0024-optional-polygon-parts.md docs/adr/README.md \
+        docs/architecture/08-crosscutting-concepts.md CHANGELOG.md
+git commit -m "docs(adr): ADR-0024 optional polygon parts + arc42/CHANGELOG (#548)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Full verification + guard arc + draft PR
+
+**Files:** none (process)
+
+- [ ] **Step 1: Full local verification**
+
+Run, expecting all green:
+```bash
+ruff check src/ tests/
+ruff format --check src/ tests/
+mypy src/hangarfit/
+pytest -q
+```
+If `ruff format --check` fails, run `ruff format src/ tests/` and re-commit.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feature/polygon-parts-realistic-geometry
+```
+
+- [ ] **Step 3: Open the draft PR (re-scoped #548)**
+
+```bash
+gh pr create --draft --base develop \
+  --title "feat: optional polygon part footprints + collision build-path (#548)" \
+  --body "$(cat <<'BODY'
+Closes #548 (re-scoped: glider taper data carved into a follow-up issue, see the stack design).
+
+PR1 of the polygon-parts stack (design: docs/superpowers/specs/2026-06-10-realistic-polygon-plane-geometry-design.md).
+Adds optional `Part.local_vertices` (load-time-canonicalized, bbox-subset), the
+`aircraft_parts_world` polygon build-path, and a parametrized `planform:` loader
+schema. Shipped fleets stay byte-identical (guarded); the viewer is untouched
+(renders boxes until #549). Determinism is exercised by a new placed-taper canary.
+BODY
+)"
+```
+Then set assignee/labels/milestone via `gh api -X PATCH` (the repo convention — `gh pr edit` is broken here).
+
+- [ ] **Step 4: Run the guard arc** (per CLAUDE.md — convert every finding into a review thread on the diff):
+  - `geometry-invariant-guard` (geometry.py touched — confirms every vertex routes through `local_to_world`, no centroid shortcut, non-axis-aligned heading covered)
+  - `type-design-analyzer` (models.py `Part` changed)
+  - `pr-review-toolkit:silent-failure-hunter` (loader changed)
+  - `determinism-guard` (runs the solver twice on the taper scenario, diffs byte-for-byte)
+  - `pr-review-toolkit:code-reviewer` (mandated main pass)
+  - `pr-review-toolkit:comment-analyzer` (ADR + docstrings)
+
+- [ ] **Step 5:** Resolve every thread (fix-in-code preferred). Re-run review if changes were non-trivial. When the arc is clean, `gh pr ready <n>` and tell the user it's clean and ready for final review. **Do not merge — the user is the sole merger.**
+
+---
+
+## Self-Review (completed)
+
+**Spec coverage:** §3.1 `local_vertices`→T2; §3.2 canonicalization→T1; §3.3 bbox invariant→T2/T4; §3.4 build-path→T3; §3.5 `planform:`/no-`vertices:`→T4; §3.6 determinism scenario→T5; byte-identity→T6; ADR/CHANGELOG (§8)→T7; guard arc (§8)→T8. PR2 (§4) and PR3 (§5) are intentionally out of this plan (separate stack PRs).
+
+**Type consistency:** `local_vertices: tuple[tuple[float, float], ...] | None` is used identically in models.py (field), the `_build_planform` return, and the geometry branch. `_canonicalize_ring` returns the same type. `load_fleet(path) -> dict[str, Aircraft]` (iterated via `.values()`). `SearchConfig(max_restarts=, spread=, nose_out=)`, `solve(scenario, budget_s=, alternatives=, seed=, search=)`, and `Placement(plane_id=, x_m=, y_m=, heading_deg=, on_carts=)` all match the existing call sites verified in `test_solver_canaries.py` / `test_geometry.py`.
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code. ADR-0024 (T7) is described by required-content bullets rather than full prose — acceptable for a doc artifact that follows the in-repo `template.md`.

--- a/docs/superpowers/specs/2026-06-10-realistic-polygon-plane-geometry-design.md
+++ b/docs/superpowers/specs/2026-06-10-realistic-polygon-plane-geometry-design.md
@@ -1,0 +1,169 @@
+# Realistic polygon plane geometry + viewer (tilt-ready) — design
+
+- **Date:** 2026-06-10
+- **Status:** Design — approved in brainstorming, pending written-spec review.
+- **Issues:** #548 (polygon parts Phase 1), #549 (scene/v2 viewer), + a new small data/regression issue carved from #548.
+- **Refs:** spike #541 (`docs/spikes/polygon-part-geometry-feasibility.md`), ADR-0001 (mesh deferral), ADR-0002 (det(−1) transform), ADR-0003 (determinism), ADR-0012 (fuselage split), ADR-0017 (3D viewer), ADR-0023 (empennage).
+- **Decision panel:** 8-agent deliberation (5 lenses → synthesis → adversarial challenge), 2026-06-10. Its code-verified findings are folded in below.
+
+---
+
+## 1. Goal & scope
+
+Make plane geometry realistic enough to:
+
+1. **Eliminate false collision / pathfinding conflicts** at tight nesting spots (the measured value: a tapered glider wingtip nests where its bounding rectangle falsely conflicts — a robust 0.10–0.30 m verdict-flip window on the real Herrenteich layout).
+2. **Let a human read the 3D viewer and map it to the real hangar** for planning — "that's the Scheibe nested under the Stemme tail."
+
+Deliver an **honest 2.5D** representation now — polygon footprints for collision, extruded prisms for the viewer — with seams left open for two future enhancements: a **wing-tilt/roll degree of freedom** (for tandem-gear gliders parked wing-down) and **true-3D curved meshes**.
+
+### In scope
+- Optional polygon footprint on `Part`, with a load-time canonicalization determinism invariant.
+- The collision/transform build-path for polygon parts (already polygon-generic per spike Q1).
+- A parametrized `planform:` loader schema (root/tip chord → loader-expanded hexagon).
+- Realistic viewer: `scene/v2` + extruded-prism rendering (N-gon outlines).
+- Glider taper data (Scheibe SF-25E wing) + the flip-window regression proving the value.
+
+### Out of scope (explicitly)
+- A tilt/roll DoF (design *toward* it only — see §6).
+- True-3D curved meshes / airfoil sections (ADR-0001's deferral stands; design *toward* it only).
+- A raw `vertices:` author primitive (no honest data source today — see §3).
+- Viewer planning UI: dimension labels, click-to-measure, scale grid (a separate future effort).
+- The folded Stemme wing as a taper (folding ≠ taper — stays a rectangle; see §5).
+
+---
+
+## 2. Delivery — a 3-PR stack
+
+All three branches base on `develop` and merge in order (per CLAUDE.md's stacking rule: feature PRs base on `develop`, never on a parent feature branch, or CI/issue-linkage silently no-ops).
+
+| PR | Issue | Delivers | Byte-identity status |
+|---|---|---|---|
+| **1 — Polygon model & collision** | #548 (re-scoped: data moves out) | `Part.local_vertices` + canonicalization invariant + `aircraft_parts_world` build-path + loader `planform:` schema + determinism solve-scenario + unit suites | Real fleet **byte-identical** (no fleet data uses the feature yet) |
+| **2 — Viewer realism** | #549 | `scene/v2` + `ExtrudeGeometry` + N-gon anchors/labels + committed `viewer.js` rebuild | Box parts render identically; N-gon path exercised by tests |
+| **3 — Glider data & value proof** | new small issue (carved from #548) | Scheibe wing taper authored + flip-window regression | First visible/measurable change — both collision & viewer already render N-gon |
+
+**Why this order.** Landing the viewer (PR2) *before* the taper data (PR3) means the "3D viewer shows boxes while the collision verdict uses a taper" contradiction **never exists on `develop`**, and the transitional `scene._anchors`-pin workaround (needed only if collision goes polygon while the viewer stays boxes) is **never written**. It also isolates the determinism crux (PR1's canonicalization) from the viewer bit-identity surface (PR2's `viewer.js` rebuild + JS parity oracle) — the two most byte-identity-sensitive surfaces in the codebase — into separate, tractable reviews.
+
+---
+
+## 3. PR1 — Polygon model & collision
+
+### 3.1 `models.Part`
+Add a trailing, defaulted field so every existing keyword construction stays valid and scalar parts are unchanged:
+
+```python
+local_vertices: tuple[tuple[float, float], ...] | None = None
+```
+
+A tuple-of-tuples (not a list) for `frozen=True, slots=True` hashability. `None` ⇒ today's scalar oriented rectangle (back-compat).
+
+### 3.2 Canonicalization invariant (the determinism crux)
+When `local_vertices is not None`, `Part.__post_init__` canonicalizes via a module-level, unit-testable `_canonicalize_ring(verts)` helper:
+
+1. Reject non-finite coordinates (NaN/inf), fewer than 3 vertices, self-intersecting (non-simple) rings, and degenerate/collinear rings (signed area ≈ 0).
+2. **Force CCW** by signed-area sign.
+3. **Rotate to a lexicographically-minimum start vertex** (canonical start).
+4. **Drop the closing duplicate** (store the open ring).
+
+Two equivalent orderings of the *same* shape must produce a **byte-identical** `Part`. The geometry layer must **never** re-orient at solve time — Shapely's `Polygon()` preserves vertex order verbatim, so order is author-controlled the moment vertices are supplied (spike Q5). This is what protects ADR-0003 (every `coords[:-1]` consumer reports the *first* violator; the JS oracle compares per-corner at 1e-6).
+
+### 3.3 Loader-asserted bbox-subset invariant
+The canonical ring must be a subset of the `length_m × width_m` local bbox. This:
+- keeps `length_m`/`width_m` the true bounding box for all scalar consumers (`metrics`, scene boxes, `towplanner` apron),
+- keeps `_check_sum_areas` a sound lower bound (polygon area ≤ bbox area),
+- and **fails loud** if a `planform:` block is later ported to an aircraft whose bbox differs (the data/fleet `length_m: 1.2` vs herrenteich `1.01` drift the panel flagged) instead of silently producing a non-subset polygon.
+
+### 3.4 `geometry.aircraft_parts_world`
+Add a branch: when `local_vertices` is set, route those canonical vertices through `local_to_world` directly (skip `oriented_rect`, no closing-dup to strip); else today's `oriented_rect` path. **Every** declared vertex rides the same det(−1) affine — no centroid/bbox shortcut (geometry-invariant-guard verifies this).
+
+### 3.5 Loader `planform:` schema
+`loader._build_part` gains a `planform: {root_chord_m, tip_chord_m}` block, mirroring the `struts:` idiom exactly (`_build_struts_spec`): required-key check + unknown-key rejection + loader expansion into `local_vertices`. Validation: `0 < tip_chord_m <= root_chord_m` (a glider wing does not taper outward).
+
+**No raw `vertices:` field.** Panel verdict: high-confidence, unanimous. 0/8 fleet aircraft expose a dimensioned outline in any TCDS; the lone traceable 3-view (Cessna 140) is constant-chord. A raw `vertices:` primitive would ship with zero honest data, *look* surveyed (which `measured:false` understates), and turn every canonicalization branch into a load-bearing gate against adversarial author rings. `Part.local_vertices` is the shared internal store, so `vertices:` is a strictly-additive future branch behind the same invariant if a surveyed outline ever lands. YAGNI.
+
+### 3.6 Determinism solve-scenario fixture
+Add a **new** scenario fixture (a taper glider actually *placed*, not bay-parked) fed to a `solve()` double-run for byte-identity. Necessary because the canaries run `solve(scenario)`, the canary fixture excludes the Scheibe, and every existing scenario that lists the Scheibe parks it as the maintenance plane (geometrically absent). Without this, the polygon ring + canonicalization would ship with **zero** ADR-0003 contract coverage. (A `check`-only test exercises collision geometry but never the seeded restart loop the contract is about.)
+
+---
+
+## 4. PR2 — Viewer realism
+
+- **`scene/v2`**: each part carries explicit footprint vertices + `[z_bottom, z_top]` (a versioned bump from v1's scalar `length`/`width`/`angle` box). The Python transform stays authoritative (ADR-0017).
+- **`viewer.js`**: `BoxGeometry` → `ExtrudeGeometry`, de-risked by the in-tree `ShapeGeometry` L-floor precedent (#530).
+- **`anchors.ts` / `labels.ts`**: generalized from a fixed 4-corner oracle to N vertices, kept bit-identical to the Python `scene._anchors` oracle (the only cross-language check; `viewer.js` is not pytest-covered). Committed `viewer.js` rebuild under the `viewer-build-drift` guard (#438).
+
+Because PR2 lands before any real taper data (PR3), box parts render identically and the N-gon rendering path is proven by tests, not by a visible fleet change.
+
+---
+
+## 5. PR3 — Glider data & the geometric decisions (panel-verified)
+
+- **Scheibe SF-25E wing only.** Symmetric double-taper with **no sweep, root kink at y=0** → a **hexagon** (both leading and trailing edge recede toward each tip; *not* a 4-vertex "trapezoid"). The convention is pinned and documented in the loader and ADR-0024.
+- **Folded Stemme wing stays a rectangle.** Folding swings the outer panels — it is not a taper; a linear-taper polygon would fabricate a planform that does not physically exist in the hangared (folded) config (a provenance violation, not a fidelity gain). The measured flip is the Scheibe *wing* over the Stemme *empennage* (tail + fin rectangles), so the Stemme wing is off the critical path.
+- **Flip-window regression.** Assert the **loader-built** hexagon reproduces the spike's measured 0.10–0.30 m rect-rejects / taper-accepts window — the value proof, grounded in the *shipped* parametrization (not a hand-built measurement polygon).
+
+### 5.1 The mean-chord-vs-bbox resolution
+The herrenteich Scheibe wing `length_m: 1.01` is the **mean** chord (= area 18.20 / span 18.00). An honest linear taper has root > mean > tip, so a single trapezoid cannot simultaneously be a strict subset of a `length_m = 1.01` bbox **and** conserve the published mean chord.
+
+**Resolution:** set `root_chord_m = 1.01` (the existing bbox length) and `tip_chord_m = 0.45 × root` (the spike's measured taper ratio). The polygon stays a **strict subset** of the existing bbox, the flip reproduces, and there is **no golden re-pin**. Wing area is intentionally **under-conserved** — the *conservative* footprint direction: the bounding box over-claims, the taper sits safely inside it, and the area-gate reads scalars (`length×width`), so it stays sound. The under-conservation is documented in ADR-0024.
+
+(Rejected alternative: grow `length_m` to the root chord — forces a herrenteich golden re-pin and scalar-consumer churn for no validity gain.)
+
+---
+
+## 6. Forward-compat seams (design-toward, NOT built)
+
+### 6.1 Wing tilt / roll DoF
+- Keep **all** part geometry vertex-routed through the single `local_to_world` (no centroid/bbox shortcuts) — a future roll transform extends the pipeline rather than rewriting consumers.
+- Keep `[z_bottom, z_top]` explicit per part.
+- **Version the scene schema** (`scene/v2`) so a future roll angle / per-vertex height extends it without a contract rewrite.
+- Generalize the viewer off a hardcoded "4 corners" (PR2 does this anyway for N-gon).
+- **Known extension point (documented, not coded):** a tilted wing is not a vertical prism — its height varies across span — so `WorldPart` would become a sloped solid and the collision predicate would gain a height-profile term. Noted as the explicit place tilt support will land.
+
+### 6.2 True-3D meshes (future B)
+- `scene/v2` carries enough (vertices + height band) that a future renderer swaps `ExtrudeGeometry` for a loaded mesh in one isolated geometry-construction site.
+- ADR-0001's mesh deferral stands; this design does not preclude it.
+
+---
+
+## 7. Testing & determinism strategy
+
+- **Canonicalization unit matrix — lands first**: CCW forcing, lex-min-start rotation, closing-dup drop, reject non-finite / <3-vert / self-intersecting / degenerate; two equivalent orderings → identical `Part`.
+- Geometry per-vertex det(−1) at a **non-axis-aligned heading** (geometry-invariant-guard requirement).
+- Loader `planform:` parse, `tip > root` rejection, unknown-key rejection, non-subset-of-bbox rejection.
+- **New placed-taper determinism scenario** fed to a `solve()` double-run (byte-identity).
+- Scalar-fleet golden byte-identity (the cleanest proof of the no-regression half).
+- **(PR2)** scene/v2 schema + N-gon anchor ↔ Python-oracle parity.
+- **(PR3)** the flip-window regression.
+
+---
+
+## 8. Guard arc, ADRs, CHANGELOG
+
+- **PR1:** geometry-invariant-guard (geometry.py) + type-design-analyzer (models.py) + silent-failure-hunter (loader) + determinism double-solve (new taper scenario) + comment-analyzer (ADR/docstrings). **ADR-0024** refines ADR-0001's mesh deferral → optional polygon parts + canonicalization invariant + the deliberate area under-conservation.
+- **PR2:** comment-analyzer + the scene-v2 schema reference doc; extend ADR-0017 (or a new ADR) for the v1→v2 seam.
+- Each PR carries its own `CHANGELOG.md [Unreleased]` entry, opens as a **draft**, runs the full `/pr-review` arc, and flips to ready only when the review arc is clean. The user is the sole merger.
+
+---
+
+## 9. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Author vertex order breaks byte-identity (ADR-0003) | Load-time canonicalization invariant + the unit matrix landing first |
+| Viewer parity banner on N-gon (`_anchors` ↔ `viewer.js` mismatch) | PR ordering (viewer before data) avoids the interim entirely; PR2 generalizes both the oracle and the JS to N vertices in lockstep |
+| Polygon ring ships with no determinism coverage | New *placed*-taper solve-scenario, not a check-only test |
+| `planform:` ported to a different bbox silently goes non-subset | Loader-asserted bbox-subset invariant fails loud |
+| Loader-built hexagon ≠ the spike's measured polygon | Regression asserts the shipped parametrization reproduces the 0.10–0.30 m flip window |
+| Fabricating a folded-Stemme taper | Stemme wing stays a rectangle |
+
+---
+
+## 10. Open decisions — resolved
+
+- **Schema:** `planform_only` (no raw `vertices:`). High confidence, unanimous.
+- **Where (fleet data):** herrenteich-only (Scheibe wing); `data/fleet.yaml` untouched.
+- **Area conservation:** intentionally under-conserved; `root = bbox length`, no golden re-pin (§5.1).
+- **Viewer scope:** extruded-prism realism now; true-3D and planning UI are future, design-toward only.
+- **Tilt:** design-toward (seams in §6); not built.

--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -207,7 +207,7 @@ def aircraft_parts_world(
             sin_h = math.sin(h)
             cx = part.offset_x_m
             cy = part.offset_y_m
-            local_coords = [
+            local_coords: list[tuple[float, float]] = [
                 (cx + x * cos_h - y * sin_h, cy + x * sin_h + y * cos_h)
                 for x, y in part.local_vertices
             ]
@@ -222,7 +222,7 @@ def aircraft_parts_world(
                 angle_deg=part.angle_deg,
             )
             # exterior.coords includes the closing-point duplicate; slice it off.
-            local_coords = list(local_poly.exterior.coords)[:-1]
+            local_coords = [(x, y) for x, y in list(local_poly.exterior.coords)[:-1]]
         # Apply the plane-local-to-world transform to each vertex.
         world_coords = [local_to_world(u, v, placement) for u, v in local_coords]
         world_poly = Polygon(world_coords)

--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -197,22 +197,34 @@ def aircraft_parts_world(
     """
     world_parts: list[WorldPart] = []
     for part in aircraft.parts:
-        # Build the part's polygon in plane-local coordinates. ``angle_deg``
-        # rotates the part within plane-local (standard CCW). This is the
-        # "in plane-local frame, where is the part?" step.
-        local_poly = oriented_rect(
-            cx=part.offset_x_m,
-            cy=part.offset_y_m,
-            length=part.length_m,
-            width=part.width_m,
-            angle_deg=part.angle_deg,
-        )
+        if part.local_vertices is not None:
+            # Polygon footprint: rotate each author vertex from the part's own
+            # frame into plane-local by the part's angle+offset (mirroring
+            # oriented_rect's per-corner affine), then route EVERY vertex through
+            # the det(-1) local_to_world transform — no centroid shortcut (ADR-0002).
+            h = math.radians(part.angle_deg)
+            cos_h = math.cos(h)
+            sin_h = math.sin(h)
+            cx = part.offset_x_m
+            cy = part.offset_y_m
+            local_coords = [
+                (cx + x * cos_h - y * sin_h, cy + x * sin_h + y * cos_h)
+                for x, y in part.local_vertices
+            ]
+        else:
+            # Scalar oriented rectangle (back-compat path). ``angle_deg`` rotates
+            # the part within plane-local (standard CCW).
+            local_poly = oriented_rect(
+                cx=part.offset_x_m,
+                cy=part.offset_y_m,
+                length=part.length_m,
+                width=part.width_m,
+                angle_deg=part.angle_deg,
+            )
+            # exterior.coords includes the closing-point duplicate; slice it off.
+            local_coords = list(local_poly.exterior.coords)[:-1]
         # Apply the plane-local-to-world transform to each vertex.
-        # local_poly.exterior.coords includes the closing-point duplicate;
-        # slice it off so Polygon() doesn't have to de-dup.
-        world_coords = [
-            local_to_world(u, v, placement) for u, v in list(local_poly.exterior.coords)[:-1]
-        ]
+        world_coords = [local_to_world(u, v, placement) for u, v in local_coords]
         world_poly = Polygon(world_coords)
         world_parts.append(
             WorldPart(

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -1038,22 +1038,95 @@ def _build_aircraft(entry: Any) -> Aircraft:
     return aircraft
 
 
+# Strict unknown-key allowlist for a `parts[i]` entry, mirroring
+# _ALLOWED_AIRCRAFT_KEYS. `planform` is a YAML-only convenience block expanded
+# into Part.local_vertices by _build_planform (NOT a Part field). Without this,
+# a typo like `planfrm:` would be silently dropped and the wing would stay a
+# rectangle with no error.
+_ALLOWED_PART_KEYS = frozenset(
+    {
+        "kind",
+        "length_m",
+        "width_m",
+        "offset_x_m",
+        "offset_y_m",
+        "angle_deg",
+        "z_bottom_m",
+        "z_top_m",
+        "planform",
+    }
+)
+
+
+def _build_planform(data: Any, span_m: float, index: int) -> tuple[tuple[float, float], ...]:
+    """Expand a parametrized symmetric double-taper wing into part-own vertices.
+
+    Convention (ADR-0024): no sweep, root kink at y=0. In the part's own frame
+    ``+x`` is the chord (forward = leading edge), and ``width_m`` is the span
+    running along ``+-y``. Produces a 6-vertex hexagon; the chord at the root
+    (y=0) is ``root_chord_m`` and at each tip (y=+-span/2) is ``tip_chord_m``.
+    Part.__post_init__ canonicalizes the ring and enforces the bbox subset.
+    """
+    if not isinstance(data, dict):
+        raise LoaderError(f"parts[{index}].planform must be a mapping")
+    required = ("root_chord_m", "tip_chord_m")
+    for key in required:
+        if key not in data:
+            raise LoaderError(f"parts[{index}].planform missing required field {key!r}")
+    unknown = set(data) - set(required)
+    if unknown:
+        raise LoaderError(f"parts[{index}].planform has unknown key(s) {sorted(unknown)}")
+    root = _to_float(data["root_chord_m"], f"parts[{index}].planform.root_chord_m")
+    tip = _to_float(data["tip_chord_m"], f"parts[{index}].planform.tip_chord_m")
+    if root <= 0 or tip <= 0:
+        raise LoaderError(
+            f"parts[{index}].planform chords must be positive, got root={root}, tip={tip}"
+        )
+    if tip > root:
+        raise LoaderError(
+            f"parts[{index}].planform tip_chord_m ({tip}) must not exceed root_chord_m "
+            f"({root}) — a wing does not taper outward"
+        )
+    half_span = span_m / 2.0
+    hr = root / 2.0
+    ht = tip / 2.0
+    return (
+        (hr, 0.0),
+        (ht, half_span),
+        (-ht, half_span),
+        (-hr, 0.0),
+        (-ht, -half_span),
+        (ht, -half_span),
+    )
+
+
 def _build_part(data: Any, index: int) -> Part:
     if not isinstance(data, dict):
         raise LoaderError(f"parts[{index}] must be a mapping")
+    unknown = set(data) - _ALLOWED_PART_KEYS
+    if unknown:
+        raise LoaderError(
+            f"parts[{index}] has unknown key(s) {sorted(unknown)}; "
+            f"allowed: {sorted(_ALLOWED_PART_KEYS)}"
+        )
     required = ("kind", "length_m", "width_m", "z_bottom_m", "z_top_m")
     for key in required:
         if key not in data:
             raise LoaderError(f"parts[{index}] missing required field {key!r}")
+    width_m = _to_float(data["width_m"], f"parts[{index}].width_m")
+    local_vertices = None
+    if "planform" in data:
+        local_vertices = _build_planform(data["planform"], width_m, index)
     return Part(
         kind=data["kind"],
         length_m=_to_float(data["length_m"], f"parts[{index}].length_m"),
-        width_m=_to_float(data["width_m"], f"parts[{index}].width_m"),
+        width_m=width_m,
         offset_x_m=_to_float(data.get("offset_x_m", 0.0), f"parts[{index}].offset_x_m"),
         offset_y_m=_to_float(data.get("offset_y_m", 0.0), f"parts[{index}].offset_y_m"),
         angle_deg=_to_float(data.get("angle_deg", 0.0), f"parts[{index}].angle_deg"),
         z_bottom_m=_to_float(data["z_bottom_m"], f"parts[{index}].z_bottom_m"),
         z_top_m=_to_float(data["z_top_m"], f"parts[{index}].z_top_m"),
+        local_vertices=local_vertices,
     )
 
 

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -1058,7 +1058,9 @@ _ALLOWED_PART_KEYS = frozenset(
 )
 
 
-def _build_planform(data: Any, span_m: float, index: int) -> tuple[tuple[float, float], ...]:
+def _build_planform(
+    data: Any, span_m: float, length_m: float, index: int
+) -> tuple[tuple[float, float], ...]:
     """Expand a parametrized symmetric double-taper wing into part-own vertices.
 
     Convention (ADR-0024): no sweep, root kink at y=0. In the part's own frame
@@ -1087,6 +1089,11 @@ def _build_planform(data: Any, span_m: float, index: int) -> tuple[tuple[float, 
             f"parts[{index}].planform tip_chord_m ({tip}) must not exceed root_chord_m "
             f"({root}) — a wing does not taper outward"
         )
+    if root > length_m:
+        raise LoaderError(
+            f"parts[{index}].planform root_chord_m ({root}) must not exceed the part "
+            f"length_m ({length_m}); the planform must fit the part bbox"
+        )
     half_span = span_m / 2.0
     hr = root / 2.0
     ht = tip / 2.0
@@ -1113,13 +1120,19 @@ def _build_part(data: Any, index: int) -> Part:
     for key in required:
         if key not in data:
             raise LoaderError(f"parts[{index}] missing required field {key!r}")
+    if "planform" in data and data["kind"] != "wing":
+        raise LoaderError(
+            f"parts[{index}]: planform: is only valid on a kind 'wing' part, "
+            f"got kind {data['kind']!r}"
+        )
     width_m = _to_float(data["width_m"], f"parts[{index}].width_m")
+    length_m = _to_float(data["length_m"], f"parts[{index}].length_m")
     local_vertices = None
     if "planform" in data:
-        local_vertices = _build_planform(data["planform"], width_m, index)
+        local_vertices = _build_planform(data["planform"], width_m, length_m, index)
     return Part(
         kind=data["kind"],
-        length_m=_to_float(data["length_m"], f"parts[{index}].length_m"),
+        length_m=length_m,
         width_m=width_m,
         offset_x_m=_to_float(data.get("offset_x_m", 0.0), f"parts[{index}].offset_x_m"),
         offset_y_m=_to_float(data.get("offset_y_m", 0.0), f"parts[{index}].offset_y_m"),
@@ -1285,6 +1298,11 @@ def _split_fuselage(fuselage: Part, wing: Part) -> list[Part]:
     aft of the tail) — a degenerate split that would produce a zero- or
     negative-length segment.
     """
+    if fuselage.local_vertices is not None:
+        raise LoaderError(
+            "a fuselage part may not carry a polygon footprint (local_vertices); "
+            "polygon footprints are wing-only"
+        )
     c = fuselage.offset_x_m
     half_len = fuselage.length_m / 2.0
     nose_x = c + half_len  # forward tip (+x)

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -14,12 +14,13 @@ from __future__ import annotations
 
 import math
 import typing
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal, cast
 
 from shapely import box, union_all
+from shapely.geometry import LinearRing
 from shapely.geometry.base import BaseGeometry
 
 if TYPE_CHECKING:
@@ -37,6 +38,67 @@ _VALID_PART_KINDS = frozenset(typing.get_args(PartKind))
 _VALID_WING_POSITIONS = frozenset(typing.get_args(WingPosition))
 _VALID_GEARS = frozenset(typing.get_args(Gear))
 _VALID_MOVEMENT_MODES = frozenset(typing.get_args(MovementMode))
+
+# Below this absolute |2·signed-area| a ring is treated as degenerate
+# (zero-area / collinear). 1e-9 m² is far tighter than any real part.
+_RING_MIN_ABS_SIGNED_AREA = 1e-9
+# Float slack for the local_vertices-within-bbox containment check.
+_PART_BBOX_TOL_M = 1e-9
+
+
+def _canonicalize_ring(
+    vertices: Sequence[tuple[float, float]],
+) -> tuple[tuple[float, float], ...]:
+    """Canonicalize an author-supplied polygon ring to a deterministic form.
+
+    Returns the ring OPEN (no closing duplicate), wound counter-clockwise,
+    rotated so the lexicographically-smallest vertex is first. Two orderings
+    of the SAME shape therefore produce a byte-identical tuple — the
+    determinism contract (ADR-0003) for polygon parts, since the geometry
+    layer never re-orients at solve time (Shapely preserves vertex order
+    verbatim). Rejects non-finite, fewer-than-3-vertex, degenerate
+    (zero-area / collinear), and self-intersecting rings.
+    """
+    pts = [(float(x), float(y)) for x, y in vertices]
+    # Drop an explicit closing duplicate if the author supplied one.
+    if len(pts) >= 2 and pts[0] == pts[-1]:
+        pts = pts[:-1]
+    if len(pts) < 3:
+        raise ValueError(f"polygon ring needs >= 3 distinct vertices, got {len(pts)}")
+    if not all(math.isfinite(x) and math.isfinite(y) for x, y in pts):
+        raise ValueError(f"polygon ring has a non-finite vertex: {pts}")
+    # Reject self-intersection (bow-ties) — shapely is the well-tested oracle.
+    # This check runs BEFORE the shoelace degeneracy gate so that a self-intersecting
+    # ring with non-zero shoelace area (e.g. a bowtie whose triangles don't cancel)
+    # is caught here. Collinear rings are also not-simple per Shapely, but their
+    # shoelace area is effectively zero — so we check collinearity first via the
+    # max absolute cross product, and emit "degenerate" for those, letting the
+    # self-intersection check handle true geometric crossings.
+    n = len(pts)
+    max_cross = max(
+        abs(
+            (pts[(i + 1) % n][0] - pts[i][0]) * (pts[(i + 2) % n][1] - pts[i][1])
+            - (pts[(i + 1) % n][1] - pts[i][1]) * (pts[(i + 2) % n][0] - pts[i][0])
+        )
+        for i in range(n)
+    )
+    if max_cross < _RING_MIN_ABS_SIGNED_AREA:
+        raise ValueError(f"polygon ring is degenerate (near-zero area): {pts}")
+    if not LinearRing([*pts, pts[0]]).is_simple:
+        raise ValueError(f"polygon ring self-intersects: {pts}")
+    # Signed area (shoelace) gives both the winding sign and a final degeneracy check.
+    signed_area2 = sum(
+        pts[i][0] * pts[(i + 1) % n][1] - pts[(i + 1) % n][0] * pts[i][1] for i in range(n)
+    )
+    if abs(signed_area2) < _RING_MIN_ABS_SIGNED_AREA:
+        raise ValueError(f"polygon ring is degenerate (near-zero area): {pts}")
+    # Force counter-clockwise (positive signed area).
+    if signed_area2 < 0:
+        pts = list(reversed(pts))
+    # Rotate to the lexicographically-minimum start vertex.
+    start = min(range(len(pts)), key=lambda i: pts[i])
+    pts = pts[start:] + pts[:start]
+    return tuple(pts)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -136,6 +136,7 @@ class Part:
     angle_deg: float
     z_bottom_m: float
     z_top_m: float
+    local_vertices: tuple[tuple[float, float], ...] | None = None
 
     def __post_init__(self) -> None:
         if self.kind not in _VALID_PART_KINDS:
@@ -155,6 +156,18 @@ class Part:
                 f"Part {self.kind!r}: z_top_m must exceed z_bottom_m, "
                 f"got z_bottom={self.z_bottom_m}, z_top={self.z_top_m}"
             )
+        if self.local_vertices is not None:
+            canonical = _canonicalize_ring(self.local_vertices)
+            half_l = self.length_m / 2.0
+            half_w = self.width_m / 2.0
+            for x, y in canonical:
+                if abs(x) > half_l + _PART_BBOX_TOL_M or abs(y) > half_w + _PART_BBOX_TOL_M:
+                    raise ValueError(
+                        f"Part {self.kind!r}: local_vertices vertex ({x}, {y}) lies outside "
+                        f"the length_m x width_m bbox (+/-{half_l} x +/-{half_w}); the polygon "
+                        f"footprint must be a subset of the bounding box"
+                    )
+            object.__setattr__(self, "local_vertices", canonical)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -45,10 +45,13 @@ _RING_MIN_ABS_SIGNED_AREA = 1e-9
 # Float slack for the local_vertices-within-bbox containment check.
 _PART_BBOX_TOL_M = 1e-9
 
+# A 2D point in a part's own (plane-local) frame; a polygon ring is a tuple of these.
+Vertex = tuple[float, float]
+
 
 def _canonicalize_ring(
-    vertices: Sequence[tuple[float, float]],
-) -> tuple[tuple[float, float], ...]:
+    vertices: Sequence[Vertex],
+) -> tuple[Vertex, ...]:
     """Canonicalize an author-supplied polygon ring to a deterministic form.
 
     Returns the ring OPEN (no closing duplicate), wound counter-clockwise,
@@ -67,13 +70,14 @@ def _canonicalize_ring(
         raise ValueError(f"polygon ring needs >= 3 distinct vertices, got {len(pts)}")
     if not all(math.isfinite(x) and math.isfinite(y) for x, y in pts):
         raise ValueError(f"polygon ring has a non-finite vertex: {pts}")
-    # Reject self-intersection (bow-ties) — shapely is the well-tested oracle.
-    # This check runs BEFORE the shoelace degeneracy gate so that a self-intersecting
-    # ring with non-zero shoelace area (e.g. a bowtie whose triangles don't cancel)
-    # is caught here. Collinear rings are also not-simple per Shapely, but their
-    # shoelace area is effectively zero — so we check collinearity first via the
-    # max absolute cross product, and emit "degenerate" for those, letting the
-    # self-intersection check handle true geometric crossings.
+    # Degeneracy + self-intersection gates, in this order so each case gets the
+    # right error message:
+    #   (a) max |cross-product| over consecutive triples == 0  -> "degenerate"
+    #       (rejects FULLY collinear / zero-area rings; a redundant collinear
+    #       vertex on an otherwise-valid ring is tolerated, not rejected).
+    #   (b) Shapely LinearRing.is_simple is False                -> "self-intersects".
+    #   (c) shoelace signed area: its SIGN drives the CCW flip below; the
+    #       |area| < eps check is defense-in-depth, unreachable after (a)+(b).
     n = len(pts)
     max_cross = max(
         abs(
@@ -91,7 +95,7 @@ def _canonicalize_ring(
         pts[i][0] * pts[(i + 1) % n][1] - pts[(i + 1) % n][0] * pts[i][1] for i in range(n)
     )
     # Defense-in-depth: unreachable for a simple, non-collinear polygon (both gated above).
-    if abs(signed_area2) < _RING_MIN_ABS_SIGNED_AREA:
+    if abs(signed_area2) < _RING_MIN_ABS_SIGNED_AREA:  # pragma: no cover
         raise ValueError(f"polygon ring is degenerate (near-zero area): {pts}")
     # Force counter-clockwise (positive signed area).
     if signed_area2 < 0:
@@ -137,7 +141,7 @@ class Part:
     angle_deg: float
     z_bottom_m: float
     z_top_m: float
-    local_vertices: tuple[tuple[float, float], ...] | None = None
+    local_vertices: tuple[Vertex, ...] | None = None
 
     def __post_init__(self) -> None:
         if self.kind not in _VALID_PART_KINDS:
@@ -161,6 +165,10 @@ class Part:
             canonical = _canonicalize_ring(self.local_vertices)
             half_l = self.length_m / 2.0
             half_w = self.width_m / 2.0
+            # The polygon is checked against the axis-aligned bbox in the part's
+            # OWN (unrotated) frame. That is sufficient even when angle_deg != 0:
+            # aircraft_parts_world rotates the polygon and the bbox together, and a
+            # rigid rotation preserves the subset relation.
             for x, y in canonical:
                 if abs(x) > half_l + _PART_BBOX_TOL_M or abs(y) > half_w + _PART_BBOX_TOL_M:
                     raise ValueError(

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -84,12 +84,13 @@ def _canonicalize_ring(
     )
     if max_cross < _RING_MIN_ABS_SIGNED_AREA:
         raise ValueError(f"polygon ring is degenerate (near-zero area): {pts}")
-    if not LinearRing([*pts, pts[0]]).is_simple:
+    if not LinearRing(pts).is_simple:
         raise ValueError(f"polygon ring self-intersects: {pts}")
     # Signed area (shoelace) gives both the winding sign and a final degeneracy check.
     signed_area2 = sum(
         pts[i][0] * pts[(i + 1) % n][1] - pts[(i + 1) % n][0] * pts[i][1] for i in range(n)
     )
+    # Defense-in-depth: unreachable for a simple, non-collinear polygon (both gated above).
     if abs(signed_area2) < _RING_MIN_ABS_SIGNED_AREA:
         raise ValueError(f"polygon ring is degenerate (near-zero area): {pts}")
     # Force counter-clockwise (positive signed area).

--- a/tests/fixtures/fleet_taper.yaml
+++ b/tests/fixtures/fleet_taper.yaml
@@ -1,0 +1,45 @@
+# TEST-ONLY fleet for the polygon-parts determinism canary (#548). One tapered
+# glider authored via a `planform:` block so the polygon build-path + load-time
+# canonicalization are exercised through solve(). NOT shipped data.
+aircraft:
+  - id: taper_glider
+    name: "Taper Glider (test)"
+    wing_position: high
+    gear: monowheel
+    movement_mode: always_cart
+    turn_radius_m: null
+    measured: false
+    parts:
+      - kind: fuselage
+        length_m: 7.6
+        width_m: 0.7
+        offset_x_m: 0.0
+        offset_y_m: 0.0
+        z_bottom_m: 0.0
+        z_top_m: 1.5
+      - kind: wing
+        length_m: 1.2
+        width_m: 18.0
+        offset_x_m: 1.5
+        offset_y_m: 0.0
+        z_bottom_m: 1.9
+        z_top_m: 2.1
+        planform:
+          root_chord_m: 1.2
+          tip_chord_m: 0.54
+      - kind: tail
+        length_m: 0.9
+        width_m: 2.6
+        offset_x_m: -3.35
+        offset_y_m: 0.0
+        z_bottom_m: 1.2
+        z_top_m: 1.5
+      - kind: vertical_stabilizer
+        length_m: 1.1
+        width_m: 0.15
+        offset_x_m: -3.25
+        offset_y_m: 0.0
+        z_bottom_m: 1.5
+        z_top_m: 1.68
+    wheels:
+      main_offset_x_m: 0.0

--- a/tests/fixtures/hangar_taper.yaml
+++ b/tests/fixtures/hangar_taper.yaml
@@ -1,0 +1,13 @@
+# Roomy test hangar for the polygon-taper determinism canary (#548). Large
+# enough for one 18 m-span tapered glider. Synthetic placeholder dimensions.
+length_m: 25.0
+width_m: 22.0
+door:
+  center_x_m: 11.0
+  width_m: 12.0
+maintenance_bay:
+  center_x_m: 18.0
+  width_m: 8.0
+  depth_m: 9.0
+clearance_m: 0.3
+wing_layer_clearance_m: 0.2

--- a/tests/fixtures/solve_taper_determinism.yaml
+++ b/tests/fixtures/solve_taper_determinism.yaml
@@ -1,0 +1,5 @@
+# Determinism canary scenario (#548): place the tapered glider so the polygon
+# build-path runs inside solve()'s seeded restart loop.
+fleet: fleet_taper.yaml
+hangar: hangar_taper.yaml
+fleet_in: [taper_glider]

--- a/tests/test_fleet_polygon_optin.py
+++ b/tests/test_fleet_polygon_optin.py
@@ -1,0 +1,23 @@
+"""PR1 guarantee: the polygon-parts feature ships PLUMBING only. No shipped
+fleet aircraft is authored as a polygon yet, so every shipped Part keeps
+local_vertices=None and the real fleets stay byte-identical. The Scheibe taper
+lands in a later PR once the viewer renders N-gon (#548 stack)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.loader import load_fleet
+
+_SHIPPED_FLEETS = ["data/fleet.yaml", "examples/herrenteich/fleet.yaml"]
+
+
+@pytest.mark.parametrize("path", _SHIPPED_FLEETS)
+def test_shipped_fleet_has_no_polygon_parts(path: str) -> None:
+    fleet = load_fleet(path)
+    for ac in fleet.values():
+        for part in ac.parts:
+            assert part.local_vertices is None, (
+                f"{path}:{ac.id} part {part.kind!r} unexpectedly carries a polygon "
+                f"footprint; PR1 must keep shipped fleets byte-identical"
+            )

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -568,7 +568,7 @@ class TestAircraftPartsWorldPolygon:
         to the SAME world polygon as the scalar oriented_rect path — proving the
         polygon branch routes every vertex through the det(-1) transform."""
         hl, hw = 1.0, 5.0  # length_m=2, width_m=10
-        rect_corners = [(hl, -hw), (hl, hw), (-hl, hw), (-hl, -hw)]
+        rect_corners = ((hl, -hw), (hl, hw), (-hl, hw), (-hl, -hw))
         scalar = _aircraft_with_one_part(
             Part(
                 kind="wing",
@@ -602,7 +602,7 @@ class TestAircraftPartsWorldPolygon:
     def test_taper_polygon_is_strict_subset_area_of_bbox(self) -> None:
         """A tapered hexagon transforms to a world polygon with LESS area than
         the bounding rectangle (the conservative footprint direction)."""
-        taper = [(1.0, 0.0), (0.4, 5.0), (-0.4, 5.0), (-1.0, 0.0), (-0.4, -5.0), (0.4, -5.0)]
+        taper = ((1.0, 0.0), (0.4, 5.0), (-0.4, 5.0), (-1.0, 0.0), (-0.4, -5.0), (0.4, -5.0))
         scalar = _aircraft_with_one_part(
             Part(
                 kind="wing",

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -560,3 +560,76 @@ class TestAircraftPartsWorldOnRealAircraft:
         assert _almost_equal(strut_xs[0], -strut_xs[1], tol=1e-6), (
             f"struts should mirror across world x=0, got centroids at {strut_xs}"
         )
+
+
+class TestAircraftPartsWorldPolygon:
+    def test_rectangle_vertices_match_scalar_path_at_45deg(self) -> None:
+        """A part whose local_vertices ARE its rectangle corners must transform
+        to the SAME world polygon as the scalar oriented_rect path — proving the
+        polygon branch routes every vertex through the det(-1) transform."""
+        hl, hw = 1.0, 5.0  # length_m=2, width_m=10
+        rect_corners = [(hl, -hw), (hl, hw), (-hl, hw), (-hl, -hw)]
+        scalar = _aircraft_with_one_part(
+            Part(
+                kind="wing",
+                length_m=2.0,
+                width_m=10.0,
+                offset_x_m=0.3,
+                offset_y_m=-0.2,
+                angle_deg=0.0,
+                z_bottom_m=1.9,
+                z_top_m=2.1,
+            )
+        )
+        poly = _aircraft_with_one_part(
+            Part(
+                kind="wing",
+                length_m=2.0,
+                width_m=10.0,
+                offset_x_m=0.3,
+                offset_y_m=-0.2,
+                angle_deg=0.0,
+                z_bottom_m=1.9,
+                z_top_m=2.1,
+                local_vertices=rect_corners,
+            )
+        )
+        pl = Placement(plane_id="probe", x_m=4.0, y_m=7.0, heading_deg=45.0, on_carts=False)
+        [ws] = aircraft_parts_world(scalar, pl)
+        [wp] = aircraft_parts_world(poly, pl)
+        assert wp.polygon.equals(ws.polygon)
+
+    def test_taper_polygon_is_strict_subset_area_of_bbox(self) -> None:
+        """A tapered hexagon transforms to a world polygon with LESS area than
+        the bounding rectangle (the conservative footprint direction)."""
+        taper = [(1.0, 0.0), (0.4, 5.0), (-0.4, 5.0), (-1.0, 0.0), (-0.4, -5.0), (0.4, -5.0)]
+        scalar = _aircraft_with_one_part(
+            Part(
+                kind="wing",
+                length_m=2.0,
+                width_m=10.0,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=1.9,
+                z_top_m=2.1,
+            )
+        )
+        poly = _aircraft_with_one_part(
+            Part(
+                kind="wing",
+                length_m=2.0,
+                width_m=10.0,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=1.9,
+                z_top_m=2.1,
+                local_vertices=taper,
+            )
+        )
+        pl = Placement(plane_id="probe", x_m=0.0, y_m=0.0, heading_deg=45.0, on_carts=False)
+        [ws] = aircraft_parts_world(scalar, pl)
+        [wp] = aircraft_parts_world(poly, pl)
+        assert wp.polygon.area < ws.polygon.area
+        assert wp.polygon.within(ws.polygon.buffer(1e-9))

--- a/tests/test_loader_planform.py
+++ b/tests/test_loader_planform.py
@@ -1,0 +1,63 @@
+"""Loader tests for the parametrized `planform:` wing block (#548)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.loader import LoaderError, _build_part
+
+
+def _wing_data(**planform):
+    return {
+        "kind": "wing",
+        "length_m": 2.0,
+        "width_m": 10.0,
+        "offset_x_m": 1.5,
+        "z_bottom_m": 1.9,
+        "z_top_m": 2.1,
+        "planform": {"root_chord_m": 2.0, "tip_chord_m": 0.9, **planform},
+    }
+
+
+def test_planform_expands_to_canonical_hexagon() -> None:
+    part = _build_part(_wing_data(), 0)
+    assert part.local_vertices is not None
+    assert len(part.local_vertices) == 6
+    # Within the 2.0 x 10.0 bbox.
+    for x, y in part.local_vertices:
+        assert abs(x) <= 1.0 + 1e-9
+        assert abs(y) <= 5.0 + 1e-9
+
+
+def test_planform_absent_leaves_local_vertices_none() -> None:
+    data = {"kind": "wing", "length_m": 2.0, "width_m": 10.0, "z_bottom_m": 1.9, "z_top_m": 2.1}
+    assert _build_part(data, 0).local_vertices is None
+
+
+def test_planform_rejects_tip_exceeding_root() -> None:
+    with pytest.raises(LoaderError, match="taper outward"):
+        _build_part(_wing_data(root_chord_m=1.0, tip_chord_m=1.5), 0)
+
+
+def test_planform_rejects_root_exceeding_length_bbox() -> None:
+    # root_chord 3.0 > length_m 2.0 -> a vertex pokes outside the bbox.
+    with pytest.raises((LoaderError, ValueError), match="bbox"):
+        _build_part(_wing_data(root_chord_m=3.0, tip_chord_m=0.9), 0)
+
+
+def test_planform_rejects_unknown_nested_key() -> None:
+    with pytest.raises(LoaderError, match="unknown key"):
+        _build_part(_wing_data(sweep_deg=3.0), 0)
+
+
+def test_build_part_rejects_unknown_part_key() -> None:
+    data = {
+        "kind": "wing",
+        "length_m": 2.0,
+        "width_m": 10.0,
+        "z_bottom_m": 1.9,
+        "z_top_m": 2.1,
+        "planfrm": {},
+    }
+    with pytest.raises(LoaderError, match="unknown key"):
+        _build_part(data, 0)

--- a/tests/test_loader_planform.py
+++ b/tests/test_loader_planform.py
@@ -61,3 +61,16 @@ def test_build_part_rejects_unknown_part_key() -> None:
     }
     with pytest.raises(LoaderError, match="unknown key"):
         _build_part(data, 0)
+
+
+def test_planform_rejected_on_non_wing_part() -> None:
+    data = {
+        "kind": "fuselage",
+        "length_m": 6.0,
+        "width_m": 0.8,
+        "z_bottom_m": 0.0,
+        "z_top_m": 1.5,
+        "planform": {"root_chord_m": 6.0, "tip_chord_m": 3.0},
+    }
+    with pytest.raises(LoaderError, match="only valid on a kind 'wing'"):
+        _build_part(data, 0)

--- a/tests/test_part_polygon.py
+++ b/tests/test_part_polygon.py
@@ -1,0 +1,104 @@
+"""Polygon-part canonicalization + Part.local_vertices tests (issue #548).
+
+The canonicalization invariant is the determinism crux (ADR-0003): two
+orderings of the same ring MUST produce a byte-identical canonical tuple.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from hangarfit.models import Part, _canonicalize_ring
+
+# A simple CCW unit square, vertices listed from a non-lex-min start.
+_SQUARE_CCW = [(1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)]
+# Same square wound CW.
+_SQUARE_CW = [(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)]
+
+
+def test_canonicalize_forces_ccw_and_lexmin_start() -> None:
+    canon = _canonicalize_ring(_SQUARE_CCW)
+    # Lex-min vertex (0,0) is first.
+    assert canon[0] == (0.0, 0.0)
+    # Wound CCW: signed area positive.
+    n = len(canon)
+    area2 = sum(
+        canon[i][0] * canon[(i + 1) % n][1] - canon[(i + 1) % n][0] * canon[i][1] for i in range(n)
+    )
+    assert area2 > 0
+
+
+def test_canonicalize_equivalent_orderings_are_identical() -> None:
+    """CCW, CW, and rotated inputs of the same shape canonicalize identically."""
+    rotated = _SQUARE_CCW[2:] + _SQUARE_CCW[:2]
+    assert _canonicalize_ring(_SQUARE_CCW) == _canonicalize_ring(_SQUARE_CW)
+    assert _canonicalize_ring(_SQUARE_CCW) == _canonicalize_ring(rotated)
+
+
+def test_canonicalize_drops_closing_duplicate() -> None:
+    closed = [*_SQUARE_CCW, _SQUARE_CCW[0]]
+    assert _canonicalize_ring(closed) == _canonicalize_ring(_SQUARE_CCW)
+
+
+def test_canonicalize_rejects_too_few_vertices() -> None:
+    with pytest.raises(ValueError, match="3"):
+        _canonicalize_ring([(0.0, 0.0), (1.0, 1.0)])
+
+
+def test_canonicalize_rejects_non_finite() -> None:
+    with pytest.raises(ValueError, match="non-finite"):
+        _canonicalize_ring([(0.0, 0.0), (1.0, 0.0), (math.inf, 1.0)])
+
+
+def test_canonicalize_rejects_degenerate_collinear() -> None:
+    with pytest.raises(ValueError, match="degenerate"):
+        _canonicalize_ring([(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)])
+
+
+def test_canonicalize_rejects_self_intersecting_bowtie() -> None:
+    with pytest.raises(ValueError, match="self-intersect"):
+        _canonicalize_ring([(0.0, 0.0), (1.0, 1.0), (1.0, 0.0), (0.0, 1.0)])
+
+
+def _wing(**kw):
+    base = dict(
+        kind="wing",
+        length_m=2.0,
+        width_m=10.0,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=1.9,
+        z_top_m=2.1,
+    )
+    base.update(kw)
+    return Part(**base)
+
+
+def test_part_defaults_local_vertices_none() -> None:
+    assert _wing().local_vertices is None
+
+
+def test_part_canonicalizes_local_vertices_on_construction() -> None:
+    # A hexagon taper, listed CW from a non-lex-min start; must come back canonical.
+    verts = [(1.0, 0.0), (0.4, -5.0), (-0.4, -5.0), (-1.0, 0.0), (-0.4, 5.0), (0.4, 5.0)]
+    p = _wing(local_vertices=verts)
+    assert p.local_vertices == _canonicalize_ring(verts)
+    # Canonical: lex-min start, CCW.
+    assert p.local_vertices[0] == min(p.local_vertices)
+
+
+def test_part_rejects_local_vertices_outside_bbox() -> None:
+    # Vertex x=1.5 exceeds half-length (length_m/2 = 1.0).
+    verts = [(1.5, 0.0), (0.4, 5.0), (-0.4, 5.0), (-1.0, 0.0), (-0.4, -5.0), (0.4, -5.0)]
+    with pytest.raises(ValueError, match="bbox"):
+        _wing(local_vertices=verts)
+
+
+def test_part_local_vertices_within_bbox_ok() -> None:
+    # Tip/root within the 2.0 x 10.0 box; touching the boundary is allowed.
+    verts = [(1.0, 0.0), (0.4, 5.0), (-0.4, 5.0), (-1.0, 0.0), (-0.4, -5.0), (0.4, -5.0)]
+    p = _wing(local_vertices=verts)
+    assert len(p.local_vertices) == 6

--- a/tests/test_part_polygon.py
+++ b/tests/test_part_polygon.py
@@ -87,6 +87,7 @@ def test_part_canonicalizes_local_vertices_on_construction() -> None:
     p = _wing(local_vertices=verts)
     assert p.local_vertices == _canonicalize_ring(verts)
     # Canonical: lex-min start, CCW.
+    assert p.local_vertices is not None
     assert p.local_vertices[0] == min(p.local_vertices)
 
 
@@ -101,4 +102,5 @@ def test_part_local_vertices_within_bbox_ok() -> None:
     # Tip/root within the 2.0 x 10.0 box; touching the boundary is allowed.
     verts = [(1.0, 0.0), (0.4, 5.0), (-0.4, 5.0), (-1.0, 0.0), (-0.4, -5.0), (0.4, -5.0)]
     p = _wing(local_vertices=verts)
+    assert p.local_vertices is not None
     assert len(p.local_vertices) == 6

--- a/tests/test_part_polygon.py
+++ b/tests/test_part_polygon.py
@@ -74,7 +74,7 @@ def _wing(**kw):
         z_top_m=2.1,
     )
     base.update(kw)
-    return Part(**base)
+    return Part(**base)  # type: ignore[arg-type]
 
 
 def test_part_defaults_local_vertices_none() -> None:

--- a/tests/test_solver_canaries.py
+++ b/tests/test_solver_canaries.py
@@ -255,6 +255,33 @@ def test_solve_deterministic_best_partial_under_max_restarts() -> None:
     assert bpl1.maintenance_plane == bpl2.maintenance_plane
 
 
+def test_solve_deterministic_polygon_taper_fleet() -> None:
+    """A fleet whose wing is a polygon (tapered hexagon) solves bit-identically
+    across two runs under a fixed max_restarts cap — proving the polygon
+    build-path + load-time vertex canonicalization are determinism-safe
+    (ADR-0003). max_restarts (not wall-clock) makes this load-independent, so
+    it stays in the parallel pool (no `serial` mark)."""
+    fixture = "tests/fixtures/solve_taper_determinism.yaml"
+    cfg = SearchConfig(max_restarts=8, spread=False, nose_out=False)
+
+    s1 = load_scenario(fixture)
+    r1 = solve(s1, budget_s=30.0, alternatives=1, seed=42, search=cfg)
+    s2 = load_scenario(fixture)
+    r2 = solve(s2, budget_s=30.0, alternatives=1, seed=42, search=cfg)
+
+    assert r1.status == r2.status
+    assert len(r1.layouts) == len(r2.layouts)
+    for la, lb in zip(r1.layouts, r2.layouts, strict=True):
+        assert la.placements == lb.placements
+        assert la.maintenance_plane == lb.maintenance_plane
+
+    bp1 = r1.diagnostics.best_partial_layout
+    bp2 = r2.diagnostics.best_partial_layout
+    if bp1 is not None:
+        assert bp2 is not None
+        assert bp1.placements == bp2.placements
+
+
 def test_solve_budget_trips_before_max_restarts() -> None:
     """When ``budget_s`` would cut the loop short of ``max_restarts``,
     the budget gate wins — exercises the compound termination


### PR DESCRIPTION
Closes #548 — re-scoped to the **plumbing** (the glider taper *data* + flip-window regression are carved into a follow-up issue; see the stack design).

**PR1 of a 3-PR polygon-parts stack.** Design spec: `docs/superpowers/specs/2026-06-10-realistic-polygon-plane-geometry-design.md`; plan: `docs/superpowers/plans/2026-06-10-polygon-parts-pr1-collision.md`.

## What
- **`models.Part.local_vertices`** — optional polygon footprint (part-own frame), **load-time-canonicalized** in `__post_init__` (force-CCW, lex-min start, drop closing dup, reject degenerate/non-finite/self-intersecting) and constrained to the `length_m × width_m` bbox. This canonicalization is the **ADR-0003 determinism crux** — two equivalent author orderings → byte-identical `Part`.
- **`geometry.aircraft_parts_world`** — polygon build-path that routes **every** vertex through the det(−1) `local_to_world` (ADR-0002), no centroid shortcut.
- **`loader`** — a parametrized `planform: {root_chord_m, tip_chord_m}` wing block (mirrors `struts:`) expanding into a hexagon; plus a part-level unknown-key allowlist (`planfrm:` now fails loud). No raw `vertices:` field (no honest data source — spike #541 Q2).
- **ADR-0024** (refines ADR-0001's mesh deferral) + arc42 "parts model" note + CHANGELOG.

## Guarantees
- **Scalar fleets are byte-identical** — no shipped fleet authors a polygon yet (guarded by `test_fleet_polygon_optin.py`); the 3D viewer keeps rendering boxes until #549.
- **Determinism** exercised by a new *placed-taper* `solve()` double-solve canary (`test_solver_canaries.py`) — the existing canaries exclude/bay-park the Scheibe, so they never exercise the polygon ring.

## Verification
`ruff` clean · `mypy src/hangarfit/` clean · **1512 passed, 8 deselected**.

## Stack / forward-compat
PR2 = `scene/v2` viewer realism (#549); PR3 = glider taper data + flip-window regression (new issue). Seams left open (design-only) for a future wing-tilt DoF and true-3D meshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)