### PR TITLE
docs(CLAUDE.md): document the ml/ learned-backend RL workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file is the durable **operational** context for the project: how we work, w
 
 `hangarfit` is an **on-demand exception tool** for a flying club: when the standard hangar parking layout breaks (delayed return, surprise maintenance, etc.), it helps find *a* valid alternative arrangement. The tool checks whether a hand-authored candidate layout is physically valid and renders a top-down PNG so a human can eyeball it; the solver searches for one when no candidate is in hand.
 
-**Status:** Phase 1 (substrate), Phase 2a (static layout solver, `hangarfit solve`), Phase 2b–2c (solver realism + spread/diversity polish), Phase 3a (tow-path planning, `hangarfit solve --render-paths`), Phase 3b (Reeds–Shepp reverse-capable tow motion), and Phase 4 (interactive 3D viewer, `hangarfit view`) have all shipped. Live milestone status lives in auto-memory and GitHub milestones, not here.
+**Status:** Phase 1 (substrate), Phase 2a (static layout solver, `hangarfit solve`), Phase 2b–2c (solver realism + spread/diversity polish), Phase 3a (tow-path planning, `hangarfit solve --render-paths`), Phase 3b (Reeds–Shepp reverse-capable tow motion), and Phase 4 (interactive 3D viewer, `hangarfit view`) have all shipped. An opt-in **learned backend** (epic #607 — the dev/CI-only `ml/` RL workspace) is in active development and **not yet shipped**. Live milestone status lives in auto-memory and GitHub milestones, not here.
 
 ---
 
@@ -34,7 +34,7 @@ This file is the durable **operational** context for the project: how we work, w
 | **The staging apron** (`hangar.apron_depth_m` / `--apron-depth N\|auto`, slide-in from outside the door, reverse nose-out seeds, depth-0 byte-identical) | [§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md#the-door-is-a-visual-marker-only) + [ADR-0021](docs/adr/0021-tow-planner-staging-apron.md). `collisions.check` is apron-inert (forbids `y<0`); the apron is a planner-level motion concept |
 | **The 3D viewer** (`hangarfit view`, interactive offline HTML, whole-fill tow timeline, the `scene/v2` JSON seam, Python-owned transform) | [§5 Building Block View](docs/architecture/05-building-block-view.md) (`scene`, `viewer`) + [ADR-0017](docs/adr/0017-3d-viewer-architecture.md) + the schema reference [docs/architecture/scene-v2-schema.md](docs/architecture/scene-v2-schema.md) |
 | **Ground objects** (fixed obstacles + placed/routed movers — cars & trailers; the Caddy hard-door egress gate; the soft right/left-region preference; movers are solver-placed since #604) | [§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md) + [ADR-0025](docs/adr/0025-ground-object-taxonomy.md) (taxonomy) + [ADR-0026](docs/adr/0026-caddy-hard-door-egress.md) (Caddy egress) + [ADR-0008](docs/adr/0008-inter-plane-spread-soft-preference.md) (region soft-term amendment) + [ADR-0010](docs/adr/0010-reeds-shepp-motion-model.md) (mover motion) |
-| **The learned-backend RL workspace** (`ml/`, #607 — cold-joint env/reward, observation tensorizer, policy net, PPO, curriculum, eval/benchmark; dev/CI-only, never in the wheel) | [`ml/README.md`](ml/README.md) + [ADR-0027](docs/adr/0027-learned-backend-determinism-scope.md) + the design spec `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md` |
+| **The learned-backend RL workspace** (`ml/`, a top-level package *outside* `src/hangarfit/`; #607 — cold-joint env/reward, observation tensorizer, policy net, PPO, curriculum, eval/benchmark) | [`ml/README.md`](ml/README.md) + [ADR-0027](docs/adr/0027-learned-backend-determinism-scope.md) (Proposed) + the design spec `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md` |
 | Why the project targets a single Python (3.12), not a range | [ADR-0009](docs/adr/0009-single-supported-python-version.md) |
 | All architecture decisions, including superseded ones | [`docs/adr/`](docs/adr/) |
 
@@ -301,6 +301,8 @@ VIEWER_OUTFILE=/tmp/viewer-scratch.js npm --prefix viewer/ run build
 # torch is the OPTIONAL `[train]` extra; torch-free modules (benchmark) vs torch-needing
 # (train/eval/policy/ppo, gated by importorskip in tests). Entry points + the 4c-ii
 # training-knob table + A/B command live in ml/README.md.
+# CI installs only the [dev] extra (no torch), so its ml/ coverage is the torch-free
+# subset — the torch modules importorskip-skip there; full torch-CI is a future #607 rung.
 pip install -e ".[train]"      # adds torch for training/eval (CPU is fine)
 pytest tests/ml/               # the ml/ test tree (collected by default; testpaths=["tests"])
 python -m ml.train --save P    # train + export state_dict (needs [train])

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ This file is the durable **operational** context for the project: how we work, w
 | **The staging apron** (`hangar.apron_depth_m` / `--apron-depth N\|auto`, slide-in from outside the door, reverse nose-out seeds, depth-0 byte-identical) | [§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md#the-door-is-a-visual-marker-only) + [ADR-0021](docs/adr/0021-tow-planner-staging-apron.md). `collisions.check` is apron-inert (forbids `y<0`); the apron is a planner-level motion concept |
 | **The 3D viewer** (`hangarfit view`, interactive offline HTML, whole-fill tow timeline, the `scene/v2` JSON seam, Python-owned transform) | [§5 Building Block View](docs/architecture/05-building-block-view.md) (`scene`, `viewer`) + [ADR-0017](docs/adr/0017-3d-viewer-architecture.md) + the schema reference [docs/architecture/scene-v2-schema.md](docs/architecture/scene-v2-schema.md) |
 | **Ground objects** (fixed obstacles + placed/routed movers — cars & trailers; the Caddy hard-door egress gate; the soft right/left-region preference; movers are solver-placed since #604) | [§8 Crosscutting Concepts](docs/architecture/08-crosscutting-concepts.md) + [ADR-0025](docs/adr/0025-ground-object-taxonomy.md) (taxonomy) + [ADR-0026](docs/adr/0026-caddy-hard-door-egress.md) (Caddy egress) + [ADR-0008](docs/adr/0008-inter-plane-spread-soft-preference.md) (region soft-term amendment) + [ADR-0010](docs/adr/0010-reeds-shepp-motion-model.md) (mover motion) |
+| **The learned-backend RL workspace** (`ml/`, #607 — cold-joint env/reward, observation tensorizer, policy net, PPO, curriculum, eval/benchmark; dev/CI-only, never in the wheel) | [`ml/README.md`](ml/README.md) + [ADR-0027](docs/adr/0027-learned-backend-determinism-scope.md) + the design spec `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md` |
 | Why the project targets a single Python (3.12), not a range | [ADR-0009](docs/adr/0009-single-supported-python-version.md) |
 | All architecture decisions, including superseded ones | [`docs/adr/`](docs/adr/) |
 
@@ -101,6 +102,8 @@ Use the best-fitted model for the task. The model class to pick is "as much reas
 - **`feature-dev:code-architect`** — only for genuinely novel design decisions, not routine implementation.
 
 Most coding goes direct in-session. Subagent dispatch is for review work and isolated heavy lifts.
+
+`ml/` is reviewable source, not scratch — run the formal `/pr-review` arc on `ml/` PRs like any `src/` change. Note CI's `mypy` only covers `src/hangarfit/`, so a Pyright complaint under `tests/ml/` is usually stale-LSP noise — `mypy`/CI is the source of truth.
 
 **Review subagents must stay read-only in the shared checkout.** A review agent that runs `git switch` / `checkout` / `stash` in the shared working tree silently reverts it under any sibling agent (and under you). Point review agents at `origin/<branch>` refs instead — `gh pr diff N`, `git diff origin/develop...origin/feature/X`, and `git show origin/develop:<path>` for the pre-change state — and **never** switch branches in place. Isolate any subagent that *writes* in its own worktree.
 
@@ -291,6 +294,16 @@ VIEWER_OUTFILE=/tmp/viewer-scratch.js npm --prefix viewer/ run build
 # it — the CI skew-guard ties all three, bump in lockstep). viewer/src uses explicit `.ts`
 # imports (tsconfig allowImportingTsExtensions) so `node --test` resolves them under Node
 # 24 type-stripping; esbuild inlines internal modules, so .ts stays bundle-neutral.
+
+# Learned-backend RL workspace (ml/, #607 — DEV/CI-ONLY, never shipped in the wheel).
+# ml/ is a TOP-LEVEL package, so the editable install (packages.find where=["src"])
+# does NOT put it on sys.path — run from the repo root (cwd=root or PYTHONPATH=$PWD).
+# torch is the OPTIONAL `[train]` extra; torch-free modules (benchmark) vs torch-needing
+# (train/eval/policy/ppo, gated by importorskip in tests). Entry points + the 4c-ii
+# training-knob table + A/B command live in ml/README.md.
+pip install -e ".[train]"      # adds torch for training/eval (CPU is fine)
+pytest tests/ml/               # the ml/ test tree (collected by default; testpaths=["tests"])
+python -m ml.train --save P    # train + export state_dict (needs [train])
 
 # GitFlow loops
 git switch develop && git pull


### PR DESCRIPTION
Closes #699

## What

`CLAUDE.md` never mentioned the `ml/` learned-backend RL workspace, even though it is now a git-tracked top-level package (env, reward, encoding, policy, ppo, train, curriculum, eval, benchmark, action_space, geometry_oracle, stage_builder, types) with its own `tests/ml/` tree, `ml/README.md`, `python -m ml.{train,eval,benchmark}` entry points, and a `[train]` torch extra. It landed across PRs #677/#681/#685/#689/#695/#697 (epic #607). This was the dominant currency gap in a CLAUDE.md audit (otherwise B/84, mostly current).

## Changes (3 minimal additions, all pointing to `ml/README.md` rather than duplicating its knob table)

1. **Quick Reference row** → `ml/README.md` + ADR-0027 + the design spec — makes the workspace discoverable.
2. **`ml/` block in Useful commands** — the operational gotchas: dev/CI-only (never in the wheel), `ml/` is a top-level pkg so the editable install (`packages.find where=["src"]`) does not put it on `sys.path` → run from the repo root; `torch` is the optional `[train]` extra; `pytest tests/ml/`.
3. **Subagents one-liner** — `ml/` is reviewable source: run `/pr-review` on its PRs; `mypy`/CI is truth over a stale Pyright complaint on `tests/ml/`.

## Verification of every asserted fact

- Both cited paths exist (ADR slug corrected to `0027-learned-backend-determinism-scope.md`); the design-spec path resolves.
- `ml/` is git-tracked; `[tool.setuptools.packages.find] where=["src"]` confirms `ml/` is not installed by the editable install (the import gotcha is real).
- `[project.optional-dependencies] train = ["torch"]` exists.
- `tests/ml/` is collected via `testpaths=["tests"]`; CI workflows carry no torch/`ml/` job (consistent with the dev/CI-only framing and the future torch-CI rung).

## Why no CHANGELOG entry

Contributor-doc (`CLAUDE.md`) change only — no user-facing behaviour change. The CHANGELOG `[Unreleased]` block documents the `ml/` *features* themselves (already present); this PR only documents the workspace for contributors.