### PR TITLE
feat(604): glider-trailer placement + soft right-region preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
-- Glider trailers are now placed and routed by the solver, with a soft right/left-region preference biasing them toward a chosen hangar wall; surfaced as per-layout `region_alignment` in `solve` output (#604).
+- **Glider-trailer placement + soft region preference (#604).** The solver now places and routes the glider trailers, with a soft right/left-region preference biasing them toward a chosen hangar wall; surfaced as per-layout `region_alignment` in `solve` output.
 - **Ground-object data model (#601).** Catalog `fixed_obstacle`/`car`/`trailer`
   types and a layout `ground_objects:` block; fixed obstacles are keep-outs
   (a `ground_obstacle` conflict names the overlapping aircraft/mover) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- Glider trailers are now placed and routed by the solver, with a soft right/left-region preference biasing them toward a chosen hangar wall; surfaced as per-layout `region_alignment` in `solve` output (#604).
 - **Ground-object data model (#601).** Catalog `fixed_obstacle`/`car`/`trailer`
   types and a layout `ground_objects:` block; fixed obstacles are keep-outs
   (a `ground_obstacle` conflict names the overlapping aircraft/mover) and

--- a/docs/adr/0008-inter-plane-spread-soft-preference.md
+++ b/docs/adr/0008-inter-plane-spread-soft-preference.md
@@ -290,6 +290,54 @@ timing scope rather than widening it (see the ADR-0003 amendment dated
 2026-06-06). The default `None` path is byte-identical to pre-F7, so the
 `spread=False` determinism canaries and `determinism-guard` are untouched.
 
+### 2026-06-12 — #604 right/left-region soft term + ground objects as solver-placed bodies
+
+**Background.** The club aligns its glider trailers to one hangar wall to keep
+the central corridor clear — a preference that the spread repulsion energy is
+position-symmetric and therefore blind to. #604 makes ground-object movers
+(glider trailers) full solver-placed citizens and adds a per-object soft
+wall-alignment preference: the soft-tier sibling of the #603 HARD Caddy
+egress gate, using the same `_spread` hill-climb as the platform.
+
+**Change.** A per-object soft wall-alignment term is folded into the SAME
+`_spread` energy, alongside the spread repulsion and the #320 back-bias:
+
+```
+E_total = Σ_{i<j} w_i·w_j·exp(−gap_ij/scale)  +  back_bias_weight·Σ_p (L−y_p)/L  +  Σ_{o∈prefs} w_o·d_o/W
+          └────────── spread (#145) ─────────┘     └──────── back bias (#320) ──────┘   └──── region (#604) ────┘
+
+where d_o = (W − x_o) for side="right", x_o for side="left", and W = hangar.width_m.
+```
+
+- The preference is **per-object scenario data** (`RegionPreference{side, weight}`,
+  `None`/absent ≡ neutral/inert) — not a global search knob; normalized by
+  `width_m` so one weight reads across hangar sizes (matching the back-bias
+  normalization by `length_m`).
+- It is **secondary**: `min_pairwise_gap_m` remains the PRIMARY cross-basin
+  selection key (#267); the region term, like the back-bias, re-ranks candidates
+  only WITHIN a basin's validity-gated hill-climb (`_spread` accepts only moves
+  keeping `_score==(0,0.0)`), and never enters basin selection.
+- **Ground objects are now solver-placed.** Movers (`placed_routed_mover`) are
+  full search citizens (sampled, perturbed in the descent, spread, routed,
+  egress-gated); fixed obstacles are authored static keep-outs. The region
+  alignment achieved is surfaced via `SolverDiagnostics.region_alignment`
+  (per-layout per-object 0-1, 1.0 = at the preferred wall).
+
+**Default & toggle.** Default INERT: a scenario with no `region_preferences`
+in its ground-object block adds nothing. The Herrenteich scenario opts its two
+glider trailers in (side `"right"`, weight 1.5).
+
+**Determinism.** The region term is RNG-free re-ranking — no random draws, no
+change to candidate generation — so same-scenario+same-seed output stays
+byte-identical (ADR-0003, max_restarts-scoped). The whole ground-object
+integration is byte-identical to pre-#604 when a scenario has no ground objects
+(no new draws, empty Layout GO args). No determinism-guard / ADR-0003 amendment
+is required (same reasoning as the #320 back-bias).
+
+**Known limitation.** The region pull is a *preference*, not a guarantee: a
+space-tight basin may keep a trailer off its preferred side (validity wins).
+Like the back-bias, it cannot move a body across an invalidating position.
+
 ### 2026-06-07 — incremental single-plane gap cache (issue #455)
 
 **Background.** A **fresh** profile taken *after* #453 (parts-world memo) and #454

--- a/docs/adr/0008-inter-plane-spread-soft-preference.md
+++ b/docs/adr/0008-inter-plane-spread-soft-preference.md
@@ -318,9 +318,10 @@ where d_o = (W − x_o) for side="right", x_o for side="left", and W = hangar.wi
   only WITHIN a basin's validity-gated hill-climb (`_spread` accepts only moves
   keeping `_score==(0,0.0)`), and never enters basin selection.
 - **Ground objects are now solver-placed.** Movers (`placed_routed_mover`) are
-  full search citizens (sampled, perturbed in the descent, spread, routed,
-  egress-gated); fixed obstacles are authored static keep-outs. The region
-  alignment achieved is surfaced via `SolverDiagnostics.region_alignment`
+  full search citizens (sampled, perturbed in the descent, spread, routed, and —
+  when flagged `hard_door_mover` (e.g. the Caddy) — egress-gated (#603));
+  fixed obstacles are authored static keep-outs. The region alignment achieved
+  is surfaced via `SolverDiagnostics.region_alignment`
   (per-layout per-object 0-1, 1.0 = at the preferred wall).
 
 **Default & toggle.** Default INERT: a scenario with no `region_preferences`

--- a/docs/adr/0010-reeds-shepp-motion-model.md
+++ b/docs/adr/0010-reeds-shepp-motion-model.md
@@ -353,8 +353,25 @@ manually-positioned trailers in scope. The byte-identical determinism contract
 jackknife kinematics are a named later follow-on if the cart approximation proves
 insufficient.
 
+## Amendment (2026-06-12) — #604: ground-object movers as solver-placed bodies
+
+**Status:** Accepted (cross-reference note). **Context:** #604 made
+`placed_routed_mover` ground objects — specifically the glider trailers —
+full RR-MC search citizens: the solver samples their poses, perturbs them in
+the min-conflicts descent, includes them in the `_spread` hill-climb, and routes
+each via `plan_fill`. No new motion model is introduced: a towed glider trailer
+already uses the free-swivel cart model (`effective_turn_radius_m() == 0`,
+`_plan_cart(allow_reverse=True)`) per the #602 amendment above, and that
+model is reused verbatim. The only change relevant to this ADR is that the
+trailer's parked pose is now **solver-chosen** rather than hand-authored in
+the layout YAML — routing still calls the same cart-fan machinery. Fixed
+obstacles (`fixed_obstacle` class) enter the solve scene as authored static
+keep-outs and are never routed.
+
 ## More Information
 
+- Amended by #604 (2026-06-12): ground-object movers are now solver-placed;
+  routing reuses the #602 cart model unchanged (see the amendment section above).
 - Amended by #602 (2026-06-12): car own-gear RS + free-swivel-cart trailer routing
   via `GroundObject.effective_turn_radius_m()`; routing oracle widened to
   `Aircraft | GroundObject` (see the amendment section above).

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -140,9 +140,9 @@ Two `object_class` values exist:
   `<sorted_kinds>_overlap` conflicts. In `solve` (#604), movers are **full
   RR-MC search citizens**: their poses are sampled, perturbed in the
   min-conflicts descent, included in the `_spread` hill-climb, routed by
-  `plan_fill`, and subject to the #603 Caddy hard-door egress gate. In
-  `check` and `view` their poses are authored in the layout YAML, exactly
-  as before.
+  `plan_fill`, and — if flagged `hard_door_mover` — subject to the #603
+  Caddy egress gate. In `check` and `view` their poses are authored in the
+  layout YAML, exactly as before.
 
 Three concrete catalog `type:` values author ground objects: `fixed_obstacle`,
 `car` (motion default `"steerable"`), and `trailer` (motion default `"towed"`).

--- a/docs/architecture/08-crosscutting-concepts.md
+++ b/docs/architecture/08-crosscutting-concepts.md
@@ -137,8 +137,12 @@ Two `object_class` values exist:
 - **`"placed_routed_mover"`** — a moveable object (car or towed trailer)
   that must eventually drive out; its world parts join the pairwise
   overlap loop exactly like aircraft parts, emitting the standard
-  `<sorted_kinds>_overlap` conflicts. Mover route search is deferred to
-  #602.
+  `<sorted_kinds>_overlap` conflicts. In `solve` (#604), movers are **full
+  RR-MC search citizens**: their poses are sampled, perturbed in the
+  min-conflicts descent, included in the `_spread` hill-climb, routed by
+  `plan_fill`, and subject to the #603 Caddy hard-door egress gate. In
+  `check` and `view` their poses are authored in the layout YAML, exactly
+  as before.
 
 Three concrete catalog `type:` values author ground objects: `fixed_obstacle`,
 `car` (motion default `"steerable"`), and `trailer` (motion default `"towed"`).
@@ -620,6 +624,8 @@ ADR.
 The hard score tuple `(conflict_count, total_penetration_m2)` measures only illegal overlap. The first **soft** preference — inter-plane spread (maximize separation once valid) — ships as an isolated post-pass (`solver._spread`), deliberately *outside* the hard tuple so the conflict-resolution determinism contract ([ADR-0003](../adr/0003-rr-mc-solver-algorithm.md)) is unaffected. See [ADR-0008](../adr/0008-inter-plane-spread-soft-preference.md) for the repulsion-energy metric and why it is a post-pass rather than a third score key.
 
 The second soft preference — **nose-out parked heading** (park each plane pointing toward the door for an easy straight-out exit) — is a second isolated post-pass (`solver._nose_out`), run *after* `_spread` and independently of it. For each movable plane it applies the zero-displacement 180° antipodal flip `(h + 180) % 360` iff that is strictly more nose-out (closer to `heading 180`, the door, under the [ADR-0002](../adr/0002-determinant-minus-one-transform.md) convention) **and** the layout stays valid. It is **default ON** (`--no-nose-out`), with a per-plane tri-state `PlaneConstraint.nose_out` override for the legitimate nose-IN exemption. Crucially the pass is **RNG-free** — it draws no random numbers — so byte-identical determinism holds *even with the feature on* (strictly stronger than `_spread`, which guarantees byte-identity only when off). It is gap-neutral (position fixed), so it cannot fight spread. The companion **`tow_pivotable`** aircraft flag (a free-castering / nose-lift plane pivots in place when towed, `effective_turn_radius_m() → 0`, routed via the existing zero-radius cart-pivot fan) is a realism flag orthogonal to `movement_mode`. See [ADR-0022](../adr/0022-nose-out-parked-heading.md); the cheap *reachability* of a nose-out slot (backing in rather than looping) is the [ADR-0010](../adr/0010-reeds-shepp-motion-model.md) #480 amendment.
+
+The third soft preference — **per-object right/left-region alignment** (#604, [ADR-0008](../adr/0008-inter-plane-spread-soft-preference.md) #604 amendment) — is a normalized distance-to-wall term folded into the same `_spread` hill-climb energy alongside the repulsion and the back-bias. It is authored **per ground object** in the scenario's `ground_objects:` block as `RegionPreference{side, weight}` (`None`/absent ≡ neutral/inert) and realized as `solver._region_energy`. It is **secondary to `min_pairwise_gap_m`** (the primary cross-basin key, #267): the term re-ranks candidates only within a basin's validity-gated hill-climb and never overrides the hard gate. It is **RNG-free**, so same-scenario+same-seed output stays byte-identical (ADR-0003). The achieved alignment per layout is surfaced as `SolverDiagnostics.region_alignment` (per-object 0–1, 1.0 = at the preferred wall) in the human and `--json` CLI output. Default inert: a scenario with no `region_preferences` is byte-identical to pre-#604.
 
 ## Visualizer colour accessibility
 

--- a/docs/superpowers/plans/2026-06-12-glider-trailer-region-and-go-solver-integration.md
+++ b/docs/superpowers/plans/2026-06-12-glider-trailer-region-and-go-solver-integration.md
@@ -1,0 +1,1536 @@
+# Glider-trailer region + ground-object solver integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the deterministic solver place + route the glider trailers as full RR-MC citizens, and add a soft right/left-region preference scored as a layered `_spread` post-pass term (#604).
+
+**Architecture:** Approach 1 — one unified *placeable-id* set (`fleet_in ++ sorted(mover_ids)`) with a `_body()` dispatch and a centralized `_build_layout()` that splits aircraft vs ground-object placements and injects fixed-obstacle keep-outs. The whole integration degenerates **byte-identically** to today when a scenario has no ground objects (zero new RNG draws, empty `Layout` args, region term not added). The region term is the #320 back-bias rotated 90°: `R = Σ wₒ·dₒ/W`, RNG-free, secondary to `min_pairwise_gap_m`.
+
+**Tech Stack:** Python 3.12, frozen dataclasses (`models.py`), `random.Random` seeded RNG, shapely polygons, pytest. Determinism is contractual (ADR-0003); the `determinism-guard` subagent gates the solver diff.
+
+**Determinism invariant (every solver task must preserve it):** with no ground objects in the scenario the change must be a no-op on the RNG stream and on `_score`. After every solver task run: `pytest tests/test_solver_canaries.py tests/test_solver_parallel.py -p no:randomly -q` must stay green **unmodified**.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/hangarfit/models.py` | `RegionPreference`, `Scenario.region_preferences` + `fixed_obstacle_placements` + mover-id helper, `SolverDiagnostics.region_alignment` | modify |
+| `src/hangarfit/solver.py` | `_body`/`_body_parts_world`, `_build_layout`, unified placeable set across init/descent/energy/spread, `_region_energy`, `_SpreadCandidate.region_alignment`, diagnostics population | modify |
+| `src/hangarfit/loader.py` | parse scenario `ground_objects:` into fixed-obstacle poses + mover entries + `region_preference`; allowlists | modify |
+| `src/hangarfit/cli.py` | surface `region_alignment` (human + `--json`) | modify |
+| `tests/fixtures/solve_region_demo.yaml` (+ `fleet_region_demo.yaml`) | tractable demo: 2-3 aircraft + 2 trailers in a roomy hangar | create |
+| `examples/herrenteich/scenario.yaml` | opt Herrenteich in (2 trailers as movers + right pref + fuel-trailer keep-out) | modify |
+| `tests/test_models_region.py` | `RegionPreference` + `Scenario` validation | create |
+| `tests/test_loader_scenario_ground_objects.py` | scenario GO parse | create |
+| `tests/test_solver_region.py` | `_region_energy` inert trio + effect + e2e + diagnostics | create |
+| `tests/test_solver_ground_objects.py` | solver places/routes movers; egress-in-solve; movers-active determinism canary | create |
+| `tests/test_cli.py` | `region_alignment` surfacing | modify |
+| `docs/adr/0008-…md`, `docs/adr/0010-…md`, `docs/architecture/08-crosscutting-concepts.md`, `CHANGELOG.md` | amendments | modify |
+
+**Conventions used below:** run tests with `pytest <path> -q` (the repo default excludes `@slow`; the PostToolUse hook also runs ruff + a pytest subset after `src/`/`tests/` edits). Commit messages use `type(604): …` and end with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer. **Never** `git add` `CLAUDE.md` or `.claude/settings.json` (user-local graphify edits).
+
+---
+
+## Task 1: `RegionPreference` model
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (add near `PlaneConstraint`, ~line 1040)
+- Test: `tests/test_models_region.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_models_region.py
+import math
+import pytest
+from hangarfit.models import RegionPreference
+
+
+def test_region_preference_valid_right():
+    rp = RegionPreference(side="right", weight=1.0)
+    assert rp.side == "right"
+    assert rp.weight == 1.0
+
+
+def test_region_preference_zero_weight_allowed():
+    assert RegionPreference(side="left", weight=0.0).weight == 0.0
+
+
+@pytest.mark.parametrize("bad", [-0.1, float("nan"), float("inf")])
+def test_region_preference_rejects_bad_weight(bad):
+    with pytest.raises(ValueError):
+        RegionPreference(side="right", weight=bad)
+
+
+def test_region_preference_rejects_bad_side():
+    with pytest.raises(ValueError):
+        RegionPreference(side="up", weight=1.0)  # type: ignore[arg-type]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_models_region.py -q`
+Expected: FAIL — `ImportError: cannot import name 'RegionPreference'`.
+
+- [ ] **Step 3: Implement `RegionPreference`**
+
+Add to `src/hangarfit/models.py` immediately before `class PlaneConstraint` (the `Literal`/`math` imports already exist at top of file):
+
+```python
+RegionSide = Literal["left", "right"]
+_VALID_REGION_SIDES: frozenset[str] = frozenset(("left", "right"))
+
+
+@dataclass(frozen=True, slots=True)
+class RegionPreference:
+    """A soft per-object preference to align a placed body to one hangar wall (#604).
+
+    ``side`` is the preferred wall in the x-axis (``"left"`` ≡ ``x → 0``,
+    ``"right"`` ≡ ``x → hangar.width_m``); ``weight`` is a non-negative, finite
+    soft importance (``0.0`` is permitted and inert). Realized as the RNG-free
+    ``solver._region_energy`` term folded into the ``_spread`` hill-climb,
+    secondary to ``min_pairwise_gap_m`` and never overriding the hard validity
+    gate (ADR-0008 amended). Modeled on :attr:`PlaneConstraint.priority`'s
+    soft-weight validation (#441).
+    """
+
+    side: RegionSide
+    weight: float
+
+    def __post_init__(self) -> None:
+        if self.side not in _VALID_REGION_SIDES:
+            raise ValueError(
+                f"RegionPreference.side must be one of {sorted(_VALID_REGION_SIDES)}, "
+                f"got {self.side!r}"
+            )
+        if not math.isfinite(self.weight):
+            raise ValueError(f"RegionPreference.weight={self.weight!r} must be finite")
+        if self.weight < 0.0:
+            raise ValueError(
+                f"RegionPreference.weight={self.weight!r} must be >= 0.0 (a soft weight)"
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_models_region.py -q`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_models_region.py
+git commit -m "feat(604): RegionPreference soft per-object region-alignment type
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `Scenario.region_preferences` + `fixed_obstacle_placements` + mover-id helper
+
+**Files:**
+- Modify: `src/hangarfit/models.py` — `Scenario` fields (~1106-1114), `_PROXY_FIELDS` (~1121), `__post_init__` (validation ~1238-1250 region), add a `mover_ids` property
+- Test: `tests/test_models_region.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/test_models_region.py
+from types import MappingProxyType
+from hangarfit.models import Scenario, GroundObject, Placement
+# Reuse existing test builders for Aircraft/GroundObject/Hangar from the suite's
+# conftest/fixtures; the snippet below assumes helpers `make_aircraft(id)`,
+# `make_mover(id)` (object_class='placed_routed_mover'), `make_hangar()` exist or
+# are constructed inline as in tests/test_models.py.
+
+def _scn(**kw):
+    fleet = {"husky": make_aircraft("husky")}
+    base = dict(fleet=fleet, hangar=make_hangar(), fleet_in=("husky",))
+    base.update(kw)
+    return Scenario(**base)
+
+
+def test_scenario_region_preferences_default_empty():
+    s = _scn()
+    assert dict(s.region_preferences) == {}
+
+
+def test_scenario_region_preference_must_reference_placeable_id():
+    with pytest.raises(ValueError):
+        _scn(region_preferences={"ghost": RegionPreference("right", 1.0)})
+
+
+def test_scenario_region_preference_on_aircraft_ok():
+    s = _scn(region_preferences={"husky": RegionPreference("right", 1.0)})
+    assert s.region_preferences["husky"].side == "right"
+
+
+def test_scenario_mover_ids_from_ground_objects():
+    mover = make_mover("glider_trailer_1")
+    s = _scn(
+        ground_objects=("glider_trailer_1",),
+        ground_object_defs={"glider_trailer_1": mover},
+    )
+    assert s.mover_ids == ("glider_trailer_1",)
+
+
+def test_scenario_region_preference_on_mover_ok():
+    mover = make_mover("glider_trailer_1")
+    s = _scn(
+        ground_objects=("glider_trailer_1",),
+        ground_object_defs={"glider_trailer_1": mover},
+        region_preferences={"glider_trailer_1": RegionPreference("right", 1.0)},
+    )
+    assert s.region_preferences["glider_trailer_1"].weight == 1.0
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_models_region.py -q`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'region_preferences'`.
+
+- [ ] **Step 3: Implement the `Scenario` additions**
+
+In `src/hangarfit/models.py` `class Scenario`, after `ground_object_defs` (line ~1114) add:
+
+```python
+    fixed_obstacle_placements: tuple[Placement, ...] = ()
+    region_preferences: Mapping[str, RegionPreference] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+```
+
+Extend `_PROXY_FIELDS` (line ~1121) to include the new mapping:
+
+```python
+    _PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = (
+        "fleet",
+        "constraints",
+        "ground_object_defs",
+        "region_preferences",
+    )
+```
+
+Add a `mover_ids` cached property after `__post_init__` (the set of placed_routed_mover ids active in the scenario, in `ground_objects` order):
+
+```python
+    @property
+    def mover_ids(self) -> tuple[str, ...]:
+        """Placed-routed-mover ids active in this scenario, in ``ground_objects`` order.
+
+        These are the ground objects the solver PLACES + routes (vs fixed
+        obstacles, which are authored static keep-outs in
+        :attr:`fixed_obstacle_placements`). Empty ⇒ the solver is aircraft-only
+        and byte-identical to the pre-#604 behaviour (ADR-0003)."""
+        return tuple(
+            gid
+            for gid in self.ground_objects
+            if self.ground_object_defs[gid].object_class == "placed_routed_mover"
+        )
+
+    @property
+    def placeable_ids(self) -> tuple[str, ...]:
+        """Aircraft (``fleet_in``) then sorted mover ids — the unified search bodies.
+
+        ``maintenance_plane`` is still excluded at sample time (it is treated as
+        away). With no movers this is exactly ``fleet_in`` (ADR-0003)."""
+        return self.fleet_in + tuple(sorted(self.mover_ids))
+```
+
+In `__post_init__`, after the ground-object validation block (after line ~1250, before the `_PROXY_FIELDS` wrap loop) add region-preference + fixed-obstacle validation:
+
+```python
+        # Region preferences (#604): every key must reference a placeable body —
+        # an aircraft in fleet_in or a placed_routed_mover ground object. A pref
+        # on a fixed obstacle is meaningless (it never moves) and is rejected.
+        placeable = set(self.fleet_in) | {
+            gid
+            for gid in self.ground_objects
+            if self.ground_object_defs[gid].object_class == "placed_routed_mover"
+        }
+        for rid in self.region_preferences:
+            if rid not in placeable:
+                raise ValueError(
+                    f"Scenario.region_preferences references {rid!r} which is not a "
+                    f"placeable body (aircraft or placed_routed_mover); "
+                    f"placeable ids: {sorted(placeable)}"
+                )
+        # Fixed-obstacle placements must reference fixed_obstacle ground objects
+        # present in ground_objects, with no duplicates.
+        seen_fixed: set[str] = set()
+        for p in self.fixed_obstacle_placements:
+            if p.plane_id not in self.ground_object_defs:
+                raise ValueError(
+                    f"Scenario.fixed_obstacle_placements references unknown ground "
+                    f"object {p.plane_id!r}"
+                )
+            if self.ground_object_defs[p.plane_id].object_class != "fixed_obstacle":
+                raise ValueError(
+                    f"Scenario.fixed_obstacle_placements[{p.plane_id!r}] is not a "
+                    f"fixed_obstacle"
+                )
+            if p.plane_id in seen_fixed:
+                raise ValueError(
+                    f"Duplicate fixed_obstacle_placement for {p.plane_id!r}"
+                )
+            seen_fixed.add(p.plane_id)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest tests/test_models_region.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Run the model + scenario regression set**
+
+Run: `pytest tests/test_models.py tests/test_solver_canaries.py -q`
+Expected: PASS (the new optional fields default empty ⇒ no behavior change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_models_region.py
+git commit -m "feat(604): Scenario.region_preferences + fixed_obstacle_placements + mover_ids
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `SolverDiagnostics.region_alignment`
+
+**Files:**
+- Modify: `src/hangarfit/models.py` — `SolverDiagnostics` field (~1420) + `__post_init__` validation (~1450)
+- Test: `tests/test_models_region.py`
+
+Representation: `tuple[tuple[tuple[str, float], ...], ...]` — outer index-aligned with `SolveResult.layouts`; inner = `(id, alignment)` pairs in sorted id order; `alignment ∈ [0, 1]` (1.0 = at the preferred wall). Hashable (frozen-dataclass-safe), JSON-friendly.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/test_models_region.py
+from hangarfit.models import SolverDiagnostics
+
+def _diag(**kw):
+    base = dict(restarts_attempted=1, wall_time_s=0.0, best_partial=None,
+                best_partial_layout=None, seed=0)
+    base.update(kw)
+    return SolverDiagnostics(**base)
+
+
+def test_region_alignment_default_empty():
+    assert _diag().region_alignment == ()
+
+
+def test_region_alignment_valid():
+    d = _diag(region_alignment=((("glider_trailer_1", 0.92),),))
+    assert d.region_alignment[0][0] == ("glider_trailer_1", 0.92)
+
+
+@pytest.mark.parametrize("bad", [-0.01, 1.01, float("nan")])
+def test_region_alignment_rejects_out_of_range(bad):
+    with pytest.raises(ValueError):
+        _diag(region_alignment(((("t", bad),),)) if False else None)  # placeholder
+```
+
+Replace the broken last test with:
+
+```python
+@pytest.mark.parametrize("bad", [-0.01, 1.01, float("nan")])
+def test_region_alignment_rejects_out_of_range(bad):
+    with pytest.raises(ValueError):
+        _diag(region_alignment=((("t", bad),),))
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_models_region.py -q -k region_alignment`
+Expected: FAIL — `TypeError: unexpected keyword argument 'region_alignment'`.
+
+- [ ] **Step 3: Implement**
+
+Add field to `SolverDiagnostics` after `nose_out_flips` (line ~1420):
+
+```python
+    region_alignment: tuple[tuple[tuple[str, float], ...], ...] = ()
+```
+
+Add validation in `SolverDiagnostics.__post_init__` after the `nose_out_flips` check (line ~1454):
+
+```python
+        for layout_alignments in self.region_alignment:
+            for _id, a in layout_alignments:
+                if math.isnan(a) or a < 0.0 or a > 1.0:
+                    raise ValueError(
+                        "SolverDiagnostics.region_alignment values must be in "
+                        f"[0.0, 1.0], got {a!r}"
+                    )
+```
+
+Document the field in the class docstring (after the `nose_out_flips` paragraph, ~line 1370):
+
+```
+``region_alignment`` is index-aligned with :attr:`SolveResult.layouts`: for each
+returned layout, a tuple of ``(body_id, alignment)`` pairs (sorted by id) for the
+bodies carrying a :class:`RegionPreference`, where ``alignment`` is 0–1 with 1.0
+meaning the body sits exactly at its preferred wall (#604, ADR-0008 amended).
+Empty when no scenario region preferences are set. Advisory / RNG-free.
+```
+
+Note: `SolveResult.__post_init__` validates index-alignment of `min_pairwise_gap_m`/`nose_out_flips` against `layouts` (models.py ~1504). Add `region_alignment` to that length check:
+
+```python
+        # in SolveResult.__post_init__, alongside the existing per-layout tuples:
+        if self.diagnostics.region_alignment and len(self.diagnostics.region_alignment) != len(self.layouts):
+            raise ValueError(
+                "SolverDiagnostics.region_alignment length must match layouts when populated"
+            )
+```
+(Read the existing check at `models.py:1504` first and mirror its exact style/guard.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest tests/test_models_region.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/test_models_region.py
+git commit -m "feat(604): SolverDiagnostics.region_alignment per-layout per-object metric
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Loader — parse scenario `ground_objects:` (fixed poses + mover entries + region_preference)
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` — scenario GO parse (`load_scenario`, ~803-822) + a new allowlist
+- Test: `tests/test_loader_scenario_ground_objects.py` (create) + fixtures under `tests/fixtures/`
+
+Scenario YAML schema (new):
+```yaml
+ground_objects:
+  - object: maul_fuel_trailer       # fixed_obstacle → REQUIRES pose, FORBIDS region_preference
+    x_m: 1.2
+    y_m: 2.0
+    heading_deg: 90.0
+  - object: glider_trailer_1        # placed_routed_mover → FORBIDS pose, allows region_preference
+    region_preference: { side: right, weight: 1.0 }
+  - glider_trailer_2                # bare string also accepted for a mover (no pref)
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_loader_scenario_ground_objects.py
+from pathlib import Path
+import pytest
+from hangarfit.loader import load_scenario, LoaderError
+
+FIX = Path(__file__).parent / "fixtures"
+
+
+def test_scenario_loads_mover_with_region_preference():
+    s = load_scenario(FIX / "scenario_region_demo.yaml")
+    assert "glider_trailer_1" in s.mover_ids
+    assert s.region_preferences["glider_trailer_1"].side == "right"
+
+
+def test_scenario_loads_fixed_obstacle_pose():
+    s = load_scenario(FIX / "scenario_region_demo.yaml")
+    ids = {p.plane_id for p in s.fixed_obstacle_placements}
+    assert "maul_fuel_trailer" in ids
+
+
+def test_scenario_fixed_obstacle_requires_pose(tmp_path):
+    # a fixed_obstacle entry WITHOUT x_m/y_m/heading_deg is rejected
+    ...  # build a minimal scenario referencing maul_fuel_trailer with no pose
+    with pytest.raises(LoaderError):
+        load_scenario(tmp_path / "bad.yaml")
+
+
+def test_scenario_mover_forbids_pose(tmp_path):
+    # a placed_routed_mover entry WITH x_m is rejected (the solver places it)
+    with pytest.raises(LoaderError):
+        load_scenario(tmp_path / "bad2.yaml")
+```
+
+(Fill the two `tmp_path` builders by writing a tiny scenario YAML mirroring `scenario_region_demo.yaml` with the offending field; see Task 16 for the demo fixture content.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_loader_scenario_ground_objects.py -q`
+Expected: FAIL (fixture missing / current loader ignores the new keys).
+
+- [ ] **Step 3: Implement the loader parse**
+
+Read `load_scenario`'s current `ground_objects` parse (`loader.py:803-822`). Replace the id-string-list parse with an entry parser that resolves each entry's `object` id against `ground_object_defs`, branches on `object_class`, and accumulates three outputs: `scenario_ground_objects` (all ids), `fixed_obstacle_placements`, `region_preferences`.
+
+```python
+_ALLOWED_SCENARIO_GO_KEYS = frozenset({"object", "x_m", "y_m", "heading_deg", "region_preference"})
+_ALLOWED_REGION_PREF_KEYS = frozenset({"side", "weight"})
+
+# inside load_scenario, replacing the id-list parse:
+go_entries = raw.get("ground_objects", [])
+if not isinstance(go_entries, list):
+    raise LoaderError(f"{path}: 'ground_objects' must be a list")
+
+scenario_ground_objects: list[str] = []
+fixed_obstacle_placements: list[Placement] = []
+region_preferences: dict[str, RegionPreference] = {}
+
+for i, entry in enumerate(go_entries):
+    if isinstance(entry, str):
+        gid, fields = entry, {}
+    elif isinstance(entry, dict):
+        unknown = set(entry) - _ALLOWED_SCENARIO_GO_KEYS
+        if unknown:
+            raise LoaderError(f"{path}: ground_objects[{i}] has unknown key(s) {sorted(unknown)}")
+        if "object" not in entry:
+            raise LoaderError(f"{path}: ground_objects[{i}] missing required 'object'")
+        gid, fields = entry["object"], entry
+    else:
+        raise LoaderError(f"{path}: ground_objects[{i}] must be a string or mapping")
+
+    if gid not in ground_objects:  # ground_objects = resolved defs dict in this fn
+        raise LoaderError(
+            f"{path}: ground_objects[{i}] references unknown object {gid!r}; "
+            f"defs have: {sorted(ground_objects)}"
+        )
+    if gid in scenario_ground_objects:
+        raise LoaderError(f"{path}: duplicate scenario ground object {gid!r}")
+    scenario_ground_objects.append(gid)
+    obj_class = ground_objects[gid].object_class
+
+    has_pose = any(k in fields for k in ("x_m", "y_m", "heading_deg"))
+    if obj_class == "fixed_obstacle":
+        if "region_preference" in fields:
+            raise LoaderError(f"{path}: ground_objects[{i}] ({gid}): a fixed_obstacle cannot carry a region_preference")
+        missing = [k for k in ("x_m", "y_m", "heading_deg") if k not in fields]
+        if missing:
+            raise LoaderError(f"{path}: ground_objects[{i}] ({gid}): fixed_obstacle requires {missing}")
+        fixed_obstacle_placements.append(
+            Placement(plane_id=gid, x_m=float(fields["x_m"]), y_m=float(fields["y_m"]),
+                      heading_deg=float(fields["heading_deg"]), on_carts=False)
+        )
+    else:  # placed_routed_mover
+        if has_pose:
+            raise LoaderError(f"{path}: ground_objects[{i}] ({gid}): a placed_routed_mover must not carry a pose (the solver places it)")
+        rp = fields.get("region_preference")
+        if rp is not None:
+            if not isinstance(rp, dict) or set(rp) - _ALLOWED_REGION_PREF_KEYS or "side" not in rp or "weight" not in rp:
+                raise LoaderError(f"{path}: ground_objects[{i}] ({gid}): region_preference must be {{side, weight}}")
+            try:
+                region_preferences[gid] = RegionPreference(side=rp["side"], weight=float(rp["weight"]))
+            except ValueError as e:
+                raise LoaderError(f"{path}: ground_objects[{i}] ({gid}): {e}") from e
+
+# pass the three through to Scenario(...)
+```
+
+Update the `Scenario(...)` construction (loader.py ~815-822) to pass `fixed_obstacle_placements=tuple(fixed_obstacle_placements)` and `region_preferences=region_preferences`. Add `RegionPreference` to the `models` import at the top of `loader.py`.
+
+- [ ] **Step 4: Create the demo fixture** (shared with Task 16) — see Task 16 Step 1 for `tests/fixtures/scenario_region_demo.yaml` + `fleet_region_demo.yaml`. Create them now so the loader tests have data.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `pytest tests/test_loader_scenario_ground_objects.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Run loader regression**
+
+Run: `pytest tests/test_loader.py tests/test_loader_catalog.py -q`
+Expected: PASS (existing scenarios have no `ground_objects:` block ⇒ untouched).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader_scenario_ground_objects.py tests/fixtures/scenario_region_demo.yaml tests/fixtures/fleet_region_demo.yaml
+git commit -m "feat(604): scenario ground_objects parse — fixed poses + mover region_preference
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Solver `_body` / `_body_parts_world` dispatch helpers
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` (add helpers near the top imports/utilities)
+- Test: `tests/test_solver_ground_objects.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_solver_ground_objects.py
+from hangarfit.solver import _body, _body_parts_world
+from hangarfit.geometry import cached_parts_world  # current aircraft world-parts path
+# build a Scenario `s` with one aircraft 'husky' and one mover 'glider_trailer_1'
+# (reuse the demo fixture via load_scenario, or construct inline).
+
+
+def test_body_returns_aircraft_for_fleet_id(region_scenario):
+    s = region_scenario
+    assert _body(s, "husky").id == "husky"
+
+
+def test_body_returns_ground_object_for_mover_id(region_scenario):
+    s = region_scenario
+    assert _body(s, "glider_trailer_1").object_class == "placed_routed_mover"
+
+
+def test_body_parts_world_aircraft_byte_identical(region_scenario):
+    # aircraft path must be the SAME object/values as cached_parts_world (ADR-0003)
+    s = region_scenario
+    from hangarfit.models import Placement
+    p = Placement("husky", 5.0, 8.0, 30.0, on_carts=False)
+    assert _body_parts_world(s, "husky", p) == cached_parts_world(s.fleet["husky"], p)
+```
+
+(Provide a `region_scenario` pytest fixture in a local `conftest.py` or the test file that `load_scenario(FIX/"scenario_region_demo.yaml")`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_solver_ground_objects.py -q -k body`
+Expected: FAIL — `ImportError: cannot import name '_body'`.
+
+- [ ] **Step 3: Implement**
+
+In `solver.py` (confirm the exact name of the current aircraft world-parts helper used by `_inter_plane_energy` — it is `cached_parts_world(scenario.fleet[pid], placement)`; reuse it for aircraft to preserve byte-identity):
+
+```python
+def _body(scenario: Scenario, body_id: str) -> Aircraft | GroundObject:
+    """Resolve a placeable body id to its Aircraft or GroundObject definition (#604).
+
+    Aircraft live in ``fleet``; placed_routed_mover ground objects in
+    ``ground_object_defs``. Aircraft are checked first so the common (and
+    pre-#604) path is unchanged."""
+    plane = scenario.fleet.get(body_id)
+    if plane is not None:
+        return plane
+    return scenario.ground_object_defs[body_id]
+
+
+def _body_parts_world(scenario: Scenario, body_id: str, placement: Placement) -> list[WorldPart]:
+    """World parts for any placeable body. Aircraft reuse the memoized
+    ``cached_parts_world`` (BYTE-IDENTICAL to the pre-#604 path, ADR-0003); movers
+    use the same world-parts transform the towplanner already applies to
+    GroundObjects (#602)."""
+    body = _body(scenario, body_id)
+    return cached_parts_world(body, placement)
+```
+
+Note: confirm `cached_parts_world` accepts a `GroundObject` (the towplanner already calls the world-parts transform on GroundObjects per #602; if the memoized variant is aircraft-only, call the uncached `aircraft_parts_world`/`parts_world` for movers — the towplanner-mover map says movers use the *uncached* `aircraft_parts_world`. Match that exactly so geometry is identical to the planner's.) Add `GroundObject`, `WorldPart` to imports if absent.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest tests/test_solver_ground_objects.py -q -k body`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_ground_objects.py
+git commit -m "feat(604): _body / _body_parts_world dispatch over Aircraft|GroundObject
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Centralize `Layout` construction in `_build_layout` (byte-identical refactor)
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` — add `_build_layout`; replace inline `Layout(...)` builds at ~255, ~287, ~320, ~1052, ~1381, ~1472, ~1808, ~1858, ~2011 (audit all)
+- Test: `tests/test_solver_ground_objects.py`
+
+`_build_layout` splits the unified placements dict into aircraft `placements=` and mover `ground_object_placements=`, appends `scenario.fixed_obstacle_placements`, and sets `ground_objects=` from the active defs. With an aircraft-only dict + no ground objects it produces a `Layout` **identical** to today's inline build.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append tests/test_solver_ground_objects.py
+from hangarfit.solver import _build_layout
+from hangarfit.models import Placement
+
+
+def test_build_layout_aircraft_only_matches_plain_layout(region_scenario_no_go):
+    s = region_scenario_no_go  # a scenario with NO ground objects
+    placements = {"husky": Placement("husky", 5.0, 8.0, 0.0, on_carts=False)}
+    from hangarfit.models import Layout
+    built = _build_layout(s, placements)
+    plain = Layout(fleet=s.fleet, hangar=s.hangar,
+                   placements=tuple(placements.values()),
+                   maintenance_plane=s.maintenance_plane)
+    assert built.placements == plain.placements
+    assert built.ground_object_placements == ()
+
+
+def test_build_layout_splits_movers_and_injects_fixed(region_scenario):
+    s = region_scenario  # husky + glider_trailer_1 (mover) + maul_fuel_trailer (fixed pose)
+    placements = {
+        "husky": Placement("husky", 5.0, 8.0, 0.0, on_carts=False),
+        "glider_trailer_1": Placement("glider_trailer_1", 12.0, 20.0, 90.0, on_carts=False),
+    }
+    built = _build_layout(s, placements)
+    assert {p.plane_id for p in built.placements} == {"husky"}
+    go_ids = {p.plane_id for p in built.ground_object_placements}
+    assert "glider_trailer_1" in go_ids and "maul_fuel_trailer" in go_ids
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_solver_ground_objects.py -q -k build_layout`
+Expected: FAIL — `_build_layout` undefined.
+
+- [ ] **Step 3: Implement `_build_layout`**
+
+```python
+def _build_layout(scenario: Scenario, placements: Mapping[str, Placement]) -> Layout:
+    """Build a Layout from a unified placeable-body dict (#604).
+
+    Splits ``placements`` into aircraft (ids in ``fleet``) and mover ground
+    objects (ids in ``ground_object_defs``), injects the authored
+    ``fixed_obstacle_placements``, and wires the active ``ground_objects`` defs.
+    With an aircraft-only dict and a scenario with no ground objects this yields a
+    Layout byte-identical to the pre-#604 inline construction (ADR-0003)."""
+    aircraft: list[Placement] = []
+    movers: list[Placement] = []
+    for pid, p in placements.items():
+        (aircraft if pid in scenario.fleet else movers).append(p)
+    go_placements = tuple(movers) + scenario.fixed_obstacle_placements
+    if not go_placements:
+        # No ground objects: identical to today's call (empty GO fields default).
+        return Layout(
+            fleet=scenario.fleet,
+            hangar=scenario.hangar,
+            placements=tuple(aircraft),
+            maintenance_plane=scenario.maintenance_plane,
+        )
+    return Layout(
+        fleet=scenario.fleet,
+        hangar=scenario.hangar,
+        placements=tuple(aircraft),
+        maintenance_plane=scenario.maintenance_plane,
+        ground_objects={gid: scenario.ground_object_defs[gid] for gid in scenario.ground_objects},
+        ground_object_placements=go_placements,
+    )
+```
+
+Note: `Layout.placements` ordering matters for downstream determinism. Today the inline builds use `tuple(placements.values())` over the aircraft dict (insertion order = `fleet_in`). Preserve that: build `aircraft` by iterating `placements` in its existing insertion order (the dict is `fleet_in`-then-mover ordered after Task 8). Since aircraft are inserted first (Task 8 appends movers after), `aircraft` keeps `fleet_in` order. **Verify** with the canaries in Step 5.
+
+- [ ] **Step 4: Replace inline builds**
+
+Replace each `Layout(fleet=scenario.fleet, hangar=scenario.hangar, placements=tuple(<dict>.values()), maintenance_plane=scenario.maintenance_plane)` in `solver.py` with `_build_layout(scenario, <dict>)`. Audit every `Layout(` in solver.py (grep) — the restart body (255/287/320), `_nose_out` (1381), `_spread` trial (1472), `_descent_step` build (1808/1858), the pin-only build (1052), and the final return (2011). **Do not** change `_build_exhausted_result`'s re-check or any `check_layout` call signature.
+
+- [ ] **Step 5: Run the determinism canaries (CRITICAL)**
+
+Run: `pytest tests/test_solver_canaries.py tests/test_solver_parallel.py tests/test_solver_spread.py -q`
+Expected: PASS, unchanged. If any canary flips, the refactor changed placement ordering — fix `_build_layout` to match the pre-refactor tuple order before proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_ground_objects.py
+git commit -m "refactor(604): centralize Layout construction in _build_layout (byte-identical)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Unified placeable set in `_initial_placements` (movers sampled; cart-excluded)
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` — `_initial_placements` (~1524-1575), `_initial_placement_for_plane` (~1140-1180), `_enumerate_cart_buckets` (mover exclusion — already iterates fleet_in, so movers are naturally excluded; confirm)
+- Test: `tests/test_solver_ground_objects.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append tests/test_solver_ground_objects.py
+import random
+from hangarfit.solver import _initial_placements
+
+
+def test_initial_placements_samples_movers(region_scenario):
+    s = region_scenario
+    rng = random.Random(0)
+    pl = _initial_placements(scenario=s, rng=rng, cart_bucket=frozenset())
+    assert "glider_trailer_1" in pl and pl["glider_trailer_1"].on_carts is False
+
+
+def test_initial_placements_no_go_unchanged(region_scenario_no_go):
+    # With no movers, the sampled aircraft poses are byte-identical to a direct
+    # pre-#604 sample (same seed, same draw order).
+    s = region_scenario_no_go
+    a = _initial_placements(scenario=s, rng=random.Random(7), cart_bucket=frozenset())
+    b = _initial_placements(scenario=s, rng=random.Random(7), cart_bucket=frozenset())
+    assert {k: (v.x_m, v.y_m, v.heading_deg) for k, v in a.items()} == \
+           {k: (v.x_m, v.y_m, v.heading_deg) for k, v in b.items()}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_solver_ground_objects.py -q -k initial_placements`
+Expected: FAIL — movers not sampled (`KeyError`).
+
+- [ ] **Step 3: Implement**
+
+In `_initial_placements` (after the `fleet_in` loop, ~line 1575), append mover sampling in `sorted(mover_ids)` order. The per-body sampler must use the body's footprint margins, so generalize `_initial_placement_for_plane` to take a body (via `_body`) instead of `scenario.fleet[pid]`:
+
+```python
+    # Movers (#604): sampled AFTER all aircraft, in sorted-id order, so adding a
+    # mover never reorders aircraft draws (ADR-0003: aircraft-only is unchanged).
+    for gid in sorted(scenario.mover_ids):
+        placements[gid] = _initial_placement_for_plane(
+            plane_id=gid,
+            scenario=scenario,
+            rng=rng,
+            on_carts=False,  # movers never ride carts
+        )
+```
+
+In `_initial_placement_for_plane` (and the bbox-margin computation it calls), replace `scenario.fleet[plane_id]` with `_body(scenario, plane_id)` and derive the bbox/margins from that body's parts. Confirm `_enumerate_cart_buckets` iterates `scenario.fleet_in` (it does — movers are not in `fleet_in`, so they are already cart-excluded; no change needed).
+
+- [ ] **Step 4: Run to verify pass + canaries**
+
+Run: `pytest tests/test_solver_ground_objects.py -q -k initial_placements && pytest tests/test_solver_canaries.py tests/test_solver_parallel.py -q`
+Expected: PASS, canaries unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_ground_objects.py
+git commit -m "feat(604): sample mover initial poses in _initial_placements (cart-excluded)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Movers perturbable in the hard descent
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` — `_perturb_plane` (~1657), `_generate_candidates` (~1711), `_descent_step` (the conflict-body selection + candidate build)
+- Test: `tests/test_solver_ground_objects.py`
+
+Goal: movers are valid perturbation targets in `_descent_step`; the unified placements dict carries them through descent. Geometry/bbox lookups dispatch via `_body`. Byte-identical when no movers (the descent target set == aircraft when no movers exist).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append tests/test_solver_ground_objects.py
+from hangarfit.solver import _perturb_plane
+from hangarfit.models import Placement, SearchConfig
+import random
+
+
+def test_perturb_mover_stays_on_gear(region_scenario):
+    s = region_scenario
+    cur = Placement("glider_trailer_1", 12.0, 20.0, 90.0, on_carts=False)
+    out = _perturb_plane(current=cur, scenario=s, rng=random.Random(0),
+                         search=SearchConfig(), large_jump=False)
+    assert out.on_carts is False
+    assert out.plane_id == "glider_trailer_1"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_solver_ground_objects.py -q -k perturb_mover`
+Expected: FAIL — `_perturb_plane` looks up `scenario.fleet[...]` and `KeyError`s on the mover id.
+
+- [ ] **Step 3: Implement**
+
+In `_perturb_plane` and `_generate_candidates`, replace `scenario.fleet[current.plane_id]` / `scenario.fleet[target]` with `_body(scenario, …)` for bbox-margin and footprint computations. In `_descent_step`, the conflict-body selection iterates the placements dict — confirm it does not special-case `scenario.fleet` membership; if it does, broaden it to the unified placeable set (movers are perturbable targets). Pinned bodies (none for movers in this cut) stay excluded.
+
+- [ ] **Step 4: Run to verify pass + canaries**
+
+Run: `pytest tests/test_solver_ground_objects.py -q -k perturb && pytest tests/test_solver_canaries.py tests/test_solver_parallel.py -q`
+Expected: PASS, canaries unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_ground_objects.py
+git commit -m "feat(604): movers are perturbable bodies in the hard descent
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Energy functions iterate the unified placeable set
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` — `_inter_plane_energy` (~1199), `_spread_quality` (~1283), `_back_bias_energy` (~1256)
+- Test: `tests/test_solver_region.py` (create)
+
+Replace `cached_parts_world(scenario.fleet[pid], …)` with `_body_parts_world(scenario, pid, …)` in `_inter_plane_energy` and `_spread_quality`. `_back_bias_energy` already sums over `sorted(placements)` and only reads `y_m`, so it works for movers unchanged. The pairwise repulsion now also repels movers from aircraft/each other (desirable).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_solver_region.py
+import math
+from hangarfit.solver import _inter_plane_energy, _resolve_spread_scale
+from hangarfit.models import Placement, SearchConfig
+
+
+def test_inter_plane_energy_includes_movers(region_scenario):
+    s = region_scenario
+    scale = _resolve_spread_scale(s, SearchConfig())
+    placements = {
+        "husky": Placement("husky", 5.0, 8.0, 0.0, on_carts=False),
+        "glider_trailer_1": Placement("glider_trailer_1", 6.0, 8.0, 0.0, on_carts=False),
+    }
+    e = _inter_plane_energy(placements, s, scale)
+    assert e > 0.0  # two near bodies repel; mover participates
+
+
+def test_inter_plane_energy_no_go_byte_identical(region_scenario_no_go):
+    s = region_scenario_no_go
+    scale = _resolve_spread_scale(s, SearchConfig())
+    placements = {"husky": Placement("husky", 5.0, 8.0, 0.0, on_carts=False),
+                  "fuji": Placement("fuji", 9.0, 8.0, 0.0, on_carts=False)}
+    e1 = _inter_plane_energy(placements, s, scale)
+    e2 = _inter_plane_energy(placements, s, scale)
+    assert e1 == e2  # exact
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_solver_region.py -q -k inter_plane_energy`
+Expected: FAIL — `scenario.fleet[...]` `KeyError` on the mover.
+
+- [ ] **Step 3: Implement**
+
+In `_inter_plane_energy` (line ~1236) and `_spread_quality` (line ~1304), change:
+```python
+world = {pid: cached_parts_world(scenario.fleet[pid], placements[pid]) for pid in ids}
+```
+to:
+```python
+world = {pid: _body_parts_world(scenario, pid, placements[pid]) for pid in ids}
+```
+(`ids = sorted(placements)` already includes movers once they are in the dict.) Leave `_priority_weight` as-is (movers have no `PlaneConstraint`, so `w == 1.0` for them — neutral, correct).
+
+- [ ] **Step 4: Run to verify pass + canaries**
+
+Run: `pytest tests/test_solver_region.py -q -k inter_plane && pytest tests/test_solver_canaries.py tests/test_solver_spread.py -q`
+Expected: PASS, canaries unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_region.py
+git commit -m "feat(604): energy functions score movers via _body_parts_world
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: `_region_energy` + fold into `_spread._energy` (inert trio)
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` — add `_region_energy`; `_spread` `_energy` local (~1425-1439) + the `back_fill`/`region_active` gating (~1418)
+- Test: `tests/test_solver_region.py`
+
+- [ ] **Step 1: Write the failing tests (the inert trio + formula)**
+
+```python
+# append tests/test_solver_region.py
+from hangarfit.solver import _region_energy
+from hangarfit.models import RegionPreference
+
+
+def test_region_energy_empty_is_zero(region_scenario_no_go):
+    s = region_scenario_no_go
+    placements = {"husky": Placement("husky", 5.0, 8.0, 0.0, on_carts=False)}
+    assert _region_energy(placements, s) == 0.0  # no preferences ⇒ inert
+
+
+def test_region_energy_right_minimized_at_right_wall(region_scenario):
+    # right pref: energy DECREASES as x → width_m
+    s = region_scenario  # has region_preferences['glider_trailer_1'] = right,1.0
+    W = s.hangar.width_m
+    near_left = {"glider_trailer_1": Placement("glider_trailer_1", 1.0, 10.0, 0.0, on_carts=False)}
+    near_right = {"glider_trailer_1": Placement("glider_trailer_1", W - 1.0, 10.0, 0.0, on_carts=False)}
+    assert _region_energy(near_right, s) < _region_energy(near_left, s)
+
+
+def test_region_energy_formula(region_scenario):
+    s = region_scenario
+    W = s.hangar.width_m
+    x = 3.0
+    pl = {"glider_trailer_1": Placement("glider_trailer_1", x, 10.0, 0.0, on_carts=False)}
+    # weight 1.0, side right ⇒ (W - x)/W
+    assert _region_energy(pl, s) == pytest.approx((W - x) / W)
+```
+
+(`import pytest` at top.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_solver_region.py -q -k region_energy`
+Expected: FAIL — `_region_energy` undefined.
+
+- [ ] **Step 3: Implement `_region_energy`**
+
+```python
+def _region_energy(placements: Mapping[str, Placement], scenario: Scenario) -> float:
+    """Soft right/left wall-alignment bias ``R = Σ wₒ·dₒ / W`` (#604).
+
+    For each body ``o`` carrying a :class:`RegionPreference`, ``dₒ`` is the
+    distance from ``x_o`` to the preferred wall — ``(W − x_o)`` for ``"right"``,
+    ``x_o`` for ``"left"`` — normalized by ``W = hangar.width_m`` so one weight
+    reads across hangar sizes (mirrors ``_back_bias_energy``'s ``length_m``
+    normalization, #320). Minimized when the body sits at its preferred wall.
+    Summed over preferring ids in ``sorted`` order (order-stable float sum).
+    RNG-free. ``0.0`` when no preferences (inert ⇒ byte-identical, ADR-0003).
+    """
+    prefs = scenario.region_preferences
+    if not prefs:
+        return 0.0
+    width = scenario.hangar.width_m
+    total = 0.0
+    for pid in sorted(prefs):
+        if pid not in placements:
+            continue  # e.g. maintenance plane (away) — not placed
+        pref = prefs[pid]
+        x = placements[pid].x_m
+        d = (width - x) if pref.side == "right" else x
+        total += pref.weight * (d / width)
+    return total
+```
+
+Fold into `_spread`. At line ~1418 add the gate alongside `back_fill`:
+```python
+    region_active = bool(scenario.region_preferences)
+```
+In the `_energy` local (line ~1436-1439) add the term:
+```python
+        e = _inter_plane_energy(trial, scenario, scale, gap_cache=gap_cache, moved=moved)
+        if back_fill:
+            e += search.back_bias_weight * _back_bias_energy(trial, scenario)
+        if region_active:
+            e += _region_energy(trial, scenario)
+        return e
+```
+(The per-object `weight` already scales the term — no extra global multiplier, matching the spec.) Also widen the early-bail guard at line ~1419 so a lone preferring body still runs the hill-climb: change `if not movable or (len(placements) < 2 and not back_fill):` to `... and not back_fill and not region_active):`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest tests/test_solver_region.py -q -k region_energy`
+Expected: PASS.
+
+- [ ] **Step 5: Inert trio at solve level — write + run**
+
+```python
+# append tests/test_solver_region.py
+from hangarfit.solver import solve
+from hangarfit.models import SearchConfig
+
+
+def _key(layouts):
+    return [[(p.plane_id, p.x_m, p.y_m, p.heading_deg) for p in l.placements] for l in layouts]
+
+
+def test_solve_no_region_pref_byte_identical(region_scenario_no_go):
+    s = region_scenario_no_go
+    cfg = SearchConfig(max_restarts=4, spread=True)
+    a = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    b = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    assert _key(a.layouts) == _key(b.layouts)
+
+
+def test_solve_region_pref_active_deterministic(region_scenario):
+    s = region_scenario
+    cfg = SearchConfig(max_restarts=4, spread=True)
+    a = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    b = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    assert _key(a.layouts) == _key(b.layouts)
+```
+
+Run: `pytest tests/test_solver_region.py -q && pytest tests/test_solver_canaries.py tests/test_solver_parallel.py tests/test_solver_spread.py -q`
+Expected: PASS, canaries unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_region.py
+git commit -m "feat(604): _region_energy soft term folded into _spread (default-inert)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: `_spread` movable includes movers + region effect
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` — `_spread` `movable` set (~1417)
+- Test: `tests/test_solver_region.py`
+
+Today `movable = sorted(pid for pid in placements if pid not in pinned_planes)` — once movers are in `placements` (Task 7), they are already movable. This task adds the **effect** test that proves the region term shifts the trailer, and confirms `movable` includes movers.
+
+- [ ] **Step 1: Write the failing/effect test**
+
+```python
+# append tests/test_solver_region.py
+def test_region_pref_pulls_trailer_right(region_scenario, region_scenario_left):
+    # Same scenario except region side; the right-pref trailer ends further right.
+    cfg = SearchConfig(max_restarts=6, spread=True)
+    r = solve(region_scenario, search=cfg, seed=1, budget_s=120.0, plan_paths=False)
+    l = solve(region_scenario_left, search=cfg, seed=1, budget_s=120.0, plan_paths=False)
+    x_right = [p for p in r.layouts[0].ground_object_placements if p.plane_id == "glider_trailer_1"][0].x_m
+    x_left = [p for p in l.layouts[0].ground_object_placements if p.plane_id == "glider_trailer_1"][0].x_m
+    assert x_right > x_left
+```
+
+(`region_scenario_left` fixture = the demo scenario with `side: left`.)
+
+- [ ] **Step 2: Run to verify it currently fails or is flaky without the term, passes with it**
+
+Run: `pytest tests/test_solver_region.py -q -k pulls_trailer_right`
+Expected: PASS now that Task 10 added the term (if it does not separate, raise `max_restarts` or `weight` in the fixtures until the pull is robust — document the chosen value).
+
+- [ ] **Step 3: Confirm `movable` includes movers** — no code change expected; add an assertion test:
+
+```python
+def test_spread_movable_includes_movers(region_scenario):
+    # indirect: after solve, the trailer is not at its initial sample for all seeds
+    # (it was moved by spread). Covered by pulls_trailer_right; keep as documentation.
+    pass
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_region.py
+git commit -m "test(604): region term pulls the trailer toward its preferred wall
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Populate `region_alignment` diagnostics
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` — `_SpreadCandidate` (~1907) add `region_alignment`; compute it where the candidate is built (~293-300); `_build_found_result` (~843) populate from selected candidates
+- Test: `tests/test_solver_region.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append tests/test_solver_region.py
+def test_region_alignment_surfaced_in_diagnostics(region_scenario):
+    cfg = SearchConfig(max_restarts=6, spread=True)
+    r = solve(region_scenario, search=cfg, seed=1, budget_s=120.0, plan_paths=False)
+    align = r.diagnostics.region_alignment
+    assert len(align) == len(r.layouts)
+    layout0 = dict(align[0])
+    assert 0.0 <= layout0["glider_trailer_1"] <= 1.0
+
+
+def test_region_alignment_empty_when_no_pref(region_scenario_no_go):
+    cfg = SearchConfig(max_restarts=4, spread=True)
+    r = solve(region_scenario_no_go, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    assert r.diagnostics.region_alignment == ()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_solver_region.py -q -k region_alignment`
+Expected: FAIL — alignment always `()`.
+
+- [ ] **Step 3: Implement**
+
+Add a helper to compute per-layout alignment (1.0 at preferred wall):
+```python
+def _region_alignment(placements: Mapping[str, Placement], scenario: Scenario) -> tuple[tuple[str, float], ...]:
+    """Per-preferring-object alignment in [0,1] (1.0 = at preferred wall), sorted by id."""
+    prefs = scenario.region_preferences
+    if not prefs:
+        return ()
+    width = scenario.hangar.width_m
+    out: list[tuple[str, float]] = []
+    for pid in sorted(prefs):
+        if pid not in placements:
+            continue
+        x = placements[pid].x_m
+        frac = (x / width) if prefs[pid].side == "right" else (1.0 - x / width)
+        out.append((pid, max(0.0, min(1.0, frac))))
+    return tuple(out)
+```
+Add `region_alignment` to `_SpreadCandidate` (NamedTuple, ~1907) and compute it where the candidate is built in the restart body (~line 293, alongside `min_gap, energy = _spread_quality(...)`):
+```python
+        cand_alignment = _region_alignment(placements, scenario)
+        candidate = _SpreadCandidate(
+            layout=candidate_layout,
+            min_gap=min_gap,
+            energy=energy,
+            restart_index=restart_index,
+            nose_out_flips=n_flips,
+            region_alignment=cand_alignment,
+        )
+```
+In `_build_found_result` (~843), add `region_alignment=tuple(c.region_alignment for c in selected)` to the `SolverDiagnostics(...)` kwargs.
+
+- [ ] **Step 4: Run to verify pass + canaries**
+
+Run: `pytest tests/test_solver_region.py -q && pytest tests/test_solver_canaries.py -q`
+Expected: PASS, canaries unchanged (alignment is RNG-free; `()` when no prefs).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_region.py
+git commit -m "feat(604): populate SolverDiagnostics.region_alignment per layout
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Egress gate fires in `solve` (verification)
+
+**Files:**
+- Test only: `tests/test_solver_ground_objects.py`
+
+Once movers are in the solved layout (Tasks 7-12) and the scenario carries a `hard_door_mover` (the Caddy), the existing #603 gate at `solver.py:766` fires. This task is a verification test (no new production code unless the gate path needs a small fix).
+
+- [ ] **Step 1: Write the test**
+
+```python
+# append tests/test_solver_ground_objects.py
+def test_solve_with_caddy_routability_gate(region_scenario_with_caddy):
+    # A scenario including the vw_caddy (hard_door_mover) routes-or-rejects via the
+    # egress gate; assert solve completes and, if the caddy is trapped, the layout
+    # is dropped (plans[i] is None) or status reflects no routable candidate.
+    cfg = SearchConfig(max_restarts=6, spread=True)
+    r = solve(region_scenario_with_caddy, search=cfg, seed=0, budget_s=120.0, plan_paths=True)
+    # The gate must have been EXERCISED (caddy present in any returned layout's GO):
+    if r.layouts:
+        go_ids = {p.plane_id for p in r.layouts[0].ground_object_placements}
+        assert "vw_caddy" in go_ids
+```
+
+- [ ] **Step 2: Run**
+
+Run: `pytest tests/test_solver_ground_objects.py -q -k caddy`
+Expected: PASS (or a clear, asserted exit-3/None-plan outcome). If the gate path errors because solve never attached GO placements before #604, this confirms the fix; if it needs a tweak in `_tow_plan_layouts`, make the minimal change and note it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_solver_ground_objects.py
+git commit -m "test(604): #603 egress gate now fires in solve once movers are placed
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: CLI surfacing of `region_alignment`
+
+**Files:**
+- Modify: `src/hangarfit/cli.py` — human `solve` summary + `--json` payload (find the `min gap` / `min_pairwise_gap_m` emission sites)
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append tests/test_cli.py (mirror test_solve_human_output_shows_min_gap / _has_spread_diagnostics)
+def test_solve_human_output_shows_region_alignment(run_cli, region_demo_scenario_path):
+    out = run_cli(["solve", str(region_demo_scenario_path)]).out
+    assert "region" in out.lower()  # a 'region alignment' line
+
+
+def test_solve_json_has_region_alignment(run_cli, region_demo_scenario_path):
+    import json
+    payload = json.loads(run_cli(["solve", str(region_demo_scenario_path), "--json"]).out)
+    diag = payload["diagnostics"]
+    assert "region_alignment" in diag
+    assert len(diag["region_alignment"]) == len(payload["layouts"])
+```
+
+(Use the existing CLI test harness/fixtures in `tests/test_cli.py`; `region_demo_scenario_path` points at the Task 16 demo.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_cli.py -q -k region`
+Expected: FAIL — no region output.
+
+- [ ] **Step 3: Implement**
+
+In `cli.py`, where `min_pairwise_gap_m` is rendered:
+- Human: after the `min gap` line, when `diagnostics.region_alignment` is non-empty, emit per-layout `region alignment: <id>=<0.00-1.00>, …`.
+- JSON: add `"region_alignment"` to the diagnostics dict, serializing each layout's `((id, a), …)` as a JSON object `{id: a}` (or list of `[id, a]` pairs — match the `min_pairwise_gap_m` null-safety; no `Infinity` tokens, values are finite floats in [0,1]).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest tests/test_cli.py -q -k region`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/cli.py tests/test_cli.py
+git commit -m "feat(604): surface region_alignment in solve human + --json output
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: Tractable demo fixture + end-to-end test
+
+**Files:**
+- Create: `tests/fixtures/scenario_region_demo.yaml`, `tests/fixtures/fleet_region_demo.yaml` (created in Task 4; finalize here)
+- Test: `tests/test_solver_region.py`
+
+The demo: a roomy hangar (reuse `tests/fixtures/test_hangar_large.yaml`'s dimensions or the demo hangar) + 2-3 aircraft (small ones: `fuji`, `cessna_150`) + 2 glider trailers (movers) with a right preference. Tuned so the solver reliably finds a valid layout AND both trailers route AND the right pull is observable. The fleet manifest references the existing catalog (aircraft + `glider_trailer_1/2.yaml`).
+
+- [ ] **Step 1: Author the fixtures**
+
+`tests/fixtures/fleet_region_demo.yaml`:
+```yaml
+aircraft:
+  - ../../data/catalog/fuji_fa200.yaml      # confirm exact catalog filenames
+  - ../../data/catalog/cessna_150.yaml
+ground_objects:
+  - ../../data/catalog/glider_trailer_1.yaml
+  - ../../data/catalog/glider_trailer_2.yaml
+  - ../../data/catalog/maul_fuel_trailer.yaml
+```
+`tests/fixtures/scenario_region_demo.yaml`:
+```yaml
+fleet: fleet_region_demo.yaml
+hangar: test_hangar_large.yaml      # roomy enough for 2 aircraft + 2 trailers
+fleet_in: [fuji, cessna_150]
+ground_objects:
+  - object: maul_fuel_trailer
+    x_m: 1.5
+    y_m: 2.0
+    heading_deg: 90.0
+  - object: glider_trailer_1
+    region_preference: { side: right, weight: 1.5 }
+  - object: glider_trailer_2
+    region_preference: { side: right, weight: 1.5 }
+```
+Also create `scenario_region_demo_left.yaml` (identical but `side: left`) for the effect test, and `scenario_region_demo_no_go.yaml` (no `ground_objects:` block) for the inert/byte-identity fixtures. Add the matching pytest fixtures (`region_scenario`, `region_scenario_left`, `region_scenario_no_go`, `region_scenario_with_caddy`) to a `conftest.py` next to the tests or inline.
+
+- [ ] **Step 2: Write the end-to-end test**
+
+```python
+# append tests/test_solver_region.py
+def test_demo_solver_places_and_routes_both_trailers(region_scenario):
+    cfg = SearchConfig(max_restarts=8, spread=True)
+    r = solve(region_scenario, search=cfg, seed=0, budget_s=120.0, plan_paths=True)
+    assert r.status in ("found", "found_partial")
+    go = {p.plane_id for p in r.layouts[0].ground_object_placements}
+    assert {"glider_trailer_1", "glider_trailer_2"}.issubset(go)
+    # both movers routed (plan present and their moves are non-None)
+    plan = r.plans[0]
+    assert plan is not None
+    mover_moves = [m for m in plan.moves if m.plane_id in ("glider_trailer_1", "glider_trailer_2")]
+    assert all(m.path is not None for m in mover_moves)
+```
+
+- [ ] **Step 3: Run to verify pass**
+
+Run: `pytest tests/test_solver_region.py -q -k demo`
+Expected: PASS. If routing is flaky, raise `--tow-max-expansions` via the search/plan call or loosen the hangar; document the tuned values in the fixture comment.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/fixtures/scenario_region_demo*.yaml tests/fixtures/fleet_region_demo.yaml tests/test_solver_region.py tests/conftest.py
+git commit -m "test(604): tractable demo fixture — solver places+routes+right-biases trailers
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 16: Herrenteich scenario opt-in
+
+**Files:**
+- Modify: `examples/herrenteich/scenario.yaml` — add the 2 glider trailers (movers, right pref) + fuel-trailer fixed keep-out
+- Test: `tests/test_examples.py` (or wherever Herrenteich is smoke-tested)
+
+- [ ] **Step 1: Add the ground_objects block to `examples/herrenteich/scenario.yaml`**
+
+```yaml
+ground_objects:
+  - object: maul_fuel_trailer
+    x_m: <real fixed location x>      # from examples/herrenteich/layout_full.yaml GO block
+    y_m: <real fixed location y>
+    heading_deg: <real heading>
+  - object: glider_trailer_1
+    region_preference: { side: right, weight: 1.5 }
+  - object: glider_trailer_2
+    region_preference: { side: right, weight: 1.5 }
+```
+(Confirm the fleet manifest `examples/herrenteich/fleet.yaml` already lists these GO catalog files — it does per the data map. Pull the fuel-trailer pose from `layout_full.yaml` lines 66-82.)
+
+- [ ] **Step 2: Write the honest smoke test**
+
+```python
+# tests/test_examples.py (or new tests/test_herrenteich_region.py)
+def test_herrenteich_scenario_loads_with_region_prefs():
+    s = load_scenario("examples/herrenteich/scenario.yaml")
+    assert s.region_preferences  # opted in
+    assert {"glider_trailer_1", "glider_trailer_2"}.issubset(set(s.mover_ids))
+
+
+@pytest.mark.slow
+def test_herrenteich_solve_is_honest():
+    # The real 8-aircraft set may be intractable (#599); assert solve TERMINATES
+    # with a well-formed result (found/found_partial/exhausted_budget), never raises.
+    s = load_scenario("examples/herrenteich/scenario.yaml")
+    r = solve(s, search=SearchConfig(max_restarts=8, spread=True), seed=0, budget_s=30.0)
+    assert r.status in ("found", "found_partial", "exhausted_budget")
+```
+
+- [ ] **Step 3: Run**
+
+Run: `pytest tests/test_herrenteich_region.py -q` (and `-m slow` for the solve)
+Expected: PASS (load test fast; solve test honest, no exception).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/herrenteich/scenario.yaml tests/test_herrenteich_region.py
+git commit -m "feat(604): opt Herrenteich scenario into trailers + right region preference
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 17: Movers-active determinism canary
+
+**Files:**
+- Test: `tests/test_solver_ground_objects.py` (or `tests/test_solver_canaries.py`)
+
+A dedicated canary that pins same-seed byte-identity with movers + region active (the live-path analogue of the existing `spread=False` canaries). Keep it NON-`@slow` so it stays in the fast coverage set; bound by `max_restarts`, not wall-clock.
+
+- [ ] **Step 1: Write the canary**
+
+```python
+# append tests/test_solver_ground_objects.py
+def test_solve_with_movers_byte_identical_same_seed(region_scenario):
+    cfg = SearchConfig(max_restarts=4, spread=True)
+    a = solve(region_scenario, search=cfg, seed=42, budget_s=120.0, plan_paths=False)
+    b = solve(region_scenario, search=cfg, seed=42, budget_s=120.0, plan_paths=False)
+    def sig(r):
+        return [
+            [(p.plane_id, p.x_m, p.y_m, p.heading_deg) for p in l.placements]
+            + [(p.plane_id, p.x_m, p.y_m, p.heading_deg) for p in l.ground_object_placements]
+            for l in r.layouts
+        ]
+    assert sig(a) == sig(b)
+```
+
+- [ ] **Step 2: Run**
+
+Run: `pytest tests/test_solver_ground_objects.py -q -k byte_identical`
+Expected: PASS.
+
+- [ ] **Step 3: Run the FULL suite**
+
+Run: `pytest -q` (default markers; then `pytest -m "" -q` for everything once before the PR)
+Expected: PASS. A subset can miss `test_loader_catalog` — run the full set as the gate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_solver_ground_objects.py
+git commit -m "test(604): movers-active same-seed byte-identity canary (ADR-0003)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 18: Docs — ADR-0008 amendment, ADR-0010 note, crosscutting, CHANGELOG
+
+**Files:**
+- Modify: `docs/adr/0008-inter-plane-spread-soft-preference.md` (amendment), `docs/adr/0010-reeds-shepp-motion-model.md` (cross-ref), `docs/architecture/08-crosscutting-concepts.md`, `CHANGELOG.md`
+
+- [ ] **Step 1: ADR-0008 amendment** — append a `### 2026-06-12 — #604 right/left-region soft term` level-3 heading mirroring the 2026-06-01 back-bias amendment structure (Background / Change with the aligned energy box / Default & toggle / Determinism / Known limitation):
+
+```
+**Change.** A per-object soft wall-alignment term folded into the same `_spread` energy:
+
+    E_total = Σ_{i<j} w_i·w_j·exp(−gap_ij/scale)  +  back_bias_weight·Σ_p (L−y_p)/L  +  Σ_{o∈prefs} w_o·d_o/W
+              └────────── spread ──────────┘        └──────── back bias (#320) ──────┘   └──── region (#604) ────┘
+
+    where d_o = (W − x_o) for side="right", x_o for side="left", W = hangar.width_m.
+```
+Key sentences to include: per-object preference is **scenario data** (default-inert), the term is **secondary** — `min_pairwise_gap_m` stays the primary basin key (#267); it is **RNG-free re-ranking** (same-seed byte-identical, no determinism-guard amendment needed); and the **known limitation** that the pull is a preference, not a guarantee (a space-tight basin may keep a trailer off-side, validity wins). Note the ground-object integration: movers are now solver-placed bodies (full RR-MC citizens), inert/byte-identical when a scenario has no ground objects.
+
+- [ ] **Step 2: ADR-0010 cross-reference** — append a short note that movers are now *solver-placed* (no new motion model; towed = cart per the #602 amendment).
+
+- [ ] **Step 3: crosscutting `08-…md`** — extend the "Soft preferences" entry (add the region term) and the "Ground objects" entry (now solver-placed in `solve`, not only authored in layouts).
+
+- [ ] **Step 4: CHANGELOG** — add an `[Unreleased]` entry: "Glider trailers are now placed + routed by the solver, with a soft right/left-region preference (#604)."
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/adr/0008-inter-plane-spread-soft-preference.md docs/adr/0010-reeds-shepp-motion-model.md docs/architecture/08-crosscutting-concepts.md CHANGELOG.md
+git commit -m "docs(604): ADR-0008 region-term amendment + ADR-0010 note + crosscutting + CHANGELOG
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 19: Quality gates + PR
+
+- [ ] **Step 1: Lint, format, type-check**
+
+Run: `ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/`
+Expected: clean. Fix any findings.
+
+- [ ] **Step 2: Full suite + graphify update**
+
+Run: `pytest -m "" -q` then `graphify update .`
+Expected: green.
+
+- [ ] **Step 3: determinism-guard subagent** — dispatch the `determinism-guard` agent on the solver diff (mandatory for any `solver.py` change). It runs the solver twice on a fixed seed and diffs; expected byte-identical. (`geometry-invariant-guard` is NOT triggered — no `geometry.py`/`collisions.py` change.)
+
+- [ ] **Step 4: Open the draft PR**
+
+```bash
+git push -u origin feature/604-glider-trailer-region
+gh pr create --draft --base develop --title "feat(604): glider-trailer placement + soft right-region preference" \
+  --body "Closes #604
+
+Full RR-MC integration of ground objects as solver-placed bodies + the soft right/left-region energy term (the #320 back-bias rotated 90°). Default-inert ⇒ byte-identical when a scenario has no ground objects. See docs/superpowers/specs/2026-06-12-glider-trailer-region-and-go-solver-integration-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+Set assignee/labels/milestone via `gh api -X PATCH` (the repo's `gh pr edit` is broken): assignee `DocGerd`, labels `enhancement` + `area:backend`, milestone #34.
+
+- [ ] **Step 5: Review arc** — run `/pr-review` (code-reviewer mandated; + `determinism-guard`, `type-design-analyzer` since `models.py` changed, `silent-failure-hunter` for the loader change). Convert findings to review threads, resolve each, re-review if non-trivial, then `gh pr ready`. **Do not merge** — hand off to the user.
+
+---
+
+## Self-review (plan vs spec)
+
+- **Spec coverage:** Part A (movers placed: Tasks 7-8; routed + egress: Tasks 13, reuses #602/#603; collisions: existing) ✓; Part B (RegionPreference: Task 1; scenario field: Tasks 2,4; `_region_energy` + fold: Task 10; secondary/inert: Tasks 10-11; determinism: Tasks 10,17) ✓; Part C (diagnostics: Tasks 3,12; CLI: Task 14; calibration via demo: Task 15 + Herrenteich opt-in: Task 16) ✓; ADRs: Task 18 ✓; fixed obstacles in scene: Tasks 2,4,6 ✓.
+- **Determinism invariant:** every solver task (6-12, 17) re-runs the canaries; the inert trio (Task 10) + movers-active canary (Task 17) + determinism-guard (Task 19) cover both the absent⇒identical and present⇒deterministic halves.
+- **Type consistency:** `RegionPreference{side, weight}`, `Scenario.region_preferences`/`fixed_obstacle_placements`/`mover_ids`/`placeable_ids`, `_body`/`_body_parts_world`/`_build_layout`/`_region_energy`/`_region_alignment`, `_SpreadCandidate.region_alignment`, `SolverDiagnostics.region_alignment` are used with the same signatures across tasks.
+- **Open item to firm during execution:** confirm the exact catalog filenames for the demo fleet (Task 15) and the real fuel-trailer pose from `layout_full.yaml` (Task 16); confirm `cached_parts_world` accepts `GroundObject` vs using the uncached `aircraft_parts_world` for movers (Task 5) to match the planner's geometry exactly.

--- a/docs/superpowers/specs/2026-06-12-glider-trailer-region-and-go-solver-integration-design.md
+++ b/docs/superpowers/specs/2026-06-12-glider-trailer-region-and-go-solver-integration-design.md
@@ -1,0 +1,156 @@
+# Design Spec — Glider-trailer placement + soft right-region preference (ground objects as solver-placed bodies)
+
+**Status:** Design / planning (2026-06-12). Audience: maintainer + future contributors.
+**Issue:** #604 (milestone #34, Ground objects + Herrenteich calibration — Stage A of the learned-backend initiative).
+**Companion ADRs:** ADR-0003 (determinism), ADR-0008 (spread soft-preference post-pass + #320 back-bias amendment), ADR-0010 (Reeds–Shepp / cart motion + #602 towed-trailer amendment).
+
+---
+
+## Intent
+
+#604 makes a **glider trailer** a first-class *placed + routed mover* and adds a **soft right-region preference** scored as a layered `_spread` post-pass term — the soft-tier sibling of the #603 hard Caddy egress gate.
+
+The non-obvious finding that shapes this work: **the deterministic solver does not place ground objects today.** `_run_one_restart` builds every `Layout(...)` from aircraft placements only; `Scenario` carries ground-object *defs* + *ids* but no placements; the Herrenteich `scenario.yaml` lists no ground objects; the CLI `solve` path never touches them; and the #603 egress gate at `solver.py:767` is therefore inert during `solve` (solved layouts carry no `ground_object_placements`). Ground-object poses exist only in hand-authored *layout* files consumed by `check` / `view`.
+
+So "the solver places the trailer" (#604 part A) is a **new capability built essentially from scratch**, not a tweak — and the soft region term (#604 part B) only does anything once the solver actually *moves* the trailers. This spec therefore covers **both**: threading ground objects into the RR-MC search, and the region scoring term layered on top.
+
+The catalog objects already exist (`data/catalog/glider_trailer_1.yaml`, `glider_trailer_2.yaml` — towed carts), `collisions.check` already treats placed movers as `ground` parts (#601), and the tow planner is already polymorphic over `Aircraft | GroundObject` (#602/#603). So the routing and collision halves of part A need **no new code** — the work is solver integration + the scoring term + scenario/diagnostics plumbing.
+
+### Locked decisions (from brainstorming, 2026-06-12)
+
+1. **Full RR-MC integration.** GO movers are full search citizens: sampled at restart init, perturbed in the hard `_descent_step`, spread in the post-pass, routed by `plan_fill`, egress-gated by `egress_first_conflict`. Fixed obstacles enter the solve scene as authored static keep-outs (the issue requires placement "outside the fuel-trailer keep-out").
+2. **Success bar = substrate + tractable demo.** Build the full machinery; verify the region pull **end-to-end** on a new small tractable fixture where the solver genuinely places + routes + right-biases the trailers. Also opt Herrenteich in, accepting that its diagnostics / egress oracle report intractability honestly if the real 8-aircraft set cannot pack routably (the #599 wall; the #603 pattern of "ship the machinery, the oracle flags it").
+
+---
+
+## Success definition ("best")
+
+Lexicographic; the hard gate dominates absolutely; the soft region term only re-ranks among already-hard-valid layouts.
+
+| Tier | Rule | Locus |
+|---|---|---|
+| **HARD (gate)** | Every body (aircraft + placed movers) is valid under `collisions.check` (inside hangar incl. notch, outside fixed-obstacle keep-outs, no overlap) **AND** every mover is routable (`plan_fill`) **AND** every `hard_door_mover` has a clear egress lane (`egress_first_conflict`). Violation ⇒ reject (collision-tier) / exit-3. | `collisions.check`, `towplanner` |
+| **SOFT (tie-break)** | A per-object right/left region preference: a preferring object closer to its preferred wall is better. Off-side when the preferred side is geometrically impossible is acceptable, **not** a failure. Strictly secondary to `min_pairwise_gap_m` (the primary basin key, #267) and never overrides the hard gate. | `solver._region_energy` |
+
+ADR-0008 spread + #320 back-bias remain the other secondary soft terms; the region term composes additively with them in the same `_spread` hill-climb.
+
+---
+
+## Architecture — ground objects as solver-placed bodies (Approach 1: unified placeable-id set)
+
+The chosen approach is a single unified set of *placeable* bodies that **degenerates byte-identically to today when a scenario has no ground objects**.
+
+- **Placeable ids** = `scenario.fleet_in` (aircraft) `++ sorted(mover_ids)` where `mover_ids` are the `placed_routed_mover` ground objects in the scenario. When there are no movers, this is exactly `fleet_in` and iteration order / RNG draws are unchanged.
+- **`_body(scenario, id) -> Aircraft | GroundObject`** dispatch replaces every `scenario.fleet[pid]` lookup in the placement / perturbation / energy code. A parallel `_body_parts_world(...)` returns world parts for either kind (aircraft use the memoized `cached_parts_world`; movers reuse the same world-parts path the towplanner uses).
+- **Fixed obstacles** are *not* placeable. They are static authored poses, injected only at `Layout` construction. They never enter the search dicts and consume no RNG.
+- **Centralized `_build_layout(scenario, placements)`** splits the unified placements dict into aircraft `placements=` vs mover `ground_object_placements=`, and appends the static fixed-obstacle placements + `ground_objects=` defs. This single helper replaces the ~6 inline `Layout(...)` builds in the restart body, `_spread`, `_nose_out`, and `_descent_step`, so ground objects flow through scoring uniformly.
+
+### The determinism contract (load-bearing invariant)
+
+> **Ground objects absent ⇒ byte-identical to today.** No new RNG draws (no movers to sample/perturb), no new `Layout` args (empty GO fields, proven byte-identical by `test_empty_ground_objects_byte_identical`), and the region term is not added (gated on `bool(scenario.region_preferences)`). Every existing fixture/scenario/canary has no ground objects, so all current determinism canaries and the `determinism-guard` remain green untouched.
+>
+> **Movers present ⇒ deterministic by construction.** Mover initial poses are seeded from the same `rng` in `sorted`-id order after aircraft; perturbation uses the same fixed candidate-generation RNG order; the region term is **RNG-free** (no draws, no candidate-set change) and summed in `sorted`-id order. Same scenario + same seed ⇒ bit-identical output, `max_restarts`-scoped (ADR-0003 as amended #267/#544). A new movers-active canary pins this.
+
+This mirrors the back-bias (#320) and priority (#441) inert contracts, applied one level up (whole-body integration rather than a single energy term).
+
+---
+
+## Components / changes by module
+
+### `models.py`
+- **`RegionPreference`** — new frozen dataclass: `side: Literal["left", "right"]`, `weight: float`. Validation mirrors `PlaneConstraint.priority`: `weight` finite and `≥ 0`; `side` in the allowed set. `weight == 0.0` is permitted and inert.
+- **`Scenario.region_preferences: Mapping[str, RegionPreference]`** — keyed by any placeable body id (aircraft or mover); default empty `MappingProxyType({})` ⇒ inert. `__post_init__` validates every key resolves to a placeable id. General/per-object — *not* Herrenteich-hardcoded. (Rejected alternative: a `SearchConfig.region_weight` global scalar + per-object side. "Where the trailers belong" is hangar/club data, not a search knob, so it lives in the scenario, like `pin`/`priority`.)
+- **`Scenario`** — distinguish mover ids (placed by the solver) from fixed-obstacle authored poses. Add `Scenario.fixed_obstacle_placements: tuple[Placement, ...]` (authored static keep-out poses; the fuel trailer's real fixed location). Mover ids derive from `ground_objects` filtered by `ground_object_defs[id].object_class == "placed_routed_mover"`.
+- **`SolverDiagnostics.region_alignment`** — per-layout, per-preferring-object normalized alignment in `[0, 1]` (1.0 = at the preferred wall), index-aligned with `layouts` (mirrors `min_pairwise_gap_m`: optional, validated finite/non-NaN, `len == len(layouts)` when populated). Represented as `tuple[Mapping[str, float], ...]` (one id→alignment map per layout), or `()` when no preferences.
+
+### `solver.py`
+- **`_body` / `_body_parts_world`** dispatch helpers (Aircraft | GroundObject).
+- **`_initial_placements`** samples mover poses after aircraft, in `sorted(mover_ids)` order, using the mover's part-bbox margins (movers always `on_carts=False`; excluded from `_enumerate_cart_buckets`).
+- **`_perturb_plane` / `_generate_candidates` / `_descent_step`** treat movers as perturbable bodies via `_body`. The 180° flip variant applies. Cart config never perturbed (unchanged).
+- **`_inter_plane_energy` / `_spread_quality` / `_back_bias_energy`** iterate the unified placeable set and look up geometry via `_body_parts_world`. (The repulsion energy now naturally repels movers from aircraft and from each other — desirable.)
+- **`_region_energy(placements, scenario)`** — new, RNG-free:
+
+  ```
+  R = Σ_{o ∈ region_preferences}  weight_o · d_o ,
+      where  d_o = (W − x_o) / W   if side_o == "right"     # minimized as x_o → W (right wall)
+             d_o =       x_o / W    if side_o == "left"      # minimized as x_o → 0 (left wall)
+      and    W   = hangar.width_m                            # normalize so one weight reads across hangar sizes
+  ```
+
+  Summed over preferring ids in `sorted` order (order-stable float sum). Folded into `_spread`'s local `_energy()` exactly like back-bias, gated `region_active = bool(scenario.region_preferences)`; when inert the term is never added (byte-identical energy).
+- **`_spread`** — `movable` now includes mover ids (pinned bodies still excluded); the region term re-ranks candidates *within* the validity-gated hill-climb. `min_pairwise_gap_m` stays the **primary** cross-basin key; region is intra-basin secondary (matching back-bias — documented, not basin-selection).
+- **`_build_layout(scenario, placements)`** centralizes Layout construction with GO splitting + fixed-obstacle injection.
+- The #603 **egress gate now actually fires in `solve`** (movers are in the layout) → exit-3 when a `hard_door_mover` is trapped; inert when no hard-door mover present.
+- **Diagnostics**: compute `region_alignment` per selected basin (RNG-free) and populate it in `_build_found_result`.
+
+### `loader.py` + scenario/catalog
+- Scenario `ground_objects:` parsing extended to author **fixed-obstacle poses** (`{object, x_m, y_m, heading_deg}`, reusing the layout GO-placement shape) and **mover entries** with an optional `region_preference: {side, weight}`. Loader allowlists extended (the hardcoded `{object, x_m, y_m, heading_deg}` frozenset at `loader.py:595` and the scenario GO parse at `loader.py:803`).
+- Glider-trailer catalog objects already exist — reused as-is, no new catalog files.
+- **New tractable demo fixture** under `tests/fixtures/`: a small scenario (≈2–3 aircraft + 2 glider trailers in a roomy hangar) the solver can genuinely place + route + right-bias. Herrenteich `scenario.yaml` opted in (2 trailers as movers with a right preference + fuel-trailer fixed keep-out).
+
+### `cli.py`
+- Surface `region_alignment` in the human `solve` summary (a line alongside "min gap") and in `--json` (per-layout, per-object; `null`/omitted when no preferences). Mirror the `min_pairwise_gap_m` serialization (no invalid JSON tokens).
+
+### Docs
+- **ADR-0008 amendment** (2026-06-12, #604): the right/left-region soft term — Background / Change (energy box, two-line aligned like the back-bias) / Default & toggle (per-object scenario data, default inert) / Determinism (RNG-free re-ranking) / Known limitation (a space-tight basin may keep a trailer off the preferred side; the pull is a preference, not a guarantee). Secondary to `min_pairwise_gap_m`.
+- **ADR-0010** cross-reference note: movers are now *solver-placed* (towed = cart motion already per the #602 amendment; no new motion model).
+- **`docs/architecture/08-crosscutting-concepts.md`** — extend the "Soft preferences" entry (region term) and the "Ground objects" entry (now solver-placed in `solve`, not only authored in layouts).
+- A CLAUDE.md Quick-Ref row for the ground-object ADRs is **deferred** until the user's local `M CLAUDE.md` graphify edit is resolved (do not touch that file).
+
+---
+
+## Data flow (solve, with movers)
+
+```
+scenario.yaml ──load──▶ Scenario{ fleet_in, ground_objects(ids), ground_object_defs,
+                                    fixed_obstacle_placements, region_preferences }
+   │
+   ▼  per restart (seeded)
+_initial_placements ─▶ unified placements{ aircraft + movers }   (fixed obstacles static)
+   │
+   ▼  hard descent (movers perturbable)            ── _build_layout splits aircraft/GO,
+_descent_step ──▶ valid layout (_score == (0,0.0)) ── injects fixed-obstacle keep-outs ──▶ _score
+   │
+   ▼  soft post-pass (validity-gated)
+_spread ─▶ _energy = inter_plane + back_bias·w_b + region·(per-object)   (region RNG-free)
+   │
+   ▼  basin pool ── primary key min_pairwise_gap_m ── select diverse
+_tow_plan_layouts ─▶ plan_fill (routes aircraft then movers, best-effort)
+   │                  └─ egress_first_conflict for each hard_door_mover ─▶ exit-3 if trapped
+   ▼
+SolveResult{ layouts, plans, diagnostics{ min_pairwise_gap_m, region_alignment, … } }
+```
+
+---
+
+## Error handling / edge cases
+- **Unroutable mover** — best-effort today (`path=None`, does not abort the fill; #197/ADR-0007). #604 keeps that; surfacing it on stderr is the sibling #612, out of scope here.
+- **Trapped hard-door mover** — exit-3 via the existing `NoFeasiblePlanError` path (now reachable in `solve`).
+- **Infeasible scenario** (e.g. real Herrenteich) — normal `exhausted_budget` / exit-3 with honest diagnostics; no special-casing.
+- **Mover that can only fit off its preferred side** — validity wins; the region term simply does not pull it across an invalidating move (only-valid-moves-accepted invariant of `_spread`).
+- **Fixed-obstacle / hangar-bounds margins for movers** — the perturbation bbox-margin logic must use the mover's part footprint, not an aircraft default.
+
+## Testing
+- **Inert trio** (mirrors the priority tests, `test_solver_spread.py`):
+  1. helper-level: `_region_energy` and total `_energy` byte-identical when `region_preferences` empty;
+  2. solve-level: `solve(scenario_no_GO)` placements byte-identical to today, `max_restarts`-scoped;
+  3. determinism-with-active-region: same seed + active preferences ⇒ byte-identical placements.
+- **No-GO byte-identity**: existing `test_empty_ground_objects_byte_identical` + the parallel `test_solver_parallel.py` canaries stay green unmodified; the machine-independent `test_solve_deterministic_best_partial_under_max_restarts` (seed=17, max_restarts=3) stays green (re-calibrate only if RNG draw counts shift — they must not, since the fixture has no movers).
+- **Region effect**: on the tractable demo fixture, `weight=0` vs `weight>0` shifts the trailer toward the preferred wall (mirrors `test_solve_back_fill_*`).
+- **End-to-end**: tractable fixture `solve` places + routes both trailers (plans non-None), egress-gated; `region_alignment` reported and improves with weight.
+- **CLI**: human summary + `--json` surface `region_alignment` (per-layout/per-object; null-safe like `min_pairwise_gap_m`).
+- **`determinism-guard`** subagent on the solver diff (mandatory; runs the solver twice on a fixed seed and diffs); **`geometry-invariant-guard`** not triggered (no geometry.py/collisions.py change expected).
+
+## Non-goals
+- No new motion planner (towed = cart per #602; steerable = own-gear per #602).
+- No change to `collisions.check` semantics or the `(conflict_count, total_penetration_m2)` score tuple — region lives entirely in the soft post-pass.
+- No hard right-side constraint (that tier is the #603 Caddy egress, already shipped).
+- `min_pairwise_gap_m` stays the primary basin key (#267) — region is purely intra-basin secondary in this cut.
+- Unroutable-mover stderr surfacing is #612; soft door-priority / requested-sequence tie-break is #614 — both separate.
+- No ML; this is deterministic Stage A substrate the learned backend (Stage C) will later read as a reward-shaping term.
+
+## Risks / open questions
+- **Determinism blast radius** is the main risk: ground-object integration touches ~10 solver functions. Mitigated by the "absent ⇒ byte-identical" invariant + the inert trio + `determinism-guard`. Every change is additive and degenerate-to-identical when no movers.
+- **Region-alignment diagnostic shape** (`tuple[Mapping[str,float], ...]`) — confirm it serializes cleanly to `--json` and passes the `SolverDiagnostics` index-alignment validator; refine during writing-plans if the map shape is awkward.
+- **Herrenteich intractability** is expected, not a bug; the tractable demo fixture is the real end-to-end proof.
+- **`_descent_step` mover participation** may make some currently-feasible aircraft-only scenarios harder to solve within budget when movers are added — acceptable; movers only exist in the new fixtures.

--- a/examples/herrenteich/scenario.yaml
+++ b/examples/herrenteich/scenario.yaml
@@ -22,3 +22,19 @@ fleet_in:
   - fk9_mkii
   - stemme_s10
   - zlin_savage
+
+# Non-aircraft ground objects on the floor with the fleet (#604). The fuel
+# trailer is a FIXED keep-out at its real surveyed pose (from layout_full.yaml);
+# the two glider trailers are placed-routed MOVERS the solver positions + routes,
+# with a soft preference to align them to the RIGHT wall (the club's habit).
+# NOTE: the real all-eight set is hard to pack (the #599 wall); opting these in
+# does not guarantee a solve — the soft preference only re-ranks valid layouts.
+ground_objects:
+  - object: maul_fuel_trailer
+    x_m: 14.05
+    y_m: 13.32
+    heading_deg: 0.0
+  - object: glider_trailer_1
+    region_preference: { side: right, weight: 1.5 }
+  - object: glider_trailer_2
+    region_preference: { side: right, weight: 1.5 }

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -605,6 +605,9 @@ def _emit_solve_human(result: SolveResult, *, alternatives: int) -> None:
                 f"  #{i}: {len(layout.placements)} planes placed; 0 conflicts; "
                 f"score=(0, 0.0); min gap {gap_str}"
             )
+        if i - 1 < len(d.region_alignment) and d.region_alignment[i - 1]:
+            ra = ", ".join(f"{bid}={a:.2f}" for bid, a in d.region_alignment[i - 1])
+            line += f"; region alignment {ra}"
         print(line)
 
 
@@ -1073,6 +1076,12 @@ def _emit_solve_json(
             # Additive (#263): nose-out heading flips applied per returned layout.
             # Backward-compatible — no schema bump.
             "nose_out_flips": list(d.nose_out_flips),
+            # Additive (#604): per-layout per-object region alignment (0-1, 1.0 =
+            # at the preferred wall). Empty list when no region preferences set.
+            # Backward-compatible — no schema bump.
+            "region_alignment": [
+                {bid: a for bid, a in layout_align} for layout_align in d.region_alignment
+            ],
         },
     }
     print(json.dumps(payload, indent=2))

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -606,7 +606,7 @@ def _emit_solve_human(result: SolveResult, *, alternatives: int) -> None:
                 f"score=(0, 0.0); min gap {gap_str}"
             )
         if i - 1 < len(d.region_alignment) and d.region_alignment[i - 1]:
-            ra = ", ".join(f"{bid}={a:.2f}" for bid, a in d.region_alignment[i - 1])
+            ra = ", ".join(f"{a.body_id}={a.alignment:.2f}" for a in d.region_alignment[i - 1])
             line += f"; region alignment {ra}"
         print(line)
 
@@ -1080,7 +1080,8 @@ def _emit_solve_json(
             # at the preferred wall). Empty list when no region preferences set.
             # Backward-compatible — no schema bump.
             "region_alignment": [
-                {bid: a for bid, a in layout_align} for layout_align in d.region_alignment
+                {ra.body_id: ra.alignment for ra in layout_align}
+                for layout_align in d.region_alignment
             ],
         },
     }

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -53,6 +53,7 @@ from .models import (
     Part,
     Placement,
     PlaneConstraint,
+    RegionPreference,
     Scenario,
     StructuralNotch,
     StrutsSpec,
@@ -797,19 +798,100 @@ def load_scenario(
         except (ValueError, KeyError, TypeError, LoaderError) as e:
             raise LoaderError(f"{path}: constraint {plane_id!r}: {e}") from e
 
-    # Parse the scenario's optional ground_objects: id-list (#601). Like
-    # fleet_in, it is a list of catalog ids; each must resolve in the defs
-    # resolved above (kwarg-injected or read from the fleet manifest).
-    go_ids_raw = raw.get("ground_objects", [])
-    if not isinstance(go_ids_raw, list):
-        raise LoaderError(f"{path}: 'ground_objects' must be a list of ids")
-    scenario_ground_objects = tuple(str(x) for x in go_ids_raw)
-    for gid in scenario_ground_objects:
+    # Parse the scenario's optional ground_objects: block (#601 id-list, #604
+    # mapping form). Each entry is either a bare catalog-id string (a mover,
+    # no preference) or a mapping with an ``object:`` id and class-dependent
+    # extra fields, and must resolve in the defs resolved above (kwarg-injected
+    # or read from the fleet manifest). Branching on the resolved def's
+    # ``object_class`` (#604):
+    #   - fixed_obstacle     -> REQUIRES a pose (x_m/y_m/heading_deg), FORBIDS
+    #                           region_preference; expands to a Placement.
+    #   - placed_routed_mover -> FORBIDS a pose (the solver places it), allows
+    #                           an optional region_preference (a soft re-rank).
+    go_entries = raw.get("ground_objects", [])
+    if not isinstance(go_entries, list):
+        raise LoaderError(f"{path}: 'ground_objects' must be a list")
+
+    scenario_ground_objects: list[str] = []
+    fixed_obstacle_placements: list[Placement] = []
+    region_preferences: dict[str, RegionPreference] = {}
+
+    for i, entry in enumerate(go_entries):
+        fields: Mapping[str, Any]
+        if isinstance(entry, str):
+            gid, fields = entry, {}
+        elif isinstance(entry, dict):
+            unknown = set(entry) - _ALLOWED_SCENARIO_GO_KEYS
+            if unknown:
+                raise LoaderError(
+                    f"{path}: ground_objects[{i}] has unknown key(s) {sorted(unknown)}"
+                )
+            if "object" not in entry:
+                raise LoaderError(f"{path}: ground_objects[{i}] missing required 'object'")
+            gid, fields = entry["object"], entry
+        else:
+            raise LoaderError(f"{path}: ground_objects[{i}] must be a string or mapping")
+
         if gid not in ground_objects:
             raise LoaderError(
-                f"{path}: ground_objects references unknown object {gid!r}; "
+                f"{path}: ground_objects[{i}] references unknown object {gid!r}; "
                 f"the available ground objects are: {sorted(ground_objects)}"
             )
+        if gid in scenario_ground_objects:
+            raise LoaderError(f"{path}: duplicate scenario ground object {gid!r}")
+        scenario_ground_objects.append(gid)
+        obj_class = ground_objects[gid].object_class
+
+        has_pose = any(k in fields for k in ("x_m", "y_m", "heading_deg"))
+        if obj_class == "fixed_obstacle":
+            if "region_preference" in fields:
+                raise LoaderError(
+                    f"{path}: ground_objects[{i}] ({gid}): a fixed_obstacle cannot "
+                    f"carry a region_preference"
+                )
+            missing = [k for k in ("x_m", "y_m", "heading_deg") if k not in fields]
+            if missing:
+                raise LoaderError(
+                    f"{path}: ground_objects[{i}] ({gid}): a fixed_obstacle requires {missing}"
+                )
+            fixed_obstacle_placements.append(
+                Placement(
+                    plane_id=gid,
+                    x_m=_to_float(fields["x_m"], f"ground_objects[{i}].x_m"),
+                    y_m=_to_float(fields["y_m"], f"ground_objects[{i}].y_m"),
+                    heading_deg=_to_float(
+                        fields["heading_deg"], f"ground_objects[{i}].heading_deg"
+                    ),
+                    on_carts=False,
+                )
+            )
+        else:  # placed_routed_mover
+            if has_pose:
+                raise LoaderError(
+                    f"{path}: ground_objects[{i}] ({gid}): a placed_routed_mover must not "
+                    f"carry a pose (the solver places it)"
+                )
+            rp = fields.get("region_preference")
+            if rp is not None:
+                if (
+                    not isinstance(rp, dict)
+                    or set(rp) - _ALLOWED_REGION_PREF_KEYS
+                    or "side" not in rp
+                    or "weight" not in rp
+                ):
+                    raise LoaderError(
+                        f"{path}: ground_objects[{i}] ({gid}): region_preference must be "
+                        f"{{side, weight}}"
+                    )
+                try:
+                    region_preferences[gid] = RegionPreference(
+                        side=rp["side"],
+                        weight=_to_float(
+                            rp["weight"], f"ground_objects[{i}].region_preference.weight"
+                        ),
+                    )
+                except (ValueError, LoaderError) as e:
+                    raise LoaderError(f"{path}: ground_objects[{i}] ({gid}): {e}") from e
 
     try:
         return Scenario(
@@ -818,14 +900,22 @@ def load_scenario(
             fleet_in=fleet_in,
             maintenance_plane=maintenance_plane,
             constraints=constraints,
-            ground_objects=scenario_ground_objects,
+            ground_objects=tuple(scenario_ground_objects),
             ground_object_defs=ground_objects,
+            fixed_obstacle_placements=tuple(fixed_obstacle_placements),
+            region_preferences=region_preferences,
         )
     except ValueError as e:
         raise LoaderError(f"{path}: {e}") from e
 
 
 _ALLOWED_CONSTRAINT_KEYS = frozenset({"pin", "force_on_carts", "priority", "nose_out"})
+
+# Keys accepted in a scenario ``ground_objects:`` mapping entry (#604). ``object``
+# is the catalog id; the pose triplet is required for a fixed_obstacle and
+# forbidden for a placed_routed_mover; ``region_preference`` is the reverse.
+_ALLOWED_SCENARIO_GO_KEYS = frozenset({"object", "x_m", "y_m", "heading_deg", "region_preference"})
+_ALLOWED_REGION_PREF_KEYS = frozenset({"side", "weight"})
 
 
 def _build_plane_constraint(plane_id: str, data: Any) -> PlaneConstraint:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -38,7 +38,7 @@ import difflib
 import math
 from collections.abc import Callable, Collection, Iterable, Mapping
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import yaml
 
@@ -54,6 +54,7 @@ from .models import (
     Placement,
     PlaneConstraint,
     RegionPreference,
+    RegionSide,
     Scenario,
     StructuralNotch,
     StrutsSpec,
@@ -878,14 +879,19 @@ def load_scenario(
                     or set(rp) - _ALLOWED_REGION_PREF_KEYS
                     or "side" not in rp
                     or "weight" not in rp
+                    or not isinstance(rp["side"], str)
                 ):
                     raise LoaderError(
                         f"{path}: ground_objects[{i}] ({gid}): region_preference must be "
                         f"{{side, weight}}"
                     )
                 try:
+                    # ``side`` is known to be a str here (checked above); the
+                    # left/right membership is enforced by
+                    # RegionPreference.__post_init__ (its ValueError is caught
+                    # + rewrapped below), so the cast is sound.
                     region_preferences[gid] = RegionPreference(
-                        side=rp["side"],
+                        side=cast(RegionSide, rp["side"]),
                         weight=_to_float(
                             rp["weight"], f"ground_objects[{i}].region_preference.weight"
                         ),

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1040,6 +1040,40 @@ class CheckResult:
         return len(self.conflicts) == 0
 
 
+RegionSide = Literal["left", "right"]
+_VALID_REGION_SIDES: frozenset[str] = frozenset(("left", "right"))
+
+
+@dataclass(frozen=True, slots=True)
+class RegionPreference:
+    """A soft per-object preference to align a placed body to one hangar wall (#604).
+
+    ``side`` is the preferred wall in the x-axis (``"left"`` ≡ ``x → 0``,
+    ``"right"`` ≡ ``x → hangar.width_m``); ``weight`` is a non-negative, finite
+    soft importance (``0.0`` is permitted and inert). Realized as the RNG-free
+    ``solver._region_energy`` term folded into the ``_spread`` hill-climb,
+    secondary to ``min_pairwise_gap_m`` and never overriding the hard validity
+    gate (ADR-0008 amended). Modeled on :attr:`PlaneConstraint.priority`'s
+    soft-weight validation (#441).
+    """
+
+    side: RegionSide
+    weight: float
+
+    def __post_init__(self) -> None:
+        if self.side not in _VALID_REGION_SIDES:
+            raise ValueError(
+                f"RegionPreference.side must be one of {sorted(_VALID_REGION_SIDES)}, "
+                f"got {self.side!r}"
+            )
+        if not math.isfinite(self.weight):
+            raise ValueError(f"RegionPreference.weight={self.weight!r} must be finite")
+        if self.weight < 0.0:
+            raise ValueError(
+                f"RegionPreference.weight={self.weight!r} must be >= 0.0 (a soft weight)"
+            )
+
+
 @dataclass(frozen=True, slots=True)
 class PlaneConstraint:
     """Per-plane constraints for a Scenario.

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1146,13 +1146,22 @@ class Scenario:
     ground_object_defs: Mapping[str, GroundObject] = field(
         default_factory=lambda: MappingProxyType({})
     )
+    fixed_obstacle_placements: tuple[Placement, ...] = ()
+    region_preferences: Mapping[str, RegionPreference] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
 
     # The mapping fields wrapped in MappingProxyType for immutability. This is
     # the single source of truth for both the construction-time wrap (in
     # __post_init__) and the pickle unwrap/re-wrap (in __getstate__/__setstate__,
     # #545) — listing them once means the two cannot silently drift. (ClassVar so
     # the dataclass excludes it from the field set and __slots__.)
-    _PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = ("fleet", "constraints", "ground_object_defs")
+    _PROXY_FIELDS: typing.ClassVar[tuple[str, ...]] = (
+        "fleet",
+        "constraints",
+        "ground_object_defs",
+        "region_preferences",
+    )
 
     def __post_init__(self) -> None:
         # fleet_in must be non-empty (otherwise there's nothing to solve;
@@ -1283,6 +1292,35 @@ class Scenario:
                     f"defs have: {sorted(self.ground_object_defs)}"
                 )
 
+        # Region preferences (#604): every key must reference a placeable body —
+        # an aircraft in fleet_in or a placed_routed_mover ground object.
+        placeable = set(self.fleet_in) | {
+            gid
+            for gid in self.ground_objects
+            if self.ground_object_defs[gid].object_class == "placed_routed_mover"
+        }
+        for rid in self.region_preferences:
+            if rid not in placeable:
+                raise ValueError(
+                    f"Scenario.region_preferences references {rid!r} which is not a "
+                    f"placeable body (aircraft or placed_routed_mover); "
+                    f"placeable ids: {sorted(placeable)}"
+                )
+        seen_fixed: set[str] = set()
+        for p in self.fixed_obstacle_placements:
+            if p.plane_id not in self.ground_object_defs:
+                raise ValueError(
+                    f"Scenario.fixed_obstacle_placements references unknown ground "
+                    f"object {p.plane_id!r}"
+                )
+            if self.ground_object_defs[p.plane_id].object_class != "fixed_obstacle":
+                raise ValueError(
+                    f"Scenario.fixed_obstacle_placements[{p.plane_id!r}] is not a fixed_obstacle"
+                )
+            if p.plane_id in seen_fixed:
+                raise ValueError(f"Duplicate fixed_obstacle_placement for {p.plane_id!r}")
+            seen_fixed.add(p.plane_id)
+
         # Wrap the mapping fields in MappingProxyType so a frozen Scenario can't
         # be mutated through e.g. ``scenario.fleet["x"] = …``. Always copy+wrap
         # (even an already-wrapped MappingProxyType arg): skipping the copy would
@@ -1291,6 +1329,25 @@ class Scenario:
         # pickle unwrap list stay a single source of truth.
         for name in self._PROXY_FIELDS:
             object.__setattr__(self, name, MappingProxyType(dict(getattr(self, name))))
+
+    @property
+    def mover_ids(self) -> tuple[str, ...]:
+        """Placed-routed-mover ids active in this scenario, in ``ground_objects`` order.
+
+        These are the ground objects the solver PLACES + routes (vs fixed
+        obstacles, authored static keep-outs in :attr:`fixed_obstacle_placements`).
+        Empty ⇒ the solver is aircraft-only and byte-identical to pre-#604 (ADR-0003)."""
+        return tuple(
+            gid
+            for gid in self.ground_objects
+            if self.ground_object_defs[gid].object_class == "placed_routed_mover"
+        )
+
+    @property
+    def placeable_ids(self) -> tuple[str, ...]:
+        """Aircraft (``fleet_in``) then sorted mover ids — the unified search bodies.
+        With no movers this is exactly ``fleet_in`` (ADR-0003)."""
+        return self.fleet_in + tuple(sorted(self.mover_ids))
 
     # Picklable across the #544 ProcessPool boundary — the worker input. See
     # _proxy_aware_getstate for the rationale (shared with Layout, #545/#544).

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1055,6 +1055,12 @@ class RegionPreference:
     secondary to ``min_pairwise_gap_m`` and never overriding the hard validity
     gate (ADR-0008 amended). Modeled on :attr:`PlaneConstraint.priority`'s
     soft-weight validation (#441).
+
+    The shape differs intentionally from that precedent: ``weight`` is a plain
+    ``float`` (not ``float | None``) because a body either has a
+    ``Scenario.region_preferences`` map entry or none — map-presence already
+    encodes the optional/neutral distinction that ``priority``'s ``| None``
+    carries inline.
     """
 
     side: RegionSide
@@ -1132,7 +1138,20 @@ class Scenario:
     - maintenance_plane (if set) must not also carry a pin or force_on_carts in
       constraints (the occupant is treated as away — those constraints would be
       incoherent and would be silently ignored by the solver)
+    - region_preferences.keys() ⊆ placeable bodies (fleet_in ∪ placed_routed_mover ids)
+    - fixed_obstacle_placements entries reference distinct fixed_obstacle ground
+      objects (in ground_object_defs)
     - fleet and constraints are wrapped in MappingProxyType (same pattern as Layout)
+
+    A fixed_obstacle may appear in ``ground_objects`` WITHOUT a matching
+    ``fixed_obstacle_placements`` entry — its pose then comes from a hand-authored
+    layout (the ``check``/``view`` path), not the solver. The scenario LOADER
+    requires a pose for any fixed_obstacle authored in a SOLVE scenario's
+    ``ground_objects:`` block (#604), so the silent-keep-out-drop that a hard
+    coverage invariant would guard against cannot arise via authored scenarios;
+    for programmatic construction it remains the caller's responsibility
+    (consistent with the #605 ground_objects model). Hence this is a documented
+    contract, not an enforced __post_init__ invariant.
 
     See spec §3.2 for the rationale.
     """
@@ -1336,7 +1355,13 @@ class Scenario:
 
         These are the ground objects the solver PLACES + routes (vs fixed
         obstacles, authored static keep-outs in :attr:`fixed_obstacle_placements`).
-        Empty ⇒ the solver is aircraft-only and byte-identical to pre-#604 (ADR-0003)."""
+        Empty ⇒ the solver is aircraft-only and byte-identical to pre-#604 (ADR-0003).
+
+        Note this exposes a DIFFERENT mover ordering than
+        :attr:`placeable_ids`: ``mover_ids`` follows ``ground_objects``
+        (declaration) order, whereas ``placeable_ids`` sorts the movers. Callers
+        must not index-align one against the other (the solver re-sorts via
+        ``sorted(scenario.mover_ids)`` at the use site)."""
         return tuple(
             gid
             for gid in self.ground_objects
@@ -1346,7 +1371,11 @@ class Scenario:
     @property
     def placeable_ids(self) -> tuple[str, ...]:
         """Aircraft (``fleet_in``) then sorted mover ids — the unified search bodies.
-        With no movers this is exactly ``fleet_in`` (ADR-0003)."""
+        With no movers this is exactly ``fleet_in`` (ADR-0003).
+
+        The mover ordering here (``fleet_in + sorted(mover_ids)``) differs from
+        :attr:`mover_ids`' ``ground_objects`` (declaration) order, so callers
+        must not index-align the two."""
         return self.fleet_in + tuple(sorted(self.mover_ids))
 
     # Picklable across the #544 ProcessPool boundary — the worker input. See

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1425,6 +1425,18 @@ SolveStatus = Literal[
 ]
 
 
+class RegionAlignment(typing.NamedTuple):
+    """A placed body's achieved wall alignment for a returned layout (#604).
+
+    ``alignment`` is 0–1 with 1.0 meaning the body sits exactly at its preferred
+    wall. A ``tuple`` subclass, so it is byte-identical under pickle/equality/repr
+    (determinism-neutral) and ``dict(layout_alignments)`` still yields
+    ``{body_id: alignment}``."""
+
+    body_id: str
+    alignment: float
+
+
 @dataclass(frozen=True, slots=True)
 class SolverDiagnostics:
     """Per-solve diagnostic information.
@@ -1490,8 +1502,9 @@ class SolverDiagnostics:
     flipped (or with ``nose_out`` disabled). Advisory / RNG-free.
 
     ``region_alignment`` is index-aligned with :attr:`SolveResult.layouts`: for each
-    returned layout, a tuple of ``(body_id, alignment)`` pairs (sorted by id) for the
-    bodies carrying a :class:`RegionPreference`, where ``alignment`` is 0–1 with 1.0
+    returned layout, a tuple of :class:`RegionAlignment` ``(body_id, alignment)`` pairs
+    (sorted by id) for the bodies carrying a :class:`RegionPreference`, where
+    ``alignment`` is 0–1 with 1.0
     meaning the body sits exactly at its preferred wall (#604, ADR-0008 amended).
     Empty when no scenario region preferences are set. Advisory / RNG-free.
 
@@ -1544,7 +1557,7 @@ class SolverDiagnostics:
     spread_stall_applied: bool = False
     apron_shallow_drops: tuple[ApronShallowDrop, ...] = ()
     nose_out_flips: tuple[int, ...] = ()
-    region_alignment: tuple[tuple[tuple[str, float], ...], ...] = ()
+    region_alignment: tuple[tuple[RegionAlignment, ...], ...] = ()
 
     def __post_init__(self) -> None:
         if (self.best_partial is None) != (self.best_partial_layout is None):
@@ -1580,11 +1593,11 @@ class SolverDiagnostics:
                 f"got {self.nose_out_flips!r}"
             )
         for layout_alignments in self.region_alignment:
-            for _id, a in layout_alignments:
-                if math.isnan(a) or a < 0.0 or a > 1.0:
+            for ra in layout_alignments:
+                if math.isnan(ra.alignment) or ra.alignment < 0.0 or ra.alignment > 1.0:
                     raise ValueError(
                         "SolverDiagnostics.region_alignment values must be in "
-                        f"[0.0, 1.0], got {a!r}"
+                        f"[0.0, 1.0], got {ra.alignment!r}"
                     )
 
 

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1460,6 +1460,12 @@ class SolverDiagnostics:
     to that returned layout (#263, ADR-0022). ``0`` for a layout where no plane was
     flipped (or with ``nose_out`` disabled). Advisory / RNG-free.
 
+    ``region_alignment`` is index-aligned with :attr:`SolveResult.layouts`: for each
+    returned layout, a tuple of ``(body_id, alignment)`` pairs (sorted by id) for the
+    bodies carrying a :class:`RegionPreference`, where ``alignment`` is 0–1 with 1.0
+    meaning the body sits exactly at its preferred wall (#604, ADR-0008 amended).
+    Empty when no scenario region preferences are set. Advisory / RNG-free.
+
     ``spread_fallback_applied`` is ``True`` when :func:`hangarfit.solver.solve`
     re-solved with the inter-plane spread post-pass disabled and substituted
     that tighter, tow-routable arrangement because the spread layout(s) came
@@ -1509,6 +1515,7 @@ class SolverDiagnostics:
     spread_stall_applied: bool = False
     apron_shallow_drops: tuple[ApronShallowDrop, ...] = ()
     nose_out_flips: tuple[int, ...] = ()
+    region_alignment: tuple[tuple[tuple[str, float], ...], ...] = ()
 
     def __post_init__(self) -> None:
         if (self.best_partial is None) != (self.best_partial_layout is None):
@@ -1543,6 +1550,13 @@ class SolverDiagnostics:
                 "SolverDiagnostics.nose_out_flips entries must be >= 0, "
                 f"got {self.nose_out_flips!r}"
             )
+        for layout_alignments in self.region_alignment:
+            for _id, a in layout_alignments:
+                if math.isnan(a) or a < 0.0 or a > 1.0:
+                    raise ValueError(
+                        "SolverDiagnostics.region_alignment values must be in "
+                        f"[0.0, 1.0], got {a!r}"
+                    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1607,6 +1621,12 @@ class SolveResult:
                 "SolveResult.diagnostics.nose_out_flips, when populated, must be "
                 f"index-aligned with layouts: got {len(self.diagnostics.nose_out_flips)} "
                 f"counts for {len(self.layouts)} layouts"
+            )
+        if self.diagnostics.region_alignment and len(self.diagnostics.region_alignment) != len(
+            self.layouts
+        ):
+            raise ValueError(
+                "SolverDiagnostics.region_alignment length must match layouts when populated"
             )
 
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -1723,8 +1723,8 @@ def _perturb_plane(
     trajectory.
     """
     hangar = scenario.hangar
-    plane = scenario.fleet[current.plane_id]
-    max_length, max_width = _plane_max_extent(plane)
+    body = _body(scenario, current.plane_id)
+    max_length, max_width = _plane_max_extent(body)
     margin = max(max_length, max_width) / 2
 
     if large_jump:
@@ -1859,7 +1859,11 @@ def _descent_step(
     conflicting: set[str] = set()
     for c in current_result.conflicts:
         for pid in c.planes:
-            if pid not in pinned_planes:
+            # Only perturbable bodies are candidates: skip pinned planes and any
+            # id not in the search dict (e.g. a fixed obstacle, an injected static
+            # keep-out — never moved). With no ground objects every conflict id is
+            # an aircraft already in `placements`, so this is byte-identical (#604).
+            if pid not in pinned_planes and pid in placements:
                 conflicting.add(pid)
     if not conflicting:
         return None  # restart — all conflicts are on pinned planes

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -1313,6 +1313,31 @@ def _back_bias_energy(placements: dict[str, Placement], scenario: Scenario) -> f
     return sum((length - placements[pid].y_m) / length for pid in sorted(placements))
 
 
+def _region_energy(placements: Mapping[str, Placement], scenario: Scenario) -> float:
+    """Soft right/left wall-alignment bias ``R = Σ wₒ·dₒ / W`` (#604).
+
+    For each body ``o`` carrying a :class:`RegionPreference`, ``dₒ`` is the
+    distance from ``x_o`` to the preferred wall — ``(W − x_o)`` for ``"right"``,
+    ``x_o`` for ``"left"`` — normalized by ``W = hangar.width_m`` so one weight
+    reads across hangar sizes (mirrors ``_back_bias_energy``'s ``length_m``
+    normalization, #320). Minimized when the body sits at its preferred wall.
+    Summed over preferring ids in ``sorted`` order (order-stable float sum).
+    RNG-free. ``0.0`` when no preferences (inert ⇒ byte-identical, ADR-0003)."""
+    prefs = scenario.region_preferences
+    if not prefs:
+        return 0.0
+    width = scenario.hangar.width_m
+    total = 0.0
+    for pid in sorted(prefs):
+        if pid not in placements:
+            continue  # e.g. a maintenance plane (treated as away) — not placed
+        pref = prefs[pid]
+        x = placements[pid].x_m
+        d = (width - x) if pref.side == "right" else x
+        total += pref.weight * (d / width)
+    return total
+
+
 def _resolve_spread_scale(scenario: Scenario, search: SearchConfig) -> float:
     """Repulsion length-scale for spread (spec §4): explicit override or
     20% of the smaller hangar dimension. Single source so ``_spread`` and
@@ -1453,10 +1478,12 @@ def _spread(
 
     movable = sorted(pid for pid in placements if pid not in pinned_planes)
     back_fill = search.back_bias_weight > 0.0
-    if not movable or (len(placements) < 2 and not back_fill):
-        # Nothing to optimize: no movable target, or <2 planes with no back-fill
-        # bias (inter-plane energy is identically 0.0). With back-fill active a
-        # lone plane is still pulled to the back wall, so we do NOT bail there.
+    region_active = bool(scenario.region_preferences)
+    if not movable or (len(placements) < 2 and not back_fill and not region_active):
+        # Nothing to optimize: no movable target, or <2 planes with neither the
+        # back-fill nor the region bias active (inter-plane energy is identically
+        # 0.0). With back-fill OR a region preference active a lone body is still
+        # pulled toward its wall, so we do NOT bail there.
         return placements
 
     def _energy(
@@ -1473,6 +1500,8 @@ def _spread(
         e = _inter_plane_energy(trial, scenario, scale, gap_cache=gap_cache, moved=moved)
         if back_fill:
             e += search.back_bias_weight * _back_bias_energy(trial, scenario)
+        if region_active:
+            e += _region_energy(trial, scenario)
         return e
 
     current_energy = _energy(placements)

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -44,6 +44,7 @@ from hangarfit.models import (
     GroundObject,
     Layout,
     Placement,
+    RegionAlignment,
     Scenario,
     SearchConfig,
     SolverDiagnostics,
@@ -1347,7 +1348,7 @@ def _region_energy(placements: Mapping[str, Placement], scenario: Scenario) -> f
 
 def _region_alignment(
     placements: Mapping[str, Placement], scenario: Scenario
-) -> tuple[tuple[str, float], ...]:
+) -> tuple[RegionAlignment, ...]:
     """Per-preferring-object wall alignment in ``[0, 1]`` (1.0 = AT the preferred
     wall), sorted by id (#604). ``()`` when the scenario has no region preferences.
     RNG-free; the observability twin of :func:`_region_energy`."""
@@ -1355,13 +1356,13 @@ def _region_alignment(
     if not prefs:
         return ()
     width = scenario.hangar.width_m
-    out: list[tuple[str, float]] = []
+    out: list[RegionAlignment] = []
     for pid in sorted(prefs):
         if pid not in placements:
             continue
         x = placements[pid].x_m
         frac = (x / width) if prefs[pid].side == "right" else (1.0 - x / width)
-        out.append((pid, max(0.0, min(1.0, frac))))
+        out.append(RegionAlignment(body_id=pid, alignment=max(0.0, min(1.0, frac))))
     return tuple(out)
 
 
@@ -2006,7 +2007,7 @@ class _SpreadCandidate(NamedTuple):
     energy: float
     restart_index: int
     nose_out_flips: int = 0
-    region_alignment: tuple[tuple[str, float], ...] = ()
+    region_alignment: tuple[RegionAlignment, ...] = ()
 
 
 def _select_spread_diverse(

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -29,6 +29,7 @@ import random as _random_module
 import secrets
 import sys
 import time
+from collections.abc import Mapping
 from dataclasses import replace
 from typing import Literal, NamedTuple, cast
 
@@ -221,6 +222,39 @@ def _restart_rng(seed: int, restart_index: int) -> _random_module.Random:
     return _random_module.Random(f"{seed}:{restart_index}")
 
 
+def _build_layout(scenario: Scenario, placements: Mapping[str, Placement]) -> Layout:
+    """Build a Layout from a unified placeable-body dict (#604).
+
+    Splits ``placements`` into aircraft (ids in ``fleet``) and mover ground
+    objects (everything else — placed_routed_mover ids), injects the authored
+    ``fixed_obstacle_placements``, and wires the active ``ground_objects`` defs.
+    With an aircraft-only dict AND a scenario with no ground objects this yields a
+    Layout byte-identical to the pre-#604 inline construction (ADR-0003): the
+    aircraft tuple preserves the dict's insertion order (== fleet_in order, since
+    movers are appended after aircraft in _initial_placements), and the GO fields
+    default empty."""
+    aircraft: list[Placement] = []
+    movers: list[Placement] = []
+    for pid, p in placements.items():
+        (aircraft if pid in scenario.fleet else movers).append(p)
+    go_placements = tuple(movers) + scenario.fixed_obstacle_placements
+    if not go_placements:
+        return Layout(
+            fleet=scenario.fleet,
+            hangar=scenario.hangar,
+            placements=tuple(aircraft),
+            maintenance_plane=scenario.maintenance_plane,
+        )
+    return Layout(
+        fleet=scenario.fleet,
+        hangar=scenario.hangar,
+        placements=tuple(aircraft),
+        maintenance_plane=scenario.maintenance_plane,
+        ground_objects={gid: scenario.ground_object_defs[gid] for gid in scenario.ground_objects},
+        ground_object_placements=go_placements,
+    )
+
+
 def _run_restart(
     scenario: Scenario,
     *,
@@ -253,12 +287,7 @@ def _run_restart(
     best_partial_layout: Layout | None = None
     candidate: _SpreadCandidate | None = None
 
-    initial_layout = Layout(
-        fleet=scenario.fleet,
-        hangar=scenario.hangar,
-        placements=tuple(placements.values()),
-        maintenance_plane=scenario.maintenance_plane,
-    )
+    initial_layout = _build_layout(scenario, placements)
     current_score = _score(initial_layout)
     if current_score < best_partial_score:
         best_partial_score = current_score
@@ -285,12 +314,7 @@ def _run_restart(
                 placements, n_flips = _nose_out(
                     placements, scenario, search, pinned_planes=pinned_planes
                 )
-            candidate_layout = Layout(
-                fleet=scenario.fleet,
-                hangar=scenario.hangar,
-                placements=tuple(placements.values()),
-                maintenance_plane=scenario.maintenance_plane,
-            )
+            candidate_layout = _build_layout(scenario, placements)
             min_gap, energy = _spread_quality(placements, scenario, spread_scale)
             candidate = _SpreadCandidate(
                 layout=candidate_layout,
@@ -318,12 +342,7 @@ def _run_restart(
 
         if current_score < best_partial_score:
             best_partial_score = current_score
-            best_partial_layout = Layout(
-                fleet=scenario.fleet,
-                hangar=scenario.hangar,
-                placements=tuple(placements.values()),
-                maintenance_plane=scenario.maintenance_plane,
-            )
+            best_partial_layout = _build_layout(scenario, placements)
 
         if iter_count - last_improved >= search.k_stall:
             break  # stall
@@ -1050,12 +1069,10 @@ def _check_pin_feasibility(scenario: Scenario) -> tuple[CheckResult, Layout] | N
     # pin.on_carts vs movement_mode). A genuinely unexpected ValueError
     # should propagate as a bug, not get silently re-wrapped as a pin
     # infeasibility.
-    pin_only_layout = Layout(
-        fleet=scenario.fleet,
-        hangar=scenario.hangar,
-        placements=tuple(pinned_placements),
-        maintenance_plane=scenario.maintenance_plane,
-    )
+    # All pins are aircraft (drawn from fleet_in) with unique ids, so the dict
+    # preserves list order and tuple(dict.values()) == tuple(pinned_placements):
+    # _build_layout yields the same aircraft-only Layout, byte-identical (#604).
+    pin_only_layout = _build_layout(scenario, {p.plane_id: p for p in pinned_placements})
 
     pin_check = check_layout(pin_only_layout)
     if not pin_check.valid:
@@ -1403,12 +1420,7 @@ def _nose_out(
         # trip any Layout cross-reference invariant (cart rule, on_carts
         # consistency, duplicate placements) — build directly. A ValueError here
         # would be a structural bug, so let it propagate rather than silently skip.
-        trial_layout = Layout(
-            fleet=scenario.fleet,
-            hangar=scenario.hangar,
-            placements=tuple(trial.values()),
-            maintenance_plane=scenario.maintenance_plane,
-        )
+        trial_layout = _build_layout(scenario, trial)
         if _score(trial_layout) != (0, 0.0):
             continue
         placements[pid] = flipped
@@ -1494,12 +1506,7 @@ def _spread(
             trial = dict(placements)
             trial[target] = cand
             try:
-                trial_layout = Layout(
-                    fleet=scenario.fleet,
-                    hangar=scenario.hangar,
-                    placements=tuple(trial.values()),
-                    maintenance_plane=scenario.maintenance_plane,
-                )
+                trial_layout = _build_layout(scenario, trial)
             except ValueError:
                 # Mirrors _descent_step's defensive catch. The only routinely-reachable
                 # trigger is the cart rule, but _perturb_plane and the 180° flip both
@@ -1830,12 +1837,7 @@ def _descent_step(
     ``Layout.__post_init__`` and are skipped.
     """
     # Build current Layout from placements (uses Layout invariants — free check).
-    current_layout = Layout(
-        fleet=scenario.fleet,
-        hangar=scenario.hangar,
-        placements=tuple(placements.values()),
-        maintenance_plane=scenario.maintenance_plane,
-    )
+    current_layout = _build_layout(scenario, placements)
 
     current_result = check_layout(current_layout)
 
@@ -1880,12 +1882,7 @@ def _descent_step(
         trial = dict(placements)
         trial[target] = cand
         try:
-            trial_layout = Layout(
-                fleet=scenario.fleet,
-                hangar=scenario.hangar,
-                placements=tuple(trial.values()),
-                maintenance_plane=scenario.maintenance_plane,
-            )
+            trial_layout = _build_layout(scenario, trial)
         except ValueError:
             # Layout invariant violated (cart rule, etc.) — skip this candidate
             continue

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -33,13 +33,14 @@ from dataclasses import replace
 from typing import Literal, NamedTuple, cast
 
 from hangarfit.collisions import check as check_layout
-from hangarfit.geometry import WorldPart, cached_parts_world, pose_cache_scope
+from hangarfit.geometry import WorldPart, aircraft_parts_world, cached_parts_world, pose_cache_scope
 from hangarfit.models import (
     Aircraft,
     ApronShallowDrop,
     CheckResult,
     Conflict,
     DiversityConfig,
+    GroundObject,
     Layout,
     Placement,
     Scenario,
@@ -1177,6 +1178,30 @@ def _initial_placement_for_plane(
         y_m=y,
         heading_deg=heading,
         on_carts=on_carts,
+    )
+
+
+def _body(scenario: Scenario, body_id: str) -> Aircraft | GroundObject:
+    """Resolve a placeable body id to its Aircraft or GroundObject definition (#604).
+
+    Aircraft (``fleet``) are checked first so the common, pre-#604 path is
+    unchanged; a placed_routed_mover id falls through to ``ground_object_defs``."""
+    plane = scenario.fleet.get(body_id)
+    if plane is not None:
+        return plane
+    return scenario.ground_object_defs[body_id]
+
+
+def _body_parts_world(scenario: Scenario, body_id: str, placement: Placement) -> list[WorldPart]:
+    """World parts for any placeable body (#604). Aircraft reuse the pose-memoized
+    ``cached_parts_world`` — BYTE-IDENTICAL to the pre-#604 solver path (ADR-0003);
+    a GroundObject mover goes through the union-typed uncached ``aircraft_parts_world``,
+    matching exactly how the towplanner computes mover geometry (#602)."""
+    body = _body(scenario, body_id)
+    return list(
+        cached_parts_world(body, placement)
+        if isinstance(body, Aircraft)
+        else aircraft_parts_world(body, placement)
     )
 
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -1275,7 +1275,7 @@ def _inter_plane_energy(
     if len(ids) < 2:
         return 0.0
     world: dict[str, list[WorldPart]] = {
-        pid: cached_parts_world(scenario.fleet[pid], placements[pid]) for pid in ids
+        pid: _body_parts_world(scenario, pid, placements[pid]) for pid in ids
     }
     w = {pid: _priority_weight(scenario, pid) for pid in ids}
     energy = 0.0
@@ -1344,7 +1344,7 @@ def _spread_quality(
     if len(ids) < 2:
         return (math.inf, 0.0)
     world: dict[str, list[WorldPart]] = {
-        pid: cached_parts_world(scenario.fleet[pid], placements[pid]) for pid in ids
+        pid: _body_parts_world(scenario, pid, placements[pid]) for pid in ids
     }
     w = {pid: _priority_weight(scenario, pid) for pid in ids}
     min_gap = math.inf

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -316,12 +316,14 @@ def _run_restart(
                 )
             candidate_layout = _build_layout(scenario, placements)
             min_gap, energy = _spread_quality(placements, scenario, spread_scale)
+            cand_alignment = _region_alignment(placements, scenario)
             candidate = _SpreadCandidate(
                 layout=candidate_layout,
                 min_gap=min_gap,
                 energy=energy,
                 restart_index=restart_index,
                 nose_out_flips=n_flips,
+                region_alignment=cand_alignment,
             )
             break  # found a basin
 
@@ -840,6 +842,10 @@ def _build_found_result(
     accepted_layouts = [c.layout for c in selected]
     min_gaps = tuple(c.min_gap for c in selected)
     nose_out_flips = tuple(c.nose_out_flips for c in selected)
+    region_alignment_per_layout = tuple(c.region_alignment for c in selected)
+    # Collapse the no-preferences case to the empty default so a scenario without
+    # region preferences reports `()` (not a tuple of empty tuples) — #604.
+    region_alignment = region_alignment_per_layout if any(region_alignment_per_layout) else ()
     status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
     plans, unroutable, apron_drops = _tow_plan_layouts(
         accepted_layouts,
@@ -865,6 +871,7 @@ def _build_found_result(
             spread_stall_applied=spread_stall_applied,
             apron_shallow_drops=apron_drops,
             nose_out_flips=nose_out_flips,
+            region_alignment=region_alignment,
         ),
     )
 
@@ -1336,6 +1343,26 @@ def _region_energy(placements: Mapping[str, Placement], scenario: Scenario) -> f
         d = (width - x) if pref.side == "right" else x
         total += pref.weight * (d / width)
     return total
+
+
+def _region_alignment(
+    placements: Mapping[str, Placement], scenario: Scenario
+) -> tuple[tuple[str, float], ...]:
+    """Per-preferring-object wall alignment in ``[0, 1]`` (1.0 = AT the preferred
+    wall), sorted by id (#604). ``()`` when the scenario has no region preferences.
+    RNG-free; the observability twin of :func:`_region_energy`."""
+    prefs = scenario.region_preferences
+    if not prefs:
+        return ()
+    width = scenario.hangar.width_m
+    out: list[tuple[str, float]] = []
+    for pid in sorted(prefs):
+        if pid not in placements:
+            continue
+        x = placements[pid].x_m
+        frac = (x / width) if prefs[pid].side == "right" else (1.0 - x / width)
+        out.append((pid, max(0.0, min(1.0, frac))))
+    return tuple(out)
 
 
 def _resolve_spread_scale(scenario: Scenario, search: SearchConfig) -> float:
@@ -1979,6 +2006,7 @@ class _SpreadCandidate(NamedTuple):
     energy: float
     restart_index: int
     nose_out_flips: int = 0
+    region_alignment: tuple[tuple[str, float], ...] = ()
 
 
 def _select_spread_diverse(

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -1081,7 +1081,7 @@ def _check_pin_feasibility(scenario: Scenario) -> tuple[CheckResult, Layout] | N
     return None
 
 
-def _plane_max_extent(plane: Aircraft) -> tuple[float, float]:
+def _plane_max_extent(plane: Aircraft | GroundObject) -> tuple[float, float]:
     """Return (max_length_m, max_width_m) over all of the plane's Parts.
 
     Takes the maximum ``length_m`` and maximum ``width_m`` across all
@@ -1167,8 +1167,8 @@ def _initial_placement_for_plane(
         return constraint.pin
 
     hangar = scenario.hangar
-    plane = scenario.fleet[plane_id]
-    max_length, max_width = _plane_max_extent(plane)
+    body = _body(scenario, plane_id)
+    max_length, max_width = _plane_max_extent(body)
     margin_x = max(max_length, max_width) / 2
     margin_y = margin_x
 
@@ -1602,6 +1602,18 @@ def _initial_placements(
             scenario=scenario,
             rng=rng,
             on_carts=on_carts,
+        )
+
+    # Movers (#604): sampled AFTER all aircraft, in sorted-id order, so adding a
+    # mover never perturbs the aircraft draw sequence — a scenario with no movers
+    # is byte-identical to the pre-#604 behaviour (ADR-0003). Movers never ride
+    # carts and are excluded from cart-bucket enumeration (it iterates fleet_in).
+    for gid in sorted(scenario.mover_ids):
+        placements[gid] = _initial_placement_for_plane(
+            plane_id=gid,
+            scenario=scenario,
+            rng=rng,
+            on_carts=False,
         )
 
     return placements

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,14 @@ constructs its objects inside its own body, on demand.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
+import pytest
+
 from hangarfit.models import Aircraft, Gear, Part, Wheels
+
+_FIXTURES = Path(__file__).parent / "fixtures"
 
 
 def _default_parts() -> tuple[Part, ...]:
@@ -97,3 +102,41 @@ def make_test_aircraft(
         wheels=wheels,
         **overrides,
     )
+
+
+# --- #604 right-region demo scenarios (loaded lazily; see module docstring) ---
+
+
+@pytest.fixture
+def region_scenario():
+    """Demo scenario: 2 aircraft + 2 glider trailers (movers, RIGHT preference) +
+    a fixed fuel-trailer keep-out, in a roomy bay-free-right hangar."""
+    from hangarfit.loader import load_scenario
+
+    return load_scenario(_FIXTURES / "scenario_region_demo.yaml")
+
+
+@pytest.fixture
+def region_scenario_left():
+    """As :func:`region_scenario` but the trailers prefer the LEFT wall."""
+    from hangarfit.loader import load_scenario
+
+    return load_scenario(_FIXTURES / "scenario_region_demo_left.yaml")
+
+
+@pytest.fixture
+def region_scenario_no_go():
+    """As :func:`region_scenario` but with NO ground objects — the inert /
+    byte-identity baseline (``mover_ids == ()``, no region preferences)."""
+    from hangarfit.loader import load_scenario
+
+    return load_scenario(_FIXTURES / "scenario_region_demo_no_go.yaml")
+
+
+@pytest.fixture
+def region_scenario_with_caddy():
+    """As :func:`region_scenario` plus the VW Caddy (a ``hard_door_mover``) so the
+    #603 egress gate is exercised in ``solve``."""
+    from hangarfit.loader import load_scenario
+
+    return load_scenario(_FIXTURES / "scenario_region_demo_caddy.yaml")

--- a/tests/fixtures/fleet_region_demo.yaml
+++ b/tests/fixtures/fleet_region_demo.yaml
@@ -1,0 +1,14 @@
+# Test-only fleet manifest for the #604 right-region demo. Thin manifest
+# referencing the central data/catalog/ (paths relative to this file).
+# Two small aircraft + the real glider-trailer / fuel-trailer / Caddy catalog
+# objects, so the demo scenarios can place + route the trailers (movers) and
+# exercise the Caddy egress gate (#603).
+aircraft:
+  - ../../data/catalog/fuji.yaml
+  - ../../data/catalog/cessna_150.yaml
+
+ground_objects:
+  - ../../data/catalog/glider_trailer_1.yaml
+  - ../../data/catalog/glider_trailer_2.yaml
+  - ../../data/catalog/maul_fuel_trailer.yaml
+  - ../../data/catalog/vw_caddy.yaml

--- a/tests/fixtures/hangar_region_demo.yaml
+++ b/tests/fixtures/hangar_region_demo.yaml
@@ -1,0 +1,23 @@
+# Test-only roomy hangar for the #604 right-region demo.
+#
+# Deliberately bay-free on the RIGHT side: the small maintenance bay sits in the
+# back-LEFT corner (x ∈ [1, 7], y ∈ [24, 30]) so the right half of the floor is
+# clear for the right-region soft preference to pull the glider trailers toward
+# the right wall (x → width_m). 30 × 24 m gives ample x-room so the pull is
+# unambiguous and the 2 aircraft + 2 trailers + fixed fuel trailer fit with slack.
+length_m: 30.0
+width_m: 24.0
+
+door:
+  center_x_m: 12.0
+  width_m: 18.0
+
+maintenance_bay:
+  center_x_m: 4.0      # x ∈ [1, 7]  (back-left, away from the right-region target)
+  width_m: 6.0
+  depth_m: 6.0         # back 6 m: y ∈ [24, 30]
+
+clearance_m: 0.3
+wing_layer_clearance_m: 0.2
+
+max_carts: 1

--- a/tests/fixtures/scenario_region_demo.yaml
+++ b/tests/fixtures/scenario_region_demo.yaml
@@ -1,0 +1,18 @@
+# #604 right-region demo: 2 small aircraft + 2 glider trailers (placed-routed
+# movers with a SOFT right-region preference) + the fuel trailer as a fixed
+# keep-out near the front-left (out of the way of the right-region pull).
+# The solver PLACES + routes the trailers; the right preference re-ranks valid
+# candidates so the trailers settle toward the right wall (ADR-0008 amended).
+fleet: fleet_region_demo.yaml
+hangar: hangar_region_demo.yaml
+fleet_in: [fuji, cessna_150]
+
+ground_objects:
+  - object: maul_fuel_trailer      # fixed keep-out, front-left (clear of the right side)
+    x_m: 2.5
+    y_m: 3.0
+    heading_deg: 0.0
+  - object: glider_trailer_1       # mover: solver places + routes; prefers the right wall
+    region_preference: { side: right, weight: 1.5 }
+  - object: glider_trailer_2
+    region_preference: { side: right, weight: 1.5 }

--- a/tests/fixtures/scenario_region_demo_caddy.yaml
+++ b/tests/fixtures/scenario_region_demo_caddy.yaml
@@ -1,0 +1,16 @@
+# #604 demo — with the VW Caddy (a hard_door_mover, #603). The solver places +
+# routes the Caddy along with the trailers; the #603 egress gate fires in solve
+# (it was inert before #604 because solved layouts carried no ground objects).
+# A layout that traps the Caddy's drive-out is rejected (exit-3 / dropped plan).
+fleet: fleet_region_demo.yaml
+hangar: hangar_region_demo.yaml
+fleet_in: [fuji, cessna_150]
+
+ground_objects:
+  - object: maul_fuel_trailer
+    x_m: 2.5
+    y_m: 3.0
+    heading_deg: 0.0
+  - object: vw_caddy               # hard_door_mover: must keep a clear drive-out (#603)
+  - object: glider_trailer_1
+    region_preference: { side: right, weight: 1.5 }

--- a/tests/fixtures/scenario_region_demo_left.yaml
+++ b/tests/fixtures/scenario_region_demo_left.yaml
@@ -1,0 +1,17 @@
+# #604 right-region demo — LEFT variant. Identical to scenario_region_demo.yaml
+# except the trailers prefer the LEFT wall. Used to prove the side selector is
+# live: the right-pref trailer settles further right than the left-pref one
+# (same seed).
+fleet: fleet_region_demo.yaml
+hangar: hangar_region_demo.yaml
+fleet_in: [fuji, cessna_150]
+
+ground_objects:
+  - object: maul_fuel_trailer
+    x_m: 2.5
+    y_m: 3.0
+    heading_deg: 0.0
+  - object: glider_trailer_1
+    region_preference: { side: left, weight: 1.5 }
+  - object: glider_trailer_2
+    region_preference: { side: left, weight: 1.5 }

--- a/tests/fixtures/scenario_region_demo_no_go.yaml
+++ b/tests/fixtures/scenario_region_demo_no_go.yaml
@@ -1,0 +1,9 @@
+# #604 demo — NO ground objects. Same aircraft + hangar as scenario_region_demo,
+# but with no ground_objects block at all: mover_ids == (), region_preferences
+# empty. This is the inert/byte-identity baseline — solving it must be
+# byte-identical to the pre-#604 solver (ADR-0003), and the region term must be a
+# no-op. (The fleet manifest still lists ground-object catalog defs, but none are
+# active in this scenario.)
+fleet: fleet_region_demo.yaml
+hangar: hangar_region_demo.yaml
+fleet_in: [fuji, cessna_150]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -352,6 +352,51 @@ def test_solve_json_output_has_spread_diagnostics(capsys):
     assert all(g is None or isinstance(g, (int, float)) for g in diag["min_pairwise_gap_m"])
 
 
+def test_solve_human_output_shows_region_alignment(capsys):
+    from hangarfit.cli import main
+
+    rc = main(
+        [
+            "solve",
+            str(FIXTURES_DIR / "scenario_region_demo.yaml"),
+            "--seed",
+            "7",
+            "--budget",
+            "5",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "region" in out.lower()  # the "region alignment ..." segment
+
+
+def test_solve_json_output_has_region_alignment(capsys):
+    import json
+
+    from hangarfit.cli import main
+
+    rc = main(
+        [
+            "solve",
+            str(FIXTURES_DIR / "scenario_region_demo.yaml"),
+            "--seed",
+            "7",
+            "--budget",
+            "5",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    diag = payload["diagnostics"]
+    assert "region_alignment" in diag
+    assert len(diag["region_alignment"]) == len(payload["layouts"])
+    # each layout's entry is an object mapping body-id -> alignment in [0,1]
+    assert all(
+        0.0 <= a <= 1.0 for layout_align in diag["region_alignment"] for a in layout_align.values()
+    )
+
+
 def test_solve_json_single_plane_min_gap_is_null(capsys):
     """A single-plane layout has no plane pairs → min_pairwise_gap_m is
     math.inf internally, which MUST serialize as JSON null (not the invalid

--- a/tests/test_herrenteich_region.py
+++ b/tests/test_herrenteich_region.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+
+from hangarfit.loader import load_scenario
+from hangarfit.models import SearchConfig
+from hangarfit.solver import solve
+
+HERRENTEICH = Path(__file__).parent.parent / "examples" / "herrenteich"
+
+
+def test_herrenteich_scenario_loads_with_region_prefs():
+    s = load_scenario(HERRENTEICH / "scenario.yaml")
+    assert s.region_preferences  # opted in
+    assert {"glider_trailer_1", "glider_trailer_2"}.issubset(set(s.mover_ids))
+    # fuel trailer is a fixed keep-out, not a mover
+    fixed_ids = {p.plane_id for p in s.fixed_obstacle_placements}
+    assert "maul_fuel_trailer" in fixed_ids
+    assert s.region_preferences["glider_trailer_1"].side == "right"
+
+
+@pytest.mark.slow
+def test_herrenteich_solve_terminates_cleanly():
+    # The real all-eight set may be intractable (#599); the contract is that solve
+    # TERMINATES with a well-formed status and never raises — not that it succeeds.
+    s = load_scenario(HERRENTEICH / "scenario.yaml")
+    r = solve(s, search=SearchConfig(max_restarts=4, spread=True), seed=0, budget_s=30.0)
+    assert r.status in ("found", "found_partial", "exhausted_budget", "trivially_infeasible")

--- a/tests/test_loader_scenario_ground_objects.py
+++ b/tests/test_loader_scenario_ground_objects.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+import pytest
+
+from hangarfit.loader import LoaderError, load_scenario
+
+FIX = Path(__file__).parent / "fixtures"
+FLEET = (FIX / "fleet_region_demo.yaml").resolve()
+HANGAR = (FIX / "hangar_region_demo.yaml").resolve()
+
+
+def test_scenario_loads_mover_with_region_preference():
+    s = load_scenario(FIX / "scenario_region_demo.yaml")
+    assert "glider_trailer_1" in s.mover_ids
+    assert s.region_preferences["glider_trailer_1"].side == "right"
+    assert s.region_preferences["glider_trailer_1"].weight == 1.5
+
+
+def test_scenario_loads_fixed_obstacle_pose():
+    s = load_scenario(FIX / "scenario_region_demo.yaml")
+    ids = {p.plane_id for p in s.fixed_obstacle_placements}
+    assert "maul_fuel_trailer" in ids
+    fp = next(p for p in s.fixed_obstacle_placements if p.plane_id == "maul_fuel_trailer")
+    assert (fp.x_m, fp.y_m, fp.heading_deg) == (2.5, 3.0, 0.0)
+
+
+def test_scenario_bare_string_mover_no_pref():
+    s = load_scenario(FIX / "scenario_region_demo_caddy.yaml")
+    # vw_caddy is listed as a bare string-or-no-pref mover entry
+    assert "vw_caddy" in s.mover_ids
+
+
+def test_scenario_left_variant_loads_with_left_side():
+    s = load_scenario(FIX / "scenario_region_demo_left.yaml")
+    assert s.region_preferences["glider_trailer_1"].side == "left"
+
+
+def _write(tmp_path, go_block: str) -> Path:
+    p = tmp_path / "bad.yaml"
+    p.write_text(
+        f"fleet: {FLEET}\nhangar: {HANGAR}\n"
+        f"fleet_in: [fuji, cessna_150]\nground_objects:\n{go_block}"
+    )
+    return p
+
+
+def test_fixed_obstacle_requires_pose(tmp_path):
+    with pytest.raises(LoaderError):
+        load_scenario(_write(tmp_path, "  - object: maul_fuel_trailer\n"))  # no pose
+
+
+def test_mover_forbids_pose(tmp_path):
+    with pytest.raises(LoaderError):
+        load_scenario(
+            _write(
+                tmp_path,
+                "  - object: glider_trailer_1\n    x_m: 5.0\n    y_m: 5.0\n    heading_deg: 0.0\n",
+            )
+        )
+
+
+def test_fixed_obstacle_forbids_region_preference(tmp_path):
+    with pytest.raises(LoaderError):
+        load_scenario(
+            _write(
+                tmp_path,
+                "  - object: maul_fuel_trailer\n    x_m: 2.0\n    y_m: 3.0\n"
+                "    heading_deg: 0.0\n    region_preference: {side: right, weight: 1.0}\n",
+            )
+        )
+
+
+def test_unknown_object_rejected(tmp_path):
+    with pytest.raises(LoaderError):
+        load_scenario(_write(tmp_path, "  - object: ghost_trailer\n"))

--- a/tests/test_loader_scenario_ground_objects.py
+++ b/tests/test_loader_scenario_ground_objects.py
@@ -73,3 +73,25 @@ def test_fixed_obstacle_forbids_region_preference(tmp_path):
 def test_unknown_object_rejected(tmp_path):
     with pytest.raises(LoaderError):
         load_scenario(_write(tmp_path, "  - object: ghost_trailer\n"))
+
+
+def test_region_preference_non_string_side_rejected(tmp_path):
+    with pytest.raises(LoaderError):
+        load_scenario(
+            _write(
+                tmp_path,
+                "  - object: glider_trailer_1\n"
+                "    region_preference: {side: [left, right], weight: 1.0}\n",
+            )
+        )
+
+
+def test_region_preference_invalid_side_string_rejected(tmp_path):
+    with pytest.raises(LoaderError):
+        load_scenario(
+            _write(
+                tmp_path,
+                "  - object: glider_trailer_1\n"
+                "    region_preference: {side: sideways, weight: 1.0}\n",
+            )
+        )

--- a/tests/test_models_region.py
+++ b/tests/test_models_region.py
@@ -9,6 +9,7 @@ from hangarfit.models import (
     Placement,
     RegionPreference,
     Scenario,
+    SolverDiagnostics,
 )
 from tests.conftest import make_test_aircraft  # noqa: E402
 
@@ -166,3 +167,31 @@ def test_scenario_fixed_obstacle_placement_validates():
         ),
     )
     assert len(s.fixed_obstacle_placements) == 1
+
+
+# ---------------------------------------------------------------------------
+# Task 3: SolverDiagnostics.region_alignment
+# ---------------------------------------------------------------------------
+
+
+def _diag(**kw):
+    base = dict(
+        restarts_attempted=1, wall_time_s=0.0, best_partial=None, best_partial_layout=None, seed=0
+    )
+    base.update(kw)
+    return SolverDiagnostics(**base)
+
+
+def test_region_alignment_default_empty():
+    assert _diag().region_alignment == ()
+
+
+def test_region_alignment_valid():
+    d = _diag(region_alignment=((("glider_trailer_1", 0.92),),))
+    assert d.region_alignment[0][0] == ("glider_trailer_1", 0.92)
+
+
+@pytest.mark.parametrize("bad", [-0.01, 1.01, float("nan")])
+def test_region_alignment_rejects_out_of_range(bad):
+    with pytest.raises(ValueError):
+        _diag(region_alignment=((("t", bad),),))

--- a/tests/test_models_region.py
+++ b/tests/test_models_region.py
@@ -1,6 +1,75 @@
 import pytest
 
-from hangarfit.models import RegionPreference
+from hangarfit.models import (
+    Door,
+    GroundObject,
+    Hangar,
+    MaintenanceBay,
+    Part,
+    Placement,
+    RegionPreference,
+    Scenario,
+)
+from tests.conftest import make_test_aircraft  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Shared builders (copied from test_towplanner_ground_object.py pattern)
+# ---------------------------------------------------------------------------
+
+
+def _hangar(clearance: float = 0.3, wlc: float = 0.2) -> Hangar:
+    return Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=clearance,
+        wing_layer_clearance_m=wlc,
+    )
+
+
+def _ground_part(length_m: float = 3.0, width_m: float = 2.0, z_top_m: float = 1.5) -> Part:
+    return Part(
+        kind="ground",
+        length_m=length_m,
+        width_m=width_m,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=z_top_m,
+    )
+
+
+def _towed_mover(obj_id: str = "glider_trailer_1") -> GroundObject:
+    """A valid placed_routed_mover with motion_mode='towed' (no turn_radius_m)."""
+    return GroundObject(
+        id=obj_id,
+        name="Glider trailer",
+        parts=(_ground_part(),),
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+    )
+
+
+def _fixed_obstacle(obj_id: str = "maul_fuel_trailer") -> GroundObject:
+    return GroundObject(
+        id=obj_id,
+        name="Fuel trailer",
+        parts=(_ground_part(),),
+        object_class="fixed_obstacle",
+    )
+
+
+def _minimal_scenario(**kwargs) -> Scenario:
+    """Minimal valid Scenario with one aircraft."""
+    ac = make_test_aircraft(id="husky")
+    return Scenario(
+        fleet={ac.id: ac},
+        hangar=_hangar(),
+        fleet_in=(ac.id,),
+        **kwargs,
+    )
 
 
 def test_region_preference_valid_right():
@@ -22,3 +91,78 @@ def test_region_preference_rejects_bad_weight(bad):
 def test_region_preference_rejects_bad_side():
     with pytest.raises(ValueError):
         RegionPreference(side="up", weight=1.0)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Task 2: Scenario.region_preferences + fixed_obstacle_placements + mover_ids
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_region_preferences_default_empty():
+    s = _minimal_scenario()
+    assert dict(s.region_preferences) == {}
+
+
+def test_scenario_region_preference_must_reference_placeable_id():
+    with pytest.raises(ValueError, match="ghost"):
+        _minimal_scenario(region_preferences={"ghost": RegionPreference(side="right", weight=1.0)})
+
+
+def test_scenario_region_preference_on_aircraft_ok():
+    ac_id = "husky"
+    s = _minimal_scenario(region_preferences={ac_id: RegionPreference(side="left", weight=0.5)})
+    assert s.region_preferences[ac_id].side == "left"
+
+
+def test_scenario_mover_ids_from_ground_objects():
+    mover = _towed_mover("glider_trailer_1")
+    s = _minimal_scenario(
+        ground_objects=(mover.id,),
+        ground_object_defs={mover.id: mover},
+    )
+    assert s.mover_ids == ("glider_trailer_1",)
+
+
+def test_scenario_region_preference_on_mover_ok():
+    mover = _towed_mover("glider_trailer_1")
+    s = _minimal_scenario(
+        ground_objects=(mover.id,),
+        ground_object_defs={mover.id: mover},
+        region_preferences={mover.id: RegionPreference(side="right", weight=1.0)},
+    )
+    assert s.region_preferences[mover.id].side == "right"
+
+
+def test_scenario_placeable_ids_is_fleet_in_when_no_movers():
+    s = _minimal_scenario()
+    assert s.placeable_ids == s.fleet_in
+
+
+def test_scenario_fixed_obstacle_placement_validates():
+    obs = _fixed_obstacle("maul_fuel_trailer")
+    mover = _towed_mover("glider_trailer_1")
+    # A fixed_obstacle_placements entry referencing a placed_routed_mover id must raise.
+    with pytest.raises(ValueError):
+        _minimal_scenario(
+            ground_objects=(mover.id,),
+            ground_object_defs={mover.id: mover},
+            fixed_obstacle_placements=(
+                Placement(plane_id=mover.id, x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),
+            ),
+        )
+    # An unknown id must also raise.
+    with pytest.raises(ValueError):
+        _minimal_scenario(
+            fixed_obstacle_placements=(
+                Placement(plane_id="ghost", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),
+            ),
+        )
+    # A valid fixed_obstacle must be accepted.
+    s = _minimal_scenario(
+        ground_objects=(obs.id,),
+        ground_object_defs={obs.id: obs},
+        fixed_obstacle_placements=(
+            Placement(plane_id=obs.id, x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    assert len(s.fixed_obstacle_placements) == 1

--- a/tests/test_models_region.py
+++ b/tests/test_models_region.py
@@ -7,6 +7,7 @@ from hangarfit.models import (
     MaintenanceBay,
     Part,
     Placement,
+    RegionAlignment,
     RegionPreference,
     Scenario,
     SolverDiagnostics,
@@ -187,11 +188,13 @@ def test_region_alignment_default_empty():
 
 
 def test_region_alignment_valid():
-    d = _diag(region_alignment=((("glider_trailer_1", 0.92),),))
+    d = _diag(region_alignment=((RegionAlignment("glider_trailer_1", 0.92),),))
+    assert d.region_alignment[0][0] == RegionAlignment("glider_trailer_1", 0.92)
+    # NamedTuple compares equal to the bare tuple by value (determinism-neutral).
     assert d.region_alignment[0][0] == ("glider_trailer_1", 0.92)
 
 
 @pytest.mark.parametrize("bad", [-0.01, 1.01, float("nan")])
 def test_region_alignment_rejects_out_of_range(bad):
     with pytest.raises(ValueError):
-        _diag(region_alignment=((("t", bad),),))
+        _diag(region_alignment=((RegionAlignment("t", bad),),))

--- a/tests/test_models_region.py
+++ b/tests/test_models_region.py
@@ -1,0 +1,24 @@
+import pytest
+
+from hangarfit.models import RegionPreference
+
+
+def test_region_preference_valid_right():
+    rp = RegionPreference(side="right", weight=1.0)
+    assert rp.side == "right"
+    assert rp.weight == 1.0
+
+
+def test_region_preference_zero_weight_allowed():
+    assert RegionPreference(side="left", weight=0.0).weight == 0.0
+
+
+@pytest.mark.parametrize("bad", [-0.1, float("nan"), float("inf")])
+def test_region_preference_rejects_bad_weight(bad):
+    with pytest.raises(ValueError):
+        RegionPreference(side="right", weight=bad)
+
+
+def test_region_preference_rejects_bad_side():
+    with pytest.raises(ValueError):
+        RegionPreference(side="up", weight=1.0)  # type: ignore[arg-type]

--- a/tests/test_solver_ground_objects.py
+++ b/tests/test_solver_ground_objects.py
@@ -142,6 +142,22 @@ def test_descent_step_handles_layout_with_mover(region_scenario):
     assert out is None or (isinstance(out, tuple) and len(out) == 3)
 
 
+def test_solve_with_movers_byte_identical_same_seed(region_scenario):
+    cfg = SearchConfig(max_restarts=4, spread=True)
+    a = solve(region_scenario, search=cfg, seed=42, budget_s=120.0, plan_paths=False)
+    b = solve(region_scenario, search=cfg, seed=42, budget_s=120.0, plan_paths=False)
+
+    def sig(result):
+        return [
+            [(p.plane_id, p.x_m, p.y_m, p.heading_deg) for p in layout.placements]
+            + [(p.plane_id, p.x_m, p.y_m, p.heading_deg) for p in layout.ground_object_placements]
+            for layout in result.layouts
+        ]
+
+    assert a.layouts  # the demo scenario solves
+    assert sig(a) == sig(b)  # aircraft AND mover poses bit-identical (max_restarts-scoped)
+
+
 @pytest.mark.slow
 def test_solve_with_caddy_exercises_egress_gate(region_scenario_with_caddy):
     # The VW Caddy is a hard_door_mover: once the solver places it, the #603

--- a/tests/test_solver_ground_objects.py
+++ b/tests/test_solver_ground_objects.py
@@ -1,5 +1,7 @@
 import random
 
+import pytest
+
 from hangarfit.geometry import aircraft_parts_world, cached_parts_world
 from hangarfit.models import Aircraft, GroundObject, Layout, Placement, SearchConfig
 from hangarfit.solver import (
@@ -9,6 +11,7 @@ from hangarfit.solver import (
     _descent_step,
     _initial_placements,
     _perturb_plane,
+    solve,
 )
 
 
@@ -137,3 +140,26 @@ def test_descent_step_handles_layout_with_mover(region_scenario):
     # returns a (placements, score, accepted) triple (or None if all conflicts pinned);
     # the key assertion is that it ran without KeyError on the mover id.
     assert out is None or (isinstance(out, tuple) and len(out) == 3)
+
+
+@pytest.mark.slow
+def test_solve_with_caddy_exercises_egress_gate(region_scenario_with_caddy):
+    # The VW Caddy is a hard_door_mover: once the solver places it, the #603
+    # egress gate runs in solve (inert before #604). Assert solve completes with a
+    # well-formed status and — when a layout is returned — the caddy is in that
+    # layout's ground_object_placements (so the gate operated on a caddy-bearing
+    # layout). A trapped caddy would drop the plan / mark it unroutable, not raise.
+    # tow_max_expansions=4000 keeps the routing budget bounded (~60-90 s on a
+    # typical dev machine); reduce to 2000 if this flakes on the CI timing gate.
+    r = solve(
+        region_scenario_with_caddy,
+        search=SearchConfig(max_restarts=4, spread=True),
+        seed=0,
+        budget_s=120.0,
+        plan_paths=True,
+        tow_max_expansions=4000,
+    )
+    assert r.status in ("found", "found_partial", "exhausted_budget")
+    if r.layouts:
+        go_ids = {p.plane_id for p in r.layouts[0].ground_object_placements}
+        assert "vw_caddy" in go_ids  # the hard-door mover is in the gated layout

--- a/tests/test_solver_ground_objects.py
+++ b/tests/test_solver_ground_objects.py
@@ -1,0 +1,34 @@
+from hangarfit.geometry import aircraft_parts_world, cached_parts_world
+from hangarfit.models import Aircraft, GroundObject, Placement
+from hangarfit.solver import _body, _body_parts_world
+
+
+def _bounds_key(parts):
+    return [(wp.plane_id, wp.kind, tuple(round(c, 9) for c in wp.polygon.bounds)) for wp in parts]
+
+
+def test_body_returns_aircraft_for_fleet_id(region_scenario):
+    b = _body(region_scenario, "fuji")
+    assert isinstance(b, Aircraft) and b.id == "fuji"
+    # identity: same object the solver looks up today
+    assert b is region_scenario.fleet["fuji"]
+
+
+def test_body_returns_ground_object_for_mover_id(region_scenario):
+    b = _body(region_scenario, "glider_trailer_1")
+    assert isinstance(b, GroundObject) and b.object_class == "placed_routed_mover"
+
+
+def test_body_parts_world_aircraft_byte_identical(region_scenario):
+    p = Placement(plane_id="fuji", x_m=10.0, y_m=12.0, heading_deg=30.0, on_carts=False)
+    # aircraft path delegates to cached_parts_world on the SAME aircraft object
+    got = _body_parts_world(region_scenario, "fuji", p)
+    ref = cached_parts_world(region_scenario.fleet["fuji"], p)
+    assert _bounds_key(got) == _bounds_key(ref)
+
+
+def test_body_parts_world_mover_matches_uncached_transform(region_scenario):
+    p = Placement(plane_id="glider_trailer_1", x_m=20.0, y_m=15.0, heading_deg=90.0, on_carts=False)
+    got = _body_parts_world(region_scenario, "glider_trailer_1", p)
+    ref = aircraft_parts_world(region_scenario.ground_object_defs["glider_trailer_1"], p)
+    assert _bounds_key(got) == _bounds_key(ref)

--- a/tests/test_solver_ground_objects.py
+++ b/tests/test_solver_ground_objects.py
@@ -1,6 +1,13 @@
+import random
+
 from hangarfit.geometry import aircraft_parts_world, cached_parts_world
 from hangarfit.models import Aircraft, GroundObject, Layout, Placement
-from hangarfit.solver import _body, _body_parts_world, _build_layout
+from hangarfit.solver import (
+    _body,
+    _body_parts_world,
+    _build_layout,
+    _initial_placements,
+)
 
 
 def _bounds_key(parts):
@@ -62,3 +69,34 @@ def test_build_layout_splits_movers_and_injects_fixed(region_scenario):
     assert {p.plane_id for p in built.placements} == {"fuji", "cessna_150"}
     go_ids = {p.plane_id for p in built.ground_object_placements}
     assert "glider_trailer_1" in go_ids and "maul_fuel_trailer" in go_ids  # mover + injected fixed
+
+
+def test_initial_placements_samples_movers(region_scenario):
+    pl = _initial_placements(
+        scenario=region_scenario, rng=random.Random(0), cart_bucket=frozenset()
+    )
+    assert "glider_trailer_1" in pl and "glider_trailer_2" in pl
+    assert pl["glider_trailer_1"].on_carts is False
+    # aircraft still present
+    assert "fuji" in pl and "cessna_150" in pl
+
+
+def test_initial_placements_deterministic_with_movers(region_scenario):
+    a = _initial_placements(scenario=region_scenario, rng=random.Random(7), cart_bucket=frozenset())
+    b = _initial_placements(scenario=region_scenario, rng=random.Random(7), cart_bucket=frozenset())
+
+    def key(d):
+        return {k: (v.x_m, v.y_m, v.heading_deg, v.on_carts) for k, v in d.items()}
+
+    assert key(a) == key(b)
+
+
+def test_initial_placements_no_go_same_seed(region_scenario_no_go):
+    a = _initial_placements(
+        scenario=region_scenario_no_go, rng=random.Random(7), cart_bucket=frozenset()
+    )
+    b = _initial_placements(
+        scenario=region_scenario_no_go, rng=random.Random(7), cart_bucket=frozenset()
+    )
+    assert {k: (v.x_m, v.y_m) for k, v in a.items()} == {k: (v.x_m, v.y_m) for k, v in b.items()}
+    assert "glider_trailer_1" not in a  # no movers in the no-GO scenario

--- a/tests/test_solver_ground_objects.py
+++ b/tests/test_solver_ground_objects.py
@@ -1,12 +1,14 @@
 import random
 
 from hangarfit.geometry import aircraft_parts_world, cached_parts_world
-from hangarfit.models import Aircraft, GroundObject, Layout, Placement
+from hangarfit.models import Aircraft, GroundObject, Layout, Placement, SearchConfig
 from hangarfit.solver import (
     _body,
     _body_parts_world,
     _build_layout,
+    _descent_step,
     _initial_placements,
+    _perturb_plane,
 )
 
 
@@ -100,3 +102,38 @@ def test_initial_placements_no_go_same_seed(region_scenario_no_go):
     )
     assert {k: (v.x_m, v.y_m) for k, v in a.items()} == {k: (v.x_m, v.y_m) for k, v in b.items()}
     assert "glider_trailer_1" not in a  # no movers in the no-GO scenario
+
+
+def test_perturb_mover_no_keyerror_and_stays_off_carts(region_scenario):
+    cur = Placement("glider_trailer_1", 20.0, 20.0, 90.0, on_carts=False)
+    out = _perturb_plane(
+        current=cur,
+        scenario=region_scenario,
+        rng=random.Random(0),
+        search=SearchConfig(),
+        large_jump=False,
+    )
+    assert out.plane_id == "glider_trailer_1"
+    assert out.on_carts is False
+
+
+def test_descent_step_handles_layout_with_mover(region_scenario):
+    # A placements dict that includes a mover overlapping an aircraft must not
+    # KeyError, and the descent must be able to choose the mover as a target.
+    placements = {
+        "fuji": Placement("fuji", 12.0, 12.0, 0.0, on_carts=False),
+        "cessna_150": Placement("cessna_150", 12.2, 12.0, 0.0, on_carts=False),  # overlap
+        # overlap (mover):
+        "glider_trailer_1": Placement("glider_trailer_1", 12.1, 12.0, 0.0, on_carts=False),
+    }
+    out = _descent_step(
+        placements=placements,
+        scenario=region_scenario,
+        rng=random.Random(1),
+        search=SearchConfig(),
+        current_score=(99, 9.9),
+        pinned_planes=frozenset(),
+    )
+    # returns a (placements, score, accepted) triple (or None if all conflicts pinned);
+    # the key assertion is that it ran without KeyError on the mover id.
+    assert out is None or (isinstance(out, tuple) and len(out) == 3)

--- a/tests/test_solver_ground_objects.py
+++ b/tests/test_solver_ground_objects.py
@@ -1,6 +1,6 @@
 from hangarfit.geometry import aircraft_parts_world, cached_parts_world
-from hangarfit.models import Aircraft, GroundObject, Placement
-from hangarfit.solver import _body, _body_parts_world
+from hangarfit.models import Aircraft, GroundObject, Layout, Placement
+from hangarfit.solver import _body, _body_parts_world, _build_layout
 
 
 def _bounds_key(parts):
@@ -32,3 +32,33 @@ def test_body_parts_world_mover_matches_uncached_transform(region_scenario):
     got = _body_parts_world(region_scenario, "glider_trailer_1", p)
     ref = aircraft_parts_world(region_scenario.ground_object_defs["glider_trailer_1"], p)
     assert _bounds_key(got) == _bounds_key(ref)
+
+
+def test_build_layout_aircraft_only_matches_plain_layout(region_scenario_no_go):
+    s = region_scenario_no_go  # NO ground objects
+    placements = {
+        "fuji": Placement("fuji", 5.0, 8.0, 0.0, on_carts=False),
+        "cessna_150": Placement("cessna_150", 12.0, 9.0, 0.0, on_carts=False),
+    }
+    built = _build_layout(s, placements)
+    plain = Layout(
+        fleet=s.fleet,
+        hangar=s.hangar,
+        placements=tuple(placements.values()),
+        maintenance_plane=s.maintenance_plane,
+    )
+    assert built.placements == plain.placements  # same order, same poses
+    assert built.ground_object_placements == ()
+
+
+def test_build_layout_splits_movers_and_injects_fixed(region_scenario):
+    s = region_scenario  # fuji+cessna_150 ; movers glider_trailer_1/2 ; fixed maul_fuel_trailer
+    placements = {
+        "fuji": Placement("fuji", 5.0, 8.0, 0.0, on_carts=False),
+        "cessna_150": Placement("cessna_150", 12.0, 9.0, 0.0, on_carts=False),
+        "glider_trailer_1": Placement("glider_trailer_1", 20.0, 20.0, 90.0, on_carts=False),
+    }
+    built = _build_layout(s, placements)
+    assert {p.plane_id for p in built.placements} == {"fuji", "cessna_150"}
+    go_ids = {p.plane_id for p in built.ground_object_placements}
+    assert "glider_trailer_1" in go_ids and "maul_fuel_trailer" in go_ids  # mover + injected fixed

--- a/tests/test_solver_region.py
+++ b/tests/test_solver_region.py
@@ -1,0 +1,23 @@
+from hangarfit.models import Placement, SearchConfig
+from hangarfit.solver import _inter_plane_energy, _resolve_spread_scale
+
+
+def test_inter_plane_energy_includes_movers(region_scenario):
+    s = region_scenario
+    scale = _resolve_spread_scale(s, SearchConfig())
+    placements = {
+        "fuji": Placement("fuji", 5.0, 8.0, 0.0, on_carts=False),
+        "glider_trailer_1": Placement("glider_trailer_1", 6.0, 8.0, 0.0, on_carts=False),
+    }
+    # must not KeyError on the mover, and two near bodies must repel (>0)
+    assert _inter_plane_energy(placements, s, scale) > 0.0
+
+
+def test_inter_plane_energy_no_go_deterministic(region_scenario_no_go):
+    s = region_scenario_no_go
+    scale = _resolve_spread_scale(s, SearchConfig())
+    placements = {
+        "fuji": Placement("fuji", 5.0, 8.0, 0.0, on_carts=False),
+        "cessna_150": Placement("cessna_150", 9.0, 8.0, 0.0, on_carts=False),
+    }
+    assert _inter_plane_energy(placements, s, scale) == _inter_plane_energy(placements, s, scale)

--- a/tests/test_solver_region.py
+++ b/tests/test_solver_region.py
@@ -1,5 +1,7 @@
+import pytest
+
 from hangarfit.models import Placement, SearchConfig
-from hangarfit.solver import _inter_plane_energy, _resolve_spread_scale
+from hangarfit.solver import _inter_plane_energy, _region_energy, _resolve_spread_scale, solve
 
 
 def test_inter_plane_energy_includes_movers(region_scenario):
@@ -21,3 +23,45 @@ def test_inter_plane_energy_no_go_deterministic(region_scenario_no_go):
         "cessna_150": Placement("cessna_150", 9.0, 8.0, 0.0, on_carts=False),
     }
     assert _inter_plane_energy(placements, s, scale) == _inter_plane_energy(placements, s, scale)
+
+
+def test_region_energy_empty_is_zero(region_scenario_no_go):
+    placements = {"fuji": Placement("fuji", 5.0, 8.0, 0.0, on_carts=False)}
+    assert _region_energy(placements, region_scenario_no_go) == 0.0  # no prefs ⇒ inert
+
+
+def test_region_energy_right_minimized_at_right_wall(region_scenario):
+    W = region_scenario.hangar.width_m
+    near_left = {"glider_trailer_1": Placement("glider_trailer_1", 1.0, 10.0, 0.0, on_carts=False)}
+    near_right = {
+        "glider_trailer_1": Placement("glider_trailer_1", W - 1.0, 10.0, 0.0, on_carts=False)
+    }
+    assert _region_energy(near_right, region_scenario) < _region_energy(near_left, region_scenario)
+
+
+def test_region_energy_formula(region_scenario):
+    W = region_scenario.hangar.width_m
+    x = 3.0
+    pl = {"glider_trailer_1": Placement("glider_trailer_1", x, 10.0, 0.0, on_carts=False)}
+    # weight 1.5, side right ⇒ 1.5 * (W - x)/W   (glider_trailer_2 absent ⇒ skipped)
+    assert _region_energy(pl, region_scenario) == pytest.approx(1.5 * (W - x) / W)
+
+
+def _key(layouts):
+    return [
+        [(p.plane_id, p.x_m, p.y_m, p.heading_deg) for p in layout.placements] for layout in layouts
+    ]
+
+
+def test_solve_no_region_pref_byte_identical(region_scenario_no_go):
+    cfg = SearchConfig(max_restarts=4, spread=True)
+    a = solve(region_scenario_no_go, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    b = solve(region_scenario_no_go, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    assert _key(a.layouts) == _key(b.layouts)
+
+
+def test_solve_region_pref_active_deterministic(region_scenario):
+    cfg = SearchConfig(max_restarts=4, spread=True)
+    a = solve(region_scenario, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    b = solve(region_scenario, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    assert _key(a.layouts) == _key(b.layouts)

--- a/tests/test_solver_region.py
+++ b/tests/test_solver_region.py
@@ -65,3 +65,20 @@ def test_solve_region_pref_active_deterministic(region_scenario):
     a = solve(region_scenario, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
     b = solve(region_scenario, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
     assert _key(a.layouts) == _key(b.layouts)
+
+
+def _trailer_x(result, trailer_id="glider_trailer_1"):
+    return next(
+        p.x_m for p in result.layouts[0].ground_object_placements if p.plane_id == trailer_id
+    )
+
+
+def test_region_pref_pulls_trailer_right(region_scenario, region_scenario_left):
+    cfg = SearchConfig(max_restarts=6, spread=True)
+    r = solve(region_scenario, search=cfg, seed=1, budget_s=120.0, plan_paths=False)
+    lft = solve(region_scenario_left, search=cfg, seed=1, budget_s=120.0, plan_paths=False)
+    assert r.status == "found" and lft.status == "found"
+    # right-preferring trailer settles further right than the left-preferring one
+    assert _trailer_x(r) > _trailer_x(lft)
+    # and the right one is actually in the right half of the 24 m-wide hangar
+    assert _trailer_x(r) > region_scenario.hangar.width_m / 2

--- a/tests/test_solver_region.py
+++ b/tests/test_solver_region.py
@@ -82,3 +82,30 @@ def test_region_pref_pulls_trailer_right(region_scenario, region_scenario_left):
     assert _trailer_x(r) > _trailer_x(lft)
     # and the right one is actually in the right half of the 24 m-wide hangar
     assert _trailer_x(r) > region_scenario.hangar.width_m / 2
+
+
+def test_region_alignment_surfaced_in_diagnostics(region_scenario):
+    r = solve(
+        region_scenario,
+        search=SearchConfig(max_restarts=6, spread=True),
+        seed=1,
+        budget_s=120.0,
+        plan_paths=False,
+    )
+    align = r.diagnostics.region_alignment
+    assert len(align) == len(r.layouts)
+    layout0 = dict(align[0])
+    assert 0.0 <= layout0["glider_trailer_1"] <= 1.0
+    # right-pref trailer ends near the right wall ⇒ alignment high
+    assert layout0["glider_trailer_1"] > 0.5
+
+
+def test_region_alignment_empty_when_no_pref(region_scenario_no_go):
+    r = solve(
+        region_scenario_no_go,
+        search=SearchConfig(max_restarts=4, spread=True),
+        seed=0,
+        budget_s=120.0,
+        plan_paths=False,
+    )
+    assert r.diagnostics.region_alignment == ()

--- a/tests/test_solver_region.py
+++ b/tests/test_solver_region.py
@@ -109,3 +109,23 @@ def test_region_alignment_empty_when_no_pref(region_scenario_no_go):
         plan_paths=False,
     )
     assert r.diagnostics.region_alignment == ()
+
+
+def test_demo_solver_places_and_right_biases_both_trailers(region_scenario):
+    cfg = SearchConfig(max_restarts=8, spread=True)
+    r = solve(region_scenario, search=cfg, seed=0, budget_s=60.0, plan_paths=False)
+    assert r.status == "found"
+    layout = r.layouts[0]
+    go_x = {p.plane_id: p.x_m for p in layout.ground_object_placements}
+    # both trailers were PLACED by the solver
+    assert {"glider_trailer_1", "glider_trailer_2"}.issubset(go_x)
+    # ... and RIGHT-biased: physically in the right half of the 24 m-wide hangar
+    half = region_scenario.hangar.width_m / 2
+    assert go_x["glider_trailer_1"] > half
+    assert go_x["glider_trailer_2"] > half
+    # ... reflected in the surfaced region_alignment diagnostic (1.0 = at right wall)
+    align = dict(r.diagnostics.region_alignment[0])
+    assert align["glider_trailer_1"] > 0.5
+    assert align["glider_trailer_2"] > 0.5
+    # the fixed fuel trailer stays at its authored keep-out pose (front-left)
+    assert go_x["maul_fuel_trailer"] < half


### PR DESCRIPTION
Closes #604

## What & why
Makes the deterministic solver **place + route the glider trailers** as full RR-MC search citizens, and adds a **soft right/left-region preference** scored as a layered `_spread` post-pass term — the soft-tier sibling of the #603 hard Caddy egress gate. Built per the brainstormed spec + plan in `docs/superpowers/{specs,plans}/2026-06-12-glider-trailer-region-and-go-solver-integration*.md`.

Key finding that shaped the work: the solver did **not** place ground objects at all (they entered only via authored layout files for `check`/`view`); so "the solver places the trailer" is a new capability — ground objects (movers + fixed obstacles) are now threaded through the whole search.

## Approach (Approach 1 — unified placeable-id set)
- One placeable set `fleet_in ++ sorted(mover_ids)` with `_body()`/`_build_layout()` dispatch. **No ground objects ⇒ provably byte-identical** to pre-#604 (zero new RNG draws, empty `Layout` GO args, region term not added).
- Movers: sampled (`_initial_placements`) → perturbed in the hard descent (`_descent_step`/`_perturb_plane`) → spread → routed (`plan_fill`, already polymorphic per #602) → egress-gated (`egress_first_conflict` now fires in `solve` for `hard_door_mover`s).
- Fixed obstacles: authored static keep-outs via `Scenario.fixed_obstacle_placements`.
- **Region term** (`solver._region_energy`): `R = Σ wₒ·dₒ/W`, the #320 back-bias rotated to the x-axis — normalized, RNG-free, default-inert, **secondary** to `min_pairwise_gap_m` (re-ranks only within a basin's validity-gated hill-climb). Authored per-object in the scenario as `RegionPreference{side, weight}`.
- Surfaced as `SolverDiagnostics.region_alignment` (per-layout per-object 0–1) in the `solve` human + `--json` output. Herrenteich scenario opted in.

## Determinism (ADR-0003)
The load-bearing invariant: **absent ground objects ⇒ byte-identical; movers present ⇒ deterministic by construction** (seeded sorted-id sampling, RNG-free region term, never in the selection key). Verified by the `determinism-guard` (twice-and-diff incl. cross-`PYTHONHASHSEED`), the unchanged existing canaries, and a new movers-active byte-identity canary.

## Tests / verification
- Full required suite: **1661 passed / 15 deselected**; `mypy` + `pyright` + `ruff` clean.
- Inert trio (helper/solve/active), region-effect, end-to-end demo (solver places + right-biases both trailers), `@slow` caddy egress-in-solve, `@slow` Herrenteich-terminates-cleanly (the real 8-set is intractable per #599 — reported honestly, not a bug).

## Review arc (done pre-merge)
`determinism-guard` (PASS), `code-reviewer` (no issues ≥80%), `type-design-analyzer`, `silent-failure-hunter`, `comment-analyzer`. Findings addressed: a real `region_preference.side` `TypeError`→`LoaderError` fix (+tests), the egress-gate-scope doc overclaim, a `RegionAlignment` NamedTuple, and Scenario docstring/invariant notes.

## Notes / scope
- Mover-routing-in-solve is proven by the `@slow` caddy test + #602 units; the demo e2e asserts placement+region (fast) because routing both trailers into the congested right wall is slow.
- Sibling follow-ups out of scope: #612 (surface unroutable movers on stderr), #614 (soft door-priority tie-break).
- `data/hangar.yaml` / `CLAUDE.md` untouched; the user's local `M CLAUDE.md`/`.claude/settings.json` graphify edits were never staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)