### PR TITLE
ci(codecov): make patch/project statuses informational (#589)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+# Codecov configuration — see https://docs.codecov.com/docs/codecovyml-reference
+#
+# Why this exists (#589): Codecov's `patch`/`project` status checks were never
+# required checks on `develop` or `main` (required = `test (3.12)`, the three
+# lockfile-drift jobs, `bench correctness`; see CLAUDE.md). They are a *signal*,
+# not a merge gate. Yet under the default auto-target they post a RED conclusion
+# whenever a diff dips below the project's current coverage — most visibly on
+# every **release PR**, whose cumulative `vX.Y.Z..develop` diff vs `main` lands a
+# couple of points under target (e.g. PR #587: 95.09% patch vs 97.17% target).
+# That red is structural noise, not a regression, and it merged anyway.
+#
+# `informational: true` makes both statuses *always pass* while still posting the
+# coverage numbers to the PR (docs: "the resulting status will pass no matter what
+# the coverage is ... great if you want to expose codecov information without
+# gating PRs"). This formalises the already-documented stance: codecov reports,
+# it does not block. The coverage % stays visible on every PR — only the misleading
+# red X (on a non-blocking check) goes away.
+#
+# Contributors should still watch the patch number on feature PRs and keep
+# >= 1 non-slow test per new path (docs/dev/test-flakes-and-ci-gotchas.md §3-§4).
+
+coverage:
+  status:
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        informational: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,9 @@
 # Codecov configuration — see https://docs.codecov.com/docs/codecovyml-reference
 #
 # Why this exists (#589): Codecov's `patch`/`project` status checks were never
-# required checks on `develop` or `main` (required = `test (3.12)`, the three
-# lockfile-drift jobs, `bench correctness`; see CLAUDE.md). They are a *signal*,
+# required checks on `develop` or `main` (required on `develop` = `test (3.12)`,
+# the three lockfile-drift jobs, `Analyze (Python)` CodeQL, `bench correctness`;
+# `main` is the same minus `Analyze`; see CLAUDE.md). They are a *signal*,
 # not a merge gate. Yet under the default auto-target they post a RED conclusion
 # whenever a diff dips below the project's current coverage — most visibly on
 # every **release PR**, whose cumulative `vX.Y.Z..develop` diff vs `main` lands a

--- a/docs/dev/test-flakes-and-ci-gotchas.md
+++ b/docs/dev/test-flakes-and-ci-gotchas.md
@@ -61,13 +61,36 @@ pytest -m "serial and not slow" --cov-append
 
 — and derives coverage from the **combined** run, so marking a test `@slow` drops
 it from coverage too. If a `@slow` test is the only one covering a new code path,
-the `codecov/patch` PR check fails — keep **≥ 1 non-slow test per new path**.
+the `codecov/patch` number dips for that path (the check is *informational* since
+#589 — it reports, never fails; see §5) — still keep **≥ 1 non-slow test per new
+path** so the signal stays honest.
 
 ## 4. ProcessPool/spawn workers are a coverage blind spot
 
 `coverage.py` does **not** measure ProcessPool/spawn **worker** subprocesses, so
 code that only runs inside a worker (e.g. `solver._run_restart_worker`, #544)
-reads as uncovered even when tests *do* exercise it via the pool → `codecov/patch`
-flags it (non-blocking). #561 closed this for the #544 worker by calling the
-worker fn **in-process** in a unit test (the worker is usually a thin wrapper; or
-wire coverage `concurrency=multiprocessing` + `COVERAGE_PROCESS_START`).
+reads as uncovered even when tests *do* exercise it via the pool → it drags the
+`codecov/patch` number down (informational, see §5). #561 closed this for the #544
+worker by calling the worker fn **in-process** in a unit test (the worker is
+usually a thin wrapper; or wire coverage `concurrency=multiprocessing` +
+`COVERAGE_PROCESS_START`).
+
+## 5. Codecov statuses are informational, not gates
+
+There is a committed [`codecov.yml`](../../codecov.yml) that sets both
+`coverage.status.patch` and `coverage.status.project` to `informational: true`,
+so **the `codecov/patch` and `codecov/project` checks always pass** while still
+posting the coverage numbers on every PR. Two reasons (#589):
+
+1. Neither status was ever a *required* check on `develop`/`main` (required =
+   `test (3.12)`, the three lockfile-drift jobs, `bench correctness`). They are a
+   signal, not a merge gate — `informational: true` just stops them rendering a
+   misleading red **X** on a check that never blocked.
+2. Under the default auto-target, every **release PR** went red: its cumulative
+   `vX.Y.Z..develop` diff vs `main` lands a couple of points under the project
+   target (e.g. PR #587: 95.09 % patch vs 97.17 %). Structural noise, not a
+   regression — and it merged anyway.
+
+So: **read the patch number** (it still shows new-code coverage), but a green/grey
+codecov status is not a quality claim and a low number does not block. The §3/§4
+guidance above keeps that number honest.

--- a/docs/dev/test-flakes-and-ci-gotchas.md
+++ b/docs/dev/test-flakes-and-ci-gotchas.md
@@ -82,8 +82,9 @@ There is a committed [`codecov.yml`](../../codecov.yml) that sets both
 so **the `codecov/patch` and `codecov/project` checks always pass** while still
 posting the coverage numbers on every PR. Two reasons (#589):
 
-1. Neither status was ever a *required* check on `develop`/`main` (required =
-   `test (3.12)`, the three lockfile-drift jobs, `bench correctness`). They are a
+1. Neither status was ever a *required* check on `develop`/`main` (required on
+   `develop` = `test (3.12)`, the three lockfile-drift jobs, `Analyze (Python)`
+   CodeQL, `bench correctness`; `main` is the same minus `Analyze`). They are a
    signal, not a merge gate — `informational: true` just stops them rendering a
    misleading red **X** on a check that never blocked.
 2. Under the default auto-target, every **release PR** went red: its cumulative


### PR DESCRIPTION
## What

Adds a committed `codecov.yml` that sets `coverage.status.patch` and `coverage.status.project` to `informational: true`, so both Codecov statuses **always pass** while still posting the coverage numbers on every PR.

## Why (#589)

Neither status was ever a *required* check on `develop`/`main` (required on `develop` = `test (3.12)`, the three lockfile-drift jobs, `Analyze (Python)` CodeQL, `bench correctness`; `main` is the same minus `Analyze`). They are a signal, not a merge gate. But under the default auto-target they rendered a misleading **red X** whenever a diff dipped below the project's current coverage — most visibly on **every release PR**, whose cumulative `vX.Y.Z..develop` diff vs `main` lands a couple of points under target (PR #587: 95.09 % patch vs 97.17 %). Structural noise, not a regression — and it merged anyway.

`informational: true` formalises the already-documented stance: **codecov reports, it does not block**. The coverage % stays visible on every PR; only the misleading red on a non-blocking check goes away.

## Decision

Picked **repo-wide informational** over the more surgical "red on feature PRs, informational only on `release/*`" scoping because the official Codecov docs leave the `branches` head-vs-base matching + negation semantics ambiguous, and that config would only be re-tested at the next release (months-long feedback loop). Repo-wide informational is unambiguous (docs: "the resulting status will pass no matter what"), robust forever, and the coverage number — the actual signal — survives on every PR.

## Changes

- **`codecov.yml`** (new) — both statuses `informational: true`, with a comment block explaining the rationale. Confirmed **Valid!** by Codecov's online validator.
- **`docs/dev/test-flakes-and-ci-gotchas.md`** — new §5 documenting the config + rationale; updated the now-stale "fails"/"flags" wording in §3/§4 (patch reports a dip, it no longer fails).

No code change; not user-facing, so no CHANGELOG entry.

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)
