### PR TITLE
feat(603): Caddy hard-door clear-egress routability gate

### DIFF
--- a/data/catalog/vw_caddy.yaml
+++ b/data/catalog/vw_caddy.yaml
@@ -6,6 +6,7 @@ id: vw_caddy
 name: "VW Caddy Maxi (rescue vehicle)"
 turn_radius_m: 5.5        # carried for #602 routing; unused by static check
 measured: false
+hard_door_mover: true    # rescue vehicle: must keep a clear drive-out egress (#603)
 parts:
   - kind: ground
     length_m: 4.88        # VW Caddy Maxi overall length (manufacturer)

--- a/docs/adr/0026-caddy-hard-door-egress.md
+++ b/docs/adr/0026-caddy-hard-door-egress.md
@@ -42,8 +42,9 @@ A static check: test whether the `hard_door_mover` is the front-most body
 (`nearest_door_mover`) at exit 2.
 
 **Rejected** — falsified by the real `examples/herrenteich/layout_full.yaml`.
-In the calibrated 11-body arrangement, `cessna_140` parks with its min-y vertex
-at `y ≈ 0.01 m` and `ctsl` at `y ≈ 0.03 m` — both forward of the Caddy
+In the calibrated 12-body arrangement (8 aircraft + 4 ground objects),
+`cessna_140` parks with its min-y vertex at `y ≈ 0.01 m` and `ctsl` at
+`y ≈ 0.03 m` — both forward of the Caddy
 (`y ≈ 5.82 m`), and both *within the Caddy's own x-lane* laterally. The predicate
 "front-most among all bodies" is structurally unachievable in a packed hangar:
 aircraft noses park as close to the door as geometry permits, and in any dense
@@ -77,8 +78,10 @@ the door against the full parked scene. A blocked egress raises
 A `GroundObject` with `hard_door_mover: true` must be able to drive OUT the door
 against the full parked scene (all aircraft + all other ground objects in their
 parked positions). The check is implemented by `egress_first_conflict`
-in `src/hangarfit/towplanner.py`, which calls `plan_path` from the parked slot
-toward a door-cone set of exit poses.
+in `src/hangarfit/towplanner.py`, which — by the reversibility below — runs the
+equivalent **entry** search: `plan_path` from a door-cone of start poses *to* the
+parked slot, against the full parked scene (the mover excluded from `placed`,
+re-injected per sample).
 
 **Reeds–Shepp reversibility (ADR-0010):** an egress (slot → out) is feasible if
 and only if an equivalent entry (door → slot) path exists. The closed-form
