### PR TITLE
Real Herrenteich 'today' layout + clearance recalibration 0.20→0.10 (#664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
   as described on 2026-06-15 — all **nine** aircraft (incl. the Scheibe Falke) +
   the **one** Duo Discus glider trailer (the spare is stored elsewhere) + the fixed
   fuel trailer + the rescue Caddy with a clear drive-out egress. Validating this
-  real set against the model was the existence-proof test: it is **infeasible at the
-  previous `clearance_m 0.20`** (a checker-driven search comes ~2 conflicts short)
-  but **valid at 0.10 m**, and the club confirms real wingtip-to-part gaps vary a lot
+  real set against the model was the existence-proof test: an offline checker-driven
+  search finds **no valid arrangement of it at the previous `clearance_m 0.20`** (its
+  best still leaves conflicts) but seats it cleanly **at 0.10 m**, and the club
+  confirms real wingtip-to-part gaps vary a lot
   and on dense days are very tight. So the Herrenteich `hangar.yaml` horizontal
   parked clearance is **recalibrated 0.20 → 0.10 m** (vertical wing-layer clearance
   unchanged at 0.15 m — it was not the binding constraint). Lowering the clearance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Real Airfield Herrenteich 'today' layout + clearance recalibration (#664).**
+  Added `examples/herrenteich/layout_today.yaml`: the club's actual in-hangar set
+  as described on 2026-06-15 — all **nine** aircraft (incl. the Scheibe Falke) +
+  the **one** Duo Discus glider trailer (the spare is stored elsewhere) + the fixed
+  fuel trailer + the rescue Caddy with a clear drive-out egress. Validating this
+  real set against the model was the existence-proof test: it is **infeasible at the
+  previous `clearance_m 0.20`** (a checker-driven search comes ~2 conflicts short)
+  but **valid at 0.10 m**, and the club confirms real wingtip-to-part gaps vary a lot
+  and on dense days are very tight. So the Herrenteich `hangar.yaml` horizontal
+  parked clearance is **recalibrated 0.20 → 0.10 m** (vertical wing-layer clearance
+  unchanged at 0.15 m — it was not the binding constraint). Lowering the clearance
+  only relaxes the constraint, so `layout.yaml`, `layout_full.yaml`, and
+  `scenario_demo.yaml` stay valid; the synthetic `data/hangar.yaml` is untouched.
+  `layout_full.yaml` is reframed as the alternative "both glider trailers inside"
+  scenario (which forces one aircraft out). The collision **model** is unchanged —
+  the gap was data calibration, and reliably packing this dense a 12-body set
+  remains beyond the deterministic search (#607).
+
 - **Caddy hard-door egress lane in 2D + 3D (#652).** The egress oracle
   (`towplanner.egress_first_conflict`) now optionally *surfaces* the winning
   drive-out corridor it used to compute and discard (new `egress_path_out`

--- a/examples/herrenteich/README.md
+++ b/examples/herrenteich/README.md
@@ -69,10 +69,11 @@ orthogonal nest. When PK described the **actual** arrangement (2026-06-15), it w
 outside; the earlier `layout_full.yaml` had done the opposite (both trailers in →
 one aircraft out), which is why it dropped the Scheibe.
 
-Reproducing the real set exposed a **calibration gap**, not a model bug: a
-checker-driven search could not seat all nine aircraft + the trailer + fuel + Caddy
-at the previous `clearance_m 0.20` (always ~2 conflicts short) but seats them at
-**0.10 m**, and PK confirmed the real wingtip-to-part gaps **vary a lot** and on
+Reproducing the real set exposed a **calibration gap**, not a model bug: an offline
+checker-driven search could not find *any* valid arrangement of all nine aircraft +
+the trailer + fuel + Caddy at the previous `clearance_m 0.20` (its best still left a
+few conflicts) but seats them cleanly at **0.10 m**, and PK confirmed the real
+wingtip-to-part gaps **vary a lot** and on
 dense days are very tight (well under 0.20 m). So the horizontal clearance was
 recalibrated **0.20 → 0.10 m** (`layout_today.yaml`'s tightest gap is ~0.10 m); the
 0.15 m vertical (wing-layer) clearance was not the binding constraint and is

--- a/examples/herrenteich/README.md
+++ b/examples/herrenteich/README.md
@@ -12,6 +12,9 @@ point the tools at these files explicitly.
 # Validate the "everyone home" layout (all eight usual occupants):
 hangarfit check examples/herrenteich/layout.yaml --render herrenteich.png
 
+# Validate the real 'today' layout (all 9 aircraft + Duo trailer + fuel + Caddy):
+hangarfit check examples/herrenteich/layout_today.yaml --render today.png
+
 # 3D viewer:
 hangarfit view examples/herrenteich/layout.yaml -o herrenteich.html
 
@@ -28,7 +31,8 @@ hangarfit view  examples/herrenteich/scenario_demo.yaml -o demo.html --seed 3
 | `hangar.yaml` | The real hangar — **15.08 m × 31.76 m**, door **13.46 m** wide. Measured 2026-06-04 from the architect's DWG. L-shaped (back-right office notch). |
 | `fleet.yaml`  | The aircraft usually hangared here — the eight usual occupants plus the permanent **Fuji FA-200-180** (#657, the only low-winger; a placeholder for a future C150) — plus (since #605) the four non-aircraft floor occupants under `ground_objects:` (Caddy, 2 glider trailers, fixed fuel trailer). Envelope (span/length/height) from published specs; part-level dimensions (wing chord, fuselage width, tail spans, gear track/wheelbase) sourced from EASA/FAA TCDS + manufacturer manuals where published (refreshed 2026-06-08, #536); the rest derived/estimated and flagged inline. |
 | `layout.yaml` | A **valid** arrangement with all eight usual aircraft parked at once (`hangarfit check` → exit 0). Aircraft only — no ground clutter. This is where the "all eight fit" promise lives. |
-| `layout_full.yaml` | **The realistic in-hangar set (#657/#659)** — seven of the eight aircraft + **all four** GOs, packed **fishbone** (Caddy near the door with a clear drive-out egress, fuel hard against the left wall by the door, Duo trailer on the right wall). With the rescue Caddy keeping its egress and all four GOs inside, the floor is one aircraft over capacity, so the Scheibe Falke parks outside. Valid at the calibrated clearances (`hangarfit check` → exit 0). |
+| `layout_today.yaml` | **The real 'today' layout (#664)** — the club's actual in-hangar set as described on 2026-06-15: all **nine** aircraft (incl. the Scheibe Falke) + the **one** Duo Discus glider trailer (the spare trailer is stored elsewhere) + the fixed fuel trailer + the rescue Caddy with a clear drive-out egress. This real composition drove the clearance recalibration (0.20 → 0.10 m — see below). Valid (`hangarfit check` → exit 0). |
+| `layout_full.yaml` | An **alternative scenario (#657/#659)** — what if **both** glider trailers must stay inside *and* the Caddy keeps its egress? That is one body over capacity, so it parks only **seven** aircraft (the Scheibe goes outside), fishbone. Kept as the "both trailers inside" what-if; the real day keeps the aircraft instead (see `layout_today.yaml`). Valid (`hangarfit check` → exit 0). |
 | `scenario.yaml` | The solver input for the all-eight "everyone home" scenario (does not fully route — see below). |
 | `scenario_demo.yaml` | A 3-aircraft subset that **solves and fully tow-routes** end-to-end in the L-shaped hangar — the working toolchain demo. |
 
@@ -52,30 +56,36 @@ solver places clear of the notch and the tow planner routes from the door around
 it (the end-to-end demo above). Replace the all-eight placements with the club's
 real parking positions when known.
 
-**3. With the rescue Caddy + fuel inside, the standard parking breaks — which is
-the whole point.** The real hangar parks more than aircraft: a VW Caddy, two
-glider trailers, and a fixed "Maul" fuel trailer. Two on-site rules are hard
-(#657): the **fuel trailer** sits front-left hard against the wall by the door
-(pushed straight in, parked last), and the **rescue Caddy** must keep a **clear
-drive-out egress** — it has to leave without anyone moving anything else
-(#603/#652). Real hangars pack **fishbone** (aircraft nosed in at mixed angles, not
-square), which interleaves the wings and packs far tighter than an orthogonal nest;
-`layout_full.yaml` parks the aircraft this way (a few near-square, the rest angled).
-Even so, fitting all four ground objects **plus** the Caddy's rescue path leaves the
-hangar one aircraft over capacity (an exhaustive search, orthogonal and fishbone,
-confirms it), so `layout_full.yaml` parks **seven** aircraft + **all four** GOs,
-with the Scheibe Falke left outside. That is not a failure — it is exactly the
-"standard layout has broken, find a valid alternative" job hangarfit exists for. (Getting even this far needed the #605
-**clearance calibration**: the placeholder `clearance_m 0.3` /
-`wing_layer_clearance_m 0.2` are too loose for a real club hangar packed this
-densely, so `hangar.yaml` was calibrated to **0.20 / 0.15**. Lowering a clearance
-only relaxes the constraint, so `layout.yaml` and `scenario_demo.yaml` stay valid.)
-The Caddy here is modelled **multi-part** (#658 — a low van body a high wing may
-overhang, plus a small roof-gear rack on top) so it isn't a full-height wall.
-Mover tow-routing (#602), the Caddy clear-egress gate (#603/#652), and
-ground-object rendering in the PNG + 3D viewer (#606) have all shipped; routing the
-full set's 18 m Scheibe and joint placement+routing remain the open hard problem
-(#607).
+**3. The real day keeps all nine aircraft + one trailer — and that recalibrated
+the clearance (#664).** The real hangar parks more than aircraft: a VW Caddy, glider
+trailers, and a fixed "Maul" fuel trailer. Two on-site rules are hard (#657): the
+**fuel trailer** sits front-left near the door (pushed straight in, parked last),
+and the **rescue Caddy** must keep a **clear drive-out egress** — it leaves without
+anyone moving anything else (#603/#652). Real hangars pack **fishbone** (aircraft
+nosed in at mixed angles), which interleaves the wings far tighter than an
+orthogonal nest. When PK described the **actual** arrangement (2026-06-15), it was
+**all nine aircraft + ONE glider trailer (the Duo) + fuel + Caddy** —
+`layout_today.yaml`. The club keeps the aircraft and leaves the *spare* trailer
+outside; the earlier `layout_full.yaml` had done the opposite (both trailers in →
+one aircraft out), which is why it dropped the Scheibe.
+
+Reproducing the real set exposed a **calibration gap**, not a model bug: a
+checker-driven search could not seat all nine aircraft + the trailer + fuel + Caddy
+at the previous `clearance_m 0.20` (always ~2 conflicts short) but seats them at
+**0.10 m**, and PK confirmed the real wingtip-to-part gaps **vary a lot** and on
+dense days are very tight (well under 0.20 m). So the horizontal clearance was
+recalibrated **0.20 → 0.10 m** (`layout_today.yaml`'s tightest gap is ~0.10 m); the
+0.15 m vertical (wing-layer) clearance was not the binding constraint and is
+unchanged. Lowering the horizontal clearance only relaxes the constraint, so
+`layout.yaml`, `layout_full.yaml`, and `scenario_demo.yaml` all stay valid. (History:
+the #605 placeholder `0.3 / 0.2` was first set to `0.20 / 0.15` from the all-8 + 4-GO
+frontier of ≤0.22/0.15.) The Caddy is modelled **multi-part** (#658 — a low van body
+a high wing may overhang, plus a small roof-gear rack on top) so it isn't a
+full-height wall. Mover tow-routing (#602), the Caddy clear-egress gate (#603/#652),
+and ground-object rendering (#606) have all shipped; **reliably packing this dense a
+12-body set is beyond the deterministic search** — both `layout_today.yaml` and
+`layout_full.yaml` are offline-search arrangements of the real composition, and the
+joint dense-placement+routing problem remains the open hard problem (#607).
 
 ## Notable aircraft
 

--- a/examples/herrenteich/hangar.yaml
+++ b/examples/herrenteich/hangar.yaml
@@ -63,9 +63,12 @@ structural_notches:
 # <=0.22/0.15, so it was first set to 0.20/0.15. But that 0.20 m horizontal gap
 # turned out TOO LOOSE to reproduce reality: when PK described how the club
 # actually parks today (all 9 aircraft + the Duo glider trailer + fuel trailer +
-# Caddy, with a clear Caddy drive-out), a checker-driven search could NOT seat that
-# real set at 0.20 m — it always came up ~2 conflicts short — yet seats it cleanly
-# at <=0.10 m. PK confirmed the real wingtip-to-part gaps VARY A LOT and on dense
+# Caddy, with a clear Caddy drive-out), an offline checker-driven search could NOT
+# find any valid arrangement of that real set at 0.20 m (its best still left a few
+# conflicts), yet finds one cleanly at <=0.10 m. (The shipped layout_today.yaml is
+# packed to the 0.10 m frontier, so checking IT at 0.20 m shows many conflicts —
+# expected; the point is that no 0.20 m arrangement of the real set was found at
+# all.) PK confirmed the real wingtip-to-part gaps VARY A LOT and on dense
 # days are very tight (well under 0.20 m). So the horizontal clearance is
 # recalibrated to 0.10 m: the demonstrated tight-pack gap of the real all-9
 # single-trailer layout (examples/herrenteich/layout_today.yaml, whose tightest gap
@@ -79,7 +82,7 @@ wing_layer_clearance_m: 0.15 # minimum vertical gap between two parts at the sam
 # Tow-MOTION clearances (#643/#646): the margin the planner keeps while a mover
 # is IN MOTION threading past parked bodies, distinct from the PARKED spacing
 # above. A spotter hand-clears wingtips far closer during a slow guided slide than
-# the long-term parked gap — applying the 0.20 m parked margin during motion
+# the long-term parked gap — applying the full parked clearance margin during motion
 # falsely rejects routable maneuvers (the #642 finding). 0.05 m models the
 # hand-cleared motion margin; like the parked values it is measured: false
 # (a documented modelling assumption pending on-site measurement). Absent ⇒ the

--- a/examples/herrenteich/hangar.yaml
+++ b/examples/herrenteich/hangar.yaml
@@ -58,16 +58,22 @@ structural_notches:
     x_max_m: 15.08
     y_max_m: 31.76
 
-# CALIBRATED for the full real set (#605). The placeholders were 0.3 / 0.2; the
-# full set (8 aircraft + Caddy + 2 glider trailers + fixed fuel trailer) is
-# INFEASIBLE at 0.3/0.2 and feasible at <=0.22/0.15 (checker-driven search).
-# 0.20 m lateral matches real hand-pushed club packing density; 0.15 m vertical
-# fixes a too-large wing-layer clearance that falsely rejected legal z-disjoint
-# wing-over-tail nestings (the real club clears fins ~0.40 m by hand, well above
-# 0.15). Lowering a clearance only RELAXES the constraint, so the existing
-# layout.yaml / scenario_demo.yaml stay valid; the synthetic data/ hangar is a
-# separate file, untouched.
-clearance_m: 0.20            # minimum horizontal gap between any two parts (PARKED)
+# CALIBRATED against the REAL 'today' layout (#664). History: the #605 placeholder
+# was 0.3/0.2; the all-8 + 4-GO set is INFEASIBLE at 0.3/0.2 and feasible at
+# <=0.22/0.15, so it was first set to 0.20/0.15. But that 0.20 m horizontal gap
+# turned out TOO LOOSE to reproduce reality: when PK described how the club
+# actually parks today (all 9 aircraft + the Duo glider trailer + fuel trailer +
+# Caddy, with a clear Caddy drive-out), a checker-driven search could NOT seat that
+# real set at 0.20 m — it always came up ~2 conflicts short — yet seats it cleanly
+# at <=0.10 m. PK confirmed the real wingtip-to-part gaps VARY A LOT and on dense
+# days are very tight (well under 0.20 m). So the horizontal clearance is
+# recalibrated to 0.10 m: the demonstrated tight-pack gap of the real all-9
+# single-trailer layout (examples/herrenteich/layout_today.yaml, whose tightest gap
+# is ~0.10 m). The 0.15 m VERTICAL (wing-layer) clearance is unchanged — it was not
+# the binding constraint (the real club clears fins ~0.40 m by hand). Lowering the
+# horizontal clearance only RELAXES the constraint, so layout.yaml / layout_full.yaml
+# / scenario_demo.yaml all stay valid; the synthetic data/ hangar is untouched.
+clearance_m: 0.10            # minimum horizontal gap between any two parts (PARKED)
 wing_layer_clearance_m: 0.15 # minimum vertical gap between two parts at the same XY (PARKED)
 
 # Tow-MOTION clearances (#643/#646): the margin the planner keeps while a mover

--- a/examples/herrenteich/layout_full.yaml
+++ b/examples/herrenteich/layout_full.yaml
@@ -40,8 +40,8 @@
 # aircraft headings, found this valid seven-aircraft + four-GO fishbone packing.
 # The product solver does not generate it. Replace with real parking positions when
 # surveyed (all dims are still measured: false). It passes `hangarfit check`
-# (exit 0) at the calibrated clearances (hangar.yaml: clearance_m 0.20,
-# wing_layer_clearance_m 0.15), and the Caddy has a clear egress.
+# (exit 0) at the calibrated clearances (see hangar.yaml), and the Caddy has a
+# clear egress.
 #
 # Coordinate convention (see hangar.yaml): world (0,0) front-left, +x right along
 # the door wall, +y deeper in; heading 0 = nose deep (+y), 90 = nose toward +x.

--- a/examples/herrenteich/layout_today.yaml
+++ b/examples/herrenteich/layout_today.yaml
@@ -1,0 +1,95 @@
+# Airfield Herrenteich — the REAL 'today' layout (#664).
+#
+# This is the club's ACTUAL in-hangar arrangement as described by PK (2026-06-15):
+# all NINE usual aircraft PLUS three floor occupants — ONE glider trailer (the Duo
+# Discus; the second single-seat trailer is stored elsewhere), the fixed Maul fuel
+# trailer, and the rescue VW Caddy. The Caddy keeps a clear drive-out egress (the
+# club's hard rule). Order parked in (real sequence): Wild Thing, Stemme, Scheibe
+# Falke, Zlin Savage, Fuji, CTSL, FK9, Duo glider trailer, Cessna 140, Husky, fuel
+# trailer (corner), Caddy (door, last).
+#
+# WHY THIS MATTERS. The earlier layout_full.yaml insisted on parking BOTH glider
+# trailers + the Caddy egress, which is one body over capacity, so it dropped the
+# Scheibe (7 aircraft). The club does the opposite — it keeps all 9 aircraft and
+# leaves the spare trailer outside. This file is the real composition; layout_full.yaml
+# is kept as the alternative 'both-trailers-inside' scenario.
+#
+# HOW THIS WAS PRODUCED. Like the other herrenteich layouts, this is the TOOL's
+# arrangement of the real COMPOSITION, not a survey of exact parking spots: an
+# offline simulated-annealing search driving the real part-based collision checker
+# (warm-started from the valid all-8 layout.yaml) + the Caddy egress oracle found
+# this valid 9-aircraft + 3-GO packing with continuous headings. The product solver
+# does not generate it (dense 12-body nesting is beyond the search — the documented
+# motivation for the learned packer, #607). Replace with surveyed positions when
+# known. All dims are still measured: false.
+#
+# It passes `hangarfit check` (exit 0) at the recalibrated clearances (hangar.yaml:
+# clearance_m 0.10, wing_layer_clearance_m 0.15) and the Caddy has a clear egress.
+# Its tightest gap is ~0.10 m (frontier-tight; recompute if part dims change).
+#
+# Coordinate convention (see hangar.yaml): world (0,0) front-left, +x right along
+# the door wall, +y deeper in; heading 0 = nose deep (+y), 90 = nose toward +x.
+
+fleet: fleet.yaml
+hangar: hangar.yaml
+
+placements:
+  - plane: wild_thing
+    x_m: 11.59
+    y_m: 16.44
+    heading_deg: 104.3
+    on_carts: true          # always_cart
+  - plane: stemme_s10
+    x_m: 5.92
+    y_m: 13.98
+    heading_deg: 115.0
+    on_carts: true          # always_cart (dolly-pivotable, #644)
+  - plane: scheibe_falke
+    x_m: 5.92
+    y_m: 22.15
+    heading_deg: 290.0
+    on_carts: true          # always_cart
+  - plane: zlin_savage
+    x_m: 3.13
+    y_m: 27.42
+    heading_deg: 303.1
+    on_carts: true          # always_cart
+  - plane: fuji
+    x_m: 7.44
+    y_m: 4.65
+    heading_deg: 348.8
+    on_carts: false         # always_own_gear
+  - plane: ctsl
+    x_m: 3.43
+    y_m: 10.91
+    heading_deg: 299.0
+    on_carts: false         # cart_eligible, on own gear
+  - plane: fk9_mkii
+    x_m: 10.81
+    y_m: 14.21
+    heading_deg: 283.1
+    on_carts: false         # cart_eligible, on own gear
+  - plane: cessna_140
+    x_m: 12.85
+    y_m: 8.32
+    heading_deg: 103.7
+    on_carts: false         # cart_eligible, on own gear
+  - plane: aviat_husky
+    x_m: 5.60
+    y_m: 18.69
+    heading_deg: 116.6
+    on_carts: false         # always_own_gear
+
+ground_objects:
+  - object: vw_caddy            # rescue vehicle at the door, clear drive-out egress (#603/#652)
+    x_m: 12.65
+    y_m: 2.60
+    heading_deg: 200.0
+  - object: maul_fuel_trailer   # fixed keep-out, near the front-left corner
+    x_m: 1.17
+    y_m: 3.87
+    heading_deg: 176.2
+  - object: glider_trailer_1    # Duo Discus trailer (10.5 m) — the only trailer inside today
+    x_m: 11.33
+    y_m: 26.03
+    heading_deg: 183.7

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -4,10 +4,13 @@ These are real (DWG-measured hangar + published-spec fleet) files kept
 separate from the synthetic `data/` placeholders. The dataset's promise is
 that all eight usual occupants fit at once — that lives in `layout.yaml`
 (aircraft only). These tests also guard the 9-entry fleet roster (incl. the
-Fuji), the four ground objects, and the realistic GO-laden `layout_full.yaml`
-(seven aircraft + four GOs, fishbone, with a clear Caddy egress). They pin the
-hangar dimensions and assert the bundled layouts still pass the real
-part-based collision checker, so a later edit cannot silently break them.
+Fuji), the four ground objects, the real 'today' `layout_today.yaml` (all nine
+aircraft + ONE glider trailer + fuel + Caddy, the #664 existence proof behind
+the 0.20 → 0.10 m clearance recalibration), and the alternative GO-laden
+`layout_full.yaml` (seven aircraft + four GOs, fishbone, with a clear Caddy
+egress). They pin the hangar dimensions and assert the bundled layouts still
+pass the real part-based collision checker, so a later edit cannot silently
+break them.
 """
 
 from pathlib import Path
@@ -55,8 +58,9 @@ def test_hangar_motion_clearance_calibrated() -> None:
     hangar = load_hangar(HERRENTEICH / "hangar.yaml")
     assert hangar.motion_clearance_m == 0.05
     assert hangar.motion_wing_layer_clearance_m == 0.05
-    # parked spacing is unchanged — static validity still uses 0.20 / 0.15
-    assert hangar.clearance_m == 0.20
+    # parked spacing is the static-validity margin, recalibrated to 0.10 / 0.15
+    # against the real 'today' layout (#664).
+    assert hangar.clearance_m == 0.10
     assert hangar.wing_layer_clearance_m == 0.15
     # the tow planner sees the tighter motion margin
     assert hangar.motion_hangar().clearance_m == 0.05
@@ -204,10 +208,14 @@ def test_ground_objects_load_from_manifest() -> None:
 
 
 def test_hangar_clearances_calibrated() -> None:
-    """The Herrenteich clearances were calibrated to fit the full real set
-    (#605): horizontal 0.20, vertical 0.15 (placeholders were 0.30/0.20)."""
+    """The Herrenteich horizontal clearance was recalibrated 0.20 -> 0.10 against
+    the real 'today' layout (#664): the actual club set (9 aircraft + Duo trailer
+    + fuel + Caddy) is infeasible at 0.20 m but valid at 0.10 m, and PK confirmed
+    real gaps vary a lot / are very tight. Vertical (wing-layer) stays 0.15 — it
+    was not the binding constraint. (History: #605 set 0.20/0.15 from the all-8 +
+    4-GO frontier of <=0.22/0.15.)"""
     hangar = load_hangar(HERRENTEICH / "hangar.yaml")
-    assert hangar.clearance_m == 0.20
+    assert hangar.clearance_m == 0.10
     assert hangar.wing_layer_clearance_m == 0.15
 
 
@@ -358,3 +366,58 @@ def test_caddy_multipart_body_clears_wing_but_rack_conflicts() -> None:
     # Directly over the rack -> conflicts (rack top 2.04 m vs wing 2.0 m = -0.04 m).
     over_rack = wing_overhang_conflicts(7.0, 8.0)
     assert over_rack and all("ground" in k for k in over_rack), over_rack
+
+
+# The REAL 'today' layout (#664): the club's actual in-hangar set as described by
+# PK — all NINE usual aircraft (incl. the Scheibe Falke) PLUS ONE glider trailer
+# (the Duo Discus; the spare is stored elsewhere), the fixed fuel trailer, and the
+# rescue Caddy with a clear drive-out. This is the existence proof that drove the
+# clearance recalibration (0.20 -> 0.10): the set is infeasible at 0.20 m but valid
+# at 0.10 m. Contrast layout_full.yaml, which keeps BOTH trailers and so must park
+# one aircraft (the Scheibe) outside.
+TODAY_PRESENT = USUAL_OCCUPANTS | {"fuji"} | {"vw_caddy", "maul_fuel_trailer", "glider_trailer_1"}
+
+
+def test_today_layout_is_valid() -> None:
+    """The real 'today' layout (9 aircraft + Duo trailer + fuel + Caddy) passes the
+    real checker at the recalibrated clearances (#664). It KEEPS the Scheibe (unlike
+    layout_full.yaml) and parks only ONE glider trailer."""
+    layout = load_layout(HERRENTEICH / "layout_today.yaml")
+    present = {p.plane_id for p in layout.placements} | {
+        gp.plane_id for gp in layout.ground_object_placements
+    }
+    assert present == TODAY_PRESENT
+    assert "scheibe_falke" in present  # the real layout keeps the Scheibe inside
+    assert "glider_trailer_2" not in present  # only the Duo trailer is inside today
+    assert len([p.plane_id for p in layout.placements]) == 9  # all nine aircraft
+    result = collisions.check(layout)
+    assert result.conflicts == (), [c.kind for c in result.conflicts]
+
+
+def test_today_layout_ground_objects_in_bounds_and_clear_notch() -> None:
+    """Independent, model-free vertex scan: every ground object in the real 'today'
+    layout is inside the L-shaped floor and clear of the office notch."""
+    layout = load_layout(HERRENTEICH / "layout_today.yaml")
+    floor = layout.hangar.floor_polygon
+    assert floor is not None
+    x0, y0, x1, y1 = NOTCH
+    for gp in layout.ground_object_placements:
+        obj = layout.ground_objects[gp.plane_id]
+        for part in aircraft_parts_world(obj, gp):
+            assert floor.covers(part.polygon), f"{gp.plane_id} {part.kind} outside floor"
+            for x, y in part.polygon.exterior.coords:
+                assert not (x0 <= x <= x1 and y0 <= y <= y1), (
+                    f"{gp.plane_id} vertex ({x:.2f},{y:.2f}) in office notch"
+                )
+
+
+@pytest.mark.slow
+def test_today_caddy_egress_clear() -> None:
+    """The rescue Caddy can drive out of the real 'today' layout without moving
+    anything (#664/#603/#652 — the club's hard rule). The egress oracle (the
+    authoritative gate, full budget) must find the drive-out corridor."""
+    from hangarfit.towplanner import egress_first_conflict
+
+    layout = load_layout(HERRENTEICH / "layout_today.yaml")
+    c = egress_first_conflict(layout, "vw_caddy")
+    assert c is None, f"expected the Caddy to have a clear egress; got {c}"


### PR DESCRIPTION
## What & why

Validated the collision model against the club's **real in-hangar arrangement** (described by PK 2026-06-15) as the known-good existence proof, and turned the finding into a data fix.

**Real set:** all **9** aircraft (incl. the 18 m Scheibe Falke) + **one** Duo Discus glider trailer (the spare is stored elsewhere) + the fixed fuel trailer + the rescue Caddy with a clear drive-out egress.

**Finding:** the algorithm is sound — every conflict it raised was a legitimate rule firing (wing-over-cockpit ban, fin-in-wing-layer, the 0.20/0.15 clearances). The gap was **data calibration**:
- A checker-driven search (warm-started from the valid all-8 `layout.yaml` + the Caddy egress oracle) **could not seat the real set at `clearance_m 0.20`** (always ~2 conflicts short) but **seats it cleanly at 0.10 m**. PK confirmed real wingtip-to-part gaps vary a lot and are very tight on dense days.
- The previous `layout_full.yaml` insisted on keeping **both** glider trailers + the Caddy egress, which is one body over capacity, so it dropped the Scheibe. The club does the opposite: keep all 9 aircraft, leave the spare trailer out.

## Changes (data + docs + tests only — no model code touched)

- **`examples/herrenteich/layout_today.yaml`** (new): the real composition. Found by the offline checker-driven search; passes `hangarfit check` (exit 0) and the Caddy egress oracle (CLEAR). Its tightest gap is ~0.10 m (frontier-tight).
- **`examples/herrenteich/hangar.yaml`**: `clearance_m` **0.20 → 0.10** (horizontal). Vertical wing-layer clearance unchanged at 0.15 (not the binding constraint). Lowering only relaxes the constraint, so `layout.yaml`, `layout_full.yaml`, `scenario_demo.yaml` all stay valid; synthetic `data/hangar.yaml` untouched.
- **README + CHANGELOG**: reframe `layout_full.yaml` as the alternative "both trailers inside" scenario; document the recalibration rationale.
- **tests**: add `layout_today` validity + ground-object bounds/notch + Caddy egress (slow) tests; update the clearance-pinning assertions 0.20 → 0.10.

## Verification

- `hangarfit check examples/herrenteich/layout_today.yaml` → **exit 0** (9 aircraft + 3 GO, 0 conflicts).
- Caddy egress oracle → **CLEAR**.
- Full suite: **1735 passed** (incl. the herrenteich slow egress tests); `layout.yaml` / `layout_full.yaml` / `scenario_demo.yaml` still valid at 0.10 m.

## Note

Reliably packing this dense a 12-body set is beyond the deterministic search (it consistently lands ~1 conflict short even at 0.05 m) — the documented motivation for the learned packer (#607). The shipped layout was produced by an offline checker-driven search, consistent with how the other herrenteich layouts were authored.

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)