### PR TITLE
feat(643): separate tow-MOTION clearance from the parked clearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Separate tow-MOTION clearance, distinct from the parked clearance (#643).**
+  A hangar may declare optional `motion_clearance_m` / `motion_wing_layer_clearance_m`
+  — the margin the tow planner clears a *moving* mover against parked bodies, which
+  reality threads far tighter than the parked spacing (a spotter watches the wingtips).
+  `collisions.check` keeps the parked `clearance_m` for static validity; only the tow
+  planner's per-pose checks (`path_first_conflict` and the in-search `_motion_clear`)
+  use the tighter motion margin. Absent (the default) ⇒ the motion clearance IS the
+  parked clearance, so plans are **byte-identical** (ADR-0003). This corrects an
+  over-strict abstraction — applying the parked margin during motion — that made
+  otherwise-routable dense layouts falsely un-routable.
+
 ### Changed
 
 ### Fixed

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -356,6 +356,8 @@ _ALLOWED_HANGAR_KEYS = frozenset(
         "structural_notches",
         "clearance_m",
         "wing_layer_clearance_m",
+        "motion_clearance_m",
+        "motion_wing_layer_clearance_m",
         "max_carts",
         "apron_depth_m",
     }
@@ -442,6 +444,20 @@ def load_hangar(path: Path | str, *, fleet: Mapping[str, Aircraft] | None = None
             clearance_m=_to_float(raw.get("clearance_m", 0.3), "clearance_m"),
             wing_layer_clearance_m=_to_float(
                 raw.get("wing_layer_clearance_m", 0.2), "wing_layer_clearance_m"
+            ),
+            # #643: optional tighter tow-motion clearances. Absent ⇒ None ⇒ the
+            # motion clearance is the parked clearance (byte-identical plan).
+            motion_clearance_m=(
+                None
+                if raw.get("motion_clearance_m") is None
+                else _to_float(raw["motion_clearance_m"], "motion_clearance_m")
+            ),
+            motion_wing_layer_clearance_m=(
+                None
+                if raw.get("motion_wing_layer_clearance_m") is None
+                else _to_float(
+                    raw["motion_wing_layer_clearance_m"], "motion_wing_layer_clearance_m"
+                )
             ),
             max_carts=_to_int(raw.get("max_carts", 1), "max_carts"),
             apron_depth_m=_resolve_apron_depth(raw.get("apron_depth_m", 0.0), fleet),

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import math
 import typing
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal, cast
 
@@ -671,6 +671,14 @@ class Hangar:
     max_carts: int = 1
     apron_depth_m: float = 0.0
     structural_notches: tuple[StructuralNotch, ...] = ()
+    # #643: a SEPARATE, tighter clearance applied only during tow MOTION — a
+    # mover threading PAST a parked body is hand-cleared far closer than the
+    # parked spacing (a spotter watches the wingtips), so the parked
+    # ``clearance_m`` over-constrains the maneuver. ``None`` (the default) ⇒ the
+    # motion clearance IS the parked clearance, so a hangar without these fields
+    # plans byte-identically to today (ADR-0003). Consumed via ``motion_hangar``.
+    motion_clearance_m: float | None = None
+    motion_wing_layer_clearance_m: float | None = None
     # Derived L-shaped floor outline (outer rectangle minus the notches),
     # computed once in __post_init__ and cached here. ``None`` when there are
     # no notches (the common case) so the checker stays on its rectangle path.
@@ -694,6 +702,18 @@ class Hangar:
             raise ValueError(f"Hangar.max_carts must be non-negative, got {self.max_carts}")
         if self.apron_depth_m < 0:
             raise ValueError(f"Hangar.apron_depth_m must be non-negative, got {self.apron_depth_m}")
+        if self.motion_clearance_m is not None and self.motion_clearance_m < 0:
+            raise ValueError(
+                f"Hangar.motion_clearance_m must be non-negative, got {self.motion_clearance_m}"
+            )
+        if (
+            self.motion_wing_layer_clearance_m is not None
+            and self.motion_wing_layer_clearance_m < 0
+        ):
+            raise ValueError(
+                f"Hangar.motion_wing_layer_clearance_m must be non-negative, "
+                f"got {self.motion_wing_layer_clearance_m}"
+            )
         door_left = self.door.center_x_m - self.door.width_m / 2
         door_right = self.door.center_x_m + self.door.width_m / 2
         if door_left < 0 or door_right > self.width_m:
@@ -755,6 +775,33 @@ class Hangar:
         value is the L-shaped outline against which parts are tested with
         ``covers`` (ADR-0018)."""
         return self._floor_polygon
+
+    def motion_hangar(self) -> Hangar:
+        """The hangar as seen by the tow-MOTION collision checks (#643).
+
+        Returns ``self`` when no motion clearance is set, so the plan is
+        byte-identical to a hangar without these fields (ADR-0003). Otherwise
+        returns a plain parked-style hangar whose ``clearance_m`` /
+        ``wing_layer_clearance_m`` ARE the (tighter) motion values — so the
+        per-sampled-pose ``collisions.check`` the tow planner runs applies the
+        motion margin, while the static parked check keeps the original
+        spacing. The motion fields are folded into the clearances and cleared on
+        the returned hangar (it is itself a parked-style hangar)."""
+        if self.motion_clearance_m is None and self.motion_wing_layer_clearance_m is None:
+            return self
+        return replace(
+            self,
+            clearance_m=(
+                self.clearance_m if self.motion_clearance_m is None else self.motion_clearance_m
+            ),
+            wing_layer_clearance_m=(
+                self.wing_layer_clearance_m
+                if self.motion_wing_layer_clearance_m is None
+                else self.motion_wing_layer_clearance_m
+            ),
+            motion_clearance_m=None,
+            motion_wing_layer_clearance_m=None,
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1259,11 +1259,17 @@ def path_first_conflict(
     path here) build ``placed`` from the full target fleet + ground objects,
     satisfying this.
     """
+    # #643: the tow-MOTION oracle clears the mover against parked bodies at the
+    # (tighter) MOTION clearance, not the parked spacing — a spotter threads the
+    # wingtips far closer in motion than the parked margin. ``motion_hangar()``
+    # IS the parked hangar when no motion clearance is set, so a layout without
+    # the motion fields is byte-identical (ADR-0003).
+    motion_hangar = placed.hangar.motion_hangar()
     for pose in arc.sample(step_m=step_m, step_deg=step_deg):
         moving = Placement(mover.id, pose.x_m, pose.y_m, pose.heading_deg, on_carts=mover_on_carts)
         # Mover hangar bounds: front-gap-exempt (a plane being towed in
         # straddles the door at y < 0). Side/back walls still bite.
-        bounds_conflict = _mover_motion_bounds_conflict(mover, moving, placed.hangar)
+        bounds_conflict = _mover_motion_bounds_conflict(mover, moving, motion_hangar)
         if bounds_conflict is not None:
             return bounds_conflict
         # Rebuilding the Layout per sample re-runs Layout.__post_init__ (cart
@@ -1274,7 +1280,7 @@ def path_first_conflict(
         if isinstance(mover, Aircraft):
             sample_layout = Layout(
                 fleet=placed.fleet,
-                hangar=placed.hangar,
+                hangar=motion_hangar,
                 placements=(*placed.placements, moving),
                 maintenance_plane=placed.maintenance_plane,
                 ground_objects=placed.ground_objects,
@@ -1283,7 +1289,7 @@ def path_first_conflict(
         else:  # GroundObject mover -> belongs in ground_object_placements
             sample_layout = Layout(
                 fleet=placed.fleet,
-                hangar=placed.hangar,
+                hangar=motion_hangar,
                 placements=placed.placements,
                 maintenance_plane=placed.maintenance_plane,
                 ground_objects=placed.ground_objects,
@@ -2296,6 +2302,14 @@ def plan_path(
     # Static obstacle set, computed once: placed planes don't move while this one
     # is routed. Drives the fast per-pose `_motion_clear` used during search.
     obstacles = _build_obstacles(placed, mover_id=mover.id)
+    # #643: the fast in-search ``_motion_clear`` screen clears the mover against
+    # parked bodies at the (tighter) MOTION clearance, matching the exact
+    # ``path_first_conflict`` oracle (which converts internally). The grid
+    # heuristic and obstacle footprints are clearance-free (bounds/geometry
+    # only), so they stay on the parked ``hangar``. ``motion_hangar()`` is the
+    # parked hangar itself when no motion clearance is set ⇒ byte-identical
+    # (ADR-0003).
+    motion_hangar = hangar.motion_hangar()
 
     # A* heuristic seam (#332). ``euclidean`` (default) is the byte-identical
     # straight-line lower bound the planner has always used. ``grid`` swaps in
@@ -2378,7 +2392,7 @@ def plan_path(
         if best_seed is not None and seed_cost >= best_seed[0]:
             continue  # can't beat the best clean seed — skip the costly checks
         if not all(
-            _motion_clear(mover, p, obstacles, hangar)
+            _motion_clear(mover, p, obstacles, motion_hangar)
             for p in seed_arc.sample(step_m=_SEARCH_STEP_M, step_deg=_SEARCH_STEP_DEG)
         ):
             continue
@@ -2437,7 +2451,7 @@ def plan_path(
         # `_motion_clear` screen always runs before the costly oracle.
         final_arc = plan_reeds_shepp(node.pose, goal, turn_radius_m=r)
         if all(
-            _motion_clear(mover, p, obstacles, hangar)
+            _motion_clear(mover, p, obstacles, motion_hangar)
             for p in final_arc.sample(step_m=_SEARCH_STEP_M, step_deg=_SEARCH_STEP_DEG)
         ):
             segs = tuple(_reconstruct_segments(node)) + final_arc.segments
@@ -2486,7 +2500,7 @@ def plan_path(
             child_pose = _step_pose(node.pose, seg, r)
             edge = DubinsArc(node.pose, child_pose, r, (seg,))
             if not all(
-                _motion_clear(mover, p, obstacles, hangar)
+                _motion_clear(mover, p, obstacles, motion_hangar)
                 for p in edge.sample(step_m=_SEARCH_STEP_M, step_deg=_SEARCH_STEP_DEG)
             ):
                 continue

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1350,6 +1350,8 @@ door: {center_x_m: 12.5, width_m: 12.0}
 maintenance_bay: {center_x_m: 21.0, width_m: 6.0, depth_m: 6.0}
 clearance_m: 0.3
 wing_layer_clearance_m: 0.2
+motion_clearance_m: 0.05
+motion_wing_layer_clearance_m: 0.04
 max_carts: 2
 apron_depth_m: 6.0
 structural_notches:

--- a/tests/test_motion_clearance.py
+++ b/tests/test_motion_clearance.py
@@ -1,0 +1,180 @@
+"""#643: a separate, tighter tow-MOTION clearance, distinct from the PARKED
+clearance used by the static checker.
+
+The tow planner threads a mover past parked bodies at a hand-realistic motion
+margin (spotters clear wingtips far tighter than the parked spacing), while
+``collisions.check`` keeps the parked ``clearance_m`` for static validity. When
+the motion fields are unset the motion clearance IS the parked clearance, so the
+plan is byte-identical to today (ADR-0003).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.models import (
+    Aircraft,
+    Door,
+    Hangar,
+    Layout,
+    MaintenanceBay,
+    Part,
+    Placement,
+    Wheels,
+)
+from hangarfit.towplanner import Pose, path_first_conflict, plan_dubins
+
+_WHEELS = Wheels(main_offset_x_m=0.20, track_m=1.0, third_wheel_offset_x_m=-1.0)
+
+
+def _box_plane(pid: str, *, always_cart: bool = False) -> Aircraft:
+    """A minimal plane: one 1.0 m × 0.6 m fuselage box, mounted forward."""
+    return Aircraft(
+        id=pid,
+        name=pid,
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_cart" if always_cart else "always_own_gear",
+        turn_radius_m=None if always_cart else 3.0,
+        measured=False,
+        parts=(
+            Part(
+                kind="fuselage_aft",
+                length_m=1.0,
+                width_m=0.6,
+                offset_x_m=0.5,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=1.0,
+            ),
+        ),
+        wheels=_WHEELS,
+    )
+
+
+def _hangar(**overrides: object) -> Hangar:
+    kwargs: dict[str, object] = dict(
+        length_m=30.0,
+        width_m=20.0,
+        door=Door(center_x_m=10.0, width_m=6.0),
+        maintenance_bay=MaintenanceBay(center_x_m=10.0, width_m=2.0, depth_m=2.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.2,
+    )
+    kwargs.update(overrides)
+    return Hangar(**kwargs)  # type: ignore[arg-type]
+
+
+def test_motion_hangar_is_self_when_unset() -> None:
+    """With no motion clearance set, the tow-motion hangar IS the parked hangar
+    (identity) — so nothing about the plan changes (byte-identical default)."""
+    h = _hangar()
+    assert h.motion_clearance_m is None
+    assert h.motion_hangar() is h
+
+
+def test_motion_hangar_folds_motion_clearance_into_parked_clearance() -> None:
+    """With a tighter motion clearance set, the motion hangar's PARKED clearance
+    fields ARE the motion values (so collisions.check applies them per pose),
+    while the original hangar keeps its parked spacing."""
+    h = _hangar(
+        clearance_m=0.30,
+        wing_layer_clearance_m=0.20,
+        motion_clearance_m=0.05,
+        motion_wing_layer_clearance_m=0.04,
+    )
+    m = h.motion_hangar()
+    assert m is not h
+    assert m.clearance_m == 0.05
+    assert m.wing_layer_clearance_m == 0.04
+    # the motion fields are folded away on the returned (parked-style) hangar
+    assert m.motion_clearance_m is None
+    assert m.motion_wing_layer_clearance_m is None
+    # the original hangar is unchanged — static checks still use parked spacing
+    assert h.clearance_m == 0.30 and h.wing_layer_clearance_m == 0.20
+
+
+def test_motion_clearance_negative_rejected() -> None:
+    """A negative motion clearance is a construction error (mirrors clearance_m)."""
+    with pytest.raises(ValueError, match="motion_clearance_m must be non-negative"):
+        _hangar(motion_clearance_m=-0.1)
+
+
+# --- the behaviour: the tow-MOTION oracle (``path_first_conflict``) applies the
+# motion clearance, not the parked one. A mover drives straight past a parked
+# obstacle with a ~0.10 m part gap — flagged at the 0.5 m parked clearance, clear
+# at a 0.05 m motion clearance. Direct-on-the-oracle (no A* search) ⇒ fast.
+
+
+def _pass_hangar(**overrides: object) -> Hangar:
+    kwargs: dict[str, object] = dict(
+        length_m=16.0,
+        width_m=3.0,
+        door=Door(center_x_m=1.5, width_m=3.0),  # whole front: the y>=0 pass needs no door gate
+        maintenance_bay=MaintenanceBay(center_x_m=2.7, width_m=0.2, depth_m=0.2),
+        clearance_m=0.5,
+        wing_layer_clearance_m=0.3,
+    )
+    kwargs.update(overrides)
+    return Hangar(**kwargs)  # type: ignore[arg-type]
+
+
+def _close_pass(hangar: Hangar):
+    """Mover B drives straight in at x=0.5 past obstacle A (x in [0.9, 1.5]) — a
+    ~0.10 m gap at the closest point. Returns the first conflict (or None)."""
+    a = _box_plane("A")
+    b = _box_plane("B", always_cart=True)
+    placed = Layout(
+        fleet={"A": a, "B": b},
+        hangar=hangar,
+        placements=(Placement("A", x_m=1.2, y_m=6.0, heading_deg=0.0, on_carts=False),),
+    )
+    arc = plan_dubins(Pose(0.5, 0.0, 0.0), Pose(0.5, 12.0, 0.0), turn_radius_m=0.0)
+    return path_first_conflict(arc, b, mover_on_carts=True, placed=placed)
+
+
+def test_parked_clearance_flags_the_close_pass() -> None:
+    """Sanity: at the 0.5 m parked clearance the close pass is a conflict (so the
+    motion-clearance test below proves a real behaviour change)."""
+    conflict = _close_pass(_pass_hangar())
+    assert conflict is not None
+    assert "B" in conflict.planes and "A" in conflict.planes
+
+
+def test_tighter_motion_clearance_allows_the_close_pass() -> None:
+    """The point of #643: at a 0.05 m tow-MOTION clearance the same pass is clean,
+    even though the parked clearance stays 0.5 m for static validity."""
+    conflict = _close_pass(
+        _pass_hangar(motion_clearance_m=0.05, motion_wing_layer_clearance_m=0.05)
+    )
+    assert conflict is None
+
+
+_HANGAR_YAML = (
+    "length_m: 30\nwidth_m: 20\n"
+    "door: {center_x_m: 10, width_m: 6}\n"
+    "maintenance_bay: {center_x_m: 10, width_m: 2, depth_m: 2}\n"
+    "clearance_m: 0.3\nwing_layer_clearance_m: 0.2\n"
+)
+
+
+def test_load_hangar_parses_motion_clearance(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    from hangarfit.loader import load_hangar
+
+    p = tmp_path / "hangar.yaml"
+    p.write_text(_HANGAR_YAML + "motion_clearance_m: 0.05\nmotion_wing_layer_clearance_m: 0.04\n")
+    h = load_hangar(p)
+    assert h.motion_clearance_m == 0.05
+    assert h.motion_wing_layer_clearance_m == 0.04
+    assert h.motion_hangar().clearance_m == 0.05
+
+
+def test_load_hangar_motion_clearance_absent_is_none(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    from hangarfit.loader import load_hangar
+
+    p = tmp_path / "hangar.yaml"
+    p.write_text(_HANGAR_YAML)
+    h = load_hangar(p)
+    assert h.motion_clearance_m is None
+    assert h.motion_hangar() is h


### PR DESCRIPTION
Closes #643. Refs #642, #644.

## What
A hangar may declare optional `motion_clearance_m` / `motion_wing_layer_clearance_m` — the (tighter) margin the tow planner clears a *moving* mover against parked bodies. `collisions.check` keeps the parked `clearance_m` for static validity and is **unchanged**; only the tow planner's per-pose checks use the motion margin.

## Why
The #642 probes showed the "fundamental un-routability" of the dense Herrenteich layout was an **abstraction artifact**: the planner enforced the full *parked* clearance at every pose along a tow, but a moving mover is hand-cleared past parked bodies far tighter (a spotter watches the wingtips). At a hand-realistic motion clearance the previously-"fundamental" 2-body pinch routes.

## Design (minimal surface)
- `Hangar.motion_clearance_m` / `motion_wing_layer_clearance_m` (optional, default `None`) + `Hangar.motion_hangar()` — returns `self` when unset, else a parked-style hangar at the motion margin.
- `path_first_conflict` (the tow-motion oracle) converts to the motion hangar internally; `plan_path` passes it to the in-search `_motion_clear` screen. The grid heuristic + obstacle footprints are clearance-free, so they stay on the parked hangar.
- `collisions.py` / `geometry.py` **untouched** — the geometry-invariant surface is zero; only `towplanner.py` + `models.py` + `loader.py` change.

## Determinism (ADR-0003)
Absent motion fields ⇒ `motion_hangar()` returns `self` (no reconstruction) ⇒ **byte-identical** plan. Determinism-guard applies (towplanner.py).

## Tests
New `tests/test_motion_clearance.py` (model identity/fold/validation; the tow-motion oracle flags a close pass at parked clearance but clears it at a tight motion clearance; loader round-trip). Allowlist-completeness fixture extended. **Full bulk suite: 1672 passed.**

## Scope
The mechanism + tests. Calibrating the *real* Herrenteich motion-clearance value (and the per-fleet pivotability, #644) is separate — this just stops applying the parked margin during motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)