### PR TITLE
fix(627,612): surface unroutable ground-object movers (no silent skip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,19 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Fixed
 
+- **Unroutable ground-object movers are surfaced, not silently dropped (#627,
+  #612).** A best-effort mover the tow planner can't route keeps a `Move(path=None)`
+  (ADR-0007 #197) — but, unlike an un-tow-routable *aircraft* (which is named on
+  stderr / in `diagnostics.unroutable_planes`), it used to be silent and just
+  rendered as a static body. `plan_fill` now threads the unroutable-mover ids out
+  via an observational out-param (the `apron_dropped_out` idiom); `solve` collects
+  them into `diagnostics.unroutable_movers` (additive `--json` field, no schema
+  bump); and `hangarfit solve --render-paths` names each on stderr. **Byte-identical**
+  (ADR-0003: the plan is unchanged) — this closes the deferred half of #602's "no
+  silent skip" acceptance. (The related #604 mover-routing *congestion* under #627
+  was separately cut ~1.8× by the #626 pose-cache extension; the residual is a
+  genuinely un-routable layout being correctly disproven.)
+
 - **Synthetic-vs-real Scheibe SF-25E divergence (#594).** The demo
   (`data/fleet.yaml`) and `examples/herrenteich/` now reference a single central
   catalog (`data/catalog/`), so each **shared** aircraft is defined exactly once

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -786,6 +786,7 @@ def cmd_solve(args: argparse.Namespace) -> int:
     # spread-fallback pass's drops never surface.
     if args.render_paths:
         _warn_unroutable(result)
+        _warn_unroutable_movers(result)
         _warn_apron_shallow_drops(result.diagnostics.apron_shallow_drops)
 
     # Renders / YAML writes. Only run if we have layouts to write —
@@ -878,6 +879,24 @@ def _warn_unroutable(result: SolveResult) -> None:
         print(
             f"warning: layout {layout_index}: no feasible tow path "
             f"(plane {plane!r} could not be routed); rendered without paths",
+            file=sys.stderr,
+        )
+
+
+def _warn_unroutable_movers(result: SolveResult) -> None:
+    """Emit one stderr warning per ground-object mover the tow planner could not
+    route (#627/#612). Unlike an un-tow-routable aircraft — which makes the whole
+    layout's plan ``None`` (see :func:`_warn_unroutable`) — a None-path mover keeps
+    a best-effort ``Move(path=None)`` inside an otherwise-present plan and renders
+    as a static body; without this it would be a silent skip (the deferred half of
+    the #602 'no silent skip' acceptance). ``diagnostics.unroutable_movers`` is the
+    deduped, advisory mover-id list the solver collected — empty when every mover
+    routed, there are no movers, or tow-planning was not attempted.
+    """
+    for mover in result.diagnostics.unroutable_movers:
+        print(
+            f"warning: ground-object mover {mover!r} could not be routed; "
+            "rendered as a static (un-towed) body",
             file=sys.stderr,
         )
 
@@ -1076,6 +1095,10 @@ def _emit_solve_json(
             # route, in returned-layout order. Empty unless --render-paths ran
             # the planner. Backward-compatible — no schema bump.
             "unroutable_planes": list(d.unroutable_planes),
+            # Additive (#627/#612): the ground-object movers the planner could not
+            # route (best-effort None-path, deduped). Empty unless --render-paths
+            # ran the planner. Backward-compatible — no schema bump.
+            "unroutable_movers": list(d.unroutable_movers),
             # Additive (#267): achieved min plan-view gap per returned layout
             # (null where <2 planes, i.e. math.inf) + basins the search had to
             # choose from. Backward-compatible — no schema bump.

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1488,6 +1488,16 @@ class SolverDiagnostics:
     still a valid static arrangement — the entry flags a planning gap, not
     an invalid layout.
 
+    ``unroutable_movers`` is the ground-object counterpart (#627/#612): a flat,
+    deduped, advisory tuple of the **mover** ids (cars / trailers) that could not
+    be routed and so kept a best-effort ``Move(path=None)`` instead of aborting
+    the fill (ADR-0007 #197). Unlike ``unroutable_planes``, a None-path mover does
+    **not** make the whole layout's plan ``None`` (the plan is still returned with
+    the mover drawn as a static body), which is exactly why it needs its own
+    advisory list rather than reusing ``unroutable_planes``. Empty when every
+    mover routed, when there are no movers, or when tow-planning was not attempted.
+    Advisory / RNG-free ⇒ ADR-0003-safe.
+
     ``min_pairwise_gap_m`` is index-aligned with :attr:`SolveResult.layouts`:
     the achieved minimum plan-view gap (m) between any two planes in that
     returned layout — the quality the best-of-all-basins spread selection
@@ -1558,6 +1568,7 @@ class SolverDiagnostics:
     apron_shallow_drops: tuple[ApronShallowDrop, ...] = ()
     nose_out_flips: tuple[int, ...] = ()
     region_alignment: tuple[tuple[RegionAlignment, ...], ...] = ()
+    unroutable_movers: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if (self.best_partial is None) != (self.best_partial_layout is None):

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -727,10 +727,12 @@ def _tow_plan_layouts(
     plan_paths: bool,
     tow_heuristic: Literal["euclidean", "grid"],
     tow_max_expansions: int | None,
-) -> tuple[tuple[MovesPlan | None, ...], tuple[str, ...], tuple[ApronShallowDrop, ...]]:
+) -> tuple[
+    tuple[MovesPlan | None, ...], tuple[str, ...], tuple[ApronShallowDrop, ...], tuple[str, ...]
+]:
     """Tow-plan every returned layout (best-effort enrichment, #197).
 
-    Returns ``(plans, unroutable, apron_drops)``. ``plans`` is index-aligned with
+    Returns ``(plans, unroutable, apron_drops, unroutable_movers)``. ``plans`` is index-aligned with
     ``accepted_layouts``. The v2 planner (Reeds–Shepp arcs + bounded Hybrid-A* —
     #222/#261 under ADR-0007 + ADR-0010) cannot route dense multi-plane fills and
     has documented false-negatives, so an un-routable layout is recorded as
@@ -747,15 +749,22 @@ def _tow_plan_layouts(
     never surface — only the chosen result's diagnostics are built (see
     :func:`solve`). Empty when no returned layout had a too-shallow drop.
 
+    ``unroutable_movers`` is the ground-object counterpart (#627/#612): the flat,
+    deduped list of mover ids that could not be routed and so kept a best-effort
+    ``Move(path=None)`` (collected via plan_fill's out-param, like ``apron_drops``).
+    Unlike ``unroutable`` (aircraft), a None-path mover does not make the layout's
+    plan ``None`` — the plan is still built — so it is collected on the SUCCESS path.
+
     With ``plan_paths=False`` no planning runs and ``plans`` is all-``None``
     (still index-aligned), with no ``unroutable`` planes and no ``apron_drops``.
     """
     if not plan_paths:
-        return (None,) * len(accepted_layouts), (), ()
+        return (None,) * len(accepted_layouts), (), (), ()
 
     built: list[MovesPlan | None] = []
     unroutable: list[str] = []
     apron_drops: list[ApronShallowDrop] = []
+    mover_drops: list[str] = []
     for layout in accepted_layouts:
         # Diagnostics-only out-param (#503): plan_fill populates this with the
         # too-shallow-apron drops of THIS layout's tow plan, plan-inert — it is
@@ -765,21 +774,25 @@ def _tow_plan_layouts(
         # collection so a plane dropped across multiple layouts appears once per
         # layout (the CLI dedups by plane id before warning).
         layout_drops: list[ApronShallowDrop] = []
+        layout_movers: list[str] = []
         try:
             # Default path calls ``plan_fill(layout)`` with NO budget kwargs (only
-            # the plan-inert diagnostics out-param), so the ADR-0003 determinism
-            # canaries are unaffected (the out-param never changes the plan). Since
+            # the plan-inert diagnostics out-params), so the ADR-0003 determinism
+            # canaries are unaffected (the out-params never change the plan). Since
             # #336 the shipped default is grid + the module budgets, which is
             # exactly what a bare ``plan_fill(layout)`` applies; an explicit
             # euclidean / custom budget takes the kwargs path below.
             if tow_heuristic == "grid" and tow_max_expansions is None:
-                plan = plan_fill(layout, apron_dropped_out=layout_drops)
+                plan = plan_fill(
+                    layout, apron_dropped_out=layout_drops, unroutable_movers=layout_movers
+                )
             else:
                 plan = plan_fill(
                     layout,
                     heuristic=tow_heuristic,
                     max_expansions=tow_max_expansions,
                     apron_dropped_out=layout_drops,
+                    unroutable_movers=layout_movers,
                 )
             # #603: a hard-door mover (e.g. the rescue Caddy) must be able to drive
             # OUT the door against the full parked scene, else the layout is
@@ -798,6 +811,10 @@ def _tow_plan_layouts(
                         raise NoFeasiblePlanError(gp.plane_id, egress)
             built.append(plan)
             apron_drops.extend(layout_drops)
+            # Unlike apron_drops, mover drops are collected on SUCCESS: a None-path
+            # mover does not abort the layout's plan (#627/#612), so the plan IS
+            # built and its unroutable movers are the ones the user receives.
+            mover_drops.extend(layout_movers)
         except NoFeasiblePlanError as e:
             built.append(None)
             unroutable.append(e.plane_id)
@@ -815,7 +832,9 @@ def _tow_plan_layouts(
                 e.conflict.kind,
                 e.conflict.detail,
             )
-    return tuple(built), tuple(unroutable), tuple(apron_drops)
+    # dict.fromkeys: order-preserving dedup — a mover unroutable in several
+    # returned layouts is named once (advisory list, the CLI warns once).
+    return tuple(built), tuple(unroutable), tuple(apron_drops), tuple(dict.fromkeys(mover_drops))
 
 
 def _build_found_result(
@@ -848,7 +867,7 @@ def _build_found_result(
     # region preferences reports `()` (not a tuple of empty tuples) — #604.
     region_alignment = region_alignment_per_layout if any(region_alignment_per_layout) else ()
     status: SolveStatus = "found" if len(accepted_layouts) >= alternatives else "found_partial"
-    plans, unroutable, apron_drops = _tow_plan_layouts(
+    plans, unroutable, apron_drops, unroutable_movers = _tow_plan_layouts(
         accepted_layouts,
         plan_paths=plan_paths,
         tow_heuristic=tow_heuristic,
@@ -873,6 +892,7 @@ def _build_found_result(
             apron_shallow_drops=apron_drops,
             nose_out_flips=nose_out_flips,
             region_alignment=region_alignment,
+            unroutable_movers=unroutable_movers,
         ),
     )
 

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1395,6 +1395,7 @@ def plan_fill(
     max_expansions: int | None = None,
     max_total_expansions: int | None = None,
     apron_dropped_out: list[ApronShallowDrop] | None = None,
+    unroutable_movers: list[str] | None = None,
 ) -> MovesPlan:
     """Plan a collision-free entry order + per-plane path for an empty fill.
 
@@ -1426,6 +1427,16 @@ def plan_fill(
     the :class:`MovesPlan`, so the plan stays byte-identical whether or not the
     list is passed (ADR-0003). ``None`` (the default) collects nothing. The caller
     (CLI / solver) emits the user-facing warning from this data, deduped.
+
+    ``unroutable_movers`` is a second diagnostics-only **out-param** (#627/#612,
+    same idiom): when supplied, it is populated — in committed-move order — with
+    the id of each ground-object **mover** that could not be routed and so kept a
+    best-effort ``Move(path=None)`` (ADR-0007 #197). Unlike an un-tow-routable
+    aircraft, which :func:`plan_fill` *raises* for (the solver records it in
+    ``diagnostics.unroutable_planes`` and the CLI warns), a None-path mover was
+    previously silent. It is equally **plan-inert** — the mover's ``Move`` still
+    carries ``path=None``, so the plan is byte-identical whether or not the list
+    is passed. ``None`` collects nothing.
 
     Walks :func:`back_first_order` (deepest slot first); for each plane searches
     for an in-bounds path from the door-cone entry poses (:func:`entry_poses`) to
@@ -1463,6 +1474,7 @@ def plan_fill(
             max_expansions=max_expansions,
             max_total_expansions=max_total_expansions,
             apron_dropped_out=apron_dropped_out,
+            unroutable_movers=unroutable_movers,
         )
 
 
@@ -1473,6 +1485,7 @@ def _plan_fill(
     max_expansions: int | None = None,
     max_total_expansions: int | None = None,
     apron_dropped_out: list[ApronShallowDrop] | None = None,
+    unroutable_movers: list[str] | None = None,
 ) -> MovesPlan:
     """Body of :func:`plan_fill`, run inside an active ``pose_cache_scope`` (#626)."""
     budget = _MAX_EXPANSIONS if max_expansions is None else max_expansions
@@ -1635,11 +1648,15 @@ def _plan_fill(
             )
         except NoFeasiblePlanError:
             # Best-effort (ADR-0007 #197): an unroutable mover keeps a None path so
-            # it never aborts the whole fill. NOTE: unlike an un-tow-routable
-            # AIRCRAFT (which raises -> solver -> stderr), a None-path mover is NOT
-            # yet surfaced to the user — it renders as a static body. Wiring that
-            # stderr surfacing is tracked as a follow-up (#612).
+            # it never aborts the whole fill. Unlike an un-tow-routable AIRCRAFT
+            # (which raises -> solver -> stderr), a None-path mover used to be
+            # silent. #627/#612: record its id in the optional ``unroutable_movers``
+            # out-param so the solver/CLI can name it on stderr — observational,
+            # plan-inert (the Move below still carries path=None), so byte-identical
+            # whether or not the list is passed (mirrors ``apron_dropped_out``).
             mover_arc = None
+            if unroutable_movers is not None:
+                unroutable_movers.append(obj.id)
         exp = mover_stats.get("expansions", 0)
         total_used += exp if isinstance(exp, int) else 0
         moves.append(Move(gp.plane_id, Pose.from_placement(gp), path=mover_arc))

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -867,7 +867,13 @@ class TestSolveRenderPaths:
 
     @staticmethod
     def _result(
-        status, layouts, plans, unroutable=(), spread_fallback_applied=False, apron_drops=()
+        status,
+        layouts,
+        plans,
+        unroutable=(),
+        spread_fallback_applied=False,
+        apron_drops=(),
+        unroutable_movers=(),
     ):
         from hangarfit.models import SolverDiagnostics, SolveResult
 
@@ -880,6 +886,7 @@ class TestSolveRenderPaths:
             unroutable_planes=unroutable,
             spread_fallback_applied=spread_fallback_applied,
             apron_shallow_drops=apron_drops,
+            unroutable_movers=unroutable_movers,
         )
         return SolveResult(status=status, layouts=layouts, plans=plans, diagnostics=diag)
 
@@ -906,6 +913,31 @@ class TestSolveRenderPaths:
         rc = main(["solve", SMOKE_FIXTURE, "--render-paths"])
         assert rc == 2
         assert "requires --render" in capsys.readouterr().err
+
+    def test_unroutable_mover_warned_on_stderr(self, tmp_path, monkeypatch, capsys):
+        """#627/#612: a best-effort un-routable mover (it keeps path=None inside an
+        otherwise-present plan) is NAMED on stderr under --render-paths — the
+        deferred half of #602's 'no silent skip' acceptance, for movers."""
+        layout = self._layout()
+        plan = self._plan(layout)
+        self._patch_solve(
+            monkeypatch,
+            self._result("found", (layout,), (plan,), unroutable_movers=("trailer1",)),
+        )
+        rc = main(
+            [
+                "solve",
+                SMOKE_FIXTURE,
+                "--render",
+                str(tmp_path / "p.png"),
+                "--render-paths",
+                "--seed",
+                "42",
+            ]
+        )
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "trailer1" in err and "could not be routed" in err
 
     def test_without_flag_solve_is_not_asked_to_plan(self, tmp_path, monkeypatch):
         captured = self._patch_solve(monkeypatch, self._result("found", (self._layout(),), (None,)))

--- a/tests/test_solver_towplanner.py
+++ b/tests/test_solver_towplanner.py
@@ -272,11 +272,82 @@ def test_hard_door_mover_egress_blocked_is_unroutable() -> None:
         ),
     )
 
-    plans, unroutable, _ = _tow_plan_layouts(
+    plans, unroutable, *_ = _tow_plan_layouts(
         [layout], plan_paths=True, tow_heuristic="grid", tow_max_expansions=None
     )
     assert plans[0] is None, "boxed-in hard-door mover must produce plans[0]=None"
     assert "caddy" in unroutable, f"caddy must be in unroutable; got {unroutable}"
+
+
+def test_tow_plan_layouts_collects_unroutable_movers() -> None:
+    """#627/#612: a PLAIN (non-hard-door) mover that cannot be routed is collected
+    in ``_tow_plan_layouts``'s 4th return element (``unroutable_movers``), while its
+    layout's plan is STILL built (``plans[0]`` is not ``None``) — best-effort,
+    ADR-0007 #197. This is the ground-object counterpart of ``unroutable_planes``,
+    and is distinct from a hard-door mover (which raises → ``plans[0]=None`` →
+    ``unroutable``, the test above)."""
+    from hangarfit.models import Door, GroundObject, Hangar, Layout, MaintenanceBay, Part, Placement
+    from hangarfit.solver import _tow_plan_layouts
+
+    hangar = Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.2,
+    )
+    wall = GroundObject(
+        id="wall",
+        name="Wall",
+        parts=(
+            Part(
+                kind="ground",
+                length_m=1.0,
+                width_m=44.0,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.5,
+            ),
+        ),
+        object_class="fixed_obstacle",
+    )
+    trailer = GroundObject(
+        id="trailer",
+        name="Glider trailer",
+        parts=(
+            Part(
+                kind="ground",
+                length_m=6.0,
+                width_m=1.2,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.5,
+            ),
+        ),
+        object_class="placed_routed_mover",
+        motion_mode="towed",  # plain: hard_door_mover defaults False → best-effort
+    )
+    layout = Layout(
+        fleet={},
+        hangar=hangar,
+        placements=(),
+        ground_objects={wall.id: wall, trailer.id: trailer},
+        ground_object_placements=(
+            Placement("wall", x_m=20.0, y_m=15.0, heading_deg=0.0, on_carts=False),
+            Placement("trailer", x_m=20.0, y_m=30.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    plans, unroutable, _apron, movers = _tow_plan_layouts(
+        [layout], plan_paths=True, tow_heuristic="grid", tow_max_expansions=200
+    )
+    assert plans[0] is not None, "a best-effort mover bail must NOT null the layout's plan"
+    assert movers == ("trailer",), f"unroutable mover must be collected; got {movers}"
+    assert unroutable == (), f"no aircraft/hard-door unroutable expected; got {unroutable}"
 
 
 def test_no_hard_door_mover_egress_gate_inert() -> None:
@@ -338,10 +409,10 @@ def test_no_hard_door_mover_egress_gate_inert() -> None:
         ),
     )
 
-    p1, u1, _ = _tow_plan_layouts(
+    p1, u1, *_ = _tow_plan_layouts(
         [layout], plan_paths=True, tow_heuristic="grid", tow_max_expansions=None
     )
-    p2, u2, _ = _tow_plan_layouts(
+    p2, u2, *_ = _tow_plan_layouts(
         [layout], plan_paths=True, tow_heuristic="grid", tow_max_expansions=None
     )
     # Gate must be inert: no unroutable planes from the egress check.

--- a/tests/test_towplanner_mover_routing.py
+++ b/tests/test_towplanner_mover_routing.py
@@ -337,3 +337,54 @@ def test_mover_routing_is_byte_identical_across_runs() -> None:
     assert [(m.plane_id, m.path) for m in a.moves] == [(m.plane_id, m.path) for m in b.moves], (
         "plan_fill must be byte-identical (ADR-0003)"
     )
+
+
+def _fixed_wall() -> GroundObject:
+    """A full-width fixed obstacle (44 m, spanning beyond the 40 m hangar) — a
+    static keep-out with no corridor around it, so a mover behind it cannot be
+    routed in from the door. A fixed_obstacle is NOT itself routed, so (unlike a
+    44 m wall *aircraft*) it doesn't abort the aircraft scan — it just blocks the
+    mover, isolating the unroutable-mover path."""
+    return GroundObject(
+        id="wall",
+        name="w",
+        parts=(_ground_part(length_m=1.0, width_m=44.0),),
+        object_class="fixed_obstacle",
+    )
+
+
+def test_unroutable_mover_is_surfaced_not_silently_dropped() -> None:
+    """#627/#612: a mover whose slot has no collision-free corridor keeps a
+    None-path Move (best-effort, ADR-0007 #197) AND is reported through the
+    optional ``unroutable_movers`` out-param — never silently dropped. The
+    ``MovesPlan`` stays byte-identical whether or not the out-param is passed (it
+    is observational, like ``apron_dropped_out``).
+
+    NON-@slow: a small global cap keeps it in the fast set so the surfacing path
+    is never dropped from coverage; the full-width wall makes the bail genuine
+    (no analytic shot), not merely budget-starved."""
+    hangar = _hangar()
+    wall = _fixed_wall()
+    caddy = _caddy(hdm=False)  # plain mover (no egress gate); slot walled off
+    layout = Layout(
+        fleet={},
+        hangar=hangar,
+        placements=(),
+        ground_objects={wall.id: wall, caddy.id: caddy},
+        ground_object_placements=(
+            Placement("wall", x_m=20.0, y_m=15.0, heading_deg=0.0, on_carts=False),
+            Placement("caddy", x_m=20.0, y_m=30.0, heading_deg=0.0, on_carts=False),
+        ),
+    )
+    movers: list[str] = []
+    plan = plan_fill(layout, unroutable_movers=movers, max_total_expansions=200)
+    # surfaced, not silently dropped
+    assert movers == ["caddy"]
+    # ...and it kept a best-effort None-path Move (not aborted/omitted)
+    caddy_move = next(m for m in plan.moves if m.plane_id == "caddy")
+    assert caddy_move.path is None
+    # byte-identical: the same fill WITHOUT the out-param yields the same plan
+    plan_no_out = plan_fill(layout, max_total_expansions=200)
+    assert [(m.plane_id, m.path) for m in plan_no_out.moves] == [
+        (m.plane_id, m.path) for m in plan.moves
+    ]


### PR DESCRIPTION
Closes #627, Closes #612.

Final v0.15.0 PR. The #627 perf half (the #604 mover-routing **congestion**) was already delivered by **#626** (pose cache → movers): the region_demo probe dropped **240.8 s → 131.9 s (~1.8×)**. The residual is a *genuinely un-routable* layout being correctly disproven (it bails on an **aircraft** whose corridor the region-biased trailers block — already surfaced), so an occupancy-adaptive faster-bail (which would re-golden tow plans for marginal gain) is **deferred**. See the [measurement on #627](https://github.com/DocGerd/hangarfit/issues/627#issuecomment-4691354784).

This PR ships #627's **byte-identical fast-fail-diagnostic** lever, which also closes **#612**: surface the unroutable **movers** the planner skips best-effort.

## Problem
#602 routes ground-object movers best-effort: an unroutable mover keeps a `Move(path=None)` so it never aborts the fill (ADR-0007 #197). But unlike an un-tow-routable **aircraft** (raises → `diagnostics.unroutable_planes` → `cli._warn_unroutable` → stderr), a None-path **mover** was **silent** — it just rendered as a static body, leaving #602's "no silent skip" acceptance unmet for movers.

## Change (the `apron_dropped_out` #503 out-param idiom)
- `plan_fill` / `_plan_fill` gain an optional `unroutable_movers: list[str]` out-param; the mover loop's `NoFeasiblePlanError` catch records the mover id (**plan-inert** — the `Move` still carries `path=None`).
- `_tow_plan_layouts` collects them on the **success** path (a None-path mover doesn't null the layout's plan, unlike an unroutable aircraft) into a deduped tuple, returned as a 4th element → `SolverDiagnostics.unroutable_movers` (new additive field, default `()`).
- `cli._warn_unroutable_movers` names each on stderr under `--render-paths`; additive `unroutable_movers` key in `--json` (no schema bump).

## Determinism — byte-identical (ADR-0003)
Every out-param / field is **observational**: the `MovesPlan` and the returned layout are unchanged. Verified by `make test` (**1659** bulk + **7** serial canaries) with **no golden re-pin**; mypy + ruff clean.

## Tests (TDD red→green, 3 layers)
- `test_towplanner_mover_routing.py::test_unroutable_mover_is_surfaced_not_silently_dropped` — the `plan_fill` out-param (walled-off plain mover; byte-identical with/without the out-param).
- `test_solver_towplanner.py::test_tow_plan_layouts_collects_unroutable_movers` — the solver 4-tuple collection (plan still built; mover named; distinct from the hard-door `unroutable` path).
- `test_cli_solve.py::TestSolveRenderPaths::test_unroutable_mover_warned_on_stderr` — the end-to-end stderr surfacing.

`determinism-guard` (solver.py + towplanner.py), `type-design-analyzer` (the new `SolverDiagnostics` field), and `code-reviewer` apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)