### PR TITLE
fix(634): surface un-routable ground-object movers in view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Fixed
 
+- **`view` surfaces un-routable ground-object movers (#634).** Layout-mode
+  `hangarfit view` already named an un-tow-routable *aircraft* (the static-degrade
+  note), but a None-path *mover* — which `plan_fill` keeps as a best-effort static
+  body rather than raising — rendered silently, unlike `solve --render-paths`
+  (#612). `view` now threads `plan_fill`'s `unroutable_movers` out-param and warns
+  one line per mover on stderr (the shared `_warn_unroutable_mover_ids` helper),
+  closing the last `view`/`solve` surfacing parity gap. Plan-inert (byte-identical).
+
 ## [0.15.0] — 2026-06-12
 
 ### Added

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -893,7 +893,15 @@ def _warn_unroutable_movers(result: SolveResult) -> None:
     deduped, advisory mover-id list the solver collected — empty when every mover
     routed, there are no movers, or tow-planning was not attempted.
     """
-    for mover in result.diagnostics.unroutable_movers:
+    _warn_unroutable_mover_ids(result.diagnostics.unroutable_movers)
+
+
+def _warn_unroutable_mover_ids(mover_ids: Iterable[str]) -> None:
+    """Emit one stderr warning per un-routable ground-object mover id. Shared by
+    the solve path (:func:`_warn_unroutable_movers`, via ``diagnostics``) and the
+    layout-mode ``view`` path (which collects the ids from ``plan_fill``'s
+    ``unroutable_movers`` out-param directly, having no ``SolverDiagnostics``)."""
+    for mover in mover_ids:
         print(
             f"warning: ground-object mover {mover!r} could not be routed; "
             "rendered as a static (un-towed) body",
@@ -1228,13 +1236,21 @@ def cmd_view(args: argparse.Namespace) -> int:
                     # plan that is actually built (no NoFeasiblePlanError) reaches
                     # the warn call, so a discarded/failed plan never warns.
                     apron_drops: list[ApronShallowDrop] = []
+                    # #634: surface un-routable MOVERS too. An un-tow-routable
+                    # aircraft makes plan_fill raise (handled below); a None-path
+                    # mover does NOT raise — it keeps a best-effort static body — so
+                    # without the out-param it would be a silent skip here, unlike
+                    # `solve --render-paths` which warns via diagnostics (#612).
+                    unroutable_movers: list[str] = []
                     moves_plan = plan_fill(
                         layout,
                         max_expansions=args.tow_max_expansions,
                         max_total_expansions=view_total_cap,
                         apron_dropped_out=apron_drops,
+                        unroutable_movers=unroutable_movers,
                     )
                     _warn_apron_shallow_drops(apron_drops)
+                    _warn_unroutable_mover_ids(unroutable_movers)
                 except NoFeasiblePlanError as e:
                     print(
                         f"note: layout not tow-routable (plane {e.plane_id!r} could not be "

--- a/tests/test_cli_view.py
+++ b/tests/test_cli_view.py
@@ -195,6 +195,34 @@ def test_view_layout_mode_warns_apron_shallow_once(tmp_path, monkeypatch, capsys
     assert "'z'" in err and "8.0 m" in err
 
 
+def test_view_layout_mode_warns_unroutable_mover(tmp_path, monkeypatch, capsys):
+    # #634: layout-mode view surfaces un-routable MOVERS. An un-tow-routable
+    # aircraft makes plan_fill raise (the "not tow-routable" static-degrade note);
+    # a None-path mover does NOT raise — it keeps a best-effort static body — so
+    # without the out-param it would be a silent skip, unlike `solve --render-paths`
+    # (#612). Stub plan_fill to populate the out-param + return a real plan; the
+    # CLI must name the mover on stderr.
+    import hangarfit.towplanner as tp
+    from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+
+    def fake_plan_fill(target, *, unroutable_movers=None, **kwargs):
+        if unroutable_movers is not None:
+            unroutable_movers.append("vw_caddy")
+        start = Pose(x_m=2.0, y_m=0.0, heading_deg=0.0)
+        end = Pose(x_m=2.0, y_m=5.0, heading_deg=0.0)
+        arc = DubinsArc(start=start, end=end, turn_radius_m=1.0, segments=(Segment("S", 5.0),))
+        return MovesPlan(
+            target_layout=target, moves=(Move(plane_id="z", target_slot=end, path=arc),)
+        )
+
+    monkeypatch.setattr(tp, "plan_fill", fake_plan_fill)
+    out = tmp_path / "v.html"
+    rc = main(["view", NESTING, "-o", str(out)])
+    assert rc == 0 and out.exists()
+    err = capsys.readouterr().err
+    assert "vw_caddy" in err and "could not be routed" in err
+
+
 def test_view_layout_mode_no_apron_drop_no_warning(tmp_path, monkeypatch, capsys):
     # No drop recorded (deep enough apron / no apron) ⇒ no warning.
     import hangarfit.towplanner as tp


### PR DESCRIPTION
Closes #634.

## What
Layout-mode `hangarfit view` already names an un-tow-routable **aircraft** (plan_fill *raises* → the "not tow-routable" static-degrade note). But a None-path **mover** does **not** raise — plan_fill keeps a best-effort static body — so it rendered **silently**, unlike `solve --render-paths` which warns via diagnostics (#612). This was the last `view`/`solve` surfacing parity gap.

## Fix
`view` now threads `plan_fill`'s `unroutable_movers` out-param (the #627 idiom, plan-inert) and warns one line per mover on stderr, via a shared `_warn_unroutable_mover_ids` helper extracted from `_warn_unroutable_movers` (so the solve and view paths emit the identical message).

## Scope
Plan-inert (the out-param never changes the `MovesPlan` → byte-identical). Test mirrors the #503 apron-drop monkeypatch pattern (stub plan_fill populates the out-param, assert the mover is named on stderr). 21 view tests pass, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)