### PR TITLE
Tow planner: order-search backtracking + hand-placed-body foundation (#667 step 1)

### DIFF
--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1003,6 +1003,16 @@ class Layout:
                     f"ground_object_placement references unknown id {gp.plane_id!r} "
                     f"(ground_objects has: {sorted(self.ground_objects)})"
                 )
+            # #667: hand_placed is an aircraft-only marker (a dolly-borne body the
+            # tow planner pre-seeds as an obstacle). A ground object is routed/fixed
+            # by its object_class, and the planner only filters AIRCRAFT placements,
+            # so hand_placed here would be silently ignored — reject it instead.
+            if gp.hand_placed:
+                raise ValueError(
+                    f"ground_object_placement {gp.plane_id!r} sets hand_placed=True, "
+                    f"which is an aircraft-only marker (ground objects are positioned "
+                    f"by their object_class, not hand-placed)"
+                )
             if gp.plane_id in seen_ground:
                 raise ValueError(f"Duplicate ground_object_placement for id {gp.plane_id!r}")
             seen_ground.add(gp.plane_id)

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -813,6 +813,11 @@ class Placement:
     y_m: float
     heading_deg: float
     on_carts: bool
+    # #667 Stage 0: a HAND-POSITIONED body (e.g. a dolly-borne glider) is parked
+    # by hand, not tow-routed. The fill planner treats it as a pre-placed
+    # obstacle and emits a path-less (at-rest) move for it. Default False keeps
+    # every existing placement byte-identical.
+    hand_placed: bool = False
 
     def __post_init__(self) -> None:
         if not self.plane_id:

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1619,9 +1619,15 @@ def _plan_fill(
     budget = _MAX_EXPANSIONS if max_expansions is None else max_expansions
     total_budget = _MAX_FILL_EXPANSIONS if max_total_expansions is None else max_total_expansions
     total_used = 0
-    ordered = list(back_first_order(target.placements))
     fleet = target.fleet
     hangar = target.hangar
+    # #667 Stage 0: HAND-POSITIONED bodies (dolly-borne gliders) are parked by
+    # hand, not tow-routed. They seed `placed` (so routed bodies treat them as
+    # obstacles) and get a path-less at-rest move emitted first. With no
+    # hand-placed body the partition is the whole fleet → `ordered` is unchanged
+    # and `placed`/`moves` start empty, so the plan stays byte-identical.
+    hand_placed_slots = back_first_order(tuple(p for p in target.placements if p.hand_placed))
+    ordered = list(back_first_order(tuple(p for p in target.placements if not p.hand_placed)))
 
     # Fixed obstacles (e.g. the fuel trailer) are static keep-outs for BOTH
     # aircraft routes and mover routes. Empty when no ground objects => inert.
@@ -1631,8 +1637,8 @@ def _plan_fill(
         if target.ground_objects[gp.plane_id].object_class == "fixed_obstacle"
     )
 
-    placed: list[Placement] = []
-    moves: list[Move] = []
+    placed: list[Placement] = list(hand_placed_slots)
+    moves: list[Move] = [Move(p.plane_id, Pose.from_placement(p), None) for p in hand_placed_slots]
 
     while ordered:
         chosen: int | None = None

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1640,36 +1640,46 @@ def _plan_fill(
     placed: list[Placement] = list(hand_placed_slots)
     moves: list[Move] = [Move(p.plane_id, Pose.from_placement(p), None) for p in hand_placed_slots]
 
-    while ordered:
-        chosen: int | None = None
-        chosen_arc: DubinsArc | None = None
-        chosen_apron_fallback = False
-        # The deepest unplaced plane is scanned first, so its conflict (if it
-        # is rejected) is the one reported when the whole scan finds nothing.
-        deepest_conflict: Conflict | None = None
-        # `placed` does not change within a scan pass, so the obstacle layout is
-        # constant across candidates. Only the already-committed planes are
-        # obstacles; plan_path adds the candidate mover per sample via its
-        # internal path_first_conflict check.
+    # #667 Stage 1 (order search): place the to-route bodies by a deterministic
+    # BACKTRACKING DFS over order, greedy-first. The first feasible candidate at
+    # each level is recursed first, so when the greedy back-first order already
+    # works the search returns that identical path untouched (byte-identical,
+    # ADR-0003); backtracking only happens where the old monotonic loop would have
+    # bailed — a greedy commit that deadlocks a later body. The global expansion
+    # budget bounds the search (expansions on dead branches are NOT refunded), so
+    # it terminates and then raises the structured bail. deepest_conflict captures
+    # the first (deepest plane's) routing conflict for that bail message.
+    deepest_conflict: Conflict | None = None
+
+    def _place_rest(
+        placed_list: list[Placement], rest: list[Placement]
+    ) -> list[tuple[Placement, DubinsArc, bool]] | None:
+        """Return the chosen (slot, arc, apron_fallback) sequence that places every
+        body in ``rest`` against ``placed_list``, greedy-first with backtracking, or
+        ``None`` if no order does. Raises on global-budget exhaustion."""
+        nonlocal total_used, deepest_conflict
+        if not rest:
+            return []
+        # `placed_list` is constant across candidates at this level; plan_path adds
+        # the candidate mover per sample via its internal path_first_conflict check.
         placed_layout = Layout(
             fleet=fleet,
             hangar=hangar,
-            placements=tuple(placed),
+            placements=tuple(placed_list),
             maintenance_plane=target.maintenance_plane,
             ground_objects=target.ground_objects,
             ground_object_placements=fixed_obstacle_placements,
         )
-        for idx, slot in enumerate(ordered):
+        for idx, slot in enumerate(rest):
             remaining = total_budget - total_used
             if remaining <= 0:
                 # Global fill-expansion budget exhausted (#336): bail in bounded
-                # time rather than paying per-plane budget × scan-retries on an
-                # un-routable fill. Name the deepest still-unplaced plane.
+                # time. Name the deepest still-unplaced plane at this level.
                 raise NoFeasiblePlanError(
-                    ordered[0].plane_id,
+                    rest[0].plane_id,
                     Conflict.single(
                         kind="no_feasible_path",
-                        plane=ordered[0].plane_id,
+                        plane=rest[0].plane_id,
                         detail=f"global fill expansion budget ({total_budget}) exhausted",
                     ),
                 )
@@ -1678,11 +1688,10 @@ def _plan_fill(
             try:
                 # The full door cone drives the multi-start search (#262). Compute
                 # it once and pass it as `entries=`; the positional `entry` arg is
-                # ignored by plan_path whenever `entries` is set, so reuse cone[0]
-                # for it rather than recomputing entry_pose() (which plan_path would
-                # never read here). Each call is capped at the smaller of the
-                # per-plane budget and the global remainder, and its expansions are
-                # charged to the global total whether it succeeds or fails (#336).
+                # ignored by plan_path whenever `entries` is set. Each call is capped
+                # at the smaller of the per-plane budget and the global remainder,
+                # and its expansions are charged to the global total whether it
+                # succeeds or fails (#336).
                 cone = entry_poses(slot, hangar)
                 arc = plan_path(
                     plane,
@@ -1697,8 +1706,8 @@ def _plan_fill(
                     stats=stats,
                 )
             except NoFeasiblePlanError as exc:
-                # This plane cannot be routed against the current obstacles; try
-                # the next candidate. Remember its conflict for the bail message.
+                # Cannot route this body against the current obstacles; try the next
+                # candidate. Remember its conflict for the bail message.
                 exp = stats.get("expansions", 0)
                 total_used += exp if isinstance(exp, int) else 0
                 if deepest_conflict is None:
@@ -1706,30 +1715,35 @@ def _plan_fill(
                 continue
             exp = stats.get("expansions", 0)
             total_used += exp if isinstance(exp, int) else 0
-            chosen, chosen_arc = idx, arc
-            # Only the COMMITTED candidate's fallback matters: the rejected
-            # candidates of the scan are not in the plan, so their stats are
-            # irrelevant to what the user sees (#503).
-            chosen_apron_fallback = stats.get("apron_fallback") is True
-            break
-        if chosen is None:
-            # Every remaining plane conflicts: greedy back-first is stuck. The
-            # deepest plane (ordered[0], scanned first) is the one we most
-            # wanted to place, and deepest_conflict is its own conflict.
-            assert deepest_conflict is not None  # ordered non-empty => scan ran
-            raise NoFeasiblePlanError(ordered[0].plane_id, deepest_conflict)
-        slot = ordered.pop(chosen)
-        assert chosen_arc is not None
-        moves.append(Move(slot.plane_id, Pose.from_placement(slot), chosen_arc))
+            apron_fb = stats.get("apron_fallback") is True
+            sub = _place_rest(placed_list + [slot], rest[:idx] + rest[idx + 1 :])
+            if sub is not None:
+                return [(slot, arc, apron_fb), *sub]
+            # Routed here, but the rest dead-ends downstream → backtrack: try the
+            # next candidate at this level (the old monotonic loop could not).
+        return None
+
+    result = _place_rest(placed, ordered)
+    if result is None:
+        # No placement order seats every body (a true lock — needs the Stage 1
+        # move-aside, still to come) or every candidate conflicts. Name the
+        # deepest body and carry its conflict (matches the old monotonic bail).
+        bail = deepest_conflict or Conflict.single(
+            kind="no_feasible_path",
+            plane=ordered[0].plane_id,
+            detail="no feasible tow order (every placement order deadlocks)",
+        )
+        raise NoFeasiblePlanError(ordered[0].plane_id, bail)
+
+    for slot, arc, apron_fb in result:
+        moves.append(Move(slot.plane_id, Pose.from_placement(slot), arc))
         placed.append(slot)
         # #503: record (plan-inert) the planes that towed via the y=0 door-line
         # fallback DESPITE an apron being set — their footprint is too deep for the
-        # apron, so every apron start pose was filtered and they show no slide-in.
-        # Populated in committed-move order (the deterministic move order, ADR-0003)
-        # only when the caller passed `apron_dropped_out`; the suggested min depth
-        # is the per-plane FOOTPRINT extent, NOT the fleet-wide `auto` over-margin
-        # (derive_apron_depth). Never read back into the plan.
-        if chosen_apron_fallback and apron_dropped_out is not None:
+        # apron. Committed-move order (deterministic, ADR-0003), only when the
+        # caller passed `apron_dropped_out`; the depth is the per-plane FOOTPRINT
+        # extent, not the fleet-wide `auto` over-margin. Never read back.
+        if apron_fb and apron_dropped_out is not None:
             apron_dropped_out.append(
                 ApronShallowDrop(
                     plane_id=slot.plane_id,

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1667,7 +1667,7 @@ def _plan_fill(
     ) -> list[tuple[Placement, DubinsArc, bool]] | None:
         """Return the chosen (slot, arc, apron_fallback) sequence that places every
         body in ``rest`` against ``placed_list``, greedy-first with backtracking, or
-        ``None`` if no order does. Raises on global-budget exhaustion."""
+        ``None`` if no order does. Raises on global-budget or backtrack-cap exhaustion."""
         nonlocal total_used, deepest_conflict, backtracks_used
         if not rest:
             return []
@@ -1736,14 +1736,16 @@ def _plan_fill(
             # search on an un-routable fill (#667); 0 ⇒ no backtracking allowed.
             backtracks_used += 1
             if backtracks_used > bt_cap:
-                raise NoFeasiblePlanError(
-                    ordered[0].plane_id,
-                    Conflict.single(
-                        kind="no_feasible_path",
-                        plane=ordered[0].plane_id,
-                        detail=f"order-search backtracking cap ({bt_cap}) exceeded",
-                    ),
+                # Surface the real per-body routing conflict (the actionable reason a
+                # body could not be seated) and name THAT body — not the already-placed
+                # deepest plane (#668 review). Synthesize a cap conflict only if nothing
+                # ever failed to route (a pure ordering lock with all routes feasible).
+                bail = deepest_conflict or Conflict.single(
+                    kind="no_feasible_path",
+                    plane=rest[0].plane_id,
+                    detail=f"order-search backtracking cap ({bt_cap}) exceeded",
                 )
+                raise NoFeasiblePlanError(bail.planes[0], bail)
         return None
 
     result = _place_rest(placed, ordered)
@@ -1756,7 +1758,10 @@ def _plan_fill(
             plane=ordered[0].plane_id,
             detail="no feasible tow order (every placement order deadlocks)",
         )
-        raise NoFeasiblePlanError(ordered[0].plane_id, bail)
+        # Name the conflict's own body so the named plane and the carried conflict
+        # always agree (#668 review): on a real routing failure that's the stuck
+        # body; on a pure ordering lock it's the deepest (the synthesized fallback).
+        raise NoFeasiblePlanError(bail.planes[0], bail)
 
     for slot, arc, apron_fb in result:
         moves.append(Move(slot.plane_id, Pose.from_placement(slot), arc))

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1522,6 +1522,7 @@ def plan_fill(
     heuristic: Literal["euclidean", "grid"] = "grid",
     max_expansions: int | None = None,
     max_total_expansions: int | None = None,
+    max_backtracks: int | None = None,
     apron_dropped_out: list[ApronShallowDrop] | None = None,
     unroutable_movers: list[str] | None = None,
 ) -> MovesPlan:
@@ -1580,13 +1581,19 @@ def plan_fill(
     is stuck (spike Risk #1) and the plan bails with :class:`NoFeasiblePlanError`
     naming the deepest unplaceable plane.
 
-    No retry *budget* is needed: an already-placed plane is only ever an added
-    obstacle, so a plane infeasible against the current obstacles can never
-    become feasible later — the scan therefore makes monotonic progress (one
-    plane committed per iteration) and cannot spin. Deterministic (ADR-0003):
-    the order, the Hybrid-A* primitive fan, the cone grid, and the next-feasible
-    scan are all RNG-free, so a given ``target`` always yields the same
-    :class:`MovesPlan`.
+    Since #667 the scan is a deterministic greedy-first **backtracking** DFS over
+    placement order (``_place_rest``): the first feasible candidate at each level is
+    recursed first, so when the greedy back-first order already routes, the search
+    returns that identical path untouched (byte-identical, ADR-0003); it backtracks
+    the order only where a greedy commit deadlocks a later body — cases the old
+    monotonic loop bailed on. The search is bounded by both ``max_total_expansions``
+    (above) and ``max_backtracks`` (``None`` ⇒ the module ``_MAX_FILL_BACKTRACKS``),
+    a separate deterministic ceiling on dead-end backtracks so a generous per-plane
+    budget can't fund a runaway order search on an un-routable fill. Deterministic
+    (ADR-0003): the order, the Hybrid-A* primitive fan, the cone grid, and the
+    candidate scan are all RNG-free, so a given ``target`` always yields the same
+    :class:`MovesPlan`. (A truly cyclic lock — no order routes — still bails; the
+    move-aside that resolves those is tracked on #667.)
     """
     # #626: memoize body world-parts for the WHOLE fill. The static obstacle field
     # is rebuilt by every plan_path's _build_obstacles, and the greedy scan re-routes
@@ -1601,6 +1608,7 @@ def plan_fill(
             heuristic=heuristic,
             max_expansions=max_expansions,
             max_total_expansions=max_total_expansions,
+            max_backtracks=max_backtracks,
             apron_dropped_out=apron_dropped_out,
             unroutable_movers=unroutable_movers,
         )
@@ -1612,13 +1620,16 @@ def _plan_fill(
     heuristic: Literal["euclidean", "grid"] = "grid",
     max_expansions: int | None = None,
     max_total_expansions: int | None = None,
+    max_backtracks: int | None = None,
     apron_dropped_out: list[ApronShallowDrop] | None = None,
     unroutable_movers: list[str] | None = None,
 ) -> MovesPlan:
     """Body of :func:`plan_fill`, run inside an active ``pose_cache_scope`` (#626)."""
     budget = _MAX_EXPANSIONS if max_expansions is None else max_expansions
     total_budget = _MAX_FILL_EXPANSIONS if max_total_expansions is None else max_total_expansions
+    bt_cap = _MAX_FILL_BACKTRACKS if max_backtracks is None else max_backtracks
     total_used = 0
+    backtracks_used = 0
     fleet = target.fleet
     hangar = target.hangar
     # #667 Stage 0: HAND-POSITIONED bodies (dolly-borne gliders) are parked by
@@ -1657,7 +1668,7 @@ def _plan_fill(
         """Return the chosen (slot, arc, apron_fallback) sequence that places every
         body in ``rest`` against ``placed_list``, greedy-first with backtracking, or
         ``None`` if no order does. Raises on global-budget exhaustion."""
-        nonlocal total_used, deepest_conflict
+        nonlocal total_used, deepest_conflict, backtracks_used
         if not rest:
             return []
         # `placed_list` is constant across candidates at this level; plan_path adds
@@ -1719,8 +1730,20 @@ def _plan_fill(
             sub = _place_rest(placed_list + [slot], rest[:idx] + rest[idx + 1 :])
             if sub is not None:
                 return [(slot, arc, apron_fb), *sub]
-            # Routed here, but the rest dead-ends downstream → backtrack: try the
-            # next candidate at this level (the old monotonic loop could not).
+            # Routed here, but the rest dead-ends downstream → backtrack to the next
+            # candidate (the old monotonic loop could not). Bound the total dead-end
+            # backtracks so a generous per-plane budget can't fund a runaway order
+            # search on an un-routable fill (#667); 0 ⇒ no backtracking allowed.
+            backtracks_used += 1
+            if backtracks_used > bt_cap:
+                raise NoFeasiblePlanError(
+                    ordered[0].plane_id,
+                    Conflict.single(
+                        kind="no_feasible_path",
+                        plane=ordered[0].plane_id,
+                        detail=f"order-search backtracking cap ({bt_cap}) exceeded",
+                    ),
+                )
         return None
 
     result = _place_rest(placed, ordered)
@@ -1866,6 +1889,16 @@ _MAX_FILL_EXPANSIONS = 16000  # GLOBAL expansion budget across one whole fill (#
 # budget VALUE (not the count) with the profiling harness if a real apron site
 # needs it; bound a hard apron fill per-run with ``--tow-max-expansions``.
 # Overridable via the ``max_total_expansions`` param on ``plan_fill()``.
+
+_MAX_FILL_BACKTRACKS = 2000  # GLOBAL cap on order-search dead-end backtracks (#667).
+# The Stage-1 order search (`_place_rest`) backtracks the placement ORDER when a
+# greedy commit deadlocks a later body. The expansion budget above is the primary
+# bound, but a generous PER-PLANE budget (needed to route tight-feasible planes)
+# also funds deep order-backtracking on an UN-routable fill — so this is a separate,
+# deterministic secondary ceiling on the number of dead-end backtracks, independent
+# of the per-plane budget. Inert for the greedy-success path (0 backtracks ⇒
+# byte-identical, ADR-0003) and far above any legitimate small reorder; it only
+# bounds a pathological/un-routable order search. Overridable via ``max_backtracks``.
 # Sampling resolution for the FAST in-search `_motion_clear` validity checks
 # (edges + the analytic-shot screen). Coarser than the exact oracle's default
 # (0.05 m / 1°) to keep the search tractable: the worst case is a plane that can

--- a/tests/test_models_ground_object.py
+++ b/tests/test_models_ground_object.py
@@ -60,6 +60,26 @@ def test_ground_partkind_is_valid() -> None:
     assert _rect_part(kind="ground").kind == "ground"
 
 
+def test_layout_rejects_hand_placed_ground_object() -> None:
+    """`hand_placed` (#667) is an aircraft-only marker — meaningless on a ground
+    object (those are routed/fixed by their object_class). Layout must reject it
+    rather than silently ignore it (the planner only filters aircraft placements)."""
+    obj = GroundObject(id="fuel", name="Fuel", parts=(_rect_part(),), object_class="fixed_obstacle")
+    with pytest.raises(ValueError, match="hand_placed"):
+        Layout(
+            fleet={},
+            hangar=_hangar(),
+            placements=(),
+            maintenance_plane=None,
+            ground_objects={"fuel": obj},
+            ground_object_placements=(
+                Placement(
+                    "fuel", x_m=5.0, y_m=5.0, heading_deg=0.0, on_carts=False, hand_placed=True
+                ),
+            ),
+        )
+
+
 def test_mover_can_be_hard_door_mover() -> None:
     m = GroundObject(
         id="caddy",

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -218,6 +218,33 @@ def test_plan_fill_swaps_past_a_conflicting_plane(monkeypatch: pytest.MonkeyPatc
     assert [m.plane_id for m in plan.moves] == ["A", "B"]
 
 
+def test_plan_fill_backtracks_order_when_greedy_commit_deadlocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#667 Stage 1 (order search): greedy back-first commits the deepest routable
+    plane, but that commit can deadlock a later plane. The planner must BACKTRACK
+    the order and find a feasible one ([B, A]) rather than bail.
+
+    Unlike the swap test, here the deepest plane A IS routable first, so the
+    per-step skip happily commits it — and only then does B deadlock. Only placing
+    B before A works, which the monotonic loop cannot reach without backtracking."""
+    h = _hangar(width_m=20.0, length_m=30.0)
+    fleet = {"A": _box_plane("A"), "B": _box_plane("B")}
+    target = _layout(fleet, h, _slot("A", 12.0, 22.0), _slot("B", 8.0, 8.0))  # A deep, B shallow
+
+    def fake_plan_path(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
+        placed_ids = {p.plane_id for p in placed.placements}
+        # A is always routable; B only while A is not yet placed. Greedy commits A
+        # first (deeper, scanned first, feasible) → B deadlocks. Only [B, A] works.
+        if mover.id == "B" and "A" in placed_ids:
+            raise _forced_infeasible("B")
+        return _fake_arc(mover, entry, goal)
+
+    monkeypatch.setattr(tp, "plan_path", fake_plan_path)
+    plan = plan_fill(target)
+    assert [m.plane_id for m in plan.moves] == ["B", "A"]
+
+
 def test_plan_fill_bails_with_structured_error_when_unplannable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -264,8 +264,12 @@ def test_plan_fill_backtrack_cap_bounds_the_order_search(
 
     monkeypatch.setattr(tp, "plan_path", fake_plan_path)
     assert [m.plane_id for m in plan_fill(target).moves] == ["B", "A"]  # default reorders
-    with pytest.raises(NoFeasiblePlanError):
+    with pytest.raises(NoFeasiblePlanError) as ei:
         plan_fill(target, max_backtracks=0)  # no backtracking allowed → bails
+    # The bail must name the actually-stuck body (B — unroutable once A is placed),
+    # not the already-placed deepest plane, and preserve a real conflict (#668 review).
+    assert ei.value.plane_id == "B"
+    assert ei.value.conflict is not None and ei.value.conflict.planes[0] == "B"
 
 
 def test_plan_fill_bails_with_structured_error_when_unplannable(

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -245,6 +245,29 @@ def test_plan_fill_backtracks_order_when_greedy_commit_deadlocks(
     assert [m.plane_id for m in plan.moves] == ["B", "A"]
 
 
+def test_plan_fill_backtrack_cap_bounds_the_order_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#667: the order search is bounded by ``max_backtracks`` so an un-routable
+    fill bails predictably regardless of the per-plane expansion budget. With zero
+    backtracks allowed the deadlock case (which needs one reorder) bails instead of
+    finding [B, A]; the generous default still finds it."""
+    h = _hangar(width_m=20.0, length_m=30.0)
+    fleet = {"A": _box_plane("A"), "B": _box_plane("B")}
+    target = _layout(fleet, h, _slot("A", 12.0, 22.0), _slot("B", 8.0, 8.0))
+
+    def fake_plan_path(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
+        placed_ids = {p.plane_id for p in placed.placements}
+        if mover.id == "B" and "A" in placed_ids:
+            raise _forced_infeasible("B")
+        return _fake_arc(mover, entry, goal)
+
+    monkeypatch.setattr(tp, "plan_path", fake_plan_path)
+    assert [m.plane_id for m in plan_fill(target).moves] == ["B", "A"]  # default reorders
+    with pytest.raises(NoFeasiblePlanError):
+        plan_fill(target, max_backtracks=0)  # no backtracking allowed → bails
+
+
 def test_plan_fill_bails_with_structured_error_when_unplannable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -155,6 +155,28 @@ def test_plan_fill_is_deterministic() -> None:
     assert plan_fill(target) == plan_fill(target)
 
 
+def test_plan_fill_skips_hand_placed_body_and_keeps_it_as_obstacle() -> None:
+    """#667 Stage 0: a hand-positioned (dolly) body is pre-placed — NOT tow-routed
+    (carried at rest with ``path is None``) while the rest route around it as an
+    obstacle. Models the Herrenteich gliders, which go in by hand, not towed."""
+    h = _hangar(width_m=20.0, length_m=30.0)
+    fleet = {"A": _box_plane("A"), "G": _box_plane("G")}
+    target = _layout(
+        fleet,
+        h,
+        _slot("A", x=8.0, y=8.0),  # towed in
+        Placement("G", x_m=12.0, y_m=22.0, heading_deg=0.0, on_carts=False, hand_placed=True),
+    )
+    plan = plan_fill(target)
+    moves = {m.plane_id: m for m in plan.moves}
+    assert set(moves) == {"A", "G"}  # both present in the plan
+    assert moves["G"].path is None  # hand-placed: present at rest, NOT routed
+    assert moves["A"].path is not None  # towed in normally
+    assert moves["G"].target_slot == Pose.from_placement(
+        next(p for p in target.placements if p.plane_id == "G")
+    )
+
+
 # ── plan_fill LOOP-logic tests ──────────────────────────────────────────────
 # These pin the back-first scan / swap / bail mechanics in isolation by faking
 # ``plan_path`` — the per-candidate call ``plan_fill`` actually makes. (Earlier


### PR DESCRIPTION
First, foundational step of #667 (shuffle-aware tow routing). **Does not yet route the full Herrenteich fleet** — that needs the move-aside search (stacked follow-up). This PR lands the verified, byte-identical groundwork.

## What's in

1. **Stage 1 — deterministic backtracking order search** (`0c4dacb`, `3242324`). `plan_fill`'s greedy back-first placement loop becomes a recursive greedy-first DFS (`_place_rest`) that **backtracks the placement order** where a greedy commit deadlocks a later body — cases the old monotonic loop just bailed on. Greedy-first ⇒ when the greedy order already routes, the search returns that **identical** path untouched (byte-identical `MovesPlan`). Bounded by the existing expansion budget **and** a new deterministic `max_backtracks` cap (`_MAX_FILL_BACKTRACKS`=2000) so a generous per-plane budget can't fund a runaway order search on an un-routable fill.

2. **Stage 0 — hand-placed bodies** (`1d9689b`). `Placement.hand_placed: bool=False`; in `plan_fill` such bodies are pre-seeded as obstacles with a path-less at-rest move. *Foundation only* — inert until the move-aside follow-up consumes it (no loader/YAML/consumer yet). Default False ⇒ byte-identical.

## What's NOT in (follow-up, #667)

**Move-aside** (displace a parked body to a staging pose + restore) — the lever that actually routes the dense fleet. Diagnostics on `examples/herrenteich/layout_today.yaml` confirm it's the right next step: every slot is reachable in an empty hangar, but the gliders block 4 of 5 powered planes, and the order search alone can't crack the cyclic lock (budget-exhausts on the Scheibe). Then: loader `hand_placed` parse, viewer/2D multi-leg animation.

## Verification

- **determinism-guard PASS** (byte-identical greedy-success path; RNG-free; deterministic order; terminating). 
- 958 tests green across the towplanner + solver + canary sweep; 71 canary+integration green after the cap; mypy clean.
- TDD throughout (`test_plan_fill_skips_hand_placed_body...`, `..._backtracks_order_when_greedy_commit_deadlocks`, `..._backtrack_cap_bounds_the_order_search`).

Refs #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)