### PR TITLE
feat(605): calibrate the Herrenteich tow-motion clearance to 0.05 m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- **Herrenteich tow-motion clearance calibrated (#605/#643).** `examples/herrenteich/hangar.yaml`
+  now sets `motion_clearance_m: 0.05` / `motion_wing_layer_clearance_m: 0.05` — the
+  hand-cleared margin while a mover is in motion, distinct from the 0.20/0.15 *parked*
+  spacing (the #646 mechanism). A `measured: false` modelling assumption like the parked
+  values. With this plus the strafe (#599) and the dolly/free-swivel pivot data (#644),
+  the broadside Scheibe and small dense subsets tow-route where the parked margin
+  rejected them; the *full* dense all-8 remains gated on the greedy planner's routing
+  search at scale (not the motion model — see #642).
+
 - **Herrenteich Stemme modelled as dolly-pivotable for tow planning (#644).** The
   `examples/herrenteich/` fleet manifest now overrides the Stemme S10 to
   `movement_mode: always_cart` — it is hand-positioned on a dolly in the hangar,

--- a/examples/herrenteich/hangar.yaml
+++ b/examples/herrenteich/hangar.yaml
@@ -67,8 +67,19 @@ structural_notches:
 # 0.15). Lowering a clearance only RELAXES the constraint, so the existing
 # layout.yaml / scenario_demo.yaml stay valid; the synthetic data/ hangar is a
 # separate file, untouched.
-clearance_m: 0.20            # minimum horizontal gap between any two parts
-wing_layer_clearance_m: 0.15 # minimum vertical gap between two parts at the same XY
+clearance_m: 0.20            # minimum horizontal gap between any two parts (PARKED)
+wing_layer_clearance_m: 0.15 # minimum vertical gap between two parts at the same XY (PARKED)
+
+# Tow-MOTION clearances (#643/#646): the margin the planner keeps while a mover
+# is IN MOTION threading past parked bodies, distinct from the PARKED spacing
+# above. A spotter hand-clears wingtips far closer during a slow guided slide than
+# the long-term parked gap — applying the 0.20 m parked margin during motion
+# falsely rejects routable maneuvers (the #642 finding). 0.05 m models the
+# hand-cleared motion margin; like the parked values it is measured: false
+# (a documented modelling assumption pending on-site measurement). Absent ⇒ the
+# motion clearance is the parked clearance (byte-identical plan, ADR-0003).
+motion_clearance_m: 0.05            # horizontal gap during tow motion
+motion_wing_layer_clearance_m: 0.05 # vertical gap during tow motion
 
 # Spare carts available to the cart_eligible pool. Bounds how many
 # cart_eligible planes may sit on carts in one layout; always_cart planes

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -47,6 +47,19 @@ def test_hangar_dimensions() -> None:
     assert hangar.door.center_x_m == 7.28
 
 
+def test_hangar_motion_clearance_calibrated() -> None:
+    """The Herrenteich hangar carries the calibrated tow-MOTION clearance (#605/#643):
+    tighter than the parked spacing, which stays the static-validity margin."""
+    hangar = load_hangar(HERRENTEICH / "hangar.yaml")
+    assert hangar.motion_clearance_m == 0.05
+    assert hangar.motion_wing_layer_clearance_m == 0.05
+    # parked spacing is unchanged — static validity still uses 0.20 / 0.15
+    assert hangar.clearance_m == 0.20
+    assert hangar.wing_layer_clearance_m == 0.15
+    # the tow planner sees the tighter motion margin
+    assert hangar.motion_hangar().clearance_m == 0.05
+
+
 def test_fleet_roster() -> None:
     fleet = load_fleet(HERRENTEICH / "fleet.yaml")
     assert set(fleet) == USUAL_OCCUPANTS


### PR DESCRIPTION
Refs #605, #642, #643, #646. (Advances #605; does not fully close it — see below.)

## What
Sets `motion_clearance_m: 0.05` / `motion_wing_layer_clearance_m: 0.05` on `examples/herrenteich/hangar.yaml` — the **#646 mechanism** applied to the real hangar. The hand-cleared margin while a mover is *in motion*, distinct from the 0.20/0.15 **parked** spacing (static validity unchanged). A `measured: false` modelling assumption, like the parked values.

## Why / result
Completes the tow-motion abstraction correction on the real dataset. With this + the strafe (#599) + the dolly/free-swivel pivot data (#644):
- The broadside Scheibe and small dense subsets **tow-route where the parked margin rejected them** (verified: the deepest-2 subset routes in ~1 s; it was infeasible before the fixes).
- **The full dense all-8 still does NOT greedily tow-route** — it boxes out `aviat_husky` at k≥4 (57–137 s). That wall is now the **greedy planner's routing search at scale**, *not* the motion model (the #642 reframe). So #605's full-set tow-routability stays open, gated on a non-greedy / learned routing search — this PR makes the *verifier* honest, which is the prerequisite.

## Scope
Data + test only; no code change (the mechanism shipped in #646). `collisions.check` / solver / towplanner untouched → no determinism exposure. Regression test asserts the hangar carries the motion clearance while the parked spacing stays the static-validity margin. **1692 bulk tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)