@@ -102,15 +105,16 @@ the `vw_caddy` catalog entry sets it to `true`.
 ### Known-hard finding: `layout_full` Caddy is egress-blocked
 
 The calibrated `examples/herrenteich/layout_full.yaml` (8 aircraft + 4 ground
-objects, the all-11 reference layout added in #605) places the Caddy at
-`(x=11.57, y=8.26, heading=180°)` — 5th-deepest of the 11 bodies, its front edge
-at `y ≈ 5.82 m` within the door window, boxed behind `cessna_140` (`y ≈ 0.01 m`).
-A bounded scan of **96 door-adjacent Caddy poses** found **2 collision-free** and
-**0 egress-routable** — the same geometric packing wall encountered in #599.
+objects = 12 bodies, the reference layout added in #605) places the Caddy at
+`(x=11.57, y=8.26, heading=180°)`, its front edge at `y ≈ 5.82 m` within the door
+window — boxed behind `cessna_140` (front edge `y ≈ 0.01 m`) and other bodies
+parked forward of it. A bounded scan of **96 door-adjacent Caddy poses** found
+**2 collision-free** and **0 egress-routable** — the same geometric packing wall
+encountered in #599.
 
 `layout_full.yaml` is **NOT modified**. It is the real-data reference for the
 herrenteich full set; its Caddy block is a correct and expected verdict from the
-verifier. Making the Caddy egress-routable requires re-nesting the full 11-body
+verifier. Making the Caddy egress-routable requires re-nesting the full 12-body
 set, which is gated on the learned backend (Epic C, #607).
 
 #603 ships the **deterministic verifier machinery**: the egress oracle correctly
@@ -133,10 +137,13 @@ identifies the blockage and reports it as tow-unroutable.
 
 - The egress check adds one `plan_path` call per `hard_door_mover` body per
   candidate layout evaluated by the solver. For the current fleet (one Caddy)
-  this is one additional path search per layout. The search is bounded by the
-  same Hybrid-A\* expansion cap as aircraft routing, so cost is predictable.
+  this is one additional path search per layout. The search is bounded by a fixed
+  Hybrid-A\* expansion cap — the full per-plane budget, deliberately *not* the
+  globally-capped `min(budget, remaining)` that `plan_fill` applies to the same
+  mover during a fill, so an exhausted fill budget can never falsely declare the
+  rescue vehicle trapped. Cost is predictable and deterministic.
 - The real `layout_full.yaml` now surfaces an exit-3 verdict. This is the
-  correct result but means the all-11 reference layout is not fully tow-routable
+  correct result but means the 12-body reference layout is not fully tow-routable
   until a re-nesting solution is found (#607).
 
 ### Neutral

--- a/docs/adr/0026-caddy-hard-door-egress.md
+++ b/docs/adr/0026-caddy-hard-door-egress.md
@@ -1,0 +1,166 @@
+# ADR-0026: Caddy hard-door egress — clear-egress routability gate
+
+- **Status:** Accepted
+
+- **Date:** 2026-06-12
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+The real Airfield Herrenteich set includes a **VW Caddy** (`vw_caddy`) — the
+club's rescue / safety vehicle — which must be able to drive **out of the hangar
+door** against the full parked scene in every valid layout. Without an explicit
+rule the solver may produce a valid layout (no aircraft–aircraft / aircraft–ground
+conflicts) in which the Caddy is geometrically boxed in and cannot exit. Such a
+layout would be operationally unsafe and must be rejected.
+
+This ADR records the decision reached in #603: what rule governs the Caddy egress,
+how it is implemented, and why an earlier geometric "nearest-door" approach was
+rejected after real-data falsification.
+
+## Decision Drivers
+
+- **Safety semantics.** The Caddy must *actually be able to drive out*, not merely
+  happen to be near the door. A static position check cannot guarantee routability.
+- **Reuse.** #602 already wired `plan_path` (Reeds–Shepp, ADR-0010) for general
+  mover routing. Reusing the same oracle for the egress check costs nothing extra.
+- **Determinism.** The check must be closed-form and RNG-free so the ADR-0003
+  byte-identical-plan contract is preserved. `plan_path` is closed-form
+  (Hybrid-A\* over Reeds–Shepp primitives, no sampling).
+- **Inert when absent.** Layouts with no `hard_door_mover` objects must produce
+  bit-identical results — no regression on any existing fixture or solver seed.
+- **Data-driven flag.** Whether a ground object is subject to the egress rule
+  should be a catalog-level datum (`hard_door_mover: true`), not a hard-coded
+  name match, so the rule generalises without code changes.
+
+## Considered Options
+
+### O1 — geometric "nearest-door" Conflict in `collisions.check` (exit 2)
+
+A static check: test whether the `hard_door_mover` is the front-most body
+(minimum `y`) among all placed bodies; if not, raise a `Conflict`
+(`nearest_door_mover`) at exit 2.
+
+**Rejected** — falsified by the real `examples/herrenteich/layout_full.yaml`.
+In the calibrated 11-body arrangement, `cessna_140` parks with its min-y vertex
+at `y ≈ 0.01 m` and `ctsl` at `y ≈ 0.03 m` — both forward of the Caddy
+(`y ≈ 5.82 m`), and both *within the Caddy's own x-lane* laterally. The predicate
+"front-most among all bodies" is structurally unachievable in a packed hangar:
+aircraft noses park as close to the door as geometry permits, and in any dense
+packing several will always be in front of the Caddy. "Nearest the door" is
+retained only as a **soft** placement preference (filed as #614), not a hard rule.
+
+### O2 — separate static near-door footprint check at exit 2
+
+Test whether the Caddy's footprint has a clear axis-aligned lane to the door,
+without running the full path planner.
+
+**Rejected** for the same reason as O1: the real data shows that aircraft legally
+park in front of the Caddy's x-lane; a static lane-clearance check would fire on
+valid layouts. It also under-approximates: a lane that appears clear under a
+rectangular sweep might still be unroutable once Reeds–Shepp turning radii are
+accounted for, and vice versa.
+
+### O3 — routability gate in `solver._tow_plan_layouts` (exit 3) *(chosen)*
+
+Reuse `plan_path` (the existing Reeds–Shepp `egress_first_conflict` oracle in
+`towplanner`) to verify that the Caddy can drive from its parked slot to *outside*
+the door against the full parked scene. A blocked egress raises
+`NoFeasiblePlanError` → exit-3 tow-unroutable (the Caddy's id named on stderr).
+
+## Decision Outcome
+
+**Chosen: O3 — clear-egress routability gate (exit 3).**
+
+### The HARD rule
+
+A `GroundObject` with `hard_door_mover: true` must be able to drive OUT the door
+against the full parked scene (all aircraft + all other ground objects in their
+parked positions). The check is implemented by `egress_first_conflict`
+in `src/hangarfit/towplanner.py`, which calls `plan_path` from the parked slot
+toward a door-cone set of exit poses.
+
+**Reeds–Shepp reversibility (ADR-0010):** an egress (slot → out) is feasible if
+and only if an equivalent entry (door → slot) path exists. The closed-form
+Reeds–Shepp word set is symmetric under time-reversal; the same Hybrid-A\* search
+therefore serves both directions without a separate reverse planner.
+
+The check is wired into `solver._tow_plan_layouts`: after routing all aircraft
+placements, `egress_first_conflict` runs for every `hard_door_mover` body. A
+failure raises `NoFeasiblePlanError`, which propagates as exit-3 tow-unroutable
+with the Caddy id on stderr — the same exit code and surface as a blocked-aircraft
+tow path (#603 wiring, consistent with ADR-0007 exit semantics).
+
+### Data-driven flag; inert/byte-identical otherwise
+
+`hard_door_mover: false` (the default for every existing catalog entry) makes
+every new code path a guarded no-op. Layouts with no `hard_door_mover` bodies
+produce bit-identical `CheckResult` and `MovesPlan` output — the ADR-0003
+determinism contract is unchanged. The flag is a boolean field on `GroundObject`;
+the `vw_caddy` catalog entry sets it to `true`.
+
+### Known-hard finding: `layout_full` Caddy is egress-blocked
+
+The calibrated `examples/herrenteich/layout_full.yaml` (8 aircraft + 4 ground
+objects, the all-11 reference layout added in #605) places the Caddy at
+`(x=11.57, y=8.26, heading=180°)` — 5th-deepest of the 11 bodies, its front edge
+at `y ≈ 5.82 m` within the door window, boxed behind `cessna_140` (`y ≈ 0.01 m`).
+A bounded scan of **96 door-adjacent Caddy poses** found **2 collision-free** and
+**0 egress-routable** — the same geometric packing wall encountered in #599.
+
+`layout_full.yaml` is **NOT modified**. It is the real-data reference for the
+herrenteich full set; its Caddy block is a correct and expected verdict from the
+verifier. Making the Caddy egress-routable requires re-nesting the full 11-body
+set, which is gated on the learned backend (Epic C, #607).
+
+#603 ships the **deterministic verifier machinery**: the egress oracle correctly
+identifies the blockage and reports it as tow-unroutable.
+
+## Consequences
+
+### Positive
+
+- The Caddy safety constraint is enforceable: any solver-produced layout in which
+  the Caddy cannot exit is rejected at exit 3, before the user sees it.
+- The rule reuses the existing `plan_path` oracle and Reeds–Shepp motion model
+  with zero new geometry code.
+- Inert/byte-identical when absent — no regression on any existing layout,
+  fixture, or solver seed.
+- Data-driven: extending the rule to a second mover (if the fleet gains one)
+  requires only setting `hard_door_mover: true` in its catalog entry.
+
+### Negative
+
+- The egress check adds one `plan_path` call per `hard_door_mover` body per
+  candidate layout evaluated by the solver. For the current fleet (one Caddy)
+  this is one additional path search per layout. The search is bounded by the
+  same Hybrid-A\* expansion cap as aircraft routing, so cost is predictable.
+- The real `layout_full.yaml` now surfaces an exit-3 verdict. This is the
+  correct result but means the all-11 reference layout is not fully tow-routable
+  until a re-nesting solution is found (#607).
+
+### Neutral
+
+- Exit code 3 (tow-unroutable) already existed for blocked-aircraft tow paths.
+  The Caddy egress failure uses the same exit code and the same `NoFeasiblePlanError`
+  propagation path — no new exit code, no new error surface.
+- "Nearest the door" as a SOFT placement preference (#614) is orthogonal and does
+  not interact with this HARD routability gate.
+
+## More Information
+
+- Related ADRs: [ADR-0003](0003-rr-mc-solver-algorithm.md) (determinism contract —
+  inert/byte-identical guarantee), [ADR-0007](0007-tow-path-planner-v1-scope.md)
+  (exit-code semantics, tow-unroutable = exit 3),
+  [ADR-0010](0010-reeds-shepp-motion-model.md) (Reeds–Shepp motion model and its
+  reversibility property), [ADR-0025](0025-ground-object-taxonomy.md)
+  (ground-object taxonomy — the `GroundObject` model, `hard_door_mover` flag).
+- Related issues: #602 (mover motion + `plan_path` oracle, the code this ADR
+  reuses), #603 (this ADR), #599 (packing wall — same blockage surfaced during
+  lateral-strafe work), #614 (soft nearest-door placement preference, the
+  non-hard complement), #607 (learned backend — prerequisite for making
+  `layout_full` egress-routable).
+- [§5 Building Block View](../architecture/05-building-block-view.md) —
+  `towplanner` module responsibilities include the `egress_first_conflict` oracle.
+- [§8 Crosscutting Concepts — "The Caddy hard-door egress gate"](../architecture/08-crosscutting-concepts.md#the-caddy-hard-door-egress-gate)
+  — companion crosscutting entry added alongside this ADR.

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -222,6 +222,31 @@ PRs. The current rule's decision is recorded in
 by ADR-0006**). The implementation lives in
 `src/hangarfit/collisions.py::_bay_intrusion_conflicts`.
 
+### The Caddy hard-door egress gate
+
+A `GroundObject` with `hard_door_mover: true` must be able to **drive out the
+door** against the full parked scene in any valid layout. This is a
+**routability / exit-3** rule, distinct from the static keep-outs above (exit 2):
+it is not a geometric position test but a full tow-path search.
+
+The check is implemented by `egress_first_conflict` in
+`src/hangarfit/towplanner.py`, which calls `plan_path` (Reeds–Shepp,
+[ADR-0010](../adr/0010-reeds-shepp-motion-model.md)) from the mover's parked
+slot toward a set of door-exit poses. By Reeds–Shepp reversibility, an egress
+(slot → out) is feasible if and only if the equivalent entry path (door → slot)
+exists — the same closed-form search serves both directions. A blocked egress
+raises `NoFeasiblePlanError` in `solver._tow_plan_layouts`, producing **exit 3
+(tow-unroutable)** with the mover id named on stderr.
+
+The flag is **data-driven**: the `vw_caddy` catalog entry sets
+`hard_door_mover: true`; all other entries default to `false`. When no
+`hard_door_mover` body is present the entire code path is a guarded no-op —
+layouts without such objects produce bit-identical output (ADR-0003 preserved).
+
+The decision and the real-data falsification of an earlier geometric
+"nearest-door" Conflict approach are recorded in
+[ADR-0026](../adr/0026-caddy-hard-door-egress.md) (Status: **Accepted**).
+
 ### Movement modes
 
 Each aircraft has a `movement_mode` in `{"always_cart",

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -230,11 +230,12 @@ door** against the full parked scene in any valid layout. This is a
 it is not a geometric position test but a full tow-path search.
 
 The check is implemented by `egress_first_conflict` in
-`src/hangarfit/towplanner.py`, which calls `plan_path` (Reeds–Shepp,
-[ADR-0010](../adr/0010-reeds-shepp-motion-model.md)) from the mover's parked
-slot toward a set of door-exit poses. By Reeds–Shepp reversibility, an egress
+`src/hangarfit/towplanner.py`. By Reeds–Shepp reversibility an egress
 (slot → out) is feasible if and only if the equivalent entry path (door → slot)
-exists — the same closed-form search serves both directions. A blocked egress
+exists, so it runs the **entry** search via `plan_path` (Reeds–Shepp,
+[ADR-0010](../adr/0010-reeds-shepp-motion-model.md)) — from a door-cone of start
+poses *to* the parked slot, against the full parked scene — one closed-form
+search serving both directions. A blocked egress
 raises `NoFeasiblePlanError` in `solver._tow_plan_layouts`, producing **exit 3
 (tow-unroutable)** with the mover id named on stderr.
 

--- a/docs/superpowers/plans/2026-06-12-603-caddy-egress-plan.md
+++ b/docs/superpowers/plans/2026-06-12-603-caddy-egress-plan.md
@@ -1,0 +1,349 @@
+# #603 Caddy clear-egress routability gate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A hard-door mover (the rescue Caddy) must be able to drive OUT the door against the full parked scene; if it can't, the layout is tow-unroutable (exit 3). One oracle, no geometric nearest-door check.
+
+**Architecture:** Per the revised spec (`docs/superpowers/specs/2026-06-11-603-caddy-egress-verifier-design.md`), the geometric nearest-door rule was dropped (falsified by `layout_full.yaml`). The HARD gate is a routability oracle `egress_first_conflict()` that reuses #602's generalized `plan_path` (Reeds–Shepp reversibility: egress feasible iff a door→slot entry path exists against the full parked scene). It's wired into `solver._tow_plan_layouts` via the existing `NoFeasiblePlanError` → exit-3 path. A per-object `hard_door_mover` flag gates it (data-driven; inert/byte-identical otherwise).
+
+**Tech stack:** Python 3.12, frozen dataclasses, shapely, pytest. Closed-form + RNG-free.
+
+**Branch:** `feature/603-caddy-egress` (off post-#602 `develop`; spec committed at `6d5c396`).
+
+---
+
+## File / change map
+
+| File | Change |
+|---|---|
+| `src/hangarfit/models.py` | `GroundObject.hard_door_mover: bool = False` + `__post_init__` guard (fixed_obstacle may not set it). |
+| `src/hangarfit/loader.py` | `_ALLOWED_MOVER_KEYS += "hard_door_mover"`; `_build_mover` reads it via `_to_bool`. |
+| `data/catalog/vw_caddy.yaml` | add `hard_door_mover: true`. |
+| `src/hangarfit/towplanner.py` | new `egress_first_conflict(target, mover_id, ...) -> Conflict | None`. |
+| `src/hangarfit/solver.py` | wire the egress gate into `_tow_plan_layouts` (import `egress_first_conflict`). |
+| `docs/adr/0026-caddy-hard-door-egress.md` | new ADR (records the rejected geometric rule + the packing-wall finding). |
+| `docs/architecture/08-crosscutting-concepts.md` | arc42 §8 entry. |
+| `CLAUDE.md` | Quick-Reference pointer row. |
+| `tests/test_models_ground_object.py`, `tests/test_loader_catalog.py` | flag + guard + loader tests. |
+| `tests/test_towplanner_mover_routing.py` | egress oracle tests (clear/blocked, @slow + fast). |
+| `tests/test_solver_towplanner.py` (or similar) | solver exit-3 integration + inert canary. |
+| `tests/test_herrenteich_dataset.py` | the `layout_full` correctly-flagged-blocked finding. |
+
+---
+
+## Task 1: `hard_door_mover` flag (model + loader + catalog)
+
+**Files:** `src/hangarfit/models.py`, `src/hangarfit/loader.py`, `data/catalog/vw_caddy.yaml`; tests in `tests/test_models_ground_object.py` + `tests/test_loader_catalog.py`.
+
+- [ ] **Step 1: Failing tests**
+
+```python
+# tests/test_models_ground_object.py
+def test_mover_can_be_hard_door_mover() -> None:
+    m = GroundObject(id="caddy", name="c", parts=(_rect_part(),),
+                     object_class="placed_routed_mover", motion_mode="steerable",
+                     turn_radius_m=5.5, hard_door_mover=True)
+    assert m.hard_door_mover is True
+
+def test_hard_door_mover_defaults_false() -> None:
+    m = GroundObject(id="tr", name="t", parts=(_rect_part(),),
+                     object_class="placed_routed_mover", motion_mode="towed")
+    assert m.hard_door_mover is False
+
+def test_fixed_obstacle_rejects_hard_door_mover() -> None:
+    with pytest.raises(ValueError, match="hard_door_mover"):
+        GroundObject(id="obst", name="o", parts=(_rect_part(),),
+                     object_class="fixed_obstacle", hard_door_mover=True)
+```
+```python
+# tests/test_loader_catalog.py
+def test_mover_hard_door_mover_loaded() -> None:
+    raw = {"type": "car", "id": "c1", "name": "Car", "parts": [
+        {"kind": "ground", "length_m": 4.0, "width_m": 1.8, "offset_x_m": 0.0,
+         "offset_y_m": 0.0, "z_bottom_m": 0.0, "z_top_m": 1.8}],
+        "turn_radius_m": 5.5, "hard_door_mover": True}
+    obj = _build_catalog_object(raw, source=Path("inline"))
+    assert obj.hard_door_mover is True
+```
+
+- [ ] **Step 2: Run, verify FAIL** (`pytest tests/test_models_ground_object.py tests/test_loader_catalog.py -k hard_door -v`): `TypeError: unexpected keyword argument 'hard_door_mover'`.
+
+- [ ] **Step 3: Implement.**
+
+`models.py` `GroundObject`: add the field as the LAST field, after `measured: bool = False`:
+```python
+    hard_door_mover: bool = False
+```
+In `__post_init__`, inside the existing `if self.object_class == "fixed_obstacle":` branch (alongside the motion_mode / turn_radius_m rejections), add:
+```python
+            if self.hard_door_mover:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: a fixed_obstacle must not set "
+                    f"hard_door_mover=True — only a placed_routed_mover may be a "
+                    f"hard-door (egress) mover"
+                )
+```
+
+`loader.py`: extend the whitelist and read the key in `_build_mover`:
+```python
+_ALLOWED_MOVER_KEYS = frozenset(
+    {"id", "name", "parts", "measured", "motion_mode", "turn_radius_m", "hard_door_mover"}
+)
+```
+and in the `GroundObject(...)` constructed by `_build_mover`, add:
+```python
+        hard_door_mover=_to_bool(entry.get("hard_door_mover", False), "hard_door_mover"),
+```
+
+`data/catalog/vw_caddy.yaml`: add after `measured: false`:
+```yaml
+hard_door_mover: true    # rescue vehicle: must keep a clear drive-out egress (#603)
+```
+
+- [ ] **Step 4: Run + verify PASS + suite slice + types.**
+`pytest tests/test_models_ground_object.py tests/test_loader_catalog.py tests/test_loader.py tests/test_herrenteich_dataset.py -q` ; `mypy src/hangarfit/` ; `ruff check src/ tests/`.
+(`_ALLOWED_FIXED_OBSTACLE_KEYS` does NOT include the key, so a `fixed_obstacle` YAML with `hard_door_mover` is rejected by the loader allowlist before the model guard — fine; add a loader-rejection test if convenient.)
+
+- [ ] **Step 5: Commit** (stage `models.py`, `loader.py`, `vw_caddy.yaml`, the two test files):
+```bash
+git commit -m "feat(603): GroundObject.hard_door_mover flag + loader/catalog wiring
+
+Refs #603"
+```
+
+---
+
+## Task 2: the `egress_first_conflict` routability oracle
+
+**Files:** `src/hangarfit/towplanner.py`; test `tests/test_towplanner_mover_routing.py`.
+
+- [ ] **Step 1: Failing tests** (reuse the file's `_hangar`/`_ground_part`/`make_test_aircraft` helpers; `egress_first_conflict` from `hangarfit.towplanner`). Build a hard-door-mover Caddy with a clear corridor (→ None) and one boxed in by an aircraft across its only corridor (→ conflict):
+
+```python
+def _caddy(hdm: bool = True) -> GroundObject:
+    return GroundObject(id="caddy", name="c",
+        parts=(_ground_part(length_m=4.5, width_m=1.8),),
+        object_class="placed_routed_mover", motion_mode="steerable",
+        turn_radius_m=5.5, hard_door_mover=hdm)
+
+def test_egress_clear_returns_none() -> None:
+    from hangarfit.towplanner import egress_first_conflict
+    hangar = _hangar()
+    caddy = _caddy()
+    layout = Layout(fleet={}, hangar=hangar, placements=(),
+        ground_objects={caddy.id: caddy},
+        ground_object_placements=(Placement("caddy", x_m=10.0, y_m=6.0, heading_deg=90.0, on_carts=False),))
+    assert egress_first_conflict(layout, "caddy") is None
+
+@pytest.mark.slow
+def test_egress_blocked_returns_caddy_egress_conflict() -> None:
+    from hangarfit.towplanner import egress_first_conflict
+    hangar = _hangar()
+    ac = make_test_aircraft(id="wall")
+    caddy = _caddy()
+    # an aircraft slab spanning the corridor between the caddy (deep) and the door
+    layout = Layout(fleet={ac.id: ac}, hangar=hangar,
+        placements=(Placement("wall", x_m=10.0, y_m=4.0, heading_deg=90.0, on_carts=False),),
+        ground_objects={caddy.id: caddy},
+        ground_object_placements=(Placement("caddy", x_m=10.0, y_m=30.0, heading_deg=90.0, on_carts=False),))
+    c = egress_first_conflict(layout, "caddy")
+    assert c is not None and c.kind == "caddy_egress" and "caddy" in c.planes
+```
+> Pick coordinates that actually produce clear vs blocked (iterate). The clear case must keep the corridor genuinely open; the blocked case must wall it off (a wide aircraft across the full door-to-slot lane).
+
+- [ ] **Step 2: Run, verify FAIL** (`egress_first_conflict` undefined).
+
+- [ ] **Step 3: Implement** in `towplanner.py` (near `path_first_conflict` / `plan_path`; `Conflict` is already imported, `_MAX_EXPANSIONS`/`entry_poses`/`plan_path`/`Pose`/`NoFeasiblePlanError` are module-local):
+
+```python
+def egress_first_conflict(
+    target: Layout,
+    mover_id: str,
+    *,
+    heuristic: Literal["euclidean", "grid"] = "grid",
+    max_expansions: int | None = None,
+) -> Conflict | None:
+    """First conflict blocking ``mover_id``'s drive-OUT through the door, else None.
+
+    By Reeds-Shepp reversibility (ADR-0010) an egress (slot -> out the door) is
+    feasible iff an entry (door-cone -> slot) path exists against the FULL parked
+    scene. Reuses #602's plan_path with the mover routed as a GroundObject; the
+    mover is EXCLUDED from ``placed`` (path_first_conflict re-injects it per
+    sample). Honors the fuel-trailer keep-out + every other parked body.
+    Closed-form, RNG-free. Returns a ``caddy_egress`` Conflict when blocked."""
+    mover = target.ground_objects[mover_id]
+    slot = next(gp for gp in target.ground_object_placements if gp.plane_id == mover_id)
+    placed = Layout(
+        fleet=target.fleet,
+        hangar=target.hangar,
+        placements=target.placements,
+        maintenance_plane=target.maintenance_plane,
+        ground_objects=target.ground_objects,
+        ground_object_placements=tuple(
+            gp for gp in target.ground_object_placements if gp.plane_id != mover_id
+        ),
+    )
+    cone = entry_poses(slot, target.hangar)
+    budget = _MAX_EXPANSIONS if max_expansions is None else max_expansions
+    try:
+        plan_path(
+            mover,
+            cone[0],
+            Pose.from_placement(slot),
+            hangar=target.hangar,
+            placed=placed,
+            mover_on_carts=False,
+            entries=cone,
+            heuristic=heuristic,
+            max_expansions=budget,
+        )
+        return None
+    except NoFeasiblePlanError as exc:
+        return Conflict.single(
+            kind="caddy_egress",
+            plane=mover_id,
+            detail=(
+                f"hard-door mover {mover_id!r} cannot drive out the door "
+                f"(no clear egress corridor): {exc.conflict.detail}"
+            ),
+        )
+```
+
+- [ ] **Step 4: Run + verify PASS + @slow + types** (`pytest tests/test_towplanner_mover_routing.py -q`, `pytest -m slow tests/test_towplanner_mover_routing.py -q`, `mypy src/hangarfit/towplanner.py`, `ruff check`).
+
+- [ ] **Step 5: Commit** (`towplanner.py` + the test):
+```bash
+git commit -m "feat(603): egress_first_conflict — Caddy drive-out routability oracle
+
+Refs #603"
+```
+
+---
+
+## Task 3: wire the egress gate into the solver (exit 3)
+
+**Files:** `src/hangarfit/solver.py`; tests in `tests/test_solver_towplanner.py` + `tests/test_herrenteich_dataset.py`.
+
+- [ ] **Step 1: Failing tests.**
+
+```python
+# tests/test_solver_towplanner.py  (or the solver-tow integration file)
+def test_hard_door_mover_egress_blocked_is_unroutable() -> None:
+    """A layout whose hard-door mover cannot egress is recorded as un-routable
+    (plans[i] is None, mover id in diagnostics.unroutable_planes)."""
+    # Build a SMALL scenario (load_scenario of a fixture, or synthesize) whose
+    # caddy is boxed in. solve(..., plan_paths=True). Then:
+    assert result.plans[0] is None
+    assert "caddy" in result.diagnostics.unroutable_planes
+
+def test_no_hard_door_mover_tow_plan_byte_identical() -> None:
+    """Inert: a scenario with no hard-door mover tow-plans byte-identically to
+    pre-#603 (the egress gate never runs)."""
+    a = solve(scen, seed=42, ... , plan_paths=True)
+    b = solve(scen, seed=42, ... , plan_paths=True)
+    assert [ (p is None, getattr(p, "moves", None)) for p in a.plans ] == [ ... b ... ]
+```
+```python
+# tests/test_herrenteich_dataset.py
+def test_full_set_caddy_egress_blocked_finding() -> None:
+    """Documents the packing-wall finding: the egress oracle correctly reports
+    layout_full.yaml's Caddy as egress-blocked (the rescue vehicle is boxed in;
+    fixing it is gated on re-nesting / Stage C)."""
+    lay = load_layout(repo_root / "examples/herrenteich/layout_full.yaml")
+    from hangarfit.towplanner import egress_first_conflict
+    c = egress_first_conflict(lay, "vw_caddy")
+    assert c is not None and c.kind == "caddy_egress"
+```
+
+- [ ] **Step 2: Run, verify FAIL.**
+
+- [ ] **Step 3: Implement.** In `solver.py`: import `egress_first_conflict` from `hangarfit.towplanner` (line ~51 alongside `plan_fill`). In `_tow_plan_layouts`, replace the `built.append(plan_fill(...))` direct appends with a computed `plan` + the egress gate, so a blocked egress raises through the EXISTING `except NoFeasiblePlanError` path:
+
+```python
+            if tow_heuristic == "grid" and tow_max_expansions is None:
+                plan = plan_fill(layout, apron_dropped_out=layout_drops)
+            else:
+                plan = plan_fill(
+                    layout,
+                    heuristic=tow_heuristic,
+                    max_expansions=tow_max_expansions,
+                    apron_dropped_out=layout_drops,
+                )
+            # #603: a hard-door mover (e.g. the rescue Caddy) must be able to drive
+            # OUT the door against the full parked scene, else the layout is
+            # operationally useless -> record it un-routable (exit 3) via the same
+            # NoFeasiblePlanError path as a boxed-in plane. Inert (byte-identical)
+            # when no hard-door mover is present (the loop body never runs).
+            for gp in layout.ground_object_placements:
+                if layout.ground_objects[gp.plane_id].hard_door_mover:
+                    egress = egress_first_conflict(
+                        layout,
+                        gp.plane_id,
+                        heuristic=tow_heuristic,
+                        max_expansions=tow_max_expansions,
+                    )
+                    if egress is not None:
+                        raise NoFeasiblePlanError(gp.plane_id, egress)
+            built.append(plan)
+            apron_drops.extend(layout_drops)
+```
+(The existing `except NoFeasiblePlanError as e:` block below appends `None`, records `e.plane_id`, and logs `e.conflict.kind`/`detail` — now `caddy_egress` — unchanged.)
+
+- [ ] **Step 4: Run + verify PASS + the broader determinism canaries** (`pytest tests/test_solver_towplanner.py tests/test_herrenteich_dataset.py -q`; `pytest -m "" tests/test_solver_canaries.py tests/test_solver_parallel.py -q`; `mypy src/hangarfit/`; `ruff check`).
+
+- [ ] **Step 5: Commit** (`solver.py` + tests):
+```bash
+git commit -m "feat(603): wire Caddy egress gate into solver -> exit-3 tow-routability
+
+Refs #603"
+```
+
+---
+
+## Task 4: ADR-0026 + arc42 + CLAUDE.md
+
+**Files:** `docs/adr/0026-caddy-hard-door-egress.md` (new), `docs/architecture/08-crosscutting-concepts.md`, `CLAUDE.md`.
+
+- [ ] **Step 1: Write ADR-0026** (match the repo's ADR template — Status: Accepted, Context, Decision, Consequences). Record:
+  - The HARD rule = clear-egress **routability** gate (exit 3), reusing #602's `plan_path` (Reeds–Shepp reversibility); the `hard_door_mover` data flag; inert/byte-identical otherwise.
+  - **Why the geometric nearest-door rule was REJECTED:** falsified by `layout_full.yaml` (cessna_140 min-y 0.01 forward of the Caddy 5.82; front-most unachievable in a packed hangar). "Nearest the door" is the SOFT term (#614).
+  - **Known-hard finding:** `layout_full`'s Caddy is fundamentally egress-blocked (96-pose scan: 0 routable); making it routable is gated on re-nesting (Stage C). The oracle correctly reports it blocked.
+  - Stays under ADR-0003 (deterministic, closed-form).
+- [ ] **Step 2: arc42 §8** — add a short subsection by the maintenance-bay / structural-notch keep-out rules: the Caddy hard-door **egress-routability** gate (a routability / exit-3 rule, distinct from the static keep-outs; reuses the tow planner).
+- [ ] **Step 3: CLAUDE.md** — add a Quick-Reference row pointing at ADR-0026 + the arc42 entry.
+- [ ] **Step 4: Commit** (the 3 docs):
+```bash
+git commit -m "docs(603): ADR-0026 Caddy egress gate + arc42 + CLAUDE.md pointer
+
+Refs #603"
+```
+
+---
+
+## Task 5: determinism + verification
+
+**Files:** tests as needed; run the guards.
+
+- [ ] **Step 1: Inert canary** (non-slow, ≥1 per new path): confirm a no-hard-door-mover scenario's `_tow_plan_layouts` output is byte-identical (covered by Task 3's `test_no_hard_door_mover_tow_plan_byte_identical`; ensure it's non-slow).
+- [ ] **Step 2: Full suite + types + lint** (`pytest -q`; `pytest -m slow -q`; `mypy src/hangarfit/`; `ruff check src/ tests/`; `ruff format --check src/ tests/`). All green.
+- [ ] **Step 3: determinism-guard** subagent (mandatory — touches `towplanner.py` + `solver.py`): fixed-seed double-solve byte-identical; confirm the egress gate is inert when no hard-door mover.
+- [ ] **Step 4: Commit** any added canary:
+```bash
+git commit -m "test(603): egress-gate inert canary + determinism verification
+
+Refs #603"
+```
+
+---
+
+## Self-review (against the spec)
+
+**Spec coverage:** flag + guard + loader/catalog → Task 1 ✓. `egress_first_conflict` (reuses #602 plan_path, full-scene, fuel-trailer keep-out, `caddy_egress` kind) → Task 2 ✓. Solver exit-3 wiring (NoFeasiblePlanError path, inert when no hard-door mover) → Task 3 ✓. ADR-0026 (rejected geometric rule + packing-wall finding) + arc42 + CLAUDE.md → Task 4 ✓. Determinism inert canary + determinism-guard → Task 5 ✓. `layout_full` correctly-flagged-blocked → Task 3 ✓.
+
+**No geometric nearest-door builder** in `collisions.py` — correctly absent (rejected design).
+
+**Placeholders:** Task 3's solver-integration test bodies use prose for fixture wiring (synthesize a boxed-in caddy scenario / reuse a fixture) — fill by mirroring `tests/test_solver_towplanner.py` conventions; the production code is fully specified.
+
+**Type consistency:** `egress_first_conflict(target, mover_id, *, heuristic, max_expansions)` returns `Conflict | None`; the solver raises `NoFeasiblePlanError(gp.plane_id, egress)` consuming it; `hard_door_mover` is the field name across model/loader/catalog/solver.
+
+**GOTCHA:** the egress oracle must EXCLUDE the mover from `placed.ground_object_placements` (path_first_conflict re-injects it per-sample) — same contract as #602's plan_fill mover routing. The `next(... if gp.plane_id == mover_id)` assumes the mover IS placed in `target`; it always is when called from `_tow_plan_layouts` (iterating `target.ground_object_placements`).

--- a/docs/superpowers/specs/2026-06-11-603-caddy-egress-verifier-design.md
+++ b/docs/superpowers/specs/2026-06-11-603-caddy-egress-verifier-design.md
@@ -1,0 +1,182 @@
+# #603 — Caddy HARD clear-egress (drive-out routability) gate
+
+**Date:** 2026-06-11 (design); **revised 2026-06-12** — collapsed to a single
+clear-egress routability oracle after real-data falsified the geometric
+nearest-door rule (see §2).
+**Issue:** #603 (Stage A / Epic #600, milestone #34).
+**Branch:** `feature/603-caddy-egress` (off `develop`, after #602 merged).
+**Builds on:** #595/#601 (ground-object model + loader), #605/#611 (`vw_caddy`
+catalog entry + `layout_full.yaml`), **#602** (the Caddy car motion model + the
+`Aircraft | GroundObject`-generalized `plan_path`/`path_first_conflict` the egress
+oracle reuses).
+**Status:** design **approved** 2026-06-12 (routability-only).
+
+---
+
+## 1. Scope (this PR)
+
+The VW Caddy is the club's **emergency-egress** rescue vehicle: it must be able to
+**drive out the door** in an emergency, against everything else parked. A layout
+that traps it is operationally useless and must be **rejected**.
+
+This PR adds **one** HARD rule to the deterministic verifier: a **clear-egress
+routability** gate. For any object the catalog flags a **hard-door mover**, the
+planner must be able to route it from its parked pose out through the door against
+the **full parked scene**; if it cannot, the layout is **tow-unroutable (exit 3)**
+— the same tier as an un-tow-routable aircraft, named on stderr.
+
+**Two-oracle → one-oracle.** The original design (two-oracle: a geometric
+"nearest-door" `Conflict` in `collisions.check` at exit 2 + a clear-egress
+routability oracle at exit 3) was **collapsed to routability-only** after the
+geometric rule was falsified by real data (§2). "Nearest the door" survives only
+as a **SOFT** preference — already filed as **#614** (door-priority tie-breaker).
+
+**Out of scope (siblings / deferred):** the Caddy motion model (#602, consumed);
+the catalog taxonomy (#595/#601); the fuel-trailer keep-out + glider-trailer soft
+region (#601/#604); the SOFT door-priority term (#614); making `layout_full`'s
+Caddy actually egress-routable (the packing wall — Stage C, see §2); any ML.
+
+## 2. Decisions locked (this session) — with the falsifying evidence
+
+| Decision | Choice | Evidence / rationale |
+|---|---|---|
+| **HARD rule shape** | **Clear-egress routability only** (exit 3). No geometric nearest-door `Conflict`. | A "front-most among all routable bodies in the door window" rule is **unachievable in a packed hangar** and **false-fires on the real `layout_full.yaml`**: `cessna_140` (min-y 0.01) and `ctsl` (0.03) sit forward of the Caddy (5.82); even within the Caddy's own x-lane, `cessna_140` is in front. Aircraft noses live at y≈0, so the Caddy can never be the absolute front-most body. The routability check is the **precise operational gate** and does not false-fire. |
+| **"Nearest the door"** | A **SOFT** preference → **#614**, not a HARD gate. | Hard front-most is unachievable; the soft door-priority term (filed) captures "the Caddy should be near the door" without rejecting valid layouts. |
+| **Reporting tier** | **Exit 3** (tow-unroutable), via the existing `NoFeasiblePlanError` → `solver` → stderr path. | `collisions.check` cannot import `towplanner` (import cycle), and the egress is inherently a routability question — it belongs in the routability oracle, exactly like aircraft tow-routability. |
+| **`layout_full.yaml`** | **Ship the machinery; the oracle correctly reports the Caddy egress-blocked.** Do **not** modify `layout_full`. | A bounded scan of 96 door-adjacent Caddy poses found **2** collision-free and **0** egress-routable — the #599 packing wall. Making the Caddy egress-routable needs re-nesting (Stage C / the learned backend). #603 delivers the deterministic verifier the learned backend validates against; the blocked Caddy is a **true finding**, documented. |
+
+## 3. Substrate (post-#602, verified)
+
+- **Exit-3 contract:** `cli.py` returns exit 3 when `--render-paths` and every
+  `result.plans` entry is `None`; `_warn_unroutable()` prints
+  `"warning: layout N: no feasible tow path (plane X could not be routed) …"` per
+  un-routed layout. `solver._tow_plan_layouts()` calls `plan_fill` per layout,
+  catches `NoFeasiblePlanError`, appends `None`, records the blocking id in
+  `SolverDiagnostics.unroutable_planes`.
+- **#602 routing oracle (reused unchanged):** `plan_path(mover: Aircraft |
+  GroundObject, entry, goal, *, hangar, placed, mover_on_carts, entries, …)`;
+  `path_first_conflict` re-injects the mover into the per-sample `Layout` (a GO
+  mover → `ground_object_placement`). `NoFeasiblePlanError(plane_id, conflict)`.
+  `entry_poses(slot, hangar)` → door-cone; `Pose` lives in `towplanner`.
+- **Reeds–Shepp reversibility (ADR-0010):** an egress (slot → out the door) is
+  feasible **iff** an entry (door → slot) path exists against the same obstacles.
+  So the egress oracle reuses `plan_path` (door-cone → Caddy slot) against the
+  **full parked scene minus the Caddy** (the Caddy is re-injected per-sample).
+- **`GroundObject`** (post-#602): `id, name, parts, object_class, motion_mode,
+  turn_radius_m, measured` + the #602 radius guards. `_ALLOWED_MOVER_KEYS` in
+  `loader.py`; `_build_mover` reads mover keys via `_to_bool`/`_to_float`.
+
+## 4. Architecture / components
+
+### 4.1 `models.py` — `GroundObject.hard_door_mover: bool = False`
+
+New field after `measured` (last field, default `False` → byte-identical).
+`__post_init__` guard (after the towed-forbids-radius guard): if `hard_door_mover`
+and `object_class != "placed_routed_mover"` → `ValueError` (only a mover may be a
+hard-door mover; a `fixed_obstacle` must not set it).
+
+### 4.2 `loader.py` + catalog
+
+`_ALLOWED_MOVER_KEYS += "hard_door_mover"`; `_build_mover` reads
+`hard_door_mover=_to_bool(entry.get("hard_door_mover", False), "hard_door_mover")`.
+`data/catalog/vw_caddy.yaml`: add `hard_door_mover: true`. **Data-driven, never
+hardcoded** — a layout with no hard-door mover is byte-identical (the oracle is
+skipped entirely).
+
+### 4.3 `towplanner.py` — the clear-egress routability oracle
+
+```python
+def egress_first_conflict(target: Layout, mover_id: str, *,
+                          heuristic="grid", max_expansions=None) -> Conflict | None:
+    """First conflict blocking <mover_id>'s drive-OUT through the door, else None.
+
+    By Reeds-Shepp reversibility (ADR-0010) an egress is feasible iff an entry
+    (door-cone -> slot) path exists against the FULL parked scene. Reuses #602's
+    plan_path with the mover routed as a GroundObject; the mover is EXCLUDED from
+    `placed` (path_first_conflict re-injects it per sample). Honors the fuel-trailer
+    keep-out + every other parked body. Closed-form, RNG-free."""
+```
+- Build `placed` = `target` with the mover removed from
+  `ground_object_placements` (kept in `ground_objects`). `cone =
+  entry_poses(mover_slot, hangar)`. `plan_path(mover, cone[0],
+  Pose.from_placement(mover_slot), …, placed=placed, mover_on_carts=False,
+  entries=cone)`. Catch `NoFeasiblePlanError` → return its `conflict` (kind
+  `caddy_egress`); success → `None`.
+
+### 4.4 `solver.py` — wire the oracle into the exit-3 path
+
+In `_tow_plan_layouts()`, **after** a layout's `plan_fill` succeeds: for each
+ground object with `hard_door_mover=True`, call `egress_first_conflict`. If it
+returns a conflict, treat the layout as un-routable — append `None` to `plans`,
+record the mover id in `unroutable` (→ exit 3 + the existing stderr warning). The
+loop body runs **only** when a hard-door mover is present ⇒ inert / byte-identical
+otherwise (no extra `plan_path` calls, no plan change).
+
+### 4.5 Docs
+
+- **New ADR-0026** (`docs/adr/0026-caddy-hard-door-egress.md`): the clear-egress
+  routability gate (exit 3); **why the geometric nearest-door rule was rejected**
+  (falsified by `layout_full` — record the evidence); "nearest the door" is SOFT
+  (#614); the `layout_full` Caddy is a documented known-hard case (packing wall,
+  Stage C). Stays under ADR-0003 (deterministic, closed-form).
+- **arc42 §8** Crosscutting Concepts: a short entry by the maintenance-bay /
+  structural-notch rules describing the Caddy hard-door **egress-routability** gate
+  (a routability/exit-3 rule, distinct from the static keep-outs).
+- **CLAUDE.md** Quick Reference: a pointer row.
+
+## 5. Determinism (ADR-0003)
+
+- The egress oracle is closed-form (reuses `plan_path`/`path_first_conflict`); no
+  new RNG, fixed cone/primitive order.
+- **Inert when no hard-door mover:** `_tow_plan_layouts` skips the oracle entirely
+  ⇒ `plans` + `diagnostics` byte-identical to pre-#603 (assert with `==`).
+- `determinism-guard` is run (touches `towplanner.py` + `solver.py`).
+
+## 6. Testing
+
+- **Egress oracle (synthetic, `test_towplanner_*`):**
+  - **clear** — a hard-door mover with an unobstructed door corridor →
+    `egress_first_conflict` returns `None` (one `@slow` route + one fast unit).
+  - **blocked** — a body parked across the mover's only corridor →
+    `egress_first_conflict` returns a `caddy_egress` conflict.
+  - The fuel-trailer fixed keep-out is honored as a corridor obstacle.
+- **Solver exit-3 integration:** a small scenario whose hard-door mover cannot
+  egress → `solve(..., plan_paths=True)` yields a `None` plan + the mover id in
+  `diagnostics.unroutable_planes` (and the CLI returns exit 3 under
+  `--render-paths`).
+- **Inert canary (non-slow):** a scenario with **no** hard-door mover →
+  `_tow_plan_layouts` / `plan_fill` output byte-identical to pre-#603.
+- **Real-data finding:** a test asserts the oracle **correctly classifies
+  `examples/herrenteich/layout_full.yaml`'s Caddy as egress-blocked** (documents
+  the packing-wall finding; proves the machinery runs on the real set).
+
+## 7. Non-goals
+
+- The Caddy motion model (#602, consumed). The catalog taxonomy (#595/#601).
+- The fuel-trailer keep-out + glider-trailer soft region (#601/#604).
+- The **geometric nearest-door** rule — **rejected** (falsified); "near the door"
+  is the SOFT **#614** term.
+- Making `layout_full`'s Caddy egress-routable (re-nesting / Stage C).
+- ADR-0008 spread; any ML.
+
+## 8. Acceptance criteria
+
+- [ ] `GroundObject.hard_door_mover` flag + `__post_init__` guard (only movers) +
+      loader wiring + `vw_caddy.yaml` sets it true.
+- [ ] `egress_first_conflict` routes the mover out via #602's `plan_path` against
+      the full parked scene; returns a `caddy_egress` conflict when blocked, `None`
+      when clear; honors the fuel-trailer keep-out.
+- [ ] Wired into `solver._tow_plan_layouts` → blocked egress surfaces as exit-3
+      tow-unroutable (named on stderr) via the existing `NoFeasiblePlanError` path.
+- [ ] **Inert / byte-identical** when no hard-door mover (canary); determinism-guard
+      passes.
+- [ ] Tests as in §6, incl. the `layout_full` correctly-flagged-blocked finding.
+- [ ] ADR-0026 (records the rejected geometric rule + the packing-wall finding) +
+      arc42 §8 + CLAUDE.md pointer.
+
+## 9. Sequencing & dependencies
+
+- Built on `feature/603-caddy-egress` off the post-#602 `develop`.
+- Reuses #602's generalized `plan_path` unchanged. New ADR-0026; under ADR-0003.
+- SOFT door-priority (#614) and the `layout_full` egress re-nest (Stage C) are
+  separate.

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -1265,7 +1265,9 @@ def _build_aircraft(entry: Any) -> Aircraft:
 # ignored field. Movers (car/trailer) may carry an explicit motion_mode override
 # and a static turn_radius_m (carried for #602's routing; unused in #601).
 _ALLOWED_FIXED_OBSTACLE_KEYS = frozenset({"id", "name", "parts", "measured"})
-_ALLOWED_MOVER_KEYS = frozenset({"id", "name", "parts", "measured", "motion_mode", "turn_radius_m"})
+_ALLOWED_MOVER_KEYS = frozenset(
+    {"id", "name", "parts", "measured", "motion_mode", "turn_radius_m", "hard_door_mover"}
+)
 
 
 def _build_ground_parts(entry: dict[str, Any]) -> tuple[Part, ...]:
@@ -1322,6 +1324,7 @@ def _build_mover(entry: Any, *, default_motion: MoverMotionMode) -> GroundObject
         motion_mode=motion_raw,
         turn_radius_m=None if tr_raw is None else _to_float(tr_raw, "turn_radius_m"),
         measured=_to_bool(entry.get("measured", False), "measured"),
+        hard_door_mover=_to_bool(entry.get("hard_door_mover", False), "hard_door_mover"),
     )
 
 

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -454,6 +454,7 @@ class GroundObject:
     motion_mode: MoverMotionMode | None = None
     turn_radius_m: float | None = None
     measured: bool = False
+    hard_door_mover: bool = False
 
     def __post_init__(self) -> None:
         if not self.id:
@@ -483,6 +484,12 @@ class GroundObject:
                 raise ValueError(
                     f"GroundObject {self.id!r}: a fixed_obstacle must not carry a "
                     f"turn_radius_m — it never moves"
+                )
+            if self.hard_door_mover:
+                raise ValueError(
+                    f"GroundObject {self.id!r}: a fixed_obstacle must not set "
+                    f"hard_door_mover=True — only a placed_routed_mover may be a "
+                    f"hard-door (egress) mover"
                 )
         else:  # placed_routed_mover
             if self.motion_mode not in _VALID_MOVER_MOTION_MODES:

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -48,7 +48,7 @@ from hangarfit.models import (
     SolveResult,
     SolveStatus,
 )
-from hangarfit.towplanner import MovesPlan, NoFeasiblePlanError, plan_fill
+from hangarfit.towplanner import MovesPlan, NoFeasiblePlanError, egress_first_conflict, plan_fill
 
 _logger = logging.getLogger(__name__)
 
@@ -750,16 +750,30 @@ def _tow_plan_layouts(
             # exactly what a bare ``plan_fill(layout)`` applies; an explicit
             # euclidean / custom budget takes the kwargs path below.
             if tow_heuristic == "grid" and tow_max_expansions is None:
-                built.append(plan_fill(layout, apron_dropped_out=layout_drops))
+                plan = plan_fill(layout, apron_dropped_out=layout_drops)
             else:
-                built.append(
-                    plan_fill(
+                plan = plan_fill(
+                    layout,
+                    heuristic=tow_heuristic,
+                    max_expansions=tow_max_expansions,
+                    apron_dropped_out=layout_drops,
+                )
+            # #603: a hard-door mover (e.g. the rescue Caddy) must be able to drive
+            # OUT the door against the full parked scene, else the layout is
+            # operationally useless -> record it un-routable (exit 3) via the same
+            # NoFeasiblePlanError path as a boxed-in plane. Inert (byte-identical)
+            # when no hard-door mover is present (the loop body never runs).
+            for gp in layout.ground_object_placements:
+                if layout.ground_objects[gp.plane_id].hard_door_mover:
+                    egress = egress_first_conflict(
                         layout,
+                        gp.plane_id,
                         heuristic=tow_heuristic,
                         max_expansions=tow_max_expansions,
-                        apron_dropped_out=layout_drops,
                     )
-                )
+                    if egress is not None:
+                        raise NoFeasiblePlanError(gp.plane_id, egress)
+            built.append(plan)
             apron_drops.extend(layout_drops)
         except NoFeasiblePlanError as e:
             built.append(None)

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1306,6 +1306,61 @@ def path_first_conflict(
     return None
 
 
+def egress_first_conflict(
+    target: Layout,
+    mover_id: str,
+    *,
+    heuristic: Literal["euclidean", "grid"] = "grid",
+    max_expansions: int | None = None,
+) -> Conflict | None:
+    """First conflict blocking ``mover_id``'s drive-OUT through the door, else None.
+
+    By Reeds-Shepp reversibility (ADR-0010) an egress (slot -> out the door) is
+    feasible iff an entry (door-cone -> slot) path exists against the FULL parked
+    scene. Reuses :func:`plan_path` with the mover routed as a
+    :class:`~hangarfit.models.GroundObject`; the mover is EXCLUDED from
+    ``placed`` (:func:`path_first_conflict` re-injects it per sample — same
+    contract as :func:`plan_fill`'s mover routing, #602). Honors the fuel-trailer
+    keep-out and every other parked body. Closed-form, RNG-free. Returns a
+    ``caddy_egress`` :class:`~hangarfit.models.Conflict` when blocked."""
+    mover = target.ground_objects[mover_id]
+    slot = next(gp for gp in target.ground_object_placements if gp.plane_id == mover_id)
+    placed = Layout(
+        fleet=target.fleet,
+        hangar=target.hangar,
+        placements=target.placements,
+        maintenance_plane=target.maintenance_plane,
+        ground_objects=target.ground_objects,
+        ground_object_placements=tuple(
+            gp for gp in target.ground_object_placements if gp.plane_id != mover_id
+        ),
+    )
+    cone = entry_poses(slot, target.hangar)
+    budget = _MAX_EXPANSIONS if max_expansions is None else max_expansions
+    try:
+        plan_path(
+            mover,
+            cone[0],
+            Pose.from_placement(slot),
+            hangar=target.hangar,
+            placed=placed,
+            mover_on_carts=False,
+            entries=cone,
+            heuristic=heuristic,
+            max_expansions=budget,
+        )
+        return None
+    except NoFeasiblePlanError as exc:
+        return Conflict.single(
+            kind="caddy_egress",
+            plane=mover_id,
+            detail=(
+                f"hard-door mover {mover_id!r} cannot drive out the door "
+                f"(no clear egress corridor): {exc.conflict.detail}"
+            ),
+        )
+
+
 # ---------------------------------------------------------------------------
 # Empty-hangar fill planner + bounded order-retry (spike Q2 / ADR-0007)
 # ---------------------------------------------------------------------------

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1324,7 +1324,12 @@ def egress_first_conflict(
     keep-out and every other parked body. Closed-form, RNG-free. Returns a
     ``caddy_egress`` :class:`~hangarfit.models.Conflict` when blocked."""
     mover = target.ground_objects[mover_id]
-    slot = next(gp for gp in target.ground_object_placements if gp.plane_id == mover_id)
+    slot = next((gp for gp in target.ground_object_placements if gp.plane_id == mover_id), None)
+    if slot is None:
+        raise ValueError(
+            f"egress_first_conflict: hard-door mover {mover_id!r} has no placement in "
+            f"target.ground_object_placements (nothing to check egress for)"
+        )
     placed = Layout(
         fleet=target.fleet,
         hangar=target.hangar,
@@ -1336,6 +1341,11 @@ def egress_first_conflict(
         ),
     )
     cone = entry_poses(slot, target.hangar)
+    # The egress gate is the AUTHORITATIVE safety verdict, so it routes with the
+    # full per-plane budget — deliberately NOT the globally-capped
+    # min(budget, remaining) that plan_fill applies to the same mover during a
+    # fill (an exhausted fill budget must never falsely declare the rescue vehicle
+    # trapped). Fixed _MAX_EXPANSIONS, RNG-free => deterministic (ADR-0003).
     budget = _MAX_EXPANSIONS if max_expansions is None else max_expansions
     try:
         plan_path(

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -10,6 +10,8 @@ cannot silently break it.
 
 from pathlib import Path
 
+import pytest
+
 from hangarfit import collisions
 from hangarfit.geometry import aircraft_parts_world
 from hangarfit.loader import load_fleet, load_hangar, load_layout
@@ -231,3 +233,22 @@ def test_full_set_caddy_near_door() -> None:
     assert caddy.y_m < layout.hangar.length_m / 3
     door = layout.hangar.door
     assert door.center_x_m - door.width_m / 2 <= caddy.x_m <= door.center_x_m + door.width_m / 2
+
+
+@pytest.mark.slow
+def test_full_set_caddy_egress_blocked_finding() -> None:
+    """Documents the packing-wall finding: the egress oracle correctly reports
+    layout_full.yaml's Caddy as egress-blocked (the rescue vehicle is boxed in by
+    the surrounding aircraft; fixing it is gated on re-nesting / Stage C — #603).
+
+    This test records the *current* state of the dataset: the Caddy IS placed near
+    the door (per test_full_set_caddy_near_door above) but the packed fleet still
+    walls off a clear egress path at the real herrenteich clearances.
+    """
+    from hangarfit.towplanner import egress_first_conflict
+
+    layout = load_layout(HERRENTEICH / "layout_full.yaml")
+    c = egress_first_conflict(layout, "vw_caddy")
+    assert c is not None and c.kind == "caddy_egress", (
+        f"expected caddy_egress conflict from layout_full.yaml; got {c}"
+    )

--- a/tests/test_loader_catalog.py
+++ b/tests/test_loader_catalog.py
@@ -230,6 +230,29 @@ def test_mover_motion_mode_override() -> None:
     assert obj.motion_mode == "steerable"
 
 
+def test_mover_hard_door_mover_loaded() -> None:
+    raw = {
+        "type": "car",
+        "id": "c1",
+        "name": "Car",
+        "parts": [
+            {
+                "kind": "ground",
+                "length_m": 4.0,
+                "width_m": 1.8,
+                "offset_x_m": 0.0,
+                "offset_y_m": 0.0,
+                "z_bottom_m": 0.0,
+                "z_top_m": 1.8,
+            }
+        ],
+        "turn_radius_m": 5.5,
+        "hard_door_mover": True,
+    }
+    obj = _build_catalog_object(raw, source=Path("inline"))
+    assert obj.hard_door_mover is True
+
+
 def test_fixed_obstacle_rejects_motion_key() -> None:
     bad = {
         "type": "fixed_obstacle",

--- a/tests/test_models_ground_object.py
+++ b/tests/test_models_ground_object.py
@@ -60,6 +60,41 @@ def test_ground_partkind_is_valid() -> None:
     assert _rect_part(kind="ground").kind == "ground"
 
 
+def test_mover_can_be_hard_door_mover() -> None:
+    m = GroundObject(
+        id="caddy",
+        name="c",
+        parts=(_rect_part(),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=5.5,
+        hard_door_mover=True,
+    )
+    assert m.hard_door_mover is True
+
+
+def test_hard_door_mover_defaults_false() -> None:
+    m = GroundObject(
+        id="tr",
+        name="t",
+        parts=(_rect_part(),),
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+    )
+    assert m.hard_door_mover is False
+
+
+def test_fixed_obstacle_rejects_hard_door_mover() -> None:
+    with pytest.raises(ValueError, match="hard_door_mover"):
+        GroundObject(
+            id="obst",
+            name="o",
+            parts=(_rect_part(),),
+            object_class="fixed_obstacle",
+            hard_door_mover=True,
+        )
+
+
 @pytest.mark.parametrize(
     "kwargs, msg",
     [

--- a/tests/test_solver_towplanner.py
+++ b/tests/test_solver_towplanner.py
@@ -180,6 +180,179 @@ def test_six_plane_fresh_fill_partial_routing_post_480():
     assert len(result.diagnostics.unroutable_planes) == sum(1 for p in result.plans if p is None)
 
 
+# ── #603 egress gate integration tests ───────────────────────────────────────
+
+
+@pytest.mark.slow
+def test_hard_door_mover_egress_blocked_is_unroutable() -> None:
+    """A hard-door mover (Caddy) boxed off from the door makes the layout
+    un-routable: _tow_plan_layouts must set plans[0]=None and record the mover id
+    in unroutable — same exit-3 path as a blocked aircraft (#603).
+
+    The wall that blocks the Caddy is a fixed_obstacle ground object (not an
+    aircraft placement) so plan_fill can produce a successful MovesPlan for the
+    one real aircraft placement.  After plan_fill succeeds, the egress gate
+    detects the Caddy cannot drive out and raises NoFeasiblePlanError(caddy),
+    which the except block converts to plans[0]=None + "caddy" in unroutable.
+    """
+    from hangarfit.models import (
+        Door,
+        GroundObject,
+        Hangar,
+        Layout,
+        MaintenanceBay,
+        Part,
+        Placement,
+    )
+    from hangarfit.solver import _tow_plan_layouts
+
+    hangar = Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.2,
+    )
+
+    # A fixed_obstacle wall spanning the full hangar width at y=15: the Caddy
+    # (y=30) has no gap to reach the door (y=0).  fixed_obstacle is inert for
+    # plan_fill's tow-routing (it is not a placement that needs routing), so
+    # plan_fill itself succeeds; only the egress gate detects the block.
+    wall = GroundObject(
+        id="wall",
+        name="Wall",
+        parts=(
+            Part(
+                kind="ground",
+                length_m=1.0,
+                width_m=44.0,  # wider than the 40 m hangar
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.5,
+            ),
+        ),
+        object_class="fixed_obstacle",
+    )
+
+    caddy = GroundObject(
+        id="caddy",
+        name="VW Caddy",
+        parts=(
+            Part(
+                kind="ground",
+                length_m=4.5,
+                width_m=1.8,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.5,
+            ),
+        ),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=5.5,
+        hard_door_mover=True,
+    )
+
+    # No aircraft placements: plan_fill has nothing to route and returns a
+    # trivial MovesPlan.  The egress gate then detects the Caddy is blocked.
+    layout = Layout(
+        fleet={},
+        hangar=hangar,
+        placements=(),
+        ground_objects={wall.id: wall, caddy.id: caddy},
+        ground_object_placements=(
+            # Wall at y=15, blocking the path from caddy (y=30) to door (y=0)
+            Placement("wall", x_m=20.0, y_m=15.0, heading_deg=0.0, on_carts=False),
+            Placement("caddy", x_m=20.0, y_m=30.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+
+    plans, unroutable, _ = _tow_plan_layouts(
+        [layout], plan_paths=True, tow_heuristic="grid", tow_max_expansions=None
+    )
+    assert plans[0] is None, "boxed-in hard-door mover must produce plans[0]=None"
+    assert "caddy" in unroutable, f"caddy must be in unroutable; got {unroutable}"
+
+
+def test_no_hard_door_mover_egress_gate_inert() -> None:
+    """When no hard-door mover is present the egress gate is a no-op:
+    _tow_plan_layouts returns a real plan and is byte-identical across two runs
+    (ADR-0003 determinism).
+
+    Builds a minimal single-plane Layout with one ground object that is NOT
+    flagged hard_door_mover, so the egress gate loop body never runs.
+    """
+    from hangarfit.models import (
+        Door,
+        GroundObject,
+        Hangar,
+        Layout,
+        MaintenanceBay,
+        Part,
+        Placement,
+    )
+    from hangarfit.solver import _tow_plan_layouts
+    from tests.conftest import make_test_aircraft
+
+    hangar = Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.2,
+    )
+    ac = make_test_aircraft(id="p1")
+    # A mover that is NOT a hard_door_mover — egress gate must skip it.
+    ordinary_mover = GroundObject(
+        id="trailer",
+        name="Glider trailer",
+        parts=(
+            Part(
+                kind="ground",
+                length_m=6.0,
+                width_m=1.2,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.5,
+            ),
+        ),
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+        hard_door_mover=False,
+    )
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id="p1", x_m=20.0, y_m=30.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={ordinary_mover.id: ordinary_mover},
+        ground_object_placements=(
+            Placement(plane_id="trailer", x_m=10.0, y_m=10.0, heading_deg=90.0, on_carts=False),
+        ),
+    )
+
+    p1, u1, _ = _tow_plan_layouts(
+        [layout], plan_paths=True, tow_heuristic="grid", tow_max_expansions=None
+    )
+    p2, u2, _ = _tow_plan_layouts(
+        [layout], plan_paths=True, tow_heuristic="grid", tow_max_expansions=None
+    )
+    # Gate must be inert: no unroutable planes from the egress check.
+    assert u1 == (), f"expected no unroutable planes, got {u1}"
+    assert u2 == (), f"expected no unroutable planes, got {u2}"
+    # Byte-identical plans across both runs.
+    assert [(x is None, getattr(x, "moves", None)) for x in p1] == [
+        (x is None, getattr(x, "moves", None)) for x in p2
+    ], "egress gate must be inert (byte-identical) when no hard-door mover present"
+
+
 def test_solve_k_gt_1_bundle_alignment_with_mixed_routability(monkeypatch):
     """K>1: the per-layout loop builds an aligned plans tuple with a mix of
     real plans and None, and unroutable_planes records exactly the failed

--- a/tests/test_towplanner_mover_routing.py
+++ b/tests/test_towplanner_mover_routing.py
@@ -1,9 +1,11 @@
-"""Mover-routing integration tests (#602).
+"""Mover-routing integration tests (#602 / #603).
 
 Covers:
 - a steerable car AND a towed trailer both route collision-free via plan_fill
 - a towed trailer (cart, r=0) routes and honours the effective_turn_radius_m()==0.0 contract
 - plan_fill is byte-identical across two runs when ground-object movers are present (ADR-0003)
+- egress_first_conflict returns None when corridor is clear (#603)
+- egress_first_conflict returns a caddy_egress Conflict when corridor is walled off (#603)
 
 Fixture helpers copied from tests/test_towplanner_ground_object.py per the
 repo's per-module fixture-duplication convention.
@@ -202,6 +204,96 @@ def test_towed_trailer_routes_with_cart_reverse_capability() -> None:
         )
         is None
     ), "towed trailer path must be collision-free"
+
+
+# ── #603 egress_first_conflict helpers + tests ───────────────────────────────
+
+
+def _caddy(hdm: bool = True) -> GroundObject:
+    return GroundObject(
+        id="caddy",
+        name="c",
+        parts=(_ground_part(length_m=4.5, width_m=1.8),),
+        object_class="placed_routed_mover",
+        motion_mode="steerable",
+        turn_radius_m=5.5,
+        hard_door_mover=hdm,
+    )
+
+
+def _wide_wall_parts() -> tuple[Part, ...]:
+    """Parts for a wall aircraft with 44 m wide fuselage parts (ground level)
+    that span beyond the 40 m hangar width, leaving no path around the wall.
+    Ground-level z (0–1.5 m) so they overlap the caddy's ground part."""
+    return (
+        Part(
+            kind="fuselage_front",
+            length_m=1.0,
+            width_m=44.0,
+            offset_x_m=0.5,
+            offset_y_m=0.0,
+            angle_deg=0.0,
+            z_bottom_m=0.0,
+            z_top_m=1.5,
+        ),
+        Part(
+            kind="fuselage_aft",
+            length_m=1.0,
+            width_m=44.0,
+            offset_x_m=-0.5,
+            offset_y_m=0.0,
+            angle_deg=0.0,
+            z_bottom_m=0.0,
+            z_top_m=1.5,
+        ),
+    )
+
+
+def test_egress_clear_returns_none() -> None:
+    """egress_first_conflict returns None when the corridor to the door is open.
+
+    Caddy placed close to the door (y=6 m), nothing between it and the door
+    → a direct egress path exists."""
+    from hangarfit.towplanner import egress_first_conflict
+
+    hangar = _hangar()
+    caddy = _caddy()
+    layout = Layout(
+        fleet={},
+        hangar=hangar,
+        placements=(),
+        ground_objects={caddy.id: caddy},
+        ground_object_placements=(
+            Placement("caddy", x_m=20.0, y_m=6.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    assert egress_first_conflict(layout, "caddy") is None
+
+
+@pytest.mark.slow
+def test_egress_blocked_returns_caddy_egress_conflict() -> None:
+    """egress_first_conflict returns a caddy_egress Conflict when an aircraft
+    walls off the caddy's only path to the door.
+
+    A wide-wing aircraft (wing_m=16, wider than the 12 m door) is placed across
+    the corridor between the caddy (y=30) and the door (y=0).  With no gap to
+    route through, egress must fail."""
+    from hangarfit.towplanner import egress_first_conflict
+
+    hangar = _hangar()
+    wall = make_test_aircraft(id="wall", parts=_wide_wall_parts())
+    caddy = _caddy()
+    layout = Layout(
+        fleet={wall.id: wall},
+        hangar=hangar,
+        placements=(Placement("wall", x_m=20.0, y_m=15.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={caddy.id: caddy},
+        ground_object_placements=(
+            Placement("caddy", x_m=20.0, y_m=30.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    c = egress_first_conflict(layout, "caddy")
+    assert c is not None and c.kind == "caddy_egress" and "caddy" in c.planes
 
 
 def test_mover_routing_is_byte_identical_across_runs() -> None:


### PR DESCRIPTION
## Summary

A hard-door mover (the rescue **VW Caddy**) must be able to **drive out the door** against the full parked scene; if it can't, the layout is **tow-unroutable (exit 3)** — the same tier as an un-tow-routable aircraft (#603).

- **`GroundObject.hard_door_mover` flag** (model + loader + `vw_caddy.yaml`) — data-driven, default `false`.
- **`egress_first_conflict` oracle** (`towplanner`): reuses #602's generalized `plan_path` — by Reeds–Shepp reversibility, an egress (slot → out) is feasible iff an **entry** path (door-cone → slot) exists against the full parked scene (the mover excluded from `placed`, re-injected per sample). Returns a `caddy_egress` conflict when blocked.
- **Solver wiring** (`_tow_plan_layouts`): after `plan_fill`, the egress gate runs for each `hard_door_mover` → a block raises `NoFeasiblePlanError` into the existing exit-3 path (named on stderr). **Inert / byte-identical when no hard-door mover.**
- **ADR-0026** + arc42 §8 crosscutting entry.

Closes #603.

## Design change — one oracle, not two (real-data falsification)

The original two-oracle design (a geometric *nearest-door* `Conflict` in `collisions.check` at exit 2 + clear-egress at exit 3) was **collapsed to routability-only** after the geometric rule was falsified by the real `examples/herrenteich/layout_full.yaml`: `cessna_140` (front edge `y ≈ 0.01`) and `ctsl` (`0.03`) park forward of the Caddy (`5.82`), even within the Caddy's own x-lane. "Front-most among all bodies" is unachievable in a packed hangar. "Nearest the door" survives only as the **SOFT** preference — filed as **#614**.

**Known-hard finding (documented, not forced):** `layout_full`'s Caddy is fundamentally egress-blocked (a 96-pose scan found 0 egress-routable slots — the #599 packing wall). #603 ships the deterministic verifier; the oracle **correctly reports the Caddy blocked**. Making it routable needs re-nesting (the learned backend, Epic C #607). `layout_full.yaml` is **not modified**.

## Review trace (run before opening, all resolved in `8906fbe`)

- **`determinism-guard`: PASS** — cross-version + empirical proof the gate is inert ⇒ byte-identical (no hard-door mover ⇒ loop body never runs); the `plan = plan_fill(...)` refactor is control-flow-equivalent; the oracle is closed-form / RNG-free; all canaries incl. `@serial` green.
- **`code-reviewer`:** 1 Important — the gate's budget is deliberately the full per-plane budget, *not* `plan_fill`'s globally-capped mover budget (so an exhausted fill budget can't falsely declare the Caddy trapped) → documented with a code comment + ADR correction. 1 Minor — hardened the exported oracle's `next()` (clear `ValueError` instead of `StopIteration` for a placement-less id). No blocking bugs.
- **`comment-analyzer`:** fixed ADR-0026 factual errors — body count (8 aircraft + 4 ground objects = **12**, not "all-11"), the search-direction prose (entry door-cone → slot), an imprecise depth rank, and a budget over-claim.

## Test plan

- [x] Full suite **1607 passed** (13 `@slow` deselected); `pytest -m slow` egress tests pass. (CI re-runs the authoritative full suite.)
- [x] `mypy` + `ruff` clean.
- [x] Determinism canaries incl. `@serial` pass; new inert (`test_no_hard_door_mover_egress_gate_inert`) + blocked + clear + `layout_full`-correctly-flagged-blocked tests.

## Deferred / follow-ups

- **#614** — the SOFT door-priority / "nearest the door" tie-breaker.
- `layout_full` Caddy egress (re-nesting → Stage C / **#607**).
- CLAUDE.md Quick-Reference pointer — deferred (the working tree carries an unrelated uncommitted CLAUDE.md edit; will add separately to avoid entangling it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)