### PR TITLE
feat(602): car + trailer motion models in the tow planner

### DIFF
--- a/docs/adr/0010-reeds-shepp-motion-model.md
+++ b/docs/adr/0010-reeds-shepp-motion-model.md
@@ -287,8 +287,77 @@ a nose-out *parked heading*): this amendment makes a nose-out slot **cheap to
 reach** when the solver picks one; #263 (separate) makes the solver *prefer* to
 pick them.
 
+## Amendment (2026-06-12) — #602: car (own-gear RS) + towed-trailer (free-swivel cart) routing
+
+**Status:** Accepted. **Context:** Epic A (ground objects, #600) introduced
+`GroundObject` movers into the hangar — specifically the VW Caddy and towed glider
+trailers. `plan_fill` must be able to route them using the existing planner
+infrastructure; no new planner and no new `SegmentKind` should be required.
+[#602](https://github.com/DocGerd/hangarfit/issues/602).
+
+### (a) Car = own-gear Reeds–Shepp parameterisation
+
+A self-driving steerable car (e.g. the VW Caddy, `turn_radius_m ≈ 5.5 m`) routes
+exactly as an own-gear aircraft: `effective_turn_radius_m()` returns the catalog
+`turn_radius_m`, `_primitives` emits the six-primitive fan `Lf, Sf, Rf, Lr, Sr,
+Rr`, and `plan_reeds_shepp` handles the full forward/reverse word algebra. No
+behavioural change to any aircraft — the machinery is reused verbatim.
+
+### (b) Towed trailer = free-swivel cart (`r = 0`)
+
+A towed glider trailer has no powered steering and is balanced at the drawbar:
+ground crew push/pull the tongue and let the trailer swivel freely.
+`effective_turn_radius_m()` returns `0.0`; the planner selects the existing
+four-primitive cart fan `Lf, Sf, Rf, Sr` via `_plan_cart(allow_reverse=True)`,
+giving forward arcs/straights plus a reverse straight — sufficient for
+push/pull-and-swivel positioning inside the hangar.
+
+**Why the cart model, not a positive tug-turning-circle?** (a) It models the
+actual human motion: a balanced trailer at the tongue can be hand-positioned with
+any lateral displacement by swivelling; a minimum-turning-circle constraint would
+be an over-restriction for manual ground handling. (b) It reuses the cart path
+verbatim — zero new code, zero new parameters. (c) It needs no new catalog data:
+the trailer carries no `turn_radius_m`, and the absence of that field is the
+data-driven selector. Richer trailer-jackknife kinematics remain a possible
+later follow-on, gated on whether the cart approximation proves insufficient for
+the real Herrenteich corridor.
+
+**Data-driven selector:** `effective_turn_radius_m()` is present and positive →
+own-gear RS fan; absent (returns `0.0`) → cart fan. Both branches already existed.
+
+### (c) The decision — new object behaviours, not a new planner
+
+`GroundObject.effective_turn_radius_m()` mirrors `Aircraft.effective_turn_radius_m()`:
+the mover is fully characterised to the planner by the pair
+`(effective_turn_radius_m, reverse-capability)`. The internal routines
+`_primitives`, `_plan_cart`, and `plan_reeds_shepp` are reused **unchanged**.
+
+The routing oracle (`path_first_conflict` / `plan_path` / `_motion_clear` /
+`_mover_motion_bounds_conflict`) was widened from `Aircraft`-only to
+`Aircraft | GroundObject`. A ground-object mover is injected into each per-sample
+`Layout` as a `ground_object_placement` so the collision substrate can check it
+against the static scene; aircraft routing is unaffected and remains byte-identical
+(ADR-0003 contract holds).
+
+### (d) Rejected alternative: dedicated kinematic-bicycle / trailer-jackknife planner
+
+A separate planner that models the full tractor–trailer articulation (jackknife
+constraint, separate front/rear swept paths) was considered and rejected:
+closed-form RS already provides forward + reverse arcs and straights, and the cart
+model already provides reverse-straight + free-pivot — both sufficient for v1
+ground handling in the measured Herrenteich corridor. A bespoke kinematic-bicycle
+model would add substantial complexity (new integrator, new collision sweep, new
+cost algebra) while the cart approximation remains valid for the balanced,
+manually-positioned trailers in scope. The byte-identical determinism contract
+(ADR-0003) is preserved with zero changes to the existing word algebra. Richer
+jackknife kinematics are a named later follow-on if the cart approximation proves
+insufficient.
+
 ## More Information
 
+- Amended by #602 (2026-06-12): car own-gear RS + free-swivel-cart trailer routing
+  via `GroundObject.effective_turn_radius_m()`; routing oracle widened to
+  `Aircraft | GroundObject` (see the amendment section above).
 - Amended by #480 (2026-06-07): cusp-penalty cost model, nose-out-gated rear cone,
   cost-aware start-seed analytic expansion (see the amendment section above).
 - Supersedes: [ADR-0007](0007-tow-path-planner-v1-scope.md) fork 2 ("Dubins-only").

--- a/docs/superpowers/plans/2026-06-11-602-car-trailer-motion-plan.md
+++ b/docs/superpowers/plans/2026-06-11-602-car-trailer-motion-plan.md
@@ -1,0 +1,491 @@
+# #602 Car + Trailer Motion Models — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the two ground-object *mover* classes (steerable car, towed trailer) with their own tow paths by parameterizing the existing ADR-0010 planner — no new planner, no new `SegmentKind`.
+
+**Architecture:** The tow planner is already mover-agnostic in its math (`_primitives` / `_plan_cart` / `plan_reeds_shepp` dispatch on a scalar turn radius). Two gaps close it: (1) `GroundObject` gains `effective_turn_radius_m()`; (2) the mover-routing oracle (`path_first_conflict`, `plan_path`, `_motion_clear`, `_mover_motion_bounds_conflict`) becomes **body-type-aware** — it injects an aircraft mover into a per-sample `Layout` as a `placement` (against `fleet`) but a ground-object mover as a `ground_object_placement` (against `ground_objects`). Then `plan_fill` routes each placed-routed mover (replacing the `#601` `Move(path=None)` placeholder). Every new branch triggers only for a `GroundObject`, so aircraft routing stays byte-identical (ADR-0003).
+
+**Tech stack:** Python 3.12, frozen dataclasses (`slots=True`), shapely (geometry), pytest. Determinism is closed-form + RNG-free.
+
+**Branch:** `feature/602-car-trailer-motion` (off `develop`, already created; spec committed at `8861f1a`).
+
+---
+
+## File / change map
+
+| File | Change |
+|---|---|
+| `src/hangarfit/models.py` | Add `GroundObject.effective_turn_radius_m()`; add `__post_init__` guard "steerable mover requires a positive `turn_radius_m`". |
+| `src/hangarfit/towplanner.py` | Import `GroundObject`; widen 4 mover-param type hints to `Aircraft \| GroundObject`; add the `isinstance` branch in `path_first_conflict`; in `plan_fill` add fixed-obstacle routing context + route GO movers. |
+| `docs/adr/0010-reeds-shepp-motion-model.md` | Dated amendment: car = own-gear RS, trailer = free-swivel cart, no-new-planner rationale. |
+| `tests/test_models.py` | `effective_turn_radius_m()` + steerable-radius-guard tests (co-locate with existing `GroundObject` validator tests; grep `GroundObject` in tests/ to confirm file). |
+| `tests/test_towplanner_ground_object.py` | Update `test_mover_in_routable_enumeration` (path now non-`None`); add a `plan_path`-routes-a-GO-mover test + reverse-cart trailer test. |
+| `tests/test_towplanner.py` | Zero-mover `plan_fill` byte-identical canary (if not already present). |
+| `tests/test_towplanner_mover_routing.py` (new) | `@slow` integration: Herrenteich-shaped car + trailer route; fixed-seed determinism canary. |
+
+---
+
+## Task 1: `GroundObject.effective_turn_radius_m()` + steerable-radius guard
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (`GroundObject`, ~lines 450–500)
+- Test: `tests/test_models.py` (co-locate with `GroundObject` validator tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_models.py  (alongside the GroundObject validator tests)
+import pytest
+from hangarfit.models import GroundObject, Part
+
+
+def _gp() -> Part:
+    return Part(kind="ground", length_m=4.0, width_m=2.0, offset_x_m=0.0,
+               offset_y_m=0.0, angle_deg=0.0, z_bottom_m=0.0, z_top_m=1.8)
+
+
+def test_steerable_mover_effective_radius_is_its_turn_radius() -> None:
+    car = GroundObject(id="caddy", name="c", parts=(_gp(),),
+                       object_class="placed_routed_mover", motion_mode="steerable",
+                       turn_radius_m=5.5)
+    assert car.effective_turn_radius_m() == 5.5
+
+
+def test_towed_mover_without_radius_is_free_swivel_cart() -> None:
+    trailer = GroundObject(id="tr1", name="t", parts=(_gp(),),
+                           object_class="placed_routed_mover", motion_mode="towed")
+    assert trailer.effective_turn_radius_m() == 0.0
+
+
+def test_steerable_mover_requires_positive_turn_radius() -> None:
+    with pytest.raises(ValueError, match="steerable.*turn_radius_m"):
+        GroundObject(id="bad", name="b", parts=(_gp(),),
+                     object_class="placed_routed_mover", motion_mode="steerable")
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pytest tests/test_models.py -k "effective_radius or free_swivel or steerable_mover_requires" -v`
+Expected: FAIL — `effective_turn_radius_m` does not exist; the steerable-no-radius case currently constructs without error.
+
+- [ ] **Step 3: Implement the method + guard**
+
+In `GroundObject.__post_init__`, inside the `else:  # placed_routed_mover` block (after the existing `turn_radius_m must be positive` check), add:
+
+```python
+            if self.motion_mode == "steerable" and self.turn_radius_m is None:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: a steerable mover requires a "
+                    f"positive turn_radius_m (a self-driven car has a turning "
+                    f"circle; it never pivots in place)"
+                )
+```
+
+Add the method to the `GroundObject` class body (after `__post_init__`):
+
+```python
+    def effective_turn_radius_m(self) -> float:
+        """Turn radius the tow planner consumes (ADR-0010 / ADR-0026).
+
+        Data-driven, mirroring :meth:`Aircraft.effective_turn_radius_m`: a
+        steerable car returns its positive ``turn_radius_m`` (own-gear
+        Reeds-Shepp, six-primitive fan); a towed trailer with no radius returns
+        ``0.0`` — a free-swivel cart (four-primitive reverse-capable fan, the
+        ground-crew hand-positioning model). Only ever called on movers; never
+        raises (``__post_init__`` guarantees a steerable mover has a radius)."""
+        if self.turn_radius_m is not None:
+            return self.turn_radius_m
+        return 0.0
+```
+
+- [ ] **Step 4: Run to verify they pass + the full model/loader suite stays green**
+
+Run: `pytest tests/test_models.py tests/test_loader.py tests/test_collisions_ground_object.py tests/test_towplanner_ground_object.py -q`
+Expected: PASS. If any existing fixture builds a `steerable` mover with no `turn_radius_m`, the new guard will flag it — fix that fixture to pass `turn_radius_m` (it is a misconfiguration the guard correctly rejects).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_models.py
+git commit -m "feat(602): GroundObject.effective_turn_radius_m() + steerable-radius guard
+
+Mirrors Aircraft.effective_turn_radius_m(): steerable car -> positive
+turn_radius_m (own-gear RS); towed trailer with no radius -> 0.0 free-swivel
+cart. A steerable mover must carry a positive radius (no pivot-in-place car).
+
+Refs #602"
+```
+
+---
+
+## Task 2: Body-type-aware mover-routing oracle
+
+**Files:**
+- Modify: `src/hangarfit/towplanner.py` (imports ~line 45; `_mover_motion_bounds_conflict` ~1108; `path_first_conflict` ~1215; `_motion_clear` ~1807; `plan_path` ~2021)
+- Test: `tests/test_towplanner_ground_object.py`
+
+- [ ] **Step 1: Write the failing test (route a GO mover directly via `plan_path`)**
+
+```python
+# tests/test_towplanner_ground_object.py
+from hangarfit.geometry import aircraft_parts_world  # noqa: F401 (pattern parity)
+from hangarfit.models import Pose
+from hangarfit.towplanner import plan_path, path_first_conflict
+
+
+def test_plan_path_routes_a_ground_object_car_mover() -> None:
+    """A steerable GO car routes from the door cone to a parked slot against a
+    placed aircraft, and the returned arc is collision-free (the oracle places
+    the mover as a ground_object_placement, not an aircraft placement)."""
+    from hangarfit.towplanner import entry_poses
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    car = GroundObject(id="caddy", name="c", parts=(_ground_part(width_m=2.0, length_m=4.5),),
+                       object_class="placed_routed_mover", motion_mode="steerable",
+                       turn_radius_m=5.5)
+    slot = Placement(plane_id="caddy", x_m=10.0, y_m=20.0, heading_deg=90.0, on_carts=False)
+    placed = Layout(
+        fleet={ac.id: ac}, hangar=hangar,
+        placements=(Placement(plane_id="p1", x_m=6.0, y_m=30.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={car.id: car},
+        ground_object_placements=(slot,),
+    )
+    cone = entry_poses(slot, hangar)
+    arc = plan_path(car, cone[0], Pose.from_placement(slot), hangar=hangar,
+                    placed=placed, mover_on_carts=False, entries=cone, heuristic="grid")
+    assert arc is not None
+    assert path_first_conflict(arc, car, mover_on_carts=False, placed=placed) is None
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_towplanner_ground_object.py::test_plan_path_routes_a_ground_object_car_mover -v`
+Expected: FAIL — `path_first_conflict` builds the per-sample `Layout` with the mover in `placements`, so `Layout.__post_init__` raises `ValueError` ("placement references unknown plane_id 'caddy'").
+
+- [ ] **Step 3: Generalize the oracle (5 edits)**
+
+**(a)** Imports (~line 45) — add `GroundObject`:
+```python
+from hangarfit.models import Aircraft, ApronShallowDrop, Conflict, GroundObject, Hangar, Layout, Placement
+```
+
+**(b)** `_mover_motion_bounds_conflict` (~1108) — widen the type hint (body unchanged; it only uses `aircraft_parts_world`, which already accepts the union):
+```python
+def _mover_motion_bounds_conflict(
+    mover: Aircraft | GroundObject, placement: Placement, hangar: Hangar
+) -> Conflict | None:
+```
+
+**(c)** `path_first_conflict` (~1215) — widen the type hint and branch the per-sample `Layout`. Replace the current `sample_layout = Layout(...)` block:
+```python
+def path_first_conflict(
+    arc: DubinsArc,
+    mover: Aircraft | GroundObject,
+    *,
+    mover_on_carts: bool,
+    placed: Layout,
+    step_m: float = 0.05,
+    step_deg: float = 1.0,
+) -> Conflict | None:
+```
+and inside the sample loop, replace the single `sample_layout = Layout(...)` with:
+```python
+        if isinstance(mover, Aircraft):
+            sample_layout = Layout(
+                fleet=placed.fleet,
+                hangar=placed.hangar,
+                placements=(*placed.placements, moving),
+                maintenance_plane=placed.maintenance_plane,
+                ground_objects=placed.ground_objects,
+                ground_object_placements=placed.ground_object_placements,
+            )
+        else:  # GroundObject mover -> belongs in ground_object_placements
+            sample_layout = Layout(
+                fleet=placed.fleet,
+                hangar=placed.hangar,
+                placements=placed.placements,
+                maintenance_plane=placed.maintenance_plane,
+                ground_objects=placed.ground_objects,
+                ground_object_placements=(*placed.ground_object_placements, moving),
+            )
+```
+> Note: the Aircraft branch now also threads `ground_objects` / `ground_object_placements` so a routed aircraft collides with placed ground objects (fuel trailer + parked movers). With no ground objects both are empty ⇒ byte-identical to today.
+
+**(d)** `_motion_clear` (~1807) — widen the type hint (body unchanged; uses `cached_parts_world` + `_mover_motion_bounds_conflict`, both union-safe):
+```python
+def _motion_clear(mover: Aircraft | GroundObject, pose: Pose, obstacles: _Obstacles, hangar: Hangar) -> bool:
+```
+
+**(e)** `plan_path` (~2021) — widen the type hint. The body calls `mover.effective_turn_radius_m()` (now on both types), `_build_obstacles(placed, mover_id=mover.id)` (already filters both placement lists), `_mover_motion_bounds_conflict`, `_motion_clear`, `path_first_conflict` (all now union-typed):
+```python
+def plan_path(
+    mover: Aircraft | GroundObject,
+    entry: Pose,
+    goal: Pose,
+    *,
+    ...
+) -> DubinsArc:
+```
+
+- [ ] **Step 4: Run to verify it passes + aircraft routing untouched**
+
+Run: `pytest tests/test_towplanner_ground_object.py tests/test_towplanner.py tests/test_towplanner_reeds_shepp.py -q`
+Expected: PASS. Then `mypy src/hangarfit/towplanner.py` — if mypy flags an `Aircraft`-only attribute access on the union, narrow it with `isinstance(mover, Aircraft)` at that site (none expected: only `.id`, `.parts`, `.effective_turn_radius_m()` are used).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/towplanner.py tests/test_towplanner_ground_object.py
+git commit -m "feat(602): body-type-aware mover-routing oracle (route GO movers)
+
+path_first_conflict/plan_path/_motion_clear/_mover_motion_bounds_conflict now
+accept Aircraft | GroundObject; a GO mover is injected into the per-sample
+Layout as a ground_object_placement (vs an aircraft placement). _build_obstacles
+already includes ground objects. Aircraft routing byte-identical (empty GO dicts).
+
+Refs #602"
+```
+
+---
+
+## Task 3: `plan_fill` routes the GO movers
+
+**Files:**
+- Modify: `src/hangarfit/towplanner.py` (`plan_fill`: `placed_layout` ~1379; the GO-mover emission loop ~1463)
+- Test: `tests/test_towplanner_ground_object.py`
+
+- [ ] **Step 1: Update the (now-wrong) deferred-path test + add a routing assertion**
+
+Replace `test_mover_in_routable_enumeration` so it asserts a **routed** (non-`None`) path, and that movers come id-sorted after aircraft:
+
+```python
+def test_plan_fill_routes_ground_object_movers() -> None:
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    car = GroundObject(id="caddy", name="c", parts=(_ground_part(width_m=2.0, length_m=4.5),),
+                       object_class="placed_routed_mover", motion_mode="steerable",
+                       turn_radius_m=5.5)
+    layout = Layout(
+        fleet={ac.id: ac}, hangar=hangar,
+        placements=(Placement(plane_id="p1", x_m=6.0, y_m=30.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={car.id: car},
+        ground_object_placements=(
+            Placement(plane_id="caddy", x_m=10.0, y_m=20.0, heading_deg=90.0, on_carts=False),
+        ),
+    )
+    plan = plan_fill(layout)
+    caddy_moves = [m for m in plan.moves if m.plane_id == "caddy"]
+    assert len(caddy_moves) == 1
+    assert caddy_moves[0].path is not None        # #602: routed, not deferred None
+    assert plan.moves[-1].plane_id == "caddy"     # movers appended after aircraft
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_towplanner_ground_object.py::test_plan_fill_routes_ground_object_movers -v`
+Expected: FAIL — `caddy_moves[0].path` is `None` (the current deferred emission).
+
+- [ ] **Step 3: Implement — fixed-obstacle routing context + mover routing**
+
+Near the top of `plan_fill` (after `hangar = target.hangar`, ~line 1363), precompute the fixed-obstacle placements once:
+```python
+    # Fixed obstacles (e.g. the fuel trailer) are static keep-outs for BOTH
+    # aircraft routes and mover routes. Empty when no ground objects ⇒ inert.
+    fixed_obstacle_placements = tuple(
+        gp for gp in target.ground_object_placements
+        if target.ground_objects[gp.plane_id].object_class == "fixed_obstacle"
+    )
+```
+
+In the aircraft scan's `placed_layout` (~1379), thread the ground-object context so aircraft route around fixed obstacles:
+```python
+        placed_layout = Layout(
+            fleet=fleet,
+            hangar=hangar,
+            placements=tuple(placed),
+            maintenance_plane=target.maintenance_plane,
+            ground_objects=target.ground_objects,
+            ground_object_placements=fixed_obstacle_placements,
+        )
+```
+
+Replace the GO-mover emission loop (~1463) — route each placed-routed mover against all placed aircraft + fixed obstacles + already-routed movers (id-sorted accumulation), best-effort (`path=None` if unroutable):
+```python
+    # Ground-object movers (#602): route each placed-routed mover with its own
+    # path. id-sorted + appended after the aircraft loop ⇒ aircraft moves stay
+    # byte-identical (no ground objects ⇒ this loop is empty). Each mover routes
+    # against all parked aircraft + fixed obstacles + movers already routed this
+    # pass; the one being routed is excluded by _build_obstacles(mover_id=...).
+    routed_mover_placements: list[Placement] = []
+    for gp in sorted(target.ground_object_placements, key=lambda p: p.plane_id):
+        obj = target.ground_objects[gp.plane_id]
+        if obj.object_class != "placed_routed_mover":
+            continue
+        mover_placed = Layout(
+            fleet=fleet,
+            hangar=hangar,
+            placements=tuple(placed),
+            maintenance_plane=target.maintenance_plane,
+            ground_objects=target.ground_objects,
+            ground_object_placements=(*fixed_obstacle_placements, *routed_mover_placements),
+        )
+        cone = entry_poses(gp, hangar)
+        stats: dict[str, object] = {}
+        remaining = total_budget - total_used
+        try:
+            arc: DubinsArc | None = plan_path(
+                obj,
+                cone[0],
+                Pose.from_placement(gp),
+                hangar=hangar,
+                placed=mover_placed,
+                mover_on_carts=False,
+                entries=cone,
+                heuristic=heuristic,
+                max_expansions=min(budget, remaining) if remaining > 0 else 1,
+                stats=stats,
+            )
+        except NoFeasiblePlanError:
+            # Best-effort (ADR-0007 #197): an unroutable mover keeps a None path
+            # (surfaced by the caller, same contract as an un-tow-routable plane).
+            arc = None
+        exp = stats.get("expansions", 0)
+        total_used += exp if isinstance(exp, int) else 0
+        moves.append(Move(gp.plane_id, Pose.from_placement(gp), path=arc))
+        routed_mover_placements.append(gp)
+```
+
+- [ ] **Step 4: Run to verify it passes + no-GO byte-identity**
+
+Run: `pytest tests/test_towplanner_ground_object.py tests/test_towplanner.py -q`
+Expected: PASS. The no-ground-object `plan_fill` path is unchanged (empty `fixed_obstacle_placements`, empty mover loop).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/towplanner.py tests/test_towplanner_ground_object.py
+git commit -m "feat(602): plan_fill routes ground-object movers
+
+Replaces the #601 Move(path=None) placeholder: each placed-routed mover routes
+from the door cone to its slot against parked aircraft + fixed obstacles +
+already-routed movers (id-sorted, best-effort path=None if unroutable). Fixed
+obstacles now also constrain aircraft routes. Inert (byte-identical) with no
+ground objects.
+
+Refs #602"
+```
+
+---
+
+## Task 4: ADR-0010 dated amendment
+
+**Files:**
+- Modify: `docs/adr/0010-reeds-shepp-motion-model.md`
+
+- [ ] **Step 1: Append a dated amendment section** (match the file's existing amendment-block format — a `### Amendment YYYY-MM-DD (#602): ...` section with `**Status:** Accepted`). Content:
+  - Car = own-gear Reeds–Shepp parameterization (positive `r_min`, six-primitive fan).
+  - Towed trailer = **free-swivel cart** (r = 0, four-primitive reverse-capable fan) — chosen model + rationale (ground-crew hand-positioning of a balanced trailer; the tug turning-circle / jackknife is deferred).
+  - Decision: these are **new object behaviours, not a new planner** — `_primitives` / `_plan_cart` / `plan_reeds_shepp` reused unchanged; mover characterized by `(effective_turn_radius_m, reverse-capable)`.
+  - Rejected: a separate kinematic-bicycle / trailer-jackknife planner (closed-form RS + cart already give forward+reverse arcs/straights + pivot — sufficient for v1; reuse preserves the byte-identical determinism contract, ADR-0003).
+
+- [ ] **Step 2: Verify the link/anchor** — `grep -n "0010" CLAUDE.md docs/` to confirm no reference needs updating (the amendment lives inside the existing ADR; no new ADR number).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/adr/0010-reeds-shepp-motion-model.md
+git commit -m "docs(602): ADR-0010 amendment — car RS + free-swivel-cart trailer
+
+Refs #602"
+```
+
+---
+
+## Task 5: Integration + determinism canaries
+
+**Files:**
+- Test: `tests/test_towplanner.py` (zero-mover byte-identical), `tests/test_towplanner_mover_routing.py` (new, `@slow` integration + determinism)
+
+- [ ] **Step 1: Zero-mover byte-identical canary** (if `tests/test_towplanner.py` lacks an explicit one)
+
+```python
+def test_plan_fill_no_ground_objects_byte_identical() -> None:
+    """plan_fill is byte-identical to a no-ground-object run when the Layout has
+    no ground objects — the #602 mover code must be inert (ADR-0003)."""
+    # build a small multi-plane Layout WITHOUT ground objects (reuse an existing
+    # fixture/helper in this file), then:
+    p1 = plan_fill(layout)
+    p2 = plan_fill(layout)
+    assert [(m.plane_id, m.path) for m in p1.moves] == [(m.plane_id, m.path) for m in p2.moves]
+```
+
+- [ ] **Step 2: `@slow` integration — car + trailer both route, reverse-cart leg exercised**
+
+```python
+# tests/test_towplanner_mover_routing.py
+import pytest
+from hangarfit.models import GroundObject, Layout, Placement, Pose
+from hangarfit.towplanner import plan_fill, path_first_conflict
+# reuse _hangar / _ground_part / make_test_aircraft patterns from
+# tests/test_towplanner_ground_object.py (copy the helpers per the repo's
+# deliberate per-module fixture-duplication convention).
+
+
+@pytest.mark.slow
+def test_car_and_trailer_both_route_collision_free() -> None:
+    ...  # car (steerable r=5.5) + trailer (towed r=0) + 1 aircraft; assert each
+         # mover's move has a non-None path and path_first_conflict(...)==None.
+
+
+@pytest.mark.slow
+def test_towed_trailer_uses_reverse_cart_leg() -> None:
+    ...  # a trailer slot reachable only by a reverse-straight cart leg; assert
+         # the routed arc contains a reverse segment (gear == -1).
+```
+
+- [ ] **Step 3: Fixed-seed determinism canary (non-slow, ≥1 per new path for two-pass coverage)**
+
+```python
+def test_mover_routing_is_byte_identical_across_runs() -> None:
+    """Same Layout -> identical mover paths across two plan_fill calls (closed-form,
+    RNG-free; ADR-0003)."""
+    # small car+trailer Layout (non-slow), then:
+    a = plan_fill(layout)
+    b = plan_fill(layout)
+    assert [(m.plane_id, m.path) for m in a.moves] == [(m.plane_id, m.path) for m in b.moves]
+```
+
+- [ ] **Step 4: Run the full suite + determinism-guard**
+
+Run: `pytest -q` then `pytest -m slow -q` then `ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/`
+Then run the **determinism-guard** subagent (mandated: this PR touches `towplanner.py`) — a fixed-seed double-solve must be byte-identical.
+Expected: all green; determinism-guard PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_towplanner.py tests/test_towplanner_mover_routing.py
+git commit -m "test(602): mover-routing integration + zero-mover & determinism canaries
+
+Refs #602"
+```
+
+---
+
+## Self-review (against the spec)
+
+**1. Spec coverage:**
+- Object → `(turn_radius, reverse)` mapping → **Task 1** (`effective_turn_radius_m`) + **Task 2** (oracle consumes it via existing `_primitives` dispatch). ✓
+- No new planner / `SegmentKind`; params from catalog → Tasks 1–3 (no primitive/segment changes; `turn_radius_m` from catalog). ✓
+- Movers routed via `path_first_conflict` + `_mover_motion_bounds_conflict` → **Task 2/3**. ✓
+- Unroutable mover → best-effort `path=None` → **Task 3** (`except NoFeasiblePlanError`). ✓
+- ADR-0010 amendment → **Task 4**. ✓
+- Determinism: closed-form, RNG-free, fixed id-order, `determinism-guard`, zero-mover byte-identical → **Task 3/5**. ✓
+- Tests: car-RS + reverse-cart, integration, canaries → **Tasks 1, 2, 5**. ✓
+
+**2. Placeholder scan:** Task 5 integration bodies use `...` for the fixture wiring — these reuse the documented `_hangar`/`_ground_part`/`make_test_aircraft` helpers (concrete construction shown in Tasks 1–3); fill them by copying those helpers per the repo's per-module fixture convention.
+
+**3. Type consistency:** `effective_turn_radius_m()` (Task 1) is the name `plan_path` calls (Task 2). `Aircraft | GroundObject` is applied uniformly across all 4 oracle functions. `fixed_obstacle_placements` defined once (Task 3) and reused in both the aircraft `placed_layout` and the mover loop. `Move(..., path=arc|None)` matches the existing `Move.path: DubinsArc | None` contract.
+
+**Sequencing:** #603's plan is written after this lands (its egress oracle reuses the **final** generalized `path_first_conflict`).

--- a/docs/superpowers/plans/2026-06-11-602-car-trailer-motion-plan.md
+++ b/docs/superpowers/plans/2026-06-11-602-car-trailer-motion-plan.md
@@ -86,7 +86,7 @@ Add the method to the `GroundObject` class body (after `__post_init__`):
 
 ```python
     def effective_turn_radius_m(self) -> float:
-        """Turn radius the tow planner consumes (ADR-0010 / ADR-0026).
+        """Turn radius the tow planner consumes (ADR-0010, 2026-06-12 amendment).
 
         Data-driven, mirroring :meth:`Aircraft.effective_turn_radius_m`: a
         steerable car returns its positive ``turn_radius_m`` (own-gear

--- a/docs/superpowers/specs/2026-06-11-602-car-trailer-motion-design.md
+++ b/docs/superpowers/specs/2026-06-11-602-car-trailer-motion-design.md
@@ -1,0 +1,208 @@
+# #602 — Car + trailer motion models in the towplanner
+
+**Date:** 2026-06-11
+**Issue:** #602 (Stage A / Epic #600, milestone #34) — *Car + trailer motion
+models (self-driving steerable car; towed rigid-body trailer) — ADR-0010
+amendment.*
+**Branch:** `feature/602-car-trailer-motion` (off `develop`, **created after PR
+#611 merges** — consumes the #605 ground-object catalog entries).
+**Status:** design — **approved** 2026-06-11; awaiting spec review.
+**Builds on:** #595 (catalog), #601 (ground-object model + loader, the
+`Move(path=None)` deferred-mover contract), #605/#611 (the 4 real GO catalog
+entries + herrenteich `fleet.yaml` wiring).
+
+---
+
+## 1. Scope (this PR)
+
+Give the two **mover** ground-object classes a *motion model* so the existing
+tow planner can route each one with its own path:
+
+- the **self-driving steerable car** (VW Caddy) → own-gear Reeds–Shepp with a
+  positive minimum turn radius (the six-primitive fan);
+- the **towed rigid-body trailer** (glider trailer) → free-swivel cart (r = 0),
+  the four-primitive reverse-capable cart fan.
+
+The load-bearing decision: **reuse the existing ADR-0010 closed-form motion
+machinery — no new planner, no new `SegmentKind`, no new search loop.** A mover
+is fully characterized to the planner by `(effective_turn_radius_m,
+reverse-capability)`; both classes are parameterizations of the primitives the
+aircraft tow planner already drives.
+
+**Explicitly out of scope** (own siblings):
+
+- the Caddy nearest-door / clear-egress HARD gate → **#603** (this PR only makes
+  the Caddy *move* once placed; #603 *consumes* the routability oracle);
+- the glider-trailer soft right-region preference → **#604**;
+- rendering movers + their paths in PNG / scene-v2 → **#606**;
+- the **fixed fuel trailer is not a mover** — it stays a static keep-out (#601),
+  only constraining the door throat / routing corridor.
+
+## 2. Decisions locked (this session)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **Trailer kinematics** | **Free-swivel cart (r = 0)** — `_plan_cart` reverse-enabled, 4-primitive fan `(Lf, Sf, Rf, Sr)`. | Models ground-crew hand-positioning of a balanced glider trailer (push/pull + swivel the tongue) in a club hangar. Reuses the existing cart path verbatim; needs **no new catalog data** (trailer `turn_radius_m` stays unset → 0). Jackknife / tug-turning-circle is explicitly deferred (issue non-goal). |
+| **Car kinematics** | **Positive-radius Reeds–Shepp** — own-gear 6-primitive fan, `turn_radius_m = 5.5` (already in `vw_caddy.yaml`). | A self-driven car has a real turning circle and cannot pivot in place. |
+| **No new planner** | Parameterize `_primitives` / `_plan_cart` / `plan_reeds_shepp` unchanged. | Preserves the byte-identical determinism contract (ADR-0003); closed-form RS + cart already give forward+reverse arcs/straights + pivot — sufficient for v1. |
+
+## 3. Substrate (verified by the understand-phase map)
+
+The planner is already mover-agnostic:
+
+- `plan_path()` (`towplanner.py:2021`) calls `mover.effective_turn_radius_m()`
+  (`:2097`) and routes the result through `_primitives(r)` (`:1545`),
+  `_plan_cart(allow_reverse=True)` (`:449`, r = 0), and `plan_reeds_shepp()`
+  (`:866`, r > 0). **No new branch is needed** — only an
+  `effective_turn_radius_m()` on `GroundObject` and an actual route call for
+  movers.
+- `plan_fill()` (`towplanner.py:1297`) today appends each GO mover as
+  `Move(path=None)` after the aircraft loop (the #601 deferred-route contract,
+  ≈ lines 1463–1474, id-sorted so the aircraft plan is byte-identical).
+- `Aircraft.effective_turn_radius_m()` (`models.py:410`) is the precedent:
+  returns `0.0` for cart / `tow_pivotable`, else the positive radius — never
+  raises, never returns `None`/negative.
+- Catalog (already on #611): `vw_caddy.yaml` carries `turn_radius_m: 5.5`
+  ("carried for #602 routing"); the glider trailers carry **no** `turn_radius_m`;
+  `maul_fuel_trailer` is a motion-less `fixed_obstacle`. Mover YAML whitelist
+  `_ALLOWED_MOVER_KEYS = {id, name, parts, measured, motion_mode, turn_radius_m}`.
+
+## 4. Architecture / components
+
+### 4.1 `models.py` — `GroundObject.effective_turn_radius_m()`
+
+Mirror `Aircraft.effective_turn_radius_m()`. Data-driven so Herrenteich
+*configures* the value and the model stays general:
+
+```python
+def effective_turn_radius_m(self) -> float:
+    """Routing turn radius for a placed-routed mover (ADR-0010/0026).
+
+    Steerable (car) -> its positive ``turn_radius_m`` (own-gear Reeds-Shepp,
+    six-primitive fan). Towed (trailer) with no radius -> 0.0 free-swivel cart
+    (four-primitive reverse-capable fan). Never called on fixed obstacles
+    (they are not routed)."""
+    if self.turn_radius_m is not None:
+        return self.turn_radius_m
+    return 0.0
+```
+
+`__post_init__` gains **one** guard: a **steerable** mover must carry a
+*positive* `turn_radius_m` (a self-driven car must never silently degrade to a
+pivot-in-place cart). A **towed** mover may omit it (→ cart). `fixed_obstacle`
+still forbids motion fields (unchanged). *Implementation note:* this validator is
+stricter than #601 — sweep test fixtures that build a steerable mover without a
+radius and the loader/`_build_car` path.
+
+### 4.2 `towplanner.py` — route GO movers in `plan_fill()`
+
+Replace the `Move(path=None)` placeholder with a real `plan_path()` call per GO
+mover:
+
+- **Order:** aircraft loop unchanged; then GO movers in **id-sorted** order,
+  appended after the aircraft moves (preserves aircraft-plan byte-identity).
+- **Obstacles** for a mover's search = already-placed aircraft + the fixed fuel
+  trailer keep-out + previously-routed movers (the back-first / id-sorted
+  accumulation already used for aircraft).
+- `mover_on_carts = False` for every GO mover (ground objects have no cart
+  accounting; never look up / mutate `on_carts` for them).
+- **Best-effort preserved:** a mover that cannot route stays `Move(path=None)`
+  (blocking object named on stderr), the same exit-3 tow-routability contract as
+  aircraft. `#606` rendering continues to skip `None` paths.
+- **Inert when no GO movers** → the loop body never executes → byte-identical
+  aircraft `MovesPlan`.
+
+### 4.3 ADR-0010 dated amendment
+
+A timestamped section within `docs/adr/0010-reeds-shepp-motion-model.md` (the
+project's amendment-block convention, not a new ADR), documenting:
+
+(a) car = own-gear Reeds–Shepp parameterization (positive `r_min`, six-primitive
+fan); (b) towed trailer = free-swivel cart (r = 0, four-primitive
+reverse-capable fan) — the chosen model + rationale (ground-crew
+hand-positioning; jackknife / hitch turning-circle deferred); (c) the explicit
+decision that these are **new object behaviours, not a new planner**, reusing
+`_primitives` / `_plan_cart` / `plan_reeds_shepp` unchanged; (d) why a separate
+kinematic-bicycle / trailer-jackknife planner was rejected (closed-form RS +
+cart already give forward+reverse arcs/straights + pivot — sufficient for v1, and
+reuse preserves the byte-identical determinism contract).
+
+## 5. Data flow
+
+```
+Scenario/Layout ground_objects
+  -> plan_fill(): aircraft loop (UNCHANGED, byte-identical)
+                  then GO movers, id-sorted:
+        mover.effective_turn_radius_m()  -- 5.5 (car) | 0.0 (trailer)
+          -> _primitives(r)              -- 6-prim RS | 4-prim cart
+          -> plan_reeds_shepp(r>0) | _plan_cart(allow_reverse=True, r==0)
+          -> DubinsArc                   -- closed-form, RNG-free
+          -> Move(plane_id, target_slot, path=arc)
+  -> MovesPlan   -- consumed by #606 rendering
+```
+
+## 6. Determinism (ADR-0003 — non-negotiable)
+
+- All new motion code stays **closed-form and RNG-free** (reuses
+  `plan_reeds_shepp` / `_plan_cart`); no new randomness, no dict/set iteration
+  order leaking into output.
+- GO movers enumerated in a **fixed id-sorted order**, appended after aircraft;
+  the existing strict tie-break discipline is untouched.
+- **`determinism-guard` is run** (touches `towplanner.py`): a fixed-seed
+  double-solve produces byte-identical output.
+- A regression test asserts the **zero-mover plan is byte-identical** to today
+  (the inert-when-empty ⇒ byte-identical pattern, like apron / notch).
+
+## 7. Testing
+
+- **Unit (non-slow):**
+  - `GroundObject.effective_turn_radius_m()` → `5.5` for the car, `0.0` for the
+    trailers; `__post_init__` rejects a steerable mover with no/`<=0` radius.
+  - Car → positive-radius RS reachable: a roundtrip-grid mirroring
+    `test_reeds_shepp_roundtrip_grid` (`tests/test_towplanner_reeds_shepp.py`),
+    `arc.pose_at(arc.length_m) == goal` (`approx(abs=1e-3)` on position,
+    `_heading_close(0.5)` on heading).
+  - Trailer → reverse-capable cart: a `test_reverse_cart_roundtrip_grid` spanning
+    trailer geometries + reverse arcs (the reverse-straight cart leg).
+  - **Zero-mover byte-identical canary** (non-slow): `plan_fill` output unchanged
+    when no GO movers present.
+- **Integration (`@slow`):** a small Herrenteich-shaped scenario with the Caddy +
+  one glider trailer routes each mover with its own non-`None` path through
+  `path_first_conflict`; a reverse-only trailer leg is exercised.
+- **Determinism canary** (non-slow, ≥ 1 per new path per the two-pass-coverage
+  rule): a fixed-seed mover scenario routes byte-identically across two runs.
+
+## 8. Non-goals
+
+- No new planner / no new `SegmentKind`. The strafe `"T"` primitive from the
+  un-merged `feature/599` branch is explicitly **not** a dependency.
+- No trailer jackknife / multi-link articulation (rigid-body reverse-capable
+  approximation only; richer kinematics are a `later` follow-on).
+- The fixed fuel trailer is **not routed** here (static keep-out, #601).
+- No placement / constraint logic (Caddy egress = #603, trailer region = #604).
+- No ML — deterministic planner only (shippable Stage A core).
+
+## 9. Acceptance criteria (from the issue)
+
+- [ ] Each mover type resolves to `(effective_turn_radius_m, reverse_capable)`
+      consumed by the existing `plan_path` / `path_first_conflict` machinery; car
+      → positive-radius six-primitive fan, trailer → reverse-capable cart.
+- [ ] No new `SegmentKind` / search loop; motion params come from the #595/#605
+      catalog, not hardcoded in `towplanner`.
+- [ ] Movers routed through the same `path_first_conflict` mover-sampling oracle;
+      bounds via `_mover_motion_bounds_conflict` (front-gap-exempt) exactly as
+      aircraft.
+- [ ] Unroutable mover surfaces via the best-effort / exit-3 path (named on
+      stderr); no silent skip.
+- [ ] ADR-0010 amendment landed (car, trailer, no-new-planner rationale).
+- [ ] Determinism: closed-form, RNG-free, fixed iteration order; `determinism-
+      guard` passes; zero-mover plan byte-identical.
+- [ ] Tests: car-RS + reverse-cart roundtrip grids, integration route, canaries.
+
+## 10. Sequencing & dependencies
+
+- **Build after PR #611 merges** (consumes its GO catalog entries). Branch off
+  `develop`.
+- **#602 lands before #603** — #603's clear-egress half routes the Caddy via this
+  motion model.
+- Amends ADR-0010; stays under ADR-0003 (determinism), ADR-0007 (cart = r 0).

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -498,6 +498,27 @@ class GroundObject:
                     f"GroundObject {self.id!r}: turn_radius_m must be positive, "
                     f"got {self.turn_radius_m}"
                 )
+            if self.motion_mode == "steerable" and self.turn_radius_m is None:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: a steerable mover requires a "
+                    f"positive turn_radius_m (a self-driven car has a turning "
+                    f"circle; it never pivots in place)"
+                )
+
+    def effective_turn_radius_m(self) -> float:
+        """Turn radius the tow planner consumes (ADR-0010 / ADR-0026).
+
+        Data-driven, mirroring :meth:`Aircraft.effective_turn_radius_m`: the branch
+        key is the presence of ``turn_radius_m``, not ``motion_mode``. A mover that
+        carries a ``turn_radius_m`` returns it (a steerable car always does -> own-gear
+        Reeds-Shepp, six-primitive fan); a mover with no radius returns ``0.0`` -- a
+        free-swivel cart (four-primitive reverse-capable fan), which is how the towed
+        glider trailers move (ground-crew hand-positioning). Only ever called on
+        movers; never raises (``__post_init__`` guarantees a steerable mover has a
+        radius)."""
+        if self.turn_radius_m is not None:
+            return self.turn_radius_m
+        return 0.0
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -504,18 +504,25 @@ class GroundObject:
                     f"positive turn_radius_m (a self-driven car has a turning "
                     f"circle; it never pivots in place)"
                 )
+            if self.motion_mode == "towed" and self.turn_radius_m is not None:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: a towed mover must not carry a "
+                    f"turn_radius_m — it moves as a free-swivel cart (radius 0.0). "
+                    f"A positive-radius towed trailer is a deliberate future change "
+                    f"(relax this guard + define the semantics first); got "
+                    f"{self.turn_radius_m}"
+                )
 
     def effective_turn_radius_m(self) -> float:
-        """Turn radius the tow planner consumes (ADR-0010 / ADR-0026).
+        """Turn radius the tow planner consumes (ADR-0010, 2026-06-12 amendment).
 
-        Data-driven, mirroring :meth:`Aircraft.effective_turn_radius_m`: the branch
-        key is the presence of ``turn_radius_m``, not ``motion_mode``. A mover that
-        carries a ``turn_radius_m`` returns it (a steerable car always does -> own-gear
-        Reeds-Shepp, six-primitive fan); a mover with no radius returns ``0.0`` -- a
-        free-swivel cart (four-primitive reverse-capable fan), which is how the towed
-        glider trailers move (ground-crew hand-positioning). Only ever called on
-        movers; never raises (``__post_init__`` guarantees a steerable mover has a
-        radius)."""
+        Data-driven, mirroring :meth:`Aircraft.effective_turn_radius_m`: returns
+        ``turn_radius_m`` when present, else ``0.0``. ``__post_init__`` co-determines
+        the two fields — a ``steerable`` mover must carry a (positive) radius and a
+        ``towed`` mover must not — so a steerable car returns its radius (-> own-gear
+        Reeds-Shepp, six-primitive fan) and a towed trailer returns ``0.0`` (->
+        free-swivel cart, four-primitive reverse-capable fan, the ground-crew
+        hand-positioning model). Only ever called on movers; never raises."""
         if self.turn_radius_m is not None:
             return self.turn_radius_m
         return 0.0

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1256,11 +1256,13 @@ def path_first_conflict(
     mid-tow), and conflicts that do not involve ``mover`` (e.g. a pre-existing
     clash among placed planes) are skipped so the mover is never blamed for them.
 
-    Precondition: ``mover.id`` must exist in ``placed.fleet`` — each per-sample
-    :class:`Layout` references it, so an unknown id raises ``ValueError`` from
+    Precondition: ``mover.id`` must exist in ``placed.fleet`` (an aircraft mover)
+    or ``placed.ground_objects`` (a ground-object mover, #602) — each per-sample
+    :class:`Layout` references it there, so an unknown id raises ``ValueError`` from
     ``Layout`` construction rather than being silently skipped. The callers
     (``plan_fill`` #196 and ``plan_path`` #222, which re-validates its final
-    path here) build ``placed`` from the full target fleet, satisfying this.
+    path here) build ``placed`` from the full target fleet + ground objects,
+    satisfying this.
     """
     for pose in arc.sample(step_m=step_m, step_deg=step_deg):
         moving = Placement(mover.id, pose.x_m, pose.y_m, pose.heading_deg, on_carts=mover_on_carts)
@@ -1523,11 +1525,13 @@ def plan_fill(
         )
         cone = entry_poses(gp, hangar)
         mover_stats: dict[str, object] = {}
-        # Budget-exhausted (remaining <= 0) routes with a single expansion so
-        # plan_path fails fast and the mover is best-effort-skipped (path=None)
-        # below — unlike the aircraft scan, which RAISES on exhaustion. Movers
-        # are best-effort (ADR-0007 #197), so an exhausted budget must not abort
-        # the whole plan.
+        # Budget-exhausted (remaining <= 0) routes with a near-zero search budget
+        # (1 expansion) so the node-expansion search bails immediately. The mover
+        # can STILL succeed if a clean closed-form analytic shot from a door-cone
+        # start exists (that path runs before the expansion cap); otherwise it is
+        # best-effort-skipped (path=None below). Unlike the aircraft scan, which
+        # RAISES on exhaustion, movers are best-effort (ADR-0007 #197), so an
+        # exhausted budget must never abort the whole plan.
         remaining = total_budget - total_used
         mover_arc: DubinsArc | None
         try:
@@ -1544,8 +1548,11 @@ def plan_fill(
                 stats=mover_stats,
             )
         except NoFeasiblePlanError:
-            # Best-effort (ADR-0007 #197): an unroutable mover keeps a None path
-            # (surfaced by the caller, same contract as an un-tow-routable plane).
+            # Best-effort (ADR-0007 #197): an unroutable mover keeps a None path so
+            # it never aborts the whole fill. NOTE: unlike an un-tow-routable
+            # AIRCRAFT (which raises -> solver -> stderr), a None-path mover is NOT
+            # yet surfaced to the user — it renders as a static body. Wiring that
+            # stderr surfacing is tracked as a follow-up (#612).
             mover_arc = None
         exp = mover_stats.get("expansions", 0)
         total_used += exp if isinstance(exp, int) else 0

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1394,6 +1394,14 @@ def plan_fill(
     fleet = target.fleet
     hangar = target.hangar
 
+    # Fixed obstacles (e.g. the fuel trailer) are static keep-outs for BOTH
+    # aircraft routes and mover routes. Empty when no ground objects => inert.
+    fixed_obstacle_placements = tuple(
+        gp
+        for gp in target.ground_object_placements
+        if target.ground_objects[gp.plane_id].object_class == "fixed_obstacle"
+    )
+
     placed: list[Placement] = []
     moves: list[Move] = []
 
@@ -1413,6 +1421,8 @@ def plan_fill(
             hangar=hangar,
             placements=tuple(placed),
             maintenance_plane=target.maintenance_plane,
+            ground_objects=target.ground_objects,
+            ground_object_placements=fixed_obstacle_placements,
         )
         for idx, slot in enumerate(ordered):
             remaining = total_budget - total_used
@@ -1492,18 +1502,55 @@ def plan_fill(
                 )
             )
 
-    # Ground-object movers (#601): enumerate each placed-routed mover as a body
-    # the planner must route, but DEFER the actual path search to #602 — emit a
-    # deferred (None-path) Move keyed on the mover id (see the Move.path contract:
-    # #601 enumerates, #602 routes). Fixed obstacles are NEVER routed (they are
-    # keep-outs, already in _build_obstacles). Appended AFTER the aircraft routing
-    # loop, in id-sorted order, so the aircraft moves are byte-identical to the
-    # pre-#601 plan (no ground objects → no extra moves).
+    # Ground-object movers (#602): route each placed-routed mover with its own
+    # path. id-sorted + appended after the aircraft loop => aircraft moves stay
+    # byte-identical (no ground objects => this loop is empty). Each mover routes
+    # against all parked aircraft + fixed obstacles + movers already routed this
+    # pass; the one being routed is excluded from `placed` (path_first_conflict
+    # re-injects it per sample, matching the aircraft routing contract).
+    routed_mover_placements: list[Placement] = []
     for gp in sorted(target.ground_object_placements, key=lambda p: p.plane_id):
         obj = target.ground_objects[gp.plane_id]
         if obj.object_class != "placed_routed_mover":
             continue
-        moves.append(Move(gp.plane_id, Pose.from_placement(gp), path=None))
+        mover_placed = Layout(
+            fleet=fleet,
+            hangar=hangar,
+            placements=tuple(placed),
+            maintenance_plane=target.maintenance_plane,
+            ground_objects=target.ground_objects,
+            ground_object_placements=(*fixed_obstacle_placements, *routed_mover_placements),
+        )
+        cone = entry_poses(gp, hangar)
+        mover_stats: dict[str, object] = {}
+        # Budget-exhausted (remaining <= 0) routes with a single expansion so
+        # plan_path fails fast and the mover is best-effort-skipped (path=None)
+        # below — unlike the aircraft scan, which RAISES on exhaustion. Movers
+        # are best-effort (ADR-0007 #197), so an exhausted budget must not abort
+        # the whole plan.
+        remaining = total_budget - total_used
+        mover_arc: DubinsArc | None
+        try:
+            mover_arc = plan_path(
+                obj,
+                cone[0],
+                Pose.from_placement(gp),
+                hangar=hangar,
+                placed=mover_placed,
+                mover_on_carts=False,
+                entries=cone,
+                heuristic=heuristic,
+                max_expansions=min(budget, remaining) if remaining > 0 else 1,
+                stats=mover_stats,
+            )
+        except NoFeasiblePlanError:
+            # Best-effort (ADR-0007 #197): an unroutable mover keeps a None path
+            # (surfaced by the caller, same contract as an un-tow-routable plane).
+            mover_arc = None
+        exp = mover_stats.get("expansions", 0)
+        total_used += exp if isinstance(exp, int) else 0
+        moves.append(Move(gp.plane_id, Pose.from_placement(gp), path=mover_arc))
+        routed_mover_placements.append(gp)
 
     return MovesPlan(target_layout=target, moves=tuple(moves))
 

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -42,7 +42,15 @@ from hangarfit.geometry import (
     cached_parts_world,
     polygon_overlap,
 )
-from hangarfit.models import Aircraft, ApronShallowDrop, Conflict, Hangar, Layout, Placement
+from hangarfit.models import (
+    Aircraft,
+    ApronShallowDrop,
+    Conflict,
+    GroundObject,
+    Hangar,
+    Layout,
+    Placement,
+)
 
 SegmentKind = Literal["L", "S", "R"]
 _VALID_SEGMENT_KINDS = frozenset(typing.get_args(SegmentKind))
@@ -1106,11 +1114,15 @@ def entry_pose(target: Placement, hangar: Hangar) -> Pose:
 
 
 def _mover_motion_bounds_conflict(
-    mover: Aircraft, placement: Placement, hangar: Hangar
+    mover: Aircraft | GroundObject, placement: Placement, hangar: Hangar
 ) -> Conflict | None:
-    """First wall violation for a plane *in transit*, else ``None``.
+    """First wall violation for a mover *in transit*, else ``None``.
 
-    **Door-aware front-gap exemption (#222, refined in #411):** a plane being
+    The mover is an ``Aircraft`` or a ``GroundObject`` (#602); part geometry comes
+    from the union-typed :func:`~hangarfit.geometry.aircraft_parts_world`, so the
+    rule is identical for both.
+
+    **Door-aware front-gap exemption (#222, refined in #411):** a mover being
     towed through the door legitimately protrudes in front of it (``y < 0`` — the
     conceptual apron, spike Q6) — but *only through the door opening*. The front
     wall is solid except for the door gap, so a ``y < 0`` vertex is allowed only
@@ -1144,7 +1156,15 @@ def _mover_motion_bounds_conflict(
     door_hi = hangar.door.center_x_m + door_half
     apron_depth = hangar.apron_depth_m
 
-    world_parts = list(cached_parts_world(mover, placement))
+    # cached_parts_world is Aircraft-typed (pose-memoized for the solve scope);
+    # a GroundObject mover goes straight through the union-typed
+    # aircraft_parts_world (uncached, byte-identical geometry). The Aircraft
+    # branch is unchanged ⇒ aircraft routing stays byte-identical.
+    world_parts = list(
+        cached_parts_world(mover, placement)
+        if isinstance(mover, Aircraft)
+        else aircraft_parts_world(mover, placement)
+    )
     # Does the footprint cross the front-wall line (vertices on both sides of
     # y=0)? Only a crossing must thread the door (#411); a footprint wholly in
     # front (all y<=0) is staged on the apron and does not cross. Computed only
@@ -1214,7 +1234,7 @@ def _mover_motion_bounds_conflict(
 
 def path_first_conflict(
     arc: DubinsArc,
-    mover: Aircraft,
+    mover: Aircraft | GroundObject,
     *,
     mover_on_carts: bool,
     placed: Layout,
@@ -1254,12 +1274,24 @@ def path_first_conflict(
         # {mover} is a subset of a valid target layout those invariants hold;
         # a future caller that violates them gets a real ValueError, not a
         # suppressed one.
-        sample_layout = Layout(
-            fleet=placed.fleet,
-            hangar=placed.hangar,
-            placements=(*placed.placements, moving),
-            maintenance_plane=placed.maintenance_plane,
-        )
+        if isinstance(mover, Aircraft):
+            sample_layout = Layout(
+                fleet=placed.fleet,
+                hangar=placed.hangar,
+                placements=(*placed.placements, moving),
+                maintenance_plane=placed.maintenance_plane,
+                ground_objects=placed.ground_objects,
+                ground_object_placements=placed.ground_object_placements,
+            )
+        else:  # GroundObject mover -> belongs in ground_object_placements
+            sample_layout = Layout(
+                fleet=placed.fleet,
+                hangar=placed.hangar,
+                placements=placed.placements,
+                maintenance_plane=placed.maintenance_plane,
+                ground_objects=placed.ground_objects,
+                ground_object_placements=(*placed.ground_object_placements, moving),
+            )
         for conflict in _check(sample_layout).conflicts:
             if mover.id not in conflict.planes:
                 continue
@@ -1804,7 +1836,9 @@ def _aabb(poly: Polygon) -> tuple[float, float, float, float]:
     return xmin, ymin, xmax, ymax
 
 
-def _motion_clear(mover: Aircraft, pose: Pose, obstacles: _Obstacles, hangar: Hangar) -> bool:
+def _motion_clear(
+    mover: Aircraft | GroundObject, pose: Pose, obstacles: _Obstacles, hangar: Hangar
+) -> bool:
     """Fast per-pose verdict: ``True`` iff the mover at ``pose`` is collision-free.
 
     Mirrors the EXACT oracle (:func:`path_first_conflict` → ``collisions.check``)
@@ -1838,7 +1872,14 @@ def _motion_clear(mover: Aircraft, pose: Pose, obstacles: _Obstacles, hangar: Ha
     module note above and the safety-net re-check in :func:`plan_path`.
     """
     placement = Placement(mover.id, pose.x_m, pose.y_m, pose.heading_deg, on_carts=False)
-    mover_parts = cached_parts_world(mover, placement)
+    # cached_parts_world is Aircraft-typed; a GroundObject mover uses the
+    # union-typed aircraft_parts_world (uncached, identical geometry). Aircraft
+    # branch unchanged ⇒ byte-identical aircraft routing.
+    mover_parts = (
+        cached_parts_world(mover, placement)
+        if isinstance(mover, Aircraft)
+        else aircraft_parts_world(mover, placement)
+    )
 
     # (A) Hangar bounds (front-gap-exempt for the mover).
     if _mover_motion_bounds_conflict(mover, placement, hangar) is not None:
@@ -2019,7 +2060,7 @@ def _build_grid_heuristic(
 
 
 def plan_path(
-    mover: Aircraft,
+    mover: Aircraft | GroundObject,
     entry: Pose,
     goal: Pose,
     *,

--- a/tests/test_collisions_ground_object.py
+++ b/tests/test_collisions_ground_object.py
@@ -246,6 +246,7 @@ def test_ground_object_in_notch_flagged() -> None:
         parts=(_ground_part(length_m=3.0, width_m=2.0),),
         object_class="placed_routed_mover",
         motion_mode="steerable",
+        turn_radius_m=4.0,
     )
     layout = Layout(
         fleet={},

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2378,6 +2378,7 @@ class TestScenarioGroundObjects:
             parts=(part,),
             object_class="placed_routed_mover",
             motion_mode="steerable",
+            turn_radius_m=4.5,
         )
 
     def test_scenario_ground_objects_idlist_resolves(self, tmp_path: Path) -> None:

--- a/tests/test_loader_catalog.py
+++ b/tests/test_loader_catalog.py
@@ -205,7 +205,8 @@ def test_trailer_loads_with_towed_default() -> None:
 
 
 def test_mover_motion_mode_override() -> None:
-    # a trailer authored with motion_mode: steerable keeps the override
+    # a trailer authored with motion_mode: steerable keeps the override.
+    # A steerable mover requires a turn_radius_m (#602 guard), so author one.
     raw = {
         "type": "trailer",
         "id": "t1",
@@ -222,6 +223,7 @@ def test_mover_motion_mode_override() -> None:
             }
         ],
         "motion_mode": "steerable",
+        "turn_radius_m": 5.0,
     }
     obj = _build_catalog_object(raw, source=Path("inline"))
     assert isinstance(obj, GroundObject)

--- a/tests/test_models_ground_object.py
+++ b/tests/test_models_ground_object.py
@@ -295,3 +295,17 @@ def test_steerable_mover_requires_positive_turn_radius() -> None:
             object_class="placed_routed_mover",
             motion_mode="steerable",
         )
+
+
+def test_towed_mover_rejects_turn_radius() -> None:
+    # A towed mover moves as a free-swivel cart (r=0); a positive radius is a
+    # deliberate future change, not a silently-accepted contradictory state (#602).
+    with pytest.raises(ValueError, match="towed.*turn_radius_m"):
+        GroundObject(
+            id="bad",
+            name="b",
+            parts=(_rect_part(),),
+            object_class="placed_routed_mover",
+            motion_mode="towed",
+            turn_radius_m=4.0,
+        )

--- a/tests/test_models_ground_object.py
+++ b/tests/test_models_ground_object.py
@@ -114,6 +114,7 @@ def _mover(obj_id: str = "caddy") -> GroundObject:
         parts=(_rect_part(),),
         object_class="placed_routed_mover",
         motion_mode="steerable",
+        turn_radius_m=4.5,
     )
 
 
@@ -254,4 +255,43 @@ def test_ground_object_rejects_non_ground_part() -> None:
             name="Bad object",
             parts=(_rect_part(kind="wing"),),
             object_class="fixed_obstacle",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task 1: effective_turn_radius_m() + steerable-radius guard (#602)
+# ---------------------------------------------------------------------------
+
+
+def test_steerable_mover_effective_radius_is_its_turn_radius() -> None:
+    car = GroundObject(
+        id="caddy",
+        name="c",
+        parts=(_rect_part(),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=5.5,
+    )
+    assert car.effective_turn_radius_m() == 5.5
+
+
+def test_towed_mover_without_radius_is_free_swivel_cart() -> None:
+    trailer = GroundObject(
+        id="tr1",
+        name="t",
+        parts=(_rect_part(),),
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+    )
+    assert trailer.effective_turn_radius_m() == 0.0
+
+
+def test_steerable_mover_requires_positive_turn_radius() -> None:
+    with pytest.raises(ValueError, match="steerable.*turn_radius_m"):
+        GroundObject(
+            id="bad",
+            name="b",
+            parts=(_rect_part(),),
+            object_class="placed_routed_mover",
+            motion_mode="steerable",
         )

--- a/tests/test_towplanner.py
+++ b/tests/test_towplanner.py
@@ -3,7 +3,7 @@ import math
 
 import pytest
 
-from hangarfit.models import Placement
+from hangarfit.models import Door, Hangar, Layout, MaintenanceBay, Placement
 from hangarfit.towplanner import (
     DubinsArc,
     Move,
@@ -11,7 +11,9 @@ from hangarfit.towplanner import (
     Pose,
     Segment,
     back_first_order,
+    plan_fill,
 )
+from tests.conftest import make_test_aircraft
 
 
 def test_pose_from_placement_drops_identity_and_cart_state():
@@ -141,3 +143,33 @@ def test_back_first_empty_input_returns_empty_tuple():
     # An all-away / maintenance-occupant-only layout has zero placements; the
     # planner must hand that through cleanly (Layout permits zero placements).
     assert back_first_order(()) == ()
+
+
+# ── Zero-mover byte-identical canary (#602, ADR-0003) ────────────────────────
+
+
+def _small_hangar() -> Hangar:
+    """Minimal roomy hangar for the zero-mover canary."""
+    return Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.2,
+    )
+
+
+def test_plan_fill_no_ground_objects_byte_identical() -> None:
+    """plan_fill is byte-identical across two runs when the Layout has no ground
+    objects — the #602 mover code is inert (ADR-0003)."""
+    hangar = _small_hangar()
+    ac = make_test_aircraft(id="p1")
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id=ac.id, x_m=6.0, y_m=8.0, heading_deg=0.0, on_carts=False),),
+    )
+    p1 = plan_fill(layout)
+    p2 = plan_fill(layout)
+    assert [(m.plane_id, m.path) for m in p1.moves] == [(m.plane_id, m.path) for m in p2.moves]

--- a/tests/test_towplanner_ground_object.py
+++ b/tests/test_towplanner_ground_object.py
@@ -116,6 +116,49 @@ def test_movers_excluded_from_static_obstacles_when_routed() -> None:
     assert all(wp.plane_id != "caddy" for wp in obstacles.world_parts)
 
 
+def test_plan_path_routes_a_ground_object_car_mover() -> None:
+    """A steerable GO car routes from the door cone to a parked slot against a
+    placed aircraft, and the returned arc is collision-free (the oracle places
+    the mover as a ground_object_placement, not an aircraft placement)."""
+    from hangarfit.towplanner import Pose, entry_poses, path_first_conflict, plan_path
+
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    car = GroundObject(
+        id="caddy",
+        name="c",
+        parts=(_ground_part(width_m=2.0, length_m=4.5),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=5.5,
+    )
+    slot = Placement(plane_id="caddy", x_m=10.0, y_m=20.0, heading_deg=90.0, on_carts=False)
+    # `placed` carries only the already-committed bodies (the aircraft) — NOT the
+    # mover's own goal slot. Mirrors the aircraft routing contract in plan_fill:
+    # the body being routed is excluded from `placed`, then re-injected per-sample
+    # by path_first_conflict (else Layout rejects the duplicate id). The mover IS
+    # registered in `ground_objects` so the per-sample layout can resolve it.
+    placed = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id="p1", x_m=6.0, y_m=30.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={car.id: car},
+    )
+    cone = entry_poses(slot, hangar)
+    arc = plan_path(
+        car,
+        cone[0],
+        Pose.from_placement(slot),
+        hangar=hangar,
+        placed=placed,
+        mover_on_carts=False,
+        entries=cone,
+        heuristic="grid",
+    )
+    assert arc is not None
+    assert path_first_conflict(arc, car, mover_on_carts=False, placed=placed) is None
+
+
 def test_empty_ground_objects_no_extra_obstacles() -> None:
     """Byte-identity guard rail: with no ground objects the obstacle set carries
     only the (other) placed planes — no spurious entries."""

--- a/tests/test_towplanner_ground_object.py
+++ b/tests/test_towplanner_ground_object.py
@@ -63,30 +63,31 @@ def test_fixed_obstacle_in_static_obstacle_set() -> None:
     assert any(wp.plane_id == "doorblock" for wp in obstacles.world_parts)
 
 
-def test_mover_in_routable_enumeration() -> None:
+def test_plan_fill_routes_ground_object_movers() -> None:
     hangar = _hangar()
     ac = make_test_aircraft(id="p1")
-    mover = GroundObject(
+    car = GroundObject(
         id="caddy",
         name="c",
-        parts=(_ground_part(width_m=2.0),),
+        parts=(_ground_part(width_m=2.0, length_m=4.5),),
         object_class="placed_routed_mover",
         motion_mode="steerable",
-        turn_radius_m=4.0,
+        turn_radius_m=5.5,
     )
     layout = Layout(
         fleet={ac.id: ac},
         hangar=hangar,
-        placements=(Placement(plane_id=ac.id, x_m=6.0, y_m=8.0, heading_deg=0.0, on_carts=False),),
-        ground_objects={mover.id: mover},
+        placements=(Placement(plane_id="p1", x_m=6.0, y_m=30.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={car.id: car},
         ground_object_placements=(
-            Placement(plane_id=mover.id, x_m=3.0, y_m=8.0, heading_deg=0.0, on_carts=False),
+            Placement(plane_id="caddy", x_m=10.0, y_m=20.0, heading_deg=90.0, on_carts=False),
         ),
     )
     plan = plan_fill(layout)
-    # the mover id appears in the plan's routed enumeration (path deferred/None to #602)
-    routed_ids = {m.plane_id for m in plan.moves}
-    assert "caddy" in routed_ids
+    caddy_moves = [m for m in plan.moves if m.plane_id == "caddy"]
+    assert len(caddy_moves) == 1
+    assert caddy_moves[0].path is not None  # #602: routed, not deferred None
+    assert plan.moves[-1].plane_id == "caddy"  # movers appended after aircraft
 
 
 def test_movers_excluded_from_static_obstacles_when_routed() -> None:

--- a/tests/test_towplanner_mover_routing.py
+++ b/tests/test_towplanner_mover_routing.py
@@ -1,0 +1,247 @@
+"""Mover-routing integration tests (#602).
+
+Covers:
+- a steerable car AND a towed trailer both route collision-free via plan_fill
+- a towed trailer (cart, r=0) routes and honours the effective_turn_radius_m()==0.0 contract
+- plan_fill is byte-identical across two runs when ground-object movers are present (ADR-0003)
+
+Fixture helpers copied from tests/test_towplanner_ground_object.py per the
+repo's per-module fixture-duplication convention.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.models import (
+    Door,
+    GroundObject,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    Placement,
+)
+from hangarfit.towplanner import path_first_conflict, plan_fill
+from tests.conftest import make_test_aircraft
+
+# ── Inline fixture helpers ────────────────────────────────────────────────────
+
+
+def _hangar(clearance: float = 0.3, wlc: float = 0.2) -> Hangar:
+    """Inline minimal hangar (copied from tests/test_towplanner_ground_object.py)."""
+    return Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=clearance,
+        wing_layer_clearance_m=wlc,
+    )
+
+
+def _ground_part(length_m: float = 3.0, width_m: float = 1.3, z_top_m: float = 1.5) -> Part:
+    return Part(
+        kind="ground",
+        length_m=length_m,
+        width_m=width_m,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=z_top_m,
+    )
+
+
+# ── Integration tests ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.slow
+def test_car_and_trailer_both_route_collision_free() -> None:
+    """A steerable car + a towed trailer both receive non-None paths from
+    plan_fill, and each path is collision-free when checked with
+    path_first_conflict (the mover is excluded from placed.ground_object_placements,
+    matching the routing contract in plan_fill)."""
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+
+    car = GroundObject(
+        id="caddy",
+        name="VW Caddy",
+        parts=(_ground_part(length_m=4.5, width_m=1.8),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=5.5,
+    )
+    trailer = GroundObject(
+        id="trailer1",
+        name="Glider trailer",
+        parts=(_ground_part(length_m=6.0, width_m=1.2),),
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+        # No turn_radius_m → cart routing (r=0.0)
+    )
+
+    # Aircraft parked deep in the hangar, well clear of the mover slots.
+    # Movers placed a few metres in from the door so paths are short and
+    # definitely achievable within the default expansion budget.
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id="p1", x_m=20.0, y_m=30.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={car.id: car, trailer.id: trailer},
+        ground_object_placements=(
+            Placement(plane_id="caddy", x_m=10.0, y_m=10.0, heading_deg=90.0, on_carts=False),
+            Placement(plane_id="trailer1", x_m=28.0, y_m=10.0, heading_deg=90.0, on_carts=False),
+        ),
+    )
+
+    plan = plan_fill(layout)
+
+    car_moves = [m for m in plan.moves if m.plane_id == "caddy"]
+    trailer_moves = [m for m in plan.moves if m.plane_id == "trailer1"]
+
+    assert len(car_moves) == 1, "car must have exactly one move"
+    assert len(trailer_moves) == 1, "trailer must have exactly one move"
+
+    assert car_moves[0].path is not None, "steerable car must route (non-None path)"
+    assert trailer_moves[0].path is not None, "towed trailer must route (non-None path)"
+
+    # Check collision-freedom: the mover under check is EXCLUDED from
+    # placed.ground_object_placements (path_first_conflict re-injects it per
+    # sample — the routing contract), while it stays registered in
+    # placed.ground_objects so the per-sample Layout can resolve its parts.
+    def _placed_excluding(mover_id: str) -> Layout:
+        return Layout(
+            fleet=layout.fleet,
+            hangar=hangar,
+            placements=layout.placements,
+            ground_objects=layout.ground_objects,
+            ground_object_placements=tuple(
+                gp for gp in layout.ground_object_placements if gp.plane_id != mover_id
+            ),
+        )
+
+    assert (
+        path_first_conflict(
+            car_moves[0].path,
+            car,
+            mover_on_carts=False,
+            placed=_placed_excluding("caddy"),
+        )
+        is None
+    ), "car path must be collision-free"
+
+    assert (
+        path_first_conflict(
+            trailer_moves[0].path,
+            trailer,
+            mover_on_carts=False,
+            placed=_placed_excluding("trailer1"),
+        )
+        is None
+    ), "trailer path must be collision-free"
+
+
+@pytest.mark.slow
+def test_towed_trailer_routes_with_cart_reverse_capability() -> None:
+    """A towed trailer (motion_mode='towed', no turn_radius_m) routes via plan_fill
+    and honours the cart contract: effective_turn_radius_m() == 0.0 and the
+    returned path is collision-free.
+
+    NOTE: forcing a reverse segment deterministically is impractical in a black-box
+    integration test (slot geometry, path search, and the Reeds–Shepp primitive fan
+    all interact non-trivially). The reverse-leg sub-assertion is therefore DROPPED
+    per the task spec — the meaningful contract asserted here is that the trailer
+    is treated as a cart (radius 0.0) and still receives a valid, collision-free
+    path from plan_fill.
+    """
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+
+    trailer = GroundObject(
+        id="gl_trailer",
+        name="Glider trailer",
+        parts=(_ground_part(length_m=5.5, width_m=1.2),),
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+        # No turn_radius_m → effective_turn_radius_m() == 0.0
+    )
+
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id="p1", x_m=20.0, y_m=30.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={trailer.id: trailer},
+        ground_object_placements=(
+            Placement(plane_id="gl_trailer", x_m=28.0, y_m=10.0, heading_deg=90.0, on_carts=False),
+        ),
+    )
+
+    # Cart contract: radius 0.0
+    assert trailer.effective_turn_radius_m() == 0.0
+
+    plan = plan_fill(layout)
+    trailer_moves = [m for m in plan.moves if m.plane_id == "gl_trailer"]
+    assert len(trailer_moves) == 1
+    assert trailer_moves[0].path is not None, "towed trailer (cart) must route"
+
+    placed_no_trailer = Layout(
+        fleet=layout.fleet,
+        hangar=hangar,
+        placements=layout.placements,
+        ground_objects=layout.ground_objects,
+        ground_object_placements=(),
+    )
+    assert (
+        path_first_conflict(
+            trailer_moves[0].path,
+            trailer,
+            mover_on_carts=False,
+            placed=placed_no_trailer,
+        )
+        is None
+    ), "towed trailer path must be collision-free"
+
+
+def test_mover_routing_is_byte_identical_across_runs() -> None:
+    """plan_fill with ground-object movers is byte-identical across two calls
+    on the same Layout — RNG-free, ADR-0003.
+
+    NON-@slow so two-pass coverage keeps this test in the fast set and the
+    mover-routing code path is never dropped from coverage."""
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+
+    car = GroundObject(
+        id="caddy",
+        name="VW Caddy",
+        parts=(_ground_part(length_m=4.5, width_m=1.8),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=5.5,
+    )
+    trailer = GroundObject(
+        id="trailer1",
+        name="Glider trailer",
+        parts=(_ground_part(length_m=6.0, width_m=1.2),),
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+    )
+
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id="p1", x_m=20.0, y_m=30.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={car.id: car, trailer.id: trailer},
+        ground_object_placements=(
+            Placement(plane_id="caddy", x_m=10.0, y_m=10.0, heading_deg=90.0, on_carts=False),
+            Placement(plane_id="trailer1", x_m=28.0, y_m=10.0, heading_deg=90.0, on_carts=False),
+        ),
+    )
+
+    a = plan_fill(layout)
+    b = plan_fill(layout)
+    assert [(m.plane_id, m.path) for m in a.moves] == [(m.plane_id, m.path) for m in b.moves], (
+        "plan_fill must be byte-identical (ADR-0003)"
+    )


### PR DESCRIPTION
## Summary

Routes the two ground-object **mover** classes through the existing ADR-0010 tow planner by *parameterization* — **no new planner, no new `SegmentKind`** (#602):

- **Car** (VW Caddy) → own-gear Reeds–Shepp (`turn_radius_m = 5.5`, six-primitive fan).
- **Towed trailer** (glider trailers) → free-swivel cart (`r = 0`, four-primitive reverse-capable fan), the ground-crew hand-positioning model.
- `GroundObject.effective_turn_radius_m()` (mirrors `Aircraft`); the routing oracle (`path_first_conflict` / `plan_path` / `_motion_clear` / `_mover_motion_bounds_conflict`) widened to `Aircraft | GroundObject` — a GO mover is injected into the per-sample `Layout` as a `ground_object_placement`.
- `plan_fill` routes each placed-routed mover (id-sorted, best-effort `path=None` if unroutable); fixed obstacles now also constrain routing.
- ADR-0010 dated amendment (2026-06-12).

**Determinism (ADR-0003):** every new branch is GroundObject-gated, so aircraft routing is **byte-identical** when there are no ground objects (`determinism-guard` verified this cross-version against `develop`, not merely self-consistently). Mover routing is closed-form, RNG-free, id-order-deterministic.

Closes #602.

## Review trace (run before opening)

- **`determinism-guard`: PASS** — cross-version proof that the no-GO aircraft plan equals pre-#602; mover routing reproducible; canary-scoping change is a correct tightening.
- **`code-reviewer`:** 1 Important — an unroutable mover is best-effort `path=None` but is **not** surfaced on stderr (unlike an un-tow-routable aircraft). The misleading comment was corrected and the surfacing (a solver/CLI concern, out of this PR's motion scope) is tracked as **#612**. + 1 Minor (ADR ref) — fixed.
- **`type-design-analyzer`:** `towed` + `turn_radius_m` was a constructible contradictory state (would route a "towed" mover as own-gear RS) → added a `__post_init__` guard forbidding it (co-determines `motion_mode` ↔ `turn_radius_m`) + a rejecting test.
- **`comment-analyzer`:** fixed the dangling `ADR-0026` reference (→ ADR-0010), reworded the budget-exhaustion comment (a closed-form analytic shot can still route), and updated the `path_first_conflict` precondition docstring for ground-object movers.

All findings resolved in `83e6131`.

## Test plan

- [x] Full suite: **1601 passed** (10 `@slow` deselected); `pytest -m slow` mover-routing tests pass.
- [x] `mypy src/hangarfit/` + `ruff check`/`format` clean.
- [x] Determinism canaries incl. the `@serial` wall-clock set pass; new **zero-mover byte-identical** + **mover-routing byte-identical** canaries added.

## Deferred / follow-ups

- **#612** — surface unroutable movers on stderr (the deferred half of the "no silent skip" acceptance criterion).
- **#603** (Caddy HARD nearest-door + clear-egress) is the next sibling; its clear-egress oracle reuses this PR's generalized `path_first_conflict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)