### PR TITLE
feat(651): animate placed-routed movers along their drive path (2D + 3D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Placed-routed movers animate along their drive path (#651).** Building on the
+  static ground-object render (#606), a placed/routed mover (the VW Caddy + glider
+  trailers) now animates in the 3D viewer's whole-fill timeline — driving in along
+  its routed path *after* every aircraft is parked — and its 2D `--render-paths`
+  route is drawn in the neutral mover body colour (matching the `_draw_movers` body)
+  so it reads as a ground vehicle, not an aircraft. A deferred (un-routable,
+  `path=None`) mover stays at its static resting pose, like a fixed obstacle. The
+  viewer reuses the same hidden→sample→parked state machine as aircraft (new pure,
+  node-tested `framePoses`). Inert / byte-identical for aircraft-only layouts
+  (ADR-0003). The Caddy hard-door egress lane (#652) is the remaining half of #606.
+
 - **Ground objects render in the 2D PNG (#606).** `hangarfit check --render` /
   `solve --render-paths` now draw the floor's ground objects: the fixed obstacle
   (the Maul fuel trailer) as a hatched keep-out (distinct from the structural-notch

--- a/data/catalog/stemme_s10.yaml
+++ b/data/catalog/stemme_s10.yaml
@@ -7,7 +7,7 @@ gear: tailwheel         # twin inward-retracting mains (track 1.15 m) + tailwhee
 movement_mode: always_own_gear
 turn_radius_m: 10.0
 measured: false
-notes: "Two-seat self-launching motor glider, T-tail. WINGS-FOLDED config: wing width = 11.4 m folded span (23 m unfolded; EASA TCDS A.054, cross-checked Jane's + AOPA). Length 8.42 m, longest fuselage in the fleet. Taildragger (corrected from monowheel). The 11.4 m folded span clears a 13.46 m door by ~2 m and a lone Stemme routes in on its own gear; the Herrenteich fleet sets always_cart for dense multi-plane maneuvering (#607), not because of width."
+notes: "Two-seat self-launching motor glider, T-tail. WINGS-FOLDED config: wing width = 11.4 m folded span (23 m unfolded; EASA TCDS A.054, cross-checked Jane's + AOPA). Length 8.42 m, longest fuselage in the fleet. Taildragger (corrected from monowheel). The 11.4 m folded span clears a 13.46 m door by ~2 m and a lone Stemme routes through it on its own gear; per-fleet movement mode (e.g. a dolly) is a consumer-side operational choice, not a width constraint (see examples/herrenteich)."
 parts:
   - kind: fuselage
     length_m: 8.42        # EASA TCDS A.054 (length)

--- a/data/catalog/stemme_s10.yaml
+++ b/data/catalog/stemme_s10.yaml
@@ -7,7 +7,7 @@ gear: tailwheel         # twin inward-retracting mains (track 1.15 m) + tailwhee
 movement_mode: always_own_gear
 turn_radius_m: 10.0
 measured: false
-notes: "Two-seat self-launching motor glider, T-tail. WINGS-FOLDED config: wing width = 11.4 m folded span (23 m unfolded; EASA TCDS A.054). Length 8.42 m, longest fuselage in the fleet. Taildragger (corrected from monowheel)."
+notes: "Two-seat self-launching motor glider, T-tail. WINGS-FOLDED config: wing width = 11.4 m folded span (23 m unfolded; EASA TCDS A.054, cross-checked Jane's + AOPA). Length 8.42 m, longest fuselage in the fleet. Taildragger (corrected from monowheel). The 11.4 m folded span clears a 13.46 m door by ~2 m and a lone Stemme routes in on its own gear; the Herrenteich fleet sets always_cart for dense multi-plane maneuvering (#607), not because of width."
 parts:
   - kind: fuselage
     length_m: 8.42        # EASA TCDS A.054 (length)

--- a/examples/herrenteich/README.md
+++ b/examples/herrenteich/README.md
@@ -78,6 +78,11 @@ rendering ground objects in the PNG/3D viewer (#606).
 - **Stemme S10** — hangared **wings folded** (11.4 m span; 23 m unfolded), which
   is what lets a 23 m glider through a 13.46 m door. A **taildragger** (twin
   retractable mains + tailwheel, EASA TCDS) — corrected from monowheel this refresh.
+  The 11.4 m folded width is verified (EASA TCDS A.054 + Jane's + AOPA) and clears
+  the door by ~2 m; a lone Stemme routes in through the door **on its own gear**
+  (probed: 1-segment straight-in). The dolly (`always_cart` in `fleet.yaml`) is for
+  maneuvering it within the *dense multi-plane* fill, not a width limit — that
+  joint placement+routing difficulty is tracked on #607, not a folded-span error.
 
 > All fleet dimensions carry `measured: false` — the envelope is published spec
 > and the part-level dimensions are 3-view/TCDS-**sourced** but not on-site

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -514,26 +514,38 @@ function affineAt(segByPlane, finals, pid, t) {
   const i = Math.round(frac * (seg.samples.length - 1));
   return { vis: true, aff: seg.samples[i] };
 }
-function createTimeline(scene2, groups2) {
+function framePoses(scene2, segByPlane, t) {
+  const out = {};
+  for (const p of scene2.planes) {
+    out[p.id] = affineAt(segByPlane, scene2.final_poses, p.id, t);
+  }
+  for (const go of scene2.ground_objects) {
+    out[go.id] = affineAt(segByPlane, { [go.id]: go.final_pose }, go.id, t);
+  }
+  return out;
+}
+function createTimeline(scene2, groups2, goGroups2 = {}) {
   const TL = scene2.timeline;
   const SEGS = TL.segments;
   const TOTAL = TL.total_s;
   const hasAnim = TOTAL > 0 && SEGS.length > 0;
   const segByPlane = {};
   for (const s of SEGS) segByPlane[s.plane_id] = s;
-  const finals = scene2.final_poses;
   const active = byId("active");
   const clock = byId("clock");
   const applyTime = (t) => {
-    for (const p of scene2.planes) {
-      const { vis, aff } = affineAt(segByPlane, finals, p.id, t);
-      const g = groups2[p.id];
+    const poses = framePoses(scene2, segByPlane, t);
+    const drive = (id, g) => {
+      if (!g) return;
+      const { vis, aff } = poses[id];
       g.visible = vis;
       if (vis && aff) {
         g.matrix.copy(affineMatrix(aff));
         g.matrixWorldNeedsUpdate = true;
       }
-    }
+    };
+    for (const p of scene2.planes) drive(p.id, groups2[p.id]);
+    for (const go of scene2.ground_objects) drive(go.id, goGroups2[go.id]);
     const cur = SEGS.find((s) => t >= s.start_s && t < s.end_s);
     active.textContent = cur ? "towing: " + cur.plane_id : "";
     clock.textContent = t.toFixed(1) + "s";
@@ -632,7 +644,7 @@ labelsToggle.addEventListener("change", () => {
   for (const m of labelMeshes) m.visible = on;
   for (const m of noseMeshes) m.visible = on;
 });
-addGroundObjects(scene, SCENE);
+var { groups: goGroups } = addGroundObjects(scene, SCENE);
 var { setVisible: setPathsVisible } = addTowPaths(scene, SCENE, BRAND);
 var pathsToggle = byId("paths");
 pathsToggle.addEventListener("change", () => setPathsVisible(pathsToggle.checked));
@@ -648,5 +660,5 @@ try {
 } catch (e) {
   banner("TRANSFORM CHECK ERRORED: " + e.message + " — do not trust this render.");
 }
-var timeline = createTimeline(SCENE, groups);
+var timeline = createTimeline(SCENE, groups, goGroups);
 startHud({ timeline, home, controls, renderer, scene, cam });

--- a/src/hangarfit/scene.py
+++ b/src/hangarfit/scene.py
@@ -186,9 +186,10 @@ def _ground_object_blocks(layout: Layout) -> list[dict]:
     brand-resolved per *class* (a warm-graphite ``fixed_obstacle`` keep-out vs the
     slate ``placed_routed_mover``), so the viewer reads ``color`` and hard-codes
     nothing (#419, the plane colour-map idiom). ``final_pose`` is the placement
-    affine — a ground object is static (no timeline) until mover animation lands
-    (a deferred follow-up; the Caddy egress lane is too, the egress oracle exports
-    no corridor geometry). Always-emitted, inert-when-empty (the
+    (resting) affine: a fixed obstacle is static, while a placed-routed mover
+    animates along its drive path via the timeline (#651, :func:`_timeline`) and
+    rests here. (The Caddy egress lane is still a follow-up — #652 — the egress
+    oracle exports no corridor geometry.) Always-emitted, inert-when-empty (the
     ``structural_notches`` discipline)."""
     blocks: list[dict] = []
     for gp in sorted(layout.ground_object_placements, key=lambda p: p.plane_id):
@@ -273,25 +274,32 @@ def _timeline(
     move_by_id = {m.plane_id: m for m in moves_plan.moves}
     segments: list[dict] = []
     t = 0.0
-    for placement in back_first_order(layout.placements):
-        move = move_by_id.get(placement.plane_id)
+
+    def _append_segment(body_id: str, *, record_final: bool) -> None:
+        nonlocal t
+        move = move_by_id.get(body_id)
         if move is None or move.path is None:
             # No move, or a deferred (path=None) move — the body stays at its final
-            # pose. A deferred path is a #601 ground-object mover (route → #602);
-            # it never keys an aircraft placement here, so this is defensive.
-            continue
+            # pose. A deferred path is an un-routable placed-routed mover (#197/#602);
+            # for an aircraft this guard is defensive (every aircraft is routed).
+            return
         samples = _sample_affines(move.path, max_samples_per_path)
         dur = min(max(move.path.length_m / tow_speed_mps, min_seg_s), max_seg_s)
-        segments.append(
-            {
-                "plane_id": placement.plane_id,
-                "start_s": t,
-                "end_s": t + dur,
-                "samples": samples,
-            }
-        )
-        finals[placement.plane_id] = samples[-1]
+        segments.append({"plane_id": body_id, "start_s": t, "end_s": t + dur, "samples": samples})
+        if record_final:
+            finals[body_id] = samples[-1]
         t += dur
+
+    # Aircraft drive in first (deepest slot first); then placed-routed movers
+    # (id-sorted, matching _ground_object_blocks) animate after every aircraft is
+    # parked (#651) — the real fill order (plan_fill routes aircraft, then movers).
+    # A mover's resting pose lives in its ground-object block's final_pose /
+    # go_anchors, not in `finals` (aircraft-only), so record_final=False for them.
+    for placement in back_first_order(layout.placements):
+        _append_segment(placement.plane_id, record_final=True)
+    for gp in sorted(layout.ground_object_placements, key=lambda p: p.plane_id):
+        _append_segment(gp.plane_id, record_final=False)
+
     return {"total_s": t, "segments": segments}, finals
 
 

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -187,7 +187,7 @@ def render_layout(
         if not (check_result is None or check_result.valid):
             _draw_conflict_overlay(ax, layout, check_result)
         if moves_plan is not None:
-            _draw_tow_paths(ax, moves_plan)
+            _draw_tow_paths(ax, moves_plan, layout)
         _finalize_axes(ax, layout, title)
         if metrics.has_placeholder_data(layout):
             _draw_placeholder_banner(fig)
@@ -714,39 +714,48 @@ def _draw_conflict_overlay(ax: Any, layout: Layout, check_result: CheckResult) -
             ax.add_patch(patch)
 
 
-def _draw_tow_paths(ax: Any, moves_plan: MovesPlan) -> None:
-    """Overlay each plane's tow path as a polyline, one colour per plane (#192).
+def _draw_tow_paths(ax: Any, moves_plan: MovesPlan, layout: Layout | None = None) -> None:
+    """Overlay each body's tow/drive path as a polyline (#192, movers #651).
 
     Companion to :func:`_draw_conflict_overlay` at the same z-tier (5), so the
     paths read on top of the aircraft parts (zorder 1-4) — spike Q7. Each path
     is the sampled :class:`~hangarfit.towplanner.DubinsArc` polyline from the
-    door-cone entry pose to the target slot. Colours are assigned by *sorted*
-    ``plane_id`` so a given plan always renders the same plane in the same
-    colour regardless of move order (the ADR-0003 determinism spirit). The
-    in-memory ``MovesPlan`` shape is rich enough that a per-move PNG sequence
-    or animation can be added later without changing it (spike Q7).
+    door-cone entry pose to the target slot.
+
+    Aircraft get one palette colour each, assigned by *sorted* ``plane_id`` so a
+    given plan always renders the same plane in the same colour regardless of
+    move order (the ADR-0003 determinism spirit). A placed-routed ground-object
+    **mover** (#651) is drawn in the neutral mover body colour (``_MOVER_FILL``),
+    matching its :func:`_draw_movers` body so its drive path reads as a ground
+    vehicle, not an aircraft. Movers are identified via ``layout.ground_objects``;
+    when ``layout`` is ``None`` (the pre-#651 call) every path is treated as an
+    aircraft, byte-identical to before.
 
     Each polyline carries its ``plane_id`` as a matplotlib ``label``. No
     legend is rendered today (``_finalize_axes`` draws none), so the label is
     currently inert — it is a deliberate forward hook for a future legend, and
     a path is already disambiguated by terminating at its annotated slot.
     """
-    # Deferred moves (path=None) — a #601 ground-object mover whose route search
-    # is deferred to #602 — have no polyline to draw; skip them.
+    # Deferred moves (path=None) — an un-routable placed-routed mover (#197/#602)
+    # — have no polyline to draw; skip them.
     routed_moves = [move for move in moves_plan.moves if move.path is not None]
-    plane_ids = sorted({move.plane_id for move in routed_moves})
+    mover_ids = set(layout.ground_objects) if layout is not None else set()
+    # Palette colours are assigned over aircraft ids only, so a mover never
+    # shifts the deterministic aircraft colour mapping.
+    aircraft_ids = sorted({m.plane_id for m in routed_moves if m.plane_id not in mover_ids})
     colour_for = {
-        pid: _TOW_PATH_COLORS[i % len(_TOW_PATH_COLORS)] for i, pid in enumerate(plane_ids)
+        pid: _TOW_PATH_COLORS[i % len(_TOW_PATH_COLORS)] for i, pid in enumerate(aircraft_ids)
     }
     for move in routed_moves:
         assert move.path is not None  # filtered above; narrows for the type-checker
         poses = list(move.path.sample())
         xs = [p.x_m for p in poses]
         ys = [p.y_m for p in poses]
+        is_mover = move.plane_id in mover_ids
         ax.plot(
             xs,
             ys,
-            color=colour_for[move.plane_id],
+            color=_MOVER_FILL if is_mover else colour_for[move.plane_id],
             lw=_TOW_PATH_LINEWIDTH,
             zorder=5,
             label=move.plane_id,

--- a/src/hangarfit/visualize.py
+++ b/src/hangarfit/visualize.py
@@ -739,10 +739,13 @@ def _draw_tow_paths(ax: Any, moves_plan: MovesPlan, layout: Layout | None = None
     # Deferred moves (path=None) — an un-routable placed-routed mover (#197/#602)
     # — have no polyline to draw; skip them.
     routed_moves = [move for move in moves_plan.moves if move.path is not None]
-    mover_ids = set(layout.ground_objects) if layout is not None else set()
-    # Palette colours are assigned over aircraft ids only, so a mover never
+    # All ground-object ids (obstacles + movers). Only placed-routed movers ever
+    # carry a routed path, so in practice this flags the movers among the moves;
+    # naming it for what the set literally holds avoids a future-maintainer trap.
+    ground_object_ids = set(layout.ground_objects) if layout is not None else set()
+    # Palette colours are assigned over aircraft ids only, so a ground object never
     # shifts the deterministic aircraft colour mapping.
-    aircraft_ids = sorted({m.plane_id for m in routed_moves if m.plane_id not in mover_ids})
+    aircraft_ids = sorted({m.plane_id for m in routed_moves if m.plane_id not in ground_object_ids})
     colour_for = {
         pid: _TOW_PATH_COLORS[i % len(_TOW_PATH_COLORS)] for i, pid in enumerate(aircraft_ids)
     }
@@ -751,7 +754,7 @@ def _draw_tow_paths(ax: Any, moves_plan: MovesPlan, layout: Layout | None = None
         poses = list(move.path.sample())
         xs = [p.x_m for p in poses]
         ys = [p.y_m for p in poses]
-        is_mover = move.plane_id in mover_ids
+        is_mover = move.plane_id in ground_object_ids
         ax.plot(
             xs,
             ys,

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -712,14 +712,43 @@ def test_timeline_mover_segments_follow_aircraft_and_stay_sequential():
     plan = _plan_with_movers(lay, glider_path=_routed_arc(), caddy_path=_routed_arc())
     tl, _ = scene._timeline(lay, plan)
     aircraft = {p.plane_id for p in lay.placements}
+    seg_ids = {s["plane_id"] for s in tl["segments"]}
     mover_segs = [s for s in tl["segments"] if s["plane_id"] not in aircraft]
     aircraft_segs = [s for s in tl["segments"] if s["plane_id"] in aircraft]
     assert mover_segs and aircraft_segs
+    assert "fuel_trailer" not in seg_ids  # the fixed obstacle never animates (no Move)
     last_aircraft_end = max(s["end_s"] for s in aircraft_segs)
     assert all(s["start_s"] >= last_aircraft_end - 1e-9 for s in mover_segs)
     for prev, nxt in zip(tl["segments"], tl["segments"][1:], strict=False):
         assert math.isclose(nxt["start_s"], prev["end_s"])
     assert math.isclose(tl["total_s"], tl["segments"][-1]["end_s"])
+
+
+def test_timeline_finals_excludes_movers():
+    """#651: a mover's resting pose lives on its ground-object block (final_pose),
+    NOT in the aircraft-only `finals` map. Guards against `record_final` being
+    flipped on for movers — which the viewer would silently ignore (it reads
+    go.final_pose), leaving the contract quietly violated."""
+    lay = _layout_with_ground_objects()
+    plan = _plan_with_movers(lay, glider_path=_routed_arc(), caddy_path=_routed_arc())
+    _, finals = scene._timeline(lay, plan)
+    assert set(finals) == {p.plane_id for p in lay.placements}
+    assert "glider_trailer" not in finals and "vw_caddy" not in finals
+
+
+def test_timeline_mover_order_is_id_sorted_not_placement_order():
+    """#651: mover segments follow `_ground_object_blocks`' id-sort, independent of
+    the placement-tuple order (ADR-0003). Reverse the GO placement order so the sort
+    is load-bearing — a regression to insertion order would flip the result."""
+    lay = _layout_with_ground_objects()
+    lay = dataclasses.replace(
+        lay, ground_object_placements=tuple(reversed(lay.ground_object_placements))
+    )
+    plan = _plan_with_movers(lay, glider_path=_routed_arc(), caddy_path=_routed_arc())
+    tl, _ = scene._timeline(lay, plan)
+    aircraft = {p.plane_id for p in lay.placements}
+    mover_seg_ids = [s["plane_id"] for s in tl["segments"] if s["plane_id"] not in aircraft]
+    assert mover_seg_ids == ["glider_trailer", "vw_caddy"]  # id-sorted, not placement order
 
 
 def test_timeline_mover_animation_byte_deterministic():

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -660,3 +660,72 @@ def test_scene_contract_ts_ground_object_keys_match():
     precedent)."""
     block = scene.build_scene(_layout_with_ground_objects())["ground_objects"][0]
     assert _ts_interface_fields("scene-contract.ts", "GroundObjectData") == set(block)
+
+
+# ── #651: placed-routed movers animate in the 3D timeline ─────────────────────
+#
+# The static GO bodies already emit (#653); #651 adds their MOTION. A routed
+# mover (its Move carries a DubinsArc) gets a timeline segment so the viewer
+# drives it in along its path, AFTER every aircraft is parked; a deferred
+# (path=None) mover stays at its static final_pose, like the fixed obstacle.
+
+
+def _routed_arc():
+    """A real DubinsArc to reuse as a mover route. The synthetic GO layout does
+    not route (a trailer near the door blocks an aircraft), so we borrow a routed
+    aircraft's arc — `_timeline` only needs a path with a length and samples."""
+    arc = plan_fill(load_layout(LAYOUT)).moves[0].path
+    assert arc is not None
+    return arc
+
+
+def _plan_with_movers(lay, *, glider_path, caddy_path):
+    """The base-layout aircraft fill plus two mover Moves appended (aircraft
+    first, then movers — the order plan_fill itself emits)."""
+    from hangarfit.towplanner import Move, MovesPlan, Pose
+
+    base = plan_fill(load_layout(LAYOUT))
+    g = next(p for p in lay.ground_object_placements if p.plane_id == "glider_trailer")
+    c = next(p for p in lay.ground_object_placements if p.plane_id == "vw_caddy")
+    movers = (
+        Move("glider_trailer", Pose.from_placement(g), glider_path),
+        Move("vw_caddy", Pose.from_placement(c), caddy_path),
+    )
+    return MovesPlan(target_layout=lay, moves=base.moves + movers)
+
+
+def test_timeline_animates_only_routed_movers():
+    """#651: a routed mover (real path) gets a timeline segment so it animates; a
+    deferred (path=None) mover does not — it stays at its static final_pose."""
+    lay = _layout_with_ground_objects()
+    plan = _plan_with_movers(lay, glider_path=_routed_arc(), caddy_path=None)
+    tl, _ = scene._timeline(lay, plan)
+    seg_ids = {s["plane_id"] for s in tl["segments"]}
+    assert "glider_trailer" in seg_ids  # routed mover animates
+    assert "vw_caddy" not in seg_ids  # deferred mover stays static
+
+
+def test_timeline_mover_segments_follow_aircraft_and_stay_sequential():
+    """#651: movers drive in after every aircraft is parked, and the whole
+    timeline stays end-to-end continuous (no gaps/overlaps)."""
+    lay = _layout_with_ground_objects()
+    plan = _plan_with_movers(lay, glider_path=_routed_arc(), caddy_path=_routed_arc())
+    tl, _ = scene._timeline(lay, plan)
+    aircraft = {p.plane_id for p in lay.placements}
+    mover_segs = [s for s in tl["segments"] if s["plane_id"] not in aircraft]
+    aircraft_segs = [s for s in tl["segments"] if s["plane_id"] in aircraft]
+    assert mover_segs and aircraft_segs
+    last_aircraft_end = max(s["end_s"] for s in aircraft_segs)
+    assert all(s["start_s"] >= last_aircraft_end - 1e-9 for s in mover_segs)
+    for prev, nxt in zip(tl["segments"], tl["segments"][1:], strict=False):
+        assert math.isclose(nxt["start_s"], prev["end_s"])
+    assert math.isclose(tl["total_s"], tl["segments"][-1]["end_s"])
+
+
+def test_timeline_mover_animation_byte_deterministic():
+    """#651: animating movers keeps build_scene byte-identical run-to-run (ADR-0003)."""
+    lay = _layout_with_ground_objects()
+    plan = _plan_with_movers(lay, glider_path=_routed_arc(), caddy_path=_routed_arc())
+    a = json.dumps(scene.build_scene(lay, moves_plan=plan))
+    b = json.dumps(scene.build_scene(lay, moves_plan=plan))
+    assert a == b

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -675,6 +675,39 @@ class TestDrawTowPaths:
         assert by_label["trailer"] == _MOVER_FILL
         assert by_label["a"] != _MOVER_FILL  # aircraft keeps a distinct palette colour
 
+    def test_mover_does_not_shift_aircraft_palette(self) -> None:
+        """#651: adding a mover must not change any aircraft's path colour — the
+        palette is assigned over aircraft ids only, so the mapping is stable
+        whether or not a mover is present (defends the determinism comment)."""
+        from hangarfit.models import GroundObject, Part
+        from hangarfit.visualize import _draw_tow_paths
+
+        aircraft = (
+            self._vertical_move("a", 0.0, 0.0, 5.0),
+            self._vertical_move("b", 2.0, 0.0, 4.0),
+        )
+        ax0 = MagicMock()
+        _draw_tow_paths(ax0, self._plan(*aircraft))  # baseline: no mover, no layout
+        base = {c.kwargs["label"]: c.kwargs["color"] for c in ax0.plot.call_args_list}
+
+        layout = MagicMock()
+        layout.ground_objects = {
+            "trailer": GroundObject(
+                id="trailer",
+                name="Glider trailer",
+                parts=(Part("ground", 6.0, 2.0, 0.0, 0.0, 0.0, 0.0, 2.0),),
+                object_class="placed_routed_mover",
+                motion_mode="towed",
+            )
+        }
+        ax1 = MagicMock()
+        _draw_tow_paths(
+            ax1, self._plan(*aircraft, self._vertical_move("trailer", 1.0, 0.0, 3.0)), layout
+        )
+        with_mover = {c.kwargs["label"]: c.kwargs["color"] for c in ax1.plot.call_args_list}
+        assert with_mover["a"] == base["a"]
+        assert with_mover["b"] == base["b"]
+
     def test_without_layout_all_paths_use_aircraft_palette(self) -> None:
         """Backward-compat: with no layout (the pre-#651 call), every path is treated
         as an aircraft and drawn from the palette — never the mover fill."""

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -649,6 +649,47 @@ class TestDrawTowPaths:
         colours = [c.kwargs["color"] for c in ax.plot.call_args_list]
         assert colours[0] == colours[1]
 
+    def test_mover_path_uses_mover_fill_colour(self) -> None:
+        """#651: a placed-routed mover's 2D path is drawn in the mover body colour
+        (_MOVER_FILL), so it reads as a ground vehicle; aircraft keep the palette."""
+        from hangarfit.models import GroundObject, Part
+        from hangarfit.visualize import _MOVER_FILL, _draw_tow_paths
+
+        layout = MagicMock()
+        layout.ground_objects = {
+            "trailer": GroundObject(
+                id="trailer",
+                name="Glider trailer",
+                parts=(Part("ground", 6.0, 2.0, 0.0, 0.0, 0.0, 0.0, 2.0),),
+                object_class="placed_routed_mover",
+                motion_mode="towed",
+            )
+        }
+        plan = self._plan(
+            self._vertical_move("a", 0.0, 0.0, 5.0),  # aircraft
+            self._vertical_move("trailer", 2.0, 0.0, 4.0),  # mover
+        )
+        ax = MagicMock()
+        _draw_tow_paths(ax, plan, layout)
+        by_label = {c.kwargs["label"]: c.kwargs["color"] for c in ax.plot.call_args_list}
+        assert by_label["trailer"] == _MOVER_FILL
+        assert by_label["a"] != _MOVER_FILL  # aircraft keeps a distinct palette colour
+
+    def test_without_layout_all_paths_use_aircraft_palette(self) -> None:
+        """Backward-compat: with no layout (the pre-#651 call), every path is treated
+        as an aircraft and drawn from the palette — never the mover fill."""
+        from hangarfit.visualize import _MOVER_FILL, _draw_tow_paths
+
+        plan = self._plan(
+            self._vertical_move("a", 0.0, 0.0, 5.0),
+            self._vertical_move("b", 2.0, 0.0, 4.0),
+        )
+        ax = MagicMock()
+        _draw_tow_paths(ax, plan)  # no layout arg
+        colours = [c.kwargs["color"] for c in ax.plot.call_args_list]
+        assert _MOVER_FILL not in colours
+        assert len(set(colours)) == 2
+
     def test_colour_assignment_is_order_independent(self) -> None:
         # Sorting plane ids before assigning colours makes the mapping
         # deterministic regardless of move order (ADR-0003 spirit).

--- a/viewer/src/ground_objects.ts
+++ b/viewer/src/ground_objects.ts
@@ -3,11 +3,13 @@
 // A thin sibling of addPlanes for the Stage-A ground objects: the fixed obstacle
 // (a keep-out, e.g. the Maul fuel trailer) and the placed/routed movers (the VW
 // Caddy + glider trailers). Each is built ONCE in plane-local coords via the
-// shared boxMesh, then parked at its static final_pose affine — there is no
-// timeline yet (mover animation + the Caddy egress lane are deferred follow-ups,
-// the egress oracle exports no corridor geometry). The viewer does NO transform
-// math: final_pose is the det-−1 affine computed in Python (ADR-0002/ADR-0017),
-// and checkAnchors() cross-checks each body's world corners against go_anchors.
+// shared boxMesh and parked at its final_pose affine. The returned Groups are
+// driven by the timeline (#651): a fixed obstacle stays static, a placed-routed
+// mover animates along its drive path (the Caddy egress lane is still a follow-up
+// — #652 — the egress oracle exports no corridor geometry). The viewer does NO
+// transform math: final_pose is the det-−1 affine computed in Python
+// (ADR-0002/ADR-0017), and checkAnchors() cross-checks each body's world corners
+// against go_anchors.
 //
 // Colour is read from each block's `color` (brand-resolved per class in
 // scene.py, the plane colour-map idiom) — nothing hard-coded here (#419).
@@ -23,8 +25,9 @@ export interface GroundObjectsBundle {
 }
 
 /** Build each ground object's affine Group (boxes only — no gear/nose), park it at
- * its static final_pose, add it to the scene, and append a legend chip. Returns
- * the groups. A GO-free scene builds nothing and is inert (no legend rows). */
+ * its final_pose, add it to the scene, and append a legend chip. Returns the
+ * groups so the timeline can drive movers per frame (#651); a fixed obstacle just
+ * stays at its pose. A GO-free scene builds nothing and is inert (no legend rows). */
 export function addGroundObjects(scene: THREE.Scene, SCENE: SceneV2): GroundObjectsBundle {
   const groups: Record<string, THREE.Group> = {};
   const legend = byId('legend');

--- a/viewer/src/main.ts
+++ b/viewer/src/main.ts
@@ -59,10 +59,11 @@ labelsToggle.addEventListener('change', () => {
   for (const m of noseMeshes) m.visible = on;
 });
 
-// ground objects (#606): fixed obstacles + placed movers, parked statically at
-// their final_pose. No timeline / toggle — they are always-on floor bodies. A
-// GO-free scene builds nothing here.
-addGroundObjects(scene, SCENE);
+// ground objects (#606): fixed obstacles + placed movers. Fixed obstacles are
+// always-on floor bodies; placed-routed movers animate along their drive path via
+// the timeline (#651) — so we keep their Groups to drive per frame. A GO-free
+// scene builds nothing here.
+const { groups: goGroups } = addGroundObjects(scene, SCENE);
 
 // floor tow paths (#505) + paths toggle. One coloured floor line per plane's
 // tow route (the 3D analogue of `solve --render-paths`), default ON so the route
@@ -92,6 +93,7 @@ try {
   banner('TRANSFORM CHECK ERRORED: ' + (e as Error).message + ' — do not trust this render.');
 }
 
-// timeline + HUD wiring + render loop
-const timeline = createTimeline(SCENE, groups);
+// timeline + HUD wiring + render loop. Movers (#651) animate from the same
+// timeline as planes, so their Groups are passed alongside the plane Groups.
+const timeline = createTimeline(SCENE, groups, goGroups);
 startHud({ timeline, home, controls, renderer, scene, cam });

--- a/viewer/src/scene-contract.ts
+++ b/viewer/src/scene-contract.ts
@@ -43,7 +43,8 @@ export interface PlaneData {
 // A placed non-aircraft body (#606): a fixed obstacle (keep-out) or a
 // placed/routed mover. Same `boxes` shape as a plane, but no wheels/carts; the
 // per-class fill is brand-resolved Python-side (`color`), and `final_pose` is the
-// static placement affine (no timeline yet — mover animation is a follow-up).
+// placement (resting) affine — a fixed obstacle stays there, a placed-routed
+// mover animates to it along its drive path via the timeline (#651).
 export interface GroundObjectData {
   id: string;
   object_class: string; // 'fixed_obstacle' | 'placed_routed_mover'

--- a/viewer/src/timeline.ts
+++ b/viewer/src/timeline.ts
@@ -26,6 +26,28 @@ export function affineAt(
   return { vis: true, aff: seg.samples[i] };
 }
 
+/** Pure: pose + visibility of EVERY animated body — planes ∪ placed-routed
+ * ground-object movers (#651) — at time `t`. A mover reuses the SAME
+ * hidden→sample→parked state machine as a plane via `affineAt`; the only
+ * difference is its resting pose lives on its own block (`final_pose`), not in
+ * `scene.final_poses` (aircraft-only), so each GO gets a single-entry finals
+ * map. A body with no segment (a static plane, a fixed obstacle, or a deferred
+ * path=None mover) shows at its own final pose. No THREE, no DOM — node-tested. */
+export function framePoses(
+  scene: SceneV2,
+  segByPlane: Record<string, SegmentData>,
+  t: number,
+): Record<string, { vis: boolean; aff: Affine | null }> {
+  const out: Record<string, { vis: boolean; aff: Affine | null }> = {};
+  for (const p of scene.planes) {
+    out[p.id] = affineAt(segByPlane, scene.final_poses, p.id, t);
+  }
+  for (const go of scene.ground_objects) {
+    out[go.id] = affineAt(segByPlane, { [go.id]: go.final_pose }, go.id, t);
+  }
+  return out;
+}
+
 export interface Timeline {
   total: number;
   hasAnim: boolean;
@@ -33,30 +55,39 @@ export interface Timeline {
   applyTime: (t: number) => void;
 }
 
-/** Wire the timeline to the built plane Groups + the `#active`/`#clock` readouts.
- * `applyTime(t)` is the per-frame impure edge around the pure `affineAt`. */
-export function createTimeline(scene: SceneV2, groups: Record<string, THREE.Group>): Timeline {
+/** Wire the timeline to the built plane + ground-object Groups and the
+ * `#active`/`#clock` readouts. `applyTime(t)` is the per-frame impure edge around
+ * the pure `framePoses`. Movers (#651) animate from the same `segments` list —
+ * `goGroups` defaults to `{}` so a GO-free scene is unchanged. */
+export function createTimeline(
+  scene: SceneV2,
+  groups: Record<string, THREE.Group>,
+  goGroups: Record<string, THREE.Group> = {},
+): Timeline {
   const TL = scene.timeline;
   const SEGS = TL.segments;
   const TOTAL = TL.total_s;
   const hasAnim = TOTAL > 0 && SEGS.length > 0;
   const segByPlane: Record<string, SegmentData> = {};
   for (const s of SEGS) segByPlane[s.plane_id] = s;
-  const finals = scene.final_poses;
 
   const active = byId('active');
   const clock = byId('clock');
 
   const applyTime = (t: number): void => {
-    for (const p of scene.planes) {
-      const { vis, aff } = affineAt(segByPlane, finals, p.id, t);
-      const g = groups[p.id];
+    const poses = framePoses(scene, segByPlane, t);
+    const drive = (id: string, g: THREE.Group | undefined): void => {
+      if (!g) return;
+      const { vis, aff } = poses[id];
       g.visible = vis;
       if (vis && aff) {
         g.matrix.copy(affineMatrix(aff));
         g.matrixWorldNeedsUpdate = true;
       }
-    }
+    };
+    for (const p of scene.planes) drive(p.id, groups[p.id]);
+    for (const go of scene.ground_objects) drive(go.id, goGroups[go.id]);
+
     const cur = SEGS.find((s) => t >= s.start_s && t < s.end_s);
     active.textContent = cur ? 'towing: ' + cur.plane_id : '';
     clock.textContent = t.toFixed(1) + 's';

--- a/viewer/test/timeline.test.ts
+++ b/viewer/test/timeline.test.ts
@@ -3,8 +3,8 @@
 // transitions of scene-v2-schema.md, untestable from pytest.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { affineAt } from '../src/timeline.ts';
-import type { Affine, SegmentData } from '../src/scene-contract.ts';
+import { affineAt, framePoses } from '../src/timeline.ts';
+import type { Affine, SceneV2, SegmentData } from '../src/scene-contract.ts';
 
 const FINAL: Affine = [1, 0, 9, 0, 1, 0];
 const A0: Affine = [1, 0, 0, 0, 1, 0];
@@ -36,4 +36,41 @@ test('mid-animation → sample chosen by the rounded fraction', () => {
   assert.deepEqual(affineAt(segByPlane, finals, 'p', 2), { vis: true, aff: A0 }); // frac 0 → i0
   assert.deepEqual(affineAt(segByPlane, finals, 'p', 4), { vis: true, aff: A1 }); // frac .5 → i1
   assert.deepEqual(affineAt(segByPlane, finals, 'p', 5.9), { vis: true, aff: A2 }); // frac .975 → round 2
+});
+
+// ── framePoses: planes ∪ ground-object movers, one state machine (#651) ───────
+// A mover reuses the SAME hidden→sample→parked transitions as a plane, but its
+// resting pose lives on its own block (final_pose), not in scene.final_poses.
+
+const CADDY_FINAL: Affine = [1, 0, 7, 0, 1, 0];
+const FUEL_FINAL: Affine = [1, 0, 3, 0, 1, 0];
+
+function sceneWithMover(): SceneV2 {
+  // Only the fields framePoses reads (planes/ground_objects/final_poses); a
+  // partial cast keeps the fixture honest about what the unit depends on.
+  return {
+    planes: [{ id: 'p' }],
+    ground_objects: [
+      { id: 'caddy', final_pose: CADDY_FINAL },
+      { id: 'fuel', final_pose: FUEL_FINAL },
+    ],
+    final_poses: { p: FINAL },
+    timeline: { total_s: 0, segments: [] },
+  } as unknown as SceneV2;
+}
+
+test('framePoses animates a routed mover (hidden → sample → parked); plane unaffected', () => {
+  const moverSeg: SegmentData = { plane_id: 'caddy', start_s: 4, end_s: 8, samples: [A0, A1, A2] };
+  const seg2: Record<string, SegmentData> = { caddy: moverSeg };
+  const sc = sceneWithMover();
+  assert.deepEqual(framePoses(sc, seg2, 0).caddy, { vis: false, aff: null }); // not entered
+  assert.deepEqual(framePoses(sc, seg2, 6).caddy, { vis: true, aff: A1 }); // mid-animation
+  assert.deepEqual(framePoses(sc, seg2, 99).caddy, { vis: true, aff: CADDY_FINAL }); // parked
+  assert.deepEqual(framePoses(sc, seg2, 99).p, { vis: true, aff: FINAL }); // plane still parked
+});
+
+test('framePoses keeps a segment-less ground object (obstacle / deferred mover) at its final pose', () => {
+  const sc = sceneWithMover();
+  assert.deepEqual(framePoses(sc, {}, 5).fuel, { vis: true, aff: FUEL_FINAL });
+  assert.deepEqual(framePoses(sc, {}, 5).caddy, { vis: true, aff: CADDY_FINAL });
 });


### PR DESCRIPTION
Closes #651.

Building on the static ground-object render (#606 → #649 2D, #653 3D), this adds the **motion** of placed-routed movers (the VW Caddy + glider trailers).

## What changed

**3D timeline** (`scene._timeline`) — after every aircraft is parked, each routed mover animates along its `DubinsArc` in id-sorted order (matching `_ground_object_blocks`). A deferred (`path=None`, un-routable) mover stays at its static resting pose, like a fixed obstacle. A mover's resting pose lives on its ground-object block (`final_pose`), not in the aircraft-only `finals` map.

**Viewer** — new pure, node-tested `framePoses()` computes pose+visibility for *planes ∪ ground-object movers* using the same `affineAt` hidden→sample→parked state machine; `createTimeline` now drives the ground-object Groups too (`goGroups` defaults to `{}` → a GO-free scene is unchanged). `viewer.js` rebuilt from `viewer/src`.

**2D** (`visualize._draw_tow_paths`) — a mover's `--render-paths` route is drawn in the neutral mover body colour (`_MOVER_FILL`), matching its `_draw_movers` body, so it reads as a ground vehicle; aircraft keep the per-plane palette. `layout` defaults to `None` → pre-#651 byte-identical behaviour.

## Determinism / invariants
- Inert / byte-identical for aircraft-only layouts (ADR-0003): the mover loops only run when ground objects are present; mover order is `sorted(by id)`.
- The det-−1 transform self-check is unaffected (anchors path unchanged).

## Verification
- New tests (RED→GREEN): `test_scene.py` (mover segment emit, follow-aircraft ordering, deferred-mover skip, byte-determinism); `test_visualize.py` (mover-fill colour, backward-compat without layout); `viewer/test/timeline.test.ts` (`framePoses` animate + static-GO).
- Full suite green (1708 + 7 serial), mypy + ruff clean, viewer typecheck/lint/30 node tests clean, no `viewer.js` drift.
- End-to-end: `view --solve` on the region demo emits an animated mover segment; headless render's transform self-check passes (banner hidden), movers in the legend.

## Also bundled
A docs-only clarifying note on the **Stemme S10** (separate commit): a session investigation confirmed the folded-wing width (11.4 m) is already correct (EASA TCDS A.054 + Jane's + AOPA) and a lone Stemme routes through the door on its own gear — the `always_cart` flag is for dense multi-plane maneuvering (#607), not a width limit. No dimension changed.

The Caddy hard-door egress lane is the remaining half of #606 → #652 (next).