### PR TITLE
feat(605): Herrenteich full real set + ground-object catalog (static calibration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ All notable changes to this project are documented here. Format follows [Keep a 
   (a `ground_obstacle` conflict names the overlapping aircraft/mover) and
   movers join collision/tow enumeration. Empty-set output is byte-identical.
   (ADR-0025)
+- **Herrenteich full real set + ground-object catalog (#605).** The real hangar's
+  four non-aircraft occupants — a VW Caddy, two glider trailers, and a fixed
+  "Maul" fuel trailer — now have `data/catalog/` entries, and a new
+  `examples/herrenteich/layout_full.yaml` parks the full real set (8 aircraft +
+  those four) in one arrangement that passes `hangarfit check`. `collisions.check`
+  now bounds/notch-checks ground objects (previously aircraft-only). The
+  Herrenteich clearances were calibrated (`clearance_m` 0.3→0.20,
+  `wing_layer_clearance_m` 0.2→0.15) so the full set is feasible — the placeholder
+  values were too loose to model real club packing density. Tow-routing of the
+  full set, the hard Caddy nearest-door egress rule, and rendering of ground
+  objects are deferred (#602/#603/#606).
 - Optional polygon part footprints: a `Part` may carry a load-time-canonicalized
   `local_vertices` polygon (authored via a parametrized `planform: {root_chord_m,
   tip_chord_m}` wing block), used by the collision build-path while `length_m`/

--- a/data/catalog/README.md
+++ b/data/catalog/README.md
@@ -104,8 +104,8 @@ must not carry either field; the loader rejects them.
 
 ```yaml
 type: car
-id: vw_caddy
-name: VW Caddy
+id: example_car               # illustration only — the real entry is vw_caddy (below)
+name: Example car
 measured: false
 motion_mode: steerable        # explicit override; default for car is already steerable
 turn_radius_m: 5.5

--- a/data/catalog/README.md
+++ b/data/catalog/README.md
@@ -120,16 +120,23 @@ parts:
     z_top_m: 1.85
 ```
 
-### Status of real Herrenteich ground-object entries
+### Real Herrenteich ground-object entries (#605)
 
-The real Airfield Herrenteich ground objects — `fuel_trailer`,
-`vw_caddy`, `glider_trailer_1`, `glider_trailer_2` — are **not yet
-authored in this catalog**. Issue #605 adds them alongside the
-dims/clearance calibration for a feasible all-11 arrangement.
+The real Airfield Herrenteich ground objects are now authored in this catalog
+(added by #605, on top of #601's taxonomy + loader):
 
-This PR (#601) ships the taxonomy and the loader; the catalog currently
-carries **test fixtures** under `tests/fixtures/catalog/` only, not
-production ground-object entries.
+| id | `type:` | envelope L×W×H (m) | basis (`measured: false`) |
+|---|---|---|---|
+| `vw_caddy` | `car` | 4.88 × 1.79 × 1.84 | VW Caddy Maxi (long-wheelbase) manufacturer data |
+| `glider_trailer_1` | `trailer` | 9.0 × 2.1 × 2.3 | typical closed glider trailer (Cobra/Spindelberger class) |
+| `glider_trailer_2` | `trailer` | 9.0 × 2.1 × 2.3 | second instance, same envelope |
+| `maul_fuel_trailer` | `fixed_obstacle` | 4.5 × 2.0 × 1.9 | Maul road-trailer envelope (estimated) |
+
+All carry `measured: false` (published/typical specs, not an on-site survey).
+They are parked together with the eight aircraft in
+`examples/herrenteich/layout_full.yaml` — the #605 full-set calibration
+reference. Tow-routing of the movers (#602), the hard Caddy nearest-door egress
+gate (#603), and rendering of ground objects (#606) are deferred.
 
 ## Real-spec provenance (Airfield Herrenteich occupants, #536/#594)
 

--- a/data/catalog/glider_trailer_1.yaml
+++ b/data/catalog/glider_trailer_1.yaml
@@ -1,0 +1,15 @@
+# Closed single-glider road trailer (one of two at Herrenteich). Envelope is a
+# TYPICAL closed trailer for a 15-18 m glider (Cobra/Spindelberger class);
+# measured: false — not an on-site survey.
+type: trailer
+id: glider_trailer_1
+name: "Glider trailer 1 (closed)"
+measured: false
+parts:
+  - kind: ground
+    length_m: 9.0         # typical closed glider-trailer length
+    width_m: 2.1          # road-legal trailer width
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 2.3          # closed-trailer height

--- a/data/catalog/glider_trailer_2.yaml
+++ b/data/catalog/glider_trailer_2.yaml
@@ -1,0 +1,15 @@
+# Second closed glider trailer at Herrenteich. Same TYPICAL envelope as
+# glider_trailer_1 (no per-trailer survey); a distinct catalog object because
+# ground_object_placements forbids duplicate ids. measured: false.
+type: trailer
+id: glider_trailer_2
+name: "Glider trailer 2 (closed)"
+measured: false
+parts:
+  - kind: ground
+    length_m: 9.0
+    width_m: 2.1
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 2.3

--- a/data/catalog/maul_fuel_trailer.yaml
+++ b/data/catalog/maul_fuel_trailer.yaml
@@ -1,0 +1,15 @@
+# "Maul Tankanhänger" — the fixed fuel trailer that lives by the hangar door.
+# A fixed_obstacle (immovable keep-out). Envelope is an ESTIMATE of a Maul
+# road fuel trailer (not surveyed). measured: false.
+type: fixed_obstacle
+id: maul_fuel_trailer
+name: "Maul fuel trailer (Tankanhänger)"
+measured: false
+parts:
+  - kind: ground
+    length_m: 4.5         # estimated road-trailer length
+    width_m: 2.0          # estimated width
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 1.9          # estimated height

--- a/data/catalog/vw_caddy.yaml
+++ b/data/catalog/vw_caddy.yaml
@@ -1,0 +1,16 @@
+# VW Caddy Maxi — the club's rescue/utility vehicle, parked in the hangar.
+# Dimensions: VW Caddy Maxi (long-wheelbase) manufacturer technical data.
+# measured: false — published spec, not an on-site survey.
+type: car
+id: vw_caddy
+name: "VW Caddy Maxi (rescue vehicle)"
+turn_radius_m: 5.5        # carried for #602 routing; unused by static check
+measured: false
+parts:
+  - kind: ground
+    length_m: 4.88        # VW Caddy Maxi overall length (manufacturer)
+    width_m: 1.79         # body width excl. mirrors (manufacturer)
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 1.84         # roof height (manufacturer)

--- a/docs/adr/0025-ground-object-taxonomy.md
+++ b/docs/adr/0025-ground-object-taxonomy.md
@@ -213,6 +213,13 @@ solver seeds are unaffected.
 
 ### Real catalog entries deferred to #605
 
+> **Update (#605, 2026-06-11): landed.** The four real entries shipped as
+> `vw_caddy`, `glider_trailer_1`, `glider_trailer_2`, and `maul_fuel_trailer`
+> (the fixed fuel trailer; the `fuel_trailer` name below was provisional), along
+> with the Herrenteich clearance calibration (0.3/0.2 → 0.20/0.15) and an
+> extension of `collisions.check` to bounds/notch-check ground objects. The text
+> below is retained as the #601 (A1) decision record.
+
 A1 ships the taxonomy and the loader; the catalog currently carries only
 **test fixtures** under `tests/fixtures/catalog/`. The real Herrenteich
 objects (`fuel_trailer`, `vw_caddy`, `glider_trailer_1`, `glider_trailer_2`)

--- a/docs/superpowers/plans/2026-06-11-605-herrenteich-full-set-calibration.md
+++ b/docs/superpowers/plans/2026-06-11-605-herrenteich-full-set-calibration.md
@@ -1,0 +1,618 @@
+# Herrenteich Full-Set Static Calibration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the full real Herrenteich set (8 aircraft + VW Caddy + 2 glider trailers + 1 fixed fuel trailer) pass `hangarfit check` as a single checked-in reference layout, give the four ground objects a real `data/catalog/` home, calibrate the Herrenteich clearances to make it feasible, and extend `collisions.check` to bounds/notch-check ground objects.
+
+**Architecture:** Pure data + one small collision-checker extension. Four new ground-object catalog files (reusing #601's `car`/`trailer`/`fixed_obstacle` builders), wired into `examples/herrenteich/fleet.yaml`. A new `layout_full.yaml` places all 11 bodies in a verified-valid arrangement. `examples/herrenteich/hangar.yaml` clearances drop (0.3→0.20 horizontal, 0.2→0.15 vertical) — the empirically-established feasibility frontier for the full set, local to this hangar and monotonic-safe. `collisions.check` gains ground objects in its bounds/notch pass (byte-identical when no ground objects).
+
+**Tech Stack:** Python 3.12, dataclasses, Shapely, pytest, ruff, mypy. No new dependencies.
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `data/catalog/vw_caddy.yaml` | Create | VW Caddy Maxi `car` catalog entry |
+| `data/catalog/glider_trailer_1.yaml` | Create | Glider trailer `trailer` entry (instance 1) |
+| `data/catalog/glider_trailer_2.yaml` | Create | Glider trailer `trailer` entry (instance 2) |
+| `data/catalog/maul_fuel_trailer.yaml` | Create | Maul fuel trailer `fixed_obstacle` entry |
+| `examples/herrenteich/fleet.yaml` | Modify | Add `ground_objects:` list referencing the four |
+| `examples/herrenteich/hangar.yaml` | Modify | `clearance_m` 0.3→0.20, `wing_layer_clearance_m` 0.2→0.15 |
+| `examples/herrenteich/layout_full.yaml` | Create | The full-set reference layout (all 11 bodies) |
+| `src/hangarfit/collisions.py` | Modify (`check`, ~L86-89) | Bounds/notch-check ground objects too |
+| `tests/test_collisions_ground_object.py` | Modify | GO out-of-bounds + in-notch conflict tests |
+| `tests/test_herrenteich_dataset.py` | Modify | Loader + full-set valid/notch/Caddy regression |
+| `examples/herrenteich/README.md` | Modify | Point at `layout_full.yaml` calibration reference |
+| `data/catalog/README.md` | Modify | Document the four ground objects |
+| `CHANGELOG.md` | Modify | `[Unreleased]` entry |
+
+**Determinism / review note:** `collisions.py` is guarded — after Task 2, the review arc must include **geometry-invariant-guard** and **silent-failure-hunter** (per CLAUDE.md). The change is bounds-only (no geometry transform, no solver/towplanner), but the guards still apply to the file.
+
+---
+
+## Task 1: Ground-object catalog entries + fleet wiring
+
+**Files:**
+- Create: `data/catalog/vw_caddy.yaml`, `data/catalog/glider_trailer_1.yaml`, `data/catalog/glider_trailer_2.yaml`, `data/catalog/maul_fuel_trailer.yaml`
+- Modify: `examples/herrenteich/fleet.yaml`
+- Test: `tests/test_herrenteich_dataset.py`
+
+- [ ] **Step 1: Write the failing test** — append to `tests/test_herrenteich_dataset.py`:
+
+```python
+def test_ground_objects_load_from_manifest() -> None:
+    """The four real ground objects load from the herrenteich fleet manifest
+    with the right object_class + motion (#605)."""
+    from hangarfit.loader import load_ground_objects
+
+    gos = load_ground_objects(HERRENTEICH / "fleet.yaml")
+    assert set(gos) == {
+        "maul_fuel_trailer",
+        "vw_caddy",
+        "glider_trailer_1",
+        "glider_trailer_2",
+    }
+    assert gos["maul_fuel_trailer"].object_class == "fixed_obstacle"
+    assert gos["vw_caddy"].object_class == "placed_routed_mover"
+    assert gos["vw_caddy"].motion_mode == "steerable"
+    assert gos["glider_trailer_1"].motion_mode == "towed"
+    assert gos["glider_trailer_2"].motion_mode == "towed"
+    # each is a single solid ground footprint
+    for go in gos.values():
+        assert len(go.parts) == 1 and go.parts[0].kind == "ground"
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `pytest tests/test_herrenteich_dataset.py::test_ground_objects_load_from_manifest -v`
+Expected: FAIL — `fleet.yaml` has no `ground_objects:` key, so `load_ground_objects` returns `{}` and the set assertion fails.
+
+- [ ] **Step 3: Create the four catalog files**
+
+`data/catalog/vw_caddy.yaml`:
+```yaml
+# VW Caddy Maxi — the club's rescue/utility vehicle, parked in the hangar.
+# Dimensions: VW Caddy Maxi (long-wheelbase) manufacturer technical data.
+# measured: false — published spec, not an on-site survey.
+type: car
+id: vw_caddy
+name: "VW Caddy Maxi (rescue vehicle)"
+turn_radius_m: 5.5        # carried for #602 routing; unused by static check
+measured: false
+parts:
+  - kind: ground
+    length_m: 4.88        # VW Caddy Maxi overall length (manufacturer)
+    width_m: 1.79         # body width excl. mirrors (manufacturer)
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 1.84         # roof height (manufacturer)
+```
+
+`data/catalog/glider_trailer_1.yaml`:
+```yaml
+# Closed single-glider road trailer (one of two at Herrenteich). Envelope is a
+# TYPICAL closed trailer for a 15–18 m glider (Cobra/Spindelberger class);
+# measured: false — not an on-site survey.
+type: trailer
+id: glider_trailer_1
+name: "Glider trailer 1 (closed)"
+measured: false
+parts:
+  - kind: ground
+    length_m: 9.0         # typical closed glider-trailer length
+    width_m: 2.1          # road-legal trailer width
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 2.3          # closed-trailer height
+```
+
+`data/catalog/glider_trailer_2.yaml` (same envelope, second instance):
+```yaml
+# Second closed glider trailer at Herrenteich. Same TYPICAL envelope as
+# glider_trailer_1 (no per-trailer survey); a distinct catalog object because
+# ground_object_placements forbids duplicate ids. measured: false.
+type: trailer
+id: glider_trailer_2
+name: "Glider trailer 2 (closed)"
+measured: false
+parts:
+  - kind: ground
+    length_m: 9.0
+    width_m: 2.1
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 2.3
+```
+
+`data/catalog/maul_fuel_trailer.yaml`:
+```yaml
+# "Maul Tankanhänger" — the fixed fuel trailer that lives by the hangar door.
+# A fixed_obstacle (immovable keep-out). Envelope is an ESTIMATE of a Maul
+# road fuel trailer (not surveyed). measured: false.
+type: fixed_obstacle
+id: maul_fuel_trailer
+name: "Maul fuel trailer (Tankanhänger)"
+measured: false
+parts:
+  - kind: ground
+    length_m: 4.5         # estimated road-trailer length
+    width_m: 2.0          # estimated width
+    offset_x_m: 0.0
+    offset_y_m: 0.0
+    z_bottom_m: 0.0
+    z_top_m: 1.9          # estimated height
+```
+
+- [ ] **Step 4: Wire the manifest** — append to `examples/herrenteich/fleet.yaml` (after the `aircraft:` list):
+
+```yaml
+
+# Non-aircraft ground objects usually on the floor with the fleet (#605/#601).
+# Referenced from the central catalog, same as aircraft. The fuel trailer is a
+# fixed keep-out; the Caddy + two glider trailers are placed movers (routing
+# lands in #602).
+ground_objects:
+  - ../../data/catalog/maul_fuel_trailer.yaml
+  - ../../data/catalog/vw_caddy.yaml
+  - ../../data/catalog/glider_trailer_1.yaml
+  - ../../data/catalog/glider_trailer_2.yaml
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `pytest tests/test_herrenteich_dataset.py::test_ground_objects_load_from_manifest -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add data/catalog/vw_caddy.yaml data/catalog/glider_trailer_1.yaml \
+        data/catalog/glider_trailer_2.yaml data/catalog/maul_fuel_trailer.yaml \
+        examples/herrenteich/fleet.yaml tests/test_herrenteich_dataset.py
+git commit -m "feat(605): real ground-object catalog entries + herrenteich manifest wiring"
+```
+
+---
+
+## Task 2: Extend `collisions.check` to bounds/notch-check ground objects
+
+**Files:**
+- Modify: `src/hangarfit/collisions.py` (`check`, ~L86-89)
+- Test: `tests/test_collisions_ground_object.py`
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_collisions_ground_object.py` (the existing `_hangar`/`_ground_part` helpers and imports are reused; add `StructuralNotch` to the model import):
+
+```python
+def test_ground_object_out_of_bounds_flagged() -> None:
+    """A ground object straddling the hangar wall is a hangar_bounds conflict
+    (#605 — #601 left ground objects un-bounds-checked)."""
+    hangar = _hangar()  # 40x40, no notch
+    obj = GroundObject(
+        id="trailer",
+        name="t",
+        parts=(_ground_part(length_m=4.0, width_m=2.0),),
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+    )
+    layout = Layout(
+        fleet={},
+        hangar=hangar,
+        placements=(),
+        ground_objects={obj.id: obj},
+        # centred on x=0.5 with a 2 m width → half the footprint is at x<0.
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=0.5, y_m=20.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    result = check(layout)
+    kinds = {c.kind for c in result.conflicts}
+    assert "hangar_bounds" in kinds
+    assert any("trailer" in "".join(c.planes) for c in result.conflicts)
+
+
+def test_ground_object_in_notch_flagged() -> None:
+    """A ground object inside a structural notch is a structural_notch conflict."""
+    from hangarfit.models import StructuralNotch
+
+    hangar = Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.2,
+        structural_notches=(
+            StructuralNotch(x_min_m=30.0, y_min_m=30.0, x_max_m=40.0, y_max_m=40.0),
+        ),
+    )
+    obj = GroundObject(
+        id="caddy",
+        name="c",
+        parts=(_ground_part(length_m=3.0, width_m=2.0),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+    )
+    layout = Layout(
+        fleet={},
+        hangar=hangar,
+        placements=(),
+        ground_objects={obj.id: obj},
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=35.0, y_m=35.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    kinds = {c.kind for c in check(layout).conflicts}
+    assert "structural_notch" in kinds
+
+
+def test_fixed_obstacle_out_of_bounds_flagged() -> None:
+    """A fixed obstacle is bounds-checked too (not just movers)."""
+    hangar = _hangar()
+    obj = GroundObject(
+        id="fuel",
+        name="f",
+        parts=(_ground_part(length_m=4.0, width_m=2.0),),
+        object_class="fixed_obstacle",
+    )
+    layout = Layout(
+        fleet={},
+        hangar=hangar,
+        placements=(),
+        ground_objects={obj.id: obj},
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=39.7, y_m=20.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    assert "hangar_bounds" in {c.kind for c in check(layout).conflicts}
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `pytest tests/test_collisions_ground_object.py -k "out_of_bounds or in_notch" -v`
+Expected: FAIL — ground objects are not currently bounds/notch-checked, so no `hangar_bounds`/`structural_notch` conflict is emitted.
+
+- [ ] **Step 3: Implement the bounds extension** — in `src/hangarfit/collisions.py`, inside `check`, replace the `placed_bodies = {**aircraft_parts, **mover_parts}` line and the `_hangar_bounds_conflicts(aircraft_parts, ...)` call:
+
+```python
+    placed_bodies = {**aircraft_parts, **mover_parts}
+    # Ground objects (movers AND fixed obstacles) are bounds/notch-checked
+    # alongside aircraft (#605): they too must fit the floor and clear the notch.
+    # Aircraft come first so the no-ground-object case is byte-identical (empty
+    # GO dicts ⇒ bounded_bodies == aircraft_parts, same dict order). Bay
+    # intrusion stays aircraft-only (an aircraft-occupancy rule, not geometry).
+    bounded_bodies = {**aircraft_parts, **mover_parts, **obstacle_parts}
+
+    conflicts: list[Conflict] = []
+    conflicts.extend(_hangar_bounds_conflicts(bounded_bodies, layout.hangar))
+    conflicts.extend(_bay_intrusion_conflicts(aircraft_parts, layout))
+```
+
+(The `_pairwise_conflicts` and `_ground_obstacle_conflicts` lines below are unchanged.)
+
+- [ ] **Step 4: Run the new tests + the byte-identity guard, verify they pass**
+
+Run: `pytest tests/test_collisions_ground_object.py -v`
+Expected: PASS — including the existing `test_empty_ground_objects_byte_identical` (confirms the no-GO path is unchanged) and `test_separated_ground_object_is_valid` (the in-bounds GO is still valid).
+
+- [ ] **Step 5: Run the full collision + integration suites (no regression)**
+
+Run: `pytest tests/test_collisions.py tests/test_collisions_ground_object.py tests/test_ground_objects_integration.py tests/test_towplanner_ground_object.py -q`
+Expected: PASS — all existing ground objects in those tests are in-bounds, so the extension adds no conflicts.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/collisions.py tests/test_collisions_ground_object.py
+git commit -m "feat(605): bounds/notch-check ground objects in collisions.check"
+```
+
+---
+
+## Task 3: Calibrate the Herrenteich clearances
+
+**Files:**
+- Modify: `examples/herrenteich/hangar.yaml`
+- Test: `tests/test_herrenteich_dataset.py`
+
+- [ ] **Step 1: Write the failing test** — append to `tests/test_herrenteich_dataset.py`:
+
+```python
+def test_hangar_clearances_calibrated() -> None:
+    """The Herrenteich clearances were calibrated to fit the full real set
+    (#605): horizontal 0.20, vertical 0.15 (placeholders were 0.30/0.20)."""
+    hangar = load_hangar(HERRENTEICH / "hangar.yaml")
+    assert hangar.clearance_m == 0.20
+    assert hangar.wing_layer_clearance_m == 0.15
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `pytest tests/test_herrenteich_dataset.py::test_hangar_clearances_calibrated -v`
+Expected: FAIL — current values are 0.3 / 0.2.
+
+- [ ] **Step 3: Edit `examples/herrenteich/hangar.yaml`** — replace the two clearance lines (currently `clearance_m: 0.3` / `wing_layer_clearance_m: 0.2`):
+
+```yaml
+# CALIBRATED for the full real set (#605). The placeholders were 0.3 / 0.2; the
+# full set (8 aircraft + Caddy + 2 glider trailers + fixed fuel trailer) is
+# INFEASIBLE at 0.3/0.2 and feasible at <=0.22/0.15 (checker-driven search).
+# 0.20 m lateral matches real hand-pushed club packing density; 0.15 m vertical
+# fixes a too-large wing-layer clearance that falsely rejected legal z-disjoint
+# wing-over-tail nestings (the real club clears fins ~0.40 m by hand, well above
+# 0.15). Lowering a clearance only RELAXES the constraint, so the existing
+# layout.yaml / scenario_demo.yaml stay valid; the synthetic data/ hangar is a
+# separate file, untouched.
+clearance_m: 0.20            # minimum horizontal gap between any two parts
+wing_layer_clearance_m: 0.15 # minimum vertical gap between two parts at the same XY
+```
+
+- [ ] **Step 4: Run the calibration test + confirm existing layouts still valid (monotonic safety)**
+
+Run:
+```bash
+pytest tests/test_herrenteich_dataset.py -v
+hangarfit check examples/herrenteich/layout.yaml          # still: valid, exit 0
+hangarfit check examples/layouts/example.yaml             # synthetic data/ untouched: valid
+```
+Expected: all PASS / `valid` (tightening clearance cannot invalidate a previously-valid layout).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/herrenteich/hangar.yaml tests/test_herrenteich_dataset.py
+git commit -m "feat(605): calibrate herrenteich clearances (0.3/0.2 -> 0.20/0.15)"
+```
+
+---
+
+## Task 4: The full-set reference layout
+
+**Files:**
+- Create: `examples/herrenteich/layout_full.yaml`
+- Test: `tests/test_herrenteich_dataset.py`
+
+> Coordinates below come from a checker-driven search (the documented norm for
+> `layout.yaml`); the search script is NOT committed. They are verified valid at
+> the calibrated 0.20/0.15 by the regression test in this task, not by the search.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/test_herrenteich_dataset.py`:
+
+```python
+FULL_SET = USUAL_OCCUPANTS | {
+    "vw_caddy",
+    "glider_trailer_1",
+    "glider_trailer_2",
+    "maul_fuel_trailer",
+}
+
+
+def test_full_set_layout_is_valid() -> None:
+    """The full real set (8 aircraft + 4 ground objects) passes the real
+    checker at the calibrated clearances (#605 primary acceptance)."""
+    layout = load_layout(HERRENTEICH / "layout_full.yaml")
+    present = {p.plane_id for p in layout.placements} | {
+        gp.plane_id for gp in layout.ground_object_placements
+    }
+    assert present == FULL_SET
+    result = collisions.check(layout)
+    assert result.conflicts == (), [c.kind for c in result.conflicts]
+
+
+def test_full_set_ground_objects_in_bounds_and_clear_notch() -> None:
+    """Independent, model-free vertex scan: every ground object is inside the
+    L-shaped floor and clear of the office notch (belt-and-suspenders over the
+    Task-2 checker extension)."""
+    layout = load_layout(HERRENTEICH / "layout_full.yaml")
+    floor = layout.hangar.floor_polygon
+    assert floor is not None
+    x0, y0, x1, y1 = NOTCH
+    for gp in layout.ground_object_placements:
+        obj = layout.ground_objects[gp.plane_id]
+        for part in aircraft_parts_world(obj, gp):
+            assert floor.covers(part.polygon), f"{gp.plane_id} {part.kind} outside floor"
+            for x, y in part.polygon.exterior.coords:
+                assert not (x0 <= x <= x1 and y0 <= y <= y1), (
+                    f"{gp.plane_id} vertex ({x:.2f},{y:.2f}) in office notch"
+                )
+
+
+def test_full_set_caddy_near_door() -> None:
+    """SOFT intent (pre-#603): the Caddy is parked near the door — in the front
+    third of the hangar and within the door's x-span — the precursor to the #603
+    hard nearest-door egress gate. (Exact 'nearest' is #603's job; the 9 m glider
+    trailers run along the walls toward the door, so a strict min-y assertion
+    would fight that geometry.)"""
+    layout = load_layout(HERRENTEICH / "layout_full.yaml")
+    caddy = next(gp for gp in layout.ground_object_placements if gp.plane_id == "vw_caddy")
+    assert caddy.y_m < layout.hangar.length_m / 3
+    door = layout.hangar.door
+    assert door.center_x_m - door.width_m / 2 <= caddy.x_m <= door.center_x_m + door.width_m / 2
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `pytest tests/test_herrenteich_dataset.py -k full_set -v`
+Expected: FAIL — `layout_full.yaml` does not exist (`LoaderError`/`FileNotFoundError`).
+
+- [ ] **Step 3: Create `examples/herrenteich/layout_full.yaml`** with this exact content (verified valid at 0.20/0.15 this session — `check`: zero conflicts, all ground objects in-bounds + notch-clear):
+
+```yaml
+# Airfield Herrenteich — the FULL real set: all 8 usual aircraft PLUS the four
+# non-aircraft floor occupants (VW Caddy, two glider trailers, fixed Maul fuel
+# trailer). This is the #605 calibration reference — it passes `hangarfit check`
+# (exit 0) at the calibrated clearances (hangar.yaml: clearance_m 0.20,
+# wing_layer_clearance_m 0.15).
+#
+# HOW THIS WAS PRODUCED. Like layout.yaml, this is the TOOL's arrangement, not a
+# record of where the club parks: an offline search driving the real part-based
+# collision checker directly found a valid all-11 packing (the product solver does
+# not generate it). The aircraft are RE-NESTED relative to layout.yaml to free
+# wall corridors for the 9 m glider trailers — layout.yaml (aircraft-only) is
+# unchanged. Replace with real parking positions when surveyed.
+#
+# DEFERRED: tow-routing of this set (#602; the 18 m Scheibe is not yet routable),
+# the hard Caddy nearest-door egress gate (#603 — the Caddy IS placed near the
+# door here, but egress is not enforced), and rendering the ground objects (#606).
+#
+# Coordinate convention (see hangar.yaml): world (0,0) front-left, +x right along
+# the door wall, +y deeper in; heading 0 = nose deep (+y), 90 = nose toward +x.
+
+fleet: fleet.yaml
+hangar: hangar.yaml
+
+placements:
+  - plane: scheibe_falke
+    x_m: 8.18
+    y_m: 22.67
+    heading_deg: 90.0
+    on_carts: true          # always_cart
+  - plane: stemme_s10
+    x_m: 3.15
+    y_m: 13.65
+    heading_deg: 270.0
+    on_carts: false         # always_own_gear
+  - plane: aviat_husky
+    x_m: 5.28
+    y_m: 16.51
+    heading_deg: 90.0
+    on_carts: false         # always_own_gear
+  - plane: cessna_140
+    x_m: 13.36
+    y_m: 5.09
+    heading_deg: 90.0
+    on_carts: false         # cart_eligible, on own gear
+  - plane: fk9_mkii
+    x_m: 7.09
+    y_m: 9.10
+    heading_deg: 270.0
+    on_carts: false         # cart_eligible, on own gear
+  - plane: zlin_savage
+    x_m: 7.41
+    y_m: 25.52
+    heading_deg: 270.0
+    on_carts: true          # always_cart
+  - plane: wild_thing
+    x_m: 11.32
+    y_m: 17.32
+    heading_deg: 90.0
+    on_carts: true          # always_cart
+  - plane: ctsl
+    x_m: 5.32
+    y_m: 3.00
+    heading_deg: 180.0
+    on_carts: false         # cart_eligible, on own gear
+
+ground_objects:
+  - object: vw_caddy            # rescue vehicle near the door (egress precursor, #603)
+    x_m: 11.57
+    y_m: 8.26
+    heading_deg: 180.0
+  - object: glider_trailer_1    # along the left wall, lengthwise
+    x_m: 1.20
+    y_m: 7.99
+    heading_deg: 180.0
+  - object: glider_trailer_2    # along the left wall, deep
+    x_m: 2.02
+    y_m: 27.16
+    heading_deg: 0.0
+  - object: maul_fuel_trailer   # fixed keep-out (clear of the back-right office notch)
+    x_m: 14.05
+    y_m: 13.32
+    heading_deg: 0.0
+```
+
+- [ ] **Step 4: Run the full-set tests, verify they pass**
+
+Run: `pytest tests/test_herrenteich_dataset.py -k full_set -v`
+Expected: PASS.
+
+- [ ] **Step 5: CLI smoke + render**
+
+Run: `hangarfit check examples/herrenteich/layout_full.yaml --render /tmp/full.png`
+Expected: `valid`, exit 0, PNG written (ground objects are not yet rendered — #606 — but the aircraft render and the check is the gate).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/herrenteich/layout_full.yaml tests/test_herrenteich_dataset.py
+git commit -m "feat(605): full-set reference layout (8 aircraft + 4 ground objects)"
+```
+
+---
+
+## Task 5: Docs + audit trail
+
+**Files:**
+- Modify: `examples/herrenteich/README.md`, `data/catalog/README.md`, `CHANGELOG.md`
+
+- [ ] **Step 1: `examples/herrenteich/README.md`** — in the Files table add a `layout_full.yaml` row ("the full real set — 8 aircraft + Caddy + 2 glider trailers + fixed fuel trailer — the calibration reference; passes `check` at the calibrated 0.20/0.15 clearances"); add a short prose paragraph: the full set is feasible only at the calibrated clearances (0.3/0.2 → 0.20/0.15); tow-routing of the full set and the hard Caddy-egress rule are deferred (#602/#603); ground objects are not yet rendered (#606).
+
+- [ ] **Step 2: `data/catalog/README.md`** — document the four new ground objects (id, type, envelope, that they are `measured: false` published/typical specs) under the existing catalog listing.
+
+- [ ] **Step 3: `CHANGELOG.md`** — add under `## [Unreleased]` → `### Added`:
+
+```markdown
+- **Herrenteich full real set + ground-object catalog (#605).** The real
+  hangar's four non-aircraft occupants — a VW Caddy, two glider trailers, and a
+  fixed "Maul" fuel trailer — now have `data/catalog/` entries, and a new
+  `examples/herrenteich/layout_full.yaml` parks the full real set (8 aircraft +
+  those four) in one arrangement that passes `hangarfit check`. `collisions.check`
+  now bounds/notch-checks ground objects (previously aircraft-only). The
+  Herrenteich clearances were calibrated (`clearance_m` 0.3→0.20,
+  `wing_layer_clearance_m` 0.2→0.15) so the full set is feasible — the placeholder
+  values were too loose to model real club packing density. Tow-routing of the
+  full set, the hard Caddy nearest-door egress rule, and rendering of ground
+  objects are deferred (#602/#603/#606).
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/herrenteich/README.md data/catalog/README.md CHANGELOG.md
+git commit -m "docs(605): full-set reference, catalog entries, CHANGELOG, audit trail"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Full test suite**
+
+Run: `pytest -q`
+Expected: all PASS (no regressions from the clearance change or the bounds extension).
+
+- [ ] **Step 2: Lint + format + types**
+
+Run:
+```bash
+ruff check src/ tests/
+ruff format --check src/ tests/
+mypy src/hangarfit/
+```
+Expected: clean.
+
+- [ ] **Step 3: Run the issue's verification recipe**
+
+Run:
+```bash
+hangarfit check examples/herrenteich/layout_full.yaml   # valid, exit 0
+hangarfit check examples/herrenteich/layout.yaml        # still valid (monotonic)
+hangarfit check examples/layouts/example.yaml           # synthetic data/ untouched
+pytest tests/test_herrenteich_dataset.py -v
+```
+Expected: all `valid` / PASS.
+
+- [ ] **Step 4: Open the PR (draft)** — per CLAUDE.md GitFlow: `gh pr create --draft --base develop`, body `Refs #605` (NOT `Closes` — #605 stays open for the deferred routing/egress/render phases), assignee DocGerd, labels `enhancement` + `area:backend`, milestone "Ground objects + Herrenteich calibration". Then run the review arc (code-reviewer + geometry-invariant-guard + silent-failure-hunter + comment-analyzer for the doc changes) before flipping out of draft.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §3 calibration → Task 3; §4 catalog → Task 1; §5 wiring+layout → Tasks 1+4; §6 check extension → Task 2; §7 tests → Tasks 1,2,4; §8 docs/audit → Task 5; verification → Task 6. All covered.
+- **#605 stays OPEN:** PR uses `Refs #605` (routing/egress/render deferred), not `Closes`.
+- **Byte-identity:** guarded by the pre-existing `test_empty_ground_objects_byte_identical` (Task 2 Step 4).

--- a/docs/superpowers/specs/2026-06-11-605-herrenteich-full-set-calibration-design.md
+++ b/docs/superpowers/specs/2026-06-11-605-herrenteich-full-set-calibration-design.md
@@ -1,0 +1,198 @@
+# #605 — Herrenteich full-set static calibration + ground-object catalog
+
+**Date:** 2026-06-11
+**Issue:** #605 (Stage A / Epic #600, milestone #34) — *Calibrate Herrenteich
+dims/clearances so the full real set is provably feasible.*
+**Branch:** `feature/605-herrenteich-full-set-calibration`
+**Status:** design — awaiting approval
+
+---
+
+## 1. Scope (this PR)
+
+Deliver the **static-feasibility** half of #605: make the **full real
+Herrenteich set** — 8 aircraft + VW Caddy + 2 glider trailers + 1 fixed fuel
+trailer — pass `hangarfit check` as a single checked-in reference layout, with
+the four ground objects given a real catalog home and a documented dims/clearance
+calibration audit.
+
+**Explicitly deferred** (gated on unbuilt siblings, per the issue's phased plan):
+
+- **Tow-routability of the full set** → needs mover route search (**#602**). The
+  18 m Scheibe is *not* tow-routable today (the #599 wall), and the two glider
+  trailers + Caddy are routed movers whose `Move.path` is `None` until #602.
+- **The hard Caddy nearest-door / egress gate** → a new rejection tier (**#603**).
+  This PR *places* the Caddy near the door as the intended arrangement but does
+  **not** enforce egress as a hard constraint.
+- **Rendering ground objects** in PNG / scene-v2 (**#606**).
+
+This split is sanctioned by the issue: *"If … the ground-object models are not yet
+landed, do the aircraft-only calibration first … and gate Phase 2 on the object
+models."* #601 landed the static ground-object model (keep-out + pairwise) but not
+routing; this PR consumes that static model to its full extent.
+
+## 2. Why a calibration is needed (empirical findings)
+
+Measured this session by driving `collisions.check` directly (read-only probes):
+
+1. The committed 8-aircraft `examples/herrenteich/layout.yaml` is **static-valid**
+   (`check` exit 0) but **not tow-routable** (Scheibe can't thread the 13.46 m
+   door) — routing stays deferred to #602.
+2. Against that **fixed** 8-aircraft nest, the Caddy and fuel trailer fit fine,
+   but a **9 m glider trailer fits zero positions at any clearance, down to 0.0** —
+   the nest leaves no 9 m corridor. **Clearance is not the only lever; the
+   aircraft arrangement is.**
+3. A random-restart + annealing search over **all 11 bodies** (driving the
+   checker directly — the same technique that produced the original `layout.yaml`)
+   establishes the feasibility frontier:
+
+   | `clearance_m` / `wing_layer_clearance_m` | full set valid? |
+   |---|---|
+   | 0.30 / 0.20 (current placeholder) | ✗ (1 residual conflict) |
+   | 0.25 / 0.15 | ✗ (1 residual conflict) |
+   | 0.20 / 0.20 | ✗ (1 residual *wing-layer* conflict) |
+   | **0.22 / 0.15** | ✓ |
+   | **0.20 / 0.15** | ✓ (chosen) |
+   | 0.20 / 0.12 | ✓ |
+
+   The full real set fits **only snugly** — feasible at `clearance_m ≤ ~0.22` **and**
+   `wing_layer_clearance_m ≤ ~0.15`. Both placeholders (0.3 / 0.2) are simply too
+   loose to model a real club hangar packed with 8 aircraft + 4 vehicles.
+
+This is exactly the issue's **hypothesis #2** ("too-generous clearances … a
+wing-layer clearance that is too large turns legal z-disjoint wing-over-tail
+nesting into a false collision"). **No aircraft dimensions need to change**
+(hypothesis #1 is *not* required); the dimension audit is documentation-only.
+
+## 3. The calibration (the one real model change)
+
+Edit **`examples/herrenteich/hangar.yaml`** only:
+
+```yaml
+clearance_m: 0.20            # was 0.30 — calibrated to real club packing density
+wing_layer_clearance_m: 0.15 # was 0.20 — 0.20 falsely rejected legal nestings
+```
+
+**Why this is safe and local:**
+
+- **Monotonic.** Lowering a clearance only *relaxes* the collision constraint, so
+  any layout valid at 0.3/0.2 stays valid at 0.20/0.15. The existing 8-aircraft
+  `layout.yaml` and `scenario_demo.yaml` cannot be broken by this change.
+- **Local.** The synthetic `data/` fixtures and `examples/layouts/example.yaml`
+  use `data/hangar.yaml` — a *different* file, untouched. The issue's "confirm the
+  looser value doesn't break other fixtures" audit reduces to: re-run their checks
+  (they pass unchanged) — done as a verification step, not a code concern.
+- **Defensible against reality.** Reality clears fins "~0.40 m by hand"
+  (`layout.yaml:11`) — well above the 0.15 model threshold, so 0.15 never accepts a
+  nesting reality wouldn't. 0.20 m lateral gaps match hand-pushed club packing.
+
+## 4. The four ground-object catalog entries
+
+New files in **`data/catalog/`** (the shared central catalog home, #595/#601), each
+`measured: false` with inline published/typical-spec citations:
+
+| File | `type:` | object_class | Envelope (L×W×H, m) | Source basis |
+|---|---|---|---|---|
+| `vw_caddy.yaml` | `car` | mover (steerable) | 4.88 × 1.79 × 1.84 | VW Caddy Maxi (long-wheelbase) manufacturer data |
+| `glider_trailer_1.yaml` | `trailer` | mover (towed) | 9.0 × 2.1 × 2.3 | typical closed single-glider road trailer (Cobra/Spindelberger class) |
+| `glider_trailer_2.yaml` | `trailer` | mover (towed) | 9.0 × 2.1 × 2.3 | second instance, same envelope |
+| `maul_fuel_trailer.yaml` | `fixed_obstacle` | keep-out | 4.5 × 2.0 × 1.9 | Maul road-trailer envelope (estimated) |
+
+Two trailers = two files (the `ground_object_placements` field forbids duplicate
+ids; one-file-per-object is the #595 grain). Each part is a single `kind: ground`
+footprint at `z_bottom 0`.
+
+## 5. Wiring + the reference layout
+
+- **`examples/herrenteich/fleet.yaml`** — add a `ground_objects:` list referencing
+  the four catalog files (`load_ground_objects` already parses this, #601).
+- **`examples/herrenteich/layout_full.yaml`** (new) — the 8 aircraft **re-nested**
+  + a `ground_objects:` block placing the four. A verified-valid arrangement at
+  0.20/0.15 already exists (this session's search); final coordinates are polished
+  during implementation by a throwaway checker-driven search (the documented norm
+  for `layout.yaml`; the search script is **not** committed). Header documents
+  provenance. **The Caddy is placed near the door** (front, low-y) as the intended
+  arrangement — a soft search bias, not the hard #603 gate.
+- **`examples/herrenteich/layout.yaml` is NOT modified** — it remains the
+  aircraft-only nested arrangement. `layout_full.yaml` is the new full-set
+  *calibration reference*.
+- **No `scenario_full.yaml`** this PR — a solve/route input belongs to the routing
+  phase (#602); the static slice's gate is `check layout_full.yaml`.
+
+## 6. `collisions.check` — extend bounds/notch to ground objects
+
+Today #601 bounds/notch-checks **aircraft only** (`collisions.py:89`, comment
+defers ground objects to "#604/#605"). So `check` passing does **not** currently
+prove the ground objects are in-bounds or clear the notch — making #605's
+"in bounds, clears the notch" acceptance vacuous.
+
+**Change:** pass the ground-object bodies (movers **and** fixed obstacles) to
+`_hangar_bounds_conflicts` alongside the aircraft, so `check` enforces in-bounds +
+notch-clearance for *every* placed body.
+
+```python
+# in check():
+all_bounded_bodies = {**aircraft_parts, **mover_parts, **obstacle_parts}
+conflicts.extend(_hangar_bounds_conflicts(all_bounded_bodies, layout.hangar))
+# _bay_intrusion stays aircraft-only (the bay is an aircraft-occupancy rule).
+```
+
+- **Byte-identity preserved.** With no ground objects, `mover_parts`/`obstacle_parts`
+  are empty → `all_bounded_bodies == aircraft_parts` (same dict order) → conflict
+  order and `total_penetration_m2` are identical to pre-#605. A regression test
+  pins this.
+- **Not a new collision primitive.** It extends the *existing* universal bounds
+  check to bodies the model already has — the change the #601 code comment
+  anticipated for "#604/#605". `_bay_intrusion_conflicts` and the pairwise/obstacle
+  logic are untouched.
+- Touches `collisions.py` → review by **geometry-invariant-guard** +
+  **silent-failure-hunter** + the main code-reviewer.
+
+## 7. Tests
+
+- **`test_herrenteich_dataset.py`** (extend): `layout_full.yaml` passes `check`
+  (valid), contains all 11 objects (8 aircraft + 4 ground objects), every ground
+  object is in-bounds + notch-clear via an **independent model-free vertex scan**
+  (mirrors the existing `test_layout_clears_office_notch`), and the Caddy is the
+  nearest-door ground object (a *soft* assertion documenting the pre-#603 intent).
+  ≥1 non-slow assertion (two-pass-coverage gotcha).
+- **`test_collisions_ground_object.py`** (extend): a ground object placed partly
+  outside the hangar yields a `hangar_bounds` conflict; one placed in the notch
+  yields a `structural_notch` conflict; **byte-identity** — a no-ground-object
+  layout's `check` result is unchanged by the extension.
+- Run the full suite + the synthetic-fixture checks (`example.yaml`, the `data/`
+  layouts) to confirm the clearance change broke nothing.
+
+## 8. Docs / audit trail
+
+- `examples/herrenteich/hangar.yaml` — inline comments justifying 0.20 / 0.15.
+- `examples/herrenteich/README.md` — point at `layout_full.yaml` as the *calibration
+  reference* (full real set), distinct from the aircraft-only `layout.yaml`; note
+  routing/egress are deferred (#602/#603).
+- `data/catalog/README.md` — the four new ground objects + their sourcing.
+- **Dimension audit** — inline per-field citations in the four catalog files; a note
+  that no aircraft dimension changed (hypothesis #1 not triggered).
+- **Clearance audit** — the table in §2 + the monotonic-safety argument, captured in
+  the hangar.yaml comments and the PR body.
+- `CHANGELOG.md [Unreleased]` — new full-set reference dataset + the four ground
+  objects + the Herrenteich clearance recalibration.
+
+## 9. Out of scope / non-goals (restated)
+
+- No solver / learned-backend work; no tow-routing; no Caddy-egress gate; no GO
+  rendering. No new collision or tow *primitives* (the bounds extension reuses the
+  existing check). `layout.yaml`, `data/`, and the synthetic placeholders are not
+  re-authored.
+
+## 10. Risks
+
+- **Tight feasibility.** The full set fits only snugly (≤0.22/0.15). The shipped
+  layout is valid at 0.20/0.15 but near the frontier; the regression test locks it,
+  and the monotonic argument means future *tightening* can't break it (only a
+  future *loosening* of clearance or *growth* of a dimension could — the test
+  catches that).
+- **Existing #601 tests** may place a ground object out of bounds and assert valid;
+  the bounds extension would flip them. Audited and fixed during TDD (expected to be
+  none, since #601 fixtures are small in-bounds footprints).
+- **Coordinate polish.** Final `layout_full.yaml` coordinates come from a throwaway
+  search; they are re-verified by the committed regression test, not the search.

--- a/examples/herrenteich/README.md
+++ b/examples/herrenteich/README.md
@@ -25,12 +25,13 @@ hangarfit view  examples/herrenteich/scenario_demo.yaml -o demo.html --seed 3
 | File | What it is |
 |---|---|
 | `hangar.yaml` | The real hangar — **15.08 m × 31.76 m**, door **13.46 m** wide. Measured 2026-06-04 from the architect's DWG. L-shaped (back-right office notch). |
-| `fleet.yaml`  | The eight aircraft usually hangared here. Envelope (span/length/height) from published specs; part-level dimensions (wing chord, fuselage width, tail spans, gear track/wheelbase) sourced from EASA/FAA TCDS + manufacturer manuals where published (refreshed 2026-06-08, #536); the rest derived/estimated and flagged inline. |
-| `layout.yaml` | A **valid** arrangement with all eight planes parked at once (`hangarfit check` → exit 0). |
+| `fleet.yaml`  | The eight aircraft usually hangared here, plus (since #605) the four non-aircraft floor occupants under `ground_objects:` (Caddy, 2 glider trailers, fixed fuel trailer). Envelope (span/length/height) from published specs; part-level dimensions (wing chord, fuselage width, tail spans, gear track/wheelbase) sourced from EASA/FAA TCDS + manufacturer manuals where published (refreshed 2026-06-08, #536); the rest derived/estimated and flagged inline. |
+| `layout.yaml` | A **valid** arrangement with all eight aircraft parked at once (`hangarfit check` → exit 0). Aircraft only. |
+| `layout_full.yaml` | **The #605 calibration reference** — the full real set (8 aircraft + Caddy + 2 glider trailers + fixed fuel trailer) parked at once, valid at the calibrated clearances (`hangarfit check` → exit 0). |
 | `scenario.yaml` | The solver input for the all-eight "everyone home" scenario (does not fully route — see below). |
 | `scenario_demo.yaml` | A 3-aircraft subset that **solves and fully tow-routes** end-to-end in the L-shaped hangar — the working toolchain demo. |
 
-## Two things this dataset is honest about
+## Three things this dataset is honest about
 
 **1. The hangar is L-shaped, and since ADR-0018 (#527) the model knows it.**
 The real back-right corner is notched out (~2.36 m × 9.10 m) — that's
@@ -49,6 +50,20 @@ solvable + tow-routable subset is `scenario_demo.yaml`** — three aircraft the
 solver places clear of the notch and the tow planner routes from the door around
 it (the end-to-end demo above). Replace the all-eight placements with the club's
 real parking positions when known.
+
+**3. The full real set fits only at calibrated clearances (#605).** The real
+hangar parks more than aircraft: a VW Caddy, two glider trailers, and a fixed
+"Maul" fuel trailer. `layout_full.yaml` parks all eleven at once and passes
+`hangarfit check`. Getting there needed a **clearance calibration** — the
+placeholder `clearance_m 0.3` / `wing_layer_clearance_m 0.2` are too loose for a
+real club hangar packed this densely (the full set is infeasible at 0.3/0.2),
+so `hangar.yaml` was calibrated to **0.20 / 0.15** (a checker-driven search puts
+the feasibility frontier at ≤0.22/0.15). Lowering a clearance only relaxes the
+constraint, so `layout.yaml` and `scenario_demo.yaml` stay valid. The aircraft in
+`layout_full.yaml` are re-nested (vs `layout.yaml`) to free wall corridors for the
+9 m glider trailers. **Deferred:** tow-routing the full set (#602; the 18 m
+Scheibe is not yet routable), the hard Caddy nearest-door egress gate (#603), and
+rendering ground objects in the PNG/3D viewer (#606).
 
 ## Notable aircraft
 

--- a/examples/herrenteich/fleet.yaml
+++ b/examples/herrenteich/fleet.yaml
@@ -10,3 +10,13 @@ aircraft:
   - ../../data/catalog/cessna_140.yaml
   - ../../data/catalog/ctsl.yaml
   - ../../data/catalog/fk9_mkii.yaml
+
+# Non-aircraft ground objects usually on the floor with the fleet (#605/#601).
+# Referenced from the central catalog, same as aircraft. The fuel trailer is a
+# fixed keep-out; the Caddy + two glider trailers are placed movers (routing
+# lands in #602).
+ground_objects:
+  - ../../data/catalog/maul_fuel_trailer.yaml
+  - ../../data/catalog/vw_caddy.yaml
+  - ../../data/catalog/glider_trailer_1.yaml
+  - ../../data/catalog/glider_trailer_2.yaml

--- a/examples/herrenteich/hangar.yaml
+++ b/examples/herrenteich/hangar.yaml
@@ -58,8 +58,17 @@ structural_notches:
     x_max_m: 15.08
     y_max_m: 31.76
 
-clearance_m: 0.3        # minimum horizontal gap between any two aircraft parts
-wing_layer_clearance_m: 0.2  # minimum vertical gap between two parts at the same XY
+# CALIBRATED for the full real set (#605). The placeholders were 0.3 / 0.2; the
+# full set (8 aircraft + Caddy + 2 glider trailers + fixed fuel trailer) is
+# INFEASIBLE at 0.3/0.2 and feasible at <=0.22/0.15 (checker-driven search).
+# 0.20 m lateral matches real hand-pushed club packing density; 0.15 m vertical
+# fixes a too-large wing-layer clearance that falsely rejected legal z-disjoint
+# wing-over-tail nestings (the real club clears fins ~0.40 m by hand, well above
+# 0.15). Lowering a clearance only RELAXES the constraint, so the existing
+# layout.yaml / scenario_demo.yaml stay valid; the synthetic data/ hangar is a
+# separate file, untouched.
+clearance_m: 0.20            # minimum horizontal gap between any two parts
+wing_layer_clearance_m: 0.15 # minimum vertical gap between two parts at the same XY
 
 # Spare carts available to the cart_eligible pool. Bounds how many
 # cart_eligible planes may sit on carts in one layout; always_cart planes

--- a/examples/herrenteich/layout_full.yaml
+++ b/examples/herrenteich/layout_full.yaml
@@ -1,0 +1,82 @@
+# Airfield Herrenteich — the FULL real set: all 8 usual aircraft PLUS the four
+# non-aircraft floor occupants (VW Caddy, two glider trailers, fixed Maul fuel
+# trailer). This is the #605 calibration reference — it passes `hangarfit check`
+# (exit 0) at the calibrated clearances (hangar.yaml: clearance_m 0.20,
+# wing_layer_clearance_m 0.15).
+#
+# HOW THIS WAS PRODUCED. Like layout.yaml, this is the TOOL's arrangement, not a
+# record of where the club parks: an offline search driving the real part-based
+# collision checker directly found a valid all-11 packing (the product solver does
+# not generate it). The aircraft are RE-NESTED relative to layout.yaml to free
+# wall corridors for the 9 m glider trailers — layout.yaml (aircraft-only) is
+# unchanged. Replace with real parking positions when surveyed.
+#
+# DEFERRED: tow-routing of this set (#602; the 18 m Scheibe is not yet routable),
+# the hard Caddy nearest-door egress gate (#603 — the Caddy IS placed near the
+# door here, but egress is not enforced), and rendering the ground objects (#606).
+#
+# Coordinate convention (see hangar.yaml): world (0,0) front-left, +x right along
+# the door wall, +y deeper in; heading 0 = nose deep (+y), 90 = nose toward +x.
+
+fleet: fleet.yaml
+hangar: hangar.yaml
+
+placements:
+  - plane: scheibe_falke
+    x_m: 8.18
+    y_m: 22.67
+    heading_deg: 90.0
+    on_carts: true          # always_cart
+  - plane: stemme_s10
+    x_m: 3.15
+    y_m: 13.65
+    heading_deg: 270.0
+    on_carts: false         # always_own_gear
+  - plane: aviat_husky
+    x_m: 5.28
+    y_m: 16.51
+    heading_deg: 90.0
+    on_carts: false         # always_own_gear
+  - plane: cessna_140
+    x_m: 13.36
+    y_m: 5.09
+    heading_deg: 90.0
+    on_carts: false         # cart_eligible, on own gear
+  - plane: fk9_mkii
+    x_m: 7.09
+    y_m: 9.10
+    heading_deg: 270.0
+    on_carts: false         # cart_eligible, on own gear
+  - plane: zlin_savage
+    x_m: 7.41
+    y_m: 25.52
+    heading_deg: 270.0
+    on_carts: true          # always_cart
+  - plane: wild_thing
+    x_m: 11.32
+    y_m: 17.32
+    heading_deg: 90.0
+    on_carts: true          # always_cart
+  - plane: ctsl
+    x_m: 5.32
+    y_m: 3.00
+    heading_deg: 180.0
+    on_carts: false         # cart_eligible, on own gear
+
+ground_objects:
+  - object: vw_caddy            # rescue vehicle near the door (egress precursor, #603)
+    x_m: 11.57
+    y_m: 8.26
+    heading_deg: 180.0
+  - object: glider_trailer_1    # along the left wall, lengthwise
+    x_m: 1.20
+    y_m: 7.99
+    heading_deg: 180.0
+  - object: glider_trailer_2    # along the left wall, deep
+    x_m: 2.02
+    y_m: 27.16
+    heading_deg: 0.0
+  - object: maul_fuel_trailer   # fixed keep-out (clear of the back-right office notch)
+    x_m: 14.05
+    y_m: 13.32
+    heading_deg: 0.0

--- a/src/hangarfit/collisions.py
+++ b/src/hangarfit/collisions.py
@@ -80,13 +80,19 @@ def check(layout: Layout) -> CheckResult:
     # come first so the no-ground-object case is byte-identical (same dict order):
     # with no ground objects mover_parts/obstacle_parts are empty, placed_bodies ==
     # aircraft_parts, _ground_obstacle_conflicts returns [], and the conflict order
-    # + total_penetration_m2 match pre-#601. _hangar_bounds_conflicts and
-    # _bay_intrusion_conflicts keep their aircraft-only input (ground-object bounds
-    # checking is out of #601 scope — #604/#605).
+    # + total_penetration_m2 match pre-#601. _bay_intrusion_conflicts keeps its
+    # aircraft-only input (an occupancy rule); _hangar_bounds_conflicts now also
+    # covers ground objects (#605, see bounded_bodies below).
     placed_bodies = {**aircraft_parts, **mover_parts}
+    # Ground objects (movers AND fixed obstacles) are bounds/notch-checked
+    # alongside aircraft (#605): they too must fit the floor and clear the notch.
+    # Aircraft come first so the no-ground-object case is byte-identical (empty
+    # GO dicts ⇒ bounded_bodies == aircraft_parts, same dict order). Bay
+    # intrusion stays aircraft-only (an aircraft-occupancy rule, not geometry).
+    bounded_bodies = {**aircraft_parts, **mover_parts, **obstacle_parts}
 
     conflicts: list[Conflict] = []
-    conflicts.extend(_hangar_bounds_conflicts(aircraft_parts, layout.hangar))
+    conflicts.extend(_hangar_bounds_conflicts(bounded_bodies, layout.hangar))
     conflicts.extend(_bay_intrusion_conflicts(aircraft_parts, layout))
     pairwise, total_penetration_m2 = _pairwise_conflicts(placed_bodies, layout.hangar)
     conflicts.extend(pairwise)

--- a/tests/test_collisions_ground_object.py
+++ b/tests/test_collisions_ground_object.py
@@ -196,3 +196,86 @@ def test_empty_ground_objects_byte_identical() -> None:
     assert result.conflicts == ()
     assert result.conflicts == ref_result.conflicts
     assert result.total_penetration_m2 == ref_result.total_penetration_m2
+
+
+def test_ground_object_out_of_bounds_flagged() -> None:
+    """A ground object straddling the hangar wall is a hangar_bounds conflict
+    (#605 — #601 left ground objects un-bounds-checked)."""
+    hangar = _hangar()  # 40x40, no notch
+    obj = GroundObject(
+        id="trailer",
+        name="t",
+        parts=(_ground_part(length_m=4.0, width_m=2.0),),
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+    )
+    layout = Layout(
+        fleet={},
+        hangar=hangar,
+        placements=(),
+        ground_objects={obj.id: obj},
+        # centred on x=0.5 with a 2 m width → half the footprint is at x<0.
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=0.5, y_m=20.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    result = check(layout)
+    kinds = {c.kind for c in result.conflicts}
+    assert "hangar_bounds" in kinds
+    assert any("trailer" in "".join(c.planes) for c in result.conflicts)
+
+
+def test_ground_object_in_notch_flagged() -> None:
+    """A ground object inside a structural notch is a structural_notch conflict."""
+    from hangarfit.models import StructuralNotch
+
+    hangar = Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.2,
+        structural_notches=(
+            StructuralNotch(x_min_m=30.0, y_min_m=30.0, x_max_m=40.0, y_max_m=40.0),
+        ),
+    )
+    obj = GroundObject(
+        id="caddy",
+        name="c",
+        parts=(_ground_part(length_m=3.0, width_m=2.0),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+    )
+    layout = Layout(
+        fleet={},
+        hangar=hangar,
+        placements=(),
+        ground_objects={obj.id: obj},
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=35.0, y_m=35.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    kinds = {c.kind for c in check(layout).conflicts}
+    assert "structural_notch" in kinds
+
+
+def test_fixed_obstacle_out_of_bounds_flagged() -> None:
+    """A fixed obstacle is bounds-checked too (not just movers)."""
+    hangar = _hangar()
+    obj = GroundObject(
+        id="fuel",
+        name="f",
+        parts=(_ground_part(length_m=4.0, width_m=2.0),),
+        object_class="fixed_obstacle",
+    )
+    layout = Layout(
+        fleet={},
+        hangar=hangar,
+        placements=(),
+        ground_objects={obj.id: obj},
+        ground_object_placements=(
+            Placement(plane_id=obj.id, x_m=39.7, y_m=20.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    assert "hangar_bounds" in {c.kind for c in check(layout).conflicts}

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -172,3 +172,11 @@ def test_ground_objects_load_from_manifest() -> None:
     # each is a single solid ground footprint
     for go in gos.values():
         assert len(go.parts) == 1 and go.parts[0].kind == "ground"
+
+
+def test_hangar_clearances_calibrated() -> None:
+    """The Herrenteich clearances were calibrated to fit the full real set
+    (#605): horizontal 0.20, vertical 0.15 (placeholders were 0.30/0.20)."""
+    hangar = load_hangar(HERRENTEICH / "hangar.yaml")
+    assert hangar.clearance_m == 0.20
+    assert hangar.wing_layer_clearance_m == 0.15

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -150,3 +150,25 @@ def test_demo_scenario_is_a_solvable_subset() -> None:
     )
     assert result.layouts and len(result.layouts[0].placements) == 3
     assert collisions.check(result.layouts[0]).valid
+
+
+def test_ground_objects_load_from_manifest() -> None:
+    """The four real ground objects load from the herrenteich fleet manifest
+    with the right object_class + motion (#605)."""
+    from hangarfit.loader import load_ground_objects
+
+    gos = load_ground_objects(HERRENTEICH / "fleet.yaml")
+    assert set(gos) == {
+        "maul_fuel_trailer",
+        "vw_caddy",
+        "glider_trailer_1",
+        "glider_trailer_2",
+    }
+    assert gos["maul_fuel_trailer"].object_class == "fixed_obstacle"
+    assert gos["vw_caddy"].object_class == "placed_routed_mover"
+    assert gos["vw_caddy"].motion_mode == "steerable"
+    assert gos["glider_trailer_1"].motion_mode == "towed"
+    assert gos["glider_trailer_2"].motion_mode == "towed"
+    # each is a single solid ground footprint
+    for go in gos.values():
+        assert len(go.parts) == 1 and go.parts[0].kind == "ground"

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -180,3 +180,54 @@ def test_hangar_clearances_calibrated() -> None:
     hangar = load_hangar(HERRENTEICH / "hangar.yaml")
     assert hangar.clearance_m == 0.20
     assert hangar.wing_layer_clearance_m == 0.15
+
+
+FULL_SET = USUAL_OCCUPANTS | {
+    "vw_caddy",
+    "glider_trailer_1",
+    "glider_trailer_2",
+    "maul_fuel_trailer",
+}
+
+
+def test_full_set_layout_is_valid() -> None:
+    """The full real set (8 aircraft + 4 ground objects) passes the real
+    checker at the calibrated clearances (#605 primary acceptance)."""
+    layout = load_layout(HERRENTEICH / "layout_full.yaml")
+    present = {p.plane_id for p in layout.placements} | {
+        gp.plane_id for gp in layout.ground_object_placements
+    }
+    assert present == FULL_SET
+    result = collisions.check(layout)
+    assert result.conflicts == (), [c.kind for c in result.conflicts]
+
+
+def test_full_set_ground_objects_in_bounds_and_clear_notch() -> None:
+    """Independent, model-free vertex scan: every ground object is inside the
+    L-shaped floor and clear of the office notch (belt-and-suspenders over the
+    checker's bounds/notch extension)."""
+    layout = load_layout(HERRENTEICH / "layout_full.yaml")
+    floor = layout.hangar.floor_polygon
+    assert floor is not None
+    x0, y0, x1, y1 = NOTCH
+    for gp in layout.ground_object_placements:
+        obj = layout.ground_objects[gp.plane_id]
+        for part in aircraft_parts_world(obj, gp):
+            assert floor.covers(part.polygon), f"{gp.plane_id} {part.kind} outside floor"
+            for x, y in part.polygon.exterior.coords:
+                assert not (x0 <= x <= x1 and y0 <= y <= y1), (
+                    f"{gp.plane_id} vertex ({x:.2f},{y:.2f}) in office notch"
+                )
+
+
+def test_full_set_caddy_near_door() -> None:
+    """SOFT intent (pre-#603): the Caddy is parked near the door — in the front
+    third of the hangar and within the door's x-span — the precursor to the #603
+    hard nearest-door egress gate. (Exact 'nearest' is #603's job; the 9 m glider
+    trailers run along the walls toward the door, so a strict min-y assertion
+    would fight that geometry.)"""
+    layout = load_layout(HERRENTEICH / "layout_full.yaml")
+    caddy = next(gp for gp in layout.ground_object_placements if gp.plane_id == "vw_caddy")
+    assert caddy.y_m < layout.hangar.length_m / 3
+    door = layout.hangar.door
+    assert door.center_x_m - door.width_m / 2 <= caddy.x_m <= door.center_x_m + door.width_m / 2

--- a/tests/test_solver_canaries.py
+++ b/tests/test_solver_canaries.py
@@ -102,19 +102,23 @@ def test_solve_deterministic_given_seed(fixture):
         assert la.placements == lb.placements
         assert la.maintenance_plane == lb.maintenance_plane
 
-    # If the run exhausted budget, best_partial_layout must also match.
-    bp1 = r1.diagnostics.best_partial_layout
-    bp2 = r2.diagnostics.best_partial_layout
-    if bp1 is not None:
-        assert bp2 is not None
-        assert bp1.placements == bp2.placements
-
-    # NOT asserted: diagnostics.wall_time_s and diagnostics.restarts_attempted.
-    # Both depend on machine speed and the wall-clock-based budget cutoff —
-    # a faster run completes more restarts within the same 5.0 s budget.
-    # The deterministic-layout assertion above is enough to catch any
-    # accidental non-determinism (unseeded random, set/dict ordering, etc.):
-    # different RNG state -> different layouts.
+    # NOT asserted here: diagnostics.wall_time_s, diagnostics.restarts_attempted,
+    # AND diagnostics.best_partial_layout. All three are functions of how many
+    # restarts completed inside the wall-clock budget, which is machine-/load-
+    # dependent: a slow or CPU-contended runner finishes FEWER restarts in the
+    # same 5.0 s window. best_partial_layout is the best basin *across* those
+    # restarts (monotonic via solver._merge_restart), and the per-restart descent
+    # is itself budget-interruptible (solver.py outer loop), so two runs that both
+    # exhaust the budget at different restart counts legitimately land on
+    # different partials. ADR-0003 scopes byte-identical determinism to
+    # max_restarts-bounded solves, NOT budget_s-bounded ones (#267); asserting a
+    # budget-dependent quantity here is the #492 wall-clock-canary flake class (a
+    # slow CI runner exhausted this fixture and the two runs' partials diverged).
+    # best_partial determinism is owned, machine-independently, by
+    # test_solve_deterministic_best_partial_under_max_restarts below. The
+    # deterministic found-layout assertion above is what catches accidental
+    # non-determinism (unseeded random, set/dict ordering): a real RNG leak
+    # changes the per-restart trajectory and thus the found layouts/status.
 
 
 def test_solve_deterministic_best_partial_under_max_restarts() -> None:


### PR DESCRIPTION
Static-feasibility slice of #605 (Stage A / milestone #34). Makes the full real Herrenteich set — 8 aircraft + VW Caddy + 2 glider trailers + 1 fixed fuel trailer — pass `hangarfit check` as a checked-in reference layout, gives the four ground objects a `data/catalog/` home, and calibrates the Herrenteich clearances so the full set is feasible.

**Refs #605** (stays OPEN — routing/egress/render deferred; see below).

## What this delivers
- **4 ground-object catalog entries** (`data/catalog/`): `vw_caddy` (car), `glider_trailer_1`/`glider_trailer_2` (trailer), `maul_fuel_trailer` (fixed_obstacle). Published/typical specs, `measured: false`, cited inline. Wired into `examples/herrenteich/fleet.yaml`.
- **`examples/herrenteich/layout_full.yaml`** — the full real set (all 11 bodies) in a fresh checker-driven arrangement that passes `check` (exit 0). Aircraft re-nested to free wall corridors for the 9 m glider trailers; `layout.yaml` (aircraft-only) is unchanged.
- **`collisions.check` now bounds/notch-checks ground objects** (movers + fixed obstacles), not just aircraft — previously deferred to "#604/#605" in the #601 code. Byte-identical when no ground objects (guarded by the existing `test_empty_ground_objects_byte_identical`).
- **Clearance calibration** (`examples/herrenteich/hangar.yaml`): `clearance_m` 0.3→0.20, `wing_layer_clearance_m` 0.2→0.15.

## The calibration finding (why the clearance changed)
A checker-driven search established the feasibility frontier for the full set:

| clearance_m / wing_layer | full set valid? |
|---|---|
| 0.30 / 0.20 (placeholder) | ✗ |
| 0.25 / 0.15 | ✗ |
| 0.22 / 0.15 | ✓ |
| **0.20 / 0.15 (shipped)** | ✓ |

The placeholder 0.3/0.2 is too loose for a real club hangar packed this densely. Lowering a clearance only *relaxes* the constraint, so `layout.yaml`/`scenario_demo.yaml` stay valid; the synthetic `data/` hangar is a separate file, untouched. No aircraft dimensions changed.

## Deferred (gated on siblings)
- Tow-routing the full set → **#602** (the 18 m Scheibe is not yet routable; mover routes too)
- The hard Caddy nearest-door egress gate → **#603** (Caddy is *placed* near the door; egress not enforced)
- Rendering ground objects in PNG / 3D viewer → **#606**

## Verification
- `pytest`: **1594 passed** (+8 new), ruff + mypy clean.
- `hangarfit check examples/herrenteich/layout_full.yaml` → valid, exit 0.
- `hangarfit check examples/herrenteich/layout.yaml` + `examples/layouts/example.yaml` → still valid (monotonic).

Design spec + plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)