### PR TITLE
feat(#607 rung 1): --backend learned CLI seam + ADR-0027 (learned determinism scope)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **`solve --backend {rrmc,learned}` seam + learned-backend determinism scope (ADR-0027, #607/#670).**
+  Added the opt-in backend switch on `hangarfit solve`. The default `rrmc` is the
+  unchanged deterministic random-restart solver (byte-identical — `determinism-guard`
+  intact). `--backend learned` selects the planned neural backend (epic #607); it is
+  **not yet implemented**, so it exits cleanly (code 2) with a pointer to #607 rather
+  than a traceback, and the new `hangarfit.learned.solve_learned()` library entry
+  returns the same `SolveResult` shape (stubbed to raise `LearnedBackendUnavailableError`).
+  New **ADR-0027** amends ADR-0003's *scope*: the verifier (`collisions.check` +
+  `towplanner`) stays strictly byte-identical and `determinism-guard`-gated, while the
+  learned *proposer* gets a weaker, documented contract (within-build bit-identical;
+  cross-machine validity-only) and is outside `determinism-guard`. No ML dependencies
+  are added.
+
 - **Real Airfield Herrenteich 'today' layout + clearance recalibration (#664).**
   Added `examples/herrenteich/layout_today.yaml`: the club's actual in-hangar set
   as described on 2026-06-15 — all **nine** aircraft (incl. the Scheibe Falke) +

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ A scenario YAML carries `fleet:` / `hangar:` refs plus a `fleet_in:` list (which
 |---|---|
 | 0 | Found at least one valid layout (`status` = `found` or `found_partial`) |
 | 1 | No valid layout found (`status` = `exhausted_budget` or `trivially_infeasible`); with `--strict-k`, also fires for `found_partial` |
-| 2 | Could not solve (file not found, bad YAML, invariant violation, IO error during render/write, or `--render-paths` without `--render`) |
+| 2 | Could not solve (file not found, bad YAML, invariant violation, IO error during render/write, `--render-paths` without `--render`, or an unavailable backend such as `--backend learned`) |
 | 3 | `--render-paths` only: valid layout(s) found but the v1 tow planner could not route **any** of them. The layouts still render (without path overlays); each blocked layout gets a stderr warning naming the plane. Distinct from code 1 (no layout at all). |
 
 `--render-paths` overlays each plane's tow path on the `--render` PNG(s) (one colour per plane). It tow-plans every returned layout; a layout the planner cannot route is rendered without paths. If **at least one** candidate is routable the exit code is 0 (un-routable ones still warn); code 3 fires only when none are routable. Under default settings, if a spread layout is fully un-routable `solve()` first re-solves once with spread disabled and prefers that tighter, routable arrangement (surfaced on stderr and in `--json` via `spread_fallback_applied`), choosing a towable layout before code 3 is returned ([ADR-0016](docs/adr/0016-spread-towability-fallback.md)).

--- a/docs/adr/0003-rr-mc-solver-algorithm.md
+++ b/docs/adr/0003-rr-mc-solver-algorithm.md
@@ -3,6 +3,11 @@
 - **Status:** Accepted
 - **Date:** 2026-05-22
 - **Deciders:** [@DocGerd](https://github.com/DocGerd)
+- **Scope:** The byte-identical contract below binds the **deterministic
+  verifier/solver** (`solver.py`, `towplanner.py`). [ADR-0027](0027-learned-backend-determinism-scope.md)
+  amends the scope for the opt-in **learned backend** (#607): its neural *proposer*
+  has a weaker, documented contract and is **not** under `determinism-guard`; the
+  verifier here remains the strict ground truth regardless.
 
 ## Context & Problem Statement
 

--- a/docs/adr/0027-learned-backend-determinism-scope.md
+++ b/docs/adr/0027-learned-backend-determinism-scope.md
@@ -1,0 +1,76 @@
+# ADR-0027: Learned-backend determinism scope — verifier strict, proposer weaker
+
+- **Status:** Proposed
+
+- **Date:** 2026-06-15
+- **Deciders:** [@DocGerd](https://github.com/DocGerd)
+
+## Context & Problem Statement
+
+[ADR-0003](0003-rr-mc-solver-algorithm.md) binds the static solver and the tow
+planner to a **byte-identical** reproducibility contract: the same `(scenario, seed)`
+must produce a bit-identical `SolveResult` / `MovesPlan`, enforced by the
+`determinism-guard` double-solve check on `solver.py` and `towplanner.py`. Epic #607
+adds an **opt-in learned backend** (a neural *proposer* of poses + place-and-tow order)
+behind the unchanged deterministic verifier. Neural inference is **not** bit-identical
+across machines — floating-point op ordering, the ONNX-runtime execution provider, and
+GPU/CPU hardware all introduce sub-ULP variation that no amount of seeding removes. So
+we must decide *how the determinism contract applies to the learned path* without either
+(a) weakening the guarantee that makes the deterministic tool trustworthy, or (b)
+pretending a cross-hardware byte-identity that is physically not achievable.
+
+## Decision Drivers
+
+- The verifier's hard guarantee (validity + routability are ground truth) must stay intact and `determinism-guard`-bound.
+- The learned path needs an **honest, useful** reproducibility contract — enough to debug and regression-test, without claiming what float/EP nondeterminism makes impossible.
+- The project's safety invariant: **no invalid layout is ever returned to a human** — the deterministic checker is the final gate regardless of what the policy proposes.
+- Keep `determinism-guard`'s scope precise so a green guard always means the same thing.
+
+## Considered Options
+
+1. **Scope split (chosen).** The verifier (`collisions.check` + `towplanner`) stays under the strict ADR-0003 byte-identical contract, `determinism-guard`-gated, exactly as today. The learned **proposer** is explicitly **outside** ADR-0003 / `determinism-guard` and gets a weaker, documented two-tier contract: **within-a-build, bit-identical** (fixed weights + fixed seed + pinned onnxruntime execution provider) and **cross-machine, verifier-validity-only** (the same valid+routable verdict, not byte-identical poses), with its own canaries.
+2. **Force the learned path under full ADR-0003 byte-identity.** Pin every float op / EP so the learned output is bit-identical cross-machine too.
+3. **Exempt the learned path from any determinism contract.** Treat its output as free-form; rely solely on the verifier to reject invalid results.
+
+## Decision Outcome
+
+**Chosen option: the scope split.** It preserves the verifier's hard guarantee unchanged while giving the learned path the strongest contract that is *actually true* — within-build bit-identity for debugging/regression, and cross-machine validity-equivalence below the verifier — and it keeps `determinism-guard`'s meaning crisp (it guards the verifier, never the proposer).
+
+### Why not force the learned path under full ADR-0003 byte-identity?
+
+Cross-hardware bit-identity for neural inference is brittle-to-impossible: it would require pinning the execution provider, disabling fast-math/fused ops, and freezing BLAS threading on every consumer's machine, and would *still* break on a different CPU/GPU. The contract would either be unmeetable (blocking the backend) or so fragile that a green check would give false confidence. The byte-identity guarantee earns its keep on the deterministic solver, where it is cheap and real; on the learned path it is neither.
+
+### Why not exempt the learned path from any determinism contract?
+
+A backend with *no* reproducibility contract cannot be debugged or regression-tested — a flaky proposal could not be distinguished from a regression, and "re-run and hope" is not a contract. Within-build bit-identity (achievable with fixed weights/seed/EP) is worth keeping; discarding it loses real value for no gain. The verifier-as-final-gate protects *safety* but says nothing about *reproducibility*, which is what this ADR is about.
+
+## Consequences
+
+### Positive
+
+- The deterministic tool's trust contract is untouched: `determinism-guard` still means "the verifier/solver is bit-reproducible," with no carve-out that dilutes it.
+- The learned backend ships with an honest, testable contract instead of an unmeetable promise or none at all.
+- The safety invariant is orthogonal and preserved: the verifier rejects any invalid proposal regardless of determinism tier.
+
+### Negative
+
+- Two reproducibility tiers must be documented and understood (verifier strict; proposer weaker).
+- The learned path needs its **own** canaries — a within-build double-run bit-identity check and a cross-machine validity-equivalence check — built when the backend lands (a later #607 rung).
+
+### Neutral
+
+- Until the learned backend is implemented, **no learned code exists**, so this ADR changes nothing about current behavior: `determinism-guard` and the verifier contract are exactly as before. The ADR records the governing decision ahead of the build so the contract cannot drift during implementation.
+- `determinism-guard` continues to guard only `solver.py` / `towplanner.py`; the `--backend learned` path is explicitly out of its remit.
+
+## Compliance
+
+- Existing: `determinism-guard` (the double-solve diff on `solver.py` / `towplanner.py`) remains the compliance check for the **verifier** contract, unchanged.
+- Future (when the learned backend lands): two new learned-path canaries — within-build double-run **bit-identical** (fixed weights + seed + pinned EP), and cross-machine **verifier-validity-only** — are the compliance checks for the **proposer** contract. They are NOT `determinism-guard`.
+- No automated check is required while the backend is a stub (`solve_learned` raises `LearnedBackendUnavailableError`); the seam is exercised by the CLI clean-error test.
+
+## More Information
+
+- Related ADRs: [ADR-0003](0003-rr-mc-solver-algorithm.md) (the byte-identical contract whose scope this amends).
+- Related specs: [`docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`](../superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md) (§8 Determinism & the verifier relationship).
+- Related spikes: `docs/spikes/cnn-layout.md` (#331), `docs/spikes/cnn-tow-path.md` (#332).
+- Related issues: epic #607; this rung #670.

--- a/docs/adr/0027-learned-backend-determinism-scope.md
+++ b/docs/adr/0027-learned-backend-determinism-scope.md
@@ -71,6 +71,6 @@ A backend with *no* reproducibility contract cannot be debugged or regression-te
 ## More Information
 
 - Related ADRs: [ADR-0003](0003-rr-mc-solver-algorithm.md) (the byte-identical contract whose scope this amends).
-- Related specs: [`docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`](../superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md) (§8 Determinism & the verifier relationship).
-- Related spikes: `docs/spikes/cnn-layout.md` (#331), `docs/spikes/cnn-tow-path.md` (#332).
+- Related specs: [`docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`](../superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md) — its §8 (Determinism & the verifier relationship) sketches the two-tier story and *defers* the binding decision to its sub-project #5; **this ADR is that decision**.
+- Related spikes: #331 (CNN layout) and #332 (CNN tow path) — concluded in `docs/spikes/cnn-layout.md` / `docs/spikes/cnn-tow-path.md` (landing via #669).
 - Related issues: epic #607; this rung #670.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -103,3 +103,5 @@ manual workflow above is canonical.
 | 0023 | [Model the empennage as explicit tail surfaces so a vertical fin in the wing layer can block wing-over-tail nesting](0023-empennage-tail-surfaces.md) | Accepted |
 | 0024 | [Optional polygon footprints on `Part` — load-time-canonicalized, authored via `planform:` (refines [ADR-0001](0001-aircraft-parts-model.md))](0024-optional-polygon-parts.md) | Accepted |
 | 0025 | [Ground-object taxonomy — concrete catalog types, Layout-uniform placement, and pairwise-set keep-out seam](0025-ground-object-taxonomy.md) | Accepted |
+| 0026 | [Caddy hard-door egress — clear-egress routability gate](0026-caddy-hard-door-egress.md) | Accepted |
+| 0027 | [Learned-backend determinism scope — verifier strict, proposer weaker (amends [ADR-0003](0003-rr-mc-solver-algorithm.md))](0027-learned-backend-determinism-scope.md) | Proposed |

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -353,6 +353,18 @@ def build_parser() -> argparse.ArgumentParser:
             "hard fills; a global per-fill cap bounds the worst case (#336)."
         ),
     )
+    solve.add_argument(
+        "--backend",
+        choices=("rrmc", "learned"),
+        default="rrmc",
+        dest="backend",
+        help=(
+            "Solver backend. 'rrmc' (default) is the shipped deterministic "
+            "random-restart min-conflicts solver (ADR-0003). 'learned' selects the "
+            "opt-in neural backend (epic #607) — not yet available, so it exits "
+            "cleanly with a message; the deterministic path is unchanged (ADR-0027)."
+        ),
+    )
 
     view = sub.add_parser(
         "view",
@@ -664,6 +676,7 @@ def cmd_solve(args: argparse.Namespace) -> int:
     # ``from hangarfit import visualize`` at module top (cli.py:20) already
     # eagerly imports matplotlib and pins the Agg backend, so both `check`
     # and `solve` callers pay that cost regardless.
+    from hangarfit.learned import LearnedBackendUnavailableError, solve_learned
     from hangarfit.loader import load_scenario
     from hangarfit.models import SearchConfig
     from hangarfit.solver import _parallel_eligible, solve
@@ -703,64 +716,81 @@ def cmd_solve(args: argparse.Namespace) -> int:
         print(f"error: {e}", file=sys.stderr)
         return 2
 
-    # Tow-plan only when the user asked to render paths (#193). Otherwise
-    # plan_paths=False: the library bundle (SolveResult.plans) is available to
-    # callers, but the CLI would just pay the per-plane Hybrid-A* search cost
-    # for output it never draws.
-    try:
-        search_cfg = SearchConfig(
-            spread=args.spread,
-            nose_out=args.nose_out,
-            back_bias_weight=_BACK_FILL_DEFAULT_WEIGHT if args.back_fill else 0.0,
-            max_restarts=args.max_restarts,
-            spread_stall_restarts=args.spread_stall_restarts,
+    # Backend dispatch (#607 / ADR-0027). The default deterministic RR-MC path is
+    # unchanged and byte-identical; `--backend learned` routes to the opt-in learned
+    # proposer, which returns the same SolveResult shape. It is not yet implemented,
+    # so it surfaces a clean exit-2 error rather than a traceback.
+    if args.backend == "learned":
+        try:
+            result = solve_learned(
+                scenario,
+                budget_s=args.budget,
+                alternatives=args.alternatives,
+                seed=args.seed,
+                plan_paths=args.render_paths,
+            )
+        except LearnedBackendUnavailableError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 2
+    else:
+        # Tow-plan only when the user asked to render paths (#193). Otherwise
+        # plan_paths=False: the library bundle (SolveResult.plans) is available to
+        # callers, but the CLI would just pay the per-plane Hybrid-A* search cost
+        # for output it never draws.
+        try:
+            search_cfg = SearchConfig(
+                spread=args.spread,
+                nose_out=args.nose_out,
+                back_bias_weight=_BACK_FILL_DEFAULT_WEIGHT if args.back_fill else 0.0,
+                max_restarts=args.max_restarts,
+                spread_stall_restarts=args.spread_stall_restarts,
+            )
+        except ValueError as e:
+            # A bad restart-budget knob (e.g. --max-restarts 0 or --spread-stall-restarts
+            # 0; both must be >= 1 when set) surfaces as a clean exit-2 input error rather
+            # than an uncaught traceback — same contract as a LoaderError on malformed input.
+            print(f"error: {e}", file=sys.stderr)
+            return 2
+        # Never silently ignore --workers (#544): if parallel restarts aren't
+        # byte-identical-eligible for this config (no --max-restarts, or --no-spread),
+        # solve() transparently runs serial — say so on stderr so the user isn't
+        # left believing they got the speedup.
+        cpu_cores = os.cpu_count() or 1
+        if args.workers > 1 and not _parallel_eligible(search_cfg, args.workers):
+            print(
+                f"note: --workers {args.workers} ignored (runs serial) — parallel "
+                "restarts need --max-restarts and the spread post-pass (drop "
+                "--no-spread); see --workers help",
+                file=sys.stderr,
+            )
+        elif args.workers == 1 and cpu_cores > 1 and _parallel_eligible(search_cfg, 2):
+            # This config IS parallel-eligible (--max-restarts + spread) but the
+            # restarts run serial on a multi-core box, leaving cores idle. Probe
+            # eligibility with a worker count of 2 (the predicate requires workers > 1;
+            # the user's actual --workers is 1). Suggest the flag rather than silently
+            # waste the cores — zero behaviour change, stderr only so --json /
+            # --write-yaml stay machine-readable (#628).
+            # Cap the SUGGESTED count: the #544 speedup is sub-linear (~4.5x at 8
+            # workers), so don't over-promise cores-2 on a big box — it's an example.
+            _suggest = min(8, max(1, cpu_cores - 2))
+            print(
+                f"hint: this is a multi-restart spread solve running serial on a "
+                f"{cpu_cores}-core box — add --workers N (e.g. --workers {_suggest}) to fan "
+                f"the {args.max_restarts} restarts across processes "
+                "(byte-identical to serial; #544).",
+                file=sys.stderr,
+            )
+        result = solve(
+            scenario,
+            budget_s=args.budget,
+            alternatives=args.alternatives,
+            seed=args.seed,
+            search=search_cfg,
+            plan_paths=args.render_paths,
+            tow_heuristic=args.tow_heuristic,
+            tow_max_expansions=args.tow_max_expansions,
+            workers=args.workers,
         )
-    except ValueError as e:
-        # A bad restart-budget knob (e.g. --max-restarts 0 or --spread-stall-restarts
-        # 0; both must be >= 1 when set) surfaces as a clean exit-2 input error rather
-        # than an uncaught traceback — same contract as a LoaderError on malformed input.
-        print(f"error: {e}", file=sys.stderr)
-        return 2
-    # Never silently ignore --workers (#544): if parallel restarts aren't
-    # byte-identical-eligible for this config (no --max-restarts, or --no-spread),
-    # solve() transparently runs serial — say so on stderr so the user isn't
-    # left believing they got the speedup.
-    cpu_cores = os.cpu_count() or 1
-    if args.workers > 1 and not _parallel_eligible(search_cfg, args.workers):
-        print(
-            f"note: --workers {args.workers} ignored (runs serial) — parallel "
-            "restarts need --max-restarts and the spread post-pass (drop "
-            "--no-spread); see --workers help",
-            file=sys.stderr,
-        )
-    elif args.workers == 1 and cpu_cores > 1 and _parallel_eligible(search_cfg, 2):
-        # This config IS parallel-eligible (--max-restarts + spread) but the
-        # restarts run serial on a multi-core box, leaving cores idle. Probe
-        # eligibility with a worker count of 2 (the predicate requires workers > 1;
-        # the user's actual --workers is 1). Suggest the flag rather than silently
-        # waste the cores — zero behaviour change, stderr only so --json /
-        # --write-yaml stay machine-readable (#628).
-        # Cap the SUGGESTED count: the #544 speedup is sub-linear (~4.5x at 8
-        # workers), so don't over-promise cores-2 on a big box — it's an example.
-        _suggest = min(8, max(1, cpu_cores - 2))
-        print(
-            f"hint: this is a multi-restart spread solve running serial on a "
-            f"{cpu_cores}-core box — add --workers N (e.g. --workers {_suggest}) to fan "
-            f"the {args.max_restarts} restarts across processes "
-            "(byte-identical to serial; #544).",
-            file=sys.stderr,
-        )
-    result = solve(
-        scenario,
-        budget_s=args.budget,
-        alternatives=args.alternatives,
-        seed=args.seed,
-        search=search_cfg,
-        plan_paths=args.render_paths,
-        tow_heuristic=args.tow_heuristic,
-        tow_max_expansions=args.tow_max_expansions,
-        workers=args.workers,
-    )
 
     # Spread-vs-towability fallback (#280 → #402 / F5; ADR-0016). The re-solve
     # that swaps in a tighter, tow-routable no-spread arrangement when the spread

--- a/src/hangarfit/learned.py
+++ b/src/hangarfit/learned.py
@@ -1,0 +1,60 @@
+"""Learned-backend seam (epic #607).
+
+The deterministic RR-MC :func:`hangarfit.solver.solve` is the default and the
+only *working* backend today. This module is the **seam** for the opt-in learned
+backend: a sibling entry point that returns the same :class:`~hangarfit.models.SolveResult`
+shape, so every downstream consumer (render / ``view`` / ``--write-yaml``) stays
+backend-agnostic.
+
+It is **not yet implemented**. Calling :func:`solve_learned` always raises
+:class:`LearnedBackendUnavailableError`; the learned policy, its training, and the
+``[learned-infer]`` runtime extra arrive in later rungs of #607.
+
+Determinism: the learned proposer is **not** under the ADR-0003 byte-identical
+contract — that contract stays on the verifier (``collisions.check`` + ``towplanner``),
+which remains the sole arbiter of validity and routability. The learned path's own
+(weaker) determinism contract is governed by ADR-0027.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hangarfit.models import Scenario, SolveResult
+
+
+class LearnedBackendUnavailableError(RuntimeError):
+    """Raised when the learned backend is requested but cannot run.
+
+    Today this is *always* raised: the learned backend (epic #607) is not yet
+    implemented. Once it ships, this will instead signal a missing optional
+    ``[learned-infer]`` runtime dependency or absent model weights — letting the
+    CLI surface a clean, actionable error rather than an import traceback.
+    """
+
+
+def solve_learned(
+    scenario: Scenario,
+    *,
+    budget_s: float = 30.0,
+    alternatives: int = 1,
+    seed: int | None = None,
+    plan_paths: bool = True,
+) -> SolveResult:
+    """Learned-backend counterpart to :func:`hangarfit.solver.solve`.
+
+    Intended contract (once implemented): propose poses **and** the place-and-tow
+    sequence with a learned policy, then return the same
+    :class:`~hangarfit.models.SolveResult` shape (poses + tow ``MovesPlan``) as the
+    deterministic backend, with the verifier accepting/rejecting every layout. The
+    signature mirrors the user-facing knobs of :func:`solve` so the CLI can dispatch
+    on ``--backend`` without reshaping the call.
+
+    **Not yet implemented** (epic #607): always raises
+    :class:`LearnedBackendUnavailableError`.
+    """
+    raise LearnedBackendUnavailableError(
+        "the learned solver backend is not yet available (tracked in #607); "
+        "use the default --backend rrmc"
+    )

--- a/src/hangarfit/learned.py
+++ b/src/hangarfit/learned.py
@@ -1,8 +1,8 @@
 """Learned-backend seam (epic #607).
 
-The deterministic RR-MC :func:`hangarfit.solver.solve` is the default and the
-only *working* backend today. This module is the **seam** for the opt-in learned
-backend: a sibling entry point that returns the same :class:`~hangarfit.models.SolveResult`
+The deterministic RR-MC :func:`hangarfit.solver.solve` is the default backend.
+This module is the **seam** for the opt-in learned backend: a sibling entry point
+that returns the same :class:`~hangarfit.models.SolveResult`
 shape, so every downstream consumer (render / ``view`` / ``--write-yaml``) stays
 backend-agnostic.
 

--- a/tests/test_cli_backend.py
+++ b/tests/test_cli_backend.py
@@ -1,0 +1,39 @@
+"""CLI surface for the ``solve --backend`` switch (epic #607 rung 1, ADR-0027).
+
+The default ``rrmc`` path is the unchanged deterministic solver; ``learned`` is the
+opt-in neural backend, not yet implemented, which must fail cleanly (exit 2).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hangarfit.cli import build_parser, main
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+SMOKE_FIXTURE = str(FIXTURES_DIR / "solve_feasible_smoke.yaml")
+
+
+class TestBackendFlag:
+    def test_backend_defaults_to_rrmc(self):
+        args = build_parser().parse_args(["solve", SMOKE_FIXTURE])
+        assert args.backend == "rrmc"
+
+    def test_backend_learned_parses(self):
+        args = build_parser().parse_args(["solve", SMOKE_FIXTURE, "--backend", "learned"])
+        assert args.backend == "learned"
+
+    def test_backend_invalid_choice_rejected(self):
+        # argparse rejects an unknown choice with SystemExit(2) before any solving.
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["solve", SMOKE_FIXTURE, "--backend", "bogus"])
+
+    def test_backend_learned_exits_2_cleanly(self, capsys):
+        # Not implemented yet (#607): a clean exit-2 error, not a traceback.
+        code = main(["solve", SMOKE_FIXTURE, "--backend", "learned"])
+        assert code == 2
+        err = capsys.readouterr().err
+        assert "learned" in err.lower()
+        assert "#607" in err

--- a/tests/test_learned.py
+++ b/tests/test_learned.py
@@ -1,0 +1,27 @@
+"""Unit tests for the learned-backend seam (epic #607 rung 1, ADR-0027).
+
+The learned backend is a stub until #607 lands: :func:`solve_learned` must raise
+the documented :class:`LearnedBackendUnavailableError` so the CLI can surface a
+clean, actionable message instead of a traceback.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hangarfit.learned import LearnedBackendUnavailableError, solve_learned
+
+
+def test_unavailable_error_is_runtime_error():
+    # A RuntimeError subclass so callers that don't know the seam still catch it,
+    # and so it reads as "couldn't run", not "bad input".
+    assert issubclass(LearnedBackendUnavailableError, RuntimeError)
+
+
+def test_solve_learned_raises_unavailable():
+    # The stub raises before touching the scenario, so a sentinel is fine here.
+    with pytest.raises(LearnedBackendUnavailableError) as exc:
+        solve_learned(None)
+    msg = str(exc.value)
+    assert "#607" in msg
+    assert "rrmc" in msg  # points the user at the working default


### PR DESCRIPTION
## What & why

First rung of the **#607 learned-backend epic** — the foundation, with **no ML dependencies**. Establishes the two things every later rung depends on: the **integration contract** (`--backend` switch + a `solve_learned()` library entry returning the same `SolveResult`) and the **determinism-scope decision** (ADR-0027).

Closes #670
Refs #607

## Changes

- **ADR-0027 (Proposed) — learned-backend determinism scope.** Amends ADR-0003's *scope*: the verifier (`collisions.check` + `towplanner`) stays strictly byte-identical and `determinism-guard`-gated; the opt-in learned **proposer** gets a weaker, documented contract (within-build bit-identical; cross-machine validity-only) and is **outside** `determinism-guard`. ADR-0003 cross-links it; the ADR README index is updated (and backfills the missing ADR-0026 row).
- **`solve --backend {rrmc,learned}`** (default `rrmc`). The deterministic path is wrapped **unchanged** in the `else` branch — byte-identical (82 `test_cli_solve` tests green; the rrmc `solve()` call + `SearchConfig` are untouched). `--backend learned` dispatches to the new `hangarfit.learned.solve_learned()` entry, which returns the same `SolveResult` shape but is **stubbed to raise** `LearnedBackendUnavailableError`; the CLI surfaces it as a clean **exit-2** error pointing at #607, not a traceback.
- **Tests:** the stub raises the documented error; the flag parses, rejects bad choices (argparse exit 2), and errors cleanly with a `#607` pointer. **CHANGELOG** entry added.

## Determinism note

No `solver.py` / `towplanner.py` change — the deterministic backend's behavior and its ADR-0003 byte-identity are untouched (the `--backend` dispatch only wraps the existing `solve()` call). ADR-0027 records that the *future* learned path sits outside `determinism-guard`, with its own canaries to land when the backend is built.

## Scope / non-goals (later #607 rungs)

No `ml/` tree, no policy network or training, no `onnxruntime` / `[learned-infer]` or `[train]` extras, no model weights. `--backend learned` is a stubbed seam only.
