### PR TITLE
feat(601): ground-object data model + loader (Stage A / #600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Ground-object data model (#601).** Catalog `fixed_obstacle`/`car`/`trailer`
+  types and a layout `ground_objects:` block; fixed obstacles are keep-outs
+  (a `ground_obstacle` conflict names the overlapping aircraft/mover) and
+  movers join collision/tow enumeration. Empty-set output is byte-identical.
+  (ADR-0025)
 - Optional polygon part footprints: a `Part` may carry a load-time-canonicalized
   `local_vertices` polygon (authored via a parametrized `planform: {root_chord_m,
   tip_chord_m}` wing block), used by the collision build-path while `length_m`/

--- a/data/catalog/README.md
+++ b/data/catalog/README.md
@@ -51,6 +51,86 @@ Conventions (see `docs/architecture/08-crosscutting-concepts.md`
   heights are sourced. All measured: false. A wing nested over another plane's
   tail now conflicts with that plane's fin unless it clears it laterally.
 
+## Ground objects (#601)
+
+The catalog supports non-aircraft floor occupants via three `type:` values.
+See [ADR-0025](../../docs/adr/0025-ground-object-taxonomy.md) for the full
+rationale; the summary is below.
+
+### `type:` vocabulary
+
+| `type:` | `object_class` | motion default | use case |
+|---|---|---|---|
+| `fixed_obstacle` | `"fixed_obstacle"` | none (no motion fields allowed) | parked fuel trailer, fixed equipment |
+| `car` | `"placed_routed_mover"` | `"steerable"` | self-driven vehicle (e.g. VW Caddy) |
+| `trailer` | `"placed_routed_mover"` | `"towed"` | towed trailer (e.g. glider trailer) |
+
+### Parts convention for ground objects
+
+All ground-object parts use `kind: ground` — a footprint-only kind distinct
+from the aircraft part kinds. The collision checker treats `kind: ground` parts
+as keep-out geometry for fixed obstacles and as pairwise collision bodies for
+movers. A `ground` part is never overhangable and is never split by the
+fuselage front/aft loader logic.
+
+Typical ground-object parts are single-rectangle footprints:
+
+```yaml
+type: fixed_obstacle
+id: fuel_trailer
+name: Fuel trailer
+measured: false
+parts:
+  - kind: ground
+    length_m: 4.20       # fore-aft in plane-local coords (object +x)
+    width_m:  1.80       # lateral (object +y)
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    angle_deg: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 1.5
+```
+
+Heights (`z_bottom_m` / `z_top_m`) should represent the real physical extent
+so the two-clause predicate can detect an aircraft wing passing over versus
+genuinely clearing the object.
+
+### Motion fields (movers only)
+
+`car` and `trailer` entries may carry an optional `motion_mode:` override
+(valid values: `"steerable"`, `"towed"`) and an optional `turn_radius_m:`
+(the minimum taxi / tow turn radius in metres, positive). Fixed obstacles
+must not carry either field; the loader rejects them.
+
+```yaml
+type: car
+id: vw_caddy
+name: VW Caddy
+measured: false
+motion_mode: steerable        # explicit override; default for car is already steerable
+turn_radius_m: 5.5
+parts:
+  - kind: ground
+    length_m: 4.59
+    width_m:  1.85
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    angle_deg: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 1.85
+```
+
+### Status of real Herrenteich ground-object entries
+
+The real Airfield Herrenteich ground objects — `fuel_trailer`,
+`vw_caddy`, `glider_trailer_1`, `glider_trailer_2` — are **not yet
+authored in this catalog**. Issue #605 adds them alongside the
+dims/clearance calibration for a feasible all-11 arrangement.
+
+This PR (#601) ships the taxonomy and the loader; the catalog currently
+carries **test fixtures** under `tests/fixtures/catalog/` only, not
+production ground-object entries.
+
 ## Real-spec provenance (Airfield Herrenteich occupants, #536/#594)
 
 Airfield Herrenteich — real fleet (the aircraft usually hangared here).

--- a/docs/adr/0025-ground-object-taxonomy.md
+++ b/docs/adr/0025-ground-object-taxonomy.md
@@ -1,0 +1,297 @@
+# ADR-0025: Ground-object taxonomy — concrete catalog types, Layout-uniform placement, and pairwise-set keep-out seam
+
+- **Status:** Accepted
+
+- **Date:** 2026-06-11
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+The hangar floor holds more than aircraft. The real Airfield Herrenteich set
+adds a **fuel trailer** (fixed, never moves), **two glider trailers** (towed),
+and a **VW Caddy** (self-driven). The current model has exactly two non-aircraft
+geometry flavours, both *hangar-intrinsic* keep-outs: the state-gated
+`MaintenanceBay` and the always-on `StructuralNotch` list (ADR-0018). There
+is **no model for a free-standing object** — fixed or moveable — authored as
+scenario/layout data with a pose. Without one there is no way to represent a
+parked fuel trailer blocking the door-throat, a glider trailer occupying corner
+space, or a van that must be able to drive out past every parked aircraft.
+
+This ADR records the **taxonomy of ground objects** introduced in #601:
+the concrete catalog `type:` vocabulary, the Layout-uniform placement approach,
+and the collision seam that makes fixed obstacles into keep-outs and movers
+into pairwise collision bodies. It does *not* cover mover route search — the
+actual path-planning for movers, including the ADR-0010 motion-model amendment,
+is deferred to issue #602.
+
+## Decision Drivers
+
+- **Real-world fidelity.** A fuel trailer parked at the door *is* a physical
+  obstacle; the validity checker must see it.
+- **Max reuse.** The existing `Part` / `Placement` / det-−1 transform
+  machinery already handles oriented rectangles at arbitrary poses — there is
+  no reason to build a parallel geometry engine.
+- **Oblique obstacles.** A fuel trailer parked diagonally at the door-corner
+  cannot be represented as a floor-polygon subtraction (axis-aligned only);
+  the pairwise-set seam handles any heading natively.
+- **Byte-identical when empty.** Existing layouts must produce bit-identical
+  `CheckResult` and `MovesPlan` output when no ground objects are present —
+  protecting the ADR-0003 solver contract.
+- **Forward-compat for movers.** The motion-mode field must be *carried as
+  data* even if the route search is deferred, so #602 and #603/#604 can layer
+  on without breaking the model.
+- **Friendlier authoring.** Catalog YAML should read like real objects
+  (`type: car`, `type: trailer`) rather than a generic discriminator
+  (`type: placed_routed_mover`).
+
+## Considered Options
+
+### D1 — catalog-type vocabulary
+
+1. **Concrete `type:` values** — `fixed_obstacle`, `car`, `trailer` — each
+   with its own `_build_*` builder; `object_class` is *derived* from the type
+   *(chosen)*.
+2. **Two abstract `type:` values** — `fixed_obstacle` and
+   `placed_routed_mover` — matching the two `object_class` literals, one
+   builder per abstract class.
+3. **Single `ground_object` type** with a mandatory `motion_mode:` field
+   (including `None` for fixed obstacles); one builder.
+
+### D2 — placement approach
+
+1. **Layout-uniform via existing `Placement`.** Ground objects reuse `Part`
+   (footprint), `Placement` (pose), and the det-−1 world transform, held in
+   parallel `ground_objects` / `ground_object_placements` fields on `Layout`
+   *(chosen)*.
+2. **A new `GroundPlacement` type** mirroring `Placement` but typed to
+   `GroundObject` rather than `Aircraft`. Separate transform path.
+3. **Embed placement inside `GroundObject`** — the catalog entry carries its
+   own pose; no separate `Placement` needed.
+
+### D3 — keep-out seam for fixed obstacles
+
+1. **Pairwise-set seam** — a fixed obstacle is a placed body whose
+   `kind="ground"` parts are checked against every aircraft/mover part exactly
+   like the existing pairwise predicate, emitting a `ground_obstacle` conflict
+   *(chosen)*.
+2. **Floor-polygon subtraction** — union the fixed-obstacle footprints into a
+   forbidden-zone Shapely polygon, check aircraft against it like the hangar
+   bounds.
+3. **Dedicated `keep_out_zones:` top-level field on `Layout`** — axis-aligned
+   rectangles, similar to `structural_notches`.
+
+## Decision Outcome
+
+**Chosen: D1 = option 1 (concrete types); D2 = option 1 (Layout-uniform via
+`Placement`); D3 = option 1 (pairwise-set seam).**
+
+### D1 — concrete catalog types
+
+Three concrete `type:` values map onto two `object_class` values:
+
+| `type:` in catalog | builder | `object_class` | motion default |
+|---|---|---|---|
+| `fixed_obstacle` | `_build_fixed_obstacle` | `"fixed_obstacle"` | `None` (rejected if authored) |
+| `car` | `_build_car` | `"placed_routed_mover"` | `"steerable"` (overridable) |
+| `trailer` | `_build_trailer` | `"placed_routed_mover"` | `"towed"` (overridable) |
+
+The `object_class` is derived from the type at load time and stored on
+`GroundObject`. Motion behaviour is **defaulted per concrete type** but kept
+as an overridable **data field** (`motion_mode:`) so a car that must be
+towed (hypothetically) can say so without requiring a code change.
+
+**Why not D1 option 2 (two abstract types)?**
+`placed_routed_mover` is a valid internal classifier but a poor catalog
+keyword — a hangar operator authoring a VW Caddy entry should write
+`type: car`, not `type: placed_routed_mover`. The concrete types are
+self-documenting, per-type allowlists catch authoring errors early, and
+the per-type builders set sensible motion defaults so the catalog author
+rarely needs `motion_mode:` at all.
+
+**Why not D1 option 3 (single type + mandatory motion_mode)?**
+It conflates the type discrimination (what the object *is*) with the
+motion model (how it *moves*). Fixed obstacles would need `motion_mode:
+null`, a surprising author requirement. A single builder cannot enforce
+the "fixed_obstacle must not carry motion fields" invariant without
+per-type branches — which is exactly what the per-type builders give
+cleanly.
+
+### D2 — Layout-uniform via `Placement`
+
+A `GroundObject` carries a `parts: tuple[Part, ...]` (footprint geometry,
+using the new `"ground"` `PartKind`) and a catalog-level pose. The layout
+adds two parallel fields:
+
+```python
+ground_objects: Mapping[str, GroundObject] = {}          # catalog subset
+ground_object_placements: tuple[Placement, ...] = ()     # poses (reuses Placement)
+```
+
+The `Placement.plane_id` field carries the ground-object id, exactly as it
+carries an aircraft id for aircraft placements. The `ground_objects` key set
+and the `fleet` key set are kept **disjoint** by a `Layout.__post_init__`
+invariant — a placement id resolves to either an aircraft or a ground object,
+never ambiguously.
+
+The det-−1 world transform (`geometry.aircraft_parts_world`) is widened to
+accept a `GroundObject` in addition to an `Aircraft`. Ground-object `Part`s
+carry the new `PartKind` value `"ground"` — a footprint-only kind, not
+subject to the wing-nesting height rule.
+
+**Why not D2 option 2 (new `GroundPlacement` type)?**
+It duplicates the `Placement` dataclass and the transform path for no
+behavioural gain. Every caller that iterates `layout.placements` would need
+a second loop over `layout.ground_object_placements` with a different type —
+two code paths to maintain, with all the same geometry logic.
+
+**Why not D2 option 3 (pose embedded in the catalog entry)?**
+The catalog is static data — it describes *what* an object is, not where it
+sits in a specific hangar layout. Embedding a pose would prevent reusing the
+same catalog entry at different positions in different layouts (e.g. a
+`glider_trailer` entry used twice in one layout). The aircraft catalog
+imposes the same discipline: `data/catalog/aviat_husky.yaml` has no position;
+every layout places its own instance.
+
+### D3 — pairwise-set keep-out seam
+
+Fixed-obstacle world parts join the pairwise overlap loop in
+`collisions.check`. Any aircraft or mover part whose plan-view polygon (plus
+clearance) overlaps a fixed-obstacle part and whose height range is within
+`wing_layer_clearance_m` fires a **`ground_obstacle`** `Conflict` — a
+single-plane conflict (only the aircraft/mover is named; the obstacle is
+named in `detail`). The `_parts_conflict` predicate is reused unchanged.
+Fixed-obstacle ↔ fixed-obstacle overlaps are **ignored** (two static keep-outs
+may coincide).
+
+Movers join the existing pairwise aircraft↔aircraft loop, emitting the
+standard `<sorted_kinds>_overlap` conflicts (using `"ground"` as the part
+kind tag in the alphabetical sort). Mover↔aircraft and mover↔mover pairs
+are both checked.
+
+**Why not D3 option 2 (floor-polygon subtraction)?**
+It is axis-aligned only — a fuel trailer parked diagonally at the door-corner
+cannot be correctly represented. It also diverges from the `_parts_conflict`
+predicate used by the oracle, creating a risk of in-search (pairwise) vs
+verifier (polygon subtraction) divergence. The pairwise approach handles any
+heading and reuses the validated predicate.
+
+**Why not D3 option 3 (dedicated `keep_out_zones:`)?**
+It would be a third keep-out mechanism alongside `structural_notches` and the
+maintenance bay, for what is fundamentally the same geometry question — does
+this shape overlap that shape? Reusing the pairwise seam keeps the rule count
+small and the predicate surface unified.
+
+### Tow-planner wiring (A1 scope)
+
+Fixed obstacles' world parts join `_build_obstacles`' **static** obstacle set
+in `towplanner.py`, sorted by id for determinism. Movers appear in `plan_fill`'s
+routable enumeration alongside aircraft. In A1 the per-mover **path search is
+deferred to #602**: a mover is recognised in the routed set but receives
+`path=None` (the existing best-effort `plans[i] = None` pattern), naming
+itself on stderr. AC4 is satisfied by the mover *appearing in the enumeration*,
+not by a successful route.
+
+The ADR-0010 *motion* amendment (Reeds–Shepp arc parameters for steerable /
+towed movers) is deferred to #602.
+
+### The `"ground"` PartKind
+
+A new `PartKind` value `"ground"` is added to the closed `Literal` set. It is
+a footprint-only kind — it participates in plan-view overlap (pairwise seam)
+and in `_parts_conflict`'s height clause when checked against aircraft/mover
+parts, but it is never overhangable (not in `metrics._OVERHANGABLE`) and is
+never split by the fuselage front/aft loader logic.
+
+### Byte-identity with empty ground-object sets
+
+When `Layout.ground_objects` is empty and `ground_object_placements` is an
+empty tuple, every new code path is a guarded no-op: `collisions.check`
+produces a bit-identical `CheckResult`, `plan_fill` produces a bit-identical
+`MovesPlan`, and the solver's double-run canary passes unchanged. This is the
+primary mechanism by which A1 is additive — existing fixtures and existing
+solver seeds are unaffected.
+
+### Real catalog entries deferred to #605
+
+A1 ships the taxonomy and the loader; the catalog currently carries only
+**test fixtures** under `tests/fixtures/catalog/`. The real Herrenteich
+objects (`fuel_trailer`, `vw_caddy`, `glider_trailer_1`, `glider_trailer_2`)
+and the dims/clearance calibration to a feasible all-11 arrangement are
+deferred to #605.
+
+## Consequences
+
+### Positive
+
+- Ground objects have a clean first-class home: a frozen-slots `GroundObject`
+  model with the same invariant discipline as `Aircraft`.
+- Fixed obstacles are keep-outs that block aircraft *and* movers; the
+  fuel-trailer-at-the-door scenario is now expressible and checked.
+- Movers join collision pairwise immediately; route search lands in #602
+  without any model change.
+- Empty-set byte-identity protects the ADR-0003 solver contract; no existing
+  test or canary needs updating.
+- Oblique obstacles (any heading) work natively via the existing pairwise path.
+
+### Negative
+
+- `PartKind` gains a new value (`"ground"`), widening the closed `Literal`.
+  Any exhaustive match on `PartKind` outside the project must be updated.
+- `geometry.aircraft_parts_world` is widened to accept `GroundObject`; callers
+  that type-annotate the first argument strictly need to update to the union
+  type.
+- The `Layout` dataclass gains two new fields; construction sites that pass
+  positional arguments rather than keyword arguments would break (standard
+  dataclass convention says: always use kwargs for anything beyond the first
+  field).
+
+### Neutral
+
+- The `"ground"` kind does not participate in the wing-nesting height rule
+  directly — ground objects are not aircraft and do not nest wings. The two-
+  clause predicate still applies when checking an *aircraft* part against a
+  ground part (the aircraft is the one that might fly over); from the ground
+  object's perspective it is simply a static obstacle at whatever z-band it
+  occupies.
+- `PartKind` is now seven values: `"fuselage_front"`, `"fuselage_aft"`,
+  `"ground"`, `"strut"`, `"tail"`, `"vertical_stabilizer"`, `"wing"`. The
+  alphabetical conflict-kind taxonomy auto-derives `ground_ground_overlap`
+  (suppressed by the fixed↔fixed exemption), `ground_wing_overlap`, etc.
+
+## Compliance
+
+- **`tests/test_models_ground_object.py`** — `GroundObject` valid
+  construction for all three concrete types; `__post_init__` rejects empty
+  id/name/parts, `fixed_obstacle` with motion fields, mover without
+  `motion_mode`, non-positive `turn_radius_m`.
+- **`tests/test_loader_ground_object.py`** — each `type:` loads from a
+  fixture; defaults applied; unknown `type:` → `LoaderError`; per-type
+  allowlists; layout `ground_objects:` block round-trip.
+- **`tests/test_collisions.py`** — a fixed obstacle overlapped by an aircraft
+  part ⇒ `ground_obstacle` conflict; non-overlapping ⇒ valid; byte-identity
+  on an existing fixture layout with empty ground-object fields.
+- **`tests/test_towplanner.py`** — a door-blocking fixed obstacle makes an
+  otherwise-routable plane un-routable; a mover appears in `plan_fill`'s
+  routed enumeration (path deferred/`None`); double-solve on a fixed seed
+  with no ground objects ⇒ byte-identical plan.
+- **The `determinism-guard`** runs on every PR touching `solver.py` or
+  `towplanner.py`; the empty-set byte-identity guarantee is its primary
+  protection here.
+
+## More Information
+
+- Related ADRs: [ADR-0001](0001-aircraft-parts-model.md) (the parts model
+  this extends), [ADR-0003](0003-rr-mc-solver-algorithm.md) (determinism
+  contract, empty-set byte-identity), [ADR-0010](0010-reeds-shepp-motion-model.md)
+  (motion model — amendment for movers deferred to #602),
+  [ADR-0018](0018-non-rectangular-hangar-footprint.md) (structural notches,
+  the other non-aircraft keep-out mechanism).
+- Related spec:
+  [`docs/superpowers/specs/2026-06-11-601-ground-object-data-model-design.md`](../superpowers/specs/2026-06-11-601-ground-object-data-model-design.md).
+- Related issues: #601 (this ADR), #602 (mover motion + ADR-0010 amendment),
+  #603 (Caddy hard-egress gate), #604 (soft trailer region), #605 (real
+  Herrenteich catalog entries + calibration), #606 (rendering).
+- [§5 Building Block View](../architecture/05-building-block-view.md) — module
+  responsibilities updated alongside this ADR.
+- [§8 Crosscutting Concepts — "The parts model"](../architecture/08-crosscutting-concepts.md#the-parts-model)
+  — "Ground objects" subsection added alongside this ADR.

--- a/docs/adr/0025-ground-object-taxonomy.md
+++ b/docs/adr/0025-ground-object-taxonomy.md
@@ -256,7 +256,8 @@ deferred to #605.
 - `PartKind` is now seven values: `"fuselage_front"`, `"fuselage_aft"`,
   `"ground"`, `"strut"`, `"tail"`, `"vertical_stabilizer"`, `"wing"`. The
   alphabetical conflict-kind taxonomy auto-derives `ground_ground_overlap`
-  (suppressed by the fixed↔fixed exemption), `ground_wing_overlap`, etc.
+  (only ever between two **movers**; two fixed obstacles are exempt — obstacles
+  never enter the pairwise set), `ground_wing_overlap`, etc.
 
 ## Compliance
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -102,3 +102,4 @@ manual workflow above is canonical.
 | 0022 | [Nose-out parked heading — RNG-free 180° flip post-pass (default on), plus the `tow_pivotable` towing-motion flag](0022-nose-out-parked-heading.md) | Accepted |
 | 0023 | [Model the empennage as explicit tail surfaces so a vertical fin in the wing layer can block wing-over-tail nesting](0023-empennage-tail-surfaces.md) | Accepted |
 | 0024 | [Optional polygon footprints on `Part` — load-time-canonicalized, authored via `planform:` (refines [ADR-0001](0001-aircraft-parts-model.md))](0024-optional-polygon-parts.md) | Accepted |
+| 0025 | [Ground-object taxonomy — concrete catalog types, Layout-uniform placement, and pairwise-set keep-out seam](0025-ground-object-taxonomy.md) | Accepted |

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -106,10 +106,19 @@ maintenance-plane-is-not-in-placements rule. A constructed instance is
 guaranteed structurally valid; nothing downstream re-checks.
 
 `PartKind` is a closed `Literal` set (`"fuselage_front"`,
-`"fuselage_aft"`, `"wing"`, `"strut"`, `"tail"`,
-`"vertical_stabilizer"`). The `Conflict.kind` taxonomy is also closed —
-adding a new conflict kind is a code change here, not just a string
-constant elsewhere.
+`"fuselage_aft"`, `"ground"`, `"strut"`, `"tail"`,
+`"vertical_stabilizer"`, `"wing"`). The `Conflict.kind` taxonomy is also
+closed — adding a new conflict kind is a code change here, not just a
+string constant elsewhere.
+
+Ground objects — non-aircraft floor occupants — are modelled as frozen
+`GroundObject` dataclasses (#601, [ADR-0025](../adr/0025-ground-object-taxonomy.md)):
+a tuple of `Part`s using the `"ground"` `PartKind`, a derived
+`object_class` (`"fixed_obstacle"` or `"placed_routed_mover"`), and an
+optional `motion_mode` / `turn_radius_m` for movers. `Layout` gains two
+parallel fields (`ground_objects` map, `ground_object_placements` tuple)
+with the same id-disjointness and invariant discipline as `fleet` /
+`placements`; `Scenario` gains a `ground_objects` id list for the solve path.
 
 This module imports nothing from the rest of the project. It is the
 project's vocabulary.
@@ -124,14 +133,22 @@ A fleet file is a thin **manifest** (#595): its `aircraft:` list holds
 resolved by path relative to the manifest's directory (the same idiom
 `fleet:`/`hangar:` already use). Each catalog file carries a `type:`
 discriminator (default `aircraft`) that the loader dispatches to a per-type
-builder (`_build_catalog_object` → `_build_aircraft`); a non-aircraft `type:`
-is reserved for the ground-objects work and rejected with a clear error today.
-Manifest list order is preserved, so the resulting `dict[str, Aircraft]`
-insertion order is deterministic (ADR-0003). A manifest entry may be a bare
-path string or a `{ref: <path>, …}` mapping that **overrides a per-fleet
-operational flag** (`movement_mode`, `tow_pivotable`) on top of the shared
-static definition — geometry is static and never override-able. Inline
-aircraft definitions are no longer supported.
+builder (`_build_catalog_object` → `_build_aircraft` / `_build_fixed_obstacle`
+/ `_build_car` / `_build_trailer`). Manifest list order is preserved, so the
+resulting `dict[str, Aircraft]` insertion order is deterministic (ADR-0003).
+A manifest entry may be a bare path string or a `{ref: <path>, …}` mapping
+that **overrides a per-fleet operational flag** (`movement_mode`,
+`tow_pivotable`) on top of the shared static definition — geometry is static
+and never override-able. Inline aircraft definitions are no longer supported.
+
+The optional manifest `ground_objects:` list loads ground objects via
+`load_ground_objects` (#601, [ADR-0025](../adr/0025-ground-object-taxonomy.md));
+a layout `ground_objects:` block resolves each entry's `object` id against
+that set and builds a `Placement`. Each concrete `type:` (`fixed_obstacle`,
+`car`, `trailer`) has its own builder with a strict key allowlist and sensible
+motion defaults (`car` → `"steerable"`, `trailer` → `"towed"`). An absent
+`ground_objects:` key in the manifest returns `{}` — existing manifests are
+byte-identical.
 
 The other non-trivial transformation is the `struts:` block — a high-level
 YAML shorthand for strut-braced aircraft that the loader expands into two
@@ -190,6 +207,13 @@ predicates and aggregates conflicts:
    every part-pair is tested with the two-clause predicate
    (plan-view distance < `clearance_m` AND height gap <
    `wing_layer_clearance_m`).
+4. **Ground-object keep-out and pairwise wiring** (#601,
+   [ADR-0025](../adr/0025-ground-object-taxonomy.md)) — fixed-obstacle world
+   parts are checked against every aircraft/mover part with the same
+   two-clause predicate, emitting a `ground_obstacle` conflict (single-plane,
+   naming the obstacle in `detail`); mover world parts join the pairwise loop
+   like aircraft. Fixed ↔ fixed overlaps are suppressed. With empty
+   `ground_object_placements` the `CheckResult` is bit-identical to before.
 
 The cart rule is **not** here — it is already enforced upstream in
 `Layout.__post_init__`. `collisions.py` operates on a structurally
@@ -351,6 +375,13 @@ the **empty-hangar fill** case — every plane enters once (ADR-0007).
   opt-in `auto` value. Default `0` reproduces the no-apron `MovesPlan`
   byte-for-byte (the whole apron lives behind an `apron_depth_m > 0` gate;
   ADR-0003); `collisions.check` is untouched (§8 *The door*).
+- **Ground-object tow wiring** (#601, [ADR-0025](../adr/0025-ground-object-taxonomy.md)) —
+  fixed-obstacle world parts (sorted by id for determinism) join the **static**
+  obstacle set in `_build_obstacles` alongside `notch_boxes` and placed-plane
+  parts. Movers appear in `plan_fill`'s routable enumeration alongside aircraft;
+  in A1 the per-mover path search is **deferred to #602** (a mover yields
+  `path=None`, the existing best-effort pattern). With no ground objects the
+  `MovesPlan` is bit-identical to before.
 - **Failure is honest** — a layout it cannot route raises
   `NoFeasiblePlanError` naming the offending plane; `solve` records it
   best-effort (see the bundling bullet above), and the CLI's

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -75,9 +75,11 @@ gap is irrelevant -- the cockpit rule drops clause (2) entirely (ADR-0012, D1).
 *A wingtip may overhang a parked plane's aft fuselage / low tailplane (Case A: legal when heights are disjoint, the two-clause `wing × fuselage_aft` rule) but never its cockpit / front fuselage (Case B: a hard `fuselage_front_wing_overlap` conflict at any nesting height). The loader auto-splits a `fuselage` part at the wing trailing edge `x_break`; front is the nose side, aft the tail side. Since [ADR-0023](../adr/0023-empennage-tail-surfaces.md) Case A also requires the wing to clear the plane's centreline `vertical_stabilizer` (fin), which rises into the wing layer — see "The empennage" below.*
 
 The closed set of `PartKind` values is `{"fuselage_front",
-"fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer"}`. The
-legacy `"fuselage"` is **not** a constructed kind — it survives only as a
-transient YAML keyword the loader auto-splits at the wing trailing-edge
+"fuselage_aft", "ground", "strut", "tail", "vertical_stabilizer", "wing"}`.
+The `"ground"` kind is used exclusively by `GroundObject` parts (see
+"Ground objects" above). The legacy `"fuselage"` is **not** a constructed kind
+— it survives only as a transient YAML keyword the loader auto-splits at the
+wing trailing-edge
 station (`wing.offset_x_m − wing.length_m/2`, the #282 wing-spar
 precedent), emitting an area-conserving `fuselage_front` + `fuselage_aft`
 pair whose union is the original box. An aircraft with a `fuselage` part
@@ -122,6 +124,27 @@ conservative direction. Canonicalization at load time (force CCW, lex-min
 start, drop the closing duplicate) is the determinism crux: equivalent
 author orderings yield a byte-identical `Part`, protecting the ADR-0003
 solver contract.
+
+**Ground objects (#601, [ADR-0025](../adr/0025-ground-object-taxonomy.md)).**
+Non-aircraft floor occupants are modelled as `GroundObject` instances.
+Two `object_class` values exist:
+
+- **`"fixed_obstacle"`** — never moves; its world parts are keep-outs.
+  Any aircraft or mover whose part (plus clearance) overlaps a
+  fixed-obstacle part fires a `ground_obstacle` conflict (single-plane
+  arity, the obstacle named in `detail`). Fixed-obstacle parts use the
+  new `"ground"` `PartKind`.
+- **`"placed_routed_mover"`** — a moveable object (car or towed trailer)
+  that must eventually drive out; its world parts join the pairwise
+  overlap loop exactly like aircraft parts, emitting the standard
+  `<sorted_kinds>_overlap` conflicts. Mover route search is deferred to
+  #602.
+
+Three concrete catalog `type:` values author ground objects: `fixed_obstacle`,
+`car` (motion default `"steerable"`), and `trailer` (motion default `"towed"`).
+The `"ground"` `PartKind` is a footprint-only kind — it is never overhangable
+and is never split by the fuselage front/aft loader logic. With empty
+`ground_object_placements` the system is byte-identical to before.
 
 **Fleet composition relevant to the parts model.** Of the nine
 aircraft in `data/fleet.yaml`, six are **strut-braced** (the Aviat

--- a/docs/superpowers/plans/2026-06-11-601-ground-object-data-model.md
+++ b/docs/superpowers/plans/2026-06-11-601-ground-object-data-model.md
@@ -1,0 +1,1775 @@
+# Ground-Object Data Model + Loader (#601) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give non-aircraft ground objects (fixed obstacles + placed/routed movers) a first-class home built on the #595 catalog, wired into the existing collision checker and tow planner as a purely *additive*, byte-identical-when-empty change.
+
+**Architecture:** A new frozen-slots `GroundObject` model (concrete catalog `type:` values `fixed_obstacle`/`car`/`trailer` → per-type builders; `object_class` derived from type). Ground objects reuse the existing `Part` footprint (via a new `"ground"` `PartKind`), the existing `Placement` pose, and the det-−1 world transform. They live in two new parallel `Layout` fields (`ground_objects` map + `ground_object_placements` tuple). Fixed obstacles become keep-outs (pairwise-set seam → `ground_obstacle` conflict); movers join pairwise collision + the tow-planner routable enumeration (route search deferred to #602).
+
+**Tech Stack:** Python 3.12, frozen `@dataclass(slots=True)`, Shapely (polygons), pytest. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-601-ground-object-data-model-design.md`
+
+---
+
+## Conventions for every task
+
+- **Branch:** `feature/601-ground-object-data-model` (already created off `develop`).
+- **Run a single test:** `pytest tests/<file>::<test> -v`
+- **Run a module's tests:** `pytest tests/test_models.py -v`
+- **Full fast suite (pre-commit safety):** `pytest`
+- **Lint/format/type after each task:** `ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/`
+- **Do NOT** `git add -A` — the working tree carries the user's local `CLAUDE.md` + `.claude/settings.json` edits that must not be committed. Always `git add` the **explicit paths** listed in each Commit step.
+- The repo's pre-commit hook runs ruff; a PostToolUse hook runs ruff+pytest after `src/`/`tests/` edits; a Stop hook runs mypy. Let them run.
+
+---
+
+## Test fixtures (READ FIRST — the snippets below use shorthand names)
+
+The test snippets in this plan use shorthand fixture names (`minimal_hangar`, `tiny_aircraft`, `low_wing_aircraft`, `existing_valid_layout`). **These are NOT pytest fixtures — they do not exist.** `tests/conftest.py` provides only plain factory *functions*, constructed on demand (the suite deliberately avoids module-level model construction — see the conftest docstring). Resolve every shorthand as follows:
+
+```python
+# Aircraft factory (a function, NOT a fixture). Import exactly like sibling tests:
+from tests.conftest import make_test_aircraft
+# tiny_aircraft / low_wing_aircraft → make_test_aircraft(id="p1", wing_position="high")
+#   (override wing_position="low", gear=..., movement_mode=... as a case needs)
+
+# There is NO hangar fixture — build one inline (copied from tests/test_collisions.py:_hangar):
+from hangarfit.models import Door, Hangar, MaintenanceBay
+
+def _hangar(clearance: float = 0.3, wlc: float = 0.2) -> Hangar:
+    return Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=clearance,
+        wing_layer_clearance_m=wlc,
+    )
+# minimal_hangar → _hangar()
+```
+
+For each test snippet: drop the fixture-style function parameters (`def test_x(minimal_hangar, tiny_aircraft)`) and instead build locals at the top of the test body — `hangar = _hangar()`, `ac = make_test_aircraft(id="p1")`. Place planes/objects at world coords well inside `0..40 × 0..40`. For `existing_valid_layout` (the byte-identity test in Task 9), load a checked-in valid layout (e.g. `load_layout(Path("examples/layouts/example.yaml"))`) or build one inline with `_hangar()` + one `make_test_aircraft()` placed clear — assert `check(it).valid` and `conflicts == ()`.
+
+> The factory's aircraft has wing z 2.0–2.2 and fuselage z 0–1.0 (see `_default_parts`). To force an aircraft-vs-ground-object overlap, give the ground footprint `z_top_m ≥ 2.2` (so it meets the wing layer) and place it under the wing; to force a *clear* case, keep the ground object's `(x,y)` far from the plane.
+
+---
+
+## File structure (what each touched file owns)
+
+- `src/hangarfit/models.py` — adds `GroundObject`, the `"ground"` `PartKind`, the `GroundObjectClass`/`MoverMotionMode` literals, and the `Layout`/`Scenario` ground-object fields + invariants.
+- `src/hangarfit/loader.py` — adds the catalog builder registry, the three `_build_*` ground-object builders + allowlists, `load_ground_objects`, and scenario/layout `ground_objects:` parsing.
+- `src/hangarfit/geometry.py` — widens `aircraft_parts_world` to accept a `GroundObject`.
+- `src/hangarfit/collisions.py` — builds ground-object world parts, adds `_ground_obstacle_conflicts`, feeds movers into pairwise.
+- `src/hangarfit/towplanner.py` — adds fixed-obstacle/mover static obstacles to `_build_obstacles`; registers movers in `plan_fill`'s routable enumeration (deferred search).
+- `src/hangarfit/metrics.py` / `visualize.py` / `scene.py` — audited for `"ground"` `PartKind` fallout (Task 11).
+- `tests/fixtures/catalog/*.yaml` — fixture ground objects.
+- `docs/adr/0025-ground-object-taxonomy.md`, `docs/architecture/05-*.md`, `08-*.md`, `data/catalog/README.md`, `CHANGELOG.md` — docs.
+
+---
+
+## Task 1: `GroundObject` model + `"ground"` PartKind
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (literals near line 29-40; new class after `Aircraft`, ~line 417)
+- Test: `tests/test_models_ground_object.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_models_ground_object.py`:
+
+```python
+"""GroundObject model + validation (#601)."""
+
+import pytest
+
+from hangarfit.models import GroundObject, Part
+
+
+def _rect_part(*, kind: str = "ground", length_m: float = 4.0, width_m: float = 2.0) -> Part:
+    return Part(
+        kind=kind,  # type: ignore[arg-type]
+        length_m=length_m,
+        width_m=width_m,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=1.5,
+    )
+
+
+def test_fixed_obstacle_constructs() -> None:
+    obj = GroundObject(
+        id="fuel_trailer",
+        name="Fuel trailer",
+        parts=(_rect_part(),),
+        object_class="fixed_obstacle",
+    )
+    assert obj.object_class == "fixed_obstacle"
+    assert obj.motion_mode is None
+    assert obj.turn_radius_m is None
+
+
+def test_mover_constructs_with_motion() -> None:
+    obj = GroundObject(
+        id="vw_caddy",
+        name="VW Caddy",
+        parts=(_rect_part(),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=4.5,
+    )
+    assert obj.motion_mode == "steerable"
+    assert obj.turn_radius_m == 4.5
+
+
+def test_ground_partkind_is_valid() -> None:
+    # A "ground" footprint Part must construct without error.
+    assert _rect_part(kind="ground").kind == "ground"
+
+
+@pytest.mark.parametrize(
+    "kwargs, msg",
+    [
+        (dict(id="", name="x", parts=(_rect_part(),), object_class="fixed_obstacle"), "id"),
+        (dict(id="x", name="", parts=(_rect_part(),), object_class="fixed_obstacle"), "name"),
+        (dict(id="x", name="x", parts=(), object_class="fixed_obstacle"), "parts"),
+        (
+            dict(id="x", name="x", parts=(_rect_part(),), object_class="bogus"),
+            "object_class",
+        ),
+        (
+            dict(
+                id="x", name="x", parts=(_rect_part(),),
+                object_class="fixed_obstacle", motion_mode="towed",
+            ),
+            "fixed_obstacle",  # a fixed obstacle must not carry motion
+        ),
+        (
+            dict(
+                id="x", name="x", parts=(_rect_part(),),
+                object_class="placed_routed_mover",
+            ),
+            "motion_mode",  # a mover must carry motion
+        ),
+        (
+            dict(
+                id="x", name="x", parts=(_rect_part(),),
+                object_class="placed_routed_mover", motion_mode="steerable",
+                turn_radius_m=-1.0,
+            ),
+            "turn_radius_m",
+        ),
+    ],
+)
+def test_invalid_ground_object_rejected(kwargs: dict, msg: str) -> None:
+    with pytest.raises(ValueError, match=msg):
+        GroundObject(**kwargs)  # type: ignore[arg-type]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_models_ground_object.py -v`
+Expected: FAIL — `ImportError: cannot import name 'GroundObject'` (and `Part(kind="ground")` would raise once import works).
+
+- [ ] **Step 3: Add the `"ground"` PartKind**
+
+In `src/hangarfit/models.py`, change the `PartKind` literal (currently line 35) to add `"ground"`:
+
+```python
+PartKind = Literal[
+    "fuselage_front", "fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer", "ground"
+]
+```
+
+(The `_VALID_PART_KINDS = frozenset(typing.get_args(PartKind))` line below it picks `"ground"` up automatically.) Update the `PartKind` comment above it to note: `"ground"` denotes a non-aircraft ground-object footprint (a solid keep-out/body, never overhangable — #601.
+
+- [ ] **Step 4: Add the literals + `GroundObject` class**
+
+In `src/hangarfit/models.py`, after the `MovementMode` literal (line 31) add:
+
+```python
+GroundObjectClass = Literal["fixed_obstacle", "placed_routed_mover"]
+MoverMotionMode = Literal["steerable", "towed"]
+```
+
+And after the `_VALID_MOVEMENT_MODES` line (line 40) add:
+
+```python
+_VALID_GROUND_OBJECT_CLASSES = frozenset(typing.get_args(GroundObjectClass))
+_VALID_MOVER_MOTION_MODES = frozenset(typing.get_args(MoverMotionMode))
+```
+
+Then add the class immediately after the `Aircraft` class (after line 417, before `class Door`):
+
+```python
+@dataclass(frozen=True, slots=True)
+class GroundObject:
+    """A non-aircraft object on the hangar floor (#601 / ADR-0025).
+
+    Two classes, set by ``object_class`` (derived by the loader from the
+    catalog ``type:`` — ``fixed_obstacle`` → ``"fixed_obstacle"``;
+    ``car``/``trailer`` → ``"placed_routed_mover"``):
+
+    * **fixed_obstacle** — a placed-but-immovable keep-out (e.g. a fuel
+      trailer at the door). Carries no motion. Its world footprint is a
+      keep-out for aircraft/mover parts; the tow planner routes around it.
+    * **placed_routed_mover** — a placed body that is itself routed (a
+      self-driving ``steerable`` car, a ``towed`` trailer). Participates in
+      pairwise collision like an aircraft. ``motion_mode`` is carried here;
+      the actual route search lands in #602 (this type only carries the field).
+
+    Geometry reuses the parts model: ``parts`` is a tuple of ``Part`` with
+    ``kind="ground"`` (a solid footprint, never overhangable), transformed to
+    world coords by the *same* :func:`hangarfit.geometry.aircraft_parts_world`
+    path aircraft use. ``turn_radius_m`` is static catalog data carried for
+    #602's routing; it is unused in #601.
+    """
+
+    id: str
+    name: str
+    parts: tuple[Part, ...]
+    object_class: GroundObjectClass
+    motion_mode: MoverMotionMode | None = None
+    turn_radius_m: float | None = None
+    measured: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("GroundObject.id must be non-empty")
+        if not self.name:
+            raise ValueError(f"GroundObject {self.id!r}: name must be non-empty")
+        if not self.parts:
+            raise ValueError(f"GroundObject {self.id!r}: parts must be non-empty")
+        if self.object_class not in _VALID_GROUND_OBJECT_CLASSES:
+            raise ValueError(
+                f"GroundObject {self.id!r}: object_class must be one of "
+                f"{sorted(_VALID_GROUND_OBJECT_CLASSES)}, got {self.object_class!r}"
+            )
+        if self.object_class == "fixed_obstacle":
+            if self.motion_mode is not None:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: a fixed_obstacle must not carry a "
+                    f"motion_mode (got {self.motion_mode!r}) — it never moves"
+                )
+            if self.turn_radius_m is not None:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: a fixed_obstacle must not carry a "
+                    f"turn_radius_m — it never moves"
+                )
+        else:  # placed_routed_mover
+            if self.motion_mode not in _VALID_MOVER_MOTION_MODES:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: a placed_routed_mover requires a "
+                    f"motion_mode in {sorted(_VALID_MOVER_MOTION_MODES)}, "
+                    f"got {self.motion_mode!r}"
+                )
+        if self.turn_radius_m is not None and self.turn_radius_m <= 0:
+            raise ValueError(
+                f"GroundObject {self.id!r}: turn_radius_m must be positive, "
+                f"got {self.turn_radius_m}"
+            )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/test_models_ground_object.py -v`
+Expected: PASS (all cases).
+
+- [ ] **Step 6: Confirm the new PartKind broke nothing**
+
+Run: `pytest && mypy src/hangarfit/`
+Expected: PASS. If mypy flags a non-exhaustive `match`/dict on `PartKind` in `metrics.py`/`visualize.py`/`scene.py`, note the file — it is handled in **Task 11**. If the *test suite* fails (not just mypy), fix the immediate fallout now (most likely none: `_OVERHANGABLE` is a frozenset that simply excludes `"ground"`, the correct default).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_models_ground_object.py
+git commit -m "feat(601): GroundObject model + 'ground' PartKind
+
+Refs #601"
+```
+
+---
+
+## Task 2: `Layout` ground-object fields + invariants
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (`Layout`, lines 706-806)
+- Test: `tests/test_models_ground_object.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_models_ground_object.py`. Add imports at top: `from hangarfit.models import Aircraft, Hangar, Layout, Placement, Wheels` plus whatever the existing test fixtures use. Use the existing test helpers if a `conftest.py` builds a minimal `Hangar`/`Aircraft`; otherwise build them inline. Reuse the repo's existing minimal-fixture helpers — grep `tests/conftest.py` for a `make_hangar`/`tiny_aircraft` factory first.
+
+```python
+def _mover(obj_id: str = "caddy") -> GroundObject:
+    return GroundObject(
+        id=obj_id, name="Caddy", parts=(_rect_part(),),
+        object_class="placed_routed_mover", motion_mode="steerable",
+    )
+
+
+def test_layout_accepts_ground_objects(minimal_hangar, tiny_aircraft) -> None:
+    # minimal_hangar / tiny_aircraft: reuse existing conftest fixtures (adjust
+    # names to the repo's actual fixtures).
+    obj = _mover()
+    layout = Layout(
+        fleet={tiny_aircraft.id: tiny_aircraft},
+        hangar=minimal_hangar,
+        placements=(Placement(plane_id=tiny_aircraft.id, x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={obj.id: obj},
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=2.0, y_m=2.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    assert layout.ground_objects[obj.id] is obj
+    assert len(layout.ground_object_placements) == 1
+
+
+def test_layout_rejects_ground_key_id_mismatch(minimal_hangar, tiny_aircraft) -> None:
+    obj = _mover("caddy")
+    with pytest.raises(ValueError, match="ground_object"):
+        Layout(
+            fleet={tiny_aircraft.id: tiny_aircraft}, hangar=minimal_hangar, placements=(),
+            ground_objects={"WRONG": obj}, ground_object_placements=(),
+        )
+
+
+def test_layout_rejects_ground_placement_unknown_id(minimal_hangar, tiny_aircraft) -> None:
+    obj = _mover("caddy")
+    with pytest.raises(ValueError, match="unknown"):
+        Layout(
+            fleet={tiny_aircraft.id: tiny_aircraft}, hangar=minimal_hangar, placements=(),
+            ground_objects={obj.id: obj},
+            ground_object_placements=(
+                Placement(plane_id="ghost", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+            ),
+        )
+
+
+def test_layout_rejects_ground_id_colliding_with_fleet(minimal_hangar, tiny_aircraft) -> None:
+    # Ground-object id must be disjoint from fleet ids.
+    obj = GroundObject(
+        id=tiny_aircraft.id, name="clash", parts=(_rect_part(),), object_class="fixed_obstacle",
+    )
+    with pytest.raises(ValueError, match="disjoint|collide|both"):
+        Layout(
+            fleet={tiny_aircraft.id: tiny_aircraft}, hangar=minimal_hangar, placements=(),
+            ground_objects={obj.id: obj}, ground_object_placements=(),
+        )
+
+
+def test_layout_empty_ground_objects_default(minimal_hangar, tiny_aircraft) -> None:
+    layout = Layout(fleet={tiny_aircraft.id: tiny_aircraft}, hangar=minimal_hangar, placements=())
+    assert dict(layout.ground_objects) == {}
+    assert layout.ground_object_placements == ()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_models_ground_object.py -k ground_object -v`
+Expected: FAIL — `TypeError: Layout.__init__() got an unexpected keyword argument 'ground_objects'`.
+
+- [ ] **Step 3: Add the fields + invariants**
+
+In `src/hangarfit/models.py` `Layout` (line 706), add two fields after `maintenance_plane` (line 737):
+
+```python
+    ground_objects: Mapping[str, GroundObject] = field(default_factory=dict)
+    ground_object_placements: tuple[Placement, ...] = ()
+```
+
+Add `"ground_objects"` to `_PROXY_FIELDS` (line 743):
+
+```python
+    _PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = ("fleet", "ground_objects")
+```
+
+In `Layout.__post_init__`, add a validation block **before** the final `_PROXY_FIELDS` wrap loop (before line 797). The wrap loop already handles `ground_objects` because it iterates `_PROXY_FIELDS`:
+
+```python
+        # Ground objects (#601): keys equal their id; placements resolve;
+        # ids disjoint from the fleet so a placement id resolves unambiguously.
+        for k, obj in self.ground_objects.items():
+            if obj.id != k:
+                raise ValueError(
+                    f"ground_objects key {k!r} does not match its GroundObject.id "
+                    f"({obj.id!r}); keys must equal their ground-object id"
+                )
+        fleet_ids = set(self.fleet)
+        ground_ids = set(self.ground_objects)
+        clash = fleet_ids & ground_ids
+        if clash:
+            raise ValueError(
+                f"ground-object id(s) {sorted(clash)} collide with fleet aircraft ids; "
+                f"ids must be disjoint so a placement resolves to exactly one object"
+            )
+        seen_ground: set[str] = set()
+        for gp in self.ground_object_placements:
+            if gp.plane_id not in self.ground_objects:
+                raise ValueError(
+                    f"ground_object_placement references unknown id {gp.plane_id!r} "
+                    f"(ground_objects has: {sorted(self.ground_objects)})"
+                )
+            if gp.plane_id in seen_ground:
+                raise ValueError(
+                    f"Duplicate ground_object_placement for id {gp.plane_id!r}"
+                )
+            seen_ground.add(gp.plane_id)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_models_ground_object.py -k ground_object -v`
+Expected: PASS.
+
+- [ ] **Step 5: Confirm pickle round-trip + no regressions**
+
+Ground objects ride the `_PROXY_FIELDS` pickle path (`__getstate__`/`__setstate__`). Add a quick pickle test:
+
+```python
+def test_layout_with_ground_objects_pickles(minimal_hangar, tiny_aircraft) -> None:
+    import pickle
+    obj = _mover()
+    layout = Layout(
+        fleet={tiny_aircraft.id: tiny_aircraft}, hangar=minimal_hangar, placements=(),
+        ground_objects={obj.id: obj},
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=1.0, y_m=1.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    back = pickle.loads(pickle.dumps(layout))
+    assert back.ground_objects[obj.id].id == obj.id
+    assert back.ground_object_placements[0].plane_id == obj.id
+```
+
+Run: `pytest tests/test_models_ground_object.py -v && pytest tests/test_models.py -v`
+Expected: PASS (existing Layout tests unaffected — new fields default empty).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_models_ground_object.py
+git commit -m "feat(601): Layout ground-object fields + invariants (proxy/pickle)
+
+Refs #601"
+```
+
+---
+
+## Task 3: `Scenario` ground-object id-list
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (`Scenario`, lines 920-1088)
+- Test: `tests/test_models_ground_object.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from hangarfit.models import Scenario
+
+
+def test_scenario_ground_objects_idlist(minimal_hangar, tiny_aircraft) -> None:
+    obj = _mover()
+    scn = Scenario(
+        fleet={tiny_aircraft.id: tiny_aircraft},
+        hangar=minimal_hangar,
+        fleet_in=(tiny_aircraft.id,),
+        ground_objects=(obj.id,),
+        ground_object_defs={obj.id: obj},
+    )
+    assert scn.ground_objects == (obj.id,)
+
+
+def test_scenario_rejects_unknown_ground_object_ref(minimal_hangar, tiny_aircraft) -> None:
+    with pytest.raises(ValueError, match="ground_object"):
+        Scenario(
+            fleet={tiny_aircraft.id: tiny_aircraft}, hangar=minimal_hangar,
+            fleet_in=(tiny_aircraft.id,),
+            ground_objects=("ghost",), ground_object_defs={},
+        )
+```
+
+> Design note: the `Scenario` needs both the *id-list* (`ground_objects`) and the *defs* (`ground_object_defs`, the `GroundObject` map) to validate the references and to forward them to a built `Layout` later. `ground_object_defs` mirrors `fleet`; `ground_objects` mirrors `fleet_in`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_models_ground_object.py -k scenario -v`
+Expected: FAIL — unexpected keyword argument `ground_objects`.
+
+- [ ] **Step 3: Add the fields + invariant**
+
+In `Scenario` (line 945), after `constraints` (line 949) add:
+
+```python
+    ground_objects: tuple[str, ...] = ()
+    ground_object_defs: Mapping[str, GroundObject] = field(default_factory=lambda: MappingProxyType({}))
+```
+
+Add `ground_object_defs` to `_PROXY_FIELDS` (line 956):
+
+```python
+    _PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = ("fleet", "constraints", "ground_object_defs")
+```
+
+In `Scenario.__post_init__`, add validation before the final wrap loop (before line 1079):
+
+```python
+        # Ground objects (#601): every referenced id has a def; keys match ids.
+        for k, obj in self.ground_object_defs.items():
+            if obj.id != k:
+                raise ValueError(
+                    f"Scenario.ground_object_defs key {k!r} != GroundObject.id ({obj.id!r})"
+                )
+        for gid in self.ground_objects:
+            if gid not in self.ground_object_defs:
+                raise ValueError(
+                    f"Scenario.ground_objects references unknown ground_object {gid!r}; "
+                    f"defs have: {sorted(self.ground_object_defs)}"
+                )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_models_ground_object.py -k scenario -v`
+Expected: PASS.
+
+- [ ] **Step 5: Regression check**
+
+Run: `pytest tests/test_models.py tests/test_solver.py -v && mypy src/hangarfit/`
+Expected: PASS (existing Scenario callers unaffected — new fields default empty).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_models_ground_object.py
+git commit -m "feat(601): Scenario ground-object id-list + defs
+
+Refs #601"
+```
+
+---
+
+## Task 4: Catalog builder registry + 3 ground-object builders
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (`_build_catalog_object` 157-172; new builders + allowlists near `_build_aircraft` 1044)
+- Test: `tests/test_loader_catalog.py` (extend) + `tests/fixtures/catalog/` (new fixtures)
+
+- [ ] **Step 1: Create fixture catalog entries**
+
+Create `tests/fixtures/catalog/fixture_fuel_trailer.yaml`:
+
+```yaml
+type: fixed_obstacle
+id: fixture_fuel_trailer
+name: "Fixture fuel trailer"
+measured: false
+parts:
+  - kind: ground
+    length_m: 5.0
+    width_m: 2.0
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 2.0
+```
+
+Create `tests/fixtures/catalog/fixture_caddy.yaml`:
+
+```yaml
+type: car
+id: fixture_caddy
+name: "Fixture rescue car"
+turn_radius_m: 5.0
+measured: false
+parts:
+  - kind: ground
+    length_m: 4.5
+    width_m: 1.8
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 1.8
+```
+
+Create `tests/fixtures/catalog/fixture_glider_trailer.yaml`:
+
+```yaml
+type: trailer
+id: fixture_glider_trailer
+name: "Fixture glider trailer"
+measured: false
+parts:
+  - kind: ground
+    length_m: 8.0
+    width_m: 2.2
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 2.5
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/test_loader_catalog.py` (it already has `test_unknown_type_is_stage_a_error`-style tests; reuse its `_FIXTURE_DIR`/read helpers — grep the file for how it loads a single catalog file, e.g. a `_build_catalog_object(_read_yaml(path), source=path)` helper or `load_fleet` on a tiny manifest):
+
+```python
+from pathlib import Path
+
+from hangarfit.loader import _build_catalog_object, _read_yaml
+from hangarfit.models import GroundObject
+
+_CAT = Path(__file__).parent / "fixtures" / "catalog"
+
+
+def _build(name: str) -> object:
+    p = _CAT / name
+    return _build_catalog_object(_read_yaml(p), source=p)
+
+
+def test_fixed_obstacle_loads() -> None:
+    obj = _build("fixture_fuel_trailer.yaml")
+    assert isinstance(obj, GroundObject)
+    assert obj.object_class == "fixed_obstacle"
+    assert obj.motion_mode is None
+    assert obj.parts[0].kind == "ground"
+
+
+def test_car_loads_with_steerable_default() -> None:
+    obj = _build("fixture_caddy.yaml")
+    assert isinstance(obj, GroundObject)
+    assert obj.object_class == "placed_routed_mover"
+    assert obj.motion_mode == "steerable"   # car default
+    assert obj.turn_radius_m == 5.0
+
+
+def test_trailer_loads_with_towed_default() -> None:
+    obj = _build("fixture_glider_trailer.yaml")
+    assert isinstance(obj, GroundObject)
+    assert obj.object_class == "placed_routed_mover"
+    assert obj.motion_mode == "towed"   # trailer default
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pytest tests/test_loader_catalog.py -k "fixed_obstacle or car_loads or trailer_loads" -v`
+Expected: FAIL — `_build_catalog_object` raises `LoaderError("object type 'fixed_obstacle' not yet supported …")`.
+
+- [ ] **Step 4: Add the allowlists + builders + registry**
+
+In `src/hangarfit/loader.py`, near `_build_aircraft` (line 1044) add the new allowlists and builders. Reuse the existing `_build_part` helper (used by `_build_aircraft`) and the `_to_float`/`_to_bool` coercers:
+
+```python
+_ALLOWED_FIXED_OBSTACLE_KEYS = frozenset({"id", "name", "parts", "measured"})
+_ALLOWED_MOVER_KEYS = frozenset({"id", "name", "parts", "measured", "motion_mode", "turn_radius_m"})
+
+
+def _build_ground_parts(entry: dict[str, Any]) -> tuple[Part, ...]:
+    """Parse a ground object's ``parts`` list. Every part must be kind 'ground'
+    (a solid footprint) — no fuselage split, no struts, no wings."""
+    parts_data = entry.get("parts")
+    if not isinstance(parts_data, list) or not parts_data:
+        raise LoaderError("'parts' must be a non-empty list")
+    parts = tuple(_build_part(p, i) for i, p in enumerate(parts_data))
+    for i, part in enumerate(parts):
+        if part.kind != "ground":
+            raise LoaderError(
+                f"parts[{i}] kind {part.kind!r} not allowed on a ground object; "
+                f"use kind: ground (a solid footprint)"
+            )
+    return parts
+
+
+def _check_ground_keys(entry: Any, allowed: frozenset[str], *, what: str) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise LoaderError(f"{what} entry must be a mapping, got {type(entry).__name__}")
+    unknown = set(entry) - allowed
+    if unknown:
+        raise LoaderError(
+            f"unknown {what} key(s) {sorted(unknown)}; allowed: {sorted(allowed)}"
+        )
+    for key in ("id", "name"):
+        if key not in entry:
+            raise LoaderError(f"missing required field {key!r}")
+    return entry
+
+
+def _build_fixed_obstacle(entry: Any) -> GroundObject:
+    entry = _check_ground_keys(entry, _ALLOWED_FIXED_OBSTACLE_KEYS, what="fixed_obstacle")
+    return GroundObject(
+        id=entry["id"],
+        name=entry["name"],
+        parts=_build_ground_parts(entry),
+        object_class="fixed_obstacle",
+        measured=_to_bool(entry.get("measured", False), "measured"),
+    )
+
+
+def _build_mover(entry: Any, *, default_motion: MoverMotionMode) -> GroundObject:
+    entry = _check_ground_keys(entry, _ALLOWED_MOVER_KEYS, what="mover")
+    motion_raw = entry.get("motion_mode", default_motion)
+    tr_raw = entry.get("turn_radius_m")
+    return GroundObject(
+        id=entry["id"],
+        name=entry["name"],
+        parts=_build_ground_parts(entry),
+        object_class="placed_routed_mover",
+        motion_mode=motion_raw,
+        turn_radius_m=None if tr_raw is None else _to_float(tr_raw, "turn_radius_m"),
+        measured=_to_bool(entry.get("measured", False), "measured"),
+    )
+
+
+def _build_car(entry: Any) -> GroundObject:
+    return _build_mover(entry, default_motion="steerable")
+
+
+def _build_trailer(entry: Any) -> GroundObject:
+    return _build_mover(entry, default_motion="towed")
+```
+
+Add the imports at the top of `loader.py`: `GroundObject` and `MoverMotionMode` to the existing `from .models import (...)` block, and `Part` if not already imported there.
+
+Now replace the Stage-A guard in `_build_catalog_object` (lines 157-172). Define a registry just above it and dispatch:
+
+```python
+_CATALOG_BUILDERS: dict[str, Callable[[dict[str, Any]], Aircraft | GroundObject]] = {
+    "aircraft": _build_aircraft,
+    "fixed_obstacle": _build_fixed_obstacle,
+    "car": _build_car,
+    "trailer": _build_trailer,
+}
+
+
+def _build_catalog_object(raw: Any, *, source: Path) -> Aircraft | GroundObject:
+    """Dispatch a catalog object on its ``type:`` discriminator to the per-type
+    builder (#595 seam; ground-object types added in #601). ``type:`` is stripped
+    before the builder runs, so each per-type allowlist needs no ``type`` member."""
+    if not isinstance(raw, dict):
+        raise LoaderError(f"{source}: catalog object must be a mapping, got {type(raw).__name__}")
+    obj_type = raw.get("type", _DEFAULT_OBJECT_TYPE)
+    builder = _CATALOG_BUILDERS.get(obj_type)
+    if builder is None:
+        raise LoaderError(
+            f"{source}: unknown catalog type {obj_type!r}; "
+            f"known types: {sorted(_CATALOG_BUILDERS)}"
+        )
+    entry = {k: v for k, v in raw.items() if k != "type"}
+    return builder(entry)
+```
+
+> Note: `_CATALOG_BUILDERS` must be defined **after** the four builder functions (Python resolves the names at dict-construction time). Put the registry + the rewritten `_build_catalog_object` at the bottom, after `_build_aircraft`/`_build_*` are all defined, and **delete** the old `_build_catalog_object` at line 157. Add `from collections.abc import Callable` (or `from typing import Callable`) to the imports if absent.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/test_loader_catalog.py -k "fixed_obstacle or car_loads or trailer_loads" -v`
+Expected: PASS.
+
+- [ ] **Step 6: Update the unknown-type test + add allowlist tests**
+
+The existing `test_unknown_type_is_stage_a_error` (or similarly named) asserts the old "Stage A #600" message. Update it to assert the new behaviour:
+
+```python
+def test_unknown_catalog_type_lists_known_types() -> None:
+    p = _CAT / "fixture_bogus_type.yaml"  # create: type: spaceship + minimal parts
+    with pytest.raises(LoaderError, match="unknown catalog type 'spaceship'.*known types"):
+        _build_catalog_object(_read_yaml(p), source=p)
+
+
+def test_mover_motion_mode_override() -> None:
+    # a trailer authored with motion_mode: steerable keeps the override
+    ...  # build from an inline dict: {"type":"trailer", ..., "motion_mode":"steerable"}
+
+
+def test_fixed_obstacle_rejects_motion_key() -> None:
+    bad = {"type": "fixed_obstacle", "id": "x", "name": "x",
+           "parts": [{"kind": "ground", "length_m": 1, "width_m": 1,
+                      "offset_x_m": 0, "offset_y_m": 0, "z_bottom_m": 0, "z_top_m": 1}],
+           "motion_mode": "towed"}
+    with pytest.raises(LoaderError, match="unknown fixed_obstacle key"):
+        _build_catalog_object(bad, source=Path("inline"))
+
+
+def test_ground_object_rejects_aircraft_part_kind() -> None:
+    bad = {"type": "car", "id": "x", "name": "x",
+           "parts": [{"kind": "wing", "length_m": 1, "width_m": 1,
+                      "offset_x_m": 0, "offset_y_m": 0, "z_bottom_m": 0, "z_top_m": 1}]}
+    with pytest.raises(LoaderError, match="not allowed on a ground object"):
+        _build_catalog_object(bad, source=Path("inline"))
+```
+
+Create `tests/fixtures/catalog/fixture_bogus_type.yaml` (`type: spaceship`, valid `id`/`name`/one `ground` part).
+
+Run: `pytest tests/test_loader_catalog.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader_catalog.py tests/fixtures/catalog/
+git commit -m "feat(601): catalog builder registry + fixed_obstacle/car/trailer builders
+
+Refs #601"
+```
+
+---
+
+## Task 5: Manifest `ground_objects:` + `load_ground_objects`
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (`load_fleet` 214-271; new `load_ground_objects`)
+- Test: `tests/test_loader_catalog.py` (extend) + `tests/fixtures/` manifest
+
+- [ ] **Step 1: Create a fixture manifest**
+
+Create `tests/fixtures/catalog/fixture_ground_manifest.yaml`:
+
+```yaml
+aircraft: []
+ground_objects:
+  - fixture_fuel_trailer.yaml
+  - fixture_caddy.yaml
+  - fixture_glider_trailer.yaml
+```
+
+(Refs are relative to the manifest's directory — same as `aircraft:` refs.)
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+from hangarfit.loader import load_ground_objects
+
+
+def test_load_ground_objects_resolves_manifest() -> None:
+    gobjs = load_ground_objects(_CAT / "fixture_ground_manifest.yaml")
+    assert set(gobjs) == {"fixture_fuel_trailer", "fixture_caddy", "fixture_glider_trailer"}
+    assert gobjs["fixture_caddy"].object_class == "placed_routed_mover"
+
+
+def test_load_ground_objects_absent_key_is_empty(tmp_path) -> None:
+    m = tmp_path / "m.yaml"
+    m.write_text("aircraft: []\n")
+    assert load_ground_objects(m) == {}
+
+
+def test_load_fleet_rejects_ground_object_under_aircraft(tmp_path) -> None:
+    # A ground-object ref listed under aircraft: must fail loudly.
+    import shutil
+    shutil.copy(_CAT / "fixture_fuel_trailer.yaml", tmp_path / "ft.yaml")
+    m = tmp_path / "m.yaml"
+    m.write_text("aircraft:\n  - ft.yaml\n")
+    with pytest.raises(LoaderError, match="aircraft|not an aircraft|ground"):
+        load_fleet(m)
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pytest tests/test_loader_catalog.py -k "load_ground_objects or ground_object_under_aircraft" -v`
+Expected: FAIL — `ImportError: cannot import name 'load_ground_objects'`.
+
+- [ ] **Step 4: Implement `load_ground_objects` + the defensive guard in `load_fleet`**
+
+In `load_fleet` (after building each object, ~line 265-270), add a type guard so an accidental ground-object ref under `aircraft:` fails:
+
+```python
+        try:
+            obj = _build_catalog_object(obj_raw, source=catalog_path)
+        except (ValueError, KeyError, TypeError, LoaderError) as e:
+            raise LoaderError(f"{path}: aircraft[{i}] ({ref}): {e}") from e
+        if not isinstance(obj, Aircraft):
+            raise LoaderError(
+                f"{path}: aircraft[{i}] ({ref}) is a {type(obj).__name__}, not an Aircraft; "
+                f"list non-aircraft objects under 'ground_objects:' instead"
+            )
+        if obj.id in fleet:
+            raise LoaderError(f"{path}: duplicate aircraft id {obj.id!r}")
+        fleet[obj.id] = obj
+```
+
+(Rename the local `aircraft` variable to `obj` in that block.)
+
+Add `load_ground_objects` next to `load_fleet`. It mirrors `load_fleet`'s ref-resolution loop but reads the `ground_objects:` list and asserts each is a `GroundObject`:
+
+```python
+def load_ground_objects(path: Path | str) -> dict[str, GroundObject]:
+    """Load the ``ground_objects:`` list of a fleet manifest into a dict keyed
+    by :attr:`GroundObject.id` (#601). Returns ``{}`` when the key is absent, so
+    existing manifests (aircraft-only) are byte-identical. Refs resolve relative
+    to the manifest dir, exactly like ``aircraft:`` refs."""
+    path = Path(path)
+    raw = _read_yaml(path)
+    if not isinstance(raw, dict):
+        raise LoaderError(f"{path}: top-level mapping required")
+    obj_list = raw.get("ground_objects")
+    if obj_list is None:
+        return {}
+    if not isinstance(obj_list, list):
+        raise LoaderError(f"{path}: 'ground_objects' must be a list")
+    manifest_dir = path.parent
+    out: dict[str, GroundObject] = {}
+    for i, entry in enumerate(obj_list):
+        ref, overrides = _parse_manifest_entry(entry, index=i, path=path)
+        if overrides:
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] overrides {sorted(overrides)} not supported"
+            )
+        try:
+            catalog_path = (manifest_dir / ref).resolve()
+            ref_exists = catalog_path.is_file()
+        except (ValueError, OSError) as e:
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] has an invalid catalog reference {ref!r}: {e}"
+            ) from e
+        if not ref_exists:
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] references {ref!r} which does not exist "
+                f"(resolved to {catalog_path})"
+            )
+        try:
+            obj = _build_catalog_object(_read_yaml(catalog_path), source=catalog_path)
+        except (ValueError, KeyError, TypeError, LoaderError) as e:
+            raise LoaderError(f"{path}: ground_objects[{i}] ({ref}): {e}") from e
+        if not isinstance(obj, GroundObject):
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] ({ref}) is a {type(obj).__name__}, not a "
+                f"GroundObject; list aircraft under 'aircraft:' instead"
+            )
+        if obj.id in out:
+            raise LoaderError(f"{path}: duplicate ground_object id {obj.id!r}")
+        out[obj.id] = obj
+    return out
+```
+
+> Note: `_parse_manifest_entry`'s error messages say "aircraft[index]". That is acceptable for #601 (movers don't use overrides). If a reviewer objects, generalise `_parse_manifest_entry` to take a `block` label — but YAGNI for now; ground objects pass bare path strings.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/test_loader_catalog.py -k "load_ground_objects or ground_object_under_aircraft" -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader_catalog.py tests/fixtures/catalog/fixture_ground_manifest.yaml
+git commit -m "feat(601): manifest ground_objects: + load_ground_objects + aircraft/ground guard
+
+Refs #601"
+```
+
+---
+
+## Task 6: Layout YAML `ground_objects:` parsing
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (`_ALLOWED_LAYOUT_KEYS` 420; `load_layout` 423-543)
+- Test: `tests/test_loader.py` (extend) + `tests/fixtures/` layout
+
+- [ ] **Step 1: Write the failing test**
+
+Build a self-contained layout fixture in `tmp_path` (so the test owns its fleet/hangar refs), or add a checked-in fixture. The layout's `fleet:` points at the fixture manifest from Task 5 (which has both `aircraft:` and `ground_objects:`), but that manifest has `aircraft: []`. For a layout test we need ≥1 aircraft too; build a tiny manifest inline. Append to `tests/test_loader.py`:
+
+```python
+def test_layout_loads_ground_objects(tmp_path) -> None:
+    # minimal manifest with one aircraft + one fixed obstacle (copy fixtures in)
+    cat = tmp_path / "catalog"
+    cat.mkdir()
+    # ... copy a known-good aircraft catalog file + fixture_fuel_trailer.yaml into cat ...
+    (tmp_path / "fleet.yaml").write_text(
+        "aircraft:\n  - catalog/<aircraft>.yaml\n"
+        "ground_objects:\n  - catalog/fixture_fuel_trailer.yaml\n"
+    )
+    # ... write hangar.yaml (reuse an existing fixture hangar) ...
+    (tmp_path / "layout.yaml").write_text(
+        "fleet: fleet.yaml\n"
+        "hangar: hangar.yaml\n"
+        "placements:\n"
+        "  - plane: <aircraft_id>\n    x_m: 5.0\n    y_m: 5.0\n    heading_deg: 0.0\n    on_carts: false\n"
+        "ground_objects:\n"
+        "  - object: fixture_fuel_trailer\n    x_m: 2.0\n    y_m: 2.0\n    heading_deg: 0.0\n"
+    )
+    layout = load_layout(tmp_path / "layout.yaml")
+    assert "fixture_fuel_trailer" in layout.ground_objects
+    assert layout.ground_object_placements[0].plane_id == "fixture_fuel_trailer"
+
+
+def test_layout_unknown_ground_object_id(tmp_path) -> None:
+    # ... same setup, but the layout references object: ghost ...
+    with pytest.raises(LoaderError, match="ghost"):
+        load_layout(tmp_path / "layout.yaml")
+
+
+def test_layout_ground_object_unknown_entry_key(tmp_path) -> None:
+    # ... a ground_objects entry with a bogus key like 'rotation' ...
+    with pytest.raises(LoaderError, match="unknown.*ground_object"):
+        load_layout(tmp_path / "layout.yaml")
+```
+
+> Implementation tip for the test author: grep `tests/` for an existing helper that scaffolds a tmp fleet/hangar/layout (several loader tests do this) and reuse it; copy a real `data/catalog/<id>.yaml` aircraft file as the fixture aircraft.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_loader.py -k "layout_loads_ground or unknown_ground" -v`
+Expected: FAIL — `load_layout` rejects the unknown top-level key `ground_objects` (`_reject_unknown_top_level_keys`).
+
+- [ ] **Step 3: Extend the allowlist + parse the block**
+
+In `loader.py`, extend `_ALLOWED_LAYOUT_KEYS` (line 420):
+
+```python
+_ALLOWED_LAYOUT_KEYS = frozenset({"fleet", "hangar", "placements", "maintenance", "ground_objects"})
+```
+
+Add a `ground_objects=` injection param to `load_layout`'s signature (after `apron_depth`):
+
+```python
+    ground_objects: dict[str, GroundObject] | None = None,
+```
+
+In `load_layout`, after the fleet is resolved (after line 462) resolve the ground-object defs from the *same* manifest, mirroring the fleet pattern:
+
+```python
+    if ground_objects is None:
+        fleet_ref = raw.get("fleet")
+        # When the layout supplies a fleet ref, the same manifest carries the
+        # ground_objects list; resolve it. When fleet is injected (no ref),
+        # ground objects default to empty unless injected.
+        if fleet_ref is not None:
+            ground_objects = load_ground_objects((path.parent / fleet_ref).resolve())
+        else:
+            ground_objects = {}
+```
+
+Then parse the layout's `ground_objects:` block (after the `placements` parse, ~line 508), building a `Placement` per entry:
+
+```python
+    go_data = raw.get("ground_objects", [])
+    if not isinstance(go_data, list):
+        raise LoaderError(f"{path}: 'ground_objects' must be a list")
+    _allowed_go_entry = frozenset({"object", "x_m", "y_m", "heading_deg"})
+    ground_object_placements_list: list[Placement] = []
+    for i, e in enumerate(go_data):
+        if not isinstance(e, dict):
+            raise LoaderError(f"{path}: ground_objects[{i}] must be a mapping")
+        unknown = set(e) - _allowed_go_entry
+        if unknown:
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] has unknown key(s) {sorted(unknown)}; "
+                f"allowed: {sorted(_allowed_go_entry)}"
+            )
+        for key in ("object", "x_m", "y_m", "heading_deg"):
+            if key not in e:
+                raise LoaderError(f"{path}: missing required field 'ground_objects[{i}].{key}'")
+        obj_id = e["object"]
+        if obj_id not in ground_objects:
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] references unknown object {obj_id!r}; "
+                f"the manifest defines: {sorted(ground_objects)}"
+            )
+        ground_object_placements_list.append(
+            Placement(
+                plane_id=obj_id,
+                x_m=_to_float(e["x_m"], f"ground_objects[{i}].x_m"),
+                y_m=_to_float(e["y_m"], f"ground_objects[{i}].y_m"),
+                heading_deg=_to_float(e["heading_deg"], f"ground_objects[{i}].heading_deg"),
+                on_carts=False,
+            )
+        )
+    ground_object_placements = tuple(ground_object_placements_list)
+```
+
+Finally, pass both to the `Layout(...)` constructor (line 536):
+
+```python
+        return Layout(
+            fleet=fleet,
+            hangar=hangar,
+            placements=placements,
+            maintenance_plane=maintenance_plane,
+            ground_objects=ground_objects,
+            ground_object_placements=ground_object_placements,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_loader.py -k "layout_loads_ground or unknown_ground" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Add the allowlist round-trip test**
+
+The repo has `test_all_allowed_layout_keys_load` (tests/test_loader.py) asserting `set(yaml_keys) == _ALLOWED_LAYOUT_KEYS`. Update its fixture to include a `ground_objects:` block so the assertion still equals the (now larger) allowlist. Run it:
+
+Run: `pytest tests/test_loader.py -k all_allowed_layout_keys -v`
+Expected: PASS.
+
+- [ ] **Step 6: Byte-identity check (no ground objects)**
+
+Run: `pytest tests/test_loader.py -v`
+Expected: PASS — existing layout fixtures (no `ground_objects:`) load unchanged (`ground_objects` defaults to the manifest's empty set or `{}`; `ground_object_placements` is `()`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader.py tests/fixtures/
+git commit -m "feat(601): layout YAML ground_objects: block parsing
+
+Refs #601"
+```
+
+---
+
+## Task 7: Scenario YAML `ground_objects:` id-list parsing
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (`_ALLOWED_SCENARIO_KEYS` 550; `load_scenario` 553-703)
+- Test: `tests/test_loader.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_scenario_loads_ground_objects(tmp_path) -> None:
+    # manifest with one aircraft + one mover; scenario lists the mover id
+    # ... scaffold fleet.yaml (aircraft + ground_objects), hangar.yaml ...
+    (tmp_path / "scn.yaml").write_text(
+        "fleet: fleet.yaml\nhangar: hangar.yaml\n"
+        "fleet_in:\n  - <aircraft_id>\n"
+        "ground_objects:\n  - fixture_caddy\n"
+    )
+    scn = load_scenario(tmp_path / "scn.yaml")
+    assert scn.ground_objects == ("fixture_caddy",)
+    assert "fixture_caddy" in scn.ground_object_defs
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_loader.py -k scenario_loads_ground -v`
+Expected: FAIL — unknown top-level key `ground_objects`.
+
+- [ ] **Step 3: Extend allowlist + parse**
+
+Extend `_ALLOWED_SCENARIO_KEYS` (line 550):
+
+```python
+_ALLOWED_SCENARIO_KEYS = frozenset(
+    {"fleet_in", "fleet", "hangar", "maintenance", "constraints", "ground_objects"}
+)
+```
+
+Add a `ground_objects=` injection param to `load_scenario` (after `apron_depth`):
+
+```python
+    ground_objects: dict[str, GroundObject] | None = None,
+```
+
+After the fleet is resolved (after line 608), resolve ground-object defs from the same manifest:
+
+```python
+    if ground_objects is None:
+        fleet_ref = raw.get("fleet")
+        ground_objects = (
+            load_ground_objects((path.parent / fleet_ref).resolve())
+            if fleet_ref is not None else {}
+        )
+```
+
+Parse the id-list (after `fleet_in` is built, ~line 594, but resolve against defs after they exist — put it just before the `Scenario(...)` build):
+
+```python
+    go_ids_raw = raw.get("ground_objects", [])
+    if not isinstance(go_ids_raw, list):
+        raise LoaderError(f"{path}: 'ground_objects' must be a list of ids")
+    scenario_ground_objects = tuple(str(x) for x in go_ids_raw)
+    for gid in scenario_ground_objects:
+        if gid not in ground_objects:
+            raise LoaderError(
+                f"{path}: ground_objects references unknown object {gid!r}; "
+                f"the manifest defines: {sorted(ground_objects)}"
+            )
+```
+
+Pass to `Scenario(...)` (line 695):
+
+```python
+        return Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=fleet_in,
+            maintenance_plane=maintenance_plane,
+            constraints=constraints,
+            ground_objects=scenario_ground_objects,
+            ground_object_defs=ground_objects,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_loader.py -k scenario_loads_ground -v`
+Expected: PASS.
+
+- [ ] **Step 5: Update the scenario allowlist round-trip test + byte-identity**
+
+Update `test_all_allowed_scenario_keys_load` to include a `ground_objects:` key. Run:
+
+Run: `pytest tests/test_loader.py -k "all_allowed_scenario or scenario" -v && pytest tests/test_solver.py -v`
+Expected: PASS — solver scenarios (no ground objects) load unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader.py
+git commit -m "feat(601): scenario YAML ground_objects: id-list parsing
+
+Refs #601"
+```
+
+---
+
+## Task 8: Geometry — widen `aircraft_parts_world` to ground objects
+
+**Files:**
+- Modify: `src/hangarfit/geometry.py` (`aircraft_parts_world` 196-259; import 32)
+- Test: `tests/test_geometry.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+`aircraft_parts_world` is guarded by `geometry-invariant-guard`; the transform is unchanged, only the accepted type widens. The test asserts a ground object's footprint transforms identically to an equivalent aircraft part. Add to `tests/test_geometry.py`:
+
+```python
+from hangarfit.geometry import aircraft_parts_world
+from hangarfit.models import GroundObject, Part, Placement
+
+
+def test_ground_object_parts_world_uses_same_transform() -> None:
+    part = Part(
+        kind="ground", length_m=4.0, width_m=2.0, offset_x_m=0.0, offset_y_m=0.0,
+        angle_deg=0.0, z_bottom_m=0.0, z_top_m=1.5,
+    )
+    obj = GroundObject(id="trolley", name="t", parts=(part,), object_class="fixed_obstacle")
+    pl = Placement(plane_id="trolley", x_m=7.0, y_m=3.0, heading_deg=37.0, on_carts=False)
+    wps = aircraft_parts_world(obj, pl)
+    assert len(wps) == 1
+    assert wps[0].plane_id == "trolley"
+    assert wps[0].kind == "ground"
+    # det-(-1) transform: a non-axis-aligned heading must produce a rotated box
+    # (the geometry-invariant-guard requirement). Centroid maps via local_to_world.
+    cx, cy = wps[0].polygon.centroid.coords[0]
+    assert cx == pytest.approx(7.0)
+    assert cy == pytest.approx(3.0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_geometry.py -k ground_object_parts_world -v`
+Expected: FAIL — `mypy`/runtime type mismatch is the *intent*, but at runtime duck-typing may already pass. If it PASSES at runtime, still proceed to Step 3 to fix the **type annotation** (mypy would otherwise reject ground-object callers in Tasks 9-10).
+
+- [ ] **Step 3: Widen the signature**
+
+In `geometry.py`, change the import (line 32) to add `GroundObject`:
+
+```python
+from .models import Aircraft, GroundObject, Part, PartKind, Placement
+```
+
+Change `aircraft_parts_world`'s signature (line 196-199) and the loop variable:
+
+```python
+def aircraft_parts_world(
+    obj: Aircraft | GroundObject,
+    placement: Placement,
+) -> list[WorldPart]:
+```
+
+In the body, change `for part in aircraft.parts:` (line 225) to `for part in obj.parts:`. Update the docstring's first line to: "Transform every part of an aircraft **or ground object** from plane-local to world coords." The transform math is untouched (ADR-0002 invariant preserved).
+
+> `cached_parts_world` (the hot per-solve memoized wrapper) is **not** changed — ground objects are few and not in the solver hot loop, so collisions/towplanner call the un-cached `aircraft_parts_world` for them directly (Tasks 9-10).
+
+- [ ] **Step 4: Run test + the guard's own tests**
+
+Run: `pytest tests/test_geometry.py -v && mypy src/hangarfit/geometry.py`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/geometry.py tests/test_geometry.py
+git commit -m "feat(601): widen aircraft_parts_world to accept GroundObject
+
+Refs #601"
+```
+
+---
+
+## Task 9: Collisions — fixed-obstacle keep-out + movers in pairwise
+
+**Files:**
+- Modify: `src/hangarfit/collisions.py` (`check` 61-74; new `_ground_obstacle_conflicts` after 75; import 51-58)
+- Test: `tests/test_collisions_ground_object.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Ground-object collision wiring (#601)."""
+
+import pytest
+
+from hangarfit.collisions import check
+from hangarfit.models import GroundObject, Layout, Part, Placement
+# reuse conftest fixtures: minimal_hangar, an aircraft factory
+
+
+def _ground_part(length_m=4.0, width_m=2.0, z_top_m=1.5) -> Part:
+    return Part(kind="ground", length_m=length_m, width_m=width_m, offset_x_m=0.0,
+                offset_y_m=0.0, angle_deg=0.0, z_bottom_m=0.0, z_top_m=z_top_m)
+
+
+def test_aircraft_over_fixed_obstacle_conflicts(minimal_hangar, low_wing_aircraft) -> None:
+    # Place a fixed obstacle directly under an aircraft part → ground_obstacle conflict.
+    obj = GroundObject(id="obstacle", name="o", parts=(_ground_part(z_top_m=3.0),),
+                       object_class="fixed_obstacle")
+    ac = low_wing_aircraft  # whatever the conftest provides; place it ON the obstacle
+    layout = Layout(
+        fleet={ac.id: ac}, hangar=minimal_hangar,
+        placements=(Placement(plane_id=ac.id, x_m=6.0, y_m=6.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={obj.id: obj},
+        ground_object_placements=(Placement(plane_id=obj.id, x_m=6.0, y_m=6.0, heading_deg=0.0, on_carts=False),),
+    )
+    result = check(layout)
+    kinds = {c.kind for c in result.conflicts}
+    assert "ground_obstacle" in kinds
+    assert any("obstacle" in "".join(c.planes) or "obstacle" in c.detail for c in result.conflicts)
+
+
+def test_mover_overlapping_aircraft_conflicts(minimal_hangar, low_wing_aircraft) -> None:
+    mover = GroundObject(id="caddy", name="c", parts=(_ground_part(z_top_m=3.0),),
+                         object_class="placed_routed_mover", motion_mode="steerable", turn_radius_m=4.0)
+    ac = low_wing_aircraft
+    layout = Layout(
+        fleet={ac.id: ac}, hangar=minimal_hangar,
+        placements=(Placement(plane_id=ac.id, x_m=6.0, y_m=6.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={mover.id: mover},
+        ground_object_placements=(Placement(plane_id=mover.id, x_m=6.0, y_m=6.0, heading_deg=0.0, on_carts=False),),
+    )
+    result = check(layout)
+    # mover participates in pairwise → a *_overlap conflict naming the ground part
+    assert any(c.kind.endswith("_overlap") and "ground" in c.kind for c in result.conflicts)
+
+
+def test_separated_ground_object_is_valid(minimal_hangar, low_wing_aircraft) -> None:
+    obj = GroundObject(id="obstacle", name="o", parts=(_ground_part(),), object_class="fixed_obstacle")
+    ac = low_wing_aircraft
+    layout = Layout(
+        fleet={ac.id: ac}, hangar=minimal_hangar,
+        placements=(Placement(plane_id=ac.id, x_m=6.0, y_m=6.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={obj.id: obj},
+        # far corner, no overlap
+        ground_object_placements=(Placement(plane_id=obj.id, x_m=1.0, y_m=1.0, heading_deg=0.0, on_carts=False),),
+    )
+    assert check(layout).valid
+```
+
+Also add a **byte-identity** test: load an existing valid fixture layout (no ground objects) and assert its `CheckResult` is unchanged:
+
+```python
+def test_empty_ground_objects_byte_identical(existing_valid_layout) -> None:
+    # existing_valid_layout: an already-checked fixture Layout with no ground objects.
+    r = check(existing_valid_layout)
+    assert r.valid  # and conflicts/total_penetration_m2 unchanged vs pre-#601
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_collisions_ground_object.py -v`
+Expected: FAIL — `check` ignores ground objects (no `ground_obstacle` conflict).
+
+- [ ] **Step 3: Implement the wiring in `check` + the new function**
+
+In `collisions.py`, add `aircraft_parts_world` and `GroundObject`/`WorldPart` to imports:
+
+```python
+from .geometry import (
+    WorldPart,
+    aircraft_parts_world,
+    axis_aligned_rect,
+    cached_parts_world,
+    polygon_overlap,
+    polygon_overlap_area,
+)
+from .models import CheckResult, Conflict, GroundObject, Hangar, Layout
+```
+
+Rewrite `check` (lines 61-74):
+
+```python
+def check(layout: Layout) -> CheckResult:
+    """Run all geometric checks and return a :class:`CheckResult`."""
+    aircraft_parts: dict[str, list[WorldPart]] = {
+        p.plane_id: cached_parts_world(layout.fleet[p.plane_id], p) for p in layout.placements
+    }
+    # Ground objects (#601): movers are placed bodies (pairwise); fixed obstacles
+    # are keep-outs. Both reuse the aircraft world-transform (det-(-1), ADR-0002).
+    mover_parts: dict[str, list[WorldPart]] = {}
+    obstacle_parts: dict[str, list[WorldPart]] = {}
+    for gp in layout.ground_object_placements:
+        obj = layout.ground_objects[gp.plane_id]
+        wparts = aircraft_parts_world(obj, gp)
+        if obj.object_class == "fixed_obstacle":
+            obstacle_parts[gp.plane_id] = wparts
+        else:
+            mover_parts[gp.plane_id] = wparts
+
+    # Movers join the placed-body set for bounds-free pairwise collision; aircraft
+    # come first so the no-ground-object case is byte-identical (same dict order).
+    placed_bodies = {**aircraft_parts, **mover_parts}
+
+    conflicts: list[Conflict] = []
+    conflicts.extend(_hangar_bounds_conflicts(aircraft_parts, layout.hangar))
+    conflicts.extend(_bay_intrusion_conflicts(aircraft_parts, layout))
+    pairwise, total_penetration_m2 = _pairwise_conflicts(placed_bodies, layout.hangar)
+    conflicts.extend(pairwise)
+    conflicts.extend(_ground_obstacle_conflicts(placed_bodies, obstacle_parts, layout.hangar))
+    return CheckResult(
+        conflicts=tuple(conflicts),
+        total_penetration_m2=total_penetration_m2,
+    )
+```
+
+> Byte-identity rationale (state in the code comment): with no ground objects, `mover_parts`/`obstacle_parts` are empty, `placed_bodies == aircraft_parts`, `_ground_obstacle_conflicts` returns `[]`, and the conflict order/`total_penetration_m2` are identical to pre-#601. `_hangar_bounds_conflicts`/`_bay_intrusion_conflicts` keep their aircraft-only input (ground-object bounds checking is out of #601 scope — #604/#605).
+
+Add `_ground_obstacle_conflicts` right after `check` (after line 74). It reuses `_parts_conflict` (the z-gap predicate) so its boundary semantics match the oracle exactly:
+
+```python
+def _ground_obstacle_conflicts(
+    placed_bodies: dict[str, list[WorldPart]],
+    obstacle_parts: dict[str, list[WorldPart]],
+    hangar: Hangar,
+) -> list[Conflict]:
+    """A fixed obstacle's footprint is a keep-out: any aircraft/mover part that
+    conflicts with it (plan-view overlap within clearance AND z-gap rule, via
+    :func:`_parts_conflict`) is a single-object ``ground_obstacle`` conflict
+    naming the offending body and the obstacle (#601 / ADR-0025).
+
+    Deterministic iteration: obstacles in dict-insertion order (manifest order),
+    bodies in placement order. Empty ``obstacle_parts`` → ``[]`` (byte-identity)."""
+    out: list[Conflict] = []
+    for obstacle_id, obs_wparts in obstacle_parts.items():
+        for body_id, body_wparts in placed_bodies.items():
+            for op in obs_wparts:
+                for bp in body_wparts:
+                    if _parts_conflict(op, bp, hangar):
+                        out.append(
+                            Conflict.single(
+                                kind="ground_obstacle",
+                                plane=body_id,
+                                detail=(
+                                    f"part {bp.kind!r} of {body_id!r} overlaps fixed "
+                                    f"obstacle {obstacle_id!r} part {op.kind!r}"
+                                ),
+                            )
+                        )
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_collisions_ground_object.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full collisions regression (byte-identity)**
+
+Run: `pytest tests/test_collisions.py tests/test_collisions_ground_object.py -v && mypy src/hangarfit/collisions.py`
+Expected: PASS — every existing collision test unchanged (empty ground objects → byte-identical).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/collisions.py tests/test_collisions_ground_object.py
+git commit -m "feat(601): fixed-obstacle keep-out + movers in pairwise collision
+
+Refs #601"
+```
+
+---
+
+## Task 10: Tow-planner — fixed obstacles as static; movers in routable enumeration
+
+**Files:**
+- Modify: `src/hangarfit/towplanner.py` (`_build_obstacles` 1720-1751; `plan_fill` 1279-1445)
+- Test: `tests/test_towplanner_ground_object.py` (new)
+
+> This file is guarded by `determinism-guard`. The empty-ground-object case MUST stay byte-identical. Read `_build_obstacles` and `plan_fill` in full before editing — the snippets below are anchored insertions, not whole-function rewrites.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tow-planner ground-object wiring (#601)."""
+
+import pytest
+
+from hangarfit.towplanner import plan_fill, _build_obstacles
+from hangarfit.models import GroundObject, Layout, Part, Placement
+
+
+def _ground_part(length_m=3.0, width_m=13.0, z_top_m=3.0) -> Part:
+    return Part(kind="ground", length_m=length_m, width_m=width_m, offset_x_m=0.0,
+                offset_y_m=0.0, angle_deg=0.0, z_bottom_m=0.0, z_top_m=z_top_m)
+
+
+def test_fixed_obstacle_in_static_obstacle_set(minimal_hangar, tiny_aircraft) -> None:
+    obj = GroundObject(id="doorblock", name="d", parts=(_ground_part(),),
+                       object_class="fixed_obstacle")
+    layout = Layout(
+        fleet={tiny_aircraft.id: tiny_aircraft}, hangar=minimal_hangar,
+        placements=(Placement(plane_id=tiny_aircraft.id, x_m=6.0, y_m=8.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={obj.id: obj},
+        # a wide obstacle just inside the door throat (small y)
+        ground_object_placements=(Placement(plane_id=obj.id, x_m=7.0, y_m=1.0, heading_deg=0.0, on_carts=False),),
+    )
+    obstacles = _build_obstacles(layout, mover_id=tiny_aircraft.id)
+    # the obstacle's footprint is present among the planner's static world parts
+    assert any(wp.plane_id == "doorblock" for wp in obstacles.world_parts)
+
+
+def test_mover_in_routable_enumeration(minimal_hangar, tiny_aircraft) -> None:
+    mover = GroundObject(id="caddy", name="c", parts=(_ground_part(width_m=2.0),),
+                         object_class="placed_routed_mover", motion_mode="steerable", turn_radius_m=4.0)
+    layout = Layout(
+        fleet={tiny_aircraft.id: tiny_aircraft}, hangar=minimal_hangar,
+        placements=(Placement(plane_id=tiny_aircraft.id, x_m=6.0, y_m=8.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={mover.id: mover},
+        ground_object_placements=(Placement(plane_id=mover.id, x_m=3.0, y_m=8.0, heading_deg=0.0, on_carts=False),),
+    )
+    plan = plan_fill(layout)
+    # the mover id appears in the plan's routed enumeration (path deferred/None to #602)
+    routed_ids = {m.plane_id for m in plan.moves}
+    assert "caddy" in routed_ids
+```
+
+> Adjust `plan.moves`/`m.plane_id` to the real `MovesPlan` shape — grep `towplanner.py` for the `MovesPlan` dataclass and the existing best-effort `plans[i] = None` pattern before finalising the assertion. The intent: the mover is enumerated as something the planner must route, even though its path is `None` in #601.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_towplanner_ground_object.py -v`
+Expected: FAIL — `_build_obstacles` ignores ground objects; `plan_fill` does not enumerate the mover.
+
+- [ ] **Step 3: Add fixed obstacles + placed movers to `_build_obstacles`**
+
+In `_build_obstacles` (line 1720-1751), after the placed-plane world-parts collection and the `notch_boxes` construction, append ground-object world parts (fixed obstacles always; movers except the one being routed). Read the function to find where `world_parts` / `world_part_aabbs` are assembled and mirror the exact AABB pairing (the `_Obstacles.__post_init__` enforces parallel-array length):
+
+```python
+    # Ground objects (#601): fixed obstacles are always static keep-outs; placed
+    # movers (other than the one being routed) are static placed bodies. Sorted by
+    # id so the world_parts tuple order is deterministic (determinism-guard).
+    from .geometry import aircraft_parts_world  # local import if not already at top
+    for gp in sorted(placed.ground_object_placements, key=lambda p: p.plane_id):
+        if gp.plane_id == mover_id:
+            continue
+        obj = placed.ground_objects[gp.plane_id]
+        for wp in aircraft_parts_world(obj, gp):
+            extra_world_parts.append(wp)
+            extra_world_part_aabbs.append(_aabb_of(wp))  # use the same AABB helper this fn uses
+```
+
+> Implementation detail: match the names the function actually uses for its world-part list and AABB list, and the AABB helper it calls (grep `_build_obstacles` for how it builds `world_part_aabbs`). Append to those before the `_Obstacles(...)` construction so the parallel-array invariant holds. If `aircraft_parts_world` is already imported at module top, drop the local import.
+
+- [ ] **Step 4: Enumerate movers in `plan_fill` (deferred route)**
+
+In `plan_fill` (line 1279-1445), after the aircraft routable order is built from `back_first_order(target.placements)`, append the movers as deferred routables. Read the loop that produces `moves`/`plans` and follow the existing best-effort `None`-path pattern: for each `gp` in `target.ground_object_placements` whose object is a `placed_routed_mover`, emit a `Move` with a `None`/deferred path (it is enumerated but not searched — #602 implements the search):
+
+```python
+    # Ground-object movers (#601): enumerate each as a body the planner must route,
+    # but DEFER the actual path search to #602 — emit a deferred (None-path) move.
+    # Fixed obstacles are never routed (they are keep-outs, handled in _build_obstacles).
+    for gp in target.ground_object_placements:
+        obj = target.ground_objects[gp.plane_id]
+        if obj.object_class != "placed_routed_mover":
+            continue
+        moves.append(_deferred_mover_move(gp))  # build a Move with path=None, plane_id=gp.plane_id
+```
+
+> Define `_deferred_mover_move` (or inline) to match the `Move` dataclass fields — grep `towplanner.py` for `class Move` and the existing place a `None` path is constructed. The deferred move must carry `plane_id = gp.plane_id`. Keep it OUT of the aircraft routing loop so aircraft plans are byte-identical.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/test_towplanner_ground_object.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Determinism + byte-identity regression**
+
+Run: `pytest tests/test_towplanner.py tests/test_solver_parallel.py -v`
+Expected: PASS — no ground objects in those fixtures → byte-identical plans. Then run the determinism double-solve canary if present:
+
+Run: `pytest -k determinism -v`
+Expected: PASS (the guard's fixtures carry no ground objects, so the plan is bit-identical).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hangarfit/towplanner.py tests/test_towplanner_ground_object.py
+git commit -m "feat(601): fixed obstacles as static keep-outs; movers in routable enumeration
+
+Refs #601"
+```
+
+---
+
+## Task 11: `"ground"` PartKind ripple audit
+
+**Files:**
+- Modify (if needed): `src/hangarfit/metrics.py`, `src/hangarfit/visualize.py`, `src/hangarfit/scene.py`
+- Test: existing suites + `mypy`
+
+- [ ] **Step 1: Find every PartKind-exhaustive consumer**
+
+Run: `grep -rn "PartKind\|_OVERHANGABLE\|part.kind\|\.kind ==" src/hangarfit/metrics.py src/hangarfit/visualize.py src/hangarfit/scene.py`
+Expected: a short list. Classify each: does it `match`/dict-lookup on kind without a default (would break on `"ground"`), or is it a membership test (safe — `"ground"` simply isn't a wing/tail/overhangable)?
+
+- [ ] **Step 2: Run mypy + full suite to surface fallout**
+
+Run: `mypy src/hangarfit/ && pytest`
+Expected: PASS. The most likely findings and their correct handling:
+- `metrics._OVERHANGABLE` (a frozenset): `"ground"` is correctly absent → a ground part is never overhangable. **No change.**
+- `visualize.py` / `scene.py` color/material lookup keyed by kind: only reachable when a layout *contains* a ground part. No existing fixture does, and #601 ships no rendering (deferred to #606). If a `dict[...]` lookup would `KeyError` or a `match` is non-exhaustive for mypy, add a minimal default branch (e.g. a neutral grey for an unknown kind) — do **not** build the full ground-object rendering here (that is #606).
+
+- [ ] **Step 3: If a default was needed, add a focused test**
+
+If you added a default render branch, add one test that a ground `Part` renders without raising (a smoke test), in the relevant test module.
+
+- [ ] **Step 4: Commit (only if changes were needed)**
+
+```bash
+git add src/hangarfit/metrics.py src/hangarfit/visualize.py src/hangarfit/scene.py tests/
+git commit -m "fix(601): handle 'ground' PartKind in metrics/visualize/scene defaults
+
+Refs #601"
+```
+
+If no changes were needed, record that in the task notes and skip the commit.
+
+---
+
+## Task 12: Docs — ADR-0025, arc42 §5/§8, catalog README, CHANGELOG
+
+**Files:**
+- Create: `docs/adr/0025-ground-object-taxonomy.md`
+- Modify: `docs/architecture/05-building-block-view.md`, `docs/architecture/08-crosscutting-concepts.md`, `data/catalog/README.md`, `CHANGELOG.md`, `docs/adr/README.md` (the ADR index)
+
+- [ ] **Step 1: Write ADR-0025**
+
+Create `docs/adr/0025-ground-object-taxonomy.md` following the format of an existing ADR (e.g. `0023-empennage-tail-surfaces.md` — read it for the header/status/context/decision/consequences shape). Content: the concrete-type taxonomy (D1), Layout-uniform-via-Placement (D2), the pairwise-set keep-out seam (D3) + the `"ground"` PartKind, the #601 scope line, and a forward note that the ADR-0010 *motion* amendment lands in #602. Mark **Status: Accepted**.
+
+- [ ] **Step 2: Update the ADR index**
+
+Add the ADR-0025 line to `docs/adr/README.md` (match the existing table/list format).
+
+- [ ] **Step 3: arc42 §5 — building-block view**
+
+In `docs/architecture/05-building-block-view.md`, add a ground-object responsibility line to the `models`, `loader`, `collisions`, and `towplanner` entries (one clause each): `models` owns `GroundObject`; `loader` resolves catalog `fixed_obstacle`/`car`/`trailer` types + the `ground_objects:` blocks; `collisions` treats fixed obstacles as keep-outs and movers as pairwise bodies; `towplanner` routes around fixed obstacles and enumerates movers.
+
+- [ ] **Step 4: arc42 §8 — crosscutting**
+
+In `docs/architecture/08-crosscutting-concepts.md`, under "The parts model", add a short "Ground objects (#601)" subsection: the two object classes, that footprints reuse `Part` with `kind="ground"`, the keep-out-vs-pairwise distinction, and the concrete catalog `type:` vocabulary. Cross-link ADR-0025.
+
+- [ ] **Step 5: Catalog README**
+
+In `data/catalog/README.md`, add a "Ground objects (#601)" section documenting the `type: fixed_obstacle | car | trailer` values, the `kind: ground` footprint convention, `motion_mode` defaults (car→steerable, trailer→towed) and override, and that real Herrenteich entries land in #605.
+
+- [ ] **Step 6: CHANGELOG**
+
+In `CHANGELOG.md` under `[Unreleased]` → `Added`, add: "Ground-object data model (#601): catalog `fixed_obstacle`/`car`/`trailer` types and a layout `ground_objects:` block; fixed obstacles are keep-outs and movers join collision/tow enumeration. Empty-set output is byte-identical."
+
+- [ ] **Step 7: Verify links + commit**
+
+Run: `grep -rn "0025" docs/adr/README.md docs/architecture/` (confirm the cross-references resolve).
+
+```bash
+git add docs/adr/0025-ground-object-taxonomy.md docs/adr/README.md docs/architecture/05-building-block-view.md docs/architecture/08-crosscutting-concepts.md data/catalog/README.md CHANGELOG.md
+git commit -m "docs(601): ADR-0025 + arc42 §5/§8 + catalog README + CHANGELOG
+
+Refs #601"
+```
+
+---
+
+## Task 13: Integration fixture + end-to-end check
+
+**Files:**
+- Create: `tests/fixtures/layouts/ground_objects_smoke.yaml` (+ supporting manifest/hangar if needed)
+- Test: `tests/test_loader.py` or a new `tests/test_ground_objects_integration.py`
+
+- [ ] **Step 1: Write the end-to-end test**
+
+A single test that loads a real layout YAML with a fixed obstacle + a mover through `load_layout`, runs `check`, and asserts the verdict — proving the data flows model→loader→collisions end to end:
+
+```python
+def test_ground_objects_end_to_end(tmp_path) -> None:
+    # Scaffold: catalog/ (one aircraft + fixture_fuel_trailer + fixture_caddy),
+    # fleet.yaml (aircraft: [...] + ground_objects: [...]), hangar.yaml, layout.yaml
+    # with the aircraft parked clear, the fuel trailer at the door, the caddy clear.
+    layout = load_layout(tmp_path / "layout.yaml")
+    assert "fixture_fuel_trailer" in layout.ground_objects
+    assert "fixture_caddy" in layout.ground_objects
+    result = check(layout)
+    assert result.valid   # everything placed clear → valid
+
+    # Now author an overlapping placement and assert the ground_obstacle conflict.
+    # (rewrite layout.yaml with the aircraft on top of the fuel trailer)
+    layout2 = load_layout(tmp_path / "layout_clash.yaml")
+    assert not check(layout2).valid
+    assert any(c.kind == "ground_obstacle" for c in check(layout2).conflicts)
+```
+
+- [ ] **Step 2: Run it (fails until fixtures exist)**
+
+Run: `pytest tests/test_ground_objects_integration.py -v`
+Expected: FAIL → then PASS once the fixtures are written. Keep this test **non-slow** (the two-pass coverage gotcha: ≥1 non-slow test per new path).
+
+- [ ] **Step 3: Full suite + lint + type**
+
+Run: `pytest && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/`
+Expected: PASS across the board.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_ground_objects_integration.py tests/fixtures/
+git commit -m "test(601): end-to-end ground-object load + check integration
+
+Refs #601"
+```
+
+---
+
+## Final verification (before opening the PR)
+
+- [ ] `pytest` (full fast suite) green.
+- [ ] `pytest -m slow` green (if any slow ground-object tests were added).
+- [ ] `ruff check src/ tests/ && ruff format --check src/ tests/` clean.
+- [ ] `mypy src/hangarfit/` clean.
+- [ ] **Byte-identity spot check:** an existing valid layout + an existing scenario solve produce unchanged output (no ground objects ⇒ no behavioural change). The `determinism-guard` double-solve is bit-identical.
+- [ ] CHANGELOG `[Unreleased]` carries the #601 entry.
+- [ ] Open the PR **as a draft**, base `develop`, body `Closes #601`, assignee `DocGerd`, label `enhancement`+`area:backend`, milestone "Ground objects + Herrenteich calibration".
+- [ ] Review arc (per CLAUDE.md): `code-reviewer` (main) + `geometry-invariant-guard` (geometry/collisions) + `silent-failure-hunter` (loader/collisions) + `type-design-analyzer` (models) + `determinism-guard` (towplanner). Convert findings to diff threads; resolve each; re-review if non-trivial; then `gh pr ready`.
+
+---
+
+## Spec-coverage self-check (run before handing off)
+
+| Spec deliverable (#601 AC) | Task |
+|---|---|
+| `GroundObject` model + validation | 1 |
+| `"ground"` footprint kind | 1 |
+| Layout fields + invariants (id==key, disjoint, resolve) | 2 |
+| Scenario id-list | 3 |
+| Catalog builder registry + 3 types + allowlists | 4 |
+| Manifest `ground_objects:` + `load_ground_objects` + aircraft/ground guards | 5 |
+| Layout YAML `ground_objects:` parsing + round-trip test | 6 |
+| Scenario YAML `ground_objects:` parsing + round-trip test | 7 |
+| Ground objects reuse the det-(-1) transform | 8 |
+| Fixed-obstacle keep-out (`ground_obstacle`) + movers in pairwise + byte-identity | 9 |
+| Fixed obstacles static in tow planner; movers in routable enumeration (deferred) | 10 |
+| Determinism preserved | 9, 10 |
+| Docs (ADR-0025, arc42 §5/§8, README, CHANGELOG) | 12 |
+| End-to-end coverage | 13 |

--- a/docs/superpowers/specs/2026-06-11-601-ground-object-data-model-design.md
+++ b/docs/superpowers/specs/2026-06-11-601-ground-object-data-model-design.md
@@ -1,0 +1,198 @@
+# A1 (#601) — Ground-object data model + loader
+
+**Status:** Approved (design), 2026-06-11
+**Issue:** #601 (child of Epic A #600 — "Ground objects + Herrenteich calibration", milestone #34)
+**Builds on:** #595 per-object catalog (`type:` discriminator → per-type builder)
+**Blocks / siblings:** #602 (mover motion + ADR-0010 amendment), #603 (Caddy hard-door/egress), #604 (soft trailer region), #605 (Herrenteich calibration), #606 (rendering)
+
+---
+
+## 1. Purpose & scope
+
+The hangar floor holds more than aircraft. The real Airfield Herrenteich set adds a **fuel trailer** (fixed, never moves), **two glider trailers** (towed), and a **VW Caddy** (self-driving). Today the model has exactly two non-aircraft geometry flavours, both *hangar-intrinsic* keep-outs: the state-gated `MaintenanceBay` and the always-on `StructuralNotch`. There is **no model for a free-standing object** — fixed or movable — authored as scenario/layout data with a pose.
+
+A1 introduces a **general, Herrenteich-agnostic ground-object data model + loader** so non-aircraft objects get a clean home built on the #595 catalog. **A1 ships data + minimal verifier wiring only** — enough to prove the two object classes flow through `collisions.check` and the tow planner. The real route search, the Caddy egress gate, the soft trailer region, the feasibility calibration, and rendering are all sibling issues.
+
+### In scope
+1. `GroundObject` model type + loader (concrete catalog `type:` values, strict allowlists, `LoaderError`).
+2. Fixed obstacles wired into the existing keep-out path (collisions pairwise-set + tow-planner static obstacles).
+3. Movers registered into the placeable (pairwise collision) + routable (`plan_fill` enumeration) sets — **as data**, with the per-mover path search deferred to #602.
+4. Empty-set **byte-identity** and **determinism** preserved (ADR-0003 / `determinism-guard`).
+5. Docs: ADR-0025, arc42 §5/§8, CHANGELOG.
+
+### Explicitly deferred (non-goals)
+- Real mover **route search** (towed Reeds–Shepp/cart vs steerable arcs) + the **ADR-0010 motion amendment** → #602.
+- Caddy **hard nearest-door + clear-egress** gate (a new rejection tier) → #603.
+- Soft **right-side trailer region** preference → #604.
+- Herrenteich **dims/clearance calibration** to a feasible real all-11 set, and authoring the **real** `fuel_trailer`/`vw_caddy`/`glider_trailer` catalog entries → #605. A1 uses **test-fixture** ground objects.
+- **Rendering / 3D view** of ground objects → #606.
+- **Constraint-hook fields** (hard-door flag, soft-region preference). YAGNI: #603/#604 add their own fields when they implement the semantics; appending optional fields to a frozen dataclass later is non-breaking.
+
+---
+
+## 2. Decisions (locked)
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Concrete catalog `type:` values** — `fixed_obstacle`, `car`, `trailer` — each with its own `_build_*` builder. `object_class` is *derived* from the type. | User choice. Friendlier, real-world catalog YAML. Motion behaviour is *defaulted per type* but stays an overridable **data field** (`motion_mode:`), so the issue's "carry the field" requirement holds. |
+| D2 | **Layout-uniform via `Placement`.** Ground objects reuse `Part` (footprint), `Placement` (pose), and the det-−1 world transform. Held in parallel `ground_objects` / `ground_object_placements` fields on `Layout`. `fleet: dict[str,Aircraft]` is untouched. | User choice + max reuse. A fixed obstacle = "a placed body whose parts are keep-outs"; a mover = "a placed body in pairwise collision." No new geometry engine; aircraft callers see zero churn. |
+| D3 | **Pairwise-set seam** for fixed-obstacle keep-out (not floor-polygon subtraction). | Falls out of D2. Supports an *oblique*-parked trailer (a fuel trailer at the door is the canonical case); floor-polygon subtraction is axis-aligned only. Matches the issue's recommendation. |
+| D4 | **Real catalog entries deferred to #605.** A1 uses test fixtures under `tests/fixtures/catalog/`. | Keeps A1 from shipping un-calibrated real data; #605 authors + calibrates the real Herrenteich objects. |
+
+---
+
+## 3. Model design (`src/hangarfit/models.py`)
+
+A new frozen-slots dataclass mirroring `Aircraft`'s conventions exactly (tuples not lists; `ValueError` from `__post_init__`; `_VALID_*` frozensets derived from `typing.get_args`; `object.__setattr__` only inside `__post_init__`).
+
+```python
+GroundObjectClass = Literal["fixed_obstacle", "placed_routed_mover"]
+MoverMotionMode   = Literal["steerable", "towed"]
+_VALID_GROUND_OBJECT_CLASSES = frozenset(typing.get_args(GroundObjectClass))
+_VALID_MOVER_MOTION_MODES    = frozenset(typing.get_args(MoverMotionMode))
+
+@dataclass(frozen=True, slots=True)
+class GroundObject:
+    id: str
+    name: str
+    parts: tuple[Part, ...]
+    object_class: GroundObjectClass
+    motion_mode: MoverMotionMode | None = None   # None iff fixed_obstacle
+    turn_radius_m: float | None = None           # static catalog data; carried-but-unconsumed in A1
+    measured: bool = False
+```
+
+**`__post_init__` invariants** (order: cheap field checks → cross-field consistency):
+- `id` non-empty; `name` non-empty; `parts` non-empty.
+- `object_class in _VALID_GROUND_OBJECT_CLASSES`.
+- `object_class == "fixed_obstacle"` ⇒ `motion_mode is None and turn_radius_m is None` (a fixed obstacle never moves).
+- `object_class == "placed_routed_mover"` ⇒ `motion_mode in _VALID_MOVER_MOTION_MODES`.
+- `turn_radius_m`, when set, `> 0` (mirrors `Aircraft` own-gear radius rule).
+
+**`Layout` changes** (`models.py`, the `Layout` dataclass). Two new fields, both default-empty so an existing layout is byte-identical:
+```python
+ground_objects: Mapping[str, GroundObject] = field(default_factory=dict)   # wrapped MappingProxyType in __post_init__, like `fleet`
+ground_object_placements: tuple[Placement, ...] = ()                       # poses, reusing Placement
+```
+- Register `ground_objects` in `_PROXY_FIELDS` so the MappingProxyType wrap + pickle (`__getstate__`/`__setstate__`) round-trips (the #544/#545 path).
+- New invariants paralleling the aircraft ones:
+  - `ground_objects[k].id == k` for every entry (mirrors the `fleet` key==id check).
+  - every `ground_object_placement.plane_id ∈ ground_objects` (mirrors "placements reference real planes").
+  - no duplicate `ground_object_placements` ids.
+  - **`set(ground_objects) ∩ set(fleet) == ∅`** — ground-object ids are disjoint from aircraft ids, so a placement id resolves to aircraft XOR ground-object unambiguously. (New invariant unique to A1.)
+
+**`Scenario` changes** — a thin id-list for the solve path:
+```python
+ground_objects: tuple[str, ...] = ()   # like fleet_in; validated to resolve against the catalog/ground-object set
+```
+The solver does **not** place movers in A1 (that's #604); the field is carried + validated for forward-compat and for the loader round-trip.
+
+---
+
+## 4. Catalog + loader design (`src/hangarfit/loader.py`)
+
+### 4.1 Builder registry (replaces the Stage-A guard)
+`_build_catalog_object` (currently `loader.py:157`, `if obj_type != "aircraft": raise LoaderError("…Stage A #600…")`) becomes a registry dispatch:
+```python
+_CATALOG_BUILDERS = {
+    "aircraft": _build_aircraft,
+    "fixed_obstacle": _build_fixed_obstacle,
+    "car": _build_car,
+    "trailer": _build_trailer,
+}
+# obj_type = raw.get("type", _DEFAULT_OBJECT_TYPE); strip "type"; dispatch.
+builder = _CATALOG_BUILDERS.get(obj_type)
+if builder is None:
+    raise LoaderError(f"{source}: unknown catalog type {obj_type!r}; known types: {sorted(_CATALOG_BUILDERS)}")
+return builder(entry, source=source)
+```
+`_build_catalog_object`'s return type widens to `Aircraft | GroundObject`. **`load_fleet` keeps returning `dict[str, Aircraft]`** — it parses only the manifest's `aircraft:` list; ground objects are loaded by a separate `load_ground_objects`. (No caller churn; the agent-flagged union-return break is avoided by keeping the two manifest lists and two loaders separate.) **Defensive guard:** `load_fleet` asserts each built object `isinstance(... , Aircraft)` and raises `LoaderError` if a `ground_object`/`car`/`trailer` ref is mistakenly listed under `aircraft:` (and `load_ground_objects` raises symmetrically if an `aircraft` ref appears under `ground_objects:`). This keeps the `dict[str,Aircraft]` contract honest rather than violating it silently.
+
+### 4.2 The three new builders
+Each takes `(raw: dict, *, source: Path) -> GroundObject`, validates a strict per-type key allowlist (mirroring `_ALLOWED_AIRCRAFT_KEYS`), and sets `object_class` + motion defaults:
+
+| `type:` | builder | `object_class` | motion default | turn_radius |
+|---|---|---|---|---|
+| `fixed_obstacle` | `_build_fixed_obstacle` | `"fixed_obstacle"` | `None` (rejected if authored) | `None` (rejected) |
+| `car` | `_build_car` | `"placed_routed_mover"` | `"steerable"` (overridable via `motion_mode:`) | optional, default `None` |
+| `trailer` | `_build_trailer` | `"placed_routed_mover"` | `"towed"` (overridable) | optional, default `None` |
+
+Allowlists: `fixed_obstacle` → `{id, name, parts, measured}`; `car`/`trailer` → `{id, name, parts, motion_mode, turn_radius_m, measured}`. `parts` parsing reuses the existing aircraft part parser (single-rectangle is the common case; the parts machinery already supports it).
+
+### 4.3 Manifest + scenario/layout wiring
+- **Manifest** (`fleet.yaml`): optional top-level `ground_objects: [catalog refs]`. New `load_ground_objects(path) -> dict[str, GroundObject]` parses it via `_build_catalog_object`; returns `{}` when the key is absent (existing manifests byte-identical). Add `ground_objects` to the manifest key allowlist.
+- **Layout YAML**: optional `ground_objects:` block — a list of `{object: <catalog id>, x_m, y_m, heading_deg}` entries. The set of *available* ground objects comes from the **same manifest** the layout's `fleet:` key already references (that manifest now carries both an `aircraft:` and a `ground_objects:` list) — i.e. when `load_layout` resolves the fleet via `load_fleet(manifest)` it also resolves the ground-object catalog via `load_ground_objects(manifest)`; an injected `ground_objects=` map overrides, mirroring `fleet=`. Each layout entry's `object` id is resolved against that set, and builds `Placement(plane_id=<id>, x_m, y_m, heading_deg, on_carts=False)`. Extend `_ALLOWED_LAYOUT_KEYS` with `"ground_objects"`; strict per-entry allowlist `{object, x_m, y_m, heading_deg}` with `LoaderError` on unknown/missing keys and on an unresolved `object` id (naming the id + the catalog, via the `_resolve_known_plane_id` near-match pattern).
+- **Scenario YAML**: optional `ground_objects: [ids]`. Extend `_ALLOWED_SCENARIO_KEYS`; validate each id resolves; pass to `Scenario(...)`.
+- `load_layout` / `load_scenario` gain an optional `ground_objects=` injection param mirroring `fleet=`/`hangar=`.
+
+### 4.4 Error discipline
+All new parsing follows the existing rules: inner builders omit the path prefix; outer loaders catch `(ValueError, KeyError, TypeError, LoaderError)` and re-wrap with `f"{path}: …"`; list fields validated `isinstance(list)` early then coerced to tuple; unknown keys → loud `LoaderError` with `sorted(unknown)` + `sorted(allowed)`.
+
+---
+
+## 5. Collision wiring (`src/hangarfit/collisions.py`)
+
+`check(layout)` builds **ground-object world parts** through the *same* transform path used for aircraft (no new geometry — sidesteps the det-−1 sign-flip trap; ground-object `Part`s carry plane-local coords transformed by the placement exactly like aircraft parts). Each world part is tagged with its owner's `object_class`.
+
+- **fixed_obstacle → keep-out.** Any aircraft or mover world part overlapping a fixed-obstacle world part ⇒ a new **single-object `ground_obstacle`** `Conflict` (`Conflict.single(kind="ground_obstacle", plane=<aircraft/mover id>, detail=…naming the obstacle…)`). Reuse the `_parts_conflict` predicate (plan-view `polygon_overlap` + height clause) for consistency with the oracle. `fixed↔fixed` overlaps are ignored (two static keep-outs may coincide).
+- **placed_routed_mover → pairwise body.** Mover world parts join the pairwise overlap loop exactly like aircraft (mover↔aircraft, mover↔mover), emitting the existing deterministic `<sorted_kinds>_overlap` conflicts and accumulating `total_penetration_m2`.
+- **Bounds.** Ground-object bounds checking is **out of A1 scope** (no AC; #604/#605 own valid placement). `_hangar_bounds_conflicts` is unchanged.
+- **Byte-identity:** with empty `ground_objects`/`ground_object_placements`, the conflict set + order + `total_penetration_m2` are bit-identical to today (the new code is a guarded no-op over an empty collection). The per-vertex-before-polygon gate ordering in the existing checkers is untouched.
+
+Implementation note: prefer one helper that converts a `(GroundObject, Placement)` pair to `list[WorldPart]` (reusing the aircraft world-part builder), so the obstacle/mover geometry uses the **same boundary semantics** as the oracle — preventing in-search vs verifier divergence (the towplanner reuse-of-oracle invariant).
+
+---
+
+## 6. Tow-planner wiring (`src/hangarfit/towplanner.py`)
+
+- **`_build_obstacles(placed, mover_id)`**: fixed-obstacle world parts (+ their AABBs, preserving the `_Obstacles` parallel-array `__post_init__` invariant) join the **static** obstacle set beside the existing `notch_boxes`/placed-plane parts. Other movers (≠ the one being routed) join as static placed bodies, exactly like placed aircraft. Fixed obstacles are collected **separately from `placed.placements`** (they are not in the aircraft placement tuple) and in a **stable sorted order** (sort by id) so the world-parts tuple — and thus every AABB/polygon-test order — is deterministic.
+- **`plan_fill`**: the routable enumeration (`back_first_order`) covers aircraft **and movers**. In A1 the per-mover path search is **deferred to #602**: a mover is recognised in the routed set but yields a deferred/`None` path, reusing the existing best-effort `plans[i] = None` Phase-3a pattern (an un-routable body names itself on stderr and the plan still renders). AC4 is satisfied by the mover *appearing in the routed enumeration*, not by a successful route. Fixed obstacles are **never** in the routable set.
+- **Determinism / byte-identity:** with no ground objects, `_build_obstacles` and `plan_fill` produce bit-identical plans; the `determinism-guard` double-run on a fixed seed stays identical (its fixtures carry no ground objects). The apron/door-throat machinery is untouched in A1 (a door-blocking fixed obstacle *narrowing* the throat is a natural consequence of it being a static obstacle; the explicit nose-out gating against door-blockers is #602/#603 polish).
+
+---
+
+## 7. Docs & housekeeping
+
+- **ADR-0025** "Ground-object taxonomy + keep-out reuse": concrete-type rationale (D1), Layout-uniform via `Placement` (D2), the pairwise-set keep-out seam (D3), and the A1 scope line. Note that the ADR-0010 *motion* amendment is deferred to #602.
+- **arc42 §5** (building-block view): add a ground-object responsibility line to `models`, `loader`, `collisions`, `towplanner`.
+- **arc42 §8** (crosscutting): a short "Ground objects" subsection under the parts model — the two object classes, the keep-out-vs-pairwise distinction, and the catalog `type:` vocabulary.
+- **CHANGELOG.md `[Unreleased]`**: a user-facing entry (new catalog types + layout `ground_objects:` block).
+- **Catalog README** (`data/catalog/README.md`): document the new `type:` values and the ground-object conventions.
+
+---
+
+## 8. Test plan (TDD — red first)
+
+Driven test-first; the byte-identity + empty-case guarantees are ideal for red-green.
+
+**Model (`tests/test_models*.py`)**
+- `GroundObject` valid construction (fixed_obstacle, car, trailer).
+- `__post_init__` rejects: empty id/name/parts; fixed_obstacle with a motion_mode/turn_radius; mover without motion_mode; non-positive turn_radius; bad object_class.
+- `Layout` rejects: ground_objects key≠id; placement referencing a missing ground object; **ground-object id colliding with a fleet id**; duplicate ground-object placement ids.
+
+**Loader (`tests/test_loader*.py`)**
+- Each new `type:` loads from a fixture catalog entry; defaults applied (car→steerable, trailer→towed); `motion_mode:` override honoured.
+- Unknown `type:` → `LoaderError` listing known types (updates `test_unknown_type_is_stage_a_error`).
+- Per-type allowlist rejects unknown keys; `fixed_obstacle` rejects `motion_mode`/`turn_radius_m`.
+- Layout `ground_objects:` block: round-trip load; unknown/missing entry key → `LoaderError`; unresolved `object` id → `LoaderError` (named). New `test_all_allowed_layout_keys_load`-sibling exercising the extended allowlist.
+- Manifest `ground_objects:` list resolves via `load_ground_objects`; absent key → `{}`.
+
+**Collisions (`tests/test_collisions*.py`)**
+- A layout with a fixed obstacle overlapped by an aircraft part ⇒ non-empty `CheckResult` with a `ground_obstacle` conflict naming both. Non-overlapping ⇒ valid.
+- A mover overlapping an aircraft ⇒ pairwise `*_overlap` conflict; non-overlapping ⇒ valid.
+- **Byte-identity:** an existing fixture layout with empty ground-object fields ⇒ identical `CheckResult` (conflicts + `total_penetration_m2`) to the pre-A1 path.
+
+**Tow-planner (`tests/test_towplanner*.py`)**
+- A door-blocking fixed obstacle makes an otherwise-routable plane un-routable through that throat (its box is present in the `_build_obstacles` static set).
+- A mover appears in `plan_fill`'s routed enumeration (path deferred/`None`).
+- **Determinism:** double-solve on a fixed seed with no ground objects ⇒ byte-identical plan (det-guard).
+
+**Slow/non-slow split:** keep ≥1 non-slow test per new path (the two-pass coverage gotcha).
+
+---
+
+## 9. Files touched (estimate)
+
+`models.py` (GroundObject + Layout/Scenario fields), `loader.py` (registry + 3 builders + manifest/layout/scenario parsing + allowlists), `collisions.py` (ground-object world parts + keep-out + pairwise), `towplanner.py` (`_build_obstacles` + `plan_fill`), `geometry.py` (possibly a small `(GroundObject, Placement) → WorldPart` helper, reusing the aircraft path), `docs/adr/0025-*.md`, `docs/architecture/05-*.md` + `08-*.md`, `data/catalog/README.md`, `CHANGELOG.md`, `tests/fixtures/catalog/*` (fixture ground objects), and the test modules above.
+
+**Review arc:** `code-reviewer` (main) + `geometry-invariant-guard` (collisions/geometry) + `silent-failure-hunter` (loader/collisions) + `type-design-analyzer` (models) + `determinism-guard` (towplanner). Draft PR, `Closes #601`, base `develop`.

--- a/src/hangarfit/collisions.py
+++ b/src/hangarfit/collisions.py
@@ -50,28 +50,82 @@ from __future__ import annotations
 
 from .geometry import (
     WorldPart,
+    aircraft_parts_world,
     axis_aligned_rect,
     cached_parts_world,
     polygon_overlap,
     polygon_overlap_area,
 )
-from .models import CheckResult, Conflict, Hangar, Layout
+from .models import CheckResult, Conflict, GroundObject, Hangar, Layout
 
 
 def check(layout: Layout) -> CheckResult:
     """Run all geometric checks and return a :class:`CheckResult`."""
-    world_parts: dict[str, list[WorldPart]] = {
+    aircraft_parts: dict[str, list[WorldPart]] = {
         p.plane_id: cached_parts_world(layout.fleet[p.plane_id], p) for p in layout.placements
     }
+    # Ground objects (#601): movers are placed bodies (pairwise); fixed obstacles
+    # are keep-outs. Both reuse the aircraft world-transform (det-(-1), ADR-0002).
+    mover_parts: dict[str, list[WorldPart]] = {}
+    obstacle_parts: dict[str, list[WorldPart]] = {}
+    for gp in layout.ground_object_placements:
+        obj: GroundObject = layout.ground_objects[gp.plane_id]
+        wparts = aircraft_parts_world(obj, gp)
+        if obj.object_class == "fixed_obstacle":
+            obstacle_parts[gp.plane_id] = wparts
+        else:
+            mover_parts[gp.plane_id] = wparts
+
+    # Movers join the placed-body set for bounds-free pairwise collision; aircraft
+    # come first so the no-ground-object case is byte-identical (same dict order):
+    # with no ground objects mover_parts/obstacle_parts are empty, placed_bodies ==
+    # aircraft_parts, _ground_obstacle_conflicts returns [], and the conflict order
+    # + total_penetration_m2 match pre-#601. _hangar_bounds_conflicts and
+    # _bay_intrusion_conflicts keep their aircraft-only input (ground-object bounds
+    # checking is out of #601 scope — #604/#605).
+    placed_bodies = {**aircraft_parts, **mover_parts}
+
     conflicts: list[Conflict] = []
-    conflicts.extend(_hangar_bounds_conflicts(world_parts, layout.hangar))
-    conflicts.extend(_bay_intrusion_conflicts(world_parts, layout))
-    pairwise, total_penetration_m2 = _pairwise_conflicts(world_parts, layout.hangar)
+    conflicts.extend(_hangar_bounds_conflicts(aircraft_parts, layout.hangar))
+    conflicts.extend(_bay_intrusion_conflicts(aircraft_parts, layout))
+    pairwise, total_penetration_m2 = _pairwise_conflicts(placed_bodies, layout.hangar)
     conflicts.extend(pairwise)
+    conflicts.extend(_ground_obstacle_conflicts(placed_bodies, obstacle_parts, layout.hangar))
     return CheckResult(
         conflicts=tuple(conflicts),
         total_penetration_m2=total_penetration_m2,
     )
+
+
+def _ground_obstacle_conflicts(
+    placed_bodies: dict[str, list[WorldPart]],
+    obstacle_parts: dict[str, list[WorldPart]],
+    hangar: Hangar,
+) -> list[Conflict]:
+    """A fixed obstacle's footprint is a keep-out: any aircraft/mover part that
+    conflicts with it (plan-view overlap within clearance AND z-gap rule, via
+    :func:`_parts_conflict`) is a single-object ``ground_obstacle`` conflict
+    naming the offending body and the obstacle (#601 / ADR-0025).
+
+    Deterministic iteration: obstacles in dict-insertion order (manifest order),
+    bodies in placement order. Empty ``obstacle_parts`` → ``[]`` (byte-identity)."""
+    out: list[Conflict] = []
+    for obstacle_id, obs_wparts in obstacle_parts.items():
+        for body_id, body_wparts in placed_bodies.items():
+            for op in obs_wparts:
+                for bp in body_wparts:
+                    if _parts_conflict(op, bp, hangar):
+                        out.append(
+                            Conflict.single(
+                                kind="ground_obstacle",
+                                plane=body_id,
+                                detail=(
+                                    f"part {bp.kind!r} of {body_id!r} overlaps fixed "
+                                    f"obstacle {obstacle_id!r} part {op.kind!r}"
+                                ),
+                            )
+                        )
+    return out
 
 
 def _hangar_bounds_conflicts(

--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 
 from shapely.geometry import Polygon, box
 
-from .models import Aircraft, Part, PartKind, Placement
+from .models import Aircraft, GroundObject, Part, PartKind, Placement
 
 
 @dataclass(frozen=True, slots=True)
@@ -194,10 +194,10 @@ def part_local_ring(part: Part) -> list[tuple[float, float]] | None:
 
 
 def aircraft_parts_world(
-    aircraft: Aircraft,
+    obj: Aircraft | GroundObject,
     placement: Placement,
 ) -> list[WorldPart]:
-    """Transform every part of an aircraft from plane-local to world coords.
+    """Transform every part of an aircraft **or ground object** from plane-local to world coords.
 
     ``placement.heading_deg`` is the compass-style angle of the nose,
     measured from world ``+y`` (deeper-into-hangar), CW positive.
@@ -222,7 +222,7 @@ def aircraft_parts_world(
     canonical definition of this transform (#293).
     """
     world_parts: list[WorldPart] = []
-    for part in aircraft.parts:
+    for part in obj.parts:
         ring = part_local_ring(part)
         if ring is not None:
             # Polygon footprint: part_local_ring has already folded the part's

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -640,7 +640,9 @@ def load_layout(
 # keys read in :func:`load_scenario`; ``test_all_allowed_scenario_keys_load`` guards
 # the too-strict direction. Per-plane ``constraints`` entries carry their own
 # allowlist (:data:`_ALLOWED_CONSTRAINT_KEYS`).
-_ALLOWED_SCENARIO_KEYS = frozenset({"fleet_in", "fleet", "hangar", "maintenance", "constraints"})
+_ALLOWED_SCENARIO_KEYS = frozenset(
+    {"fleet_in", "fleet", "hangar", "maintenance", "constraints", "ground_objects"}
+)
 
 
 def load_scenario(
@@ -650,6 +652,7 @@ def load_scenario(
     hangar: Hangar | None = None,
     max_carts: int | None = None,
     apron_depth: float | Literal["auto"] | None = None,
+    ground_objects: dict[str, GroundObject] | None = None,
 ) -> Scenario:
     """Load a scenario YAML into a validated :class:`Scenario`.
 
@@ -736,6 +739,16 @@ def load_scenario(
         except ValueError as e:
             raise LoaderError(f"{path}: {e}") from e
 
+    # Ground-object defs: kwarg overrides; otherwise resolve from the same
+    # manifest the fleet: key points at (which returns {} when the manifest has
+    # no ground_objects: list); absent both, default to empty (#601).
+    if ground_objects is None:
+        fleet_ref = raw.get("fleet")
+        if fleet_ref is not None:
+            ground_objects = load_ground_objects((path.parent / fleet_ref).resolve())
+        else:
+            ground_objects = {}
+
     for pid in fleet_in:
         _resolve_known_plane_id(pid, fleet, role="fleet_in entry", path=path)
 
@@ -784,6 +797,20 @@ def load_scenario(
         except (ValueError, KeyError, TypeError, LoaderError) as e:
             raise LoaderError(f"{path}: constraint {plane_id!r}: {e}") from e
 
+    # Parse the scenario's optional ground_objects: id-list (#601). Like
+    # fleet_in, it is a list of catalog ids; each must resolve in the defs
+    # resolved above (kwarg-injected or read from the fleet manifest).
+    go_ids_raw = raw.get("ground_objects", [])
+    if not isinstance(go_ids_raw, list):
+        raise LoaderError(f"{path}: 'ground_objects' must be a list of ids")
+    scenario_ground_objects = tuple(str(x) for x in go_ids_raw)
+    for gid in scenario_ground_objects:
+        if gid not in ground_objects:
+            raise LoaderError(
+                f"{path}: ground_objects references unknown object {gid!r}; "
+                f"the available ground objects are: {sorted(ground_objects)}"
+            )
+
     try:
         return Scenario(
             fleet=fleet,
@@ -791,6 +818,8 @@ def load_scenario(
             fleet_in=fleet_in,
             maintenance_plane=maintenance_plane,
             constraints=constraints,
+            ground_objects=scenario_ground_objects,
+            ground_object_defs=ground_objects,
         )
     except ValueError as e:
         raise LoaderError(f"{path}: {e}") from e

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -260,6 +260,61 @@ def load_fleet(path: Path | str) -> dict[str, Aircraft]:
     return fleet
 
 
+def load_ground_objects(path: Path | str) -> dict[str, GroundObject]:
+    """Load the ``ground_objects:`` list of a fleet manifest into a dict keyed
+    by :attr:`GroundObject.id` (#601).
+
+    Returns ``{}`` when the key is absent, so existing manifests (aircraft-only)
+    are byte-identical. Refs resolve relative to the manifest dir, exactly like
+    ``aircraft:`` refs. Each referenced catalog file must resolve to a
+    :class:`GroundObject`; an aircraft ref under ``ground_objects:`` is rejected
+    loudly with a hint to move it under ``aircraft:`` instead.
+    """
+    path = Path(path)
+    raw = _read_yaml(path)
+    if not isinstance(raw, dict):
+        raise LoaderError(f"{path}: top-level mapping required")
+    obj_list = raw.get("ground_objects")
+    if obj_list is None:
+        return {}
+    if not isinstance(obj_list, list):
+        raise LoaderError(f"{path}: 'ground_objects' must be a list")
+    manifest_dir = path.parent
+    out: dict[str, GroundObject] = {}
+    for i, entry in enumerate(obj_list):
+        ref, overrides = _parse_manifest_entry(entry, index=i, path=path)
+        if overrides:
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] overrides {sorted(overrides)} not supported; "
+                f"ground objects carry no per-fleet operational flags"
+            )
+        try:
+            catalog_path = (manifest_dir / ref).resolve()
+            ref_exists = catalog_path.is_file()
+        except (ValueError, OSError) as e:
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] has an invalid catalog reference {ref!r}: {e}"
+            ) from e
+        if not ref_exists:
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] references {ref!r} which does not exist "
+                f"(resolved to {catalog_path})"
+            )
+        try:
+            obj = _build_catalog_object(_read_yaml(catalog_path), source=catalog_path)
+        except (ValueError, KeyError, TypeError, LoaderError) as e:
+            raise LoaderError(f"{path}: ground_objects[{i}] ({ref}): {e}") from e
+        if not isinstance(obj, GroundObject):
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] ({ref}) is a {type(obj).__name__}, not a "
+                f"GroundObject; list aircraft under 'aircraft:' instead"
+            )
+        if obj.id in out:
+            raise LoaderError(f"{path}: duplicate ground_object id {obj.id!r}")
+        out[obj.id] = obj
+    return out
+
+
 def _resolve_apron_depth(
     value: Any, fleet: Mapping[str, Aircraft] | None, *, field_name: str = "apron_depth_m"
 ) -> float:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import dataclasses
 import difflib
 import math
-from collections.abc import Collection, Iterable, Mapping
+from collections.abc import Callable, Collection, Iterable, Mapping
 from pathlib import Path
 from typing import Any, Literal
 
@@ -45,9 +45,11 @@ import yaml
 from .models import (
     Aircraft,
     Door,
+    GroundObject,
     Hangar,
     Layout,
     MaintenanceBay,
+    MoverMotionMode,
     Part,
     Placement,
     PlaneConstraint,
@@ -142,8 +144,8 @@ def _reject_unknown_top_level_keys(
 
 # A fleet manifest references per-object CATALOG files (#595). Each catalog file
 # carries a `type:` discriminator (default 'aircraft') routing to a per-type
-# builder. Only 'aircraft' is registered here; non-aircraft objects (fuel
-# trailer, glider trailer, rescue vehicle) arrive in Stage A (#600).
+# builder in :data:`_CATALOG_BUILDERS`. As of #601 the registry also resolves the
+# ground-object types ('fixed_obstacle', 'car', 'trailer'); see _build_catalog_object.
 _DEFAULT_OBJECT_TYPE = "aircraft"
 
 # Operational flags a fleet manifest entry may override on a catalog object.
@@ -152,24 +154,6 @@ _DEFAULT_OBJECT_TYPE = "aircraft"
 # merged onto the catalog dict BEFORE _build_aircraft's allowlist check, so an
 # override key absent from that allowlist would be rejected as an "unknown" key.
 _ALLOWED_MANIFEST_OVERRIDE_KEYS = frozenset({"movement_mode", "tow_pivotable"})
-
-
-def _build_catalog_object(raw: Any, *, source: Path) -> Aircraft:
-    """Dispatch a catalog object on its ``type:`` discriminator to the per-type
-    builder. ``type:`` is stripped before the builder runs, so the aircraft
-    allowlist (:data:`_ALLOWED_AIRCRAFT_KEYS`, which has no ``type`` member) is
-    unchanged. An unregistered type is rejected today with a clear error (the
-    slot is reserved for the Stage A ground objects, #600)."""
-    if not isinstance(raw, dict):
-        raise LoaderError(f"{source}: catalog object must be a mapping, got {type(raw).__name__}")
-    obj_type = raw.get("type", _DEFAULT_OBJECT_TYPE)
-    if obj_type != _DEFAULT_OBJECT_TYPE:
-        raise LoaderError(
-            f"{source}: object type {obj_type!r} not yet supported (non-aircraft "
-            f"objects arrive in Stage A, #600); known types: ['aircraft']"
-        )
-    entry = {k: v for k, v in raw.items() if k != "type"}
-    return _build_aircraft(entry)
 
 
 def _parse_manifest_entry(entry: Any, *, index: int, path: Path) -> tuple[str, dict[str, Any]]:
@@ -262,12 +246,17 @@ def load_fleet(path: Path | str) -> dict[str, Aircraft]:
         if isinstance(obj_raw, dict) and overrides:
             obj_raw = {**obj_raw, **overrides}
         try:
-            aircraft = _build_catalog_object(obj_raw, source=catalog_path)
+            obj = _build_catalog_object(obj_raw, source=catalog_path)
         except (ValueError, KeyError, TypeError, LoaderError) as e:
             raise LoaderError(f"{path}: aircraft[{i}] ({ref}): {e}") from e
-        if aircraft.id in fleet:
-            raise LoaderError(f"{path}: duplicate aircraft id {aircraft.id!r}")
-        fleet[aircraft.id] = aircraft
+        if not isinstance(obj, Aircraft):
+            raise LoaderError(
+                f"{path}: aircraft[{i}] ({ref}) is a {type(obj).__name__}, not an Aircraft; "
+                f"list non-aircraft objects under 'ground_objects:' instead"
+            )
+        if obj.id in fleet:
+            raise LoaderError(f"{path}: duplicate aircraft id {obj.id!r}")
+        fleet[obj.id] = obj
     return fleet
 
 
@@ -1135,6 +1124,109 @@ def _build_aircraft(entry: Any) -> Aircraft:
     )
     _validate_wheels_vs_turn_radius(aircraft)
     return aircraft
+
+
+# Per-type key allowlists for ground objects (#601 / ADR-0025). A fixed obstacle
+# never moves, so its allowlist deliberately EXCLUDES motion_mode/turn_radius_m —
+# authoring one is a loud "unknown fixed_obstacle key" rather than a silently
+# ignored field. Movers (car/trailer) may carry an explicit motion_mode override
+# and a static turn_radius_m (carried for #602's routing; unused in #601).
+_ALLOWED_FIXED_OBSTACLE_KEYS = frozenset({"id", "name", "parts", "measured"})
+_ALLOWED_MOVER_KEYS = frozenset({"id", "name", "parts", "measured", "motion_mode", "turn_radius_m"})
+
+
+def _build_ground_parts(entry: dict[str, Any]) -> tuple[Part, ...]:
+    """Parse a ground object's ``parts`` list. Every part must be kind 'ground'
+    (a solid footprint) — ground objects do NOT do the fuselage front/aft split,
+    struts, or wheels, and an aircraft part kind (wing, tail, …) is rejected."""
+    parts_data = entry.get("parts")
+    if not isinstance(parts_data, list) or not parts_data:
+        raise LoaderError("'parts' must be a non-empty list")
+    parts = tuple(_build_part(p, i) for i, p in enumerate(parts_data))
+    for i, part in enumerate(parts):
+        if part.kind != "ground":
+            raise LoaderError(
+                f"parts[{i}] kind {part.kind!r} not allowed on a ground object; "
+                f"use kind: ground (a solid footprint)"
+            )
+    return parts
+
+
+def _check_ground_keys(entry: Any, allowed: frozenset[str], *, what: str) -> dict[str, Any]:
+    """Reject unknown keys + require id/name on a ground-object catalog dict,
+    mirroring :func:`_build_aircraft`'s allowlist discipline (#513)."""
+    if not isinstance(entry, dict):
+        raise LoaderError(f"{what} entry must be a mapping, got {type(entry).__name__}")
+    unknown = set(entry) - allowed
+    if unknown:
+        raise LoaderError(f"unknown {what} key(s) {sorted(unknown)}; allowed: {sorted(allowed)}")
+    for key in ("id", "name"):
+        if key not in entry:
+            raise LoaderError(f"missing required field {key!r}")
+    return entry
+
+
+def _build_fixed_obstacle(entry: Any) -> GroundObject:
+    entry = _check_ground_keys(entry, _ALLOWED_FIXED_OBSTACLE_KEYS, what="fixed_obstacle")
+    return GroundObject(
+        id=entry["id"],
+        name=entry["name"],
+        parts=_build_ground_parts(entry),
+        object_class="fixed_obstacle",
+        measured=_to_bool(entry.get("measured", False), "measured"),
+    )
+
+
+def _build_mover(entry: Any, *, default_motion: MoverMotionMode) -> GroundObject:
+    entry = _check_ground_keys(entry, _ALLOWED_MOVER_KEYS, what="mover")
+    motion_raw = entry.get("motion_mode", default_motion)
+    tr_raw = entry.get("turn_radius_m")
+    return GroundObject(
+        id=entry["id"],
+        name=entry["name"],
+        parts=_build_ground_parts(entry),
+        object_class="placed_routed_mover",
+        motion_mode=motion_raw,
+        turn_radius_m=None if tr_raw is None else _to_float(tr_raw, "turn_radius_m"),
+        measured=_to_bool(entry.get("measured", False), "measured"),
+    )
+
+
+def _build_car(entry: Any) -> GroundObject:
+    """A self-driving rescue car — defaults to ``steerable`` motion (#601)."""
+    return _build_mover(entry, default_motion="steerable")
+
+
+def _build_trailer(entry: Any) -> GroundObject:
+    """A towed glider/fuel trailer — defaults to ``towed`` motion (#601)."""
+    return _build_mover(entry, default_motion="towed")
+
+
+# The catalog builder registry (#595 seam; ground-object types added #601). It is
+# defined AFTER all four builders so the names resolve at dict-construction time.
+_CATALOG_BUILDERS: dict[str, Callable[[Any], Aircraft | GroundObject]] = {
+    "aircraft": _build_aircraft,
+    "fixed_obstacle": _build_fixed_obstacle,
+    "car": _build_car,
+    "trailer": _build_trailer,
+}
+
+
+def _build_catalog_object(raw: Any, *, source: Path) -> Aircraft | GroundObject:
+    """Dispatch a catalog object on its ``type:`` discriminator to the per-type
+    builder (#595 seam; ground-object types added in #601). ``type:`` is stripped
+    before the builder runs, so each per-type allowlist needs no ``type`` member.
+    An unknown type is rejected with the list of known types."""
+    if not isinstance(raw, dict):
+        raise LoaderError(f"{source}: catalog object must be a mapping, got {type(raw).__name__}")
+    obj_type = raw.get("type", _DEFAULT_OBJECT_TYPE)
+    builder = _CATALOG_BUILDERS.get(obj_type)
+    if builder is None:
+        raise LoaderError(
+            f"{source}: unknown catalog type {obj_type!r}; known types: {sorted(_CATALOG_BUILDERS)}"
+        )
+    entry = {k: v for k, v in raw.items() if k != "type"}
+    return builder(entry)
 
 
 # Strict unknown-key allowlist for a `parts[i]` entry, mirroring

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -461,7 +461,7 @@ def load_hangar(path: Path | str, *, fleet: Mapping[str, Aircraft] | None = None
 # keys read in :func:`load_layout`; ``test_all_allowed_layout_keys_load`` guards the
 # too-strict direction. ``fleet``/``hangar`` are optional in the file (they may arrive
 # as kwargs instead); the file-vs-kwarg conflict is handled separately, below.
-_ALLOWED_LAYOUT_KEYS = frozenset({"fleet", "hangar", "placements", "maintenance"})
+_ALLOWED_LAYOUT_KEYS = frozenset({"fleet", "hangar", "placements", "maintenance", "ground_objects"})
 
 
 def load_layout(
@@ -471,6 +471,7 @@ def load_layout(
     hangar: Hangar | None = None,
     max_carts: int | None = None,
     apron_depth: float | Literal["auto"] | None = None,
+    ground_objects: dict[str, GroundObject] | None = None,
 ) -> Layout:
     """Load a layout YAML.
 
@@ -543,6 +544,16 @@ def load_layout(
         except ValueError as e:
             raise LoaderError(f"{path}: {e}") from e
 
+    # Ground-object defs: kwarg overrides; otherwise resolve from the same
+    # manifest the fleet: key points at (which may return {} when the manifest
+    # has no ground_objects: list); absent both, default to empty (#601).
+    if ground_objects is None:
+        fleet_ref = raw.get("fleet")
+        if fleet_ref is not None:
+            ground_objects = load_ground_objects((path.parent / fleet_ref).resolve())
+        else:
+            ground_objects = {}
+
     placements_data = raw.get("placements", [])
     if not isinstance(placements_data, list):
         raise LoaderError(f"{path}: 'placements' must be a list")
@@ -576,12 +587,50 @@ def load_layout(
                     f"id if it doesn't match an aircraft in the fleet)."
                 )
 
+    # Parse the layout's optional ground_objects: block (#601). Each entry maps
+    # to a Placement (using plane_id for the object id, matching Layout's field).
+    go_data = raw.get("ground_objects", [])
+    if not isinstance(go_data, list):
+        raise LoaderError(f"{path}: 'ground_objects' must be a list")
+    _allowed_go_entry = frozenset({"object", "x_m", "y_m", "heading_deg"})
+    ground_object_placements_list: list[Placement] = []
+    for i, go_entry in enumerate(go_data):
+        if not isinstance(go_entry, dict):
+            raise LoaderError(f"{path}: ground_objects[{i}] must be a mapping")
+        unknown = set(go_entry) - _allowed_go_entry
+        if unknown:
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] has unknown ground_object key(s) "
+                f"{sorted(unknown)}; allowed: {sorted(_allowed_go_entry)}"
+            )
+        for key in ("object", "x_m", "y_m", "heading_deg"):
+            if key not in go_entry:
+                raise LoaderError(f"{path}: missing required field 'ground_objects[{i}].{key}'")
+        obj_id = go_entry["object"]
+        if obj_id not in ground_objects:
+            raise LoaderError(
+                f"{path}: ground_objects[{i}] references unknown object {obj_id!r}; "
+                f"the available ground objects are: {sorted(ground_objects)}"
+            )
+        ground_object_placements_list.append(
+            Placement(
+                plane_id=obj_id,
+                x_m=_to_float(go_entry["x_m"], f"ground_objects[{i}].x_m"),
+                y_m=_to_float(go_entry["y_m"], f"ground_objects[{i}].y_m"),
+                heading_deg=_to_float(go_entry["heading_deg"], f"ground_objects[{i}].heading_deg"),
+                on_carts=False,
+            )
+        )
+    ground_object_placements = tuple(ground_object_placements_list)
+
     try:
         return Layout(
             fleet=fleet,
             hangar=hangar,
             placements=placements,
             maintenance_plane=maintenance_plane,
+            ground_objects=ground_objects,
+            ground_object_placements=ground_object_placements,
         )
     except ValueError as e:
         raise LoaderError(f"{path}: {e}") from e

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -799,26 +799,41 @@ class Layout:
       placements** (the occupant is treated as "away" — physically
       absent from the parking problem).
 
+    Ground objects (#601 / ADR-0025) live in two parallel fields that
+    mirror ``fleet`` / ``placements``:
+
+    - ``ground_objects`` — a map of :class:`GroundObject` keyed by id (keys
+      equal their ``GroundObject.id``, like ``fleet``),
+    - ``ground_object_placements`` — the placed poses (``plane_id`` carries
+      the ground-object id, no duplicates).
+
+    Their cross-reference invariants are validated alongside the fleet's:
+    every ground-object placement resolves to a known object, and the
+    ground-object ids are **disjoint** from the fleet aircraft ids so a
+    placement id resolves unambiguously to exactly one object.
+
     The bay-closure rule (no other plane's parts may cross into the
     closed bay rectangle) is a geometric check; it lives in the
     collision checker alongside the other geometric rules.
 
-    On construction, ``fleet`` is wrapped in ``MappingProxyType`` so
-    that the cross-reference invariants stay valid for the lifetime of
-    the ``Layout`` (a plain ``dict`` field, even on a frozen dataclass,
-    can be mutated through ``layout.fleet["x"] = …``).
+    On construction, ``fleet`` and ``ground_objects`` are wrapped in
+    ``MappingProxyType`` so that the cross-reference invariants stay valid
+    for the lifetime of the ``Layout`` (a plain ``dict`` field, even on a
+    frozen dataclass, can be mutated through ``layout.fleet["x"] = …``).
     """
 
     fleet: Mapping[str, Aircraft]
     hangar: Hangar
     placements: tuple[Placement, ...]
     maintenance_plane: str | None = None
+    ground_objects: Mapping[str, GroundObject] = field(default_factory=dict)
+    ground_object_placements: tuple[Placement, ...] = ()
 
-    # The mapping field wrapped in MappingProxyType for immutability — single
+    # The mapping fields wrapped in MappingProxyType for immutability — single
     # source of truth for the construction-time wrap (__post_init__) and the
     # pickle unwrap/re-wrap (__getstate__/__setstate__, #544 ProcessPool
     # boundary). See _proxy_aware_getstate. (ClassVar ⇒ not a dataclass field.)
-    _PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = ("fleet",)
+    _PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = ("fleet", "ground_objects")
 
     def __post_init__(self) -> None:
         for k, a in self.fleet.items():
@@ -871,6 +886,33 @@ class Layout:
                     f"maintenance_plane {self.maintenance_plane!r} must NOT be in "
                     f"placements when in maintenance (occupant is treated as away)"
                 )
+
+        # Ground objects (#601): keys equal their id; placements resolve;
+        # ids disjoint from the fleet so a placement id resolves unambiguously.
+        for k, obj in self.ground_objects.items():
+            if obj.id != k:
+                raise ValueError(
+                    f"ground_objects key {k!r} does not match its GroundObject.id "
+                    f"({obj.id!r}); keys must equal their ground-object id"
+                )
+        fleet_ids = set(self.fleet)
+        ground_ids = set(self.ground_objects)
+        clash = fleet_ids & ground_ids
+        if clash:
+            raise ValueError(
+                f"ground-object id(s) {sorted(clash)} collide with fleet aircraft ids; "
+                f"ids must be disjoint so a placement resolves to exactly one object"
+            )
+        seen_ground: set[str] = set()
+        for gp in self.ground_object_placements:
+            if gp.plane_id not in self.ground_objects:
+                raise ValueError(
+                    f"ground_object_placement references unknown id {gp.plane_id!r} "
+                    f"(ground_objects has: {sorted(self.ground_objects)})"
+                )
+            if gp.plane_id in seen_ground:
+                raise ValueError(f"Duplicate ground_object_placement for id {gp.plane_id!r}")
+            seen_ground.add(gp.plane_id)
 
         for name in self._PROXY_FIELDS:
             object.__setattr__(self, name, MappingProxyType(dict(getattr(self, name))))

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -462,6 +462,12 @@ class GroundObject:
             raise ValueError(f"GroundObject {self.id!r}: name must be non-empty")
         if not self.parts:
             raise ValueError(f"GroundObject {self.id!r}: parts must be non-empty")
+        for p in self.parts:
+            if p.kind != "ground":
+                raise ValueError(
+                    f"GroundObject {self.id!r}: all parts must be kind 'ground' "
+                    f"(a solid footprint), got {p.kind!r}"
+                )
         if self.object_class not in _VALID_GROUND_OBJECT_CLASSES:
             raise ValueError(
                 f"GroundObject {self.id!r}: object_class must be one of "

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1067,13 +1067,17 @@ class Scenario:
     fleet_in: tuple[str, ...]
     maintenance_plane: str | None = None
     constraints: Mapping[str, PlaneConstraint] = field(default_factory=lambda: MappingProxyType({}))
+    ground_objects: tuple[str, ...] = ()
+    ground_object_defs: Mapping[str, GroundObject] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
 
     # The mapping fields wrapped in MappingProxyType for immutability. This is
     # the single source of truth for both the construction-time wrap (in
     # __post_init__) and the pickle unwrap/re-wrap (in __getstate__/__setstate__,
     # #545) — listing them once means the two cannot silently drift. (ClassVar so
     # the dataclass excludes it from the field set and __slots__.)
-    _PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = ("fleet", "constraints")
+    _PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = ("fleet", "constraints", "ground_object_defs")
 
     def __post_init__(self) -> None:
         # fleet_in must be non-empty (otherwise there's nothing to solve;
@@ -1189,6 +1193,20 @@ class Scenario:
                         f"Scenario.constraints[{plane_id!r}].priority="
                         f"{constraint.priority!r} must be >= 0.0 (a soft importance weight)"
                     )
+
+        # Ground objects (#601): defs keys must equal their GroundObject.id;
+        # every id in ground_objects must resolve in ground_object_defs.
+        for k, obj in self.ground_object_defs.items():
+            if obj.id != k:
+                raise ValueError(
+                    f"Scenario.ground_object_defs key {k!r} != GroundObject.id ({obj.id!r})"
+                )
+        for gid in self.ground_objects:
+            if gid not in self.ground_object_defs:
+                raise ValueError(
+                    f"Scenario.ground_objects references unknown ground_object {gid!r}; "
+                    f"defs have: {sorted(self.ground_object_defs)}"
+                )
 
         # Wrap the mapping fields in MappingProxyType so a frozen Scenario can't
         # be mutated through e.g. ``scenario.fleet["x"] = …``. Always copy+wrap

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -29,15 +29,23 @@ if TYPE_CHECKING:
 WingPosition = Literal["high", "mid", "low"]
 Gear = Literal["tailwheel", "nosewheel", "monowheel"]
 MovementMode = Literal["always_cart", "always_own_gear", "cart_eligible"]
+GroundObjectClass = Literal["fixed_obstacle", "placed_routed_mover"]
+MoverMotionMode = Literal["steerable", "towed"]
 # `tail` denotes the horizontal stabilizer specifically (a wide, usually-low
 # overhangable surface — see metrics._OVERHANGABLE); `vertical_stabilizer` is the
 # fin (thin, tall, never overhangable). Empennage split per ADR-0023.
-PartKind = Literal["fuselage_front", "fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer"]
+# `ground` denotes a non-aircraft ground-object footprint (a solid keep-out/body,
+# never overhangable — #601).
+PartKind = Literal[
+    "fuselage_front", "fuselage_aft", "wing", "strut", "tail", "vertical_stabilizer", "ground"
+]
 
 _VALID_PART_KINDS = frozenset(typing.get_args(PartKind))
 _VALID_WING_POSITIONS = frozenset(typing.get_args(WingPosition))
 _VALID_GEARS = frozenset(typing.get_args(Gear))
 _VALID_MOVEMENT_MODES = frozenset(typing.get_args(MovementMode))
+_VALID_GROUND_OBJECT_CLASSES = frozenset(typing.get_args(GroundObjectClass))
+_VALID_MOVER_MOTION_MODES = frozenset(typing.get_args(MoverMotionMode))
 
 # Below this absolute |2·signed-area| a ring is treated as degenerate
 # (zero-area / collinear). 1e-9 m² is far tighter than any real part.
@@ -414,6 +422,76 @@ class Aircraft:
         if self.movement_mode == "always_cart" or self.tow_pivotable:
             return 0.0
         return self.required_turn_radius_m()
+
+
+@dataclass(frozen=True, slots=True)
+class GroundObject:
+    """A non-aircraft object on the hangar floor (#601 / ADR-0025).
+
+    Two classes, set by ``object_class`` (derived by the loader from the
+    catalog ``type:`` — ``fixed_obstacle`` → ``"fixed_obstacle"``;
+    ``car``/``trailer`` → ``"placed_routed_mover"``):
+
+    * **fixed_obstacle** — a placed-but-immovable keep-out (e.g. a fuel
+      trailer at the door). Carries no motion. Its world footprint is a
+      keep-out for aircraft/mover parts; the tow planner routes around it.
+    * **placed_routed_mover** — a placed body that is itself routed (a
+      self-driving ``steerable`` car, a ``towed`` trailer). Participates in
+      pairwise collision like an aircraft. ``motion_mode`` is carried here;
+      the actual route search lands in #602 (this type only carries the field).
+
+    Geometry reuses the parts model: ``parts`` is a tuple of ``Part`` with
+    ``kind="ground"`` (a solid footprint, never overhangable), transformed to
+    world coords by the *same* :func:`hangarfit.geometry.aircraft_parts_world`
+    path aircraft use. ``turn_radius_m`` is static catalog data carried for
+    #602's routing; it is unused in #601.
+    """
+
+    id: str
+    name: str
+    parts: tuple[Part, ...]
+    object_class: GroundObjectClass
+    motion_mode: MoverMotionMode | None = None
+    turn_radius_m: float | None = None
+    measured: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("GroundObject.id must be non-empty")
+        if not self.name:
+            raise ValueError(f"GroundObject {self.id!r}: name must be non-empty")
+        if not self.parts:
+            raise ValueError(f"GroundObject {self.id!r}: parts must be non-empty")
+        if self.object_class not in _VALID_GROUND_OBJECT_CLASSES:
+            raise ValueError(
+                f"GroundObject {self.id!r}: object_class must be one of "
+                f"{sorted(_VALID_GROUND_OBJECT_CLASSES)}, got {self.object_class!r}"
+            )
+        if self.object_class == "fixed_obstacle":
+            if self.motion_mode is not None:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: a fixed_obstacle must not carry a "
+                    f"motion_mode (got {self.motion_mode!r}) — it never moves"
+                )
+            if self.turn_radius_m is not None:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: a fixed_obstacle must not carry a "
+                    f"turn_radius_m — it never moves"
+                )
+        else:  # placed_routed_mover
+            if self.motion_mode not in _VALID_MOVER_MOTION_MODES:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: a placed_routed_mover requires a "
+                    f"motion_mode in {sorted(_VALID_MOVER_MOTION_MODES)}, "
+                    f"got {self.motion_mode!r}"
+                )
+            # Only movers may carry a turn radius (fixed_obstacle rejects any
+            # non-None above), and when present it must be positive.
+            if self.turn_radius_m is not None and self.turn_radius_m <= 0:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: turn_radius_m must be positive, "
+                    f"got {self.turn_radius_m}"
+                )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/hangarfit/scene.py
+++ b/src/hangarfit/scene.py
@@ -226,8 +226,11 @@ def _timeline(
     t = 0.0
     for placement in back_first_order(layout.placements):
         move = move_by_id.get(placement.plane_id)
-        if move is None:
-            continue  # defensive: a placement with no move stays at its final pose
+        if move is None or move.path is None:
+            # No move, or a deferred (path=None) move — the body stays at its final
+            # pose. A deferred path is a #601 ground-object mover (route → #602);
+            # it never keys an aircraft placement here, so this is defensive.
+            continue
         samples = _sample_affines(move.path, max_samples_per_path)
         dur = min(max(move.path.length_m / tow_speed_mps, min_seg_s), max_seg_s)
         segments.append(

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -36,7 +36,12 @@ from shapely.geometry import Point, Polygon
 # Importing a sibling-module private is the same pattern as `check as _check`.
 from hangarfit.collisions import _parts_conflict
 from hangarfit.collisions import check as _check
-from hangarfit.geometry import WorldPart, cached_parts_world, polygon_overlap
+from hangarfit.geometry import (
+    WorldPart,
+    aircraft_parts_world,
+    cached_parts_world,
+    polygon_overlap,
+)
 from hangarfit.models import Aircraft, ApronShallowDrop, Conflict, Hangar, Layout, Placement
 
 SegmentKind = Literal["L", "S", "R"]
@@ -201,11 +206,24 @@ class DubinsArc:
 
 @dataclass(frozen=True, slots=True)
 class Move:
-    """One plane's entry: from the door-cone entry pose to its target slot."""
+    """One body's entry: from the door-cone entry pose to its target slot.
+
+    ``path`` is the routed tow arc, or ``None`` for a **deferred** move — a body
+    that is enumerated as something the planner must route but whose route search
+    has not been run (a #601 placed-routed ground-object mover; the search lands
+    in #602). This mirrors the established best-effort idiom where an un-routed
+    body is carried as ``None`` rather than dropped (Phase 3a / #197), now at
+    per-move granularity. Consumers that draw a path (visualize/scene) skip a
+    ``None``-path move."""
 
     plane_id: str
     target_slot: Pose
-    path: DubinsArc
+    # ``path is None`` marks a DEFERRED move: a placed-routed ground-object mover
+    # enumerated in the plan as a body the planner must route, but whose actual
+    # route search lands in #602 — today it carries no path (#601 enumerates,
+    # #602 routes). A routed aircraft (or, post-#602, a routed mover) always has a
+    # DubinsArc here. See the class docstring for the full contract.
+    path: DubinsArc | None
 
     def __post_init__(self) -> None:
         if not self.plane_id:
@@ -1442,6 +1460,19 @@ def plan_fill(
                 )
             )
 
+    # Ground-object movers (#601): enumerate each placed-routed mover as a body
+    # the planner must route, but DEFER the actual path search to #602 — emit a
+    # deferred (None-path) Move keyed on the mover id (see the Move.path contract:
+    # #601 enumerates, #602 routes). Fixed obstacles are NEVER routed (they are
+    # keep-outs, already in _build_obstacles). Appended AFTER the aircraft routing
+    # loop, in id-sorted order, so the aircraft moves are byte-identical to the
+    # pre-#601 plan (no ground objects → no extra moves).
+    for gp in sorted(target.ground_object_placements, key=lambda p: p.plane_id):
+        obj = target.ground_objects[gp.plane_id]
+        if obj.object_class != "placed_routed_mover":
+            continue
+        moves.append(Move(gp.plane_id, Pose.from_placement(gp), path=None))
+
     return MovesPlan(target_layout=target, moves=tuple(moves))
 
 
@@ -1736,6 +1767,17 @@ def _build_obstacles(placed: Layout, *, mover_id: str) -> _Obstacles:
         if placement.plane_id == mover_id:
             continue
         parts.extend(cached_parts_world(placed.fleet[placement.plane_id], placement))
+    # Ground objects (#601): fixed obstacles are ALWAYS static keep-outs; placed
+    # movers are static placed bodies EXCEPT the one currently being routed
+    # (mover_id), mirroring how the routed aircraft is excluded above. Iterate in
+    # id-sorted order so the world_parts tuple order is deterministic regardless
+    # of the placements' authored order (determinism-guard, ADR-0003). Empty when
+    # there are no ground objects → byte-identical to the pre-#601 obstacle set.
+    for gp in sorted(placed.ground_object_placements, key=lambda p: p.plane_id):
+        if gp.plane_id == mover_id:
+            continue
+        obj = placed.ground_objects[gp.plane_id]
+        parts.extend(aircraft_parts_world(obj, gp))
     bay = placed.hangar.maintenance_bay
     return _Obstacles(
         world_parts=tuple(parts),

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -653,11 +653,15 @@ def _draw_tow_paths(ax: Any, moves_plan: MovesPlan) -> None:
     currently inert — it is a deliberate forward hook for a future legend, and
     a path is already disambiguated by terminating at its annotated slot.
     """
-    plane_ids = sorted({move.plane_id for move in moves_plan.moves})
+    # Deferred moves (path=None) — a #601 ground-object mover whose route search
+    # is deferred to #602 — have no polyline to draw; skip them.
+    routed_moves = [move for move in moves_plan.moves if move.path is not None]
+    plane_ids = sorted({move.plane_id for move in routed_moves})
     colour_for = {
         pid: _TOW_PATH_COLORS[i % len(_TOW_PATH_COLORS)] for i, pid in enumerate(plane_ids)
     }
-    for move in moves_plan.moves:
+    for move in routed_moves:
+        assert move.path is not None  # filtered above; narrows for the type-checker
         poses = list(move.path.sample())
         xs = [p.x_m for p in poses]
         ys = [p.y_m for p in poses]

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -471,6 +471,12 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
     elif part.kind == "ground":
         # Ground-object footprint (#601): solid keep-out, drawn opaque like a
         # fuselage body at the fuselage z-level (above wings).
+        # NOTE: currently UNREACHABLE — render_layout/scene iterate only
+        # layout.placements (aircraft), never ground_object_placements, so no
+        # ground WorldPart reaches _draw_part yet. This branch is a forward hook
+        # for #606 (ground-object rendering) AND satisfies the closed-PartKind
+        # exhaustiveness contract (the else-raise below must stay reachable for
+        # any future unknown kind).
         patch = MplPolygon(
             coords,
             closed=True,

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -468,6 +468,18 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
             lw=0.5,
             zorder=4,
         )
+    elif part.kind == "ground":
+        # Ground-object footprint (#601): solid keep-out, drawn opaque like a
+        # fuselage body at the fuselage z-level (above wings).
+        patch = MplPolygon(
+            coords,
+            closed=True,
+            facecolor=color,
+            edgecolor=_INK_EDGE,
+            alpha=_FUSELAGE_ALPHA,
+            lw=0.5,
+            zorder=2,
+        )
     else:
         raise ValueError(
             f"_draw_part: unhandled part kind {part.kind!r}. "

--- a/tests/fixtures/catalog/fixture_bogus_type.yaml
+++ b/tests/fixtures/catalog/fixture_bogus_type.yaml
@@ -1,0 +1,12 @@
+type: spaceship
+id: fixture_bogus
+name: "Fixture bogus object"
+measured: false
+parts:
+  - kind: ground
+    length_m: 1.0
+    width_m: 1.0
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 1.0

--- a/tests/fixtures/catalog/fixture_caddy.yaml
+++ b/tests/fixtures/catalog/fixture_caddy.yaml
@@ -1,0 +1,13 @@
+type: car
+id: fixture_caddy
+name: "Fixture rescue car"
+turn_radius_m: 5.0
+measured: false
+parts:
+  - kind: ground
+    length_m: 4.5
+    width_m: 1.8
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 1.8

--- a/tests/fixtures/catalog/fixture_fuel_trailer.yaml
+++ b/tests/fixtures/catalog/fixture_fuel_trailer.yaml
@@ -1,0 +1,12 @@
+type: fixed_obstacle
+id: fixture_fuel_trailer
+name: "Fixture fuel trailer"
+measured: false
+parts:
+  - kind: ground
+    length_m: 5.0
+    width_m: 2.0
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 2.0

--- a/tests/fixtures/catalog/fixture_glider_trailer.yaml
+++ b/tests/fixtures/catalog/fixture_glider_trailer.yaml
@@ -1,0 +1,12 @@
+type: trailer
+id: fixture_glider_trailer
+name: "Fixture glider trailer"
+measured: false
+parts:
+  - kind: ground
+    length_m: 8.0
+    width_m: 2.2
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 2.5

--- a/tests/fixtures/catalog/fixture_ground_manifest.yaml
+++ b/tests/fixtures/catalog/fixture_ground_manifest.yaml
@@ -1,0 +1,5 @@
+aircraft: []
+ground_objects:
+  - fixture_fuel_trailer.yaml
+  - fixture_caddy.yaml
+  - fixture_glider_trailer.yaml

--- a/tests/test_collisions_ground_object.py
+++ b/tests/test_collisions_ground_object.py
@@ -1,0 +1,198 @@
+"""Ground-object collision wiring (#601).
+
+Task 9 wires ground objects into :func:`hangarfit.collisions.check`:
+
+* a **fixed_obstacle** footprint is a keep-out — any aircraft/mover part
+  conflicting with it emits a single-object ``ground_obstacle`` conflict;
+* a **placed_routed_mover** joins the placed-body set and participates in
+  pairwise collision exactly like an aircraft (its ``"ground"`` part shows up
+  in a ``*_overlap`` kind);
+* with **no** ground objects the result is byte-identical to pre-#601.
+
+These tests build their own locals (no pytest fixtures): an aircraft via
+:func:`tests.conftest.make_test_aircraft`, a hangar via the inline ``_hangar``
+helper (copied from ``tests/test_collisions.py``), and a ``"ground"`` footprint
+via the local ``_ground_part`` helper. The factory aircraft has wing z 2.0–2.2
+and fuselage z 0–1.0, so a ground footprint with ``z_top_m >= 2.2`` placed under
+the plane meets the wing layer and conflicts; a footprint placed in a far corner
+is clear.
+"""
+
+from __future__ import annotations
+
+from hangarfit.collisions import check
+from hangarfit.models import (
+    Door,
+    GroundObject,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    Placement,
+)
+from tests.conftest import make_test_aircraft
+
+
+def _hangar(clearance: float = 0.3, wlc: float = 0.2) -> Hangar:
+    return Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=clearance,
+        wing_layer_clearance_m=wlc,
+    )
+
+
+def _ground_part(length_m: float = 4.0, width_m: float = 2.0, z_top_m: float = 1.5) -> Part:
+    return Part(
+        kind="ground",
+        length_m=length_m,
+        width_m=width_m,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=z_top_m,
+    )
+
+
+def test_aircraft_over_fixed_obstacle_conflicts() -> None:
+    # A fixed obstacle directly under an aircraft (footprint reaching the wing
+    # layer) → a ground_obstacle conflict naming the body and the obstacle.
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    obj = GroundObject(
+        id="obstacle",
+        name="o",
+        parts=(_ground_part(z_top_m=3.0),),
+        object_class="fixed_obstacle",
+    )
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id=ac.id, x_m=6.0, y_m=6.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={obj.id: obj},
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=6.0, y_m=6.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    result = check(layout)
+    kinds = {c.kind for c in result.conflicts}
+    assert "ground_obstacle" in kinds
+    assert any("obstacle" in "".join(c.planes) or "obstacle" in c.detail for c in result.conflicts)
+    assert not result.valid
+
+
+def test_mover_overlapping_aircraft_conflicts() -> None:
+    # A mover overlapping the aircraft participates in pairwise collision; its
+    # "ground" part shows up in a *_overlap conflict kind.
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    mover = GroundObject(
+        id="caddy",
+        name="c",
+        parts=(_ground_part(z_top_m=3.0),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=4.0,
+    )
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id=ac.id, x_m=6.0, y_m=6.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={mover.id: mover},
+        ground_object_placements=(
+            Placement(plane_id=mover.id, x_m=6.0, y_m=6.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    result = check(layout)
+    assert any(c.kind.endswith("_overlap") and "ground" in c.kind for c in result.conflicts)
+    assert not result.valid
+
+
+def test_separated_ground_object_is_valid() -> None:
+    # A fixed obstacle in a far corner does not conflict with the aircraft.
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    obj = GroundObject(
+        id="obstacle",
+        name="o",
+        parts=(_ground_part(),),
+        object_class="fixed_obstacle",
+    )
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(
+            Placement(plane_id=ac.id, x_m=20.0, y_m=20.0, heading_deg=0.0, on_carts=False),
+        ),
+        ground_objects={obj.id: obj},
+        ground_object_placements=(
+            # Far corner, no overlap with the plane at (20, 20).
+            Placement(plane_id=obj.id, x_m=2.0, y_m=2.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    result = check(layout)
+    assert result.valid
+    assert result.conflicts == ()
+
+
+def test_separated_mover_is_valid() -> None:
+    # A mover in a far corner does not conflict either (pairwise, no overlap).
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    mover = GroundObject(
+        id="caddy",
+        name="c",
+        parts=(_ground_part(),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=4.0,
+    )
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(
+            Placement(plane_id=ac.id, x_m=20.0, y_m=20.0, heading_deg=0.0, on_carts=False),
+        ),
+        ground_objects={mover.id: mover},
+        ground_object_placements=(
+            Placement(plane_id=mover.id, x_m=2.0, y_m=2.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    assert check(layout).valid
+
+
+def test_empty_ground_objects_byte_identical() -> None:
+    """A valid layout with EMPTY ground-object fields is byte-identical to the
+    pre-#601 result: valid, no conflicts, and the same total penetration.
+
+    The reference values are computed from the SAME aircraft-only layout (the
+    ground-object fields are constructed empty), so this pins that the new
+    ``check`` wiring is inert when no ground objects are present: ``placed_bodies
+    == aircraft_parts`` (same dict order) and ``_ground_obstacle_conflicts``
+    returns ``[]``.
+    """
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    placements = (Placement(plane_id=ac.id, x_m=10.0, y_m=10.0, heading_deg=0.0, on_carts=False),)
+
+    # Reference: the layout WITHOUT touching ground-object fields at all.
+    reference = Layout(fleet={ac.id: ac}, hangar=hangar, placements=placements)
+    ref_result = check(reference)
+
+    # The same layout, but with the ground-object fields explicitly empty.
+    with_empty = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=placements,
+        ground_objects={},
+        ground_object_placements=(),
+    )
+    result = check(with_empty)
+
+    assert result.valid
+    assert result.conflicts == ()
+    assert result.conflicts == ref_result.conflicts
+    assert result.total_penetration_m2 == ref_result.total_penetration_m2

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -21,7 +21,7 @@ from hangarfit.geometry import (
     polygon_overlap,
     polygon_overlap_area,
 )
-from hangarfit.models import Aircraft, Part, Placement, Wheels
+from hangarfit.models import Aircraft, GroundObject, Part, Placement, Wheels
 
 SQRT2_2 = math.sqrt(2) / 2  # ≈ 0.7071...
 
@@ -633,4 +633,27 @@ class TestAircraftPartsWorldPolygon:
         [ws] = aircraft_parts_world(scalar, pl)
         [wp] = aircraft_parts_world(poly, pl)
         assert wp.polygon.area < ws.polygon.area
-        assert wp.polygon.within(ws.polygon.buffer(1e-9))
+
+
+def test_ground_object_parts_world_uses_same_transform() -> None:
+    part = Part(
+        kind="ground",
+        length_m=4.0,
+        width_m=2.0,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=1.5,
+    )
+    obj = GroundObject(id="trolley", name="t", parts=(part,), object_class="fixed_obstacle")
+    pl = Placement(plane_id="trolley", x_m=7.0, y_m=3.0, heading_deg=37.0, on_carts=False)
+    wps = aircraft_parts_world(obj, pl)
+    assert len(wps) == 1
+    assert wps[0].plane_id == "trolley"
+    assert wps[0].kind == "ground"
+    # det-(-1) transform: a non-axis-aligned heading must produce a rotated box
+    # (the geometry-invariant-guard requirement). Centroid maps via local_to_world.
+    cx, cy = wps[0].polygon.centroid.coords[0]
+    assert cx == pytest.approx(7.0)
+    assert cy == pytest.approx(3.0)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -657,3 +657,36 @@ def test_ground_object_parts_world_uses_same_transform() -> None:
     cx, cy = wps[0].polygon.centroid.coords[0]
     assert cx == pytest.approx(7.0)
     assert cy == pytest.approx(3.0)
+
+    # Stronger check: a part offset in +y (plane-local right) must map to the
+    # det-(-1) quadrant, NOT to a CCW +1 rotation result.
+    # For a heading-37° placement: the det-(-1) transform maps plane-local +y
+    # to world via local_to_world(0, offset_y, pl).
+    # A CCW (+1) rotation at 37° would send (0, 1) to (-sin37°, cos37°) ≈ (−0.60, 0.80).
+    # The det-(-1) correct answer sends (0, 1) to (+sin37°, cos37°) ≈ (+0.60, 0.80).
+    offset_y = 1.0
+    part_offset = Part(
+        kind="ground",
+        length_m=4.0,
+        width_m=2.0,
+        offset_x_m=0.0,
+        offset_y_m=offset_y,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=1.5,
+    )
+    obj_offset = GroundObject(
+        id="trolley2", name="t2", parts=(part_offset,), object_class="fixed_obstacle"
+    )
+    wps_offset = aircraft_parts_world(obj_offset, pl)
+    ox, oy = wps_offset[0].polygon.centroid.coords[0]
+    # Expected world centroid = local_to_world(0, offset_y, pl)
+    exp_x, exp_y = local_to_world(0.0, offset_y, pl)
+    assert ox == pytest.approx(exp_x, abs=1e-9)
+    assert oy == pytest.approx(exp_y, abs=1e-9)
+    # Confirm the det-(-1) transform sent the +y offset into positive world-x
+    # delta (sin37° > 0), ruling out a CCW rotation (which would go negative).
+    assert ox > 7.0, (
+        f"det-(-1) transform must push a +y-offset part into world +x at heading 37°, "
+        f"got centroid x={ox:.6f} (expected > 7.0)"
+    )

--- a/tests/test_ground_objects_integration.py
+++ b/tests/test_ground_objects_integration.py
@@ -1,0 +1,186 @@
+"""End-to-end integration: load a real layout YAML with ground objects through
+``load_layout``, run ``check``, and assert the verdict (#601).
+
+Proves the data flows model → loader → collisions without any kwarg injection:
+the entire path goes through YAML files on disk.
+"""
+
+import shutil
+import textwrap
+from pathlib import Path
+
+from hangarfit.collisions import check
+from hangarfit.loader import load_layout
+
+# ---------------------------------------------------------------------------
+# Repo-relative paths for the real catalog files we copy into tmp_path.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[1]  # tests/ → repo root
+_DATA_CATALOG = _REPO_ROOT / "data" / "catalog"
+_FIXTURE_CATALOG = _REPO_ROOT / "tests" / "fixtures" / "catalog"
+
+
+def _build_world(tmp_path) -> None:  # type: ignore[type-arg]
+    """Populate *tmp_path* with a self-contained world:
+
+    - ``catalog/cessna_150.yaml``   (real aircraft catalog entry)
+    - ``catalog/fixture_fuel_trailer.yaml``  (fixed_obstacle, 5×2m, z 0–2.0)
+    - ``catalog/fixture_caddy.yaml``         (car/mover, 4.5×1.8m, z 0–1.8)
+    - ``fleet.yaml``  — points at the three catalog files above
+    - ``hangar.yaml`` — a roomy 40×40 m placeholder hangar
+    - ``layout.yaml`` — cessna clear at (20,20), fuel trailer at (5,5), caddy
+      at (5,15); nothing overlaps → ``check`` returns **valid**.
+    - ``layout_clash.yaml`` — same, but the fuel trailer is placed at (20,20),
+      co-located with the cessna; their parts overlap in XY and Z → ``check``
+      returns **invalid** with a ``ground_obstacle`` conflict.
+    """
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+
+    # -- Aircraft ----------------------------------------------------------------
+    shutil.copy(
+        _DATA_CATALOG / "cessna_150.yaml",
+        catalog_dir / "cessna_150.yaml",
+    )
+
+    # -- Ground objects ----------------------------------------------------------
+    shutil.copy(
+        _FIXTURE_CATALOG / "fixture_fuel_trailer.yaml",
+        catalog_dir / "fixture_fuel_trailer.yaml",
+    )
+    shutil.copy(
+        _FIXTURE_CATALOG / "fixture_caddy.yaml",
+        catalog_dir / "fixture_caddy.yaml",
+    )
+
+    # -- fleet.yaml --------------------------------------------------------------
+    (tmp_path / "fleet.yaml").write_text(
+        textwrap.dedent(
+            """\
+            aircraft:
+              - catalog/cessna_150.yaml
+            ground_objects:
+              - catalog/fixture_fuel_trailer.yaml
+              - catalog/fixture_caddy.yaml
+            """
+        )
+    )
+
+    # -- hangar.yaml -------------------------------------------------------------
+    # A 40×40 m square hangar — generous enough that any valid single-aircraft
+    # placement stays well inside the boundary.
+    (tmp_path / "hangar.yaml").write_text(
+        textwrap.dedent(
+            """\
+            length_m: 40.0
+            width_m: 40.0
+            door:
+              center_x_m: 20.0
+              width_m: 12.0
+            maintenance_bay:
+              center_x_m: 20.0
+              width_m: 8.0
+              depth_m: 6.0
+            clearance_m: 0.3
+            wing_layer_clearance_m: 0.2
+            """
+        )
+    )
+
+    # -- layout.yaml (clear) -----------------------------------------------------
+    # Cessna 150 at world (20, 20) heading 0 (nose into hangar, +y direction).
+    #   Fuselage center ≈ (19.67, 20), spans x∈[19.22,20.12] y∈[16.72,23.28] z 0–1.5
+    #   Wing center ≈ (20.77, 20), spans x∈[15.68,25.86] y∈[19.25,20.75] z 2.0–2.3
+    # Fuel trailer at (5, 5): center (5,5), spans x∈[2.5,7.5] y∈[2.5,7.5] — far clear.
+    # Caddy at (5, 15): center (5,15), spans x∈[2.75,7.25] y∈[13.1,16.9] — also clear.
+    (tmp_path / "layout.yaml").write_text(
+        textwrap.dedent(
+            """\
+            fleet: fleet.yaml
+            hangar: hangar.yaml
+            placements:
+              - plane: cessna_150
+                x_m: 20.0
+                y_m: 20.0
+                heading_deg: 0.0
+                on_carts: false
+            ground_objects:
+              - object: fixture_fuel_trailer
+                x_m: 5.0
+                y_m: 5.0
+                heading_deg: 0.0
+              - object: fixture_caddy
+                x_m: 5.0
+                y_m: 15.0
+                heading_deg: 0.0
+            """
+        )
+    )
+
+    # -- layout_clash.yaml (ground_obstacle clash) --------------------------------
+    # Fuel trailer placed at (20, 20) — same as the cessna.
+    # Cessna fuselage: x∈[19.22,20.12] y∈[16.72,23.28] z 0–1.5
+    # Fuel trailer 5×2 at (20,20) heading 0: x∈[19,21] y∈[17.5,22.5] z 0–2.0
+    # XY overlap is clear; z ranges 0–1.5 (fuselage) ∩ 0–2.0 (trailer) = 0–1.5 → conflict.
+    (tmp_path / "layout_clash.yaml").write_text(
+        textwrap.dedent(
+            """\
+            fleet: fleet.yaml
+            hangar: hangar.yaml
+            placements:
+              - plane: cessna_150
+                x_m: 20.0
+                y_m: 20.0
+                heading_deg: 0.0
+                on_carts: false
+            ground_objects:
+              - object: fixture_fuel_trailer
+                x_m: 20.0
+                y_m: 20.0
+                heading_deg: 0.0
+              - object: fixture_caddy
+                x_m: 5.0
+                y_m: 15.0
+                heading_deg: 0.0
+            """
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_ground_objects_end_to_end(tmp_path) -> None:  # type: ignore[type-arg]
+    """Full path: YAML files → load_layout → check, with and without a clash."""
+    _build_world(tmp_path)
+
+    # ---- valid case -----------------------------------------------------------
+    layout = load_layout(tmp_path / "layout.yaml")
+
+    # Both ground objects resolved from the manifest
+    assert "fixture_fuel_trailer" in layout.ground_objects, (
+        "fixture_fuel_trailer was not resolved by load_layout"
+    )
+    assert "fixture_caddy" in layout.ground_objects, "fixture_caddy was not resolved by load_layout"
+    # Two placements were parsed
+    assert len(layout.ground_object_placements) == 2
+
+    result = check(layout)
+    assert result.valid, (
+        f"Expected a valid layout (aircraft and ground objects placed clear of each "
+        f"other), but check returned invalid with conflicts: {result.conflicts}"
+    )
+
+    # ---- clash case -----------------------------------------------------------
+    layout2 = load_layout(tmp_path / "layout_clash.yaml")
+
+    result2 = check(layout2)
+    assert not result2.valid, (
+        "Expected an invalid layout when the aircraft overlaps the fuel trailer, "
+        "but check returned valid"
+    )
+    assert any(c.kind == "ground_obstacle" for c in result2.conflicts), (
+        f"Expected a 'ground_obstacle' conflict, got: {result2.conflicts}"
+    )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -16,6 +16,7 @@ from hangarfit.loader import (
     _ALLOWED_AIRCRAFT_KEYS,
     _ALLOWED_HANGAR_KEYS,
     _ALLOWED_LAYOUT_KEYS,
+    _ALLOWED_SCENARIO_KEYS,
     LoaderError,
     _resolve_known_plane_id,
     _suggest_plane_id,
@@ -2335,3 +2336,146 @@ class TestLayoutGroundObjects:
                 hangar=self._hangar(),
                 ground_objects={"fuel_trailer": obj},
             )
+
+
+# ----------------------------------------------------------------------------
+# Task 7: Scenario YAML ground_objects: id-list parsing (#601).
+# Uses kwarg-injection so no catalog manifest is needed for the scenario tests.
+# ----------------------------------------------------------------------------
+
+
+class TestScenarioGroundObjects:
+    """Tests for the ground_objects: id-list in scenario YAML (Task 7 / #601)."""
+
+    def _hangar(self) -> Hangar:
+        from hangarfit.models import Door, MaintenanceBay
+
+        return Hangar(
+            length_m=40.0,
+            width_m=40.0,
+            door=Door(center_x_m=20.0, width_m=12.0),
+            maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+            clearance_m=0.3,
+            wing_layer_clearance_m=0.2,
+        )
+
+    def _mover(self, obj_id: str = "caddy") -> GroundObject:
+        from hangarfit.models import Part
+
+        part = Part(
+            kind="ground",
+            length_m=4.5,
+            width_m=1.8,
+            offset_x_m=0.0,
+            offset_y_m=0.0,
+            angle_deg=0.0,
+            z_bottom_m=0.0,
+            z_top_m=1.8,
+        )
+        return GroundObject(
+            id=obj_id,
+            name="Rescue car",
+            parts=(part,),
+            object_class="placed_routed_mover",
+            motion_mode="steerable",
+        )
+
+    def test_scenario_ground_objects_idlist_resolves(self, tmp_path: Path) -> None:
+        """A valid ground_objects: id-list resolves against the injected defs."""
+        from tests.conftest import make_test_aircraft
+
+        ac = make_test_aircraft(id="p1")
+        obj = self._mover("caddy")
+        scn_path = _write(
+            tmp_path / "scn.yaml",
+            "fleet_in:\n  - p1\nground_objects:\n  - caddy\n",
+        )
+        scn = load_scenario(
+            scn_path,
+            fleet={ac.id: ac},
+            hangar=self._hangar(),
+            ground_objects={obj.id: obj},
+        )
+        assert scn.ground_objects == ("caddy",)
+        assert "caddy" in scn.ground_object_defs
+
+    def test_scenario_unknown_ground_object_id_raises(self, tmp_path: Path) -> None:
+        """An unknown id in the list must raise LoaderError naming it."""
+        from tests.conftest import make_test_aircraft
+
+        ac = make_test_aircraft(id="p1")
+        obj = self._mover("caddy")
+        scn_path = _write(
+            tmp_path / "scn.yaml",
+            "fleet_in:\n  - p1\nground_objects:\n  - ghost\n",
+        )
+        with pytest.raises(LoaderError, match="ghost"):
+            load_scenario(
+                scn_path,
+                fleet={ac.id: ac},
+                hangar=self._hangar(),
+                ground_objects={obj.id: obj},
+            )
+
+    def _minimal_fleet_and_hangar(self, dir_: Path) -> None:
+        """Scaffold a real ``fleet.yaml`` (one aircraft ``foo`` + a ground-object
+        ref to the checked-in ``fixture_caddy.yaml``) and ``hangar.yaml`` so a
+        full-allowlist scenario naming ``fleet:``/``hangar:`` as keys loads
+        through the real manifest path (no kwarg injection — those keys forbid it)."""
+        import shutil
+
+        from tests._fleet_test_utils import explode_fleet
+
+        explode_fleet(
+            dir_,
+            _minimal_aircraft_yaml("foo", movement_mode="always_own_gear", turn_radius_m=5.0),
+        )
+        # explode_fleet only writes the aircraft: block; append a ground_objects:
+        # ref so the manifest's load_ground_objects resolves the scenario id.
+        cat = dir_ / "catalog"
+        cat.mkdir(exist_ok=True)
+        shutil.copy(
+            Path(__file__).parent / "fixtures" / "catalog" / "fixture_caddy.yaml",
+            cat / "fixture_caddy.yaml",
+        )
+        manifest = dir_ / "fleet.yaml"
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8")
+            + "ground_objects:\n  - catalog/fixture_caddy.yaml\n",
+            encoding="utf-8",
+        )
+        _write(
+            dir_ / "hangar.yaml",
+            """
+length_m: 25.0
+width_m: 18.0
+door: {center_x_m: 9.0, width_m: 12.0}
+maintenance_bay: {center_x_m: 13.5, width_m: 9, depth_m: 9}
+""",
+        )
+
+    def test_all_allowed_scenario_keys_load(self, tmp_path: Path) -> None:
+        """Completeness guard: a scenario declaring EVERY allowed top-level key
+        loads — so the allowlist can never be too strict. Self-enforcing against
+        ``_ALLOWED_SCENARIO_KEYS``."""
+        self._minimal_fleet_and_hangar(tmp_path)
+        # The constraint uses only `priority` (a soft spread weight): a `pin`
+        # or `force_on_carts` on the maintenance plane is rejected by Scenario,
+        # but priority is allowed, so foo can be both maintenance + constrained.
+        body = (
+            "fleet: fleet.yaml\nhangar: hangar.yaml\n"
+            "fleet_in:\n  - foo\n"
+            "maintenance:\n  plane: foo\n"
+            "constraints:\n  foo:\n    priority: 1.0\n"
+            "ground_objects:\n  - fixture_caddy\n"
+        )
+        file_keys = set(yaml.safe_load(body))
+        assert file_keys == _ALLOWED_SCENARIO_KEYS, (
+            f"fixture must cover the full allowlist; "
+            f"missing={sorted(_ALLOWED_SCENARIO_KEYS - file_keys)} "
+            f"extra={sorted(file_keys - _ALLOWED_SCENARIO_KEYS)}"
+        )
+        scn = load_scenario(_write(tmp_path / "scn.yaml", body))
+        assert scn.ground_objects == ("fixture_caddy",)
+        assert "fixture_caddy" in scn.ground_object_defs
+        assert scn.maintenance_plane == "foo"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -24,6 +24,7 @@ from hangarfit.loader import (
     load_layout,
     load_scenario,
 )
+from hangarfit.models import GroundObject, Hangar
 from tests._fleet_test_utils import explode_fleet as _explode_fleet
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -1427,12 +1428,13 @@ placements:
 
     def test_all_allowed_layout_keys_load(self, tmp_path: Path) -> None:
         """Completeness guard: a layout declaring EVERY allowed top-level key
-        (``maintenance`` + ``placements`` alongside the ``fleet``/``hangar`` refs)
-        loads — so the allowlist can never be too strict. Self-enforcing against
-        ``_ALLOWED_LAYOUT_KEYS``."""
+        (``maintenance`` + ``placements`` + ``ground_objects`` alongside the
+        ``fleet``/``hangar`` refs) loads — so the allowlist can never be too
+        strict. Self-enforcing against ``_ALLOWED_LAYOUT_KEYS``."""
         self._minimal_fleet_and_hangar(tmp_path)
         body = (
-            "fleet: fleet.yaml\nhangar: hangar.yaml\nmaintenance:\n  plane: foo\nplacements: []\n"
+            "fleet: fleet.yaml\nhangar: hangar.yaml\nmaintenance:\n  plane: foo\n"
+            "placements: []\nground_objects: []\n"
         )
         file_keys = set(yaml.safe_load(body))
         assert file_keys == _ALLOWED_LAYOUT_KEYS, (
@@ -1443,6 +1445,8 @@ placements:
         layout = load_layout(_write(tmp_path / "layout.yaml", body))
         assert layout.maintenance_plane == "foo"
         assert layout.placements == ()
+        assert dict(layout.ground_objects) == {}
+        assert layout.ground_object_placements == ()
 
     def test_unknown_plane_reference_propagates(self, tmp_path: Path) -> None:
         self._minimal_fleet_and_hangar(tmp_path)
@@ -2181,3 +2185,153 @@ class TestStructuralNotchesLoading:
         )
         with pytest.raises(LoaderError, match="must be greater than"):
             load_hangar(path)
+
+
+# ----------------------------------------------------------------------------
+# Task 6: Layout YAML ground_objects: block parsing (#601).
+# Uses kwarg-injection so no catalog manifest is needed for the layout tests.
+# ----------------------------------------------------------------------------
+
+
+_P1_PLACEMENT = (
+    "placements:\n"
+    "  - plane: p1\n"
+    "    x_m: 20.0\n"
+    "    y_m: 20.0\n"
+    "    heading_deg: 0.0\n"
+    "    on_carts: false\n"
+)
+
+
+class TestLayoutGroundObjects:
+    """Tests for ground_objects: block in layout YAML (Task 6 / #601)."""
+
+    def _hangar(self) -> Hangar:
+        from hangarfit.models import Door, MaintenanceBay
+
+        return Hangar(
+            length_m=40.0,
+            width_m=40.0,
+            door=Door(center_x_m=20.0, width_m=12.0),
+            maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+            clearance_m=0.3,
+            wing_layer_clearance_m=0.2,
+        )
+
+    def _fixed_obstacle(self, obj_id: str = "fuel_trailer") -> GroundObject:
+        from hangarfit.models import Part
+
+        part = Part(
+            kind="ground",
+            length_m=5.0,
+            width_m=2.0,
+            offset_x_m=0.0,
+            offset_y_m=0.0,
+            angle_deg=0.0,
+            z_bottom_m=0.0,
+            z_top_m=1.5,
+        )
+        return GroundObject(
+            id=obj_id,
+            name="Fuel trailer",
+            parts=(part,),
+            object_class="fixed_obstacle",
+        )
+
+    def test_ground_objects_block_parsed(self, tmp_path: Path) -> None:
+        """A valid ground_objects: block builds ground_object_placements."""
+        from tests.conftest import make_test_aircraft
+
+        ac = make_test_aircraft(id="p1")
+        obj = self._fixed_obstacle("fuel_trailer")
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            _P1_PLACEMENT
+            + "ground_objects:\n"
+            + "  - object: fuel_trailer\n    x_m: 5.0\n    y_m: 5.0\n    heading_deg: 0.0\n",
+        )
+        layout = load_layout(
+            layout_path,
+            fleet={ac.id: ac},
+            hangar=self._hangar(),
+            ground_objects={"fuel_trailer": obj},
+        )
+        assert "fuel_trailer" in layout.ground_objects
+        assert len(layout.ground_object_placements) == 1
+        assert layout.ground_object_placements[0].plane_id == "fuel_trailer"
+
+    def test_unknown_ground_object_id_raises(self, tmp_path: Path) -> None:
+        """Referencing an unknown object id must raise LoaderError naming it."""
+        from tests.conftest import make_test_aircraft
+
+        ac = make_test_aircraft(id="p1")
+        obj = self._fixed_obstacle("fuel_trailer")
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            _P1_PLACEMENT
+            + "ground_objects:\n"
+            + "  - object: ghost\n    x_m: 5.0\n    y_m: 5.0\n    heading_deg: 0.0\n",
+        )
+        with pytest.raises(LoaderError, match="ghost"):
+            load_layout(
+                layout_path,
+                fleet={ac.id: ac},
+                hangar=self._hangar(),
+                ground_objects={"fuel_trailer": obj},
+            )
+
+    def test_unknown_entry_key_raises(self, tmp_path: Path) -> None:
+        """An unknown key in a ground_objects entry (e.g. rotation:) must raise LoaderError."""
+        from tests.conftest import make_test_aircraft
+
+        ac = make_test_aircraft(id="p1")
+        obj = self._fixed_obstacle("fuel_trailer")
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            _P1_PLACEMENT
+            + "ground_objects:\n"
+            + "  - object: fuel_trailer\n    x_m: 5.0\n    y_m: 5.0\n"
+            + "    heading_deg: 0.0\n    rotation: 45.0\n",
+        )
+        with pytest.raises(LoaderError, match="unknown.*ground_object|rotation"):
+            load_layout(
+                layout_path,
+                fleet={ac.id: ac},
+                hangar=self._hangar(),
+                ground_objects={"fuel_trailer": obj},
+            )
+
+    def test_empty_ground_objects_block_allowed(self, tmp_path: Path) -> None:
+        """Layout without ground_objects: key loads fine with empty placements."""
+        from tests.conftest import make_test_aircraft
+
+        ac = make_test_aircraft(id="p1")
+        layout_path = _write(tmp_path / "layout.yaml", _P1_PLACEMENT)
+        layout = load_layout(
+            layout_path,
+            fleet={ac.id: ac},
+            hangar=self._hangar(),
+            ground_objects={},
+        )
+        assert dict(layout.ground_objects) == {}
+        assert layout.ground_object_placements == ()
+
+    def test_missing_ground_object_entry_field_raises(self, tmp_path: Path) -> None:
+        """A ground_objects entry omitting a required field (heading_deg) must raise."""
+        from tests.conftest import make_test_aircraft
+
+        ac = make_test_aircraft(id="p1")
+        obj = self._fixed_obstacle("fuel_trailer")
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            _P1_PLACEMENT
+            + "ground_objects:\n"
+            + "  - object: fuel_trailer\n    x_m: 5.0\n    y_m: 5.0\n",
+        )
+        with pytest.raises(LoaderError, match="missing required field|heading_deg"):
+            load_layout(
+                layout_path,
+                fleet={ac.id: ac},
+                hangar=self._hangar(),
+                ground_objects={"fuel_trailer": obj},
+            )

--- a/tests/test_loader_catalog.py
+++ b/tests/test_loader_catalog.py
@@ -8,7 +8,13 @@ from typing import Any
 import pytest
 import yaml
 
-from hangarfit.loader import LoaderError, _build_catalog_object, _read_yaml, load_fleet
+from hangarfit.loader import (
+    LoaderError,
+    _build_catalog_object,
+    _read_yaml,
+    load_fleet,
+    load_ground_objects,
+)
 from hangarfit.models import GroundObject
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -263,3 +269,29 @@ def test_ground_object_rejects_aircraft_part_kind() -> None:
     }
     with pytest.raises(LoaderError, match="not allowed on a ground object"):
         _build_catalog_object(bad, source=Path("inline"))
+
+
+# --- Task 5: manifest ground_objects: + load_ground_objects (#601) -----------
+
+
+def test_load_ground_objects_resolves_manifest() -> None:
+    gobjs = load_ground_objects(_CAT / "fixture_ground_manifest.yaml")
+    assert set(gobjs) == {"fixture_fuel_trailer", "fixture_caddy", "fixture_glider_trailer"}
+    assert gobjs["fixture_caddy"].object_class == "placed_routed_mover"
+
+
+def test_load_ground_objects_absent_key_is_empty(tmp_path: Path) -> None:
+    m = tmp_path / "m.yaml"
+    m.write_text("aircraft: []\n")
+    assert load_ground_objects(m) == {}
+
+
+def test_load_fleet_rejects_ground_object_under_aircraft(tmp_path: Path) -> None:
+    # A ground-object ref listed under aircraft: must fail loudly.
+    import shutil
+
+    shutil.copy(_CAT / "fixture_fuel_trailer.yaml", tmp_path / "ft.yaml")
+    m = tmp_path / "m.yaml"
+    m.write_text("aircraft:\n  - ft.yaml\n")
+    with pytest.raises(LoaderError, match="aircraft|not an aircraft|ground"):
+        load_fleet(m)

--- a/tests/test_loader_catalog.py
+++ b/tests/test_loader_catalog.py
@@ -8,9 +8,16 @@ from typing import Any
 import pytest
 import yaml
 
-from hangarfit.loader import LoaderError, load_fleet
+from hangarfit.loader import LoaderError, _build_catalog_object, _read_yaml, load_fleet
+from hangarfit.models import GroundObject
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+_CAT = Path(__file__).parent / "fixtures" / "catalog"
+
+
+def _build(name: str) -> object:
+    p = _CAT / name
+    return _build_catalog_object(_read_yaml(p), source=p)
 
 
 def _aircraft_doc(aid: str = "p1", **overrides: Any) -> dict[str, Any]:
@@ -78,13 +85,10 @@ def test_type_omitted_defaults_to_aircraft(tmp_path: Path) -> None:
     assert set(load_fleet(manifest)) == {"p1"}
 
 
-def test_unknown_type_is_stage_a_error(tmp_path: Path) -> None:
-    cat = tmp_path / "catalog"
-    cat.mkdir()
-    _write(cat / "trailer.yaml", {"type": "ground_object", "id": "t1"})
-    manifest = _write(tmp_path / "fleet.yaml", {"aircraft": ["catalog/trailer.yaml"]})
-    with pytest.raises(LoaderError, match=r"not yet supported.*Stage A"):
-        load_fleet(manifest)
+def test_unknown_catalog_type_lists_known_types() -> None:
+    p = _CAT / "fixture_bogus_type.yaml"  # type: spaceship + a minimal ground part
+    with pytest.raises(LoaderError, match="unknown catalog type 'spaceship'.*known types"):
+        _build_catalog_object(_read_yaml(p), source=p)
 
 
 def test_type_key_does_not_trip_aircraft_allowlist(tmp_path: Path) -> None:
@@ -166,3 +170,96 @@ def test_data_fleet_loads_after_migration() -> None:
     # The shipped manifest still resolves to the same ids (guards the migration).
     fleet = load_fleet(REPO_ROOT / "data" / "fleet.yaml")
     assert "scheibe_falke" in fleet and "fk9_mkii" in fleet
+
+
+# --- Ground objects: per-type catalog builders (#601) -----------------------
+
+
+def test_fixed_obstacle_loads() -> None:
+    obj = _build("fixture_fuel_trailer.yaml")
+    assert isinstance(obj, GroundObject)
+    assert obj.object_class == "fixed_obstacle"
+    assert obj.motion_mode is None
+    assert obj.parts[0].kind == "ground"
+
+
+def test_car_loads_with_steerable_default() -> None:
+    obj = _build("fixture_caddy.yaml")
+    assert isinstance(obj, GroundObject)
+    assert obj.object_class == "placed_routed_mover"
+    assert obj.motion_mode == "steerable"  # car default
+    assert obj.turn_radius_m == 5.0
+
+
+def test_trailer_loads_with_towed_default() -> None:
+    obj = _build("fixture_glider_trailer.yaml")
+    assert isinstance(obj, GroundObject)
+    assert obj.object_class == "placed_routed_mover"
+    assert obj.motion_mode == "towed"  # trailer default
+
+
+def test_mover_motion_mode_override() -> None:
+    # a trailer authored with motion_mode: steerable keeps the override
+    raw = {
+        "type": "trailer",
+        "id": "t1",
+        "name": "Override trailer",
+        "parts": [
+            {
+                "kind": "ground",
+                "length_m": 1.0,
+                "width_m": 1.0,
+                "offset_x_m": 0.0,
+                "offset_y_m": 0.0,
+                "z_bottom_m": 0.0,
+                "z_top_m": 1.0,
+            }
+        ],
+        "motion_mode": "steerable",
+    }
+    obj = _build_catalog_object(raw, source=Path("inline"))
+    assert isinstance(obj, GroundObject)
+    assert obj.motion_mode == "steerable"
+
+
+def test_fixed_obstacle_rejects_motion_key() -> None:
+    bad = {
+        "type": "fixed_obstacle",
+        "id": "x",
+        "name": "x",
+        "parts": [
+            {
+                "kind": "ground",
+                "length_m": 1,
+                "width_m": 1,
+                "offset_x_m": 0,
+                "offset_y_m": 0,
+                "z_bottom_m": 0,
+                "z_top_m": 1,
+            }
+        ],
+        "motion_mode": "towed",
+    }
+    with pytest.raises(LoaderError, match="unknown fixed_obstacle key"):
+        _build_catalog_object(bad, source=Path("inline"))
+
+
+def test_ground_object_rejects_aircraft_part_kind() -> None:
+    bad = {
+        "type": "car",
+        "id": "x",
+        "name": "x",
+        "parts": [
+            {
+                "kind": "wing",
+                "length_m": 1,
+                "width_m": 1,
+                "offset_x_m": 0,
+                "offset_y_m": 0,
+                "z_bottom_m": 0,
+                "z_top_m": 1,
+            }
+        ],
+    }
+    with pytest.raises(LoaderError, match="not allowed on a ground object"):
+        _build_catalog_object(bad, source=Path("inline"))

--- a/tests/test_loader_catalog.py
+++ b/tests/test_loader_catalog.py
@@ -295,3 +295,35 @@ def test_load_fleet_rejects_ground_object_under_aircraft(tmp_path: Path) -> None
     m.write_text("aircraft:\n  - ft.yaml\n")
     with pytest.raises(LoaderError, match="aircraft|not an aircraft|ground"):
         load_fleet(m)
+
+
+def test_load_ground_objects_invalid_motion_mode_raises_loader_error(tmp_path: Path) -> None:
+    # A car/trailer catalog entry with an invalid motion_mode value must raise
+    # LoaderError through the public load_ground_objects path.
+    # The model raises ValueError; load_ground_objects wraps it to LoaderError.
+    cat = tmp_path / "catalog"
+    cat.mkdir()
+    bad_catalog = {
+        "type": "trailer",
+        "id": "bad_trailer",
+        "name": "Bad trailer",
+        "parts": [
+            {
+                "kind": "ground",
+                "length_m": 2.0,
+                "width_m": 1.0,
+                "offset_x_m": 0.0,
+                "offset_y_m": 0.0,
+                "z_bottom_m": 0.0,
+                "z_top_m": 1.0,
+            }
+        ],
+        "motion_mode": "jetpack",
+    }
+    _write(cat / "bad_trailer.yaml", bad_catalog)
+    manifest = _write(
+        tmp_path / "fleet.yaml",
+        {"ground_objects": ["catalog/bad_trailer.yaml"]},
+    )
+    with pytest.raises(LoaderError, match="jetpack|motion_mode"):
+        load_ground_objects(manifest)

--- a/tests/test_loader_scenario.py
+++ b/tests/test_loader_scenario.py
@@ -350,9 +350,13 @@ def test_load_scenario_rejects_unknown_top_level_key(tmp_path, typo):
 
 def test_load_scenario_all_allowed_top_level_keys_load(tmp_path):
     """Completeness guard: a scenario declaring EVERY allowed top-level key
-    (``maintenance`` + ``constraints`` alongside ``fleet_in``/``fleet``/``hangar``)
-    loads — so the allowlist can never be too strict. Self-enforcing against
-    ``_ALLOWED_SCENARIO_KEYS``."""
+    (``maintenance`` + ``constraints`` + ``ground_objects`` alongside
+    ``fleet_in``/``fleet``/``hangar``) loads — so the allowlist can never be too
+    strict. Self-enforcing against ``_ALLOWED_SCENARIO_KEYS``. The
+    ``ground_objects:`` id-list is empty here (the real ``data/fleet.yaml``
+    manifest declares no ground objects yet), which still exercises the key's
+    presence in the allowlist; non-empty id-list resolution is covered in
+    ``tests/test_loader.py::TestScenarioGroundObjects`` (#601)."""
     import yaml
 
     from hangarfit.loader import _ALLOWED_SCENARIO_KEYS, load_scenario
@@ -364,7 +368,8 @@ def test_load_scenario_all_allowed_top_level_keys_load(tmp_path):
         "  plane: ctsl\n"
         "constraints:\n"
         "  aviat_husky:\n"
-        "    priority: 1.0\n",
+        "    priority: 1.0\n"
+        "ground_objects: []\n",
     )
     file_keys = set(yaml.safe_load(p.read_text()))
     assert file_keys == _ALLOWED_SCENARIO_KEYS, (
@@ -375,6 +380,7 @@ def test_load_scenario_all_allowed_top_level_keys_load(tmp_path):
     s = load_scenario(p)
     assert s.maintenance_plane == "ctsl"
     assert "aviat_husky" in s.constraints
+    assert s.ground_objects == ()
 
 
 def test_load_scenario_unknown_key_wins_over_missing_required(tmp_path):

--- a/tests/test_models_ground_object.py
+++ b/tests/test_models_ground_object.py
@@ -1,0 +1,95 @@
+"""GroundObject model + validation (#601)."""
+
+import pytest
+
+from hangarfit.models import GroundObject, Part
+
+
+def _rect_part(*, kind: str = "ground", length_m: float = 4.0, width_m: float = 2.0) -> Part:
+    return Part(
+        kind=kind,  # type: ignore[arg-type]
+        length_m=length_m,
+        width_m=width_m,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=1.5,
+    )
+
+
+def test_fixed_obstacle_constructs() -> None:
+    obj = GroundObject(
+        id="fuel_trailer",
+        name="Fuel trailer",
+        parts=(_rect_part(),),
+        object_class="fixed_obstacle",
+    )
+    assert obj.object_class == "fixed_obstacle"
+    assert obj.motion_mode is None
+    assert obj.turn_radius_m is None
+
+
+def test_mover_constructs_with_motion() -> None:
+    obj = GroundObject(
+        id="vw_caddy",
+        name="VW Caddy",
+        parts=(_rect_part(),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=4.5,
+    )
+    assert obj.motion_mode == "steerable"
+    assert obj.turn_radius_m == 4.5
+
+
+def test_ground_partkind_is_valid() -> None:
+    # A "ground" footprint Part must construct without error.
+    assert _rect_part(kind="ground").kind == "ground"
+
+
+@pytest.mark.parametrize(
+    "kwargs, msg",
+    [
+        (dict(id="", name="x", parts=(_rect_part(),), object_class="fixed_obstacle"), "id"),
+        (dict(id="x", name="", parts=(_rect_part(),), object_class="fixed_obstacle"), "name"),
+        (dict(id="x", name="x", parts=(), object_class="fixed_obstacle"), "parts"),
+        (
+            dict(id="x", name="x", parts=(_rect_part(),), object_class="bogus"),
+            "object_class",
+        ),
+        (
+            dict(
+                id="x",
+                name="x",
+                parts=(_rect_part(),),
+                object_class="fixed_obstacle",
+                motion_mode="towed",
+            ),
+            "fixed_obstacle",  # a fixed obstacle must not carry motion
+        ),
+        (
+            dict(
+                id="x",
+                name="x",
+                parts=(_rect_part(),),
+                object_class="placed_routed_mover",
+            ),
+            "motion_mode",  # a mover must carry motion
+        ),
+        (
+            dict(
+                id="x",
+                name="x",
+                parts=(_rect_part(),),
+                object_class="placed_routed_mover",
+                motion_mode="steerable",
+                turn_radius_m=-1.0,
+            ),
+            "turn_radius_m",
+        ),
+    ],
+)
+def test_invalid_ground_object_rejected(kwargs: dict, msg: str) -> None:
+    with pytest.raises(ValueError, match=msg):
+        GroundObject(**kwargs)  # type: ignore[arg-type]

--- a/tests/test_models_ground_object.py
+++ b/tests/test_models_ground_object.py
@@ -244,3 +244,14 @@ def test_scenario_rejects_unknown_ground_object_ref() -> None:
             ground_objects=("ghost",),
             ground_object_defs={},
         )
+
+
+def test_ground_object_rejects_non_ground_part() -> None:
+    """GroundObject.__post_init__ must reject any part whose kind != 'ground'."""
+    with pytest.raises(ValueError, match="ground"):
+        GroundObject(
+            id="bad_obj",
+            name="Bad object",
+            parts=(_rect_part(kind="wing"),),
+            object_class="fixed_obstacle",
+        )

--- a/tests/test_models_ground_object.py
+++ b/tests/test_models_ground_object.py
@@ -2,7 +2,19 @@
 
 import pytest
 
-from hangarfit.models import GroundObject, Part
+from hangarfit.models import Door, GroundObject, Hangar, Layout, MaintenanceBay, Part, Placement
+from tests.conftest import make_test_aircraft
+
+
+def _hangar(clearance: float = 0.3, wlc: float = 0.2) -> Hangar:
+    return Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=clearance,
+        wing_layer_clearance_m=wlc,
+    )
 
 
 def _rect_part(*, kind: str = "ground", length_m: float = 4.0, width_m: float = 2.0) -> Part:
@@ -93,3 +105,108 @@ def test_ground_partkind_is_valid() -> None:
 def test_invalid_ground_object_rejected(kwargs: dict, msg: str) -> None:
     with pytest.raises(ValueError, match=msg):
         GroundObject(**kwargs)  # type: ignore[arg-type]
+
+
+def _mover(obj_id: str = "caddy") -> GroundObject:
+    return GroundObject(
+        id=obj_id,
+        name="Caddy",
+        parts=(_rect_part(),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+    )
+
+
+def test_layout_accepts_ground_objects() -> None:
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    obj = _mover()
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id=ac.id, x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={obj.id: obj},
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=2.0, y_m=2.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    assert layout.ground_objects[obj.id] is obj
+    assert len(layout.ground_object_placements) == 1
+
+
+def test_layout_rejects_ground_key_id_mismatch() -> None:
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    obj = _mover("caddy")
+    with pytest.raises(ValueError, match="ground_object"):
+        Layout(
+            fleet={ac.id: ac},
+            hangar=hangar,
+            placements=(),
+            ground_objects={"WRONG": obj},
+            ground_object_placements=(),
+        )
+
+
+def test_layout_rejects_ground_placement_unknown_id() -> None:
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    obj = _mover("caddy")
+    with pytest.raises(ValueError, match="unknown"):
+        Layout(
+            fleet={ac.id: ac},
+            hangar=hangar,
+            placements=(),
+            ground_objects={obj.id: obj},
+            ground_object_placements=(
+                Placement(plane_id="ghost", x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
+            ),
+        )
+
+
+def test_layout_rejects_ground_id_colliding_with_fleet() -> None:
+    # Ground-object id must be disjoint from fleet ids.
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    obj = GroundObject(
+        id=ac.id,
+        name="clash",
+        parts=(_rect_part(),),
+        object_class="fixed_obstacle",
+    )
+    with pytest.raises(ValueError, match="disjoint|collide|both"):
+        Layout(
+            fleet={ac.id: ac},
+            hangar=hangar,
+            placements=(),
+            ground_objects={obj.id: obj},
+            ground_object_placements=(),
+        )
+
+
+def test_layout_empty_ground_objects_default() -> None:
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    layout = Layout(fleet={ac.id: ac}, hangar=hangar, placements=())
+    assert dict(layout.ground_objects) == {}
+    assert layout.ground_object_placements == ()
+
+
+def test_layout_with_ground_objects_pickles() -> None:
+    import pickle
+
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    obj = _mover()
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(),
+        ground_objects={obj.id: obj},
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=1.0, y_m=1.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    back = pickle.loads(pickle.dumps(layout))
+    assert back.ground_objects[obj.id].id == obj.id
+    assert back.ground_object_placements[0].plane_id == obj.id

--- a/tests/test_models_ground_object.py
+++ b/tests/test_models_ground_object.py
@@ -210,3 +210,37 @@ def test_layout_with_ground_objects_pickles() -> None:
     back = pickle.loads(pickle.dumps(layout))
     assert back.ground_objects[obj.id].id == obj.id
     assert back.ground_object_placements[0].plane_id == obj.id
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Scenario ground-object id-list
+# ---------------------------------------------------------------------------
+
+from hangarfit.models import Scenario  # noqa: E402
+
+
+def test_scenario_ground_objects_idlist() -> None:
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    obj = _mover()
+    scn = Scenario(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        fleet_in=(ac.id,),
+        ground_objects=(obj.id,),
+        ground_object_defs={obj.id: obj},
+    )
+    assert scn.ground_objects == (obj.id,)
+
+
+def test_scenario_rejects_unknown_ground_object_ref() -> None:
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    with pytest.raises(ValueError, match="ground_object"):
+        Scenario(
+            fleet={ac.id: ac},
+            hangar=hangar,
+            fleet_in=(ac.id,),
+            ground_objects=("ghost",),
+            ground_object_defs={},
+        )

--- a/tests/test_towplanner_ground_object.py
+++ b/tests/test_towplanner_ground_object.py
@@ -1,0 +1,135 @@
+"""Tow-planner ground-object wiring (#601).
+
+Fixed obstacles join the planner's static keep-out set (``_build_obstacles``);
+placed-routed movers are enumerated in ``plan_fill`` as bodies the planner must
+route, though the actual route search is deferred to #602 (their move carries a
+``None`` / deferred path). The empty-ground-object case stays byte-identical
+(determinism-guard, ADR-0003) — covered by tests/test_towplanner.py.
+"""
+
+from __future__ import annotations
+
+from hangarfit.models import Door, GroundObject, Hangar, Layout, MaintenanceBay, Part, Placement
+from hangarfit.towplanner import _build_obstacles, plan_fill
+from tests.conftest import make_test_aircraft
+
+
+def _hangar(clearance: float = 0.3, wlc: float = 0.2) -> Hangar:
+    """Inline minimal hangar (copied from tests/test_collisions.py:_hangar)."""
+    return Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=clearance,
+        wing_layer_clearance_m=wlc,
+    )
+
+
+def _ground_part(length_m: float = 3.0, width_m: float = 13.0, z_top_m: float = 3.0) -> Part:
+    return Part(
+        kind="ground",
+        length_m=length_m,
+        width_m=width_m,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=z_top_m,
+    )
+
+
+def test_fixed_obstacle_in_static_obstacle_set() -> None:
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    obj = GroundObject(
+        id="doorblock",
+        name="d",
+        parts=(_ground_part(),),
+        object_class="fixed_obstacle",
+    )
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id=ac.id, x_m=6.0, y_m=8.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={obj.id: obj},
+        # a wide obstacle just inside the door throat (small y)
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=7.0, y_m=1.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    obstacles = _build_obstacles(layout, mover_id=ac.id)
+    # the obstacle's footprint is present among the planner's static world parts
+    assert any(wp.plane_id == "doorblock" for wp in obstacles.world_parts)
+
+
+def test_mover_in_routable_enumeration() -> None:
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    mover = GroundObject(
+        id="caddy",
+        name="c",
+        parts=(_ground_part(width_m=2.0),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=4.0,
+    )
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id=ac.id, x_m=6.0, y_m=8.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={mover.id: mover},
+        ground_object_placements=(
+            Placement(plane_id=mover.id, x_m=3.0, y_m=8.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    plan = plan_fill(layout)
+    # the mover id appears in the plan's routed enumeration (path deferred/None to #602)
+    routed_ids = {m.plane_id for m in plan.moves}
+    assert "caddy" in routed_ids
+
+
+def test_movers_excluded_from_static_obstacles_when_routed() -> None:
+    """A mover being routed (mover_id) is excluded from the static obstacle set,
+    exactly like the placed aircraft being routed. Here we route the mover itself
+    and assert it is NOT among the obstacles."""
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    mover = GroundObject(
+        id="caddy",
+        name="c",
+        parts=(_ground_part(width_m=2.0),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=4.0,
+    )
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id=ac.id, x_m=6.0, y_m=8.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={mover.id: mover},
+        ground_object_placements=(
+            Placement(plane_id=mover.id, x_m=3.0, y_m=8.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    obstacles = _build_obstacles(layout, mover_id="caddy")
+    assert all(wp.plane_id != "caddy" for wp in obstacles.world_parts)
+
+
+def test_empty_ground_objects_no_extra_obstacles() -> None:
+    """Byte-identity guard rail: with no ground objects the obstacle set carries
+    only the (other) placed planes — no spurious entries."""
+    hangar = _hangar()
+    a = make_test_aircraft(id="p1")
+    b = make_test_aircraft(id="p2")
+    layout = Layout(
+        fleet={a.id: a, b.id: b},
+        hangar=hangar,
+        placements=(
+            Placement(plane_id="p1", x_m=6.0, y_m=8.0, heading_deg=0.0, on_carts=False),
+            Placement(plane_id="p2", x_m=14.0, y_m=8.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    obstacles = _build_obstacles(layout, mover_id="p1")
+    plane_ids = {wp.plane_id for wp in obstacles.world_parts}
+    assert plane_ids == {"p2"}


### PR DESCRIPTION
Closes #601.

**Stage A / Epic #600, rung A1** — the foundational ground-object data model the rest of the epic (and Stage C) builds on. Ships the taxonomy + loader + verifier wiring; the real Herrenteich entries, mover route search, the Caddy egress gate, the soft trailer region, and rendering are deferred to sibling issues (#602–#606).

## What shipped
- **Model** — a frozen-slots `GroundObject` (`id`, `name`, `parts`, `object_class`, `motion_mode?`, `turn_radius_m?`) + a new `"ground"` `PartKind` for non-aircraft footprints. `Layout` gains parallel `ground_objects` / `ground_object_placements` fields; `Scenario` gains a `ground_objects` id-list + `ground_object_defs`. All default-empty → existing layouts/scenarios byte-identical.
- **Catalog + loader** — the #595 `type:` Stage-A guard becomes a builder registry: concrete catalog types `fixed_obstacle` / `car` / `trailer` (per the locked design decision), each with a strict key allowlist. `object_class` is derived from the type; motion is defaulted per type (car→`steerable`, trailer→`towed`) but stays overridable data. New `load_ground_objects` + manifest `ground_objects:` list; layout/scenario YAML `ground_objects:` parsing; symmetric guards so an aircraft listed under `ground_objects:` (or vice-versa) fails loudly.
- **Verifier** — ground objects reuse the existing `Placement` pose + det-(−1) world transform (`aircraft_parts_world` widened, transform untouched). A **fixed obstacle** is a keep-out: an aircraft/mover part overlapping it → a single-object `ground_obstacle` conflict (the pairwise-set seam, so an oblique-parked trailer at the door works). **Movers** join pairwise collision as placed bodies, and join the tow planner's routable enumeration as **deferred** moves (`Move.path=None`) — fixed obstacles also become static tow-obstacles. Actual mover routing is #602.

## Safety
- **Empty-set byte-identity** is the gate: with no ground objects, `check()` and the tow plan are bit-identical to today (proven structurally + by a dedicated test).
- **Determinism (ADR-0003)** preserved — `determinism-guard` double-run + the solver canaries stay byte-identical (no ground objects in their fixtures); new iteration is `sorted`-by-id.
- Full suite **1584 passed**, mypy clean, ruff clean.

## Docs
ADR-0025 (taxonomy + keep-out reuse), arc42 §5/§8, `data/catalog/README.md`, CHANGELOG `[Unreleased]`.

## Scope held (deferred to siblings)
Real Herrenteich catalog entries + dims/clearance calibration (#605) · mover route search + ADR-0010 motion amendment (#602) · Caddy hard nearest-door/egress gate (#603) · soft right-side trailer region (#604) · rendering (#606).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
