### PR TITLE
feat(644): model Herrenteich Stemme as dolly-pivotable (always_cart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- **Herrenteich Stemme modelled as dolly-pivotable for tow planning (#644).** The
+  `examples/herrenteich/` fleet manifest now overrides the Stemme S10 to
+  `movement_mode: always_cart` — it is hand-positioned on a dolly in the hangar,
+  so it pivots in place rather than using its 10 m *taxi* turn radius (a per-fleet
+  operational override, #595; flight specs stay in the catalog). Part of correcting
+  the tow-motion abstraction (#643).
+
 ### Fixed
 
 ## [0.15.0] — 2026-06-12

--- a/examples/herrenteich/fleet.yaml
+++ b/examples/herrenteich/fleet.yaml
@@ -3,7 +3,12 @@
 # catalog's numbers, #595/#594).
 aircraft:
   - ../../data/catalog/scheibe_falke.yaml
-  - ../../data/catalog/stemme_s10.yaml
+  # The Stemme is hand-positioned on a dolly in the hangar, so it pivots in
+  # place — its catalog 10 m turn_radius_m is a TAXI figure, irrelevant to
+  # in-hangar maneuvering (a 10 m arc can't thread a deep slot in a 15 m-wide
+  # hangar). Model it cart-borne for tow planning via a per-fleet operational
+  # override (#595); flight specs stay in the catalog. See #644 / #643.
+  - { ref: ../../data/catalog/stemme_s10.yaml, movement_mode: always_cart }
   - ../../data/catalog/aviat_husky.yaml
   - ../../data/catalog/wild_thing.yaml
   - ../../data/catalog/zlin_savage.yaml

--- a/examples/herrenteich/layout.yaml
+++ b/examples/herrenteich/layout.yaml
@@ -41,7 +41,7 @@ placements:
     x_m: 3.50
     y_m: 13.65
     heading_deg: 270.0
-    on_carts: false         # always_own_gear
+    on_carts: true          # dolly-pivotable in the hangar (#644)
   - plane: aviat_husky
     x_m: 5.60
     y_m: 16.40

--- a/examples/herrenteich/layout_full.yaml
+++ b/examples/herrenteich/layout_full.yaml
@@ -31,7 +31,7 @@ placements:
     x_m: 3.15
     y_m: 13.65
     heading_deg: 270.0
-    on_carts: false         # always_own_gear
+    on_carts: true          # dolly-pivotable in the hangar (#644)
   - plane: aviat_husky
     x_m: 5.28
     y_m: 16.51


### PR DESCRIPTION
Closes #644. Refs #643, #642.

## What
A one-flag per-fleet override (#595): the Herrenteich Stemme S10 → `movement_mode: always_cart`, plus `on_carts: true` on its placement in both layouts (loader invariant). Flight specs stay in the catalog; only in-hangar mobility changes.

## Why
The Stemme is **hand-positioned on a dolly** in the hangar — it pivots in place. Its catalog **10 m `turn_radius_m` is a taxi figure**, irrelevant to in-hangar maneuvering (a 10 m arc can't thread a deep slot in a 15 m-wide hangar), which made it the binding blocker for routing.

**Evidence (#642 probes):** with the Stemme cart-borne (effective turn radius → 0), the Scheibe + Stemme pair that previously failed *both* entry orders **routes at the original 0.20 m clearance**. This overturned the earlier "fundamental un-routability" finding — it was an abstraction artifact.

## Scope
One concrete instance of the **tow-motion abstraction fidelity** cluster (#643). On its own it does **not** make the all-8 routable on develop — the 18 m broadside Scheibe still needs the lateral-strafe primitive (#599 / ADR-0010 amendment), and the separate `motion_clearance_m` fix (#643) is the larger lever. This just stops modelling the Stemme as a 10 m-taxi-radius body in the hangar.

## Tests
`tests/test_herrenteich_dataset.py` + `tests/test_loader.py` green (163 passed); broader herrenteich/scenario sweep green (132 passed). Static validity of both layouts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)