### PR TITLE
feat(607): 4c-ii train-to-mastery enablement + knobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#607, 4c-ii): cold-joint RL env fixed-obstacle support and
+  four default-neutral basin-escape knobs.** Fixed-obstacle pre-placements
+  (immovable keep-outs from `Scenario.fixed_obstacle_placements`) are now honoured
+  by `HangarFitEnv` — they are rendered into the occupancy raster and block the
+  agent from parking on top of them, unblocking the eval benchmark's policy column
+  on the Herrenteich anchors. Four optional training knobs are added, all
+  default-neutral (byte-identical to prior runs when not set): `--r-valid-park`
+  (bonus per Park action when the full layout passes `layout_valid`),
+  `--dense-slot-potential` (in-hangar nearest-free-pocket shaping),
+  `--entropy-start/--entropy-end/--entropy-anneal-iters` (per-rung entropy
+  coefficient anneal), and `--normalize-returns` (std-only Welford return
+  normalization before GAE). Training defaults are unchanged.
+
 - **Cold-joint RL curriculum schedule (#607 sub-project #4b).** `python -m ml.train
   --schedule curriculum` now climbs a competency-gated difficulty ladder (object
   count → hangar shape → clearance) instead of training a single fixed stage; the
@@ -227,6 +240,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
   the tow-motion abstraction (#643).
 
 ### Fixed
+
+- **Learned backend env validity now matches `collisions.check` (#694).** The
+  `HangarFitEnv` oracle no longer over-enforces the inert placeholder maintenance
+  bay (the bay is only active when an aircraft is explicitly placed there; the
+  `layout_valid` helper that the benchmark already uses is now the single shared
+  validity gate for both the env reward and `ml/eval`).
 
 - **`view` surfaces un-routable ground-object movers (#634).** Layout-mode
   `hangarfit view` already named an un-tow-routable *aircraft* (the static-degrade

--- a/docs/superpowers/plans/2026-06-17-607-4cii-train-to-mastery-enablement.md
+++ b/docs/superpowers/plans/2026-06-17-607-4cii-train-to-mastery-enablement.md
@@ -1,0 +1,1125 @@
+# 4c-ii Train-to-Mastery Enablement + Knobs — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unblock the learned-backend benchmark's policy column on the real Herrenteich anchors (env fixed-obstacle support), fix the #694 maintenance-bay oracle divergence, and add four default-neutral knobs that let the policy escape the place-nothing/place-invalid local optimum — all without touching `src/` or the deterministic solver.
+
+**Architecture:** All work lives in the top-level torch-free-where-possible `ml/` package (never in the wheel). The deterministic `collisions.check` is consumed read-only as the single source of validity truth via a new shared `ml/geometry_oracle.layout_valid()` helper. The four knobs (`r_valid_park`, `dense_slot_potential`, per-rung entropy anneal, std-only return normalization) all default to a neutral value that reproduces today's training byte-identically; only the #694 fix changes behavior at defaults (a deliberate bugfix).
+
+**Tech Stack:** Python 3.12, shapely (geometry oracle), PyTorch (`[train]` extra — ppo/train tests use `importorskip`), pytest. Hangarfit deterministic core (`collisions.check`, `towplanner` motion primitives) reused as the reward oracle only.
+
+## Global Constraints
+
+- **(A) Apron-entry realism:** `reset()`/`_spawn()` are NEVER modified. Every object the policy places is driven in from the apron. No teleport / mid-hangar spawn.
+- **(B) Solver-independence:** `solve()` / RR-MC / Hybrid-A* is NEVER invoked in the training loop. No anchor/witness/label/start-state from the deterministic search. The `dense_slot_potential` query is a pure `state → scalar` shapely query — never a placement search or nester.
+- **Default-neutral knobs:** All seven new config fields default neutral; knobs-off ⇒ reward scalar + PPO update bit-identical to the post-#694 code. The #694 fix itself is NOT neutral (it changes behavior on bay-clipping layouts by design).
+- **No `src/` changes.** Only files under `ml/`, `tests/ml/`, `docs/`, `CHANGELOG.md`. `collisions.check` is read-only.
+- **No `--no-verify`, no force-push.** The PostToolUse hook runs ruff+pytest after `ml/`/`tests/` edits; the Stop hook runs mypy. Fix root causes.
+- **Lint/type:** `ruff check ml/ tests/ml/`, `ruff format ml/ tests/ml/`, `mypy ml/` (or the project's configured `mypy` target) must pass.
+- **`seed_anchor` stays the unused `False` placeholder** in `DifficultyConfig`. Do not wire it.
+- Branch: `feature/693-train-to-mastery-enablement` (already created; spec committed at `f37bca8`). PR body: `Closes #693`, `Closes #694`.
+
+---
+
+## File structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `ml/geometry_oracle.py` | Add `layout_valid()` (shared validity); gate `intrusion_area_m2` bay term; add `active_misfit_m2()` | Modify |
+| `ml/types.py` | `RewardWeights`: add `r_valid_park`, `dense_slot_potential` | Modify |
+| `ml/reward.py` | `RewardContext.park_valid`; `potential(active_misfit_m2=...)`; `step_reward` bonus | Modify |
+| `ml/env.py` | `_fixed` list + `_layout()` union; delegate `_layout_valid` to oracle; `park_valid` + bay-gated intrusion in Park; dense potential | Modify |
+| `ml/benchmark.py` | `_layout_valid` → call-through; `build_scenario_env` pre-places fixed obstacles | Modify |
+| `ml/ppo.py` | `PPOConfig` fields; `entropy_coef_at()`; `ReturnNormalizer`; `ppo_update` optional normalizer | Modify |
+| `ml/train.py` | Thread `RewardWeights`; per-rung entropy wiring; normalizer; CLI flags | Modify |
+| `tests/ml/test_geometry_oracle.py` | bay-gate, layout_valid, active_misfit, #694 regression | Modify |
+| `tests/ml/test_reward.py` | r_valid_park gate + ordering; potential neutrality | Modify |
+| `tests/ml/test_env.py` | fixed-obstacle union, terminal_fraction, #694 integration | Modify |
+| `tests/ml/test_benchmark.py` | build_scenario_env accepts anchors | Modify |
+| `tests/ml/test_ppo.py` | entropy schedule fn; return normalizer | Modify |
+| `tests/ml/test_train_curriculum.py` | per-rung entropy; defaults neutral | Modify |
+| `CHANGELOG.md`, `ml/README.md` | `[Unreleased]` entry + knob docs | Modify |
+
+**Run tests with:** `pytest tests/ml/ -q` (torch tests `importorskip`; torch is installed CPU locally per project notes). Single test: `pytest tests/ml/test_x.py::test_y -v`.
+
+---
+
+## Task 1: #694 — unify validity through one shared oracle helper
+
+**Files:**
+- Modify: `ml/geometry_oracle.py` (add `layout_valid`; gate `intrusion_area_m2` bay term)
+- Modify: `ml/env.py` (`_layout_valid` delegates; Park-branch intrusion uses `bay_closed=False`)
+- Modify: `ml/benchmark.py` (`_layout_valid` becomes a call-through)
+- Test: `tests/ml/test_geometry_oracle.py`, `tests/ml/test_env.py`
+
+**Interfaces:**
+- Produces: `geometry_oracle.layout_valid(layout: Layout) -> bool` (= `check(layout).valid and not egress_blocked(layout)`); `intrusion_area_m2(body, placement, hangar, *, bay_closed: bool = False) -> float`.
+- Consumes: `hangarfit.collisions.check` (`CheckResult.valid` property; `.conflicts`), `geometry_oracle.egress_blocked`.
+
+- [ ] **Step 1: Write the failing test for the bay gate**
+
+In `tests/ml/test_geometry_oracle.py` add (reuse `_fuji`, `empty_hangar` from conftest):
+
+```python
+from shapely.geometry import box
+from hangarfit.geometry import aircraft_parts_world
+from hangarfit.models import Placement
+from ml import geometry_oracle as go
+
+
+def _bay_area_for(body, placement, hangar):
+    bay = hangar.maintenance_bay
+    bay_poly = box(bay.center_x_m - bay.width_m / 2, hangar.length_m - bay.depth_m,
+                   bay.center_x_m + bay.width_m / 2, hangar.length_m)
+    return sum(wp.polygon.intersection(bay_poly).area for wp in aircraft_parts_world(body, placement))
+
+
+def test_intrusion_bay_term_gated_on_bay_closed():
+    fleet = _fuji()
+    hangar = empty_hangar()
+    body = fleet["fuji"]
+    bay = hangar.maintenance_bay
+    # Park inside the bay rectangle (centroid at the bay centre, one body-length in).
+    pl = Placement(plane_id="fuji", x_m=bay.center_x_m,
+                   y_m=hangar.length_m - bay.depth_m / 2, heading_deg=0.0, on_carts=False)
+    overlap_area = _bay_area_for(body, pl, hangar)
+    assert overlap_area > 0.0, "fixture must actually clip the bay; adjust y if not"
+    open_intr = go.intrusion_area_m2(body, pl, hangar, bay_closed=False)
+    closed_intr = go.intrusion_area_m2(body, pl, hangar, bay_closed=True)
+    assert closed_intr - open_intr == pytest.approx(overlap_area, abs=1e-6)
+```
+
+Add `import pytest` if absent.
+
+- [ ] **Step 2: Run it — expect FAIL** (`bay_closed` is not a parameter yet)
+
+Run: `pytest tests/ml/test_geometry_oracle.py::test_intrusion_bay_term_gated_on_bay_closed -v`
+Expected: FAIL — `TypeError: intrusion_area_m2() got an unexpected keyword argument 'bay_closed'`.
+
+- [ ] **Step 3: Gate the bay term in `intrusion_area_m2`**
+
+In `ml/geometry_oracle.py`, change the signature and the bay loop:
+
+```python
+def intrusion_area_m2(
+    body: Aircraft | GroundObject,
+    placement: Placement,
+    hangar: Hangar,
+    *,
+    bay_closed: bool = False,
+) -> float:
+    """Footprint area (m²) outside the hangar floor or inside a CLOSED maintenance bay.
+
+    Mirrors collisions.check's ADR-0006 rule: the maintenance bay is a keep-out ONLY when
+    it is closed (``layout.maintenance_plane is not None``). The env never sets a maintenance
+    occupant, so it always passes ``bay_closed=False`` and the bay term vanishes — fixing the
+    #694 over-strict-inert-bay divergence on the reward gradient. Out-of-floor (walls/notch via
+    ``floor_polygon``) is always counted. The front apron (``y < 0``) counts as intrusion for a
+    PARKED pose (it is a motion region, not a parked-validity region)."""
+    floor = hangar.floor_polygon
+    if floor is None:
+        floor = box(0.0, 0.0, hangar.width_m, hangar.length_m)
+    bay = hangar.maintenance_bay
+    bay_poly = box(
+        bay.center_x_m - bay.width_m / 2.0,
+        hangar.length_m - bay.depth_m,
+        bay.center_x_m + bay.width_m / 2.0,
+        hangar.length_m,
+    )
+    total = 0.0
+    for wp in aircraft_parts_world(body, placement):
+        poly = wp.polygon
+        total += poly.difference(floor).area  # outside the floor (walls/notch)
+        if bay_closed:
+            total += poly.intersection(bay_poly).area  # inside a CLOSED maintenance bay
+    return total
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pytest tests/ml/test_geometry_oracle.py::test_intrusion_bay_term_gated_on_bay_closed -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test for `layout_valid` + the #694 integration regression**
+
+```python
+from pathlib import Path
+from hangarfit.collisions import check
+from hangarfit.loader import load_layout
+
+_ROOT = Path(__file__).resolve().parents[2]  # repo root
+
+
+def test_layout_valid_matches_product_checker_plus_egress():
+    layout = single_object_layout(x_m=5.0, y_m=5.0)  # a clean, valid placement
+    assert go.layout_valid(layout) == (check(layout).valid and not go.egress_blocked(layout))
+    assert go.layout_valid(layout) is True
+
+
+def test_layout_full_witness_is_valid_694_regression():
+    # The committed herrenteich_full witness was WRONGLY rejected by the old env oracle
+    # (inert maintenance bay over-enforced, #694). It is valid per the product checker.
+    layout = load_layout(str(_ROOT / "examples/herrenteich/layout_full.yaml"))
+    assert check(layout).valid, "precondition: witness valid per collisions.check"
+    assert go.layout_valid(layout) is True
+```
+
+- [ ] **Step 6: Run — expect FAIL** (`layout_valid` not defined)
+
+Run: `pytest tests/ml/test_geometry_oracle.py -k "layout_valid or 694" -v`
+Expected: FAIL — `AttributeError: module 'ml.geometry_oracle' has no attribute 'layout_valid'`.
+
+- [ ] **Step 7: Add `layout_valid` to `ml/geometry_oracle.py`**
+
+Add to `__all__` (`"layout_valid"`) and define (place near `egress_blocked`):
+
+```python
+def layout_valid(layout: Layout) -> bool:
+    """Whole-layout validity per the PRODUCT deterministic checker (== ``hangarfit check``):
+    collisions.check reports no conflicts (overlap + hangar bounds/notch + CONDITIONAL
+    maintenance bay + ground-obstacle keep-outs) AND no Caddy hard-door egress violation
+    (ADR-0026). The single source of validity truth shared by the env gate, the r_valid_park
+    bonus gate, and the benchmark — so the bonus and the promotion metric can never disagree.
+    Replaces the env's old hand-rolled overlap+intrusion+egress, which over-enforced the inert
+    maintenance bay (#694)."""
+    return check(layout).valid and not egress_blocked(layout)
+```
+
+- [ ] **Step 8: Run — expect PASS**
+
+Run: `pytest tests/ml/test_geometry_oracle.py -k "layout_valid or 694" -v`
+Expected: PASS.
+
+- [ ] **Step 9: Delegate `env._layout_valid` to the oracle; bay-gate the Park intrusion**
+
+In `ml/env.py`, replace `_layout_valid` (lines ~255-269) with:
+
+```python
+    def _layout_valid(self) -> bool:
+        """Whole-layout validity == the product checker (the prime directive's final gate),
+        via the shared ``geometry_oracle.layout_valid``. Reward terms read ctx, not this, so
+        this is gate/reporting only. (Was hand-rolled overlap+intrusion+egress that
+        over-enforced the inert maintenance bay — #607 SP#4c-ii / #694.)"""
+        return go.layout_valid(self._layout())
+```
+
+In the Park branch (line ~178), pass `bay_closed=False` (the env never closes the bay):
+
+```python
+            intrusion = go.intrusion_area_m2(body, pl, self.hangar, bay_closed=False)
+```
+
+- [ ] **Step 10: Write the env-level #694 integration test**
+
+In `tests/ml/test_env.py`:
+
+```python
+def test_env_layout_valid_delegates_to_product_checker():
+    from ml import geometry_oracle as go
+    env = HangarFitEnv(hangar=empty_hangar(), fleet=_fuji(), requested_ids=("fuji",))
+    env.reset()
+    assert env._layout_valid() == go.layout_valid(env._layout())
+```
+
+- [ ] **Step 11: Run the full Task-1 test set + lint/type**
+
+Run: `pytest tests/ml/test_geometry_oracle.py tests/ml/test_env.py -q`
+Then: `ruff check ml/ tests/ml/ && ruff format --check ml/ tests/ml/ && mypy ml/`
+Expected: all PASS. (If a 4b golden reward/history fixture asserted bay-clipping behavior, it now changes — re-baseline it and note the diff as the #694 correction.)
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add ml/geometry_oracle.py ml/env.py ml/benchmark.py tests/ml/test_geometry_oracle.py tests/ml/test_env.py
+git commit -m "fix(607): unify env validity via shared layout_valid oracle; gate bay on ADR-0006 (#694)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+(Also make `benchmark._layout_valid` a call-through in this commit — see Step 13.)
+
+- [ ] **Step 13: Make `benchmark._layout_valid` a call-through (single source of truth)**
+
+In `ml/benchmark.py`, replace the body of `_layout_valid` with:
+
+```python
+def _layout_valid(layout: Layout) -> bool:
+    """Valid per the PRODUCT deterministic checker — delegates to the shared
+    geometry_oracle.layout_valid so the env gate, the policy scorer, and witness_valid are
+    judged by one identical predicate (collisions.check + Caddy egress; the inert maintenance
+    bay is conditional, #694)."""
+    return go.layout_valid(layout)
+```
+
+Run: `pytest tests/ml/test_benchmark.py -q` — expect PASS (existing benchmark validity tests unchanged in behavior). Amend the commit or commit separately.
+
+---
+
+## Task 2: Fixed-obstacle env support
+
+**Files:**
+- Modify: `ml/env.py` (constructor `fixed_placements`; `self._fixed`; `_layout()` union)
+- Modify: `ml/benchmark.py` (`build_scenario_env` pre-places fixed obstacles)
+- Test: `tests/ml/test_env.py`, `tests/ml/test_benchmark.py`
+
+**Interfaces:**
+- Consumes: `Scenario.fixed_obstacle_placements: tuple[Placement, ...]`, `Scenario.ground_object_defs`, `Scenario.mover_ids`/`placeable_ids` (benchmark already uses these).
+- Produces: `HangarFitEnv(..., fixed_placements: tuple[Placement, ...] = ())`; `env._fixed: list[Placement]`; `_layout()` includes fixed obstacles.
+
+- [ ] **Step 1: Write the failing test — fixed obstacle is in `_layout()` but not `_parked`, terminal_fraction uncorrupted**
+
+In `tests/ml/test_env.py` (reuse `_fuji`, `empty_hangar`; build a `GroundObject` fixed obstacle):
+
+```python
+from hangarfit.models import GroundObject, Placement
+
+
+def _fuel_trailer() -> GroundObject:
+    # Minimal fixed obstacle; mirrors the catalog maul_fuel_trailer shape closely enough.
+    return GroundObject(id="fuel", length_m=4.0, width_m=2.0, height_m=2.0,
+                        object_class="fixed_obstacle")
+
+
+def test_fixed_obstacle_in_layout_not_parked_and_fraction_uncorrupted():
+    fleet = _fuji()
+    fuel = _fuel_trailer()
+    fixed = (Placement(plane_id="fuel", x_m=2.0, y_m=10.0, heading_deg=0.0, on_carts=False),)
+    env = HangarFitEnv(
+        hangar=empty_hangar(), fleet=fleet, requested_ids=("fuji",),
+        ground_objects={"fuel": fuel}, fixed_placements=fixed,
+    )
+    env.reset()
+    # The fixed obstacle is present in the scene from step 0...
+    layout = env._layout()
+    assert "fuel" in {gp.plane_id for gp in layout.ground_object_placements}
+    # ...but it is NOT counted as a parked (driven-in) object.
+    assert env._fixed == list(fixed)
+    assert all(p.plane_id != "fuel" for p in env._parked)
+    # terminal_fraction denominator is the requested (driven) set only -> 1 here, not 2.
+    # Drive fuji nowhere and Park it: fraction = 1/1 even with the fixed obstacle present.
+    from ml.types import Park
+    _obs, _r, done, info = env.step(Park())
+    assert done and info.total == 1 and info.placed == 1
+```
+
+If `GroundObject`'s required fields differ, mirror an existing GroundObject construction in `tests/` (grep `GroundObject(` under `tests/`).
+
+- [ ] **Step 2: Run — expect FAIL** (`fixed_placements` unknown kwarg)
+
+Run: `pytest tests/ml/test_env.py::test_fixed_obstacle_in_layout_not_parked_and_fraction_uncorrupted -v`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'fixed_placements'`.
+
+- [ ] **Step 3: Add `fixed_placements` to the env constructor + `_fixed`; union in `_layout()`**
+
+In `ml/env.py` `__init__`, add the parameter and store it (after `ground_objects`):
+
+```python
+        ground_objects: Mapping[str, GroundObject] | None = None,
+        fixed_placements: tuple[Placement, ...] = (),
+        difficulty: DifficultyConfig | None = None,
+        weights: RewardWeights | None = None,
+    ) -> None:
+        self.hangar = hangar
+        self.fleet = dict(fleet)
+        self.ground_objects = dict(ground_objects or {})
+        self.requested_ids = requested_ids
+        self._fixed: list[Placement] = list(fixed_placements)
+        self.difficulty = difficulty or DifficultyConfig()
+        self.weights = weights or RewardWeights()
+        self._reset_state()
+```
+
+Change `_layout()` to union parked + fixed:
+
+```python
+    def _layout(self) -> Layout:
+        """The scene of FROZEN objects: driven-in (parked) PLUS pre-placed fixed obstacles
+        (immovable keep-outs). The active object is not yet in it. Fixed obstacles are NOT in
+        ``_parked`` (so terminal_fraction is uncorrupted) but ARE in the scene so overlap /
+        egress / motion-clearance see them."""
+        frozen = self._parked + self._fixed
+        frozen_ids = [p.plane_id for p in frozen]
+        ac = {pid: self.fleet[pid] for pid in frozen_ids if pid in self.fleet}
+        go_ids = [pid for pid in frozen_ids if pid in self.ground_objects]
+        return Layout(
+            fleet=ac or {next(iter(self.fleet)): next(iter(self.fleet.values()))},
+            hangar=self.hangar,
+            placements=tuple(p for p in frozen if p.plane_id in self.fleet),
+            ground_objects={pid: self.ground_objects[pid] for pid in go_ids},
+            ground_object_placements=tuple(p for p in frozen if p.plane_id in self.ground_objects),
+        )
+```
+
+Note: `_fixed` must survive `_reset_state()` (it is set in `__init__`, not in `_reset_state`, so it persists across resets — correct, it is scenario-level).
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pytest tests/ml/test_env.py::test_fixed_obstacle_in_layout_not_parked_and_fraction_uncorrupted -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test — a placed body overlapping a fixed obstacle is invalid**
+
+```python
+def test_placed_body_overlapping_fixed_obstacle_is_invalid():
+    fleet = _fuji()
+    fuel = _fuel_trailer()
+    # Place the fuel obstacle exactly where we will park the fuji -> guaranteed overlap.
+    fixed = (Placement(plane_id="fuel", x_m=9.0, y_m=10.0, heading_deg=0.0, on_carts=False),)
+    env = HangarFitEnv(hangar=empty_hangar(), fleet=fleet, requested_ids=("fuji",),
+                       ground_objects={"fuel": fuel}, fixed_placements=fixed)
+    env.reset()
+    env._active_pose = type(env._active_pose)(x_m=9.0, y_m=10.0, heading_deg=0.0)
+    from ml.types import Park
+    env.step(Park())
+    assert env._layout_valid() is False  # fuji parts overlap the fixed fuel obstacle
+```
+
+- [ ] **Step 6: Run — expect PASS** (already works via `_layout()` union + `layout_valid`)
+
+Run: `pytest tests/ml/test_env.py::test_placed_body_overlapping_fixed_obstacle_is_invalid -v`
+Expected: PASS. (If FAIL, the overlap fixture didn't actually overlap — adjust coordinates so the fuji footprint covers the fuel obstacle.)
+
+- [ ] **Step 7: Write the failing test — `build_scenario_env` accepts a fixed-obstacle anchor**
+
+In `tests/ml/test_benchmark.py`, replace the old "raises NotImplementedError" assertion with:
+
+```python
+from ml.benchmark import BENCH_SET, build_scenario_env
+
+
+def test_build_scenario_env_preplaces_fixed_obstacles_for_anchors():
+    anchor = next(s for s in BENCH_SET if s.name == "herrenteich_full")
+    env = build_scenario_env(anchor)  # must NOT raise
+    env.reset()
+    layout = env._layout()
+    # The fuel trailer (fixed_obstacle) is pre-placed in the scene from step 0...
+    go_ids = {gp.plane_id for gp in layout.ground_object_placements}
+    assert "maul_fuel_trailer" in go_ids
+    # ...and is NOT in the driven queue (requested set excludes fixed obstacles).
+    assert "maul_fuel_trailer" not in env.requested_ids
+```
+
+(Grep the old test name asserting `NotImplementedError` / `pytest.raises` on `build_scenario_env` and delete it.)
+
+- [ ] **Step 8: Run — expect FAIL** (`build_scenario_env` still raises)
+
+Run: `pytest tests/ml/test_benchmark.py::test_build_scenario_env_preplaces_fixed_obstacles_for_anchors -v`
+Expected: FAIL — `NotImplementedError: ... carries fixed obstacle(s)`.
+
+- [ ] **Step 9: Replace the raise with pre-placement in `build_scenario_env`**
+
+In `ml/benchmark.py`, replace the `fixed`/`if fixed: raise NotImplementedError(...)` block and the env construction with:
+
+```python
+    fixed_ids = [
+        gid for gid in sc.ground_objects
+        if sc.ground_object_defs[gid].object_class == "fixed_obstacle"
+    ]
+    placeable = sc.placeable_ids
+    # Movers (placed_routed_mover) are driven in; fixed obstacles are pre-placed keep-outs.
+    movers = {gid: sc.ground_object_defs[gid] for gid in sc.mover_ids}
+    fixed_defs = {gid: sc.ground_object_defs[gid] for gid in fixed_ids}
+    per_object = 120
+    difficulty = DifficultyConfig(
+        max_objects=len(placeable),
+        per_object_step_budget=per_object,
+        total_step_budget=per_object * max(1, len(placeable)),
+    )
+    hangar = replace(sc.hangar, apron_depth_m=8.0)
+    return HangarFitEnv(
+        hangar=hangar,
+        fleet=sc.fleet,
+        requested_ids=placeable,
+        ground_objects={**movers, **fixed_defs},
+        fixed_placements=sc.fixed_obstacle_placements,
+        difficulty=difficulty,
+    )
+```
+
+Verify `sc.placeable_ids` excludes fixed-obstacle ids (it is aircraft + movers). If `placeable_ids` includes fixed obstacles, subtract `fixed_ids` from `requested_ids` explicitly:
+`requested_ids = tuple(i for i in placeable if i not in set(fixed_ids))`. (Confirm from `models.Scenario.placeable_ids` definition during implementation; adjust the docstring accordingly.) Update `build_scenario_env`'s docstring to describe pre-placement instead of the raise.
+
+- [ ] **Step 10: Run — expect PASS + lint/type**
+
+Run: `pytest tests/ml/test_benchmark.py tests/ml/test_env.py -q && ruff check ml/ tests/ml/ && mypy ml/`
+Expected: PASS.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add ml/env.py ml/benchmark.py tests/ml/test_env.py tests/ml/test_benchmark.py
+git commit -m "feat(607): env fixed-obstacle pre-placement; benchmark policy column unblocked (#693)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Reward knobs — `r_valid_park` + `dense_slot_potential`
+
+**Files:**
+- Modify: `ml/types.py` (`RewardWeights.r_valid_park`, `.dense_slot_potential`)
+- Modify: `ml/reward.py` (`RewardContext.park_valid`; `potential(active_misfit_m2=...)`; `step_reward` bonus)
+- Modify: `ml/geometry_oracle.py` (`active_misfit_m2`)
+- Modify: `ml/env.py` (set `park_valid`; compute dense potential)
+- Test: `tests/ml/test_reward.py`, `tests/ml/test_geometry_oracle.py`, `tests/ml/test_env.py`
+
+**Interfaces:**
+- Produces: `RewardWeights.r_valid_park: float = 0.0`, `RewardWeights.dense_slot_potential: bool = False`; `RewardContext.park_valid: bool = False`; `potential(*, remaining_overlap_m2, active_dist_to_slot_m, unplaced, active_misfit_m2: float = 0.0)`; `geometry_oracle.active_misfit_m2(body, pose, parked_layout, hangar) -> float`.
+- Consumes: `geometry_oracle.layout_valid` (Task 1) for the `park_valid` gate.
+
+- [ ] **Step 1: Write the failing test — `r_valid_park=0.0` is byte-identical; bonus paid iff `park_valid`**
+
+In `tests/ml/test_reward.py`:
+
+```python
+from ml.reward import RewardContext, step_reward
+from ml.types import RewardWeights
+
+
+def _ctx(**kw):
+    base = dict(overlap_m2=0.0, intrusion_m2=0.0, swept_intrusion_m2=0.0, egress_blocked=False,
+               move_cost=0.0, min_gap_m=0.0, seq_deviation=0.0, region_match=0.0,
+               prev_potential=0.0, potential=0.0, terminal_fraction=None)
+    base.update(kw)
+    return RewardContext(**base)
+
+
+def test_r_valid_park_default_zero_is_byte_identical():
+    # park_valid defaults False and r_valid_park defaults 0.0 -> no change.
+    ctx = _ctx()
+    assert step_reward(ctx, RewardWeights()) == step_reward(ctx, RewardWeights(r_valid_park=0.0))
+
+
+def test_r_valid_park_paid_only_when_park_valid():
+    w = RewardWeights(r_valid_park=2.0)
+    valid = _ctx(park_valid=True)
+    invalid = _ctx(park_valid=False)
+    assert step_reward(valid, w) - step_reward(invalid, w) == pytest.approx(2.0)
+
+
+def test_r_valid_park_cannot_make_an_overlapping_park_profitable():
+    # Ordering invariant: bonus << w_col * smallest meaningful overlap, and only paid on valid.
+    w = RewardWeights(r_valid_park=2.0)
+    overlapping = _ctx(overlap_m2=0.05, park_valid=False)  # invalid -> no bonus, big penalty
+    assert step_reward(overlapping, w) < 0.0
+    assert w.r_valid_park < w.w_col * 0.05
+```
+
+`RewardContext` needs a `park_valid` field with a default for `_ctx` to omit it.
+
+- [ ] **Step 2: Run — expect FAIL** (`r_valid_park` / `park_valid` unknown)
+
+Run: `pytest tests/ml/test_reward.py -k r_valid_park -v`
+Expected: FAIL — `TypeError: ... unexpected keyword argument 'r_valid_park'` (or `park_valid`).
+
+- [ ] **Step 3: Add the fields + the bonus term**
+
+`ml/types.py` — add to `RewardWeights` (after `gamma`):
+
+```python
+    r_valid_park: float = 0.0  # bonus paid in Park ONLY when the layout is valid (basin escape)
+    dense_slot_potential: bool = False  # add an in-hangar nearest-free-pocket shaping term
+```
+
+`ml/reward.py` — add to `RewardContext` (after `terminal_fraction`):
+
+```python
+    park_valid: bool = False  # this Park left the whole layout valid (per layout_valid); Park steps only
+```
+
+`ml/reward.py` — in `step_reward`, add the bonus:
+
+```python
+    terminal = w.r_terminal * ctx.terminal_fraction if ctx.terminal_fraction is not None else 0.0
+    shaping = w.gamma * ctx.potential - ctx.prev_potential
+    valid_park = w.r_valid_park if ctx.park_valid else 0.0
+    return hard + movement + soft + terminal + shaping + valid_park
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pytest tests/ml/test_reward.py -k r_valid_park -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `park_valid` in the env Park branch**
+
+In `ml/env.py` Park branch, after computing `placed_layout` and before building `ctx`, compute validity and pass it:
+
+```python
+            placed_layout = self._layout()
+            overlap = go.overlap_area_m2(placed_layout)
+            intrusion = go.intrusion_area_m2(body, pl, self.hangar, bay_closed=False)
+            egress = go.egress_blocked(placed_layout)
+            park_valid = go.layout_valid(placed_layout)
+            ...
+            ctx = RewardContext(
+                ...
+                terminal_fraction=terminal_fraction,
+                park_valid=park_valid,
+            )
+```
+
+(The movement branch leaves `park_valid` at its `False` default — bonus is a Park-only term.)
+
+- [ ] **Step 6: Write the failing test — `active_misfit_m2`**
+
+In `tests/ml/test_geometry_oracle.py`:
+
+```python
+from ml.types import Pose
+
+
+def test_active_misfit_zero_in_clean_pocket_and_positive_when_overlapping():
+    fleet = _fuji()
+    hangar = empty_hangar()
+    body = fleet["fuji"]
+    empty = single_object_layout(x_m=5.0, y_m=5.0)  # one parked body near (5,5)
+    # Clean pocket far from the parked body, well inside the floor -> misfit 0.
+    clean = Pose(x_m=14.0, y_m=20.0, heading_deg=0.0)
+    assert go.active_misfit_m2(body, clean, empty, hangar) == pytest.approx(0.0, abs=1e-9)
+    # Right on top of the parked body -> positive misfit.
+    on_top = Pose(x_m=5.0, y_m=5.0, heading_deg=0.0)
+    assert go.active_misfit_m2(body, on_top, empty, hangar) > 0.0
+
+
+def test_active_misfit_never_invokes_search(monkeypatch):
+    import hangarfit.solver as solver
+    monkeypatch.setattr(solver, "solve", lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("active_misfit_m2 must not call solve()")))
+    fleet = _fuji()
+    go.active_misfit_m2(fleet["fuji"], Pose(x_m=5.0, y_m=5.0, heading_deg=0.0),
+                        single_object_layout(x_m=12.0, y_m=20.0), empty_hangar())
+```
+
+Adjust `single_object_layout` coordinates if the default parked body sits where `clean` is.
+
+- [ ] **Step 7: Run — expect FAIL** (`active_misfit_m2` not defined)
+
+Run: `pytest tests/ml/test_geometry_oracle.py -k active_misfit -v`
+Expected: FAIL — `AttributeError`.
+
+- [ ] **Step 8: Implement `active_misfit_m2` (pure geometry, no search)**
+
+In `ml/geometry_oracle.py` add to `__all__` (`"active_misfit_m2"`) and define:
+
+```python
+def active_misfit_m2(
+    body: Aircraft | GroundObject,
+    pose: Pose,
+    parked_layout: Layout,
+    hangar: Hangar,
+) -> float:
+    """Coarse, monotone 'how bad is parking the active body HERE' — for the
+    dense_slot_potential shaping term. Pure state→scalar shapely query: the active
+    footprint's overlap with parked bodies PLUS its in-hangar (y≥0) out-of-floor area.
+    0.0 in a clean pocket; grows with intrusion. The apron (y<0) is EXCLUDED (the object
+    legitimately starts there; the door-ingress term handles entry). NEVER calls solve()/a
+    nester — that would re-import a search's reachable-distribution bias (constraint B)."""
+    floor = hangar.floor_polygon
+    if floor is None:
+        floor = box(0.0, 0.0, hangar.width_m, hangar.length_m)
+    upper = box(-1.0e6, 0.0, 1.0e6, hangar.length_m + 1.0e6)  # y >= 0 half-plane
+    pl = Placement(plane_id="__active__", x_m=pose.x_m, y_m=pose.y_m,
+                   heading_deg=pose.heading_deg, on_carts=False)
+    obstacle_parts = [
+        wp for p in parked_layout.placements
+        for wp in aircraft_parts_world(parked_layout.fleet[p.plane_id], p)
+    ] + [
+        wp for gp in parked_layout.ground_object_placements
+        for wp in aircraft_parts_world(parked_layout.ground_objects[gp.plane_id], gp)
+    ]
+    total = 0.0
+    for wp in aircraft_parts_world(body, pl):
+        poly = wp.polygon
+        total += poly.difference(floor).intersection(upper).area  # in-hangar wall/notch intrusion
+        for op in obstacle_parts:
+            if poly.intersects(op.polygon):
+                total += poly.intersection(op.polygon).area
+    return total
+```
+
+Import `Pose` at the top of `geometry_oracle.py` if not already imported (it imports from `hangarfit.towplanner`).
+
+- [ ] **Step 9: Run — expect PASS**
+
+Run: `pytest tests/ml/test_geometry_oracle.py -k active_misfit -v`
+Expected: PASS.
+
+- [ ] **Step 10: Write the failing test — `dense_slot_potential` neutrality + effect**
+
+In `tests/ml/test_reward.py`:
+
+```python
+from ml.reward import potential
+
+
+def test_potential_active_misfit_default_zero_is_byte_identical():
+    a = potential(remaining_overlap_m2=1.0, active_dist_to_slot_m=2.0, unplaced=3)
+    b = potential(remaining_overlap_m2=1.0, active_dist_to_slot_m=2.0, unplaced=3, active_misfit_m2=0.0)
+    assert a == b
+
+
+def test_potential_active_misfit_lowers_potential():
+    base = potential(remaining_overlap_m2=0.0, active_dist_to_slot_m=0.0, unplaced=0)
+    worse = potential(remaining_overlap_m2=0.0, active_dist_to_slot_m=0.0, unplaced=0, active_misfit_m2=5.0)
+    assert worse < base  # higher misfit -> lower potential (Φ is negative cost)
+```
+
+- [ ] **Step 11: Run — expect FAIL** (`active_misfit_m2` not a `potential` param)
+
+Run: `pytest tests/ml/test_reward.py -k potential_active_misfit -v`
+Expected: FAIL — `TypeError`.
+
+- [ ] **Step 12: Extend `potential()` and compute it in the env**
+
+`ml/reward.py`:
+
+```python
+def potential(
+    *,
+    remaining_overlap_m2: float,
+    active_dist_to_slot_m: float,
+    unplaced: int,
+    active_misfit_m2: float = 0.0,
+) -> float:
+    """Shaping potential Φ(s) (spec §5). Higher is better. Φ is the NEGATIVE of the costs.
+    ``active_misfit_m2`` (the dense_slot_potential in-hangar term) defaults 0.0 → byte-identical
+    when the knob is off. Policy-invariant per Ng–Harada–Russell — cannot be reward-hacked."""
+    return -(remaining_overlap_m2 + active_dist_to_slot_m + float(unplaced) + active_misfit_m2)
+```
+
+`ml/env.py` `_potential()`:
+
+```python
+    def _potential(self) -> float:
+        layout = self._layout()
+        remaining_overlap = go.overlap_area_m2(layout) if (self._parked or self._fixed) else 0.0
+        misfit = 0.0
+        if self.weights.dense_slot_potential and self._active_pose is not None and self._active_id is not None:
+            misfit = go.active_misfit_m2(self._body(self._active_id), self._active_pose, layout, self.hangar)
+        return potential(
+            remaining_overlap_m2=remaining_overlap,
+            active_dist_to_slot_m=self._active_dist_to_slot_m(),
+            unplaced=len(self._queue) + (1 if self._active_id is not None else 0),
+            active_misfit_m2=misfit,
+        )
+```
+
+Note the `or self._fixed` guard: a fixed obstacle alone means `_layout()` is non-trivial, so overlap must be measured even before the first park.
+
+- [ ] **Step 13: Run — expect PASS + the full Task-3 suite + lint/type**
+
+Run: `pytest tests/ml/test_reward.py tests/ml/test_geometry_oracle.py tests/ml/test_env.py -q && ruff check ml/ tests/ml/ && mypy ml/`
+Expected: PASS.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add ml/types.py ml/reward.py ml/geometry_oracle.py ml/env.py tests/ml/test_reward.py tests/ml/test_geometry_oracle.py tests/ml/test_env.py
+git commit -m "feat(607): r_valid_park bonus + dense_slot_potential shaping knobs (default-neutral) (#693)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Optimizer knobs — entropy anneal + std-only return normalization
+
+**Files:**
+- Modify: `ml/ppo.py` (`PPOConfig` fields; `entropy_coef_at`; `ReturnNormalizer`; `ppo_update` optional normalizer)
+- Modify: `ml/train.py` (thread `RewardWeights`; per-rung entropy wiring; normalizer; CLI flags)
+- Test: `tests/ml/test_ppo.py`, `tests/ml/test_train_curriculum.py`
+
+**Interfaces:**
+- Produces: `PPOConfig.{entropy_coef_start: float|None=None, entropy_coef_end: float|None=None, entropy_anneal_iters: int=0, normalize_returns: bool=False, return_norm_eps: float=1e-8}`; `ppo.entropy_coef_at(iteration: int, *, base: float, start: float|None, end: float|None, anneal_iters: int) -> float`; `ppo.ReturnNormalizer(eps: float, warmup: int)` with `.normalize(rewards: Tensor) -> Tensor`; `ppo_update(policy, optimizer, buffer, config, *, normalizer: ReturnNormalizer | None = None)`.
+- Consumes: `RewardWeights` (Task 3) threaded into `build_stage_env`/`build_trivial_env`.
+
+- [ ] **Step 1: Write the failing test — `entropy_coef_at` schedule**
+
+In `tests/ml/test_ppo.py` (these are pure; no torch needed for the schedule fn, but the module imports torch — keep the existing `importorskip("torch")` at the top of the file):
+
+```python
+from ml.ppo import entropy_coef_at
+
+
+def test_entropy_coef_constant_when_off():
+    # start None -> constant base regardless of iteration.
+    assert entropy_coef_at(0, base=0.01, start=None, end=None, anneal_iters=0) == 0.01
+    assert entropy_coef_at(50, base=0.01, start=None, end=None, anneal_iters=0) == 0.01
+
+
+def test_entropy_coef_linear_anneal_boundaries_and_monotone():
+    f = lambda it: entropy_coef_at(it, base=0.01, start=0.05, end=0.005, anneal_iters=40)
+    assert f(0) == pytest.approx(0.05)
+    assert f(40) == pytest.approx(0.005)
+    assert f(100) == pytest.approx(0.005)  # clamped past the window
+    assert f(10) > f(30)  # monotone non-increasing
+    assert f(20) == pytest.approx(0.05 + (0.005 - 0.05) * 0.5)
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`entropy_coef_at` not defined)
+
+Run: `pytest tests/ml/test_ppo.py -k entropy_coef -v`
+Expected: FAIL — `ImportError`/`AttributeError`.
+
+- [ ] **Step 3: Add `PPOConfig` fields + `entropy_coef_at`**
+
+`ml/ppo.py` `PPOConfig` (append fields):
+
+```python
+    entropy_coef_start: float | None = None  # high->low anneal start; None = fixed entropy_coef
+    entropy_coef_end: float | None = None     # anneal end; consulted only when start is set
+    entropy_anneal_iters: int = 0             # iters over which to anneal; 0 = no schedule
+    normalize_returns: bool = False           # std-only reward normalization before GAE
+    return_norm_eps: float = 1e-8             # numerical floor on the running std
+```
+
+Add the pure schedule fn:
+
+```python
+def entropy_coef_at(
+    iteration: int, *, base: float, start: float | None, end: float | None, anneal_iters: int
+) -> float:
+    """Per-iteration entropy coefficient. Constant ``base`` when no schedule is configured
+    (``start is None`` or ``anneal_iters <= 0``); else a linear ``start``→``end`` ramp over
+    ``anneal_iters`` iterations, clamped at ``end`` past the window. Monotone non-increasing
+    when start >= end (the intended high→low warmup)."""
+    if start is None or anneal_iters <= 0:
+        return base
+    finish = end if end is not None else start
+    if iteration >= anneal_iters:
+        return finish
+    frac = iteration / anneal_iters
+    return start + (finish - start) * frac
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `pytest tests/ml/test_ppo.py -k entropy_coef -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test — `ReturnNormalizer` (identity off/warmup; std-only; eps floor)**
+
+```python
+import torch
+from ml.ppo import ReturnNormalizer
+
+
+def test_return_normalizer_identity_during_warmup():
+    norm = ReturnNormalizer(eps=1e-8, warmup=1000)
+    r = torch.tensor([1.0, -100.0, 50.0])
+    out = norm.normalize(r)
+    assert torch.equal(out, r)  # still warming up -> identity
+
+
+def test_return_normalizer_std_only_scales_without_mean_shift():
+    norm = ReturnNormalizer(eps=1e-8, warmup=0)
+    r = torch.tensor([2.0, -2.0, 4.0, -4.0])  # mean 0
+    out = norm.normalize(r)
+    # std-only: divided by running std, NO mean subtraction -> sign preserved, ratios preserved.
+    assert torch.all(torch.sign(out) == torch.sign(r))
+    assert out[2] / out[0] == pytest.approx(r[2] / r[0])
+
+
+def test_return_normalizer_eps_floor_finite_on_zero_variance():
+    norm = ReturnNormalizer(eps=1e-8, warmup=0)
+    out = norm.normalize(torch.zeros(4))
+    assert torch.isfinite(out).all()
+```
+
+- [ ] **Step 6: Run — expect FAIL** (`ReturnNormalizer` not defined)
+
+Run: `pytest tests/ml/test_ppo.py -k return_normalizer -v`
+Expected: FAIL.
+
+- [ ] **Step 7: Implement `ReturnNormalizer` (running std, Welford, std-only, warmup-to-identity)**
+
+`ml/ppo.py`:
+
+```python
+class ReturnNormalizer:
+    """Std-only reward normalizer (cleanrl convention: NO mean-subtraction) with a running
+    variance (Welford) and warmup-to-identity. Divides the reward stream by the running std
+    so −w_col collision spikes and +r_terminal sit on a scale the value head can fit, letting
+    GAE propagate terminal credit through the drive-in. Identity until ``warmup`` samples seen
+    and identity-equivalent at zero variance (eps floor). Std-only preserves the relative
+    ordering of shaped rewards."""
+
+    def __init__(self, *, eps: float = 1e-8, warmup: int = 256) -> None:
+        self.eps = eps
+        self.warmup = warmup
+        self._count = 0
+        self._mean = 0.0
+        self._m2 = 0.0
+
+    def _update(self, rewards: Tensor) -> None:
+        for r in rewards.tolist():
+            self._count += 1
+            delta = r - self._mean
+            self._mean += delta / self._count
+            self._m2 += delta * (r - self._mean)
+
+    def normalize(self, rewards: Tensor) -> Tensor:
+        self._update(rewards)
+        if self._count < self.warmup or self._count < 2:
+            return rewards
+        var = self._m2 / self._count
+        std = max(var, 0.0) ** 0.5
+        return rewards / (std + self.eps)
+```
+
+- [ ] **Step 8: Run — expect PASS**
+
+Run: `pytest tests/ml/test_ppo.py -k return_normalizer -v`
+Expected: PASS.
+
+- [ ] **Step 9: Write the failing test — `ppo_update` applies the normalizer only when on; off = identity**
+
+```python
+def test_ppo_update_normalizer_off_does_not_touch_rewards(monkeypatch):
+    # When normalize_returns is False, compute_gae sees the raw rewards (normalizer ignored).
+    import ml.ppo as ppo
+    seen = {}
+    real_gae = ppo.compute_gae
+    def spy(rewards, *a, **k):
+        seen["rewards"] = rewards.clone()
+        return real_gae(rewards, *a, **k)
+    monkeypatch.setattr(ppo, "compute_gae", spy)
+    # ... build a tiny buffer with known rewards via the existing test helper in this file ...
+    # (reuse whatever minimal-buffer helper test_ppo.py already uses for ppo_update tests)
+```
+
+Look at the existing `ppo_update` test in `tests/ml/test_ppo.py` and mirror its buffer-construction helper; assert `seen["rewards"]` equals the raw buffer rewards when `normalize_returns=False`, and differs when `True` with a non-degenerate `ReturnNormalizer` passed.
+
+- [ ] **Step 10: Run — expect FAIL** (normalizer not wired into `ppo_update`)
+
+Run: `pytest tests/ml/test_ppo.py -k normalizer_off -v`
+Expected: FAIL (or the spy shows rewards unchanged because the param doesn't exist yet — make the test assert the new `normalizer=` kwarg exists).
+
+- [ ] **Step 11: Wire the normalizer into `ppo_update`**
+
+`ml/ppo.py` — change the signature and apply before GAE:
+
+```python
+def ppo_update(
+    policy: HangarFitPolicy,
+    optimizer: torch.optim.Optimizer,
+    buffer: RolloutBuffer,
+    config: PPOConfig,
+    *,
+    normalizer: ReturnNormalizer | None = None,
+) -> dict[str, float]:
+    data = buffer.batch()
+    rewards = data["reward"]
+    if config.normalize_returns and normalizer is not None:
+        rewards = normalizer.normalize(rewards)
+    advantages, returns = compute_gae(
+        rewards, data["value"], data["done"], buffer.last_value,
+        gamma=config.gamma, lam=config.lam,
+    )
+    ...
+```
+
+(Default `normalizer=None` ⇒ existing callers + behavior unchanged ⇒ byte-identical.)
+
+- [ ] **Step 12: Run — expect PASS**
+
+Run: `pytest tests/ml/test_ppo.py -q`
+Expected: PASS.
+
+- [ ] **Step 13: Write the failing test — per-rung entropy re-warm + RewardWeights threading + defaults neutral**
+
+In `tests/ml/test_train_curriculum.py`:
+
+```python
+def test_entropy_coef_at_rewarms_per_stage():
+    # A schedule keyed on the PER-STAGE iteration re-warms each rung (iter resets to 0).
+    from ml.ppo import entropy_coef_at
+    cfg_start, cfg_end, anneal = 0.05, 0.005, 40
+    # stage 1 iter 0 and stage 2 iter 0 must BOTH be the high start (re-warm), not decayed.
+    assert entropy_coef_at(0, base=0.01, start=cfg_start, end=cfg_end, anneal_iters=anneal) == pytest.approx(0.05)
+
+
+def test_build_stage_env_threads_reward_weights():
+    from ml.stage_builder import build_stage_env
+    from ml.curriculum import CurriculumSchedule
+    from ml.types import RewardWeights
+    stage = CurriculumSchedule.default().stages[0]
+    env = build_stage_env(stage, weights=RewardWeights(r_valid_park=2.0))
+    assert env.weights.r_valid_park == 2.0
+```
+
+- [ ] **Step 14: Run — expect FAIL** (`build_stage_env` has no `weights` param)
+
+Run: `pytest tests/ml/test_train_curriculum.py -k "rewarms or threads_reward" -v`
+Expected: FAIL — `TypeError: build_stage_env() got an unexpected keyword argument 'weights'`.
+
+- [ ] **Step 15: Thread `RewardWeights` through stage/trivial env builders + wire the entropy schedule per stage + create the normalizer**
+
+`ml/stage_builder.py` — add `weights` param:
+
+```python
+def build_stage_env(stage: Stage, *, weights: RewardWeights | None = None) -> HangarFitEnv:
+    ...
+    return HangarFitEnv(
+        hangar=hangar, fleet=fleet, requested_ids=tuple(pool[:n]),
+        difficulty=stage.difficulty, weights=weights,
+    )
+```
+
+Import `RewardWeights` from `ml.types`. Do the same for `build_trivial_env(seed, *, weights=None)` in `ml/train.py`.
+
+`ml/train.py` `train_curriculum` — create one normalizer per run and apply the per-stage entropy schedule:
+
+```python
+    from dataclasses import replace as _replace
+    from ml.ppo import ReturnNormalizer, entropy_coef_at
+    normalizer = ReturnNormalizer(eps=cfg.return_norm_eps) if cfg.normalize_returns else None
+    ...
+    for stage_index, stage in enumerate(sched.stages):
+        env = build_stage_env(stage, weights=weights)   # weights is a new train_curriculum param
+        ...
+        for it in range(pol.max_iters):
+            it_cfg = _replace(cfg, entropy_coef=entropy_coef_at(
+                it, base=cfg.entropy_coef, start=cfg.entropy_coef_start,
+                end=cfg.entropy_coef_end, anneal_iters=cfg.entropy_anneal_iters))
+            buf, ep_stats = collect_rollout(env, policy, enc, rollout_len, sample_request=next_request)
+            ppo_update(policy, optimizer, buf, it_cfg, normalizer=normalizer)
+            ...
+```
+
+Add a `weights: RewardWeights | None = None` parameter to `train_curriculum` (and `train`), defaulting to `None` → `RewardWeights()` (neutral). Apply the same per-iteration entropy schedule + normalizer in `train` (the trivial path), keyed on its own `it`.
+
+- [ ] **Step 16: Run — expect PASS**
+
+Run: `pytest tests/ml/test_train_curriculum.py tests/ml/test_ppo.py -q`
+Expected: PASS.
+
+- [ ] **Step 17: Add the CLI flags**
+
+`ml/train.py` `build_argparser` — add:
+
+```python
+    p.add_argument("--r-valid-park", type=float, default=0.0)
+    p.add_argument("--dense-slot-potential", action="store_true")
+    p.add_argument("--entropy-start", type=float, default=None)
+    p.add_argument("--entropy-end", type=float, default=None)
+    p.add_argument("--entropy-anneal-iters", type=int, default=0)
+    p.add_argument("--normalize-returns", action="store_true")
+```
+
+`main()` — build the configs from the flags and pass them:
+
+```python
+    weights = RewardWeights(r_valid_park=args.r_valid_park, dense_slot_potential=args.dense_slot_potential)
+    ppo_cfg = PPOConfig(
+        lr=args.lr, entropy_coef_start=args.entropy_start, entropy_coef_end=args.entropy_end,
+        entropy_anneal_iters=args.entropy_anneal_iters, normalize_returns=args.normalize_returns,
+    )
+```
+
+Pass `ppo=ppo_cfg, weights=weights` to `train(...)`/`train_curriculum(...)`. Import `RewardWeights` in `train.py`.
+
+- [ ] **Step 18: Smoke-run the CLI at defaults (1 trivial iter) to prove wiring**
+
+Run: `python -m ml.train --schedule trivial --iterations 1 --rollout-len 64`
+Expected: runs to completion, prints one `iter 0 ...` line, no error. (Confirms flags + threading + normalizer-off path work.)
+
+- [ ] **Step 19: Lint/type + commit**
+
+Run: `ruff check ml/ tests/ml/ && ruff format --check ml/ tests/ml/ && mypy ml/`
+
+```bash
+git add ml/ppo.py ml/train.py ml/stage_builder.py tests/ml/test_ppo.py tests/ml/test_train_curriculum.py
+git commit -m "feat(607): per-rung entropy anneal + std-only return normalization knobs (#693)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Validation run + docs
+
+**Files:**
+- Modify: `CHANGELOG.md` (`[Unreleased]`), `ml/README.md` (knob docs)
+- No code; produces the PR-body validation evidence.
+
+- [ ] **Step 1: Run the control vs treatment A/B on rungs 1–3**
+
+Control:
+```bash
+python -m ml.train --schedule curriculum --max-iters-per-stage 30 --seed 0 --rollout-len 1024 2>&1 | tee /tmp/4cii-control.log
+```
+Treatment:
+```bash
+python -m ml.train --schedule curriculum --max-iters-per-stage 30 --seed 0 --rollout-len 1024 \
+  --r-valid-park 2.0 --dense-slot-potential --entropy-start 0.05 --entropy-end 0.005 \
+  --entropy-anneal-iters 40 --normalize-returns 2>&1 | tee /tmp/4cii-treatment.log
+```
+(The default ladder's rungs 4–5 may run long on CPU; if needed, cap the comparison to rungs 1–3 by editing the schedule locally or reading only the rung-1..3 lines from the logs.)
+
+- [ ] **Step 2: Extract the signals**
+
+Compare across control vs treatment: per-rung mean `valid_placed` (does treatment climb and hold where control stalls near 0?); `terminal_fraction` rising off ~0 (escapes place-nothing); the `fraction_placed − valid_placed` gap shrinking (escapes place-invalid); `hard_overlap` trending toward 0 (bonus not buying invalid parks); entropy starting higher and decaying. Record the numbers for the PR body. If `valid_placed` rises while `fraction_placed ≫ valid_placed` persists, the bonus gate is leaking — STOP and debug before claiming success.
+
+- [ ] **Step 3: Write the CHANGELOG `[Unreleased]` entry**
+
+Add under `[Unreleased]` in `CHANGELOG.md` (match the existing entry style):
+
+```markdown
+### Added
+- Learned backend (#607, 4c-ii): cold-joint RL env fixed-obstacle support (pre-placed
+  immovable keep-outs) — unblocks the eval benchmark's policy column on the Herrenteich
+  anchors; and four default-neutral basin-escape knobs (`r_valid_park`, `dense_slot_potential`,
+  per-rung entropy anneal, std-only return normalization). Training defaults are unchanged.
+
+### Fixed
+- Learned backend env validity now matches the product `collisions.check` (no longer
+  over-enforces the inert maintenance bay) via a single shared `layout_valid` oracle (#694).
+```
+
+- [ ] **Step 4: Document the knobs in `ml/README.md`**
+
+Add a short "Training knobs (4c-ii)" section listing each flag, its default (neutral), and the recommended treatment value, plus the one-line A/B validation command. Note that the real run to mastery + statistical reach-rate are deferred (still in #693).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md ml/README.md
+git commit -m "docs(607): 4c-ii CHANGELOG + ml/README knob docs; A/B validation in PR body (#693)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 6: Full suite + open the draft PR**
+
+Run: `pytest tests/ml/ -q && ruff check ml/ tests/ml/ && ruff format --check ml/ tests/ml/ && mypy ml/`
+Then push and open the PR as a DRAFT:
+```bash
+git push -u origin feature/693-train-to-mastery-enablement
+gh pr create --draft --base develop --title "feat(607): 4c-ii train-to-mastery enablement + knobs" \
+  --body "Closes #693
+Closes #694
+... (summary + the A/B validation numbers from Step 2) ..."
+```
+Then run the review arc (`/pr-review`) before flipping out of draft. Do NOT merge.
+
+---
+
+## Self-review (against the spec)
+
+**Spec coverage:**
+- §2 Goal 1 (fixed-obstacle) → Task 2. ✓
+- §2 Goal 2 (four knobs) → `r_valid_park`/`dense_slot_potential` Task 3; entropy anneal + return norm Task 4. ✓
+- §2 Goal 3 (#694 unify) → Task 1. ✓
+- §2 Goal 4 (validate) → Task 5. ✓
+- §3 (A)/(B) constraints → `reset()`/`_spawn()` untouched (all tasks); `active_misfit` no-search test (Task 3 Step 6); no `src/` change. ✓
+- §4.1–4.7 component edits → mapped 1:1 to Tasks 1–4. ✓
+- §5 default-neutral → byte-identical tests (Task 3 Steps 1/10; Task 4 normalizer-off/entropy-off). ✓
+- §6 testing list → covered across Tasks 1–4 test steps. ✓
+- §8 verify-first items → resolved before planning (Scenario.fixed_obstacle_placements confirmed; check honors notch via floor.covers; PPOConfig non-frozen → `replace`). ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows the code. The two "mirror the existing helper" notes (Task 4 Step 9; GroundObject construction in Task 2 Step 1) point at concrete existing patterns to copy, not invented APIs.
+
+**Type consistency:** `layout_valid`, `intrusion_area_m2(..., bay_closed=)`, `active_misfit_m2`, `RewardWeights.r_valid_park/.dense_slot_potential`, `RewardContext.park_valid`, `potential(active_misfit_m2=)`, `PPOConfig` fields, `entropy_coef_at`, `ReturnNormalizer.normalize`, `ppo_update(normalizer=)`, `build_stage_env(weights=)` — names are consistent across all tasks and match the spec.

--- a/docs/superpowers/specs/2026-06-17-607-4cii-train-to-mastery-enablement-design.md
+++ b/docs/superpowers/specs/2026-06-17-607-4cii-train-to-mastery-enablement-design.md
@@ -1,0 +1,279 @@
+# 2026-06-17 — #607 sub-project 4c-ii (#693): train-to-mastery **enablement + knobs**
+
+**Status:** design (brainstormed; agent-team-deliberated). Successor to the 4c-i eval
+benchmark (PR #695, merged). Epic [#607](https://github.com/DocGerd/hangarfit/issues/607),
+issue [#693](https://github.com/DocGerd/hangarfit/issues/693). Also `Closes #694`.
+
+## 1. Context
+
+The cold-joint RL learned backend is fully built through 4c-i: env → tensorizer → policy →
+PPO core (#685) → curriculum ladder (#689) → reach-not-beat benchmark (#695). The benchmark
+already records the RR-MC baseline — the 3 dense Herrenteich anchors are *missed*, the demo
+control is *reached* — but **the policy's own column on the anchors is empty**:
+`benchmark.build_scenario_env()` raises `NotImplementedError` on any scenario containing a
+`fixed_obstacle`, because the env cannot pre-place immovable keep-outs (fuel trailer / glider
+trailers / Caddy static keeps).
+
+Training *learns* on the trivial rung (4a) but collapses into a **place-nothing / place-invalid
+local optimum** on the harder rungs: with `w_col = 100` hard-overlap penalty and no explicit
+place-nothing cost, the reward-greedy policy wanders until the step budget expires and parks
+nothing (or parks invalidly); `valid_placed` caps (4b). There is no entropy schedule, no
+exploration tooling, and the soft reward terms are zeroed.
+
+Issue #693 is deliberately two-natured: a clean **engineering** deliverable (fixed-obstacle
+support) plus open-ended **RL research** (the real run to mastery, statistical reach-rate).
+This spec covers the agreed slice — **"enablement + knobs"**: ship the env enablement and the
+exploration/reward knobs as **default-neutral** capabilities, validate they move the metric on
+the easy rungs with short in-session CPU runs, and **defer** the multi-hour real run and the
+statistical reach-rate methodology to a follow-up.
+
+## 2. Goals / Non-goals
+
+### Goals
+1. **Env fixed-obstacle support** — pre-place immovable keep-outs into a new `_fixed` list,
+   unioned into `_layout()` but kept **out of `_parked`** (so `terminal_fraction` is not
+   corrupted). Replace `build_scenario_env`'s `NotImplementedError` with pre-placement, so the
+   benchmark's policy column populates on the real Herrenteich anchors.
+2. **Four default-neutral basin-escape knobs** (the agent-team recommendation):
+   `r_valid_park`, `dense_slot_potential`, an **entropy-coefficient anneal** (per-rung
+   re-warmed), and **std-only return normalization**.
+3. **Fix #694** by *unifying* validity: hoist one shared `layout_valid(layout)` oracle helper
+   (= product `collisions.check` reports no conflicts **and** not egress-blocked) and route the
+   env gate, the `r_valid_park` bonus gate, and the benchmark through it. Separately gate the
+   reward's graded intrusion term on the same ADR-0006 bay rule so the gradient stops
+   over-penalizing the inert bay.
+4. **Validate** the knobs on rungs 1–3 with short fixed-seed CPU A/B runs; document the result
+   in the PR body.
+
+### Non-goals (deferred to the #693 "real-run" follow-up)
+- The **multi-hour real training run to mastery** and `PromotionPolicy` θ/window/`max_iters`
+  tuning on the dense rungs.
+- **Statistical reach-rate methodology** (larger *sampled* scenario sets; 4c-i is an
+  existence-demonstration only). Multi-alternative RR-MC routing (the `rrmc_reach`
+  `alternatives=1` note) stays deferred.
+- **Vectorized envs** for throughput.
+- The **backward/start-state curriculum** (pre-park k objects from a witness) — the team's
+  *runner-up*; it brushes apron-realism (its k>0 episodes contain poses not driven in that
+  episode) and carries a `terminal_fraction` denominator-coupling hazard. It is the first thing
+  to graft in the real-run PR **if** the pure-reward set escapes place-nothing but not the
+  dense anchors.
+
+### Explicitly rejected (do not implement)
+- **`seed_anchor` in any form** — both the solver/witness *source* (violates
+  solver-independence) and the mid-hangar *teleport* (violates apron-entry / routability-by-
+  construction) are dropped. `DifficultyConfig.seed_anchor` stays the unused `False` placeholder.
+- The **`w_col` anneal / saturating-penalty / asymmetric reward-clip** levers (policy-non-
+  invariant; reward-hacking surfaces).
+- A **Skip action** / action-space growth (invasive `ACTION_DIM`/`SCHEMA_VERSION` change with
+  determinism-canary risk, for benefit the chosen set already covers).
+
+## 3. The two hard constraints (every design choice honors both)
+
+- **(A) Apron-entry realism / routability-by-construction.** The physical apron (ADR-0021) stays
+  the entry for everything the policy learns to place. No teleport, no mid-hangar spawn. Every
+  recommended lever is paid *only in the Park branch* (after the object was driven in) or is a
+  pure transform of the scalar reward / sampling temperature — structurally incapable of
+  injecting a start state. `reset()`/`_spawn()` are **untouched**.
+- **(B) Solver-independence.** No anchor, witness, label, or start-state is ever sourced from
+  the deterministic search. The only deterministic-geometry code touched is the permitted reward
+  **oracle** (`collisions.check` / parts transform / motion primitives / egress) and the final
+  gate. `solve()` is never invoked in the training loop. The `dense_slot_potential` free-space
+  query MUST be a pure `state → scalar` shapely query — **never** a placement search or nester
+  (that would re-import a search's reachable-distribution bias).
+
+## 4. Design — component by component
+
+All new config fields default to a **neutral** value that reproduces today's training
+**byte-identically** (the 4a/4b determinism canary must still pass at all-defaults).
+
+### 4.1 `ml/types.py` — `RewardWeights`
+Add:
+- `r_valid_park: float = 0.0` — bounded per-valid-park bonus. Recommended train value `2.0`
+  (≪ `w_col = 100` and ≪ `r_terminal = 50`).
+- `dense_slot_potential: bool = False` — toggles the in-hangar shaping term.
+
+The existing ordering invariant (any hard term dominates the soft sum) is extended: a test
+asserts `r_valid_park` is paid **only** when the layout is valid, and `r_valid_park < w_col ×
+(smallest meaningful overlap)` so a marginally-overlapping park can never be net-profitable.
+
+### 4.2 `ml/reward.py`
+- `RewardContext` gains `park_valid: bool = False` (whether *this* park left the whole layout
+  valid — meaningful only on Park steps) and the potential already arrives precomputed via
+  `ctx.potential`.
+- `potential(...)` gains `active_misfit_m2: float = 0.0`, added to the summed cost:
+  `Φ = −(remaining_overlap_m2 + active_dist_to_slot_m + unplaced + active_misfit_m2)`.
+  Default `0.0` ⇒ byte-identical. It enters reward **only** as `γΦ′ − Φ`, so it stays
+  Ng–Harada–Russell **policy-invariant** (the optimum is unchanged).
+- `step_reward(...)` adds `bonus = w.r_valid_park if ctx.park_valid else 0.0`. With
+  `r_valid_park = 0.0` and `park_valid = False` defaults, the scalar is bit-identical to today.
+
+### 4.3 `ml/geometry_oracle.py`
+- **New `layout_valid(layout: Layout) -> bool`** = `not check(layout).conflicts and not
+  egress_blocked(layout)`. This is the single shared product-checker validity helper. Hoisted
+  from `benchmark._layout_valid` (which becomes a thin re-export / call-through), and called by
+  the env gate and the `r_valid_park` gate too — so the bonus gate and the promotion metric can
+  **never disagree** on "valid". Fixes #694 for the gate by construction (the conditional bay
+  rule lives inside `check`).
+- **`intrusion_area_m2(body, placement, hangar, *, bay_closed: bool = False)`** — the bay term
+  (`poly.intersection(bay_poly).area`) is added **only when `bay_closed`**, mirroring
+  collisions.py `_bay_intrusion_conflicts` (ADR-0006: bay is a keep-out only when
+  `layout.maintenance_plane is not None`). The out-of-floor (walls/notch via `floor_polygon`)
+  term is unchanged. The env's layouts never set a maintenance occupant, so the env always
+  passes `bay_closed=False` → the bay over-penalty in the **reward gradient** disappears too
+  (not just the validity gate). This is the #694 fix on the reward side.
+- **New `active_misfit_m2(body, pose, parked_layout, hangar) -> float`** (for
+  `dense_slot_potential`) — a pure geometry query: the active body's footprint overlap against
+  parked bodies + its out-of-floor area for the in-bounds region (apron `y < 0` **excluded**,
+  since the object legitimately starts there and the door-ingress term handles entry). `0.0`
+  when the active pose sits in a clean pocket; grows monotonically as it intrudes. **No search,
+  no nester, no `solve()`** — a no-import / call-count guard test enforces this.
+
+### 4.4 `ml/env.py`
+- **Constructor:** add `fixed_placements: tuple[Placement, ...] = ()`. Store `self._fixed =
+  list(fixed_placements)`. The fixed objects' `GroundObject` defs are passed in `ground_objects`
+  (so `_body` resolves them); their ids are **not** in `requested_ids`/the queue.
+- **`_layout()`:** build the scene from `self._parked + self._fixed` (partitioning each placement
+  by fleet-vs-ground_objects membership as today). Overlap / egress / motion-clearance now see
+  the fixed keep-outs.
+- **`_layout_valid()`:** delegate to `go.layout_valid(self._layout())`. (Removes the hand-rolled
+  overlap+intrusion+egress; #694 gone.) Fixed obstacles need no bounds re-check — they are given;
+  a placed body colliding with one is caught by `check`'s pairwise overlap.
+- **Park branch:** compute `park_valid = go.layout_valid(placed_layout)` and pass it into
+  `RewardContext`; the graded intrusion term uses `go.intrusion_area_m2(body, pl, hangar,
+  bay_closed=False)`.
+- **`_potential()`:** when `self.weights.dense_slot_potential`, compute `active_misfit_m2` for
+  the active object at its current pose and pass it to `potential(...)`; else `0.0` (unchanged).
+- **`terminal_fraction`** = `len(self._parked) / len(self.requested_ids)`. Because `requested_ids`
+  excludes fixed obstacles and `_fixed` is never appended to `_parked`, the denominator is
+  uncorrupted (the issue's explicit warning).
+
+### 4.5 `ml/ppo.py` — `PPOConfig` + helpers
+Add fields (all neutral by default):
+- `entropy_coef_start: float | None = None`, `entropy_coef_end: float | None = None`,
+  `entropy_anneal_iters: int = 0`. `None`/`0` ⇒ use the fixed `entropy_coef = 0.01`, no schedule.
+- `normalize_returns: bool = False`, `return_norm_eps: float = 1e-8`.
+
+Add a **pure** schedule fn `entropy_coef_at(iteration, *, base, start, end, anneal_iters) -> float`
+(linear high→low; constant `base` when `start is None`/`start == end`/`anneal_iters == 0`;
+clamped at `end` past the window; monotone non-increasing in between).
+
+Add a **std-only** return normalizer (a small running-std accumulator; **no mean-subtraction**,
+cleanrl convention) applied to the reward stream **before** `compute_gae` when
+`normalize_returns`. **Warmup-to-identity** until N samples; floor `sqrt(var)` by
+`return_norm_eps`. std-only scaling preserves the relative ordering of shaped rewards
+(bounding the PBRS-transient concern). `normalize_returns=False` ⇒ reward stream untouched ⇒
+byte-identical.
+
+### 4.6 `ml/train.py`
+- Thread `RewardWeights` and `PPOConfig` through env/stage construction (today the env uses
+  default `RewardWeights`; the stage builder must accept and forward the weights).
+- **Entropy schedule wiring (per-rung re-warm):** each curriculum stage has its own iteration
+  counter; before each `ppo_update`, set the iteration's coefficient via `entropy_coef_at(...)`
+  keyed on the **per-stage** iteration (so a schedule tuned for rung 1 does not reach ~0 entropy
+  by rung 3 and re-collapse exploration). If `PPOConfig` is frozen, apply via
+  `dataclasses.replace`.
+- **CLI flags** (all default to the neutral config): `--r-valid-park`, `--dense-slot-potential`,
+  `--entropy-start`, `--entropy-end`, `--entropy-anneal-iters`, `--normalize-returns`.
+
+### 4.7 `ml/benchmark.py`
+- `build_scenario_env`: **replace** the `NotImplementedError` with pre-placement — partition the
+  scenario's ground objects by `object_class`, pass `fixed_obstacle` placements (with their poses
+  from the scenario's fixed-obstacle placement entries) as `fixed_placements` + their defs in
+  `ground_objects`, and keep movers in the queue as today. The herrenteich anchors then build a
+  rollable env and the policy column populates.
+- `_layout_valid` becomes a call-through to `go.layout_valid` (single source of truth).
+
+## 5. Determinism, the default-neutral contract, and the #694 behavior change
+
+Two distinct claims — keep them separate:
+
+- **The four knobs are default-neutral.** All seven new config fields default to neutral; with
+  the knobs off, the reward scalar and PPO update are bit-identical to the post-#694 code.
+- **The #694 fix is a deliberate bugfix, NOT neutral.** Gating the bay term changes the
+  reward gradient *and* the validity verdict on any layout that clips the (inert) maintenance bay
+  — by design, that is the bug being fixed. So training at all-defaults differs from the
+  *pre-#694* code on bay-clipping layouts. This is correct (it aligns the env with
+  `collisions.check`), but it means **any committed golden training/reward fixture from 4a/4b that
+  involves a bay-clipping layout must be re-baselined** in this PR, with the diff called out as
+  the #694 correction (verify which fixtures are affected at implementation start).
+- **The determinism canary still holds.** The 4a/4b canary asserts *run-to-run* byte-identity
+  (same seed → same output within a build), not identity to a previous commit — so it passes
+  unchanged. A test asserts the four knobs at defaults leave the reward/`CurriculumHistory`
+  bit-identical *relative to the post-#694 baseline*.
+- The learned path is **not** under ADR-0003 / `determinism-guard` (epic contract). These changes
+  do not touch `src/hangarfit/solver.py` or `towplanner.py`; there is **no `src/` change at all**
+  — the #694 fix lives entirely in `ml/geometry_oracle.py` (the env-side bay gate), and the
+  product `collisions.check` is consumed read-only.
+
+## 6. Testing
+
+Torch-free where possible (the `[train]` extra / torch CI lane is epic rung #6; ppo tests use
+`importorskip`).
+- **reward:** `r_valid_park=0.0` ⇒ bit-identical; bonus paid **iff** `park_valid`; ordering
+  invariant (`r_valid_park < w_col × smallest_meaningful_overlap`); `potential` byte-identical at
+  `active_misfit_m2=0.0`; telescoping check that Φ stays a pure function of state.
+- **geometry_oracle:** `intrusion_area_m2` bay term gated (`bay_closed=False` drops it, `True`
+  counts it); **#694 regression** — a layout clipping the *inert* bay is `layout_valid` (matches
+  `collisions.check`); `active_misfit_m2` is `0` in a free pocket, monotone in intrusion, and
+  **never calls `solve()`/a nester** (import/call-count guard).
+- **env:** fixed obstacle unioned into `_layout()`, **not** in `_parked`; `terminal_fraction`
+  uncorrupted with a fixed obstacle present; a placed body overlapping a fixed obstacle is caught;
+  #694 regression at env level.
+- **ppo:** `entropy_coef_at` boundaries / monotonicity / constant-when-off; `normalize_returns`
+  identity when off and during warmup; **std-only** (no mean subtracted); constant-σ
+  scalar-equivalence (gradient direction preserved up to a positive scalar); `return_norm_eps`
+  floor (finite at `var=0`).
+- **benchmark:** `build_scenario_env` now **accepts** the fixed-obstacle anchors (replaces the
+  old `NotImplementedError` test); `eval.policy_reach` populates the anchor policy column.
+- **train_curriculum:** entropy per-rung re-warm; all-defaults byte-identical.
+
+## 7. Validation (in-session, documented in the PR body — not CI)
+
+Two short fixed-seed CPU runs on rungs 1–3 of `DEFAULT_LADDER` (trivial / pair-box / trio-box —
+loose hangars, small budgets), via `python -m ml.train --schedule curriculum
+--max-iters-per-stage 30`:
+- **CONTROL** = all knobs at defaults.
+- **TREATMENT** = `r_valid_park=2.0`, `dense_slot_potential=True`,
+  `entropy_start=0.05 / entropy_end=0.005 / entropy_anneal_iters≈40`, `normalize_returns=True`.
+
+**Primary signal** (the exact 4b mastery metric that capped under the basin): mean `valid_placed`
+climbs and holds in treatment where control stalls near 0 — a clean win is rung-1 `valid_placed`
+reaching the 0.9 promotion threshold with `history.promotions` registering `by="competency"`
+within the 30-iter cap. **Leading indicators:** (1) `terminal_fraction` rises off ~0 (escapes
+place-nothing); (2) the `fraction_placed − valid_placed` gap shrinks (escapes place-invalid);
+(3) `hard_overlap` term mean trends to 0, **not** up (the bonus is not buying invalid parks —
+if `valid_placed` rises but `fraction_placed ≫ valid_placed` persists, the gate is leaking:
+**fail the knob, do not ship**); (4) entropy starts higher and decays (schedule wired); (5)
+value-loss flatter with RetNorm on. Expect minutes per rung; the multi-hour run is deferred.
+
+## 8. Implementation order (subagent-friendly chunks)
+
+1. **#694 unification** — `go.layout_valid` + `intrusion_area_m2` bay gate; env `_layout_valid`
+   delegates; benchmark `_layout_valid` call-through; #694 regression tests. (`Closes #694`.)
+2. **Fixed-obstacle env support** — `_fixed`, `_layout()` union, `build_scenario_env`
+   pre-placement; env + benchmark tests; verify the anchor policy column rolls out.
+3. **Reward knobs** — `r_valid_park` (+ `park_valid` plumbing) and `dense_slot_potential`
+   (+ `active_misfit_m2`); reward + oracle tests.
+4. **PPO/optimizer knobs** — entropy schedule fn + per-rung wiring; std-only return normalizer;
+   ppo + train tests; CLI flags.
+5. **Validation run + docs** — A/B run, CHANGELOG `[Unreleased]` entry, `ml/README` knob docs,
+   PR body with the validation result.
+
+**Verify-first at implementation start:** (a) the exact field name on the `load_scenario` result
+that carries fixed-obstacle placement poses (the benchmark comment references
+`fixed_obstacle_placements`); (b) that `collisions.check`'s `hangar_bounds` conflict honors the
+L-shaped `floor_polygon` (notch) so delegating the env gate to `check` does not lose notch
+enforcement; (c) whether `PPOConfig` is frozen (drives `replace` vs in-place for the per-iter
+entropy coef).
+
+## 9. References
+- Epic [#607](https://github.com/DocGerd/hangarfit/issues/607); issue
+  [#693](https://github.com/DocGerd/hangarfit/issues/693); bug
+  [#694](https://github.com/DocGerd/hangarfit/issues/694).
+- Cold-joint env design: `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`.
+- 4c-i eval benchmark: `docs/superpowers/specs/2026-06-17-learned-backend-eval-benchmark-design.md` (PR #695).
+- ADR-0003 (determinism scope), ADR-0006 (bay-intrusion rule), ADR-0008 (spread/region soft term),
+  ADR-0010 (motion primitives), ADR-0021 (staging apron), ADR-0025 (ground-object taxonomy),
+  ADR-0026 (Caddy hard-door egress).
+- Agent-team deliberation (this session): 4 approaches × adversarial critique → synthesis;
+  dropped seed_anchor; runner-up = backward curriculum (deferred).

--- a/ml/README.md
+++ b/ml/README.md
@@ -38,7 +38,7 @@ runs. Recommended treatment values for curriculum training runs:
 | `--entropy-start S` | `None` (fixed coef) | `0.05` | Entropy coefficient anneal start; pairs with `--entropy-end` and `--entropy-anneal-iters` for per-rung exploration decay |
 | `--entropy-end E` | `None` | `0.005` | Entropy anneal end value (consulted only when `--entropy-start` is set) |
 | `--entropy-anneal-iters N` | `0` | `40` | Iterations over which to anneal entropy from start→end (0 = no schedule) |
-| `--normalize-returns` | off | on | Std-only Welford return normalization before GAE; stabilises training across rungs with different reward scales |
+| `--normalize-returns` | off | on | Std-only Welford return normalization before GAE; stabilises training across rungs with different reward scales. The running std is shared **run-level** across all rungs (not reset per rung) — a deliberate global-scale choice; revisit per-rung resets in the deferred run-to-mastery study if rung reward scales diverge sharply |
 
 ### One-line A/B validation command
 

--- a/ml/README.md
+++ b/ml/README.md
@@ -35,7 +35,7 @@ runs. Recommended treatment values for curriculum training runs:
 |---|---|---|---|
 | `--r-valid-park R` | `0.0` | `2.0` | Bonus per Park step when `layout_valid` passes; gates the reward on the product checker so only conflict-free placements are rewarded |
 | `--dense-slot-potential` | off | on | Adds in-hangar nearest-free-pocket potential shaping; guides the agent toward open space while it is still placing |
-| `--entropy-start S` | `None` (fixed coef) | `0.05` | Entropy coefficient anneal start; pairs with `--entropy-end` and `--entropy-anneal-iters` for per-rung exploration decay |
+| `--entropy-start S` | `None` (fixed coef) | `0.05` | Entropy coefficient anneal start; pairs with `--entropy-end` and `--entropy-anneal-iters`. With `--schedule curriculum` the schedule resets per rung (per-rung decay); with `--schedule trivial` it decays once over the run |
 | `--entropy-end E` | `None` | `0.005` | Entropy anneal end value (consulted only when `--entropy-start` is set) |
 | `--entropy-anneal-iters N` | `0` | `40` | Iterations over which to anneal entropy from start→end (0 = no schedule) |
 | `--normalize-returns` | off | on | Std-only Welford return normalization before GAE; stabilises training across rungs with different reward scales. The running std is shared **run-level** across all rungs (not reset per rung) — a deliberate global-scale choice; revisit per-rung resets in the deferred run-to-mastery study if rung reward scales diverge sharply |

--- a/ml/README.md
+++ b/ml/README.md
@@ -20,9 +20,48 @@ environment + reward (`HangarFitEnv`), reusing `hangarfit`'s geometry oracle.
 
 The benchmark judges validity via the product deterministic checker
 `collisions.check` + Caddy egress (the spec's prime directive), **not** the env
-oracle — the oracle's over-strict treatment of the inert placeholder maintenance
-bay is tracked as #694. The Herrenteich anchors' policy column (env
-fixed-obstacle pre-placement) is deferred to 4c-ii (#693).
+oracle — the single shared `layout_valid` oracle is now used by both the env
+reward and `ml/eval` (the prior over-enforcement of the inert maintenance bay
+was fixed in 4c-ii, #694). Fixed-obstacle pre-placements from
+`Scenario.fixed_obstacle_placements` are honoured by the env since 4c-ii (#693).
+
+## Training knobs (4c-ii)
+
+Four optional basin-escape knobs were added in sub-project #4c-ii (#693). All
+are **default-neutral** — omitting them produces byte-identical results to prior
+runs. Recommended treatment values for curriculum training runs:
+
+| Flag | Default (neutral) | Recommended treatment | Effect |
+|---|---|---|---|
+| `--r-valid-park R` | `0.0` | `2.0` | Bonus per Park step when `layout_valid` passes; gates the reward on the product checker so only conflict-free placements are rewarded |
+| `--dense-slot-potential` | off | on | Adds in-hangar nearest-free-pocket potential shaping; guides the agent toward open space while it is still placing |
+| `--entropy-start S` | `None` (fixed coef) | `0.05` | Entropy coefficient anneal start; pairs with `--entropy-end` and `--entropy-anneal-iters` for per-rung exploration decay |
+| `--entropy-end E` | `None` | `0.005` | Entropy anneal end value (consulted only when `--entropy-start` is set) |
+| `--entropy-anneal-iters N` | `0` | `40` | Iterations over which to anneal entropy from start→end (0 = no schedule) |
+| `--normalize-returns` | off | on | Std-only Welford return normalization before GAE; stabilises training across rungs with different reward scales |
+
+### One-line A/B validation command
+
+```bash
+# Control (neutral — no knobs):
+python -m ml.train --schedule curriculum --max-iters-per-stage 30 --seed 0 --rollout-len 1024
+
+# Treatment (all four knobs active):
+python -m ml.train --schedule curriculum --max-iters-per-stage 30 --seed 0 --rollout-len 1024 \
+  --r-valid-park 2.0 --dense-slot-potential \
+  --entropy-start 0.05 --entropy-end 0.005 --entropy-anneal-iters 40 \
+  --normalize-returns
+```
+
+Primary signal: `valid_placed` rising in treatment where control stalls near 0.
+Leading indicators: `terminal_fraction` leaving ~0 (escapes place-nothing basin);
+`fraction_placed − valid_placed` gap shrinking (escapes place-invalid basin);
+entropy starting higher and decaying across rungs.
+
+**Note:** A full run-to-mastery study and statistical reach-rate measurement
+against the benchmark are deferred to the second half of #693. The knobs are
+wired, unit-tested, and default-neutral; the A/B here is a smoke-level
+demonstration that they move the easy-rung metric in the expected direction.
 
 ## Design
 See `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`

--- a/ml/benchmark.py
+++ b/ml/benchmark.py
@@ -185,34 +185,32 @@ BENCH_SET: tuple[BenchScenario, ...] = (
 
 def build_scenario_env(scenario: BenchScenario) -> HangarFitEnv:
     """Build a HangarFitEnv for a scenario's MOVABLE bodies (aircraft + placed-routed
-    movers), with an apron for drive-in. RAISES NotImplementedError if the scenario carries
-    any fixed obstacle — env pre-placement of immovable keep-outs is deferred to 4c-ii, and
-    silently dropping the keep-out would score the policy on an easier scenario than RR-MC
-    faces (spec §5.5/D11)."""
+    movers), with an apron for drive-in. Fixed obstacles (immovable keep-outs, e.g. the
+    fuel trailer) are PRE-PLACED into the env's ``_fixed`` list at their surveyed poses —
+    part of the scene from step 0, never driven and never in the requested/driven queue —
+    so the policy is scored against the SAME keep-outs RR-MC faces (spec §5.5/D11). This
+    unblocks the policy column on the fixed-obstacle anchors (#607 4c-ii / #693)."""
     sc = load_scenario(_ROOT / scenario.scenario_path)
     # Detect fixed obstacles among the scenario's ACTIVE ground objects by object_class,
     # NOT via fixed_obstacle_placements: a class-`fixed_obstacle` listed in the scenario's
-    # ground_objects but WITHOUT a placement entry would otherwise slip past the gate, land
-    # in the env un-queued, and be silently absent from scoring (the silent-keep-out-drop
-    # the gate exists to prevent). Scan sc.ground_objects (the active id tuple), not the
-    # catalog-merged ground_object_defs — the latter always carries every catalog def
-    # (e.g. the fuel trailer) even for a scenario that doesn't use it.
-    fixed = [
+    # ground_objects but WITHOUT a placement entry would otherwise slip past, land in the
+    # env un-placed, and be silently absent from scoring. Scan sc.ground_objects (the active
+    # id tuple), not the catalog-merged ground_object_defs — the latter always carries every
+    # catalog def (e.g. the fuel trailer) even for a scenario that doesn't use it.
+    fixed_ids = [
         gid
         for gid in sc.ground_objects
         if sc.ground_object_defs[gid].object_class == "fixed_obstacle"
     ]
-    if fixed:
-        raise NotImplementedError(
-            f"build_scenario_env: scenario {scenario.name!r} carries fixed obstacle(s) {fixed}; "
-            f"the env cannot yet pre-place immovable keep-outs (deferred to #607 sub-project "
-            f"4c-ii). Use a ground-object-free scenario for the policy rollout."
-        )
+    # ``placeable_ids`` is ``fleet_in + sorted(mover_ids)`` (aircraft + placed-routed
+    # movers), so it ALREADY excludes fixed obstacles — they are never driven. Use it
+    # directly as the driven queue.
     placeable = sc.placeable_ids
-    # Pass only the MOVER defs (placed-routed movers), not the whole catalog-merged
-    # ``ground_object_defs``: a GO-free scenario must yield an env with NO ground objects,
-    # and the env should carry exactly the bodies it can drive.
+    # Movers (placed_routed_mover) are driven in; fixed obstacles are pre-placed keep-outs.
+    # Pass both sets of defs so the env's ``_body()`` resolves a pre-placed fixed obstacle,
+    # but only ``placeable`` is queued.
     movers = {gid: sc.ground_object_defs[gid] for gid in sc.mover_ids}
+    fixed_defs = {gid: sc.ground_object_defs[gid] for gid in fixed_ids}
     per_object = 120
     difficulty = DifficultyConfig(
         max_objects=len(placeable),
@@ -224,7 +222,8 @@ def build_scenario_env(scenario: BenchScenario) -> HangarFitEnv:
         hangar=hangar,
         fleet=sc.fleet,
         requested_ids=placeable,
-        ground_objects=movers,
+        ground_objects={**movers, **fixed_defs},
+        fixed_placements=sc.fixed_obstacle_placements,
         difficulty=difficulty,
     )
 

--- a/ml/benchmark.py
+++ b/ml/benchmark.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Literal
 
-from hangarfit.collisions import check
 from hangarfit.loader import load_layout, load_scenario
 from hangarfit.models import Layout, SearchConfig, SolveStatus
 from hangarfit.solver import solve
@@ -112,15 +111,11 @@ def _verdict_from(
 
 
 def _layout_valid(layout: Layout) -> bool:
-    """Valid per the PRODUCT deterministic checker (the spec's 'prime directive' final
-    gate, == `hangarfit check`): collisions.check reports no conflicts (overlap + hangar
-    bounds/notch + CONDITIONAL maintenance bay + ground-obstacle keep-outs) AND no Caddy
-    hard-door egress violation (ADR-0026). Deliberately NOT the env oracle's
-    `intrusion_area_m2`, which over-strictly enforces an INERT placeholder maintenance bay
-    (issue #694) — the herrenteich bay is explicitly inert, so layout_full is valid here.
-    Used identically by witness_valid, rrmc_reach, and the policy scorer so all sides are
-    judged apples-to-apples."""
-    return not check(layout).conflicts and not go.egress_blocked(layout)
+    """Valid per the PRODUCT deterministic checker — delegates to the shared
+    geometry_oracle.layout_valid so the env gate, the policy scorer, and witness_valid are
+    judged by one identical predicate (collisions.check + Caddy egress; the inert maintenance
+    bay is conditional, #694)."""
+    return go.layout_valid(layout)
 
 
 def witness_valid(scenario: BenchScenario) -> bool:

--- a/ml/benchmark.py
+++ b/ml/benchmark.py
@@ -112,9 +112,9 @@ def _verdict_from(
 
 def _layout_valid(layout: Layout) -> bool:
     """Valid per the PRODUCT deterministic checker — delegates to the shared
-    geometry_oracle.layout_valid so the env gate, the policy scorer, and witness_valid are
-    judged by one identical predicate (collisions.check + Caddy egress; the inert maintenance
-    bay is conditional, #694)."""
+    geometry_oracle.layout_valid so the env gate, the policy scorer, witness_valid, and
+    rrmc_reach are judged by one identical predicate (collisions.check + Caddy egress; the
+    inert maintenance bay is conditional, #694)."""
     return go.layout_valid(layout)
 
 
@@ -202,6 +202,13 @@ def build_scenario_env(scenario: BenchScenario) -> HangarFitEnv:
         for gid in sc.ground_objects
         if sc.ground_object_defs[gid].object_class == "fixed_obstacle"
     ]
+    missing = [g for g in fixed_ids if g not in {p.plane_id for p in sc.fixed_obstacle_placements}]
+    if missing:
+        raise ValueError(
+            f"build_scenario_env: fixed obstacle(s) {missing} have no entry in "
+            f"scenario.fixed_obstacle_placements — they would silently appear un-placed "
+            f"(absent from scoring). Add surveyed placements or remove them from ground_objects."
+        )
     # ``placeable_ids`` is ``fleet_in + sorted(mover_ids)`` (aircraft + placed-routed
     # movers), so it ALREADY excludes fixed obstacles — they are never driven. Use it
     # directly as the driven queue.

--- a/ml/env.py
+++ b/ml/env.py
@@ -175,7 +175,7 @@ class HangarFitEnv:
             self._parked.append(pl)
             placed_layout = self._layout()
             overlap = go.overlap_area_m2(placed_layout)
-            intrusion = go.intrusion_area_m2(body, pl, self.hangar)
+            intrusion = go.intrusion_area_m2(body, pl, self.hangar, bay_closed=False)
             egress = go.egress_blocked(placed_layout)
             self._active_id = None
             self._active_pose = None
@@ -253,20 +253,11 @@ class HangarFitEnv:
         return False, ""
 
     def _layout_valid(self) -> bool:
-        """Whole-layout validity matching the deterministic checker the prime directive
-        enforces: no part overlap, no out-of-bounds / notch / apron (y<0) intrusion by ANY
-        parked body, and no Caddy hard-door egress violation. (StepInfo.valid previously
-        checked overlap only, leaving the promotion gate looser than the real checker —
-        #607 SP#4b review.) Reward terms read ctx, not this, so this is gate/reporting only."""
-        layout = self._layout()
-        if go.overlap_area_m2(layout) > 0.0:
-            return False
-        if go.egress_blocked(layout):
-            return False
-        return all(
-            go.intrusion_area_m2(self._body(pl.plane_id), pl, self.hangar) == 0.0
-            for pl in self._parked
-        )
+        """Whole-layout validity == the product checker (the prime directive's final gate),
+        via the shared ``geometry_oracle.layout_valid``. Reward terms read ctx, not this, so
+        this is gate/reporting only. (Was hand-rolled overlap+intrusion+egress that
+        over-enforced the inert maintenance bay — #607 SP#4c-ii / #694.)"""
+        return go.layout_valid(self._layout())
 
     def _info(self, ctx: RewardContext, done: bool, reason: str) -> StepInfo:
         return StepInfo(

--- a/ml/env.py
+++ b/ml/env.py
@@ -31,6 +31,7 @@ class HangarFitEnv:
         fleet: Mapping[str, Aircraft],
         requested_ids: tuple[str, ...],
         ground_objects: Mapping[str, GroundObject] | None = None,
+        fixed_placements: tuple[Placement, ...] = (),
         difficulty: DifficultyConfig | None = None,
         weights: RewardWeights | None = None,
     ) -> None:
@@ -38,6 +39,11 @@ class HangarFitEnv:
         self.fleet = dict(fleet)
         self.ground_objects = dict(ground_objects or {})
         self.requested_ids = requested_ids
+        # Pre-placed immovable keep-outs (e.g. the fuel trailer): part of the scene
+        # from step 0, but NEVER driven and NEVER in ``_parked`` (so terminal_fraction's
+        # denominator stays the requested/driven set). Set here (scenario-level) rather
+        # than in ``_reset_state`` so it survives ``reset()``.
+        self._fixed: list[Placement] = list(fixed_placements)
         self.difficulty = difficulty or DifficultyConfig()
         self.weights = weights or RewardWeights()
         self._reset_state()
@@ -84,18 +90,20 @@ class HangarFitEnv:
         self._steps_this_object = 0
 
     def _layout(self) -> Layout:
-        """The scene of FROZEN (parked) objects only — the active one is not yet in it."""
-        parked_ids = [p.plane_id for p in self._parked]
-        ac = {pid: self.fleet[pid] for pid in parked_ids if pid in self.fleet}
-        go_ids = [pid for pid in parked_ids if pid in self.ground_objects]
+        """The scene of FROZEN objects: driven-in (parked) PLUS pre-placed fixed obstacles
+        (immovable keep-outs). The active object is not yet in it. Fixed obstacles are NOT in
+        ``_parked`` (so terminal_fraction is uncorrupted) but ARE in the scene so overlap /
+        egress / motion-clearance see them."""
+        frozen = self._parked + self._fixed
+        frozen_ids = [p.plane_id for p in frozen]
+        ac = {pid: self.fleet[pid] for pid in frozen_ids if pid in self.fleet}
+        go_ids = [pid for pid in frozen_ids if pid in self.ground_objects]
         return Layout(
             fleet=ac or {next(iter(self.fleet)): next(iter(self.fleet.values()))},
             hangar=self.hangar,
-            placements=tuple(p for p in self._parked if p.plane_id in self.fleet),
+            placements=tuple(p for p in frozen if p.plane_id in self.fleet),
             ground_objects={pid: self.ground_objects[pid] for pid in go_ids},
-            ground_object_placements=tuple(
-                p for p in self._parked if p.plane_id in self.ground_objects
-            ),
+            ground_object_placements=tuple(p for p in frozen if p.plane_id in self.ground_objects),
         )
 
     def _observe(self) -> Observation:

--- a/ml/env.py
+++ b/ml/env.py
@@ -117,7 +117,12 @@ class HangarFitEnv:
             )
         return Observation(
             active=active,
-            parked=tuple(ParkedObject(p.plane_id, p) for p in self._parked),
+            # The observed frozen set is parked (driven-in) PLUS the pre-placed fixed
+            # obstacles, so the tensorizer rasters + tokenizes the immovable keep-outs and
+            # the policy can PERCEIVE what it is penalized for colliding with. Fixed
+            # obstacles stay out of ``_parked``, so info.placed / terminal_fraction (which
+            # divide over ``_parked`` / ``requested_ids``, not ``obs.parked``) are unchanged.
+            parked=tuple(ParkedObject(p.plane_id, p) for p in self._parked + self._fixed),
             unplaced_ids=tuple(self._queue),
             steps_this_object=self._steps_this_object,
             steps_total=self._steps_total,

--- a/ml/env.py
+++ b/ml/env.py
@@ -120,8 +120,9 @@ class HangarFitEnv:
             # The observed frozen set is parked (driven-in) PLUS the pre-placed fixed
             # obstacles, so the tensorizer rasters + tokenizes the immovable keep-outs and
             # the policy can PERCEIVE what it is penalized for colliding with. Fixed
-            # obstacles stay out of ``_parked``, so info.placed / terminal_fraction (which
-            # divide over ``_parked`` / ``requested_ids``, not ``obs.parked``) are unchanged.
+            # obstacles stay out of ``_parked``, so info.placed (= len(_parked)) and
+            # terminal_fraction (= len(_parked)/len(requested_ids)) are unchanged — the
+            # denominator is the driven/requested set only, not the full observed set.
             parked=tuple(ParkedObject(p.plane_id, p) for p in self._parked + self._fixed),
             unplaced_ids=tuple(self._queue),
             steps_this_object=self._steps_this_object,

--- a/ml/env.py
+++ b/ml/env.py
@@ -133,11 +133,21 @@ class HangarFitEnv:
 
     def _potential(self) -> float:
         layout = self._layout()
-        remaining_overlap = go.overlap_area_m2(layout) if self._parked else 0.0
+        remaining_overlap = go.overlap_area_m2(layout) if (self._parked or self._fixed) else 0.0
+        misfit = 0.0
+        if (
+            self.weights.dense_slot_potential
+            and self._active_pose is not None
+            and self._active_id is not None
+        ):
+            misfit = go.active_misfit_m2(
+                self._body(self._active_id), self._active_pose, layout, self.hangar
+            )
         return potential(
             remaining_overlap_m2=remaining_overlap,
             active_dist_to_slot_m=self._active_dist_to_slot_m(),
             unplaced=len(self._queue) + (1 if self._active_id is not None else 0),
+            active_misfit_m2=misfit,
         )
 
     def reset(self, requested_ids: tuple[str, ...] | None = None) -> Observation:
@@ -185,6 +195,7 @@ class HangarFitEnv:
             overlap = go.overlap_area_m2(placed_layout)
             intrusion = go.intrusion_area_m2(body, pl, self.hangar, bay_closed=False)
             egress = go.egress_blocked(placed_layout)
+            park_valid = go.layout_valid(placed_layout)
             self._active_id = None
             self._active_pose = None
             done = not self._queue
@@ -204,6 +215,7 @@ class HangarFitEnv:
                 prev_potential=self._prev_potential,
                 potential=new_phi,
                 terminal_fraction=terminal_fraction,
+                park_valid=park_valid,
             )
             reward = step_reward(ctx, weights)
             self._prev_potential = new_phi

--- a/ml/geometry_oracle.py
+++ b/ml/geometry_oracle.py
@@ -36,6 +36,7 @@ __all__ = [
     "swept_intrusion_m2",
     "movement_cost",
     "egress_blocked",
+    "active_misfit_m2",
 ]
 
 # Re-export so callers can use go.CUSP_PENALTY
@@ -199,3 +200,45 @@ def egress_blocked(layout: Layout, *, mover_id: str | None = None) -> bool:
     if mover_id is None:
         return False
     return egress_first_conflict(layout, mover_id) is not None
+
+
+def active_misfit_m2(
+    body: Aircraft | GroundObject,
+    pose: Pose,
+    parked_layout: Layout,
+    hangar: Hangar,
+) -> float:
+    """Coarse, monotone 'how bad is parking the active body HERE' — for the
+    dense_slot_potential shaping term. Pure state→scalar shapely query: the active
+    footprint's overlap with parked bodies PLUS its in-hangar (y≥0) out-of-floor area.
+    0.0 in a clean pocket; grows with intrusion. The apron (y<0) is EXCLUDED (the object
+    legitimately starts there; the door-ingress term handles entry). NEVER calls solve()/a
+    nester — that would re-import a search's reachable-distribution bias (constraint B)."""
+    floor = hangar.floor_polygon
+    if floor is None:
+        floor = box(0.0, 0.0, hangar.width_m, hangar.length_m)
+    upper = box(-1.0e6, 0.0, 1.0e6, hangar.length_m + 1.0e6)  # y >= 0 half-plane
+    pl = Placement(
+        plane_id="__active__",
+        x_m=pose.x_m,
+        y_m=pose.y_m,
+        heading_deg=pose.heading_deg,
+        on_carts=False,
+    )
+    obstacle_parts = [
+        wp
+        for p in parked_layout.placements
+        for wp in aircraft_parts_world(parked_layout.fleet[p.plane_id], p)
+    ] + [
+        wp
+        for gp in parked_layout.ground_object_placements
+        for wp in aircraft_parts_world(parked_layout.ground_objects[gp.plane_id], gp)
+    ]
+    total = 0.0
+    for wp in aircraft_parts_world(body, pl):
+        poly = wp.polygon
+        total += poly.difference(floor).intersection(upper).area  # in-hangar wall/notch intrusion
+        for op in obstacle_parts:
+            if poly.intersects(op.polygon):
+                total += poly.intersection(op.polygon).area
+    return total

--- a/ml/geometry_oracle.py
+++ b/ml/geometry_oracle.py
@@ -70,6 +70,7 @@ def intrusion_area_m2(
     floor = hangar.floor_polygon
     if floor is None:
         floor = box(0.0, 0.0, hangar.width_m, hangar.length_m)
+    bay_poly = None
     if bay_closed:
         bay = hangar.maintenance_bay
         bay_poly = box(
@@ -82,7 +83,7 @@ def intrusion_area_m2(
     for wp in aircraft_parts_world(body, placement):
         poly = wp.polygon
         total += poly.difference(floor).area  # outside the floor (walls/notch)
-        if bay_closed:
+        if bay_poly is not None:
             total += poly.intersection(bay_poly).area  # inside a CLOSED maintenance bay
     return total
 

--- a/ml/geometry_oracle.py
+++ b/ml/geometry_oracle.py
@@ -70,13 +70,14 @@ def intrusion_area_m2(
     floor = hangar.floor_polygon
     if floor is None:
         floor = box(0.0, 0.0, hangar.width_m, hangar.length_m)
-    bay = hangar.maintenance_bay
-    bay_poly = box(
-        bay.center_x_m - bay.width_m / 2.0,
-        hangar.length_m - bay.depth_m,
-        bay.center_x_m + bay.width_m / 2.0,
-        hangar.length_m,
-    )
+    if bay_closed:
+        bay = hangar.maintenance_bay
+        bay_poly = box(
+            bay.center_x_m - bay.width_m / 2.0,
+            hangar.length_m - bay.depth_m,
+            bay.center_x_m + bay.width_m / 2.0,
+            hangar.length_m,
+        )
     total = 0.0
     for wp in aircraft_parts_world(body, placement):
         poly = wp.polygon
@@ -219,7 +220,7 @@ def active_misfit_m2(
         floor = box(0.0, 0.0, hangar.width_m, hangar.length_m)
     upper = box(-1.0e6, 0.0, 1.0e6, hangar.length_m + 1.0e6)  # y >= 0 half-plane
     pl = Placement(
-        plane_id="__active__",
+        plane_id=body.id,
         x_m=pose.x_m,
         y_m=pose.y_m,
         heading_deg=pose.heading_deg,
@@ -228,11 +229,15 @@ def active_misfit_m2(
     obstacle_parts = [
         wp
         for p in parked_layout.placements
-        for wp in aircraft_parts_world(parked_layout.fleet[p.plane_id], p)
+        for b in [parked_layout.fleet.get(p.plane_id)]
+        if b is not None
+        for wp in aircraft_parts_world(b, p)
     ] + [
         wp
         for gp in parked_layout.ground_object_placements
-        for wp in aircraft_parts_world(parked_layout.ground_objects[gp.plane_id], gp)
+        for b in [parked_layout.ground_objects.get(gp.plane_id)]
+        if b is not None
+        for wp in aircraft_parts_world(b, gp)
     ]
     total = 0.0
     for wp in aircraft_parts_world(body, pl):

--- a/ml/geometry_oracle.py
+++ b/ml/geometry_oracle.py
@@ -30,6 +30,7 @@ from ml.types import Primitive
 __all__ = [
     "overlap_area_m2",
     "intrusion_area_m2",
+    "layout_valid",
     "legal_primitives",
     "apply_primitive",
     "swept_intrusion_m2",
@@ -50,15 +51,21 @@ def overlap_area_m2(layout: Layout) -> float:
     return check(layout).total_penetration_m2
 
 
-def intrusion_area_m2(body: Aircraft | GroundObject, placement: Placement, hangar: Hangar) -> float:
-    """Footprint area (m²) outside the hangar floor or inside a notch/keep-out.
+def intrusion_area_m2(
+    body: Aircraft | GroundObject,
+    placement: Placement,
+    hangar: Hangar,
+    *,
+    bay_closed: bool = False,
+) -> float:
+    """Footprint area (m²) outside the hangar floor or inside a CLOSED maintenance bay.
 
-    Graded counterpart to the binary bounds/notch checks (spec §5). Uses the same
-    shapely polygons: the L-shaped ``hangar.floor_polygon`` when present, else the
-    outer rectangle; plus the maintenance bay rectangle (a keep-out for placement).
-    The front apron (``y < 0``) is part of the *motion* model, not a parked-validity
-    region, so anything below ``y = 0`` counts as intrusion for a PARKED pose.
-    """
+    Mirrors collisions.check's ADR-0006 rule: the maintenance bay is a keep-out ONLY when
+    it is closed (``layout.maintenance_plane is not None``). The env never sets a maintenance
+    occupant, so it always passes ``bay_closed=False`` and the bay term vanishes — fixing the
+    #694 over-strict-inert-bay divergence on the reward gradient. Out-of-floor (walls/notch via
+    ``floor_polygon``) is always counted. The front apron (``y < 0``) counts as intrusion for a
+    PARKED pose (it is a motion region, not a parked-validity region)."""
     floor = hangar.floor_polygon
     if floor is None:
         floor = box(0.0, 0.0, hangar.width_m, hangar.length_m)
@@ -73,7 +80,8 @@ def intrusion_area_m2(body: Aircraft | GroundObject, placement: Placement, hanga
     for wp in aircraft_parts_world(body, placement):
         poly = wp.polygon
         total += poly.difference(floor).area  # outside the floor (walls/notch)
-        total += poly.intersection(bay_poly).area  # inside the maintenance bay
+        if bay_closed:
+            total += poly.intersection(bay_poly).area  # inside a CLOSED maintenance bay
     return total
 
 
@@ -163,6 +171,17 @@ def movement_cost(primitive: Primitive, *, prev_gear: int | None, cusp_penalty: 
     translates = primitive.kind in ("S", "T")
     cusp = 1.0 if (translates and prev_gear is not None and primitive.gear != prev_gear) else 0.0
     return abs(primitive.magnitude) + cusp_penalty * cusp
+
+
+def layout_valid(layout: Layout) -> bool:
+    """Whole-layout validity per the PRODUCT deterministic checker (== ``hangarfit check``):
+    collisions.check reports no conflicts (overlap + hangar bounds/notch + CONDITIONAL
+    maintenance bay + ground-obstacle keep-outs) AND no Caddy hard-door egress violation
+    (ADR-0026). The single source of validity truth shared by the env gate, the r_valid_park
+    bonus gate, and the benchmark — so the bonus and the promotion metric can never disagree.
+    Replaces the env's old hand-rolled overlap+intrusion+egress, which over-enforced the inert
+    maintenance bay (#694)."""
+    return check(layout).valid and not egress_blocked(layout)
 
 
 def egress_blocked(layout: Layout, *, mover_id: str | None = None) -> bool:

--- a/ml/ppo.py
+++ b/ml/ppo.py
@@ -39,10 +39,11 @@ def entropy_coef_at(
     """Per-iteration entropy coefficient. Constant ``base`` when no schedule is configured
     (``start is None`` or ``anneal_iters <= 0``); else a linear ``start``→``end`` ramp over
     ``anneal_iters`` iterations, clamped at ``end`` past the window. Monotone non-increasing
-    when start >= end (the intended high→low warmup)."""
+    when start >= end (the intended high→low warmup). If ``end`` is None, anneals toward
+    ``base``."""
     if start is None or anneal_iters <= 0:
         return base
-    finish = end if end is not None else start
+    finish = end if end is not None else base
     if iteration >= anneal_iters:
         return finish
     frac = iteration / anneal_iters
@@ -55,7 +56,9 @@ class ReturnNormalizer:
     so −w_col collision spikes and +r_terminal sit on a scale the value head can fit, letting
     GAE propagate terminal credit through the drive-in. Identity until ``warmup`` samples seen
     and identity-equivalent at zero variance (eps floor). Std-only preserves the relative
-    ordering of shaped rewards."""
+    ordering of shaped rewards.
+
+    SIDE EFFECT: ``normalize()`` updates the running stats — call once per rollout batch."""
 
     def __init__(self, *, eps: float = 1e-8, warmup: int = 256) -> None:
         self.eps = eps
@@ -74,7 +77,8 @@ class ReturnNormalizer:
     def normalize(self, rewards: Tensor) -> Tensor:
         self._update(rewards)
         if self._count < self.warmup or self._count < 2:
-            return rewards
+            return rewards.clone()
+        # population (biased, ÷N) variance — deliberate, cleanrl convention
         var = self._m2 / self._count
         std = max(var, 0.0) ** 0.5
         return rewards / (std + self.eps)
@@ -200,7 +204,12 @@ def ppo_update(
     GAE. Existing callers that pass no ``normalizer`` are byte-identical (default None)."""
     data = buffer.batch()
     rewards = data["reward"]
-    if config.normalize_returns and normalizer is not None:
+    if config.normalize_returns:
+        if normalizer is None:
+            raise ValueError(
+                "ppo_update: config.normalize_returns=True but normalizer=None; "
+                "pass a ReturnNormalizer instance or set normalize_returns=False"
+            )
         rewards = normalizer.normalize(rewards)
     advantages, returns = compute_gae(
         rewards,

--- a/ml/ppo.py
+++ b/ml/ppo.py
@@ -26,6 +26,58 @@ class PPOConfig:
     value_coef: float = 0.5
     entropy_coef: float = 0.01
     max_grad_norm: float = 0.5
+    entropy_coef_start: float | None = None  # high->low anneal start; None = fixed entropy_coef
+    entropy_coef_end: float | None = None  # anneal end; consulted only when start is set
+    entropy_anneal_iters: int = 0  # iters over which to anneal; 0 = no schedule
+    normalize_returns: bool = False  # std-only reward normalization before GAE
+    return_norm_eps: float = 1e-8  # numerical floor on the running std
+
+
+def entropy_coef_at(
+    iteration: int, *, base: float, start: float | None, end: float | None, anneal_iters: int
+) -> float:
+    """Per-iteration entropy coefficient. Constant ``base`` when no schedule is configured
+    (``start is None`` or ``anneal_iters <= 0``); else a linear ``start``→``end`` ramp over
+    ``anneal_iters`` iterations, clamped at ``end`` past the window. Monotone non-increasing
+    when start >= end (the intended high→low warmup)."""
+    if start is None or anneal_iters <= 0:
+        return base
+    finish = end if end is not None else start
+    if iteration >= anneal_iters:
+        return finish
+    frac = iteration / anneal_iters
+    return start + (finish - start) * frac
+
+
+class ReturnNormalizer:
+    """Std-only reward normalizer (cleanrl convention: NO mean-subtraction) with a running
+    variance (Welford) and warmup-to-identity. Divides the reward stream by the running std
+    so −w_col collision spikes and +r_terminal sit on a scale the value head can fit, letting
+    GAE propagate terminal credit through the drive-in. Identity until ``warmup`` samples seen
+    and identity-equivalent at zero variance (eps floor). Std-only preserves the relative
+    ordering of shaped rewards."""
+
+    def __init__(self, *, eps: float = 1e-8, warmup: int = 256) -> None:
+        self.eps = eps
+        self.warmup = warmup
+        self._count = 0
+        self._mean = 0.0
+        self._m2 = 0.0
+
+    def _update(self, rewards: Tensor) -> None:
+        for r in rewards.tolist():
+            self._count += 1
+            delta = r - self._mean
+            self._mean += delta / self._count
+            self._m2 += delta * (r - self._mean)
+
+    def normalize(self, rewards: Tensor) -> Tensor:
+        self._update(rewards)
+        if self._count < self.warmup or self._count < 2:
+            return rewards
+        var = self._m2 / self._count
+        std = max(var, 0.0) ** 0.5
+        return rewards / (std + self.eps)
 
 
 def factored_logprob_entropy(
@@ -136,13 +188,22 @@ def ppo_update(
     optimizer: torch.optim.Optimizer,
     buffer: RolloutBuffer,
     config: PPOConfig,
+    *,
+    normalizer: ReturnNormalizer | None = None,
 ) -> dict[str, float]:
     """One PPO update over the buffer: GAE, then `epochs` of clipped-surrogate +
     value-loss + entropy-bonus over shuffled minibatches. Returns the metrics averaged
-    over every minibatch in the update (not just the last one)."""
+    over every minibatch in the update (not just the last one).
+
+    ``normalizer``: when ``config.normalize_returns`` is True and a ``ReturnNormalizer``
+    is supplied, rewards are std-scaled (Welford running std, NO mean-subtraction) before
+    GAE. Existing callers that pass no ``normalizer`` are byte-identical (default None)."""
     data = buffer.batch()
+    rewards = data["reward"]
+    if config.normalize_returns and normalizer is not None:
+        rewards = normalizer.normalize(rewards)
     advantages, returns = compute_gae(
-        data["reward"],
+        rewards,
         data["value"],
         data["done"],
         buffer.last_value,

--- a/ml/reward.py
+++ b/ml/reward.py
@@ -22,8 +22,9 @@ class RewardContext:
     prev_potential: float
     potential: float
     terminal_fraction: float | None  # set only on the terminal step
-    # this Park left the whole layout valid (per layout_valid); Park steps only
-    park_valid: bool = False
+    # None = not a Park step (bonus structurally absent);
+    # False = Park step with invalid layout; True = Park step with valid layout.
+    park_valid: bool | None = None
 
 
 def potential(

--- a/ml/reward.py
+++ b/ml/reward.py
@@ -22,6 +22,8 @@ class RewardContext:
     prev_potential: float
     potential: float
     terminal_fraction: float | None  # set only on the terminal step
+    # this Park left the whole layout valid (per layout_valid); Park steps only
+    park_valid: bool = False
 
 
 def potential(
@@ -29,11 +31,12 @@ def potential(
     remaining_overlap_m2: float,
     active_dist_to_slot_m: float,
     unplaced: int,
+    active_misfit_m2: float = 0.0,
 ) -> float:
-    """Shaping potential Φ(s) (spec §5). Higher is better (less overlap / closer /
-    fewer unplaced), so Φ is the NEGATIVE of those costs. Policy-invariant per
-    Ng–Harada–Russell, so it cannot be reward-hacked."""
-    return -(remaining_overlap_m2 + active_dist_to_slot_m + float(unplaced))
+    """Shaping potential Φ(s) (spec §5). Higher is better. Φ is the NEGATIVE of the costs.
+    ``active_misfit_m2`` (the dense_slot_potential in-hangar term) defaults 0.0 → byte-identical
+    when the knob is off. Policy-invariant per Ng–Harada–Russell — cannot be reward-hacked."""
+    return -(remaining_overlap_m2 + active_dist_to_slot_m + float(unplaced) + active_misfit_m2)
 
 
 def step_reward(ctx: RewardContext, w: RewardWeights) -> float:
@@ -49,4 +52,5 @@ def step_reward(ctx: RewardContext, w: RewardWeights) -> float:
     soft = w.w_gap * ctx.min_gap_m - w.w_seq * ctx.seq_deviation + w.w_region * ctx.region_match
     terminal = w.r_terminal * ctx.terminal_fraction if ctx.terminal_fraction is not None else 0.0
     shaping = w.gamma * ctx.potential - ctx.prev_potential
-    return hard + movement + soft + terminal + shaping
+    valid_park = w.r_valid_park if ctx.park_valid else 0.0
+    return hard + movement + soft + terminal + shaping + valid_park

--- a/ml/stage_builder.py
+++ b/ml/stage_builder.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from hangarfit.loader import load_fleet, load_hangar
 from ml.curriculum import Stage
 from ml.env import HangarFitEnv
+from ml.types import RewardWeights
 
 _ROOT = Path(__file__).resolve().parent.parent  # repo root (ml/ sits at the root)
 
@@ -24,11 +25,14 @@ def effective_fleet_ids(stage: Stage) -> tuple[str, ...]:
     return tuple(load_fleet(str(_ROOT / stage.fleet_path)).keys())
 
 
-def build_stage_env(stage: Stage) -> HangarFitEnv:
+def build_stage_env(stage: Stage, *, weights: RewardWeights | None = None) -> HangarFitEnv:
     """Load the rung's hangar + fleet, apply the clearance/apron overrides, and build
     a HangarFitEnv whose difficulty is the stage's. The initial requested_ids is just
     the first ``max_objects`` of the pool — every episode resamples via
-    env.reset(requested_ids=...). Raises if the pool can't supply max_objects."""
+    env.reset(requested_ids=...). Raises if the pool can't supply max_objects.
+
+    ``weights``: optional reward weights to forward to the env (defaults to
+    ``RewardWeights()`` inside the env when None)."""
     hangar = load_hangar(str(_ROOT / stage.hangar_path))
     overrides: dict[str, float] = {"apron_depth_m": stage.apron_depth_m}
     if stage.clearance_m is not None:
@@ -49,4 +53,5 @@ def build_stage_env(stage: Stage) -> HangarFitEnv:
         fleet=fleet,
         requested_ids=tuple(pool[:n]),
         difficulty=stage.difficulty,
+        weights=weights,
     )

--- a/ml/train.py
+++ b/ml/train.py
@@ -30,21 +30,31 @@ from ml.curriculum import (
 from ml.encoding import EncoderConfig, encode
 from ml.env import HangarFitEnv
 from ml.policy import HangarFitPolicy, to_batch
-from ml.ppo import PPOConfig, RolloutBuffer, factored_logprob_entropy, ppo_update, sample_action
+from ml.ppo import (
+    PPOConfig,
+    ReturnNormalizer,
+    RolloutBuffer,
+    entropy_coef_at,
+    factored_logprob_entropy,
+    ppo_update,
+    sample_action,
+)
 from ml.stage_builder import build_stage_env, effective_fleet_ids
-from ml.types import DifficultyConfig
+from ml.types import DifficultyConfig, RewardWeights
 
 _TRIVIAL_DIFFICULTY = DifficultyConfig(
     max_objects=1, per_object_step_budget=40, total_step_budget=40
 )
 
 
-def build_trivial_env(seed: int = 0) -> HangarFitEnv:
+def build_trivial_env(seed: int = 0, *, weights: RewardWeights | None = None) -> HangarFitEnv:
     """A 1-object, loose-hangar, small-budget env — the easiest curriculum rung.
 
     seed is accepted for forward-compat (#4b); the trivial env itself is deterministic
     (no RNG), so it is unused here.
-    """
+
+    ``weights``: optional reward weights forwarded to the env (defaults to
+    ``RewardWeights()`` inside the env when None)."""
     _ = seed  # reserved for #4b object-set sampling; the trivial env has no RNG
     root = Path(__file__).resolve().parent.parent
     fleet = load_fleet(str(root / "data/fleet.yaml"))
@@ -56,6 +66,7 @@ def build_trivial_env(seed: int = 0) -> HangarFitEnv:
         fleet=fleet,
         requested_ids=("fuji",),
         difficulty=_TRIVIAL_DIFFICULTY,
+        weights=weights,
     )
 
 
@@ -126,20 +137,38 @@ def train(
     ppo: PPOConfig | None = None,
     policy_kwargs: dict | None = None,
     encoder: EncoderConfig | None = None,
+    weights: RewardWeights | None = None,
     log: bool = False,
     save: str | None = None,
 ) -> list[float]:
-    """Train on the trivial stage; return the per-iteration mean episode reward."""
+    """Train on the trivial stage; return the per-iteration mean episode reward.
+
+    ``weights``: optional reward weights forwarded to the env (defaults to neutral).
+    ``ppo.entropy_coef_start/end/anneal_iters``: per-iteration entropy schedule; keyed
+    on the iteration index so it re-warms from ``it=0`` each run.
+    ``ppo.normalize_returns``: std-only Welford return normalizer (single run-level
+    normalizer; identity until warmed up)."""
     torch.manual_seed(seed)
     cfg = ppo or PPOConfig()
     enc = encoder or EncoderConfig()
-    env = build_trivial_env(seed)
+    env = build_trivial_env(seed, weights=weights)
     policy = HangarFitPolicy(**(policy_kwargs or {}))
     optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.lr)
+    normalizer = ReturnNormalizer(eps=cfg.return_norm_eps) if cfg.normalize_returns else None
     history: list[float] = []
     for it in range(iterations):
+        it_cfg = replace(
+            cfg,
+            entropy_coef=entropy_coef_at(
+                it,
+                base=cfg.entropy_coef,
+                start=cfg.entropy_coef_start,
+                end=cfg.entropy_coef_end,
+                anneal_iters=cfg.entropy_anneal_iters,
+            ),
+        )
         buf, ep_stats = collect_rollout(env, policy, enc, rollout_len)
-        metrics = ppo_update(policy, optimizer, buf, cfg)
+        metrics = ppo_update(policy, optimizer, buf, it_cfg, normalizer=normalizer)
         # NaN (not 0.0) when no episode finished within the rollout, so a short rollout
         # is not mistaken for a genuine zero-reward iteration in the curve.
         mean_r = sum(s.total_reward for s in ep_stats) / len(ep_stats) if ep_stats else float("nan")
@@ -166,11 +195,18 @@ def train_curriculum(
     ppo: PPOConfig | None = None,
     policy_kwargs: dict | None = None,
     encoder: EncoderConfig | None = None,
+    weights: RewardWeights | None = None,
     log: bool = False,
     save: str | None = None,
 ) -> CurriculumHistory:
     """Climb the ladder: one policy/optimizer across rungs (transfer); per rung, run
-    PPO until the competency gate fires or the per-stage cap is hit, then advance."""
+    PPO until the competency gate fires or the per-stage cap is hit, then advance.
+
+    ``weights``: optional reward weights forwarded to every stage env (defaults to neutral).
+    ``ppo.entropy_coef_start/end/anneal_iters``: per-rung entropy schedule; the iteration
+    index resets to 0 at each new stage, so each rung re-warms from the high start.
+    ``ppo.normalize_returns``: std-only Welford return normalizer (single run-level
+    normalizer shared across all rungs; identity until warmed up)."""
     torch.manual_seed(seed)
     cfg = ppo or PPOConfig()
     enc = encoder or EncoderConfig()
@@ -182,9 +218,10 @@ def train_curriculum(
     pol = sched.policy
     policy = HangarFitPolicy(**(policy_kwargs or {}))
     optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.lr)
+    normalizer = ReturnNormalizer(eps=cfg.return_norm_eps) if cfg.normalize_returns else None
     history = CurriculumHistory()
     for stage_index, stage in enumerate(sched.stages):
-        env = build_stage_env(stage)
+        env = build_stage_env(stage, weights=weights)
         pool = effective_fleet_ids(stage)
         n = stage.difficulty.max_objects if stage.difficulty.max_objects is not None else len(pool)
         rng = stage_rng(seed, stage_index)
@@ -198,10 +235,22 @@ def train_curriculum(
         # where a default-arg lambda would not be.
         next_request = partial(sample_request, pool, n, rng)
         for it in range(pol.max_iters):
+            # Per-rung entropy schedule: `it` resets to 0 each stage, so each rung
+            # re-warms from entropy_coef_start (the intended high→low warmup per rung).
+            it_cfg = replace(
+                cfg,
+                entropy_coef=entropy_coef_at(
+                    it,
+                    base=cfg.entropy_coef,
+                    start=cfg.entropy_coef_start,
+                    end=cfg.entropy_coef_end,
+                    anneal_iters=cfg.entropy_anneal_iters,
+                ),
+            )
             buf, ep_stats = collect_rollout(
                 env, policy, enc, rollout_len, sample_request=next_request
             )
-            ppo_update(policy, optimizer, buf, cfg)
+            ppo_update(policy, optimizer, buf, it_cfg, normalizer=normalizer)
             window.extend(ep_stats)
             history.record(stage.name, it, ep_stats)
             if log:
@@ -245,17 +294,63 @@ def build_argparser() -> argparse.ArgumentParser:
     p.add_argument(
         "--save", type=str, default=None, help="write the trained policy state_dict to this path"
     )
+    p.add_argument(
+        "--r-valid-park",
+        type=float,
+        default=0.0,
+        help="bonus per Park action when the full layout is valid (basin-escape shaping)",
+    )
+    p.add_argument(
+        "--dense-slot-potential",
+        action="store_true",
+        help="add in-hangar nearest-free-pocket shaping term",
+    )
+    p.add_argument(
+        "--entropy-start",
+        type=float,
+        default=None,
+        help="entropy coef anneal start (high→low per rung); None = fixed entropy_coef",
+    )
+    p.add_argument(
+        "--entropy-end",
+        type=float,
+        default=None,
+        help="entropy coef anneal end value (consulted only when --entropy-start is set)",
+    )
+    p.add_argument(
+        "--entropy-anneal-iters",
+        type=int,
+        default=0,
+        help="number of iterations over which to anneal entropy_coef (0 = no schedule)",
+    )
+    p.add_argument(
+        "--normalize-returns",
+        action="store_true",
+        help="std-only Welford return normalization before GAE",
+    )
     return p
 
 
 def main() -> None:
     args = build_argparser().parse_args()
+    weights = RewardWeights(
+        r_valid_park=args.r_valid_park,
+        dense_slot_potential=args.dense_slot_potential,
+    )
+    ppo_cfg = PPOConfig(
+        lr=args.lr,
+        entropy_coef_start=args.entropy_start,
+        entropy_coef_end=args.entropy_end,
+        entropy_anneal_iters=args.entropy_anneal_iters,
+        normalize_returns=args.normalize_returns,
+    )
     if args.schedule == "trivial":
         train(
             seed=args.seed,
             iterations=args.iterations,
             rollout_len=args.rollout_len,
-            ppo=PPOConfig(lr=args.lr),
+            ppo=ppo_cfg,
+            weights=weights,
             log=True,
             save=args.save,
         )
@@ -267,7 +362,8 @@ def main() -> None:
             seed=args.seed,
             schedule=sched,
             rollout_len=args.rollout_len,
-            ppo=PPOConfig(lr=args.lr),
+            ppo=ppo_cfg,
+            weights=weights,
             log=True,
             save=args.save,
         )

--- a/ml/train.py
+++ b/ml/train.py
@@ -144,8 +144,10 @@ def train(
     """Train on the trivial stage; return the per-iteration mean episode reward.
 
     ``weights``: optional reward weights forwarded to the env (defaults to neutral).
-    ``ppo.entropy_coef_start/end/anneal_iters``: per-iteration entropy schedule; keyed
-    on the iteration index so it re-warms from ``it=0`` each run.
+    ``ppo.entropy_coef_start/end/anneal_iters``: per-iteration entropy schedule; decays
+    ONCE over the run's iterations (NO per-stage reset — that is ``train_curriculum()``
+    only, where ``it`` resets to 0 at each new stage). Keyed on the iteration index so
+    it decays from ``it=0`` at the start of the run.
     ``ppo.normalize_returns``: std-only Welford return normalizer (single run-level
     normalizer; identity until warmed up)."""
     torch.manual_seed(seed)

--- a/ml/types.py
+++ b/ml/types.py
@@ -99,6 +99,8 @@ class RewardWeights:
     w_region: float = 1.0  # soft: region preference
     r_terminal: float = 50.0  # terminal: per fraction-placed
     gamma: float = 0.99  # shaping discount
+    r_valid_park: float = 0.0  # bonus paid in Park ONLY when the layout is valid (basin escape)
+    dense_slot_potential: bool = False  # add an in-hangar nearest-free-pocket shaping term
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/ml/test_benchmark.py
+++ b/tests/ml/test_benchmark.py
@@ -176,7 +176,6 @@ def test_bench_set_anchor_witnesses_all_valid():
 
 
 _DEMO = next(s for s in BENCH_SET if s.name == "herrenteich_demo")
-_ALL8 = next(s for s in BENCH_SET if s.name == "herrenteich_all8")
 
 
 def test_build_scenario_env_go_free_control():
@@ -185,9 +184,16 @@ def test_build_scenario_env_go_free_control():
     assert env.ground_objects == {}
 
 
-def test_build_scenario_env_refuses_fixed_obstacle_scenario():
-    with pytest.raises(NotImplementedError, match="4c-ii"):
-        build_scenario_env(_ALL8)
+def test_build_scenario_env_preplaces_fixed_obstacles_for_anchors():
+    anchor = next(s for s in BENCH_SET if s.name == "herrenteich_full")
+    env = build_scenario_env(anchor)  # must NOT raise
+    env.reset()
+    layout = env._layout()
+    # The fuel trailer (fixed_obstacle) is pre-placed in the scene from step 0...
+    go_ids = {gp.plane_id for gp in layout.ground_object_placements}
+    assert "maul_fuel_trailer" in go_ids
+    # ...and is NOT in the driven queue (requested set excludes fixed obstacles).
+    assert "maul_fuel_trailer" not in env.requested_ids
 
 
 def _fuji_env() -> HangarFitEnv:

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -254,3 +254,11 @@ def test_parked_out_of_bounds_layout_is_invalid():
     _, _, done, info = env.step(Park())
     assert done is True and info.placed == 1
     assert info.valid is False  # parked on the apron / out of bounds
+
+
+def test_env_layout_valid_delegates_to_product_checker():
+    from ml import geometry_oracle as go
+
+    env = HangarFitEnv(hangar=empty_hangar(), fleet=_fuji(), requested_ids=("fuji",))
+    env.reset()
+    assert env._layout_valid() == go.layout_valid(env._layout())

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -6,6 +6,7 @@ import random
 
 import pytest
 
+from hangarfit.models import GroundObject, Part, Placement
 from ml import geometry_oracle as go
 from ml.env import HangarFitEnv
 from ml.types import DifficultyConfig, Park, Primitive
@@ -262,3 +263,62 @@ def test_env_layout_valid_delegates_to_product_checker():
     env = HangarFitEnv(hangar=empty_hangar(), fleet=_fuji(), requested_ids=("fuji",))
     env.reset()
     assert env._layout_valid() == go.layout_valid(env._layout())
+
+
+# ---------------------------------------------------------------------------
+# Task 2 (#607 SP#4c-ii / #693) — fixed-obstacle pre-placement
+# ---------------------------------------------------------------------------
+def _fuel_trailer() -> GroundObject:
+    # Minimal fixed obstacle; mirrors the catalog maul_fuel_trailer shape closely
+    # enough. GroundObject carries a `parts` tuple of kind="ground" Parts (no
+    # length_m/width_m/height_m fields) — Part positional args after kind are
+    # length/width/offset_x/offset_y/angle/z_bottom/z_top (verified vs
+    # tests/test_scene.py:541). A fixed_obstacle carries no motion_mode/hard_door_mover.
+    return GroundObject(
+        id="fuel",
+        name="Fuel trailer",
+        parts=(Part("ground", 2.0, 1.5, 0.0, 0.0, 0.0, 0.0, 1.2),),
+        object_class="fixed_obstacle",
+    )
+
+
+def test_fixed_obstacle_in_layout_not_parked_and_fraction_uncorrupted():
+    fleet = _fuji()
+    fuel = _fuel_trailer()
+    fixed = (Placement(plane_id="fuel", x_m=2.0, y_m=10.0, heading_deg=0.0, on_carts=False),)
+    env = HangarFitEnv(
+        hangar=empty_hangar(),
+        fleet=fleet,
+        requested_ids=("fuji",),
+        ground_objects={"fuel": fuel},
+        fixed_placements=fixed,
+    )
+    env.reset()
+    # The fixed obstacle is present in the scene from step 0...
+    layout = env._layout()
+    assert "fuel" in {gp.plane_id for gp in layout.ground_object_placements}
+    # ...but it is NOT counted as a parked (driven-in) object.
+    assert env._fixed == list(fixed)
+    assert all(p.plane_id != "fuel" for p in env._parked)
+    # terminal_fraction denominator is the requested (driven) set only -> 1 here, not 2.
+    # Drive fuji nowhere and Park it: fraction = 1/1 even with the fixed obstacle present.
+    _obs, _r, done, info = env.step(Park())
+    assert done and info.total == 1 and info.placed == 1
+
+
+def test_placed_body_overlapping_fixed_obstacle_is_invalid():
+    fleet = _fuji()
+    fuel = _fuel_trailer()
+    # Place the fuel obstacle exactly where we will park the fuji -> guaranteed overlap.
+    fixed = (Placement(plane_id="fuel", x_m=9.0, y_m=10.0, heading_deg=0.0, on_carts=False),)
+    env = HangarFitEnv(
+        hangar=empty_hangar(),
+        fleet=fleet,
+        requested_ids=("fuji",),
+        ground_objects={"fuel": fuel},
+        fixed_placements=fixed,
+    )
+    env.reset()
+    env._active_pose = type(env._active_pose)(x_m=9.0, y_m=10.0, heading_deg=0.0)
+    env.step(Park())
+    assert env._layout_valid() is False  # fuji parts overlap the fixed fuel obstacle

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -322,3 +322,32 @@ def test_placed_body_overlapping_fixed_obstacle_is_invalid():
     env._active_pose = type(env._active_pose)(x_m=9.0, y_m=10.0, heading_deg=0.0)
     env.step(Park())
     assert env._layout_valid() is False  # fuji parts overlap the fixed fuel obstacle
+
+
+def test_fixed_obstacle_is_perceived_in_observation_and_encoding():
+    # The policy must PERCEIVE the keep-out it is penalized for hitting: the fixed obstacle
+    # belongs in obs.parked (the observed frozen set) and surfaces in the encoded tokens
+    # (its fixed_obstacle type column, row[4]==1) — NOT just in the reward-side _layout().
+    from ml.encoding import EncoderConfig, encode
+
+    fuel = _fuel_trailer()
+    fixed = (Placement(plane_id="fuel", x_m=2.0, y_m=10.0, heading_deg=0.0, on_carts=False),)
+    env = HangarFitEnv(
+        hangar=empty_hangar(),
+        fleet=_fuji(),
+        requested_ids=("fuji",),
+        ground_objects={"fuel": fuel},
+        fixed_placements=fixed,
+    )
+    obs = env.reset()
+    # (a) The fixed obstacle is in the observed frozen set from step 0...
+    assert "fuel" in {po.object_id for po in obs.parked}
+    # ...and it is NOT counted as parked/driven (the LIST, not obs.parked).
+    assert all(p.plane_id != "fuel" for p in env._parked)
+    # (b) The encoded observation surfaces it: a token row with the fixed_obstacle type
+    # column (row[4]) set. (Bodies = fleet ∪ ground_objects so the encoder resolves it.)
+    tensors = encode(obs, env.hangar, {**env.fleet, **env.ground_objects}, EncoderConfig())
+    fixed_rows = [
+        i for i in range(tensors.tokens.shape[0]) if tensors.token_mask[i] and tensors.tokens[i, 4]
+    ]
+    assert fixed_rows, "no fixed_obstacle token row (row[4]) — keep-out is not perceived"

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -258,11 +258,13 @@ def test_parked_out_of_bounds_layout_is_invalid():
 
 
 def test_env_layout_valid_delegates_to_product_checker():
-    from ml import geometry_oracle as go
-
+    # At reset, no objects are parked yet (_layout() is effectively empty of aircraft).
+    # The Layout is structurally valid (no overlaps, no out-of-bounds placements).
+    # The expected value is True for a clean empty state (not a tautology — it asserts
+    # the predicate returns a concrete expected result on a known-good state).
     env = HangarFitEnv(hangar=empty_hangar(), fleet=_fuji(), requested_ids=("fuji",))
     env.reset()
-    assert env._layout_valid() == go.layout_valid(env._layout())
+    assert env._layout_valid() is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ml/test_geometry_oracle.py
+++ b/tests/ml/test_geometry_oracle.py
@@ -216,3 +216,43 @@ def test_layout_full_witness_is_valid_694_regression():
     layout = load_layout(str(_ROOT / "examples/herrenteich/layout_full.yaml"))
     assert check(layout).valid, "precondition: witness valid per collisions.check"
     assert go.layout_valid(layout) is True
+
+
+# ---------------------------------------------------------------------------
+# Task 3 — active_misfit_m2 (Step 6)
+# ---------------------------------------------------------------------------
+
+
+def test_active_misfit_zero_in_clean_pocket_and_positive_when_overlapping():
+    from ml.types import Pose
+
+    fleet = _fuji()
+    hangar = empty_hangar()
+    body = fleet["fuji"]
+    empty = single_object_layout(x_m=5.0, y_m=5.0)  # one parked body near (5,5)
+    # Clean pocket far from the parked body, well inside the floor -> misfit 0.
+    clean = Pose(x_m=14.0, y_m=20.0, heading_deg=0.0)
+    assert go.active_misfit_m2(body, clean, empty, hangar) == pytest.approx(0.0, abs=1e-9)
+    # Right on top of the parked body -> positive misfit.
+    on_top = Pose(x_m=5.0, y_m=5.0, heading_deg=0.0)
+    assert go.active_misfit_m2(body, on_top, empty, hangar) > 0.0
+
+
+def test_active_misfit_never_invokes_search(monkeypatch):
+    import hangarfit.solver as solver
+    from ml.types import Pose
+
+    monkeypatch.setattr(
+        solver,
+        "solve",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("active_misfit_m2 must not call solve()")
+        ),
+    )
+    fleet = _fuji()
+    go.active_misfit_m2(
+        fleet["fuji"],
+        Pose(x_m=5.0, y_m=5.0, heading_deg=0.0),
+        single_object_layout(x_m=12.0, y_m=20.0),
+        empty_hangar(),
+    )

--- a/tests/ml/test_geometry_oracle.py
+++ b/tests/ml/test_geometry_oracle.py
@@ -256,3 +256,16 @@ def test_active_misfit_never_invokes_search(monkeypatch):
         single_object_layout(x_m=12.0, y_m=20.0),
         empty_hangar(),
     )
+
+
+def test_active_misfit_zero_on_apron():
+    """A pose on the apron (y < 0) must return 0.0 — the apron is the legitimate start
+    zone (excluded by the upper y>=0 half-plane in active_misfit_m2)."""
+    from ml.types import Pose
+
+    fleet = _fuji()
+    hangar = empty_hangar()
+    body = fleet["fuji"]
+    empty = single_object_layout(x_m=5.0, y_m=5.0)  # one parked body inside; empty apron
+    apron_pose = Pose(x_m=hangar.door.center_x_m, y_m=-4.0, heading_deg=0.0)  # well on apron
+    assert go.active_misfit_m2(body, apron_pose, empty, hangar) == pytest.approx(0.0, abs=1e-9)

--- a/tests/ml/test_geometry_oracle.py
+++ b/tests/ml/test_geometry_oracle.py
@@ -2,10 +2,20 @@
 
 from __future__ import annotations
 
-from hangarfit.loader import load_fleet
+from pathlib import Path
+
+import pytest
+from shapely.geometry import box
+
+from hangarfit.collisions import check
+from hangarfit.geometry import aircraft_parts_world
+from hangarfit.loader import load_fleet, load_layout
+from hangarfit.models import Placement
 from ml import geometry_oracle as go
 from ml.types import Park, Primitive, RewardWeights
-from tests.ml.conftest import single_object_layout, two_object_layout
+from tests.ml.conftest import _fuji, empty_hangar, single_object_layout, two_object_layout
+
+_ROOT = Path(__file__).resolve().parents[2]  # repo root
 
 
 def test_primitive_and_park_construct():
@@ -149,3 +159,60 @@ def test_movement_cost_adds_cusp_penalty_on_reversal():
 def test_egress_blocked_false_without_hard_door_mover():
     layout = single_object_layout(x_m=5.0, y_m=8.0)
     assert go.egress_blocked(layout) is False  # no hard-door mover present
+
+
+# ---------------------------------------------------------------------------
+# T9: intrusion_area_m2 bay gate (#694)
+# ---------------------------------------------------------------------------
+
+
+def _bay_area_for(body, placement, hangar):
+    bay = hangar.maintenance_bay
+    bay_poly = box(
+        bay.center_x_m - bay.width_m / 2,
+        hangar.length_m - bay.depth_m,
+        bay.center_x_m + bay.width_m / 2,
+        hangar.length_m,
+    )
+    return sum(
+        wp.polygon.intersection(bay_poly).area for wp in aircraft_parts_world(body, placement)
+    )
+
+
+def test_intrusion_bay_term_gated_on_bay_closed():
+    fleet = _fuji()
+    hangar = empty_hangar()
+    body = fleet["fuji"]
+    bay = hangar.maintenance_bay
+    # Park inside the bay rectangle (centroid at the bay centre, one body-length in).
+    pl = Placement(
+        plane_id="fuji",
+        x_m=bay.center_x_m,
+        y_m=hangar.length_m - bay.depth_m / 2,
+        heading_deg=0.0,
+        on_carts=False,
+    )
+    overlap_area = _bay_area_for(body, pl, hangar)
+    assert overlap_area > 0.0, "fixture must actually clip the bay; adjust y if not"
+    open_intr = go.intrusion_area_m2(body, pl, hangar, bay_closed=False)
+    closed_intr = go.intrusion_area_m2(body, pl, hangar, bay_closed=True)
+    assert closed_intr - open_intr == pytest.approx(overlap_area, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# T10: layout_valid + #694 regression
+# ---------------------------------------------------------------------------
+
+
+def test_layout_valid_matches_product_checker_plus_egress():
+    layout = single_object_layout(x_m=5.0, y_m=5.0)  # a clean, valid placement
+    assert go.layout_valid(layout) == (check(layout).valid and not go.egress_blocked(layout))
+    assert go.layout_valid(layout) is True
+
+
+def test_layout_full_witness_is_valid_694_regression():
+    # The committed herrenteich_full witness was WRONGLY rejected by the old env oracle
+    # (inert maintenance bay over-enforced, #694). It is valid per the product checker.
+    layout = load_layout(str(_ROOT / "examples/herrenteich/layout_full.yaml"))
+    assert check(layout).valid, "precondition: witness valid per collisions.check"
+    assert go.layout_valid(layout) is True

--- a/tests/ml/test_ppo.py
+++ b/tests/ml/test_ppo.py
@@ -306,6 +306,19 @@ def test_entropy_coef_linear_anneal_boundaries_and_monotone():
     assert f(20) == pytest.approx(0.05 + (0.005 - 0.05) * 0.5)
 
 
+def test_entropy_coef_at_end_none_anneals_toward_base():
+    # When end=None the schedule must anneal from start toward base (not stay flat at start).
+    base = 0.01
+    start = 0.05
+    at0 = entropy_coef_at(0, base=base, start=start, end=None, anneal_iters=40)
+    at20 = entropy_coef_at(20, base=base, start=start, end=None, anneal_iters=40)
+    at40 = entropy_coef_at(40, base=base, start=start, end=None, anneal_iters=40)
+    assert at0 == pytest.approx(start)
+    assert at40 == pytest.approx(base)  # converges to base (not stuck at start)
+    assert at20 == pytest.approx(start + (base - start) * 0.5)
+    assert at0 > at20 > at40  # strictly decreasing
+
+
 # ---------------------------------------------------------------------------
 # Task 4: ReturnNormalizer
 # ---------------------------------------------------------------------------
@@ -380,7 +393,8 @@ def test_ppo_update_normalizer_off_does_not_touch_rewards(monkeypatch):
 
 
 def test_ppo_update_normalizer_on_changes_rewards(monkeypatch):
-    # When normalize_returns=True and a warm normalizer is passed, compute_gae sees scaled rewards.
+    # When normalize_returns=True and a warm normalizer is passed, compute_gae sees scaled rewards
+    # and the scaling ratio matches 1/(std+eps) for the known batch.
     import ml.ppo as ppo
 
     seen: dict[str, object] = {}
@@ -396,9 +410,34 @@ def test_ppo_update_normalizer_on_changes_rewards(monkeypatch):
     buf = _filled_buffer(policy)
     raw_rewards = buf.batch()["reward"].clone()
     opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    eps = 1e-8
     # warmup=0 so normalizer is active immediately
-    norm = ReturnNormalizer(eps=1e-8, warmup=0)
+    norm = ReturnNormalizer(eps=eps, warmup=0)
     cfg_on = PPOConfig(minibatch_size=16, normalize_returns=True)
     ppo_update(policy, opt, buf, cfg_on, normalizer=norm)
-    # rewards should have been scaled (not equal to raw unless std=1, which is very unlikely)
+    # Rewards should have been scaled (not equal to raw unless std=1, very unlikely).
     assert not torch.equal(seen["rewards"], raw_rewards)
+    # Verify the scaling matches 1/(std+eps) for nonzero rewards: check that
+    # seen_rewards == raw_rewards / (std+eps) element-wise on non-zero entries.
+    mean = raw_rewards.mean()
+    pop_var = float(((raw_rewards - mean) ** 2).mean().item())
+    expected_std = pop_var**0.5
+    expected_scale = 1.0 / (expected_std + eps)
+    seen_rewards = seen["rewards"]
+    assert isinstance(seen_rewards, torch.Tensor)
+    expected_scaled = raw_rewards * expected_scale
+    assert torch.allclose(seen_rewards, expected_scaled, atol=1e-4), (
+        f"scaling mismatch: expected first 5={expected_scaled[:5].tolist()}, "
+        f"got {seen_rewards[:5].tolist()}"
+    )
+
+
+def test_ppo_update_raises_when_normalize_returns_true_but_normalizer_none():
+    # Loud guard: if normalize_returns=True and no normalizer is supplied → ValueError.
+    torch.manual_seed(0)
+    policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2)
+    buf = _filled_buffer(policy)
+    opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    cfg = PPOConfig(minibatch_size=16, normalize_returns=True)
+    with pytest.raises(ValueError, match="normalizer"):
+        ppo_update(policy, opt, buf, cfg, normalizer=None)

--- a/tests/ml/test_ppo.py
+++ b/tests/ml/test_ppo.py
@@ -328,6 +328,24 @@ def test_return_normalizer_std_only_scales_without_mean_shift():
     assert out[2] / out[0] == pytest.approx(r[2] / r[0])
 
 
+def test_return_normalizer_no_mean_subtraction_on_nonzero_mean():
+    # DISCRIMINATING: zero-mean data passes even for a mean-subtracting normalizer, so use
+    # all-positive (non-zero-mean) data. Std-only must keep every output positive and equal
+    # to r / (std + eps) exactly; a mean-subtracting normalizer would push the low values
+    # negative.
+    eps = 1e-8
+    norm = ReturnNormalizer(eps=eps, warmup=0)
+    r = torch.tensor([3.0, 4.0, 5.0, 6.0])  # mean 4.5, all positive
+    out = norm.normalize(r)
+    # Welford over this single batch: population variance = m2 / count = var(r, unbiased=False).
+    mean = r.mean()
+    pop_var = ((r - mean) ** 2).mean()
+    std = float(pop_var.item()) ** 0.5
+    expected = r / (std + eps)
+    assert torch.all(out > 0)  # no mean subtraction -> nothing flipped negative
+    assert torch.allclose(out, expected, atol=1e-6)
+
+
 def test_return_normalizer_eps_floor_finite_on_zero_variance():
     norm = ReturnNormalizer(eps=1e-8, warmup=0)
     out = norm.normalize(torch.zeros(4))

--- a/tests/ml/test_ppo.py
+++ b/tests/ml/test_ppo.py
@@ -281,3 +281,106 @@ def test_sample_action_all_illegal_raises():
     )
     with pytest.raises(ValueError, match="all kind logits are -inf"):
         sample_action(out)
+
+
+# ---------------------------------------------------------------------------
+# Task 4: entropy_coef_at schedule
+# ---------------------------------------------------------------------------
+from ml.ppo import entropy_coef_at  # noqa: E402
+
+
+def test_entropy_coef_constant_when_off():
+    # start None -> constant base regardless of iteration.
+    assert entropy_coef_at(0, base=0.01, start=None, end=None, anneal_iters=0) == 0.01
+    assert entropy_coef_at(50, base=0.01, start=None, end=None, anneal_iters=0) == 0.01
+
+
+def test_entropy_coef_linear_anneal_boundaries_and_monotone():
+    def f(it):
+        return entropy_coef_at(it, base=0.01, start=0.05, end=0.005, anneal_iters=40)
+
+    assert f(0) == pytest.approx(0.05)
+    assert f(40) == pytest.approx(0.005)
+    assert f(100) == pytest.approx(0.005)  # clamped past the window
+    assert f(10) > f(30)  # monotone non-increasing
+    assert f(20) == pytest.approx(0.05 + (0.005 - 0.05) * 0.5)
+
+
+# ---------------------------------------------------------------------------
+# Task 4: ReturnNormalizer
+# ---------------------------------------------------------------------------
+from ml.ppo import ReturnNormalizer  # noqa: E402
+
+
+def test_return_normalizer_identity_during_warmup():
+    norm = ReturnNormalizer(eps=1e-8, warmup=1000)
+    r = torch.tensor([1.0, -100.0, 50.0])
+    out = norm.normalize(r)
+    assert torch.equal(out, r)  # still warming up -> identity
+
+
+def test_return_normalizer_std_only_scales_without_mean_shift():
+    norm = ReturnNormalizer(eps=1e-8, warmup=0)
+    r = torch.tensor([2.0, -2.0, 4.0, -4.0])  # mean 0
+    out = norm.normalize(r)
+    # std-only: divided by running std, NO mean subtraction -> sign preserved, ratios preserved.
+    assert torch.all(torch.sign(out) == torch.sign(r))
+    assert out[2] / out[0] == pytest.approx(r[2] / r[0])
+
+
+def test_return_normalizer_eps_floor_finite_on_zero_variance():
+    norm = ReturnNormalizer(eps=1e-8, warmup=0)
+    out = norm.normalize(torch.zeros(4))
+    assert torch.isfinite(out).all()
+
+
+# ---------------------------------------------------------------------------
+# Task 4: ppo_update normalizer wiring
+# ---------------------------------------------------------------------------
+
+
+def test_ppo_update_normalizer_off_does_not_touch_rewards(monkeypatch):
+    # When normalize_returns is False, compute_gae sees the raw rewards (normalizer ignored).
+    import ml.ppo as ppo
+
+    seen: dict[str, object] = {}
+    real_gae = ppo.compute_gae
+
+    def spy(rewards, *a, **k):
+        seen["rewards"] = rewards.clone()
+        return real_gae(rewards, *a, **k)
+
+    monkeypatch.setattr(ppo, "compute_gae", spy)
+    torch.manual_seed(0)
+    policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2)
+    buf = _filled_buffer(policy)
+    raw_rewards = buf.batch()["reward"].clone()
+    opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    ppo_update(policy, opt, buf, PPOConfig(minibatch_size=16, normalize_returns=False))
+    # normalizer=None (default) -> rewards arrive unchanged
+    assert torch.equal(seen["rewards"], raw_rewards)
+
+
+def test_ppo_update_normalizer_on_changes_rewards(monkeypatch):
+    # When normalize_returns=True and a warm normalizer is passed, compute_gae sees scaled rewards.
+    import ml.ppo as ppo
+
+    seen: dict[str, object] = {}
+    real_gae = ppo.compute_gae
+
+    def spy(rewards, *a, **k):
+        seen["rewards"] = rewards.clone()
+        return real_gae(rewards, *a, **k)
+
+    monkeypatch.setattr(ppo, "compute_gae", spy)
+    torch.manual_seed(0)
+    policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2)
+    buf = _filled_buffer(policy)
+    raw_rewards = buf.batch()["reward"].clone()
+    opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    # warmup=0 so normalizer is active immediately
+    norm = ReturnNormalizer(eps=1e-8, warmup=0)
+    cfg_on = PPOConfig(minibatch_size=16, normalize_returns=True)
+    ppo_update(policy, opt, buf, cfg_on, normalizer=norm)
+    # rewards should have been scaled (not equal to raw unless std=1, which is very unlikely)
+    assert not torch.equal(seen["rewards"], raw_rewards)

--- a/tests/ml/test_reward.py
+++ b/tests/ml/test_reward.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from ml.reward import RewardContext, potential, step_reward
-from ml.types import Park, Primitive, RewardWeights
+from ml.types import RewardWeights
 
 
 def _ctx(**kw):
@@ -47,7 +47,7 @@ def test_terminal_fraction_rewards_more_placed():
 
 
 def test_r_valid_park_default_zero_is_byte_identical():
-    # park_valid defaults False and r_valid_park defaults 0.0 -> no change.
+    # park_valid defaults None (not a Park step) and r_valid_park defaults 0.0 -> no change.
     ctx = _ctx()
     assert step_reward(ctx, RewardWeights()) == step_reward(ctx, RewardWeights(r_valid_park=0.0))
 
@@ -94,49 +94,41 @@ def test_potential_active_misfit_lowers_potential():
 # ---------------------------------------------------------------------------
 
 
-def test_dense_slot_potential_on_lowers_reward_vs_off():
-    """dense_slot_potential=True must produce a LOWER reward than False when the active
-    object sits in a bad position (active_misfit_m2 > 0), catching a gate-inversion the
-    pure helper-level potential() test would miss (the env wires it via _potential())."""
+def test_dense_slot_potential_on_lowers_potential_when_misfit_positive():
+    """dense_slot_potential=True must STRICTLY lower the shaping potential vs False when the
+    active object sits in a bad pose (active_misfit_m2 > 0), catching a gate-inversion the
+    pure helper-level potential() test would miss (the env wires it via _potential()).
+
+    NOTE: active_misfit_m2 EXCLUDES the apron (y<0) — misfit comes only from in-hangar
+    (y>=0) out-of-floor (wall/notch) intrusion, so we place the object inside the y-band but
+    poking the left wall (x<0), and assert that pose has positive misfit before comparing."""
+    from ml import geometry_oracle as go
     from ml.env import HangarFitEnv
-    from tests.ml.conftest import _fuji, empty_hangar
+    from ml.types import Pose
+    from tests.ml.conftest import _fuji, empty_hangar, single_object_layout
 
     fleet = _fuji()
     hangar = empty_hangar()
-
-    # Same env geometry, only dense_slot_potential differs.
-    env_off = HangarFitEnv(
-        hangar=hangar,
-        fleet=fleet,
-        requested_ids=("fuji",),
-        weights=RewardWeights(dense_slot_potential=False),
-    )
-    env_on = HangarFitEnv(
-        hangar=hangar,
-        fleet=fleet,
-        requested_ids=("fuji",),
-        weights=RewardWeights(dense_slot_potential=True),
+    # In the hangar y-band (y>=0) but straddling the left wall (x<0) -> out-of-floor area > 0.
+    # A far-away parked fuji stands in for "some obstacle layout"; it does not overlap bad_pose,
+    # so the misfit here is pure in-hangar wall intrusion (matching the env's empty _layout()).
+    bad_pose = Pose(x_m=-3.0, y_m=10.0, heading_deg=0.0)
+    obstacle_layout = single_object_layout(x_m=15.0, y_m=25.0)
+    assert go.active_misfit_m2(fleet["fuji"], bad_pose, obstacle_layout, hangar) > 0.0, (
+        "fixture must put the active object in a positive-misfit pose"
     )
 
-    # Drive both envs along the same path (straight into the hangar, then Park).
-    # The active object is outside the floor until it crosses y=0, so the misfit
-    # term is non-zero when dense_slot_potential=True (in-hangar wall/notch intrusion).
-    actions: list = [Primitive(kind="S", magnitude=1.0, gear=1)] * 3 + [Park()]
-
-    def rollout(env):
+    def potential_at(dense: bool) -> float:
+        env = HangarFitEnv(
+            hangar=hangar,
+            fleet=fleet,
+            requested_ids=("fuji",),
+            weights=RewardWeights(dense_slot_potential=dense),
+        )
         env.reset()
-        total = 0.0
-        for a in actions:
-            _, r, done, _ = env.step(a)
-            total += r
-            if done:
-                break
-        return total
+        env._active_pose = bad_pose  # override the apron spawn with the bad in-hangar pose
+        return env._potential()
 
-    r_off = rollout(env_off)
-    r_on = rollout(env_on)
-    # When dense_slot_potential=True the misfit penalty lowers the shaping term,
-    # so total reward must be strictly lower than with the knob off.
-    assert r_on <= r_off, (
-        f"dense_slot_potential=True should lower reward vs off (got on={r_on}, off={r_off})"
-    )
+    # Only the misfit term differs between the two (same dist-to-slot, unplaced, overlap),
+    # so the knob-on potential must be STRICTLY lower by exactly the misfit penalty.
+    assert potential_at(dense=True) < potential_at(dense=False)

--- a/tests/ml/test_reward.py
+++ b/tests/ml/test_reward.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from ml.reward import RewardContext, step_reward
+import pytest
+
+from ml.reward import RewardContext, potential, step_reward
 from ml.types import RewardWeights
 
 
@@ -37,3 +39,50 @@ def test_terminal_fraction_rewards_more_placed():
     half = step_reward(_ctx(terminal_fraction=0.5), w)
     full = step_reward(_ctx(terminal_fraction=1.0), w)
     assert full > half
+
+
+# ---------------------------------------------------------------------------
+# Task 3 — r_valid_park bonus (Step 1)
+# ---------------------------------------------------------------------------
+
+
+def test_r_valid_park_default_zero_is_byte_identical():
+    # park_valid defaults False and r_valid_park defaults 0.0 -> no change.
+    ctx = _ctx()
+    assert step_reward(ctx, RewardWeights()) == step_reward(ctx, RewardWeights(r_valid_park=0.0))
+
+
+def test_r_valid_park_paid_only_when_park_valid():
+    w = RewardWeights(r_valid_park=2.0)
+    valid = _ctx(park_valid=True)
+    invalid = _ctx(park_valid=False)
+    assert step_reward(valid, w) - step_reward(invalid, w) == pytest.approx(2.0)
+
+
+def test_r_valid_park_cannot_make_an_overlapping_park_profitable():
+    # Ordering invariant: bonus << w_col * smallest meaningful overlap, and only paid on valid.
+    w = RewardWeights(r_valid_park=2.0)
+    overlapping = _ctx(overlap_m2=0.05, park_valid=False)  # invalid -> no bonus, big penalty
+    assert step_reward(overlapping, w) < 0.0
+    assert w.r_valid_park < w.w_col * 0.05
+
+
+# ---------------------------------------------------------------------------
+# Task 3 — dense_slot_potential / active_misfit_m2 in potential() (Step 10)
+# ---------------------------------------------------------------------------
+
+
+def test_potential_active_misfit_default_zero_is_byte_identical():
+    a = potential(remaining_overlap_m2=1.0, active_dist_to_slot_m=2.0, unplaced=3)
+    b = potential(
+        remaining_overlap_m2=1.0, active_dist_to_slot_m=2.0, unplaced=3, active_misfit_m2=0.0
+    )
+    assert a == b
+
+
+def test_potential_active_misfit_lowers_potential():
+    base = potential(remaining_overlap_m2=0.0, active_dist_to_slot_m=0.0, unplaced=0)
+    worse = potential(
+        remaining_overlap_m2=0.0, active_dist_to_slot_m=0.0, unplaced=0, active_misfit_m2=5.0
+    )
+    assert worse < base  # higher misfit -> lower potential (Φ is negative cost)

--- a/tests/ml/test_reward.py
+++ b/tests/ml/test_reward.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from ml.reward import RewardContext, potential, step_reward
-from ml.types import RewardWeights
+from ml.types import Park, Primitive, RewardWeights
 
 
 def _ctx(**kw):
@@ -60,11 +60,12 @@ def test_r_valid_park_paid_only_when_park_valid():
 
 
 def test_r_valid_park_cannot_make_an_overlapping_park_profitable():
-    # Ordering invariant: bonus << w_col * smallest meaningful overlap, and only paid on valid.
+    # An overlapping invalid Park (park_valid=False, overlap>0) must yield a LOWER step_reward
+    # than a clean valid Park (park_valid=True, no overlap) with the same r_valid_park weight.
     w = RewardWeights(r_valid_park=2.0)
-    overlapping = _ctx(overlap_m2=0.05, park_valid=False)  # invalid -> no bonus, big penalty
-    assert step_reward(overlapping, w) < 0.0
-    assert w.r_valid_park < w.w_col * 0.05
+    overlapping_invalid = _ctx(overlap_m2=0.05, park_valid=False)
+    clean_valid = _ctx(overlap_m2=0.0, park_valid=True)
+    assert step_reward(overlapping_invalid, w) < step_reward(clean_valid, w)
 
 
 # ---------------------------------------------------------------------------
@@ -86,3 +87,56 @@ def test_potential_active_misfit_lowers_potential():
         remaining_overlap_m2=0.0, active_dist_to_slot_m=0.0, unplaced=0, active_misfit_m2=5.0
     )
     assert worse < base  # higher misfit -> lower potential (Φ is negative cost)
+
+
+# ---------------------------------------------------------------------------
+# Task 3 — dense_slot_potential reward effect (Step 12)
+# ---------------------------------------------------------------------------
+
+
+def test_dense_slot_potential_on_lowers_reward_vs_off():
+    """dense_slot_potential=True must produce a LOWER reward than False when the active
+    object sits in a bad position (active_misfit_m2 > 0), catching a gate-inversion the
+    pure helper-level potential() test would miss (the env wires it via _potential())."""
+    from ml.env import HangarFitEnv
+    from tests.ml.conftest import _fuji, empty_hangar
+
+    fleet = _fuji()
+    hangar = empty_hangar()
+
+    # Same env geometry, only dense_slot_potential differs.
+    env_off = HangarFitEnv(
+        hangar=hangar,
+        fleet=fleet,
+        requested_ids=("fuji",),
+        weights=RewardWeights(dense_slot_potential=False),
+    )
+    env_on = HangarFitEnv(
+        hangar=hangar,
+        fleet=fleet,
+        requested_ids=("fuji",),
+        weights=RewardWeights(dense_slot_potential=True),
+    )
+
+    # Drive both envs along the same path (straight into the hangar, then Park).
+    # The active object is outside the floor until it crosses y=0, so the misfit
+    # term is non-zero when dense_slot_potential=True (in-hangar wall/notch intrusion).
+    actions: list = [Primitive(kind="S", magnitude=1.0, gear=1)] * 3 + [Park()]
+
+    def rollout(env):
+        env.reset()
+        total = 0.0
+        for a in actions:
+            _, r, done, _ = env.step(a)
+            total += r
+            if done:
+                break
+        return total
+
+    r_off = rollout(env_off)
+    r_on = rollout(env_on)
+    # When dense_slot_potential=True the misfit penalty lowers the shaping term,
+    # so total reward must be strictly lower than with the knob off.
+    assert r_on <= r_off, (
+        f"dense_slot_potential=True should lower reward vs off (got on={r_on}, off={r_off})"
+    )

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -106,3 +106,54 @@ def test_train_curriculum_validates_ladder_eagerly():
     sched = CurriculumSchedule(stages=(bad,), policy=PromotionPolicy(window=1, max_iters=1))
     with pytest.raises(ValueError):
         train_curriculum(seed=0, schedule=sched, rollout_len=8)
+
+
+# ---------------------------------------------------------------------------
+# Task 4: per-rung entropy re-warm + RewardWeights threading + defaults neutral
+# ---------------------------------------------------------------------------
+
+
+def test_entropy_coef_at_rewarms_per_stage():
+    # A schedule keyed on the PER-STAGE iteration re-warms each rung (iter resets to 0).
+    from ml.ppo import entropy_coef_at
+
+    cfg_start, cfg_end, anneal = 0.05, 0.005, 40
+    # stage 1 iter 0 and stage 2 iter 0 must BOTH be the high start (re-warm), not decayed.
+    assert entropy_coef_at(
+        0, base=0.01, start=cfg_start, end=cfg_end, anneal_iters=anneal
+    ) == pytest.approx(0.05)
+
+
+def test_build_stage_env_threads_reward_weights():
+    from ml.curriculum import CurriculumSchedule
+    from ml.stage_builder import build_stage_env
+    from ml.types import RewardWeights
+
+    stage = CurriculumSchedule.default().stages[0]
+    env = build_stage_env(stage, weights=RewardWeights(r_valid_park=2.0))
+    assert env.weights.r_valid_park == 2.0
+
+
+def test_build_trivial_env_threads_reward_weights():
+    from ml.train import build_trivial_env
+    from ml.types import RewardWeights
+
+    env = build_trivial_env(seed=0, weights=RewardWeights(r_valid_park=3.0))
+    assert env.weights.r_valid_park == 3.0
+
+
+def test_train_weights_default_neutral():
+    # Passing no weights → default RewardWeights() → r_valid_park == 0.0 (neutral)
+    from ml.types import RewardWeights
+
+    env_weights = RewardWeights()
+    assert env_weights.r_valid_park == 0.0
+    history = train(seed=0, iterations=1, rollout_len=16)
+    assert len(history) == 1  # runs without error
+
+
+def test_train_curriculum_weights_default_neutral():
+    # weights=None → neutral defaults; trivial schedule with cap-2 iters completes
+    sched = _tiny_schedule(threshold=2.0)  # always caps
+    h = train_curriculum(seed=0, schedule=sched, rollout_len=8)
+    assert len(h.promotions) == 2

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 torch = pytest.importorskip("torch")
@@ -113,15 +115,51 @@ def test_train_curriculum_validates_ladder_eagerly():
 # ---------------------------------------------------------------------------
 
 
-def test_entropy_coef_at_rewarms_per_stage():
-    # A schedule keyed on the PER-STAGE iteration re-warms each rung (iter resets to 0).
-    from ml.ppo import entropy_coef_at
+def test_entropy_schedule_rewarms_per_stage_in_train_curriculum(monkeypatch):
+    # BEHAVIORAL: prove train_curriculum keys the entropy schedule on the PER-STAGE
+    # iteration `it` (resets 0 each rung), not a global counter that would decay to ~end
+    # by later rungs. Monkeypatch ppo_update to record the entropy_coef actually applied
+    # and collect_rollout to a cheap no-episode stub so the per-stage loop runs its full
+    # max_iters without promoting or doing any real torch training.
+    import ml.train as train_mod
+    from ml.ppo import PPOConfig, RolloutBuffer
 
-    cfg_start, cfg_end, anneal = 0.05, 0.005, 40
-    # stage 1 iter 0 and stage 2 iter 0 must BOTH be the high start (re-warm), not decayed.
-    assert entropy_coef_at(
-        0, base=0.01, start=cfg_start, end=cfg_end, anneal_iters=anneal
-    ) == pytest.approx(0.05)
+    recorded: list[float] = []
+
+    def recorder(policy, optimizer, buf, config, *, normalizer=None):
+        recorded.append(config.entropy_coef)
+        return {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0, "loss": 0.0}
+
+    def empty_rollout(env, policy, enc, rollout_len, *, sample_request=None):
+        return RolloutBuffer(), []  # no completed episodes -> never promotes by competency
+
+    monkeypatch.setattr(train_mod, "ppo_update", recorder)
+    monkeypatch.setattr(train_mod, "collect_rollout", empty_rollout)
+
+    max_iters = 3
+    # threshold 2.0 + zero episodes -> the window stays empty -> every rung caps at max_iters.
+    sched = _tiny_schedule(threshold=2.0)
+    sched = CurriculumSchedule(
+        stages=sched.stages,
+        policy=replace(sched.policy, max_iters=max_iters),
+    )
+    cfg = PPOConfig(entropy_coef_start=0.05, entropy_coef_end=0.005, entropy_anneal_iters=4)
+    train_curriculum(seed=0, schedule=sched, rollout_len=8, ppo=cfg)
+
+    n_stages = len(sched.stages)
+    assert len(recorded) == n_stages * max_iters  # full cap each rung, no early promote
+    stage0 = recorded[:max_iters]
+    stage1 = recorded[max_iters : 2 * max_iters]
+    # Each rung RE-WARMS to start at its first iteration (proves per-stage keying):
+    assert stage0[0] == pytest.approx(0.05)
+    assert stage1[0] == pytest.approx(0.05)
+    # ...and decays within each rung (it=0,1,2 -> start + (end-start)*it/4, non-increasing):
+    for seq in (stage0, stage1):
+        # seq[1:] is intentionally one shorter (consecutive-pair idiom) -> strict=False.
+        assert all(later <= earlier for earlier, later in zip(seq, seq[1:], strict=False))
+        assert seq[1] < seq[0]  # strictly decaying inside the anneal window
+    # If the schedule were keyed on a GLOBAL counter, stage1[0] would be the it=3 value
+    # (already decayed), NOT the 0.05 start — this is the discriminating assertion.
 
 
 def test_build_stage_env_threads_reward_weights():


### PR DESCRIPTION
Closes #693
Closes #694

Sub-project **4c-ii "enablement + knobs"** of the cold-joint RL learned-backend epic (#607). Ships the env enablement + exploration/reward knobs that unblock and de-risk training the policy on the real Herrenteich anchors, and folds in the #694 maintenance-bay oracle fix. **No `src/` changes** — everything is in the torch-free-where-possible top-level `ml/` package (never in the wheel). Built brainstorm → agent-team design deliberation → spec → plan → subagent-driven TDD (per-task reviews + a final whole-branch review, all clean).

## What changed

1. **#694 — unified validity (deliberate bugfix, not neutral).** One shared `geometry_oracle.layout_valid(layout)` = `collisions.check(layout).valid and not egress_blocked(layout)`. The env gate, the new `r_valid_park` bonus gate, and `benchmark._layout_valid` all route through it, so the reward bonus and the curriculum promotion metric can never disagree. `intrusion_area_m2` now gates the maintenance-bay term on `bay_closed` (ADR-0006: the bay is a keep-out only when occupied) — the env stops over-rejecting layouts that clip the *inert* placeholder bay (the `herrenteich_full` witness was wrongly rejected before).

2. **Fixed-obstacle env support.** `HangarFitEnv` gains `fixed_placements` / `_fixed`, unioned into `_layout()` (so reward/validity see the keep-outs) **and** surfaced through `_observe()` (so the policy *perceives* them — the encoder rasterizes + tokenizes them via the already-present `fixed_obstacle` token column). Kept **out** of `_parked`, so `terminal_fraction` stays over the driven set only. `benchmark.build_scenario_env` now pre-places them (was: `NotImplementedError`), **unblocking the benchmark's policy column on the Herrenteich anchors**.

3. **Reward knobs (default-neutral).** `RewardWeights.r_valid_park` (a bounded bonus paid in Park **only** when `layout_valid`; default `0.0`) and `dense_slot_potential` (adds a coarse in-hangar nearest-free-pocket term `active_misfit_m2` — a pure, no-search shapely query — to the shaping potential Φ, so it stays Ng–Harada–Russell **policy-invariant**; default off).

4. **Optimizer knobs (default-neutral).** Per-rung entropy-coefficient anneal (`entropy_coef_at`, applied via `replace` keyed on the per-stage iteration so each rung re-warms) and a std-only `ReturnNormalizer` (Welford, warmup-to-identity, applied before GAE only when on). `RewardWeights` is threaded through the env builders; new CLI flags `--r-valid-park`, `--dense-slot-potential`, `--entropy-start/-end/-anneal-iters`, `--normalize-returns`.

5. **Docs.** CHANGELOG `[Unreleased]` (Added + Fixed) and an `ml/README` "Training knobs" section (flags, defaults, recommended treatment values, A/B command, deferral note).

## Default-neutral / determinism

All four knobs default to neutral → with the knobs off, `step_reward`, `potential`, `ppo_update`, and the entropy coef are **byte-identical** to the post-#694 code. The learned path is **not** under ADR-0003 / `determinism-guard` (epic contract); no `src/` change, `collisions.check` consumed read-only. The #694 fix is the one deliberate behavior change (on bay-clipping layouts, by design).

## Validation — A/B smoke (directional, not mastery)

Short CPU A/B on the easy box rungs (the place-invalid basin bites on multi-object rungs). Two independent runs (12 iters × 3 rungs, and 15 iters × 2 rungs) **agree**:

| rung | metric | control (neutral) | treatment (all knobs) |
|---|---|---|---|
| pair-box | `valid_rate` | 0.029 | **0.286** |
| pair-box | `valid_placed` | 0.000 | 0.000 |
| trio-box | `valid_rate` | 0.000 | **0.314** |
| trio-box | `valid_placed` | 0.000 | 0.000 |
| trio-box | `fraction_placed` | 0.991 | 0.476 |

The control reproduces the **place-invalid basin** exactly (places everything, ~all overlapping → `valid_placed` → 0). Treatment shifts the targeted axis: `valid_rate` rises from ~0/0.03 to ~0.29–0.31 (genuinely valid layouts appear) at the cost of lower `fraction_placed` (the agent becomes *cautious*). The compound `valid_placed` metric hasn't lifted off 0 in this short budget — reaching *dense-and-valid* is the **deferred** run-to-mastery target. **No gate leak**: `valid_placed` did not rise while `fraction_placed ≫ valid_placed`, so `r_valid_park` is not rewarding invalid parks.

## Deferred (the second half of #693)

- The real run-to-mastery + `PromotionPolicy` tuning; statistical reach-rate methodology; vectorized envs.
- The **backward/start-state curriculum** (pre-park *k* objects from a witness) — the agent-team's runner-up; deferred because it brushes apron-entry realism and carries a `terminal_fraction` denominator hazard. First thing to graft if the pure-reward knobs escape place-nothing but not the dense anchors.

## Constraints honored

- **Apron-entry realism:** `reset()`/`_spawn()` unchanged; every placed object is driven in from the apron. The solver/witness `seed_anchor` idea was **dropped** entirely.
- **Solver-independence:** no `solve()`/RR-MC in the training loop; deterministic code is the reward oracle + final gate only; `active_misfit_m2` is a pure state→scalar query (guarded by a no-search test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
