### PR TITLE
perf(626): extend the #453 pose cache to ground-object movers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- **Pose cache extended to ground-object movers (#626).** The #453 per-solve
+  geometry memo now serves any placeable body — a `GroundObject` car/trailer as
+  well as an aircraft — so a static mover obstacle's world parts are no longer
+  rebuilt on every collision/clearance check (the #453 churn movers bypassed,
+  which drove the #604 mover-routing congestion). `plan_fill` now also runs
+  inside a pose-cache scope, so a *standalone* fill memoizes its obstacle field
+  across the whole search (previously only an in-`solve` fill did). Output is
+  **byte-identical** (ADR-0003: the cache returns the same immutable `WorldPart`
+  list, exact-float keyed); the speed-up is routing-only — on the measured #604
+  right-region two-trailer demo the standalone fill dropped ~1.8× and an
+  aircraft-only fill ~2×. (#626)
+
 - **Local test ergonomics: two-pass `make test` + host-relative perf canary
   (#624, #625).** A root `Makefile` mirrors CI's #492 two-pass test split for
   local dev (`make test` = a parallel bulk pass + a separate serial pass for the

--- a/src/hangarfit/geometry.py
+++ b/src/hangarfit/geometry.py
@@ -307,8 +307,12 @@ def pose_cache_scope() -> Iterator[None]:
         _pose_cache.reset(token)
 
 
-def cached_parts_world(aircraft: Aircraft, placement: Placement) -> list[WorldPart]:
+def cached_parts_world(obj: Aircraft | GroundObject, placement: Placement) -> list[WorldPart]:
     """Pose-memoized :func:`aircraft_parts_world` for the active solve scope.
+
+    Accepts any placeable body — an :class:`~hangarfit.models.Aircraft` or a
+    :class:`~hangarfit.models.GroundObject` mover (#626) — since the underlying
+    transform is union-typed and the key is pose-generic.
 
     When a :func:`pose_cache_scope` is active, the result is cached on
     ``(plane_id, x_m, y_m, heading_deg)`` and reused for the lifetime of that
@@ -317,14 +321,15 @@ def cached_parts_world(aircraft: Aircraft, placement: Placement) -> list[WorldPa
     so non-solve callers stay byte-identical (just uncached).
 
     Caller contract: the key omits the parts/geometry, so within one scope a
-    given ``plane_id`` must always resolve to the same aircraft geometry. That
-    holds because a single ``solve()`` is driven by one fixed ``scenario.fleet``
-    (one :class:`~hangarfit.models.Aircraft` per id) — which is exactly why the
-    cache is per-solve and never module-global.
+    given ``plane_id`` must always resolve to the same body geometry. That holds
+    because a single ``solve()`` (or :func:`~hangarfit.towplanner.plan_fill`) is
+    driven by one fixed ``scenario.fleet`` + ``ground_objects`` (one
+    :class:`~hangarfit.models.Aircraft` / :class:`~hangarfit.models.GroundObject`
+    per id) — which is exactly why the cache is per-solve and never module-global.
     """
     cache = _pose_cache.get()
     if cache is None:
-        return aircraft_parts_world(aircraft, placement)
+        return aircraft_parts_world(obj, placement)
     key: _PoseKey = (
         placement.plane_id,
         placement.x_m,
@@ -332,5 +337,5 @@ def cached_parts_world(aircraft: Aircraft, placement: Placement) -> list[WorldPa
         placement.heading_deg,
     )
     if key not in cache:
-        cache[key] = aircraft_parts_world(aircraft, placement)
+        cache[key] = aircraft_parts_world(obj, placement)
     return cache[key]

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -34,7 +34,7 @@ from dataclasses import replace
 from typing import Literal, NamedTuple, cast
 
 from hangarfit.collisions import check as check_layout
-from hangarfit.geometry import WorldPart, aircraft_parts_world, cached_parts_world, pose_cache_scope
+from hangarfit.geometry import WorldPart, cached_parts_world, pose_cache_scope
 from hangarfit.models import (
     Aircraft,
     ApronShallowDrop,
@@ -1218,16 +1218,16 @@ def _body(scenario: Scenario, body_id: str) -> Aircraft | GroundObject:
 
 
 def _body_parts_world(scenario: Scenario, body_id: str, placement: Placement) -> list[WorldPart]:
-    """World parts for any placeable body (#604). Aircraft reuse the pose-memoized
-    ``cached_parts_world`` — BYTE-IDENTICAL to the pre-#604 solver path (ADR-0003);
-    a GroundObject mover goes through the union-typed uncached ``aircraft_parts_world``,
-    matching exactly how the towplanner computes mover geometry (#602)."""
+    """World parts for any placeable body (#604/#626). Both an Aircraft and a
+    GroundObject mover reuse the pose-memoized ``cached_parts_world`` — the cache
+    key ``(plane_id, x, y, heading)`` and the union-typed transform are body-
+    generic, so a mover obstacle's fixed-pose geometry is now served from the
+    cache instead of rebuilt on every collision/clearance check (#453 churn that
+    movers previously bypassed). BYTE-IDENTICAL to the pre-#604 solver path
+    (ADR-0003): the cache returns the same immutable ``WorldPart`` list the pure
+    transform would build, exact-float keyed."""
     body = _body(scenario, body_id)
-    return list(
-        cached_parts_world(body, placement)
-        if isinstance(body, Aircraft)
-        else aircraft_parts_world(body, placement)
-    )
+    return list(cached_parts_world(body, placement))
 
 
 def _priority_weight(scenario: Scenario, pid: str) -> float:

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -38,9 +38,9 @@ from hangarfit.collisions import _parts_conflict
 from hangarfit.collisions import check as _check
 from hangarfit.geometry import (
     WorldPart,
-    aircraft_parts_world,
     cached_parts_world,
     polygon_overlap,
+    pose_cache_scope,
 )
 from hangarfit.models import (
     Aircraft,
@@ -1156,15 +1156,10 @@ def _mover_motion_bounds_conflict(
     door_hi = hangar.door.center_x_m + door_half
     apron_depth = hangar.apron_depth_m
 
-    # cached_parts_world is Aircraft-typed (pose-memoized for the solve scope);
-    # a GroundObject mover goes straight through the union-typed
-    # aircraft_parts_world (uncached, byte-identical geometry). The Aircraft
-    # branch is unchanged ⇒ aircraft routing stays byte-identical.
-    world_parts = list(
-        cached_parts_world(mover, placement)
-        if isinstance(mover, Aircraft)
-        else aircraft_parts_world(mover, placement)
-    )
+    # Pose-memoized for any placeable body (#626): an Aircraft or a GroundObject
+    # mover both reuse cached_parts_world. The key is pose-generic, and outside an
+    # active pose_cache_scope it is a pure passthrough ⇒ byte-identical.
+    world_parts = list(cached_parts_world(mover, placement))
     # Does the footprint cross the front-wall line (vertices on both sides of
     # y=0)? Only a crossing must thread the door (#411); a footprint wholly in
     # front (all y<=0) is staged on the apron and does not cross. Computed only
@@ -1454,6 +1449,32 @@ def plan_fill(
     scan are all RNG-free, so a given ``target`` always yields the same
     :class:`MovesPlan`.
     """
+    # #626: memoize body world-parts for the WHOLE fill. The static obstacle field
+    # is rebuilt by every plan_path's _build_obstacles, and the greedy scan re-routes
+    # the same bodies across iterations, so a fill-wide pose cache turns those
+    # repeated fixed-pose rebuilds into hits — the #453 win movers previously
+    # bypassed, and the root of the #604 routing congestion. Byte-identical
+    # (ADR-0003: the cache returns the same immutable WorldPart list); nesting
+    # inside an in-``solve`` scope is a no-op.
+    with pose_cache_scope():
+        return _plan_fill(
+            target,
+            heuristic=heuristic,
+            max_expansions=max_expansions,
+            max_total_expansions=max_total_expansions,
+            apron_dropped_out=apron_dropped_out,
+        )
+
+
+def _plan_fill(
+    target: Layout,
+    *,
+    heuristic: Literal["euclidean", "grid"] = "grid",
+    max_expansions: int | None = None,
+    max_total_expansions: int | None = None,
+    apron_dropped_out: list[ApronShallowDrop] | None = None,
+) -> MovesPlan:
+    """Body of :func:`plan_fill`, run inside an active ``pose_cache_scope`` (#626)."""
     budget = _MAX_EXPANSIONS if max_expansions is None else max_expansions
     total_budget = _MAX_FILL_EXPANSIONS if max_total_expansions is None else max_total_expansions
     total_used = 0
@@ -1928,7 +1949,10 @@ def _build_obstacles(placed: Layout, *, mover_id: str) -> _Obstacles:
         if gp.plane_id == mover_id:
             continue
         obj = placed.ground_objects[gp.plane_id]
-        parts.extend(aircraft_parts_world(obj, gp))
+        # Pose-memoized (#626): a static mover obstacle's fixed-pose world parts are
+        # rebuilt by every plan_path's _build_obstacles otherwise — the #453 churn
+        # movers bypassed, and the root of the #604 routing congestion.
+        parts.extend(cached_parts_world(obj, gp))
     bay = placed.hangar.maintenance_bay
     return _Obstacles(
         world_parts=tuple(parts),
@@ -1991,14 +2015,11 @@ def _motion_clear(
     module note above and the safety-net re-check in :func:`plan_path`.
     """
     placement = Placement(mover.id, pose.x_m, pose.y_m, pose.heading_deg, on_carts=False)
-    # cached_parts_world is Aircraft-typed; a GroundObject mover uses the
-    # union-typed aircraft_parts_world (uncached, identical geometry). Aircraft
-    # branch unchanged ⇒ byte-identical aircraft routing.
-    mover_parts = (
-        cached_parts_world(mover, placement)
-        if isinstance(mover, Aircraft)
-        else aircraft_parts_world(mover, placement)
-    )
+    # Pose-memoized for any placeable body (#626): an Aircraft or a GroundObject
+    # mover both reuse cached_parts_world. NOTE the TOWED mover's pose changes per
+    # sampled expansion, so it mostly MISSES here (expected) — the cache win is the
+    # static obstacle field (_build_obstacles), memoized across the fill.
+    mover_parts = cached_parts_world(mover, placement)
 
     # (A) Hangar bounds (front-gap-exempt for the mover).
     if _mover_motion_bounds_conflict(mover, placement, hangar) is not None:

--- a/tests/test_parts_cache.py
+++ b/tests/test_parts_cache.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import pytest
 
 from hangarfit.geometry import aircraft_parts_world, cached_parts_world, pose_cache_scope
-from hangarfit.models import Aircraft, Part, Placement, Wheels
+from hangarfit.models import Aircraft, GroundObject, Part, Placement, Wheels
 
 
 def _probe_aircraft() -> Aircraft:
@@ -62,9 +62,46 @@ def _probe_aircraft() -> Aircraft:
     )
 
 
+def _probe_ground_object() -> GroundObject:
+    """A placed-routed mover (trailer) — the #626 cache target. Only the geometry
+    matters here; the motion fields just satisfy the model invariants."""
+    return GroundObject(
+        id="trailer",
+        name="Trailer",
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+        turn_radius_m=None,
+        parts=(
+            Part(
+                kind="ground",
+                length_m=8.0,
+                width_m=2.5,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=2.0,
+            ),
+        ),
+    )
+
+
 def _coords(parts: list) -> list:
     """Exterior coords of every part polygon — a bit-exact geometry fingerprint."""
     return [list(p.polygon.exterior.coords) for p in parts]
+
+
+def test_ground_object_mover_is_a_cache_hit() -> None:
+    """#626: a GroundObject mover memoizes by pose exactly like an aircraft — a
+    repeated pose returns the *same* object (no rebuild), and the byte-identical
+    geometry the pure union-typed transform produces."""
+    go = _probe_ground_object()
+    pl = Placement(plane_id="trailer", x_m=5.0, y_m=12.0, heading_deg=20.0, on_carts=False)
+    with pose_cache_scope():
+        first = cached_parts_world(go, pl)
+        second = cached_parts_world(go, pl)
+    assert second is first  # hit: identical object, geometry not rebuilt
+    assert _coords(first) == _coords(aircraft_parts_world(go, pl))
 
 
 def test_repeated_pose_is_a_cache_hit() -> None:

--- a/tests/test_towplanner_ground_object.py
+++ b/tests/test_towplanner_ground_object.py
@@ -9,6 +9,8 @@ route, though the actual route search is deferred to #602 (their move carries a
 
 from __future__ import annotations
 
+import pytest
+
 from hangarfit.models import Door, GroundObject, Hangar, Layout, MaintenanceBay, Part, Placement
 from hangarfit.towplanner import _build_obstacles, plan_fill
 from tests.conftest import make_test_aircraft
@@ -177,3 +179,58 @@ def test_empty_ground_objects_no_extra_obstacles() -> None:
     obstacles = _build_obstacles(layout, mover_id="p1")
     plane_ids = {wp.plane_id for wp in obstacles.world_parts}
     assert plane_ids == {"p2"}
+
+
+def test_static_mover_obstacle_served_from_pose_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#626: within a ``pose_cache_scope``, a STATIC mover obstacle's world parts
+    are memoized across repeated ``_build_obstacles`` calls instead of rebuilt each
+    time — the pre-#626 uncached ``aircraft_parts_world`` path that drove the #604
+    routing congestion. Pre-#626 the trailer is rebuilt once per ``_build_obstacles``
+    call; after #626 it is built once and served from the cache thereafter."""
+    import hangarfit.geometry as geom
+    import hangarfit.towplanner as tp
+    from hangarfit.geometry import pose_cache_scope
+
+    hangar = _hangar()
+    ac = make_test_aircraft(id="p1")
+    trailer = GroundObject(
+        id="trailer",
+        name="t",
+        parts=(_ground_part(width_m=2.5, length_m=8.0),),
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+        turn_radius_m=None,
+    )
+    layout = Layout(
+        fleet={ac.id: ac},
+        hangar=hangar,
+        placements=(Placement(plane_id="p1", x_m=6.0, y_m=30.0, heading_deg=0.0, on_carts=False),),
+        ground_objects={trailer.id: trailer},
+        ground_object_placements=(
+            Placement(plane_id="trailer", x_m=10.0, y_m=20.0, heading_deg=90.0, on_carts=False),
+        ),
+    )
+
+    # Count world-part builds per body id. cached_parts_world (post-#626) builds
+    # via geometry's binding; the pre-#626 _build_obstacles called towplanner's
+    # imported binding directly for the mover (removed by #626, so patch it
+    # tolerantly so this test is meaningful on both sides of the change).
+    real = geom.aircraft_parts_world
+    builds: list[str] = []
+
+    def _counting(obj: object, placement: object) -> object:
+        builds.append(obj.id)  # type: ignore[attr-defined]
+        return real(obj, placement)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(geom, "aircraft_parts_world", _counting)
+    monkeypatch.setattr(tp, "aircraft_parts_world", _counting, raising=False)
+
+    # Route the aircraft (mover_id="p1") so the trailer is a STATIC obstacle.
+    with pose_cache_scope():
+        _build_obstacles(layout, mover_id="p1")
+        _build_obstacles(layout, mover_id="p1")
+
+    assert builds.count("trailer") == 1, (
+        f"static mover obstacle rebuilt {builds.count('trailer')}× across two "
+        "_build_obstacles calls — expected 1 (the pose cache should serve it; #626)"
+    )


### PR DESCRIPTION
Closes #626.

Wave 2 of v0.15.0 (graduated from the #617 profiling spike, lever **L3** — the concrete post-#604 root cause).

## Problem
The #453 per-solve geometry memo (`cached_parts_world`) was **Aircraft-typed**, so a `GroundObject` mover went through the **uncached** `aircraft_parts_world` at four `isinstance(body, Aircraft)` branch sites. A static mover obstacle therefore rebuilt its world parts on *every* collision/clearance check — the #453 churn movers bypassed, and the concrete root of the #604 mover-routing congestion (the #617 spike profiled `aircraft_parts_world` at **231 s cum** in the right-region demo).

## Change
- `geometry.cached_parts_world` now accepts `Aircraft | GroundObject` — the cache key `(plane_id, x, y, heading)` is already pose-generic and the transform is already union-typed.
- Route the four branch sites through it: `solver._body_parts_world`, the towplanner door-crossing helper, `_build_obstacles` (the static mover obstacle), and `_motion_clear`.
- `plan_fill` now runs inside its own `pose_cache_scope` (mirrors `solve`→`_run_solve`). This is the lever that reaches the congestion: a **standalone** fill previously had no active scope, so #453 was inert there; now its obstacle field is memoized across the whole search **and across the greedy scan's `plan_path` retries** (the deterministic search re-explores the same poses each retry → hits).

## Determinism — byte-identical (ADR-0003)
The cache returns the **same immutable `WorldPart` list**, exact-float keyed — a memo, not a behaviour change. Proven green & unchanged:
- 7 serial determinism canaries (`pytest -m "serial and not slow"`).
- 61 mover/region/tow goldens (`test_towplanner*`, `test_solver_ground_objects`, `test_solver_region`, `test_collisions_ground_object`, `test_parts_cache`).
- `mypy src/hangarfit` clean.

`determinism-guard` (solver.py + towplanner.py) and `geometry-invariant-guard` (geometry.py) apply — the geometry change is a type-widen only; the det-−1 transform is untouched.

## Tests (TDD red→green)
- `test_parts_cache.py::test_ground_object_mover_is_a_cache_hit` — the widened contract.
- `test_towplanner_ground_object.py::test_static_mover_obstacle_served_from_pose_cache` — behavioral: a static mover obstacle is built **once** across two `_build_obstacles` calls in a scope (was 2 on develop). Confirmed red on develop, green after.

## Measured (standalone `plan_fill`, #604 right-region two-trailer demo, seed 7, WSL2)
| probe | develop | #626 | speedup |
|---|---:|---:|---:|
| region_demo (congestion) | 240.8 s → BAIL | **131.9 s → BAIL** | **1.83×** |
| no_go (aircraft-only control) | 3.3 s ✓ | **1.7 s ✓** | ~2× |

The congestion case still **BAILs** — the layout is genuinely un-routable, and the residual ~132 s search-budget spin is the **#627** routing-order/budget lever (this PR attacks the geometry-rebuild root cause; #627 handles the spin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)