### PR TITLE
feat(606): render ground objects in the 2D PNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Ground objects render in the 2D PNG (#606).** `hangarfit check --render` /
+  `solve --render-paths` now draw the floor's ground objects: the fixed obstacle
+  (the Maul fuel trailer) as a hatched keep-out (distinct from the structural-notch
+  hatch — an object, not absent floor), and the placed/routed movers (VW Caddy + the
+  two glider trailers) as solid bodies in a neutral mover fill, deliberately outside
+  the per-plane aircraft palette so a glance separates aircraft from trailer/vehicle.
+  Each is labelled. Inert for aircraft-only layouts (byte-identical). The conflict
+  validator now also knows about ground-object ids, so a real mover/obstacle conflict
+  is not mistaken for a cross-layout mismatch. (scene/v2 + 3D-viewer rendering and the
+  Caddy egress-lane decal are the follow-up half of #606.)
+
 - **Lateral cart-strafe + free-swivel pivot tow motion (#599, ADR-0010).** The cart
   motion model gains a lateral *strafe* primitive (`Segment(kind="T")`) — a slide
   perpendicular to heading — so a broadside-parked cart-borne plane (e.g. the 18 m

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -377,7 +377,7 @@ def _draw_fixed_obstacles(ax: Any, layout: Layout) -> None:
                     closed=True,
                     facecolor="none",
                     edgecolor=_HANGAR_EDGE,
-                    hatch="oo",  # distinct from the notch "xx": an object, not absent floor
+                    hatch="oo",  # a distinct hatch from the structural notch's
                     lw=1.5,
                     zorder=0,
                 )
@@ -405,6 +405,8 @@ def _draw_movers(ax: Any, layout: Layout) -> None:
             continue
         for wp in aircraft_parts_world(obj, gp):
             _draw_part(ax, wp, _MOVER_FILL)
+        # Label above the near-opaque mover body (z=2) and any tow-path overlay,
+        # so it stays legible where a mover sits under an aircraft wing.
         ax.text(
             gp.x_m,
             gp.y_m,
@@ -540,14 +542,13 @@ def _draw_part(ax: Any, part: WorldPart, color: str) -> None:
             zorder=4,
         )
     elif part.kind == "ground":
-        # Ground-object footprint (#601): solid keep-out, drawn opaque like a
-        # fuselage body at the fuselage z-level (above wings).
-        # NOTE: currently UNREACHABLE — render_layout/scene iterate only
-        # layout.placements (aircraft), never ground_object_placements, so no
-        # ground WorldPart reaches _draw_part yet. This branch is a forward hook
-        # for #606 (ground-object rendering) AND satisfies the closed-PartKind
-        # exhaustiveness contract (the else-raise below must stay reachable for
-        # any future unknown kind).
+        # Ground-object footprint (#601): a placed/routed mover body (car /
+        # trailer), drawn near-opaque like a fuselage body at the fuselage
+        # z-level (above wings). Reached via :func:`_draw_movers` (#606); fixed
+        # obstacles take the hatched-keep-out path in :func:`_draw_fixed_obstacles`
+        # instead, so only ``placed_routed_mover`` parts arrive here. Keeping the
+        # branch also satisfies the closed-``PartKind`` exhaustiveness contract
+        # (the else-raise below stays reachable for any future unknown kind).
         patch = MplPolygon(
             coords,
             closed=True,

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -183,6 +183,7 @@ def render_layout(
     try:
         _draw_hangar(ax, layout)
         _draw_aircraft(ax, layout)
+        _draw_movers(ax, layout)
         if not (check_result is None or check_result.valid):
             _draw_conflict_overlay(ax, layout, check_result)
         if moves_plan is not None:
@@ -211,7 +212,13 @@ def _validate_check_result_planes(layout: Layout, check_result: CheckResult) -> 
     caller passed a result from a *different* layout, and silently
     rendering a clean PNG for an invalid result is the precise kind of
     "looks OK so the bug ships" failure this tool exists to prevent."""
-    placed = {p.plane_id for p in layout.placements}
+    # Ground objects (#606) participate in collision/egress conflicts (ADR-0025/
+    # 0026), so a CheckResult may legitimately name a mover/obstacle id — include
+    # them in the known set so a real ground-object conflict isn't mistaken for a
+    # cross-layout mismatch.
+    placed = {p.plane_id for p in layout.placements} | {
+        gp.plane_id for gp in layout.ground_object_placements
+    }
     conflicting = {pid for c in check_result.conflicts for pid in c.planes}
     unknown = conflicting - placed
     if unknown:
@@ -253,6 +260,7 @@ def _draw_hangar(ax: Any, layout: Layout) -> None:
     # Keep-out overlays first (zorder=0) so walls and aircraft layer on top.
     _draw_maintenance_bay(ax, layout)
     _draw_structural_notches(ax, layout)
+    _draw_fixed_obstacles(ax, layout)
 
     # Back, left, right walls — solid.
     ax.plot(
@@ -344,6 +352,69 @@ def _draw_structural_notches(ax: Any, layout: Layout) -> None:
             zorder=0,
         )
         ax.add_patch(patch)
+
+
+# Mover bodies (#606) read in a neutral slate fill, deliberately OUTSIDE the
+# per-plane PLANES aircraft palette, so a glance separates "aircraft" from
+# "trailer / vehicle".
+_MOVER_FILL = "#8A8F98"
+
+
+def _draw_fixed_obstacles(ax: Any, layout: Layout) -> None:
+    """Overlay each *fixed-obstacle* ground object (#606, e.g. the Maul fuel
+    trailer) as a keep-out — like a structural notch but a distinct hatch, so it
+    reads as "an object on the floor", not "missing floor". No-op when there are
+    no fixed obstacles (mirrors :func:`_draw_structural_notches`, so an
+    aircraft-only layout renders byte-identically)."""
+    for gp in layout.ground_object_placements:
+        obj = layout.ground_objects[gp.plane_id]
+        if obj.object_class != "fixed_obstacle":
+            continue
+        for wp in aircraft_parts_world(obj, gp):
+            ax.add_patch(
+                MplPolygon(
+                    list(wp.polygon.exterior.coords),
+                    closed=True,
+                    facecolor="none",
+                    edgecolor=_HANGAR_EDGE,
+                    hatch="oo",  # distinct from the notch "xx": an object, not absent floor
+                    lw=1.5,
+                    zorder=0,
+                )
+            )
+        ax.text(
+            gp.x_m,
+            gp.y_m,
+            gp.plane_id,
+            ha="center",
+            va="center",
+            fontsize=6,
+            color=_HANGAR_EDGE,
+            zorder=1,
+        )
+
+
+def _draw_movers(ax: Any, layout: Layout) -> None:
+    """Draw each *placed/routed mover* ground object (#606, the VW Caddy + glider
+    trailers) as a solid body in the neutral mover fill — visually distinct from
+    the per-plane aircraft hues — with an id label. No-op when there are no movers
+    (so an aircraft-only layout renders byte-identically)."""
+    for gp in layout.ground_object_placements:
+        obj = layout.ground_objects[gp.plane_id]
+        if obj.object_class != "placed_routed_mover":
+            continue
+        for wp in aircraft_parts_world(obj, gp):
+            _draw_part(ax, wp, _MOVER_FILL)
+        ax.text(
+            gp.x_m,
+            gp.y_m,
+            gp.plane_id,
+            ha="center",
+            va="center",
+            fontsize=6,
+            color=_INK_EDGE,
+            zorder=5,
+        )
 
 
 def _draw_aircraft(ax: Any, layout: Layout) -> None:

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -67,6 +67,62 @@ def _assert_valid_png(path: Path) -> None:
         assert width > 0 and height > 0, f"invalid image size {img.size}"
 
 
+_HERRENTEICH = REPO_ROOT / "examples" / "herrenteich"
+
+
+class TestGroundObjectRendering:
+    """#606: fixed-obstacle keep-outs + mover bodies render in the 2D PNG."""
+
+    def test_renders_layout_with_ground_objects(self, tmp_path: Path) -> None:
+        """The Herrenteich full set (8 aircraft + fixed fuel trailer + VW Caddy +
+        2 glider trailers) renders to a valid PNG."""
+        layout = load_layout(_HERRENTEICH / "layout_full.yaml")
+        assert layout.ground_object_placements, "fixture must carry ground objects"
+        classes = {
+            layout.ground_objects[gp.plane_id].object_class
+            for gp in layout.ground_object_placements
+        }
+        assert classes == {"fixed_obstacle", "placed_routed_mover"}  # both classes exercised
+        out = tmp_path / "full.png"
+        render_layout(layout, out)
+        _assert_valid_png(out)
+
+    def test_aircraft_only_layout_renders(self, tmp_path: Path) -> None:
+        """A layout with no ground objects renders fine — the new draw helpers are
+        no-ops (inert-when-empty)."""
+        layout = load_layout(_HERRENTEICH / "layout.yaml")
+        assert not layout.ground_object_placements
+        out = tmp_path / "ac_only.png"
+        render_layout(layout, out)
+        _assert_valid_png(out)
+
+    def test_validator_accepts_a_ground_object_conflict(self) -> None:
+        """A CheckResult whose conflict names a ground-object id must NOT be
+        rejected as a cross-layout mismatch (the #606 validator widening)."""
+        from hangarfit.models import CheckResult, Conflict
+        from hangarfit.visualize import _validate_check_result_planes
+
+        layout = load_layout(_HERRENTEICH / "layout_full.yaml")
+        mover_id = next(gp.plane_id for gp in layout.ground_object_placements)
+        result = CheckResult(
+            conflicts=(Conflict.single(kind="ground_obstacle", plane=mover_id, detail="x"),)
+        )
+        _validate_check_result_planes(layout, result)  # must not raise
+
+    def test_validator_still_rejects_a_truly_unknown_id(self) -> None:
+        """The cross-layout guard still fires for an id in neither aircraft nor
+        ground objects."""
+        from hangarfit.models import CheckResult, Conflict
+        from hangarfit.visualize import _validate_check_result_planes
+
+        layout = load_layout(_HERRENTEICH / "layout_full.yaml")
+        result = CheckResult(
+            conflicts=(Conflict.single(kind="x", plane="not_a_real_body", detail="x"),)
+        )
+        with pytest.raises(ValueError, match="not placed in this layout"):
+            _validate_check_result_planes(layout, result)
+
+
 class TestRenderLayout:
     def test_produces_valid_png_for_valid_layout(self, tmp_path: Path) -> None:
         layout = _load("valid_two_separated")


### PR DESCRIPTION
Refs #606 (the **2D half** — scene/v2 + 3D viewer + egress-lane decal are the follow-up PR; full blueprint recorded).

## What
The top-down PNG (`hangarfit check --render` / `solve --render-paths`) now draws the floor's ground objects:
- **Fixed obstacle** (Maul fuel trailer) → an `"oo"`-hatched keep-out, distinct from the structural-notch `"xx"` (reads as "an object", not "absent floor").
- **Placed/routed movers** (VW Caddy + 2 glider trailers) → solid bodies in a neutral slate fill, deliberately **outside the per-plane aircraft palette** so a glance separates aircraft from trailer/vehicle. Each labelled.

So a human can finally eyeball the *real* Herrenteich floor — the deterministic checker is ground truth, but trust comes from the PNG.

## Design
- Reuses `aircraft_parts_world` (accepts `GroundObject` since #602) + the existing `_draw_part` `"ground"` hook (a forward hook from #601, now reachable).
- `_draw_fixed_obstacles` (zorder-0 keep-out group, beside notch/bay) + `_draw_movers` (after `_draw_aircraft`). Both **no-op for aircraft-only layouts** → byte-identical.
- Widens `_validate_check_result_planes` to include ground-object ids — a real mover/obstacle conflict (ADR-0025/0026) is no longer mistaken for a cross-layout mismatch.

## Render-only
No change to `collisions.check` / `towplanner` / solver output. Mover tow-paths flow through the existing `_draw_tow_paths` overlay unchanged when a `MovesPlan` carries them.

## Tests
Ground-object PNG smoke (exercises **both** classes) + aircraft-only inert + validator accepts-mover / rejects-unknown. **1695 bulk tests pass**, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)