### PR TITLE
chore(624,625): local test ergonomics — Makefile two-pass split + host-relative perf canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- **Local test ergonomics: two-pass `make test` + host-relative perf canary
+  (#624, #625).** A root `Makefile` mirrors CI's #492 two-pass test split for
+  local dev (`make test` = a parallel bulk pass + a separate serial pass for the
+  wall-clock determinism canaries; ~588 s → ~169 s, 3.5× on a 32-core box), with
+  `make test-fast` / `lint` / `typecheck` / `format` / `check` rounding out the
+  CI-parity targets. The `@slow` `plan_fill` perf canary
+  (`tests/test_towplanner_perf.py`) is now **host-relative**: it calibrates its
+  wall-clock ceiling off a per-run warm-up probe (floored at the original 400 s)
+  rather than an absolute bound, so a slower box (e.g. WSL2) no longer
+  false-fails on byte-identical, expansion-bound work. Dev/CI tooling only — no
+  runtime, solver, or determinism impact. (#624, #625)
+
 - **Per-object catalog data model (#595).** Fleet data is now a per-object
   **catalog** (`data/catalog/`, one file per aircraft carrying a `type:`
   discriminator) referenced **by path** from thin fleet manifests; inline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,15 @@ pytest -m slow
 # Or run everything regardless of marker
 pytest -m ""
 
+# Mirror CI's #492 two-pass split locally (588 s serial → ~169 s, 3.5×; #624).
+# A bare `pytest -n auto` is UNSAFE — it re-flakes the @serial wall-clock
+# canaries (rationale: docs/dev/test-flakes-and-ci-gotchas.md §1). The Makefile
+# keeps the split (and lint/typecheck/format) in one place:
+make test        # two-pass split: parallel bulk + serial canaries (the safe mirror)
+make test-fast   # parallel bulk only (5.2×; skips the serial canaries)
+make check       # full pre-push gate: lint + typecheck + two-pass tests
+make help        # list all targets
+
 # GOTCHA (test flakes + CI quirks) → docs/dev/test-flakes-and-ci-gotchas.md.
 # Read it before treating a determinism/coverage CI failure as a regression: the
 # `serial` wall-clock double-solve canaries (run OUTSIDE `-n auto`, #492); the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,14 +176,12 @@ pytest -m slow
 # Or run everything regardless of marker
 pytest -m ""
 
-# Mirror CI's #492 two-pass split locally (588 s serial → ~169 s, 3.5×; #624).
+# Mirror CI's #492 two-pass split locally (~3.5× vs a plain serial `pytest`; #624).
 # A bare `pytest -n auto` is UNSAFE — it re-flakes the @serial wall-clock
-# canaries (rationale: docs/dev/test-flakes-and-ci-gotchas.md §1). The Makefile
-# keeps the split (and lint/typecheck/format) in one place:
+# canaries (rationale: docs/dev/test-flakes-and-ci-gotchas.md §1):
 make test        # two-pass split: parallel bulk + serial canaries (the safe mirror)
-make test-fast   # parallel bulk only (5.2×; skips the serial canaries)
-make check       # full pre-push gate: lint + typecheck + two-pass tests
-make help        # list all targets
+make test-fast   # parallel bulk only (skips the serial canaries — faster iteration)
+# `make help` lists every target (test-slow / lint / typecheck / format / check).
 
 # GOTCHA (test flakes + CI quirks) → docs/dev/test-flakes-and-ci-gotchas.md.
 # Read it before treating a determinism/coverage CI failure as a regression: the

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# hangarfit dev Makefile — a local mirror of the CI gates (.github/workflows/ci.yml).
+#
+# `make test` runs CI's two-pass test split (#492) LOCALLY: a parallel bulk pass
+# plus a separate serial pass for the wall-clock determinism canaries. On a
+# 32-core box this is ~169 s versus ~588 s for a plain serial `pytest`
+# (3.5x; profiling spike #617, lever #624).
+#
+# Why two passes and not a bare `pytest -n auto`? The `serial`-marked canaries
+# run solve() twice in-process under a wall-clock budget; under xdist CPU
+# starvation the two solves can complete different restart counts and DIVERGE,
+# re-exposing a determinism flake. Keeping them in a separate single-process pass
+# is the whole point — do NOT collapse `test` into one `-n auto` run.
+# Full rationale: docs/dev/test-flakes-and-ci-gotchas.md §1.
+#
+# These targets drop CI's `--cov` flags (coverage is a Codecov-upload concern,
+# not a local gate) but otherwise mirror ci.yml — including linting `bench/`
+# alongside `src/` and `tests/`. Run from the repo root (no `cd` needed).
+
+.PHONY: help test test-fast test-slow test-all lint format typecheck check
+
+help:  ## Show this help (default target)
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[1m%-11s\033[0m %s\n", $$1, $$2}'
+
+test:  ## Two-pass split (parallel bulk + serial canaries) — the safe local CI mirror
+	pytest -n auto -m "not slow and not serial"
+	pytest -m "serial and not slow"
+
+test-fast:  ## Parallel bulk only (5.2x; SKIPS the serial canaries — run `make test` before pushing)
+	pytest -n auto -m "not slow and not serial"
+
+test-slow:  ## The @slow set only (heavy solves; excluded from `make test` and from CI)
+	pytest -m slow
+
+test-all:  ## Everything regardless of marker, single-process (slowest but always safe)
+	pytest -m ""
+
+lint:  ## ruff check + format --check (mirrors ci.yml, incl. bench/)
+	ruff check src/ tests/ bench/
+	ruff format --check src/ tests/ bench/
+
+format:  ## Auto-fix lint findings and format in place
+	ruff check --fix src/ tests/ bench/
+	ruff format src/ tests/ bench/
+
+typecheck:  ## mypy (mirrors ci.yml)
+	mypy src/hangarfit
+
+check: lint typecheck test  ## Full local pre-push gate: lint + typecheck + two-pass tests

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # hangarfit dev Makefile — a local mirror of the CI gates (.github/workflows/ci.yml).
 #
 # `make test` runs CI's two-pass test split (#492) LOCALLY: a parallel bulk pass
-# plus a separate serial pass for the wall-clock determinism canaries. On a
-# 32-core box this is ~169 s versus ~588 s for a plain serial `pytest`
-# (3.5x; profiling spike #617, lever #624).
+# plus a separate serial pass for the wall-clock determinism canaries. It is
+# roughly 3.5x faster than a plain serial `pytest` (~169 s vs ~588 s measured on
+# a 32-core box; profiling spike #617, lever #624).
 #
 # Why two passes and not a bare `pytest -n auto`? The `serial`-marked canaries
 # run solve() twice in-process under a wall-clock budget; under xdist CPU
@@ -26,7 +26,7 @@ test:  ## Two-pass split (parallel bulk + serial canaries) — the safe local CI
 	pytest -n auto -m "not slow and not serial"
 	pytest -m "serial and not slow"
 
-test-fast:  ## Parallel bulk only (5.2x; SKIPS the serial canaries — run `make test` before pushing)
+test-fast:  ## Parallel bulk only (~5x, #617; SKIPS the serial canaries — run `make test` before pushing)
 	pytest -n auto -m "not slow and not serial"
 
 test-slow:  ## The @slow set only (heavy solves; excluded from `make test` and from CI)

--- a/docs/dev/test-flakes-and-ci-gotchas.md
+++ b/docs/dev/test-flakes-and-ci-gotchas.md
@@ -25,8 +25,10 @@ pytest -n auto -m "not slow and not serial"
 pytest -m "serial and not slow"
 ```
 
-or just re-run a flagged canary in isolation before treating a failure as a
-regression. The `max_restarts`-scoped companion
+`make test` runs exactly this two-pass split for you (the root `Makefile`, #624),
+so the recipe and the dev shortcut stay in sync; `make test-fast` runs only the
+parallel bulk pass. Or just re-run a flagged canary in isolation before treating
+a failure as a regression. The `max_restarts`-scoped companion
 (`test_solve_deterministic_best_partial_under_max_restarts`) is the
 load-independent determinism check.
 

--- a/tests/test_towplanner_perf.py
+++ b/tests/test_towplanner_perf.py
@@ -46,7 +46,7 @@ from hangarfit.towplanner import NoFeasiblePlanError, path_first_conflict, plan_
 # global cap removed) balloons the heavy fill while the easy warm-up — which
 # routes without exhausting any budget — stays flat, so the ratio still trips it.
 _PLAN_FILL_CEILING_FLOOR_S = 400.0
-_WARMUP_CEILING_MULTIPLE = 1800.0  # heavy/warm-up ≈ 871 measured; ×~2 for margin
+_WARMUP_CEILING_MULTIPLE = 1800.0  # heavy/warm-up ≈ 871 measured (WSL2 ref box); ×~2 margin
 _WARMUP_SCENARIO = "tests/fixtures/solve_feasible_smoke.yaml"
 
 
@@ -71,7 +71,12 @@ def host_plan_fill_ceiling_s() -> float:
     if not result.layouts:
         return _PLAN_FILL_CEILING_FLOOR_S
     t0 = time.monotonic()
-    plan_fill(result.layouts[0])
+    try:
+        plan_fill(result.layouts[0])
+    except NoFeasiblePlanError:
+        # A bailed warm-up is a poor speed probe (a fast bail under-measures host
+        # speed → an artificially tight ceiling), so fall back to the floor.
+        return _PLAN_FILL_CEILING_FLOOR_S
     warmup_s = time.monotonic() - t0
     return max(_PLAN_FILL_CEILING_FLOOR_S, warmup_s * _WARMUP_CEILING_MULTIPLE)
 

--- a/tests/test_towplanner_perf.py
+++ b/tests/test_towplanner_perf.py
@@ -20,35 +20,60 @@ import time
 import pytest
 
 from hangarfit.loader import load_scenario
-from hangarfit.models import Layout
+from hangarfit.models import Layout, SolveResult
 from hangarfit.solver import solve
 from hangarfit.towplanner import NoFeasiblePlanError, path_first_conflict, plan_fill
 
-# Wall-clock ceiling for one layout's fill. The search budget is per-plane
-# (_MAX_EXPANSIONS expansions), so an un-towable plane costs ~budget-exhaustion
-# time to prove infeasible. This `slow`-marked gate is a runaway guard, not a
-# tight regression bound — it catches the order-of-magnitude (pre-tuning the
-# same layout took ~177s).
+# This `slow`-marked gate is a runaway guard, not a tight regression bound — it
+# catches the order-of-magnitude. `plan_fill` is RNG-free and expansion-bound
+# (per-plane budget _MAX_EXPANSIONS; GLOBAL per-fill cap _MAX_FILL_EXPANSIONS),
+# so the WORK it does for a given layout is FIXED across machines — only the
+# wall-clock speed varies. The budget evolved as the model grew: the absolute
+# ceiling went 30s → 75s (Reeds–Shepp 3→6 primitive fan, ADR-0010) → 400s
+# (_MAX_EXPANSIONS 700→2000, #335; the seed=7 six-plane bail measured ~271s on
+# the development machine, ×1.5 + rounding) and held at 400s through #336 (budget
+# 2000→8000 + the _MAX_FILL_EXPANSIONS=16000 global cap, which bounds the fill at
+# ~334s on that machine instead of grid@8000's uncapped ~997s).
 #
-# Bumped 30s → 75s for the Reeds–Shepp motion model (ADR-0010): the primitive
-# fan grew from 3 (forward L/S/R) to 6 (+ reverse L/S/R), so each expansion now
-# screens roughly twice the edges.
-#
-# Bumped 75s → 400s for the _MAX_EXPANSIONS 700 → 2000 raise (#335).  The
-# per-plane cost scales linearly with budget; with budget 2000 the worst-case
-# bail on the six-plane fresh fill (seed=7, two un-routable planes each
-# exhausting the full budget, tried multiple times by the greedy scan) measured
-# ~271 s on the development machine.  400 s = ~271 s × 1.5 + rounding — keeps
-# the runaway guard meaningful while allowing for slower CI machines.  Tighten
-# once real (measured) hangar geometry is available.
-#
-# #336: the per-plane budget rose 2000 → 8000 (grid heuristic became the
-# plan_fill default) AND a GLOBAL per-fill expansion cap
-# (_MAX_FILL_EXPANSIONS = 16000) was added. The cap is what keeps this gate
-# green: grid@8000 with NO global cap measured ~997 s on the seed=7 fill
-# (blowing 400 s), but the cap bails it at ~334 s. So 400 s still holds — now
-# bounded by the global fill cap, not per-plane budget × scan-retries.
-_PLAN_FILL_CEILING_S = 400.0
+# #625: an ABSOLUTE ceiling false-fails byte-identical work on a slower box. The
+# same seed=7 fill measured ~492s on a WSL2 dev box — over 400s with NO
+# regression. So the ceiling is now HOST-RELATIVE: time one cheap warm-up fill
+# (its work is also fixed, so its wall-clock is a faithful per-host speed probe),
+# then bound the real fill at a machine-INVARIANT multiple of it. The multiple is
+# the measured heavy/warm-up work ratio (~871 on the WSL2 reference box) doubled
+# for margin; the absolute FLOOR keeps a fast box from deriving a TIGHTER bound
+# than the original 400s guard. A genuine algorithmic runaway (e.g. the #336
+# global cap removed) balloons the heavy fill while the easy warm-up — which
+# routes without exhausting any budget — stays flat, so the ratio still trips it.
+_PLAN_FILL_CEILING_FLOOR_S = 400.0
+_WARMUP_CEILING_MULTIPLE = 1800.0  # heavy/warm-up ≈ 871 measured; ×~2 for margin
+_WARMUP_SCENARIO = "tests/fixtures/solve_feasible_smoke.yaml"
+
+
+def _solve_for_fill(scenario_path: str) -> SolveResult:
+    """Solve a scenario the way this gate drives the planner (seed=7, no internal
+    tow-planning — the gate times its OWN ``plan_fill`` calls)."""
+    return solve(
+        load_scenario(scenario_path), budget_s=10.0, alternatives=1, seed=7, plan_paths=False
+    )
+
+
+@pytest.fixture(scope="module")
+def host_plan_fill_ceiling_s() -> float:
+    """Per-host wall-clock ceiling for one fill, calibrated off a warm-up probe.
+
+    Times one ``plan_fill`` of the light feasible scenario (a faithful machine-
+    speed probe, since its work is fixed) and scales it by the measured
+    heavy/warm-up work ratio. Floored at ``_PLAN_FILL_CEILING_FLOOR_S`` so a fast
+    box never gets a tighter bound than the original absolute runaway guard.
+    """
+    result = _solve_for_fill(_WARMUP_SCENARIO)
+    if not result.layouts:
+        return _PLAN_FILL_CEILING_FLOOR_S
+    t0 = time.monotonic()
+    plan_fill(result.layouts[0])
+    warmup_s = time.monotonic() - t0
+    return max(_PLAN_FILL_CEILING_FLOOR_S, warmup_s * _WARMUP_CEILING_MULTIPLE)
 
 
 @pytest.mark.slow
@@ -59,15 +84,17 @@ _PLAN_FILL_CEILING_S = 400.0
         "tests/fixtures/solve_fresh_six_planes.yaml",
     ],
 )
-def test_plan_fill_on_solved_layouts_completes_within_budget(scenario_path: str) -> None:
-    scenario = load_scenario(scenario_path)
+def test_plan_fill_on_solved_layouts_completes_within_budget(
+    scenario_path: str, host_plan_fill_ceiling_s: float
+) -> None:
     # plan_paths=False: this gate times its OWN plan_fill calls below, so the
     # layout search must NOT also tow-plan internally (wasted work that, since
     # #336's grid default + larger budget, costs as much as the timed section).
-    result = solve(scenario, budget_s=10.0, alternatives=1, seed=7, plan_paths=False)
+    result = _solve_for_fill(scenario_path)
     if not result.layouts:
         pytest.skip(f"{scenario_path}: solve produced no layout (status={result.status})")
 
+    ceiling_s = host_plan_fill_ceiling_s
     for layout in result.layouts:
         t0 = time.monotonic()
         try:
@@ -75,12 +102,15 @@ def test_plan_fill_on_solved_layouts_completes_within_budget(scenario_path: str)
         except NoFeasiblePlanError:
             # Un-towable solver layout: the only guarantee here is a fast bail.
             elapsed = time.monotonic() - t0
-            assert elapsed < _PLAN_FILL_CEILING_S, (
-                f"{scenario_path}: plan_fill ran away ({elapsed:.1f}s) before bailing"
+            assert elapsed < ceiling_s, (
+                f"{scenario_path}: plan_fill ran away "
+                f"({elapsed:.1f}s > {ceiling_s:.1f}s host ceiling) before bailing"
             )
             continue
         elapsed = time.monotonic() - t0
-        assert elapsed < _PLAN_FILL_CEILING_S, f"{scenario_path}: plan_fill took {elapsed:.1f}s"
+        assert elapsed < ceiling_s, (
+            f"{scenario_path}: plan_fill took {elapsed:.1f}s (> {ceiling_s:.1f}s host ceiling)"
+        )
 
         # Every routed move's path is exact-oracle clean against the planes towed
         # before it — the real #222 tow-ability guarantee, not just timing.


### PR DESCRIPTION
Closes #624, Closes #625.

Wave 1 of the v0.15.0 milestone (graduated from the #617 profiling spike). Both items are **dev/CI tooling only — no runtime, solver, or determinism impact**, so they're bundled into one PR (they also share `docs/dev/test-flakes-and-ci-gotchas.md`).

## #624 — local two-pass `make test` (3.5× dev speedup)
A developer's plain `pytest -m "not slow"` runs **serial** (~588 s @ 111 % CPU on a 32-core box). CI was parallelized by #492's two-pass xdist split but local dev never was. This adds a root `Makefile`:
- `make test` — the safe local mirror of CI: `pytest -n auto -m "not slow and not serial"` then a separate serial pass `pytest -m "serial and not slow"` (~588 s → ~169 s).
- `make test-fast` / `test-slow` / `test-all` / `lint` / `format` / `typecheck` / `check`.

The **why-not-bare-`-n auto`** rationale (it re-flakes the `@serial` wall-clock canaries under xdist CPU starvation) ships *next to the target* and is cross-referenced from `CLAUDE.md` (Useful commands) and `docs/dev/test-flakes-and-ci-gotchas.md` §1. The Makefile drops CI's `--cov` flags (Codecov-only) but otherwise mirrors `ci.yml`, including linting `bench/`.

## #625 — host-relative `@slow` perf canary
`tests/test_towplanner_perf.py` had an **absolute** `_PLAN_FILL_CEILING_S = 400 s`. `plan_fill` is RNG-free and expansion-bound, so its **work is fixed across machines** — only wall-clock speed varies. On this WSL2 box the **byte-identical** seed=7 six-plane fill measures **492 s > 400 s** → false-fail with no regression.

Fix: calibrate the ceiling per-host. Time one cheap warm-up fill (its work is also fixed, so its wall-clock is a faithful machine-speed probe), then bound the real fill at a machine-**invariant** multiple of it (measured heavy/warm-up ratio ≈ 871, doubled for margin), **floored at the original 400 s** so a fast box never derives a *tighter* bound. A genuine algorithmic runaway (e.g. the #336 global cap removed) balloons the heavy fill while the easy warm-up stays flat, so the ratio still trips it.

## Verification
- `make lint` / `make help` / `make -n test` confirmed.
- `pytest -m slow tests/test_towplanner_perf.py` — host-relative ceiling computed from the warm-up; the previously-false-failing heavy case now passes (run attached in review).
- No change to the default (`-m "not slow"`) suite — `@slow` is excluded from CI and coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)