### PR TITLE
feat(628): suggest --workers on idle-core multi-restart solves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
   a regime where `--workers` would silently run serial (no `--max-restarts`,
   `--no-spread`, `--spread-stall-restarts` set, or a single core), so the default
   stays byte-identical. The `--workers` help text now states exactly when the flag
-  is effective. (#628)
+  is effective.
 
 - **Glider-trailer placement + soft region preference (#604).** The solver now places and routes the glider trailers, with a soft right/left-region preference biasing them toward a chosen hangar wall; surfaced as per-layout `region_alignment` in `solve` output.
 - **Ground-object data model (#601).** Catalog `fixed_obstacle`/`car`/`trailer`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **`solve` suggests `--workers` on idle-core multi-restart runs (#628).** When a
+  parallel-eligible solve (`--max-restarts` + spread) is left at the default
+  `--workers 1` on a multi-core box, `hangarfit solve` now prints a one-line
+  stderr hint naming the flag (with a capped example, e.g. `--workers 8`). Stderr
+  only — stdout / `--json` / `--write-yaml` stay untouched — and it never fires in
+  a regime where `--workers` would silently run serial (no `--max-restarts`,
+  `--no-spread`, `--spread-stall-restarts` set, or a single core), so the default
+  stays byte-identical. The `--workers` help text now states exactly when the flag
+  is effective. (#628)
+
 - **Glider-trailer placement + soft region preference (#604).** The solver now places and routes the glider trailers, with a soft right/left-region preference biasing them toward a chosen hangar wall; surfaced as per-layout `region_alignment` in `solve` output.
 - **Ground-object data model (#601).** Catalog `fixed_obstacle`/`car`/`trailer`
   types and a layout `ground_objects:` block; fixed obstacles are keep-outs

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -720,6 +720,7 @@ def cmd_solve(args: argparse.Namespace) -> int:
     # byte-identical-eligible for this config (no --max-restarts, or --no-spread),
     # solve() transparently runs serial — say so on stderr so the user isn't
     # left believing they got the speedup.
+    cpu_cores = os.cpu_count() or 1
     if args.workers > 1 and not _parallel_eligible(search_cfg, args.workers):
         print(
             f"note: --workers {args.workers} ignored (runs serial) — parallel "
@@ -727,21 +728,21 @@ def cmd_solve(args: argparse.Namespace) -> int:
             "--no-spread); see --workers help",
             file=sys.stderr,
         )
-    elif args.workers == 1 and _parallel_eligible(search_cfg, 2) and (os.cpu_count() or 1) > 1:
+    elif args.workers == 1 and cpu_cores > 1 and _parallel_eligible(search_cfg, 2):
         # This config IS parallel-eligible (--max-restarts + spread) but the
         # restarts run serial on a multi-core box, leaving cores idle. Probe
-        # eligibility with a worker count of 2 (the predicate's first conjunct is
-        # workers > 1); the user's actual --workers is 1. Suggest the flag rather
-        # than silently waste the cores — zero behaviour change, stderr only so
-        # --json / --write-yaml stay machine-readable (#628).
-        _cores = os.cpu_count() or 1
+        # eligibility with a worker count of 2 (the predicate requires workers > 1;
+        # the user's actual --workers is 1). Suggest the flag rather than silently
+        # waste the cores — zero behaviour change, stderr only so --json /
+        # --write-yaml stay machine-readable (#628).
         # Cap the SUGGESTED count: the #544 speedup is sub-linear (~4.5x at 8
         # workers), so don't over-promise cores-2 on a big box — it's an example.
-        _suggest = min(8, max(1, _cores - 2))
+        _suggest = min(8, max(1, cpu_cores - 2))
         print(
-            f"hint: this is a multi-restart spread solve running serial on {_cores} "
-            f"cores — add --workers N (e.g. --workers {_suggest}) to fan the "
-            f"{args.max_restarts} restarts across processes (byte-identical to serial; #544).",
+            f"hint: this is a multi-restart spread solve running serial on a "
+            f"{cpu_cores}-core box — add --workers N (e.g. --workers {_suggest}) to fan "
+            f"the {args.max_restarts} restarts across processes "
+            "(byte-identical to serial; #544).",
             file=sys.stderr,
         )
     result = solve(

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import sys
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Literal
@@ -299,9 +300,12 @@ def build_parser() -> argparse.ArgumentParser:
         dest="workers",
         help=(
             "Fan the restarts across N worker processes (#544; default 1 = "
-            "serial). Byte-identical to serial in the --max-restarts + spread "
-            "regime; for any other config it runs serial (a note is printed). "
-            "Speedup is sub-linear and placement-only — most useful on roomy "
+            "serial, single-core). Effective (and byte-identical to serial) ONLY "
+            "in the --max-restarts + spread regime; for any other config (no "
+            "--max-restarts, --no-spread, or --spread-stall-restarts set) it "
+            "silently runs serial and prints a note. A multi-restart spread solve "
+            "left at the default on a multi-core box prints a hint suggesting the "
+            "flag. Speedup is sub-linear and placement-only — most useful on roomy "
             "spread-on fills with many restarts."
         ),
     )
@@ -721,6 +725,23 @@ def cmd_solve(args: argparse.Namespace) -> int:
             f"note: --workers {args.workers} ignored (runs serial) — parallel "
             "restarts need --max-restarts and the spread post-pass (drop "
             "--no-spread); see --workers help",
+            file=sys.stderr,
+        )
+    elif args.workers == 1 and _parallel_eligible(search_cfg, 2) and (os.cpu_count() or 1) > 1:
+        # This config IS parallel-eligible (--max-restarts + spread) but the
+        # restarts run serial on a multi-core box, leaving cores idle. Probe
+        # eligibility with a worker count of 2 (the predicate's first conjunct is
+        # workers > 1); the user's actual --workers is 1. Suggest the flag rather
+        # than silently waste the cores — zero behaviour change, stderr only so
+        # --json / --write-yaml stay machine-readable (#628).
+        _cores = os.cpu_count() or 1
+        # Cap the SUGGESTED count: the #544 speedup is sub-linear (~4.5x at 8
+        # workers), so don't over-promise cores-2 on a big box — it's an example.
+        _suggest = min(8, max(1, _cores - 2))
+        print(
+            f"hint: this is a multi-restart spread solve running serial on {_cores} "
+            f"cores — add --workers N (e.g. --workers {_suggest}) to fan the "
+            f"{args.max_restarts} restarts across processes (byte-identical to serial; #544).",
             file=sys.stderr,
         )
     result = solve(

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -1630,3 +1630,54 @@ class TestSolveApronDepth:
         with pytest.raises(SystemExit) as exc:
             main(["solve", self._SCEN, "--apron-depth=-3"])
         assert exc.value.code == 2
+
+
+class TestWorkersAutoSuggestHint:
+    """#628: when a multi-restart spread solve is parallel-eligible but ``--workers``
+    was left at its default of 1 on a multi-core box, a one-line stderr HINT names
+    the flag. Zero behaviour change (default stays 1); the hint never touches stdout
+    and never fires in a regime where ``--workers`` would silently run serial."""
+
+    def test_hint_fires_when_eligible_serial_on_multicore(self, capsys, monkeypatch):
+        monkeypatch.setattr("os.cpu_count", lambda: 8)
+        rc = main(["solve", SMOKE_FIXTURE, "--max-restarts", "2"])
+        assert rc == 0
+        out = capsys.readouterr()
+        assert "hint:" in out.err and "--workers" in out.err
+        # stdout stays machine-readable — the hint is stderr-only
+        assert "hint:" not in out.out
+
+    def test_hint_silent_without_max_restarts(self, capsys, monkeypatch):
+        """A plain solve (no --max-restarts) is wall-clock-budget, NOT parallel-
+        eligible (#267) — suggesting --workers there would mislead."""
+        monkeypatch.setattr("os.cpu_count", lambda: 8)
+        rc = main(["solve", SMOKE_FIXTURE])
+        assert rc == 0
+        assert "hint:" not in capsys.readouterr().err
+
+    def test_hint_silent_when_no_spread(self, capsys, monkeypatch):
+        monkeypatch.setattr("os.cpu_count", lambda: 8)
+        rc = main(["solve", SMOKE_FIXTURE, "--max-restarts", "2", "--no-spread"])
+        assert rc == 0
+        assert "hint:" not in capsys.readouterr().err
+
+    def test_hint_silent_when_spread_stall_set(self, capsys, monkeypatch):
+        monkeypatch.setattr("os.cpu_count", lambda: 8)
+        rc = main(["solve", SMOKE_FIXTURE, "--max-restarts", "2", "--spread-stall-restarts", "5"])
+        assert rc == 0
+        assert "hint:" not in capsys.readouterr().err
+
+    def test_hint_silent_on_single_core(self, capsys, monkeypatch):
+        monkeypatch.setattr("os.cpu_count", lambda: 1)
+        rc = main(["solve", SMOKE_FIXTURE, "--max-restarts", "2"])
+        assert rc == 0
+        assert "hint:" not in capsys.readouterr().err
+
+    def test_hint_silent_when_workers_already_set(self, capsys, monkeypatch):
+        """Eligible config with --workers>1 already: neither the 'ignored' note
+        (it's eligible) nor the suggest hint (workers already set) should fire."""
+        monkeypatch.setattr("os.cpu_count", lambda: 8)
+        rc = main(["solve", SMOKE_FIXTURE, "--max-restarts", "2", "--workers", "4"])
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "hint:" not in err and "ignored" not in err


### PR DESCRIPTION
Closes #628.

Wave 3 of v0.15.0 (graduated from the #617 profiling spike, lever **L5** — low priority, educate don't surprise).

## Problem
The solver is single-threaded by default (#617 spike: bench at 102 % CPU on a 32-core box). The #544 `--workers` parallel-restart path defaults to `1` and is only byte-identical-eligible in the `--max-restarts` + spread regime (`_parallel_eligible`), so a user running a deliberate multi-restart spread solve on a multi-core box leaves every other core idle and never discovers the flag.

## Change — Option 1 (auto-suggest hint), not `--workers auto`
When the config is parallel-eligible, `--workers` is at the default `1`, and `os.cpu_count() > 1`, print a one-line **stderr** hint naming the flag:
```
hint: this is a multi-restart spread solve running serial on 32 cores — add --workers N (e.g. --workers 8) to fan the 4 restarts across processes (byte-identical to serial; #544).
```
- Eligibility is probed via `_parallel_eligible(search_cfg, 2)` (the predicate's first conjunct is `workers > 1`; the user's actual `--workers` is 1), reusing the single source of truth — so the hint can **never** fire in a regime where `--workers` would silently run serial.
- The suggested count is **capped** at `min(8, cores-2)` — the #544 speedup is sub-linear (~4.5× at 8 workers), so it doesn't over-promise `cores-2` on a big box.
- **stderr only** — stdout / `--json` / `--write-yaml` stay machine-readable.
- **Default behaviour byte-identical**: a plain solve (no `--max-restarts`) is not eligible → silent. No new flag; default `--workers` stays `1`, so the #267 wall-clock-budget determinism scoping is unaffected.
- `--workers` help text tightened to state exactly when the flag is effective vs silently serial.

Option 2 (`--workers auto`) was rejected: `auto` must still resolve to `1` in the non-eligible regime, making `auto` itself the surprising value the issue warns against.

## Tests (TDD red→green)
`tests/test_cli_solve.py::TestWorkersAutoSuggestHint`:
- `test_hint_fires_when_eligible_serial_on_multicore` (red→green; `monkeypatch os.cpu_count → 8`) + a **stdout-purity** assertion.
- 5 silent guards: no `--max-restarts`, `--no-spread`, `--spread-stall-restarts` set, single core (`cpu_count → 1`), and `--workers` already > 1.
- The existing `--workers N ignored (runs serial)` note branch is unchanged (`if`/`elif`).

## Determinism
None — `cli.py`-only; default stays `1`; `_parallel_eligible`/`solver.py` untouched. ruff + mypy clean; the existing parallel-flags + serial-note tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)