### PR TITLE
feat(607): ONNX export + `solve --backend learned` inference (sub-project #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend inference (#706, epic #607).** `solve --backend learned --weights PATH`
+  now runs: a trained policy is exported to ONNX (`ml/export.py`, `train --save-onnx`) and
+  run torch-free via onnxruntime (`ml/infer.py`), returning a `SolveResult` (valid layout +
+  the policy's own drive-in tow plan) behind the deterministic verifier. New optional
+  `[learned-infer]` extra (onnxruntime). The verifier (`collisions.check` + Caddy egress)
+  remains the sole arbiter of validity (ADR-0027); an invalid proposal returns a no-layout
+  result. Wheel distribution, CI, and signed weights are tracked in #6.
+
 - **Learned backend (#607, 4c-ii): cold-joint RL env fixed-obstacle support and
   four default-neutral basin-escape knobs.** Fixed-obstacle pre-placements
   (immovable keep-outs from `Scenario.fixed_obstacle_placements`) are now honoured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ All notable changes to this project are documented here. Format follows [Keep a 
   now runs: a trained policy is exported to ONNX (`ml/export.py`, `train --save-onnx`) and
   run torch-free via onnxruntime (`ml/infer.py`), returning a `SolveResult` (valid layout +
   the policy's own drive-in tow plan) behind the deterministic verifier. New optional
-  `[learned-infer]` extra (onnxruntime). The verifier (`collisions.check` + Caddy egress)
-  remains the sole arbiter of validity (ADR-0027); an invalid proposal returns a no-layout
-  result. Wheel distribution, CI, and signed weights are tracked in #6.
+  `[learned-infer]` extra (onnxruntime); the `[train]` extra also gains `onnx>=1.16`
+  (required by `ml/export.py` to serialize the ONNX proto). The verifier
+  (`collisions.check` + Caddy egress) remains the sole arbiter of validity (ADR-0027); an
+  invalid proposal returns a no-layout result. Wheel distribution, CI, and signed weights
+  are tracked in #6.
 
 - **Learned backend (#607, 4c-ii): cold-joint RL env fixed-obstacle support and
   four default-neutral basin-escape knobs.** Fixed-obstacle pre-placements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,10 @@ pytest tests/ml/               # the ml/ test tree (collected by default; testpa
 python -m ml.train --save P    # train + export state_dict (needs [train])
 
 # #706 learned-backend inference (epic #607 sub-project #5). Export a trained policy to
-# ONNX, then run it torch-free behind the verifier. Needs the [learned-infer] extra.
+# ONNX, then run it torch-free behind the verifier. Export needs [train] (torch + onnx);
+# inference needs the [learned-infer] extra (onnxruntime). With trivial-schedule (under-
+# trained) weights the verifier rejects the proposal → a no-layout result, NOT an error;
+# reaching valid dense layouts is the train-to-mastery work (#698/#7).
 python -m ml.train --schedule trivial --save /tmp/p.pt --save-onnx /tmp/p.onnx   # [train]
 hangarfit solve tests/fixtures/scenario_minimal.yaml --backend learned --weights /tmp/p.onnx
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,11 @@ pip install -e ".[train]"      # adds torch for training/eval (CPU is fine)
 pytest tests/ml/               # the ml/ test tree (collected by default; testpaths=["tests"])
 python -m ml.train --save P    # train + export state_dict (needs [train])
 
+# #706 learned-backend inference (epic #607 sub-project #5). Export a trained policy to
+# ONNX, then run it torch-free behind the verifier. Needs the [learned-infer] extra.
+python -m ml.train --schedule trivial --save /tmp/p.pt --save-onnx /tmp/p.onnx   # [train]
+hangarfit solve tests/fixtures/scenario_minimal.yaml --backend learned --weights /tmp/p.onnx
+
 # GitFlow loops
 git switch develop && git pull
 git switch -c feature/<slug>

--- a/docs/adr/0027-learned-backend-determinism-scope.md
+++ b/docs/adr/0027-learned-backend-determinism-scope.md
@@ -65,7 +65,7 @@ A backend with *no* reproducibility contract cannot be debugged or regression-te
 ## Compliance
 
 - Existing: `determinism-guard` (the double-solve diff on `solver.py` / `towplanner.py`) remains the compliance check for the **verifier** contract, unchanged.
-- Future (when the learned backend lands): two new learned-path canaries — within-build double-run **bit-identical** (fixed weights + seed + pinned EP), and cross-machine **verifier-validity-only** — are the compliance checks for the **proposer** contract. They are NOT `determinism-guard`.
+- **Tier-1 (within-build bit-identity) canary now exists:** `tests/ml/test_infer.py::test_learned_within_build_bit_identity` verifies that two fresh single-threaded CPU-EP ONNX sessions on the same weights + seed produce byte-identical logits. Cross-machine (tier-2) validity-equivalence remains deferred to sub-project #7 (needs a shared trained checkpoint).
 - No automated check is required while the backend is a stub (`solve_learned` raises `LearnedBackendUnavailableError`); the seam is exercised by the CLI clean-error test.
 
 ## More Information

--- a/docs/superpowers/plans/2026-06-17-learned-backend-onnx-inference.md
+++ b/docs/superpowers/plans/2026-06-17-learned-backend-onnx-inference.md
@@ -1,0 +1,1178 @@
+# Learned-backend ONNX export + `solve --backend learned` inference — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `solve --backend learned` produce a real `SolveResult` (valid layout + the policy's own drive-in tow plan) from a trained checkpoint, with no torch in the inference path, behind the unchanged deterministic verifier.
+
+**Architecture:** A thin wheel-shipped seam (`src/hangarfit/learned.py`) lazy-imports a torch-free `ml/infer.py` that builds the cold-joint env from a production `Scenario`, runs an argmax rollout via an onnxruntime session, records each object's drive-in `Primitive`s, and assembles a `SolveResult` whose tow `MovesPlan` maps the recorded `Primitive`s 1:1 onto a `DubinsArc`. The deterministic `collisions.check` + Caddy egress gate is the sole arbiter of validity.
+
+**Tech Stack:** Python 3.12, PyTorch 2.12 (`[train]` extra, contributor-only export), onnxruntime (new `[learned-infer]` extra, inference), numpy, shapely.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-learned-backend-onnx-inference-design.md`. **Issue:** #706 (epic #607 sub-project #5).
+
+## Global Constraints
+
+- **Python 3.12 only** (ADR-0009).
+- **No torch / onnxruntime in the default install or the wheel.** torch stays the `[train]` extra; onnxruntime is the new `[learned-infer]` extra. `ml/` is never in the wheel (`[tool.setuptools.packages.find] where=["src"]`).
+- **The dependency direction is `ml → src` only.** `src/hangarfit/learned.py` must NOT import `ml.*` at module load; it lazy-imports inside the function body.
+- **Verifier is the final gate** (ADR-0027 / the prime directive): an invalid policy proposal yields a no-layout `SolveResult` (status `"exhausted_budget"`, empty `layouts`/`plans`), never an exception. The verifier (`collisions.check` + egress) is `go.layout_valid(layout)`.
+- **Determinism (ADR-0027):** the verifier stays strict & `determinism-guard`-bound (unchanged). The learned proposer is OUTSIDE `determinism-guard`; this rung lands the **tier-1** within-build bit-identity canary (fixed weights + seed + pinned `CPUExecutionProvider`). Do NOT add `ml.infer` to `determinism-guard`.
+- **Tests:** ml-side tests live in `tests/ml/`. torch tests `pytest.importorskip("torch")`; onnxruntime tests `pytest.importorskip("onnxruntime")`. CI installs only `[dev]`, so these skip in CI until #6 adds the lane (matches the existing torch-test pattern).
+- **`DubinsArc.segments` must be non-empty** (its `__post_init__` raises otherwise) → a zero-primitive object emits `Move(path=None)`.
+- **ONNX I/O contract (frozen):** inputs `raster (B,7,192,96) f32`, `tokens (B,N,24) f32`, `token_mask (B,N) bool`, `active_index (B,) i64`, `legal_action_mask (B,9) bool`; outputs `kind_gear_logits (B,9) f32`, `magnitude_bin_logits (B,5) f32`. The `-inf` legal-mask `masked_fill` stays inside the graph.
+- **Local dev:** `pip install onnxruntime` (not yet in any lockfile) before running the inference tests; `torch` is already present.
+- After ml/ edits the PostToolUse hook runs `ruff` + `pytest tests/ml/`; the Stop hook runs `mypy` (over `src/hangarfit/`, plus `ml/` when torch is importable). Keep both green.
+
+---
+
+### Task 1: ONNX export — `ml/export.py`
+
+**Files:**
+- Create: `ml/export.py`
+- Test: `tests/ml/test_export.py`
+
+**Interfaces:**
+- Consumes: `ml.policy.HangarFitPolicy`, `ml.policy.to_batch`, `ml.encoding.{ObservationTensors, EncoderConfig, encode, RASTER_CHANNELS, TOKEN_DIM, ACTION_DIM}`, `ml.policy.PolicyOutput`.
+- Produces: `export_onnx(policy: HangarFitPolicy, path: str | Path, *, example: ObservationTensors | None = None, opset: int = 17) -> None` — writes an ONNX graph of the policy forward (value head dropped). `ONNX_INPUT_NAMES`, `ONNX_OUTPUT_NAMES` (tuples of str) for downstream `ml.infer`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/ml/test_export.py
+"""ONNX export of HangarFitPolicy (sub-project #5, #607). Needs the [train] extra
+(torch) to export and the [learned-infer] extra (onnxruntime) to run the round-trip."""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+ort = pytest.importorskip("onnxruntime")
+
+import numpy as np
+
+from ml.encoding import EncoderConfig, encode
+from ml.export import ONNX_INPUT_NAMES, ONNX_OUTPUT_NAMES, export_onnx
+from ml.policy import HangarFitPolicy, to_batch
+from ml.train import build_trivial_env
+
+
+def _example_obs():
+    env = build_trivial_env()
+    obs = env.reset()
+    return encode(obs, env.hangar, {**env.fleet, **env.ground_objects}, EncoderConfig())
+
+
+def test_export_argmax_parity(tmp_path):
+    torch.manual_seed(0)
+    policy = HangarFitPolicy()
+    policy.eval()
+    obs_t = _example_obs()
+    out_path = tmp_path / "policy.onnx"
+    export_onnx(policy, out_path)
+
+    batch = to_batch([obs_t])
+    with torch.no_grad():
+        torch_out = policy(batch)
+    feed = {
+        "raster": batch["raster"].numpy(),
+        "tokens": batch["tokens"].numpy(),
+        "token_mask": batch["token_mask"].numpy(),
+        "active_index": batch["active_index"].numpy(),
+        "legal_action_mask": batch["legal_action_mask"].numpy(),
+    }
+    sess = ort.InferenceSession(str(out_path), providers=["CPUExecutionProvider"])
+    kind_logits, mag_logits = sess.run(list(ONNX_OUTPUT_NAMES), feed)
+
+    assert tuple(ONNX_INPUT_NAMES) == ("raster", "tokens", "token_mask", "active_index", "legal_action_mask")
+    assert int(np.argmax(kind_logits, axis=-1)[0]) == int(torch_out.kind_gear_logits.argmax(-1)[0])
+    assert int(np.argmax(mag_logits, axis=-1)[0]) == int(torch_out.magnitude_bin_logits.argmax(-1)[0])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pip install onnxruntime` (once), then `pytest tests/ml/test_export.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'ml.export'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# ml/export.py
+"""Export a trained HangarFitPolicy to ONNX (sub-project #5, epic #607). Needs the
+[train] extra (torch). The exported graph is the per-step policy FORWARD — the value
+head (critic) is dropped, since inference only needs the two action heads. The
+``-inf`` legal-mask is applied inside the graph, so a downstream numpy ``argmax``
+yields a legal action with no extra masking. Inference (onnxruntime) lives in
+``ml/infer.py`` and needs no torch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+
+from ml.encoding import ACTION_DIM, EncoderConfig, RASTER_CHANNELS, TOKEN_DIM
+from ml.policy import HangarFitPolicy, to_batch
+
+ONNX_INPUT_NAMES = ("raster", "tokens", "token_mask", "active_index", "legal_action_mask")
+ONNX_OUTPUT_NAMES = ("kind_gear_logits", "magnitude_bin_logits")
+
+
+class _ForwardWrapper(nn.Module):
+    """Positional-input wrapper over the dict-input policy forward, returning only the
+    two action-head logit tensors (drops the scalar value head)."""
+
+    def __init__(self, policy: HangarFitPolicy) -> None:
+        super().__init__()
+        self.policy = policy
+
+    def forward(
+        self,
+        raster: Tensor,
+        tokens: Tensor,
+        token_mask: Tensor,
+        active_index: Tensor,
+        legal_action_mask: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        out = self.policy(
+            {
+                "raster": raster,
+                "tokens": tokens,
+                "token_mask": token_mask,
+                "active_index": active_index,
+                "legal_action_mask": legal_action_mask,
+            }
+        )
+        return out.kind_gear_logits, out.magnitude_bin_logits
+
+
+def _dummy_inputs(config: EncoderConfig) -> tuple[Tensor, ...]:
+    """A single-sample batch with the encoder's shapes; values are irrelevant to the
+    traced graph (masks all-True so nothing is force-masked during tracing)."""
+    n = config.max_objects
+    raster = torch.zeros(1, RASTER_CHANNELS, config.grid_h, config.grid_w, dtype=torch.float32)
+    tokens = torch.zeros(1, n, TOKEN_DIM, dtype=torch.float32)
+    token_mask = torch.ones(1, n, dtype=torch.bool)
+    active_index = torch.zeros(1, dtype=torch.long)
+    legal = torch.ones(1, ACTION_DIM, dtype=torch.bool)
+    return raster, tokens, token_mask, active_index, legal
+
+
+def export_onnx(
+    policy: HangarFitPolicy,
+    path: str | Path,
+    *,
+    example=None,
+    opset: int = 17,
+) -> None:
+    """Trace ``policy``'s forward to an ONNX file at ``path``. Pass ``example`` (an
+    ``ObservationTensors``) to trace real shapes, else a default-config dummy is used.
+    Batch ``B`` and token count ``N`` are dynamic axes."""
+    policy.eval()
+    wrapper = _ForwardWrapper(policy)
+    if example is not None:
+        b = to_batch([example])
+        args = (b["raster"], b["tokens"], b["token_mask"], b["active_index"], b["legal_action_mask"])
+    else:
+        args = _dummy_inputs(EncoderConfig())
+    dynamic_axes = {
+        "raster": {0: "B"},
+        "tokens": {0: "B", 1: "N"},
+        "token_mask": {0: "B", 1: "N"},
+        "active_index": {0: "B"},
+        "legal_action_mask": {0: "B"},
+        "kind_gear_logits": {0: "B"},
+        "magnitude_bin_logits": {0: "B"},
+    }
+    with torch.no_grad():
+        torch.onnx.export(
+            wrapper,
+            args,
+            str(path),
+            input_names=list(ONNX_INPUT_NAMES),
+            output_names=list(ONNX_OUTPUT_NAMES),
+            dynamic_axes=dynamic_axes,
+            opset_version=opset,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/ml/test_export.py -v`
+Expected: PASS. (If the TransformerEncoder mask export fails, bump `opset` to 18 in `export_onnx`'s default; if it still fails, that is the known risk — escalate before changing the network.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/export.py tests/ml/test_export.py
+git commit -m "feat(706): ONNX export of HangarFitPolicy forward (argmax parity)
+
+Refs #706"
+```
+
+---
+
+### Task 2: `train.py --save-onnx` wiring
+
+**Files:**
+- Modify: `ml/train.py` (add `save_onnx` param to `train` + `train_curriculum`; `--save-onnx` arg; call `export_onnx` after each `torch.save`)
+- Test: `tests/ml/test_train_curriculum.py` (add one fast test) OR `tests/ml/test_export.py`
+
+**Interfaces:**
+- Consumes: `ml.export.export_onnx`.
+- Produces: `train(..., save_onnx: str | None = None)` and `train_curriculum(..., save_onnx: str | None = None)` write an ONNX file when `save_onnx` is set; CLI flag `--save-onnx PATH`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/ml/test_export.py — append
+def test_train_save_onnx_writes_file(tmp_path):
+    from ml.train import train
+
+    onnx_path = tmp_path / "trivial.onnx"
+    train(iterations=1, rollout_len=16, save_onnx=str(onnx_path))
+    assert onnx_path.exists() and onnx_path.stat().st_size > 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/ml/test_export.py::test_train_save_onnx_writes_file -v`
+Expected: FAIL — `TypeError: train() got an unexpected keyword argument 'save_onnx'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ml/train.py`:
+- Add the import near the top: `from ml.export import export_onnx`.
+- In `train(...)`: add `save_onnx: str | None = None` to the signature; after `if save is not None: torch.save(...)`, add:
+
+```python
+    if save_onnx is not None:
+        export_onnx(policy, save_onnx)
+```
+
+- In `train_curriculum(...)`: add the same `save_onnx: str | None = None` param and the same two-line export after its `torch.save`.
+- In `build_argparser()`: add
+
+```python
+    p.add_argument(
+        "--save-onnx",
+        type=str,
+        default=None,
+        help="also export the trained policy forward to this ONNX path (inference)",
+    )
+```
+
+- In `main()`: pass `save_onnx=args.save_onnx` to both the `train(...)` and `train_curriculum(...)` calls.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/ml/test_export.py::test_train_save_onnx_writes_file -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/train.py tests/ml/test_export.py
+git commit -m "feat(706): train --save-onnx exports the policy alongside state_dict
+
+Refs #706"
+```
+
+---
+
+### Task 3: `learned-infer` optional extra — `pyproject.toml`
+
+**Files:**
+- Modify: `pyproject.toml` (`[project.optional-dependencies]`)
+
+**Interfaces:**
+- Produces: `pip install -e ".[learned-infer]"` installs onnxruntime.
+
+- [ ] **Step 1: Inspect the current extras block**
+
+Run: `grep -n -A6 "\[project.optional-dependencies\]" pyproject.toml`
+Expected: shows `train = ["torch"]` (and `dev`, etc.).
+
+- [ ] **Step 2: Add the extra**
+
+Add to `[project.optional-dependencies]` (mirror the `train` entry's style; pin floor consistent with the repo's convention):
+
+```toml
+learned-infer = ["onnxruntime>=1.18"]
+```
+
+- [ ] **Step 3: Verify it resolves**
+
+Run: `pip install -e ".[learned-infer]" 2>&1 | tail -3`
+Expected: installs/【already satisfied】onnxruntime; no error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "build(706): add [learned-infer] optional extra (onnxruntime)
+
+Lockfile regen + CI lane are #6. Refs #706"
+```
+
+> Note: the dev/build lockfiles are regenerated separately (`docs/dev/lockfiles.md`); wiring `learned-infer` into CI's install is **#6**. Do not hand-edit `requirements-*.txt` (the PreToolUse guard blocks it).
+
+---
+
+### Task 4: `ml/infer.py` — `OrtPolicy` (torch-free onnxruntime forward)
+
+**Files:**
+- Create: `ml/infer.py`
+- Test: `tests/ml/test_infer.py`
+
+**Interfaces:**
+- Consumes: the ONNX file from Task 1; `ml.encoding.{ObservationTensors, ACTION_DIM}`; `ml.action_space.decode`; `ml.types.{Primitive, Park}`.
+- Produces: `class OrtPolicy` with `__init__(self, onnx_path: str | Path)` and `act(self, obs: ObservationTensors, *, turn_radius_m: float) -> Primitive | Park` (numpy argmax + decode; mirrors `HangarFitPolicy.act(deterministic=True)` without torch).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/ml/test_infer.py
+"""Torch-free onnxruntime inference for the learned backend (sub-project #5, #607)."""
+
+from __future__ import annotations
+
+import pytest
+
+ort = pytest.importorskip("onnxruntime")
+torch = pytest.importorskip("torch")  # OrtPolicy is torch-free, but we export with torch here
+
+from ml.encoding import EncoderConfig, encode
+from ml.export import export_onnx
+from ml.infer import OrtPolicy
+from ml.policy import HangarFitPolicy
+from ml.train import build_trivial_env
+
+
+def test_ortpolicy_matches_torch_act(tmp_path):
+    torch.manual_seed(0)
+    policy = HangarFitPolicy()
+    policy.eval()
+    env = build_trivial_env()
+    obs = env.reset()
+    obs_t = encode(obs, env.hangar, {**env.fleet, **env.ground_objects}, EncoderConfig())
+    tr = obs.active.body.effective_turn_radius_m()
+
+    onnx_path = tmp_path / "p.onnx"
+    export_onnx(policy, onnx_path, example=obs_t)
+    ort_pol = OrtPolicy(onnx_path)
+
+    (_k, _m), _lp, torch_action = policy.act(obs_t, turn_radius_m=tr, deterministic=True)
+    ort_action = ort_pol.act(obs_t, turn_radius_m=tr)
+    assert type(ort_action) is type(torch_action)
+    assert ort_action == torch_action
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/ml/test_infer.py::test_ortpolicy_matches_torch_act -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'ml.infer'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# ml/infer.py
+"""Torch-free inference for the learned backend (sub-project #5, epic #607).
+
+Runs a trained policy exported to ONNX (``ml/export.py``) with onnxruntime + numpy —
+NO torch in this module. ``solve_learned_impl`` (later task) drives the cold-joint env
+to a terminal layout and returns a ``SolveResult`` behind the deterministic verifier.
+
+Determinism (ADR-0027): the proposer's tier-1 contract is within-build bit-identity
+(fixed weights + seed + pinned CPUExecutionProvider). The verifier stays strict and is
+the sole arbiter of validity — an invalid proposal yields a no-layout SolveResult."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from ml.action_space import decode
+from ml.encoding import ObservationTensors
+from ml.export import ONNX_OUTPUT_NAMES
+from ml.types import Park, Primitive
+
+
+class OrtPolicy:
+    """A trained policy forward as an onnxruntime session. ``act`` mirrors
+    ``HangarFitPolicy.act(deterministic=True)`` with numpy argmax — the ``-inf`` legal
+    mask is already baked into the graph, so argmax always yields a legal action."""
+
+    def __init__(self, onnx_path: str | Path) -> None:
+        import onnxruntime as ort  # local import: onnxruntime is the [learned-infer] extra
+
+        # Pin CPUExecutionProvider single-threaded for the ADR-0027 tier-1 bit-identity
+        # contract (within-build double-run reproducibility).
+        opts = ort.SessionOptions()
+        opts.intra_op_num_threads = 1
+        opts.inter_op_num_threads = 1
+        self._session = ort.InferenceSession(
+            str(onnx_path), sess_options=opts, providers=["CPUExecutionProvider"]
+        )
+
+    def act(self, obs: ObservationTensors, *, turn_radius_m: float) -> Primitive | Park:
+        if obs.active_index < 0:
+            raise ValueError("OrtPolicy.act called on a terminal observation (active_index < 0)")
+        feed = {
+            "raster": obs.raster[None].astype(np.float32),
+            "tokens": obs.tokens[None].astype(np.float32),
+            "token_mask": obs.token_mask[None],
+            "active_index": np.asarray([obs.active_index], dtype=np.int64),
+            "legal_action_mask": obs.legal_action_mask[None],
+        }
+        kind_logits, mag_logits = self._session.run(list(ONNX_OUTPUT_NAMES), feed)
+        kind_idx = int(np.argmax(kind_logits[0]))
+        mag_idx = int(np.argmax(mag_logits[0]))
+        return decode(kind_idx, mag_idx, turn_radius_m=turn_radius_m)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/ml/test_infer.py::test_ortpolicy_matches_torch_act -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/infer.py tests/ml/test_infer.py
+git commit -m "feat(706): OrtPolicy — torch-free onnxruntime forward + argmax decode
+
+Refs #706"
+```
+
+---
+
+### Task 5: `ml/infer.py` — `env_from_scenario`
+
+**Files:**
+- Modify: `ml/infer.py` (add `env_from_scenario`)
+- Test: `tests/ml/test_infer.py` (add)
+
+**Interfaces:**
+- Consumes: `hangarfit.models.Scenario` (fields `fleet`, `hangar`, `fleet_in`, `ground_objects`, `ground_object_defs`, `fixed_obstacle_placements`; properties `placeable_ids`, `mover_ids`); `ml.env.HangarFitEnv`; `ml.types.DifficultyConfig`; `dataclasses.replace`.
+- Produces: `env_from_scenario(scenario: Scenario, *, apron_depth_m: float = 8.0) -> HangarFitEnv` — the production-`Scenario` counterpart of `ml.benchmark.build_scenario_env`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/ml/test_infer.py — append
+from hangarfit.loader import load_scenario  # noqa: E402
+
+
+def test_env_from_scenario_queues_placeables(tmp_path):
+    import pathlib
+
+    from ml.infer import env_from_scenario
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    scenario = load_scenario(str(root / "tests/fixtures/scenario_minimal.yaml"))
+    env = env_from_scenario(scenario)
+    obs = env.reset()
+    assert obs.active is not None
+    assert set(env.requested_ids) == set(scenario.placeable_ids)
+    assert env.hangar.apron_depth_m == 8.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/ml/test_infer.py::test_env_from_scenario_queues_placeables -v`
+Expected: FAIL — `ImportError: cannot import name 'env_from_scenario'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `ml/infer.py` (and the imports it needs at the top):
+
+```python
+from dataclasses import replace
+
+from hangarfit.models import Scenario
+from ml.env import HangarFitEnv
+from ml.types import DifficultyConfig
+
+
+def env_from_scenario(scenario: Scenario, *, apron_depth_m: float = 8.0) -> HangarFitEnv:
+    """Build a cold-joint env from a production ``Scenario`` (the inference counterpart
+    of ``ml.benchmark.build_scenario_env``, which builds from a ``BenchScenario`` path).
+
+    Movable bodies (aircraft + placed-routed movers) are driven in from an apron; fixed
+    obstacles (immovable keep-outs) are PRE-PLACED at their surveyed poses, never driven —
+    the same scene the deterministic verifier sees. The difficulty budgets are generous
+    (a safety stop, not a curriculum cap)."""
+    fixed_ids = [
+        gid
+        for gid in scenario.ground_objects
+        if scenario.ground_object_defs[gid].object_class == "fixed_obstacle"
+    ]
+    placed = {p.plane_id for p in scenario.fixed_obstacle_placements}
+    missing = [g for g in fixed_ids if g not in placed]
+    if missing:
+        raise ValueError(
+            f"env_from_scenario: fixed obstacle(s) {missing} have no entry in "
+            f"scenario.fixed_obstacle_placements — they would silently appear un-placed."
+        )
+    placeable = scenario.placeable_ids
+    movers = {gid: scenario.ground_object_defs[gid] for gid in scenario.mover_ids}
+    fixed_defs = {gid: scenario.ground_object_defs[gid] for gid in fixed_ids}
+    per_object = 120
+    difficulty = DifficultyConfig(
+        max_objects=len(placeable),
+        per_object_step_budget=per_object,
+        total_step_budget=per_object * max(1, len(placeable)),
+    )
+    hangar = replace(scenario.hangar, apron_depth_m=apron_depth_m)
+    return HangarFitEnv(
+        hangar=hangar,
+        fleet=scenario.fleet,
+        requested_ids=placeable,
+        ground_objects={**movers, **fixed_defs},
+        fixed_placements=scenario.fixed_obstacle_placements,
+        difficulty=difficulty,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/ml/test_infer.py::test_env_from_scenario_queues_placeables -v`
+Expected: PASS.
+(If `tests/fixtures/scenario_minimal.yaml` lacks an apron or movers, the test still holds — it only asserts the queue == `placeable_ids` and the apron override.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/infer.py tests/ml/test_infer.py
+git commit -m "feat(706): env_from_scenario — cold-joint env from a production Scenario
+
+Refs #706"
+```
+
+---
+
+### Task 6: `ml/infer.py` — rollout + `MovesPlan` (Primitive → DubinsArc)
+
+**Files:**
+- Modify: `ml/infer.py` (add `_DrivenObject`, `rollout`, `build_moves_plan`)
+- Test: `tests/ml/test_infer.py` (add the endpoint-parity canary)
+
+**Interfaces:**
+- Consumes: `OrtPolicy`, `env_from_scenario`, `ml.encoding.{EncoderConfig, encode}`, `hangarfit.towplanner.{Pose, Segment, DubinsArc, Move, MovesPlan}`, `ml.types.{Primitive, Park}`, `hangarfit.models.Layout`.
+- Produces:
+  - `rollout(env, ort_policy, encoder) -> tuple[Layout, list[_DrivenObject], StepInfo]` — drives the env to termination, recording each PARKED object's `(object_id, start_pose, end_pose, primitives)`.
+  - `build_moves_plan(layout, driven, env) -> MovesPlan` — one `Move` per driven object; `path` a `DubinsArc` built from its `Primitive`s, or `None` if it parked with zero primitives.
+  - `_DrivenObject` dataclass: `object_id: str`, `start_pose: Pose`, `end_pose: Pose`, `primitives: list[Primitive]`.
+
+- [ ] **Step 1: Write the failing test (DubinsArc endpoint parity)**
+
+```python
+# tests/ml/test_infer.py — append
+import math  # noqa: E402
+
+from hangarfit.towplanner import DubinsArc, Segment  # noqa: E402
+from ml.geometry_oracle import apply_primitive  # noqa: E402
+from ml.types import Primitive  # noqa: E402
+
+
+def test_primitive_sequence_dubinsarc_endpoint_parity():
+    """A multi-segment DubinsArc built from a primitive sequence integrates to the same
+    pose as chaining apply_primitive — the guarantee build_moves_plan relies on."""
+    from hangarfit.towplanner import Pose
+
+    start = Pose(x_m=5.0, y_m=-4.0, heading_deg=0.0)
+    prims = [
+        Primitive(kind="S", magnitude=2.0, gear=1),
+        Primitive(kind="L", magnitude=3.0, gear=1),
+        Primitive(kind="S", magnitude=1.0, gear=1),
+    ]
+    tr = 4.0
+    pose = start
+    for p in prims:
+        pose, _ = apply_primitive(pose, p, turn_radius_m=tr)
+    arc = DubinsArc(
+        start=start,
+        end=pose,
+        turn_radius_m=tr,
+        segments=tuple(Segment(kind=p.kind, length_m=p.magnitude, gear=p.gear) for p in prims),
+    )
+    integrated = arc.pose_at(arc.length_m)
+    assert math.isclose(integrated.x_m, pose.x_m, abs_tol=1e-6)
+    assert math.isclose(integrated.y_m, pose.y_m, abs_tol=1e-6)
+    assert math.isclose(integrated.heading_deg, pose.heading_deg, abs_tol=1e-6)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/ml/test_infer.py::test_primitive_sequence_dubinsarc_endpoint_parity -v`
+Expected: PASS immediately if the integrators already agree (they share `pose_at`), or FAIL on a tolerance bug. This test pins the invariant; if it passes, that confirms the design assumption. (It does not need `rollout` yet — it is the canary that justifies Step 3's builder.)
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `ml/infer.py`:
+
+```python
+from dataclasses import dataclass, field
+
+from hangarfit.models import Layout
+from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+from ml.encoding import EncoderConfig, encode
+from ml.types import StepInfo  # re-exported via ml.types
+
+
+@dataclass(slots=True)
+class _DrivenObject:
+    object_id: str
+    start_pose: Pose
+    end_pose: Pose
+    primitives: list[Primitive] = field(default_factory=list)
+
+
+def rollout(
+    env: HangarFitEnv, policy: OrtPolicy, encoder: EncoderConfig | None = None
+) -> tuple[Layout, list[_DrivenObject], StepInfo]:
+    """Drive ``env`` to termination under ``policy`` (argmax). Record each PARKED object's
+    spawn pose, the ordered primitives it was driven with, and its frozen (parked) pose.
+    Objects abandoned at budget exhaustion are NOT recorded (they are not in the terminal
+    layout). Returns (terminal_layout, driven_objects_in_park_order, last_step_info)."""
+    enc = encoder or EncoderConfig()
+    bodies = {**env.fleet, **env.ground_objects}
+    obs = env.reset()
+    driven: list[_DrivenObject] = []
+    # The active object is identified at spawn; its primitives accumulate until a Park.
+    current = _DrivenObject(obs.active.object_id, obs.active.pose, obs.active.pose)
+    done = False
+    info: StepInfo | None = None
+    while not done and obs.active is not None:
+        obs_t = encode(obs, env.hangar, bodies, enc)
+        tr = obs.active.body.effective_turn_radius_m()
+        action = policy.act(obs_t, turn_radius_m=tr)
+        if isinstance(action, Park):
+            current.end_pose = obs.active.pose  # the pose Park freezes
+            driven.append(current)
+        else:
+            current.primitives.append(action)
+        obs, _reward, done, info = env.step(action)
+        if isinstance(action, Park) and not done and obs.active is not None:
+            current = _DrivenObject(obs.active.object_id, obs.active.pose, obs.active.pose)
+    if info is None:
+        raise ValueError("rollout: episode produced no steps")
+    return env._layout(), driven, info
+
+
+def build_moves_plan(layout: Layout, driven: list[_DrivenObject], env: HangarFitEnv) -> MovesPlan:
+    """Map each driven object's recorded primitives onto a DubinsArc tow Move (1:1
+    Primitive->Segment). A zero-primitive object (parked at spawn) gets Move(path=None)
+    — the established best-effort idiom, since DubinsArc.segments must be non-empty."""
+    moves: list[Move] = []
+    for d in driven:
+        target = Pose(x_m=d.end_pose.x_m, y_m=d.end_pose.y_m, heading_deg=d.end_pose.heading_deg)
+        if not d.primitives:
+            moves.append(Move(plane_id=d.object_id, target_slot=target, path=None))
+            continue
+        tr = env._body(d.object_id).effective_turn_radius_m()
+        segments = tuple(
+            Segment(kind=p.kind, length_m=p.magnitude, gear=p.gear) for p in d.primitives
+        )
+        arc = DubinsArc(start=d.start_pose, end=target, turn_radius_m=tr, segments=segments)
+        moves.append(Move(plane_id=d.object_id, target_slot=target, path=arc))
+    return MovesPlan(target_layout=layout, moves=tuple(moves))
+```
+
+- [ ] **Step 4: Add a rollout integration test**
+
+```python
+# tests/ml/test_infer.py — append
+def test_rollout_builds_moves_plan(tmp_path):
+    from ml.infer import OrtPolicy, build_moves_plan, env_from_scenario, rollout
+    import pathlib
+
+    torch.manual_seed(0)
+    policy = HangarFitPolicy()
+    policy.eval()
+    onnx_path = tmp_path / "p.onnx"
+    export_onnx(policy, onnx_path)
+    ort_pol = OrtPolicy(onnx_path)
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    scenario = load_scenario(str(root / "tests/fixtures/scenario_minimal.yaml"))
+    env = env_from_scenario(scenario)
+    layout, driven, info = rollout(env, ort_pol)
+    plan = build_moves_plan(layout, driven, env)
+    # Every parked object has a Move; every Move targets a real slot pose.
+    assert len(plan.moves) == len(driven)
+    assert all(m.target_slot is not None for m in plan.moves)
+```
+
+Run: `pytest tests/ml/test_infer.py -v`
+Expected: PASS (the untrained policy may park few/no objects — the test only asserts structural coherence, not reachability).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/infer.py tests/ml/test_infer.py
+git commit -m "feat(706): rollout + Primitive->DubinsArc MovesPlan builder
+
+Endpoint parity is by construction (env apply_primitive shares DubinsArc.pose_at).
+Refs #706"
+```
+
+---
+
+### Task 7: `ml/infer.py` — `solve_learned_impl` (assemble `SolveResult` behind the verifier)
+
+**Files:**
+- Modify: `ml/infer.py` (add `solve_learned_impl`)
+- Test: `tests/ml/test_infer.py` (add shape/validity + invalid→no-layout tests)
+
+**Interfaces:**
+- Consumes: `rollout`, `build_moves_plan`, `env_from_scenario`, `OrtPolicy`, `ml.geometry_oracle.layout_valid`, `hangarfit.models.{SolveResult, SolverDiagnostics, Scenario}`.
+- Produces: `solve_learned_impl(scenario: Scenario, *, weights_path: str | Path, budget_s: float, alternatives: int, seed: int | None, plan_paths: bool) -> SolveResult`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/ml/test_infer.py — append
+def test_solve_learned_impl_returns_well_formed_result(tmp_path):
+    import pathlib
+
+    from ml.infer import solve_learned_impl
+
+    torch.manual_seed(0)
+    policy = HangarFitPolicy()
+    policy.eval()
+    onnx_path = tmp_path / "p.onnx"
+    export_onnx(policy, onnx_path)
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    scenario = load_scenario(str(root / "tests/fixtures/scenario_minimal.yaml"))
+    result = solve_learned_impl(
+        scenario, weights_path=onnx_path, budget_s=30.0, alternatives=1, seed=0, plan_paths=True
+    )
+    # SolveResult.__post_init__ enforces status/layouts/plans coherence; construction
+    # succeeding is the structural assertion. An untrained policy almost always fails to
+    # park the whole set validly, so expect a no-layout status here.
+    assert result.status in ("found", "exhausted_budget")
+    assert len(result.plans) == len(result.layouts)
+    from ml.geometry_oracle import layout_valid
+
+    if result.status == "found":
+        assert layout_valid(result.layouts[0])
+        assert len(result.plans) == 1
+    else:
+        assert result.layouts == ()
+        assert result.plans == ()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/ml/test_infer.py::test_solve_learned_impl_returns_well_formed_result -v`
+Expected: FAIL — `ImportError: cannot import name 'solve_learned_impl'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `ml/infer.py`:
+
+```python
+import time
+
+from hangarfit.models import SolveResult, SolverDiagnostics
+from ml import geometry_oracle as go
+
+
+def solve_learned_impl(
+    scenario: Scenario,
+    *,
+    weights_path: str | Path,
+    budget_s: float,
+    alternatives: int,
+    seed: int | None,
+    plan_paths: bool,
+) -> SolveResult:
+    """Run the learned backend: argmax rollout of the ONNX policy over the env built from
+    ``scenario``, then return a verifier-gated SolveResult. The verifier (collisions.check
+    + Caddy egress, via go.layout_valid) is the sole arbiter — an invalid or incomplete
+    proposal yields a no-layout 'exhausted_budget' result, never an exception.
+
+    ``alternatives`` > 1 is accepted but yields a single (deterministic argmax) layout;
+    diverse sampling is #696. ``budget_s`` is advisory here (the env's step budget bounds
+    the rollout); it is recorded but not enforced as a wall-clock deadline (ADR-0003-style
+    reproducibility favours the step-count bound)."""
+    start = time.monotonic()
+    resolved_seed = seed if seed is not None else 0
+    policy = OrtPolicy(weights_path)
+    env = env_from_scenario(scenario)
+    layout, driven, info = rollout(env, policy)
+
+    complete = info.placed == info.total
+    if complete and go.layout_valid(layout):
+        plan = build_moves_plan(layout, driven, env) if plan_paths else None
+        return SolveResult(
+            status="found",
+            layouts=(layout,),
+            diagnostics=SolverDiagnostics(
+                restarts_attempted=0, wall_time_s=time.monotonic() - start, seed=resolved_seed
+            ),
+            plans=(plan,),
+        )
+    return SolveResult(
+        status="exhausted_budget",
+        layouts=(),
+        diagnostics=SolverDiagnostics(
+            restarts_attempted=0, wall_time_s=time.monotonic() - start, seed=resolved_seed
+        ),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/ml/test_infer.py -v`
+Expected: PASS. (Confirm `SolverDiagnostics(restarts_attempted=..., wall_time_s=..., seed=...)` constructs — those three are the only no-default fields per `solver.py`'s call sites. If mypy/construction complains about a missing required field, add it with the solver's default value.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/infer.py tests/ml/test_infer.py
+git commit -m "feat(706): solve_learned_impl — verifier-gated SolveResult assembly
+
+Refs #706"
+```
+
+---
+
+### Task 8: Seam wiring — `src/hangarfit/learned.py`
+
+**Files:**
+- Modify: `src/hangarfit/learned.py` (add `weights_path`; lazy-import `ml.infer`; clean fallbacks)
+- Test: `tests/test_learned.py` (extend)
+
+**Interfaces:**
+- Consumes: `ml.infer.solve_learned_impl` (lazy).
+- Produces: `solve_learned(scenario, *, weights_path=None, budget_s=30.0, alternatives=1, seed=None, plan_paths=True) -> SolveResult`. Raises `LearnedBackendUnavailableError` (specific message) when `weights_path` is None, `ml`/`onnxruntime` unimportable, or the weights file is absent.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_learned.py — extend (read the file first; keep existing tests)
+import pytest
+
+from hangarfit.learned import LearnedBackendUnavailableError, solve_learned
+
+
+def _minimal_scenario():
+    from hangarfit.loader import load_scenario
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parent.parent
+    return load_scenario(str(root / "tests/fixtures/scenario_minimal.yaml"))
+
+
+def test_solve_learned_no_weights_is_clean_error():
+    with pytest.raises(LearnedBackendUnavailableError, match="--weights"):
+        solve_learned(_minimal_scenario(), weights_path=None)
+
+
+def test_solve_learned_missing_weights_file_is_clean_error(tmp_path):
+    missing = tmp_path / "nope.onnx"
+    with pytest.raises(LearnedBackendUnavailableError, match="weights"):
+        solve_learned(_minimal_scenario(), weights_path=str(missing))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_learned.py -v`
+Expected: FAIL — `solve_learned()` got an unexpected keyword `weights_path` (current signature has no `weights_path`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the body of `solve_learned` in `src/hangarfit/learned.py` (keep the module docstring; update it to drop "always raises"). New signature + body:
+
+```python
+def solve_learned(
+    scenario: Scenario,
+    *,
+    weights_path: str | Path | None = None,
+    budget_s: float = 30.0,
+    alternatives: int = 1,
+    seed: int | None = None,
+    plan_paths: bool = True,
+) -> SolveResult:
+    """Learned-backend counterpart to :func:`hangarfit.solver.solve` (epic #607).
+
+    Lazy-imports the torch-free ``ml.infer`` inference path (onnxruntime). Raises
+    :class:`LearnedBackendUnavailableError` with an actionable message when the backend
+    cannot run: no ``--weights`` given, the ``ml`` package is absent (a bare wheel — see
+    #6), ``onnxruntime`` (the ``[learned-infer]`` extra) is missing, or the weights file
+    does not exist. The deterministic verifier remains the sole arbiter of validity
+    (ADR-0027); an invalid proposal returns a no-layout ``SolveResult``, not an error.
+    """
+    if weights_path is None:
+        raise LearnedBackendUnavailableError(
+            "the learned backend needs trained weights: pass --weights PATH "
+            "(no default weights ship yet; tracked in #6)"
+        )
+    if not Path(weights_path).is_file():
+        raise LearnedBackendUnavailableError(
+            f"learned-backend weights not found at {weights_path!r}"
+        )
+    try:
+        from ml.infer import solve_learned_impl
+    except ImportError as exc:
+        raise LearnedBackendUnavailableError(
+            "the learned backend requires the inference dependencies: install the "
+            "'[learned-infer]' extra (onnxruntime) in a source checkout that includes "
+            "the 'ml/' package (wheel distribution is tracked in #6). "
+            f"(import failed: {exc})"
+        ) from exc
+    return solve_learned_impl(
+        scenario,
+        weights_path=weights_path,
+        budget_s=budget_s,
+        alternatives=alternatives,
+        seed=seed,
+        plan_paths=plan_paths,
+    )
+```
+
+Add the imports at the top of `learned.py` (these are stdlib/typing-safe — no torch/onnxruntime/ml at module load):
+
+```python
+from pathlib import Path
+```
+
+and move `Scenario`, `SolveResult` out of `TYPE_CHECKING` into a runtime import IF the new signature annotations are evaluated — they are not (`from __future__ import annotations` is already at the top), so keep them under `TYPE_CHECKING`. Verify `from __future__ import annotations` is present (it is).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_learned.py -v`
+Expected: PASS. (The no-weights and missing-file errors fire before any `ml` import, so they pass even without onnxruntime installed.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/learned.py tests/test_learned.py
+git commit -m "feat(706): wire the learned seam to ml.infer with clean fallbacks
+
+Refs #706"
+```
+
+---
+
+### Task 9: CLI `--weights` flag — `src/hangarfit/cli.py`
+
+**Files:**
+- Modify: `src/hangarfit/cli.py` (add `--weights` to the `solve` subparser; pass it on the `--backend learned` branch)
+- Test: `tests/test_cli_backend.py` (extend)
+
+**Interfaces:**
+- Consumes: `args.weights`.
+- Produces: `solve --backend learned --weights PATH`; `--backend learned` without `--weights` exits 2 with a clean message.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_cli_backend.py — extend (read first; keep existing tests)
+def test_backend_learned_without_weights_exits_2(capsys, tmp_path):
+    from hangarfit.cli import main
+
+    # a minimal valid solve scenario fixture
+    code = main(["solve", "tests/fixtures/scenario_minimal.yaml", "--backend", "learned"])
+    assert code == 2
+    err = capsys.readouterr().err
+    assert "weights" in err.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cli_backend.py -v`
+Expected: FAIL — currently `--backend learned` raises the stub "not yet available" message; after Task 8 the seam needs `weights`, but the CLI does not pass it yet, so the no-weights branch is not reached with the right wiring. (Confirm the failure mode, then implement.)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `cli.py`, add to the `solve` subparser (near the `--backend` add_argument, ~line 367):
+
+```python
+    solve.add_argument(
+        "--weights",
+        type=str,
+        default=None,
+        dest="weights",
+        help=(
+            "Path to the learned backend's ONNX weights (only with --backend learned). "
+            "No default ships yet (#6); omitting it with --backend learned exits cleanly."
+        ),
+    )
+```
+
+In the dispatch (~line 725), pass `weights_path=args.weights`:
+
+```python
+        result = solve_learned(
+            scenario,
+            weights_path=args.weights,
+            budget_s=args.budget,
+            alternatives=args.alternatives,
+            seed=args.seed,
+            plan_paths=args.render_paths,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_cli_backend.py -v`
+Expected: PASS (exit 2, message mentions weights).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/cli.py tests/test_cli_backend.py
+git commit -m "feat(706): solve --weights flag for the learned backend
+
+Refs #706"
+```
+
+---
+
+### Task 10: ADR-0027 tier-1 within-build bit-identity canary
+
+**Files:**
+- Test: `tests/ml/test_infer.py` (add the canary)
+
+**Interfaces:**
+- Consumes: `solve_learned_impl` (twice, identical inputs).
+
+- [ ] **Step 1: Write the failing/asserting test**
+
+```python
+# tests/ml/test_infer.py — append
+def test_learned_within_build_bit_identity(tmp_path):
+    """ADR-0027 tier-1: same weights + seed + pinned CPU EP -> bit-identical SolveResult
+    (poses + plan), within a single build. Cross-machine validity-only equivalence is a
+    separate (deferred) canary."""
+    import pathlib
+
+    from ml.infer import solve_learned_impl
+
+    torch.manual_seed(0)
+    policy = HangarFitPolicy()
+    policy.eval()
+    onnx_path = tmp_path / "p.onnx"
+    export_onnx(policy, onnx_path)
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    scenario = load_scenario(str(root / "tests/fixtures/scenario_minimal.yaml"))
+    kw = dict(weights_path=onnx_path, budget_s=30.0, alternatives=1, seed=0, plan_paths=True)
+    r1 = solve_learned_impl(scenario, **kw)
+    r2 = solve_learned_impl(scenario, **kw)
+
+    assert r1.status == r2.status
+    assert r1.layouts == r2.layouts  # Layout is a frozen dataclass: structural equality
+    assert r1.plans == r2.plans
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `pytest tests/ml/test_infer.py::test_learned_within_build_bit_identity -v`
+Expected: PASS. (argmax is deterministic; the pinned single-thread CPU EP is reproducible within a build. If it flakes, verify `intra_op_num_threads=1`/`inter_op_num_threads=1` in `OrtPolicy`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/ml/test_infer.py
+git commit -m "test(706): ADR-0027 tier-1 within-build bit-identity canary
+
+Refs #706"
+```
+
+> The `ml-rl-guard` subagent guards this file family — the review (Task 11 / PR) runs it. `determinism-guard` is NOT involved (it guards only `solver.py`/`towplanner.py`).
+
+---
+
+### Task 11: Docs + CHANGELOG + ADR-0027 status
+
+**Files:**
+- Modify: `CHANGELOG.md` (`[Unreleased]`)
+- Modify: `ml/README.md` (export + inference entry points)
+- Modify: `CLAUDE.md` (a `solve --backend learned` command example under "Useful commands")
+- Modify: `docs/adr/0027-learned-backend-determinism-scope.md` (note the tier-1 canary now exists)
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: CHANGELOG entry**
+
+Add under `## [Unreleased]` → `### Added`:
+
+```markdown
+- **Learned backend inference (#706, epic #607).** `solve --backend learned --weights PATH`
+  now runs: a trained policy is exported to ONNX (`ml/export.py`, `train --save-onnx`) and
+  run torch-free via onnxruntime (`ml/infer.py`), returning a `SolveResult` (valid layout +
+  the policy's own drive-in tow plan) behind the deterministic verifier. New optional
+  `[learned-infer]` extra (onnxruntime). The verifier (`collisions.check` + Caddy egress)
+  remains the sole arbiter of validity (ADR-0027); an invalid proposal returns a no-layout
+  result. Wheel distribution, CI, and signed weights are tracked in #6.
+```
+
+- [ ] **Step 2: ml/README.md entry points**
+
+Add an "Inference (#5)" subsection documenting:
+- `python -m ml.train --schedule trivial --save model.pt --save-onnx model.onnx`
+- `hangarfit solve <scenario> --backend learned --weights model.onnx [--render-paths]`
+- the `[learned-infer]` extra (`pip install -e ".[learned-infer]"`).
+
+- [ ] **Step 3: CLAUDE.md command example**
+
+Under "Useful commands", near the existing learned-workspace block, add:
+
+```bash
+# #706 learned-backend inference (epic #607 sub-project #5). Export a trained policy to
+# ONNX, then run it torch-free behind the verifier. Needs the [learned-infer] extra.
+python -m ml.train --schedule trivial --save /tmp/p.pt --save-onnx /tmp/p.onnx   # [train]
+hangarfit solve tests/fixtures/scenario_minimal.yaml --backend learned --weights /tmp/p.onnx
+```
+
+- [ ] **Step 4: ADR-0027 status note**
+
+In `docs/adr/0027-...md` "Compliance" section, change the "Future (when the learned backend lands)" bullet to note the tier-1 within-build bit-identity canary now exists (`tests/ml/test_infer.py::test_learned_within_build_bit_identity`); tier-2 cross-machine validity-equivalence remains deferred (needs a shared trained checkpoint, #7). Leave Status as Proposed unless the user wants to flip it to Accepted.
+
+- [ ] **Step 5: Run the full ml + seam test set and lint/type**
+
+Run:
+```bash
+pytest tests/ml/test_export.py tests/ml/test_infer.py tests/test_learned.py tests/test_cli_backend.py -v
+ruff check ml/ src/hangarfit/ tests/ && ruff format --check ml/ src/hangarfit/ tests/
+mypy src/hangarfit/ && mypy ml/
+```
+Expected: all green (onnxruntime/torch tests run locally where installed; they skip cleanly where not).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CHANGELOG.md ml/README.md CLAUDE.md docs/adr/0027-learned-backend-determinism-scope.md
+git commit -m "docs(706): CHANGELOG + ml/README + CLAUDE.md + ADR-0027 tier-1 canary note
+
+Refs #706"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3.1 thin seam + lazy import + clean fallbacks → Task 8. CLI `--weights` → Task 9. ✓
+- §3.2 `env_from_scenario` → Task 5; rollout + MovesPlan(DubinsArc) → Task 6; verifier-gated `solve_learned_impl` + status mapping → Task 7. ✓
+- §3.3 ONNX export (drop value head, dynamic axes, opset≥17) + `train --save-onnx` → Tasks 1–2. ✓
+- §3.4 `learned-infer` extra → Task 3. ✓
+- §3.5 tests (a) export parity → T1; (b) DubinsArc endpoint → T6; (c) SolveResult shape+validity → T7; (d) tier-1 bit-identity → T10; (e) clean fallbacks → T8/T9; (f) verifier-rejects → T7. ✓
+- §4 determinism (tier-1 canary, no determinism-guard) → T10 + the note. ✓
+- §6 CHANGELOG + `learned-infer` extra → T3/T11. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows real code. The one runtime unknown (TransformerEncoder ONNX export under opset 17) is called out with a concrete remedy in T1 Step 4, not left vague.
+
+**Type consistency:** `solve_learned`/`solve_learned_impl` share the keyword set `(weights_path, budget_s, alternatives, seed, plan_paths)`. `OrtPolicy.act` returns `Primitive | Park` (matches `action_space.decode`). `rollout` returns `(Layout, list[_DrivenObject], StepInfo)`; `build_moves_plan(layout, driven, env)` consumes exactly that. `ONNX_OUTPUT_NAMES`/`ONNX_INPUT_NAMES` defined in `ml/export.py`, consumed in `ml/infer.py` (T4) and the test (T1). `SolverDiagnostics(restarts_attempted, wall_time_s, seed)` matches `solver.py`'s minimal call shape.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-17-learned-backend-onnx-inference.md`.

--- a/docs/superpowers/plans/2026-06-17-learned-backend-onnx-inference.md
+++ b/docs/superpowers/plans/2026-06-17-learned-backend-onnx-inference.md
@@ -294,12 +294,20 @@ Refs #706"
 Run: `grep -n -A6 "\[project.optional-dependencies\]" pyproject.toml`
 Expected: shows `train = ["torch"]` (and `dev`, etc.).
 
-- [ ] **Step 2: Add the extra**
+- [ ] **Step 2: Add the extras**
 
-Add to `[project.optional-dependencies]` (mirror the `train` entry's style; pin floor consistent with the repo's convention):
+Add the inference extra to `[project.optional-dependencies]` (mirror the `train` entry's style):
 
 ```toml
 learned-infer = ["onnxruntime>=1.18"]
+```
+
+Also add `onnx` to the existing `train` extra — `ml/export.py`'s legacy `torch.onnx.export`
+serializes the proto via the `onnx` package (torch does not vendor it; discovered in Task 1).
+Inference (`onnxruntime`) does NOT need `onnx`; export (contributor `[train]`) does:
+
+```toml
+train = ["torch", "onnx>=1.16"]
 ```
 
 - [ ] **Step 3: Verify it resolves**
@@ -363,7 +371,16 @@ def test_ortpolicy_matches_torch_act(tmp_path):
     export_onnx(policy, onnx_path, example=obs_t)
     ort_pol = OrtPolicy(onnx_path)
 
-    (_k, _m), _lp, torch_action = policy.act(obs_t, turn_radius_m=tr, deterministic=True)
+    # OrtPolicy runs the ONNX graph (standard attention path). `policy.act` uses the fused
+    # fast path by default, which on an UNTRAINED near-tie policy can flip the argmax. Compute
+    # the torch reference on the same standard path so the comparison is apples-to-apples (a
+    # trained policy's decisive logits make this moot). Discovered in Task 1.
+    prev_fastpath = torch.backends.mha.get_fastpath_enabled()
+    torch.backends.mha.set_fastpath_enabled(False)
+    try:
+        (_k, _m), _lp, torch_action = policy.act(obs_t, turn_radius_m=tr, deterministic=True)
+    finally:
+        torch.backends.mha.set_fastpath_enabled(prev_fastpath)
     ort_action = ort_pol.act(obs_t, turn_radius_m=tr)
     assert type(ort_action) is type(torch_action)
     assert ort_action == torch_action

--- a/docs/superpowers/specs/2026-06-17-learned-backend-onnx-inference-design.md
+++ b/docs/superpowers/specs/2026-06-17-learned-backend-onnx-inference-design.md
@@ -1,0 +1,232 @@
+# Learned-backend ONNX export + `solve --backend learned` inference — design
+
+- **Date:** 2026-06-17
+- **Issue:** #706 (epic #607, sub-project #5)
+- **Status:** Design (approved for planning)
+- **Governing decisions:** [ADR-0027](../../adr/0027-learned-backend-determinism-scope.md) (proposer/verifier determinism scope split); the cold-joint env spec [`2026-06-12-learned-backend-cold-joint-rl-env-design.md`](2026-06-12-learned-backend-cold-joint-rl-env-design.md).
+
+## 1. Goal & scope
+
+Make `solve --backend learned` **actually produce a `SolveResult`** from a trained
+checkpoint, with **no torch in the user-facing inference path**, behind the unchanged
+deterministic verifier. Concretely:
+
+1. Export a trained `HangarFitPolicy` (`ml/policy.py`) to ONNX.
+2. Run inference with onnxruntime + numpy (no torch), driving the existing cold-joint
+   env (`ml/env.py`) rollout to a terminal layout.
+3. Return the same `SolveResult` shape (poses + a tow `MovesPlan`) the deterministic
+   `solve()` returns, so every downstream consumer (render / `view` / `--write-yaml`)
+   stays backend-agnostic.
+
+**Weights-agnostic by design.** Export round-trip, onnxruntime wiring, the
+`SolveResult` adapter, and the clean fallbacks are all testable **today** against the
+tiny untrained checkpoint the eval benchmark already uses. Model *quality* gates the
+acceptance verdict (#7 / #698), **not** this rung's plumbing. An untrained policy that
+proposes garbage yields an honest no-layout `SolveResult`, never a traceback — because
+the verifier is the final gate.
+
+### Out of scope (deferred to later rungs)
+
+- Wheel-shippable inference (relocating the torch-free inference core into
+  `src/hangarfit/`), a CI lane that installs the extras, and signed Release-asset
+  weights → **#6 (packaging)**.
+- The reach-not-beat *acceptance run* against a converged model → **#7** / #698.
+- Recording richer per-leg tow metadata beyond what `MovesPlan`/`Move` already carry.
+
+## 2. Current state (verified against the code)
+
+- **Seam is live.** `cli.py` (`--backend {rrmc,learned}`, default `rrmc`) dispatches to
+  `learned.solve_learned(scenario, *, budget_s, alternatives, seed, plan_paths)`
+  (`src/hangarfit/learned.py`), which today always raises
+  `LearnedBackendUnavailableError`. Landed in #670.
+- **Policy forward is a clean per-step function.** `HangarFitPolicy.act()` runs **one**
+  `forward()` per env step → `argmax` over the `kind_gear` (9) and `magnitude` (5) heads
+  → `action_space.decode(kind, mag, turn_radius)` → a `Primitive | Park`. No in-`act()`
+  refiner, no autoregressive sub-loop. The value head is the critic — **unused at
+  inference**.
+- **Dependency direction is one-way `ml → src`.** Nothing under `src/hangarfit/` imports
+  `ml.*`. `ml/env.py`, `ml/encoding.py`, `ml/geometry_oracle.py`, `ml/types.py`,
+  `ml/action_space.py` are **torch-free** (numpy at most). Only `ml/policy.py`,
+  `ml/ppo.py`, `ml/train.py` import torch.
+- **`ml/` is excluded from the wheel** (`[tool.setuptools.packages.find] where=["src"]`).
+  The only optional extra today is `train = ["torch"]`; there is no `learned-infer`/
+  onnxruntime.
+- **The motion vocabulary already matches.** `ml.types.Primitive(kind: SegmentKind,
+  magnitude: float, gear: ±1)` and `towplanner.Segment(kind: SegmentKind, length_m:
+  float, gear: ±1)` are the same vocabulary (S/L/R/T; metres, or **radians** for a cart
+  pivot at `turn_radius==0` — both interpret it identically). `ml.geometry_oracle.
+  apply_primitive` already "builds a single-segment `DubinsArc` and integrates it with
+  the same `pose_at`/`sample` machinery the renderers and towplanner consume."
+
+## 3. Architecture
+
+```
+solve --backend learned                       (CLI, unchanged dispatch)
+        │
+        ▼
+src/hangarfit/learned.py  solve_learned(...)   (WHEEL-SHIPPED, thin seam)
+        │  lazy import ml.infer; clean error if ml / onnxruntime / weights absent
+        ▼
+ml/infer.py  solve_learned_impl(...)           (torch-free runtime: onnxruntime + numpy)
+        ├── env_from_scenario(scenario)  ───►  HangarFitEnv          (ml/env.py)
+        ├── OrtPolicy(onnx_path)         ───►  onnxruntime session    (forward only)
+        ├── rollout loop: encode → forward → argmax → decode → step  (records primitives)
+        ├── build MovesPlan: Primitive[] → DubinsArc per object       (towplanner types)
+        └── verify: collisions.check + Caddy egress                  (FINAL GATE)
+        ▼
+SolveResult(status, layouts, diagnostics, plans)
+
+ml/export.py  export_onnx(policy, path)        (torch; contributor-only)
+ml/train.py   --save-onnx PATH                 (export after training)
+```
+
+### 3.1 Seam — `src/hangarfit/learned.py` (wheel-shipped, thin)
+
+`solve_learned` gains a `weights_path: str | Path | None = None` keyword (the rest of the
+signature is unchanged). It lazy-imports `ml.infer` inside the function body (so importing
+`hangarfit.learned` never pulls `ml`/onnxruntime) and delegates. The CLI `solve` subparser
+gains a `--weights PATH` flag, passed through on the `--backend learned` branch; there is
+**no default weights path** in this rung (a default lookup over signed Release-asset
+weights is #6), so `--backend learned` without `--weights` is a clean
+`LearnedBackendUnavailableError`. `solve_learned` raises `LearnedBackendUnavailableError`
+with a specific, actionable message when:
+
+- `weights_path` is `None` → *"pass `--weights PATH` (no default weights ship yet; see #6)."*
+
+- `ml` is not importable (a bare pip-installed wheel — `ml/` isn't shipped) →
+  *"the learned backend requires a source checkout (the `ml/` package); wheel
+  distribution lands in #6."*
+- `onnxruntime` is not importable → *"install the `[learned-infer]` extra."*
+- the weights file is absent / unreadable → name the path looked up.
+
+This keeps torch/onnxruntime/`ml` out of the wheel's hard dependencies. Making the
+inference path work from a bare wheel is **#6's** packaging job (it decides whether to
+relocate the torch-free inference core into `src/hangarfit/`).
+
+### 3.2 Inference impl — `ml/infer.py` (NEW)
+
+Runtime deps: `onnxruntime` + `numpy` only (no torch). Public entry:
+
+```python
+def solve_learned_impl(
+    scenario: Scenario, *, weights_path: str | Path,
+    budget_s: float, alternatives: int, seed: int | None, plan_paths: bool,
+) -> SolveResult: ...
+```
+
+- **`env_from_scenario(scenario, difficulty)`** — adapt a production
+  `hangarfit.models.Scenario` into the env's constructor args (`hangar`, `fleet`,
+  `requested_ids`, `ground_objects`, `fixed_placements`). Uses a generous default
+  `DifficultyConfig` for production: `max_objects=None` (drive the whole requested set),
+  with `per_object_step_budget` / `total_step_budget` large enough that the budget is a
+  safety stop, not a curriculum cap.
+- **`OrtPolicy`** — a thin wrapper over an onnxruntime `InferenceSession` (pinned
+  `CPUExecutionProvider`, single-threaded for determinism per ADR-0027 tier-1). Method
+  `forward(obs_tensors) -> (kind_gear_logits, magnitude_bin_logits)` returns numpy
+  arrays; `act(obs, turn_radius)` does numpy `argmax` + `action_space.decode` (mirrors
+  `policy.act(deterministic=True)` without torch).
+- **Rollout** — mirrors `ml/eval.py::policy_reach`: `obs = env.reset()`; while not done and
+  `obs.active is not None`: `encode(obs)` → `OrtPolicy.act` → `env.step(action)`. Accumulate,
+  **per active object**, its spawn `start` pose and the ordered list of emitted
+  `Primitive`s (the env grades-then-discards swept paths, so the driver must record them).
+- **`MovesPlan` construction** — for each driven object: `DubinsArc(start=spawn_pose,
+  end=parked_pose, turn_radius_m=body.effective_turn_radius_m(), segments=tuple(
+  Segment(kind=p.kind, length_m=p.magnitude, gear=p.gear) for p in primitives))`, wrapped
+  in `Move(plane_id, target_slot=parked_pose, path=arc)`. **Edge case:** an object parked
+  with **zero** primitives → `DubinsArc.segments` would be empty (which `__post_init__`
+  rejects) → emit `Move(..., path=None)` (the established best-effort `None`-path idiom).
+- **Verification & status** — build the terminal `Layout` (from the env's frozen set),
+  run the deterministic `collisions.check` + Caddy egress gate.
+  - valid → `status="found"`, `layouts=(layout,)`,
+    `plans=(MovesPlan,)` when `plan_paths` else `(None,)`.
+  - invalid / budget-exhausted before a full park set → a no-layout status
+    (`"exhausted_budget"`), `layouts=()`, `plans=()`. **Never** raise on a bad proposal —
+    the verifier rejecting a layout is a normal outcome, identical tier to RR-MC failing
+    to find one.
+  - `alternatives > 1`: this rung emits a **single** layout (argmax rollout is
+    deterministic); diverse sampling is #696. Note in diagnostics if `alternatives > 1`
+    was requested; do not error.
+
+### 3.3 ONNX export — `ml/export.py` (NEW) + `ml/train.py --save-onnx`
+
+- `export_onnx(policy, path, *, opset=17)`: wrap `forward` in a thin positional-input
+  `nn.Module` that takes the five tensors (`raster, tokens, token_mask, active_index,
+  legal_action_mask`) and returns the two logit tensors (**drops the value head**).
+  `torch.onnx.export` with dynamic axes for batch `B` and token count `N`.
+- I/O contract (frozen here so the parity test and the numpy adapter agree):
+  - inputs: `raster (B,C,H,W) f32`, `tokens (B,N,24) f32`, `token_mask (B,N) bool`,
+    `active_index (B,) i64`, `legal_action_mask (B,9) bool`.
+  - outputs: `kind_gear_logits (B,9) f32`, `magnitude_bin_logits (B,5) f32`.
+  - The `-inf` legal-mask `masked_fill` stays **inside** the exported graph, so the
+    inference `argmax` matches the torch `act()` argmax exactly (clean parity test).
+- `train.py --save-onnx PATH` exports alongside the existing `torch.save(state_dict)`.
+- **Known implementation risk:** `nn.TransformerEncoder` with `src_key_padding_mask`
+  can be opset-finicky to export. The export-parity test (3.5a) is the tripwire; the
+  remedy is bumping the opset or, if needed, swapping the encoder for an explicit
+  attention block with the same weights. The numpy adapter never has to know — it only
+  consumes the exported graph.
+
+### 3.4 Packaging — `pyproject.toml`
+
+Add `learned-infer = ["onnxruntime"]` under `[project.optional-dependencies]`. Version
+pin + lockfile regeneration tracked here; CI wiring (a lane that installs the extra) is
+**#6**.
+
+### 3.5 Tests (TDD)
+
+All ml/-side tests live under `tests/ml/`. torch / onnxruntime are absent from CI's
+`[dev]` install, so the relevant tests `importorskip` there (the established pattern) —
+real coverage arrives with #6's CI lane.
+
+a. **Export parity** [needs torch]: build a fixed-seed `HangarFitPolicy`, export to a
+   temp ONNX, and assert `argmax` of each head matches between the torch `forward` and
+   the onnxruntime session on a fixed observation batch (logits may differ sub-ULP;
+   **argmax must match** — that is the inference-relevant invariant).
+b. **DubinsArc endpoint parity** [torch-free]: given a recorded `Primitive` sequence and
+   the env's accumulated parked pose, assert `DubinsArc(...).pose_at(length) ≈
+   parked_pose` within tolerance (guards the 1:1 segment mapping).
+c. **`SolveResult` shape & validity** [needs onnxruntime + a checkpoint]: a learned solve
+   returns a well-formed `SolveResult` (status/layouts/plans index-aligned per the
+   `__post_init__` invariants), and any returned layout passes `collisions.check`.
+d. **ADR-0027 tier-1 canary** [needs onnxruntime]: two within-build runs (same weights +
+   seed + pinned CPU EP) produce bit-identical `SolveResult`s.
+e. **Clean fallbacks**: missing onnxruntime / missing weights / `ml` unimportable each
+   raise `LearnedBackendUnavailableError` with an actionable message; the CLI surfaces
+   exit-2 (extends the existing seam clean-error test).
+f. **Verifier-rejects path**: a policy proposing an invalid terminal layout yields a
+   no-layout status, not an exception.
+
+## 4. Determinism (ADR-0027)
+
+The verifier (`collisions.check` + towplanner) stays strict and `determinism-guard`-bound,
+unchanged. The learned proposer is **outside** ADR-0003 / `determinism-guard`. This rung
+lands the **tier-1** canary (within-build bit-identity: fixed weights + seed + pinned CPU
+EP). Tier-2 (cross-machine validity-only) is recorded by ADR-0027 and exercised once a
+shared trained checkpoint exists (#7). `ml.infer` is **not** added to `determinism-guard`'s
+remit.
+
+## 5. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| TransformerEncoder mask export breaks under opset 17 | Export-parity test (3.5a) is the tripwire; bump opset or use an explicit attention block. |
+| Untrained checkpoint proposes only invalid layouts | Expected — verifier yields a no-layout `SolveResult`; tests assert the *shape*/*fallback*, not reachability. |
+| Zero-primitive object (immediate Park) → empty `DubinsArc.segments` | Emit `Move(path=None)` (best-effort idiom). |
+| `alternatives > 1` requested | Emit one layout, note in diagnostics, do not error; diverse sampling is #696. |
+| Inference can't run from a bare wheel (`ml/` not shipped) | Out of scope by design — clean error; wheel distribution is #6. |
+
+## 6. Acceptance criteria
+
+Mirrors issue #706:
+
+- [ ] `ml/export.py` exports a `HangarFitPolicy` to ONNX; `train.py --save-onnx PATH` writes it.
+- [ ] Export-parity test passes (argmax match, both heads).
+- [ ] `solve --backend learned --weights PATH` returns a `SolveResult`; a valid terminal
+      layout passes `collisions.check` + egress; `--render-paths`/`view` consume the emitted
+      `DubinsArc` tow plan.
+- [ ] DubinsArc endpoint ≈ env parked pose (integration-parity canary).
+- [ ] ADR-0027 tier-1 within-build double-run is bit-identical.
+- [ ] Clean fallbacks (no onnxruntime / weights / `ml`) → `LearnedBackendUnavailableError`,
+      CLI exit-2.
+- [ ] Invalid policy proposal → no-layout status, not an exception.
+- [ ] `learned-infer` extra added; CHANGELOG `[Unreleased]` entry added.

--- a/ml/README.md
+++ b/ml/README.md
@@ -21,17 +21,24 @@ environment + reward (`HangarFitEnv`), reusing `hangarfit`'s geometry oracle.
 ### Inference (#5)
 
 Export a trained policy to ONNX and run it torch-free via the deterministic
-verifier. Needs the `[learned-infer]` extra (`pip install -e ".[learned-infer]"`
-installs onnxruntime; no torch required at inference time).
+verifier. Exporting needs the `[train]` extra (torch **and** `onnx>=1.16`, which
+`ml/export.py` uses to serialize the proto); inference needs only the
+`[learned-infer]` extra (`pip install -e ".[learned-infer]"` installs onnxruntime;
+no torch required at inference time).
 
 ```bash
 # 1. Train (trivial schedule) and export both a state_dict and the ONNX model:
-python -m ml.train --schedule trivial --save model.pt --save-onnx model.onnx  # [train]
+python -m ml.train --schedule trivial --save model.pt --save-onnx model.onnx  # [train] (torch + onnx)
 
 # 2. Run the learned backend (torch-free at inference time):
 hangarfit solve <scenario.yaml> --backend learned --weights model.onnx
 hangarfit solve <scenario.yaml> --backend learned --weights model.onnx --render-paths out.png
 ```
+
+Note: with weights from the **trivial** schedule (an undertrained policy) the
+verifier will usually reject the proposal, so `solve` returns a no-layout result
+(not an error) — the inference *plumbing* is what #5 delivers; reaching valid
+dense layouts is the train-to-mastery work (#698 / #7).
 
 The verifier (`collisions.check` + Caddy egress) is the sole arbiter of validity
 — an invalid or incomplete proposal returns a no-layout result (never an

--- a/ml/README.md
+++ b/ml/README.md
@@ -18,6 +18,26 @@ environment + reward (`HangarFitEnv`), reusing `hangarfit`'s geometry oracle.
   side-by-side both-rates table against the recorded RR-MC baseline (needs the
   `[train]` extra / torch).
 
+### Inference (#5)
+
+Export a trained policy to ONNX and run it torch-free via the deterministic
+verifier. Needs the `[learned-infer]` extra (`pip install -e ".[learned-infer]"`
+installs onnxruntime; no torch required at inference time).
+
+```bash
+# 1. Train (trivial schedule) and export both a state_dict and the ONNX model:
+python -m ml.train --schedule trivial --save model.pt --save-onnx model.onnx  # [train]
+
+# 2. Run the learned backend (torch-free at inference time):
+hangarfit solve <scenario.yaml> --backend learned --weights model.onnx
+hangarfit solve <scenario.yaml> --backend learned --weights model.onnx --render-paths out.png
+```
+
+The verifier (`collisions.check` + Caddy egress) is the sole arbiter of validity
+— an invalid or incomplete proposal returns a no-layout result (never an
+exception). Wheel distribution, CI lane, and signed Release-asset weights are
+deferred to sub-project #6.
+
 The benchmark judges validity via the product deterministic checker
 `collisions.check` + Caddy egress (the spec's prime directive), **not** the env
 oracle — the single shared `layout_valid` oracle is now used by both the env

--- a/ml/README.md
+++ b/ml/README.md
@@ -32,7 +32,7 @@ python -m ml.train --schedule trivial --save model.pt --save-onnx model.onnx  # 
 
 # 2. Run the learned backend (torch-free at inference time):
 hangarfit solve <scenario.yaml> --backend learned --weights model.onnx
-hangarfit solve <scenario.yaml> --backend learned --weights model.onnx --render-paths out.png
+hangarfit solve <scenario.yaml> --backend learned --weights model.onnx --render out.png --render-paths
 ```
 
 Note: with weights from the **trivial** schedule (an undertrained policy) the

--- a/ml/export.py
+++ b/ml/export.py
@@ -1,0 +1,129 @@
+"""Export a trained HangarFitPolicy to ONNX (sub-project #5, epic #607). Needs the
+[train] extra (torch). The exported graph is the per-step policy FORWARD — the value
+head (critic) is dropped, since inference only needs the two action heads. The
+``-inf`` legal-mask is applied inside the graph, so a downstream numpy ``argmax``
+yields a legal action with no extra masking. Inference (onnxruntime) lives in
+``ml/infer.py`` and needs no torch."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import torch
+from torch import Tensor, nn
+
+from ml.encoding import ACTION_DIM, RASTER_CHANNELS, TOKEN_DIM, EncoderConfig
+from ml.policy import HangarFitPolicy, to_batch
+
+ONNX_INPUT_NAMES = ("raster", "tokens", "token_mask", "active_index", "legal_action_mask")
+ONNX_OUTPUT_NAMES = ("kind_gear_logits", "magnitude_bin_logits")
+
+
+class _ForwardWrapper(nn.Module):
+    """Positional-input wrapper over the dict-input policy forward, returning only the
+    two action-head logit tensors (drops the scalar value head)."""
+
+    def __init__(self, policy: HangarFitPolicy) -> None:
+        super().__init__()
+        self.policy = policy
+
+    def forward(
+        self,
+        raster: Tensor,
+        tokens: Tensor,
+        token_mask: Tensor,
+        active_index: Tensor,
+        legal_action_mask: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        out = self.policy(
+            {
+                "raster": raster,
+                "tokens": tokens,
+                "token_mask": token_mask,
+                "active_index": active_index,
+                "legal_action_mask": legal_action_mask,
+            }
+        )
+        return out.kind_gear_logits, out.magnitude_bin_logits
+
+
+def _dummy_inputs(config: EncoderConfig) -> tuple[Tensor, ...]:
+    """A single-sample batch with the encoder's shapes; values are irrelevant to the
+    traced graph (masks all-True so nothing is force-masked during tracing)."""
+    n = config.max_objects
+    raster = torch.zeros(1, RASTER_CHANNELS, config.grid_h, config.grid_w, dtype=torch.float32)
+    tokens = torch.zeros(1, n, TOKEN_DIM, dtype=torch.float32)
+    token_mask = torch.ones(1, n, dtype=torch.bool)
+    active_index = torch.zeros(1, dtype=torch.long)
+    legal = torch.ones(1, ACTION_DIM, dtype=torch.bool)
+    return raster, tokens, token_mask, active_index, legal
+
+
+def export_onnx(
+    policy: HangarFitPolicy,
+    path: str | Path,
+    *,
+    example=None,
+    opset: int = 17,
+) -> None:
+    """Trace ``policy``'s forward to an ONNX file at ``path``. Pass ``example`` (an
+    ``ObservationTensors``) to trace real shapes, else a default-config dummy is used.
+    Batch ``B`` and token count ``N`` are dynamic axes."""
+    # The legacy TorchScript ONNX exporter leaves the module in train() mode on return,
+    # which would silently re-activate the encoder dropout for any later forward the caller
+    # makes on this policy. Capture and restore the original mode so export has no side
+    # effect on the caller's model.
+    was_training = policy.training
+    policy.eval()
+    wrapper = _ForwardWrapper(policy)
+    args: tuple[Tensor, ...]
+    if example is not None:
+        b = to_batch([example])
+        args = (
+            b["raster"],
+            b["tokens"],
+            b["token_mask"],
+            b["active_index"],
+            b["legal_action_mask"],
+        )
+    else:
+        args = _dummy_inputs(EncoderConfig())
+    dynamic_axes = {
+        "raster": {0: "B"},
+        "tokens": {0: "B", 1: "N"},
+        "token_mask": {0: "B", 1: "N"},
+        "active_index": {0: "B"},
+        "legal_action_mask": {0: "B"},
+        "kind_gear_logits": {0: "B"},
+        "magnitude_bin_logits": {0: "B"},
+    }
+    # Disable the TransformerEncoder/Layer sparsity fast paths for the export trace: in
+    # eval mode they dispatch the fused ``aten::_transformer_encoder_layer_fwd`` and
+    # ``aten::_nested_tensor_from_mask`` ops, which have no ONNX symbolic at any opset.
+    # The standard attention path they fall back to is numerically identical (a perf
+    # optimization only). The toggle is process-global, so restore it in ``finally`` —
+    # training/inference elsewhere keep the fast path.
+    fastpath_was_enabled = torch.backends.mha.get_fastpath_enabled()
+    torch.backends.mha.set_fastpath_enabled(False)
+    try:
+        # We deliberately use the legacy TorchScript exporter (dynamo=False): the dynamo
+        # exporter does not yet handle this model's masked attention cleanly. It and the
+        # tracing of PolicyOutput's shape asserts emit known, benign DeprecationWarning /
+        # TracerWarning noise — scope-suppress so callers' output stays pristine.
+        with warnings.catch_warnings(), torch.no_grad():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            warnings.simplefilter("ignore", category=torch.jit.TracerWarning)
+            torch.onnx.export(
+                wrapper,
+                args,
+                str(path),
+                input_names=list(ONNX_INPUT_NAMES),
+                output_names=list(ONNX_OUTPUT_NAMES),
+                dynamic_axes=dynamic_axes,
+                opset_version=opset,
+                dynamo=False,
+            )
+    finally:
+        torch.backends.mha.set_fastpath_enabled(fastpath_was_enabled)
+        policy.train(was_training)

--- a/ml/export.py
+++ b/ml/export.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import torch
 from torch import Tensor, nn
 
-from ml.encoding import ACTION_DIM, RASTER_CHANNELS, TOKEN_DIM, EncoderConfig
+from ml.encoding import ACTION_DIM, RASTER_CHANNELS, TOKEN_DIM, EncoderConfig, ObservationTensors
 from ml.policy import HangarFitPolicy, to_batch
 
 ONNX_INPUT_NAMES = ("raster", "tokens", "token_mask", "active_index", "legal_action_mask")
@@ -64,7 +64,7 @@ def export_onnx(
     policy: HangarFitPolicy,
     path: str | Path,
     *,
-    example=None,
+    example: ObservationTensors | None = None,
     opset: int = 17,
 ) -> None:
     """Trace ``policy``'s forward to an ONNX file at ``path``. Pass ``example`` (an

--- a/ml/infer.py
+++ b/ml/infer.py
@@ -1,8 +1,8 @@
 """Torch-free inference for the learned backend (sub-project #5, epic #607).
 
 Runs a trained policy exported to ONNX (``ml/export.py``) with onnxruntime + numpy —
-NO torch in this module. ``solve_learned_impl`` (later task) drives the cold-joint env
-to a terminal layout and returns a ``SolveResult`` behind the deterministic verifier.
+NO torch in this module. ``solve_learned_impl`` drives the cold-joint env to a terminal
+layout and returns a ``SolveResult`` behind the deterministic verifier.
 
 Determinism (ADR-0027): the proposer's tier-1 contract is within-build bit-identity
 (fixed weights + seed + pinned CPUExecutionProvider). The verifier stays strict and is
@@ -10,13 +10,15 @@ the sole arbiter of validity — an invalid proposal yields a no-layout SolveRes
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import numpy as np
 
-from hangarfit.models import Layout, Scenario
+from hangarfit.models import Layout, Scenario, SolverDiagnostics, SolveResult
 from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+from ml import geometry_oracle as go
 from ml.action_space import decode
 from ml.encoding import EncoderConfig, ObservationTensors, encode
 from ml.env import HangarFitEnv
@@ -158,3 +160,56 @@ def build_moves_plan(layout: Layout, driven: list[_DrivenObject], env: HangarFit
         arc = DubinsArc(start=d.start_pose, end=target, turn_radius_m=tr, segments=segments)
         moves.append(Move(plane_id=d.object_id, target_slot=target, path=arc))
     return MovesPlan(target_layout=layout, moves=tuple(moves))
+
+
+def solve_learned_impl(
+    scenario: Scenario,
+    *,
+    weights_path: str | Path,
+    budget_s: float,
+    alternatives: int,
+    seed: int | None,
+    plan_paths: bool,
+) -> SolveResult:
+    """Run the learned backend: argmax rollout of the ONNX policy over the env built from
+    ``scenario``, then return a verifier-gated SolveResult. The verifier (collisions.check
+    + Caddy egress, via go.layout_valid) is the sole arbiter — an invalid or incomplete
+    proposal yields a no-layout 'exhausted_budget' result, never an exception.
+
+    ``alternatives`` > 1 is accepted but yields a single (deterministic argmax) layout;
+    diverse sampling is #696. ``budget_s`` is advisory here (the env's step budget bounds
+    the rollout); it is recorded but not enforced as a wall-clock deadline (ADR-0003-style
+    reproducibility favours the step-count bound)."""
+    start = time.monotonic()
+    resolved_seed = seed if seed is not None else 0
+    policy = OrtPolicy(weights_path)
+    env = env_from_scenario(scenario)
+    layout, driven, info = rollout(env, policy)
+
+    complete = info.placed == info.total
+    if complete and go.layout_valid(layout):
+        plan = build_moves_plan(layout, driven, env) if plan_paths else None
+        return SolveResult(
+            status="found",
+            layouts=(layout,),
+            diagnostics=SolverDiagnostics(
+                restarts_attempted=0,
+                wall_time_s=time.monotonic() - start,
+                best_partial=None,
+                best_partial_layout=None,
+                seed=resolved_seed,
+            ),
+            plans=(plan,),
+        )
+    return SolveResult(
+        status="exhausted_budget",
+        layouts=(),
+        diagnostics=SolverDiagnostics(
+            restarts_attempted=0,
+            wall_time_s=time.monotonic() - start,
+            best_partial=None,
+            best_partial_layout=None,
+            seed=resolved_seed,
+        ),
+        plans=(),
+    )

--- a/ml/infer.py
+++ b/ml/infer.py
@@ -43,9 +43,9 @@ class OrtPolicy:
         feed = {
             "raster": obs.raster[None].astype(np.float32),
             "tokens": obs.tokens[None].astype(np.float32),
-            "token_mask": obs.token_mask[None],
+            "token_mask": obs.token_mask[None].astype(np.bool_),
             "active_index": np.asarray([obs.active_index], dtype=np.int64),
-            "legal_action_mask": obs.legal_action_mask[None],
+            "legal_action_mask": obs.legal_action_mask[None].astype(np.bool_),
         }
         kind_logits, mag_logits = self._session.run(list(ONNX_OUTPUT_NAMES), feed)
         kind_idx = int(np.argmax(kind_logits[0]))

--- a/ml/infer.py
+++ b/ml/infer.py
@@ -10,17 +10,18 @@ the sole arbiter of validity — an invalid proposal yields a no-layout SolveRes
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import numpy as np
 
-from hangarfit.models import Scenario
+from hangarfit.models import Layout, Scenario
+from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
 from ml.action_space import decode
-from ml.encoding import ObservationTensors
+from ml.encoding import EncoderConfig, ObservationTensors, encode
 from ml.env import HangarFitEnv
 from ml.export import ONNX_OUTPUT_NAMES
-from ml.types import DifficultyConfig, Park, Primitive
+from ml.types import DifficultyConfig, Park, Primitive, StepInfo
 
 
 class OrtPolicy:
@@ -94,3 +95,64 @@ def env_from_scenario(scenario: Scenario, *, apron_depth_m: float = 8.0) -> Hang
         fixed_placements=scenario.fixed_obstacle_placements,
         difficulty=difficulty,
     )
+
+
+@dataclass(slots=True)
+class _DrivenObject:
+    """Record of one PARKED object: spawn pose, ordered primitives, and frozen end pose."""
+
+    object_id: str
+    start_pose: Pose
+    end_pose: Pose
+    primitives: list[Primitive] = field(default_factory=list)
+
+
+def rollout(
+    env: HangarFitEnv, policy: OrtPolicy, encoder: EncoderConfig | None = None
+) -> tuple[Layout, list[_DrivenObject], StepInfo]:
+    """Drive ``env`` to termination under ``policy`` (argmax). Record each PARKED object's
+    spawn pose, the ordered primitives it was driven with, and its frozen (parked) pose.
+    Objects abandoned at budget exhaustion are NOT recorded (they are not in the terminal
+    layout). Returns (terminal_layout, driven_objects_in_park_order, last_step_info)."""
+    enc = encoder or EncoderConfig()
+    bodies = {**env.fleet, **env.ground_objects}
+    obs = env.reset()
+    driven: list[_DrivenObject] = []
+    # The active object is identified at spawn; its primitives accumulate until a Park.
+    current = _DrivenObject(obs.active.object_id, obs.active.pose, obs.active.pose)
+    done = False
+    info: StepInfo | None = None
+    while not done and obs.active is not None:
+        obs_t = encode(obs, env.hangar, bodies, enc)
+        tr = obs.active.body.effective_turn_radius_m()
+        action = policy.act(obs_t, turn_radius_m=tr)
+        if isinstance(action, Park):
+            current.end_pose = obs.active.pose  # the pose Park freezes
+            driven.append(current)
+        else:
+            current.primitives.append(action)
+        obs, _reward, done, info = env.step(action)
+        if isinstance(action, Park) and not done and obs.active is not None:
+            current = _DrivenObject(obs.active.object_id, obs.active.pose, obs.active.pose)
+    if info is None:
+        raise ValueError("rollout: episode produced no steps")
+    return env._layout(), driven, info
+
+
+def build_moves_plan(layout: Layout, driven: list[_DrivenObject], env: HangarFitEnv) -> MovesPlan:
+    """Map each driven object's recorded primitives onto a DubinsArc tow Move (1:1
+    Primitive->Segment). A zero-primitive object (parked at spawn) gets Move(path=None)
+    — the established best-effort idiom, since DubinsArc.segments must be non-empty."""
+    moves: list[Move] = []
+    for d in driven:
+        target = Pose(x_m=d.end_pose.x_m, y_m=d.end_pose.y_m, heading_deg=d.end_pose.heading_deg)
+        if not d.primitives:
+            moves.append(Move(plane_id=d.object_id, target_slot=target, path=None))
+            continue
+        tr = env._body(d.object_id).effective_turn_radius_m()
+        segments = tuple(
+            Segment(kind=p.kind, length_m=p.magnitude, gear=p.gear) for p in d.primitives
+        )
+        arc = DubinsArc(start=d.start_pose, end=target, turn_radius_m=tr, segments=segments)
+        moves.append(Move(plane_id=d.object_id, target_slot=target, path=arc))
+    return MovesPlan(target_layout=layout, moves=tuple(moves))

--- a/ml/infer.py
+++ b/ml/infer.py
@@ -1,0 +1,53 @@
+"""Torch-free inference for the learned backend (sub-project #5, epic #607).
+
+Runs a trained policy exported to ONNX (``ml/export.py``) with onnxruntime + numpy —
+NO torch in this module. ``solve_learned_impl`` (later task) drives the cold-joint env
+to a terminal layout and returns a ``SolveResult`` behind the deterministic verifier.
+
+Determinism (ADR-0027): the proposer's tier-1 contract is within-build bit-identity
+(fixed weights + seed + pinned CPUExecutionProvider). The verifier stays strict and is
+the sole arbiter of validity — an invalid proposal yields a no-layout SolveResult."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from ml.action_space import decode
+from ml.encoding import ObservationTensors
+from ml.export import ONNX_OUTPUT_NAMES
+from ml.types import Park, Primitive
+
+
+class OrtPolicy:
+    """A trained policy forward as an onnxruntime session. ``act`` mirrors
+    ``HangarFitPolicy.act(deterministic=True)`` with numpy argmax — the ``-inf`` legal
+    mask is already baked into the graph, so argmax always yields a legal action."""
+
+    def __init__(self, onnx_path: str | Path) -> None:
+        import onnxruntime as ort  # local import: onnxruntime is the [learned-infer] extra
+
+        # Pin CPUExecutionProvider single-threaded for the ADR-0027 tier-1 bit-identity
+        # contract (within-build double-run reproducibility).
+        opts = ort.SessionOptions()
+        opts.intra_op_num_threads = 1
+        opts.inter_op_num_threads = 1
+        self._session = ort.InferenceSession(
+            str(onnx_path), sess_options=opts, providers=["CPUExecutionProvider"]
+        )
+
+    def act(self, obs: ObservationTensors, *, turn_radius_m: float) -> Primitive | Park:
+        if obs.active_index < 0:
+            raise ValueError("OrtPolicy.act called on a terminal observation (active_index < 0)")
+        feed = {
+            "raster": obs.raster[None].astype(np.float32),
+            "tokens": obs.tokens[None].astype(np.float32),
+            "token_mask": obs.token_mask[None],
+            "active_index": np.asarray([obs.active_index], dtype=np.int64),
+            "legal_action_mask": obs.legal_action_mask[None],
+        }
+        kind_logits, mag_logits = self._session.run(list(ONNX_OUTPUT_NAMES), feed)
+        kind_idx = int(np.argmax(kind_logits[0]))
+        mag_idx = int(np.argmax(mag_logits[0]))
+        return decode(kind_idx, mag_idx, turn_radius_m=turn_radius_m)

--- a/ml/infer.py
+++ b/ml/infer.py
@@ -10,14 +10,17 @@ the sole arbiter of validity — an invalid proposal yields a no-layout SolveRes
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 import numpy as np
 
+from hangarfit.models import Scenario
 from ml.action_space import decode
 from ml.encoding import ObservationTensors
+from ml.env import HangarFitEnv
 from ml.export import ONNX_OUTPUT_NAMES
-from ml.types import Park, Primitive
+from ml.types import DifficultyConfig, Park, Primitive
 
 
 class OrtPolicy:
@@ -51,3 +54,43 @@ class OrtPolicy:
         kind_idx = int(np.argmax(kind_logits[0]))
         mag_idx = int(np.argmax(mag_logits[0]))
         return decode(kind_idx, mag_idx, turn_radius_m=turn_radius_m)
+
+
+def env_from_scenario(scenario: Scenario, *, apron_depth_m: float = 8.0) -> HangarFitEnv:
+    """Build a cold-joint env from a production ``Scenario`` (the inference counterpart
+    of ``ml.benchmark.build_scenario_env``, which builds from a ``BenchScenario`` path).
+
+    Movable bodies (aircraft + placed-routed movers) are driven in from an apron; fixed
+    obstacles (immovable keep-outs) are PRE-PLACED at their surveyed poses, never driven —
+    the same scene the deterministic verifier sees. The difficulty budgets are generous
+    (a safety stop, not a curriculum cap)."""
+    fixed_ids = [
+        gid
+        for gid in scenario.ground_objects
+        if scenario.ground_object_defs[gid].object_class == "fixed_obstacle"
+    ]
+    placed = {p.plane_id for p in scenario.fixed_obstacle_placements}
+    missing = [g for g in fixed_ids if g not in placed]
+    if missing:
+        raise ValueError(
+            f"env_from_scenario: fixed obstacle(s) {missing} have no entry in "
+            f"scenario.fixed_obstacle_placements — they would silently appear un-placed."
+        )
+    placeable = scenario.placeable_ids
+    movers = {gid: scenario.ground_object_defs[gid] for gid in scenario.mover_ids}
+    fixed_defs = {gid: scenario.ground_object_defs[gid] for gid in fixed_ids}
+    per_object = 120
+    difficulty = DifficultyConfig(
+        max_objects=len(placeable),
+        per_object_step_budget=per_object,
+        total_step_budget=per_object * max(1, len(placeable)),
+    )
+    hangar = replace(scenario.hangar, apron_depth_m=apron_depth_m)
+    return HangarFitEnv(
+        hangar=hangar,
+        fleet=scenario.fleet,
+        requested_ids=placeable,
+        ground_objects={**movers, **fixed_defs},
+        fixed_placements=scenario.fixed_obstacle_placements,
+        difficulty=difficulty,
+    )

--- a/ml/infer.py
+++ b/ml/infer.py
@@ -147,7 +147,7 @@ def build_moves_plan(layout: Layout, driven: list[_DrivenObject], env: HangarFit
     — the established best-effort idiom, since DubinsArc.segments must be non-empty."""
     moves: list[Move] = []
     for d in driven:
-        target = Pose(x_m=d.end_pose.x_m, y_m=d.end_pose.y_m, heading_deg=d.end_pose.heading_deg)
+        target = d.end_pose  # Pose is frozen; no need to reconstruct
         if not d.primitives:
             moves.append(Move(plane_id=d.object_id, target_slot=target, path=None))
             continue

--- a/ml/infer.py
+++ b/ml/infer.py
@@ -173,15 +173,25 @@ def solve_learned_impl(
 ) -> SolveResult:
     """Run the learned backend: argmax rollout of the ONNX policy over the env built from
     ``scenario``, then return a verifier-gated SolveResult. The verifier (collisions.check
-    + Caddy egress, via go.layout_valid) is the sole arbiter — an invalid or incomplete
-    proposal yields a no-layout 'exhausted_budget' result, never an exception.
+    + Caddy egress, via go.layout_valid) is the sole arbiter.
+
+    No-exception scope (the Prime Directive, ADR-0027): the verifier rejecting a bad
+    *proposal* — an invalid or incomplete terminal layout — never raises; it yields a
+    no-layout ``'exhausted_budget'`` result. That contract is about proposal rejection.
+    Malformed *inputs* (a degenerate scenario whose env produces no driveable object, an
+    onnxruntime load failure, a fixed obstacle missing its placement) DO propagate from
+    ``OrtPolicy`` / ``env_from_scenario`` / ``rollout`` — masking those as
+    ``exhausted_budget`` would be a silent failure hiding a real bug, so they surface loudly.
 
     ``alternatives`` > 1 is accepted but yields a single (deterministic argmax) layout;
-    diverse sampling is #696. ``budget_s`` is advisory here (the env's step budget bounds
-    the rollout); it is recorded but not enforced as a wall-clock deadline (ADR-0003-style
-    reproducibility favours the step-count bound)."""
+    diverse sampling is #696. ``budget_s`` is advisory (the env's step budget bounds the
+    rollout, not a wall-clock deadline — ADR-0003-style reproducibility favours the
+    step-count bound); it is not separately surfaced — ``diagnostics.wall_time_s`` records
+    the elapsed time actually spent."""
     start = time.monotonic()
     resolved_seed = seed if seed is not None else 0
+    # alternatives > 1 is accepted for seam signature-compat but produces one argmax layout
+    # (deterministic rollout). TODO(#696): run N sampled rollouts for diverse alternatives.
     policy = OrtPolicy(weights_path)
     env = env_from_scenario(scenario)
     layout, driven, info = rollout(env, policy)

--- a/ml/infer.py
+++ b/ml/infer.py
@@ -117,6 +117,8 @@ def rollout(
     enc = encoder or EncoderConfig()
     bodies = {**env.fleet, **env.ground_objects}
     obs = env.reset()
+    if obs.active is None:
+        raise ValueError("rollout: env.reset() produced no active object to drive")
     driven: list[_DrivenObject] = []
     # The active object is identified at spawn; its primitives accumulate until a Park.
     current = _DrivenObject(obs.active.object_id, obs.active.pose, obs.active.pose)

--- a/ml/train.py
+++ b/ml/train.py
@@ -29,6 +29,7 @@ from ml.curriculum import (
 )
 from ml.encoding import EncoderConfig, encode
 from ml.env import HangarFitEnv
+from ml.export import export_onnx
 from ml.policy import HangarFitPolicy, to_batch
 from ml.ppo import (
     PPOConfig,
@@ -140,6 +141,7 @@ def train(
     weights: RewardWeights | None = None,
     log: bool = False,
     save: str | None = None,
+    save_onnx: str | None = None,
 ) -> list[float]:
     """Train on the trivial stage; return the per-iteration mean episode reward.
 
@@ -186,6 +188,8 @@ def train(
             )
     if save is not None:
         torch.save(policy.state_dict(), save)
+    if save_onnx is not None:
+        export_onnx(policy, save_onnx)
     return history
 
 
@@ -200,6 +204,7 @@ def train_curriculum(
     weights: RewardWeights | None = None,
     log: bool = False,
     save: str | None = None,
+    save_onnx: str | None = None,
 ) -> CurriculumHistory:
     """Climb the ladder: one policy/optimizer across rungs (transfer); per rung, run
     PPO until the competency gate fires or the per-stage cap is hit, then advance.
@@ -275,6 +280,8 @@ def train_curriculum(
             print(f"[{stage.name}] promoted by {by}")
     if save is not None:
         torch.save(policy.state_dict(), save)
+    if save_onnx is not None:
+        export_onnx(policy, save_onnx)
     return history
 
 
@@ -295,6 +302,12 @@ def build_argparser() -> argparse.ArgumentParser:
     p.add_argument("--lr", type=float, default=3e-4)
     p.add_argument(
         "--save", type=str, default=None, help="write the trained policy state_dict to this path"
+    )
+    p.add_argument(
+        "--save-onnx",
+        type=str,
+        default=None,
+        help="also export the trained policy forward to this ONNX path (inference)",
     )
     p.add_argument(
         "--r-valid-park",
@@ -355,6 +368,7 @@ def main() -> None:
             weights=weights,
             log=True,
             save=args.save,
+            save_onnx=args.save_onnx,
         )
     else:
         sched = CurriculumSchedule.default()
@@ -368,6 +382,7 @@ def main() -> None:
             weights=weights,
             log=True,
             save=args.save,
+            save_onnx=args.save_onnx,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,10 +123,15 @@ module = [
 ignore_missing_imports = true
 
 # learned.py's lazy `from ml.infer import solve_learned_impl` causes mypy to
-# follow into ml/ when running `mypy src/hangarfit/`. ml/ is dev/CI-only and
-# has its own mypy pass; suppress errors surfaced in ml.* files so they don't
-# bleed into the src/hangarfit/ check. ml/ errors are caught by the dedicated
-# `mypy ml/` invocation and tests/ml/ coverage — not by the wheel type-check.
+# follow into ml/ when running `mypy src/hangarfit/`. Under that follow, ml/'s
+# own `hangarfit.*` imports resolve as Any (per the ignore_missing_imports
+# override above), which surfaces spurious errors that do NOT appear under the
+# dedicated `mypy ml/` pass. `follow_imports = skip` stops the src-check from
+# type-checking ml/ internals (the import resolves to Any in learned.py) WITHOUT
+# disabling `mypy ml/`: explicitly-passed files are always checked, so the Stop
+# hook's `mypy ml/` still fully type-checks the workspace. (Do NOT use
+# ignore_errors here — that suppresses errors even under `mypy ml/`, silently
+# neutering the ml/ type-check.)
 [[tool.mypy.overrides]]
 module = "ml.*"
-ignore_errors = true
+follow_imports = "skip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=7.4", "pytest-cov>=4.0", "pytest-xdist>=3.5", "ruff>=0.7.0", "mypy>=1.0", "types-PyYAML", "types-shapely", "hypothesis>=6.100"]
-train = ["torch"]
+train = ["torch", "onnx>=1.16"]
+learned-infer = ["onnxruntime>=1.18"]
 
 [project.scripts]
 hangarfit = "hangarfit.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,3 +121,12 @@ module = [
     "hangarfit.towplanner",
 ]
 ignore_missing_imports = true
+
+# learned.py's lazy `from ml.infer import solve_learned_impl` causes mypy to
+# follow into ml/ when running `mypy src/hangarfit/`. ml/ is dev/CI-only and
+# has its own mypy pass; suppress errors surfaced in ml.* files so they don't
+# bleed into the src/hangarfit/ check. ml/ errors are caught by the dedicated
+# `mypy ml/` invocation and tests/ml/ coverage — not by the wheel type-check.
+[[tool.mypy.overrides]]
+module = "ml.*"
+ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,12 @@ ignore_errors = false
 module = "matplotlib.*"
 ignore_missing_imports = true
 
+# onnxruntime (the [learned-infer] extra, #706) ships no py.typed marker, so mypy
+# raises import-untyped on ml/infer.py's local import. Same rationale as matplotlib.
+[[tool.mypy.overrides]]
+module = "onnxruntime.*"
+ignore_missing_imports = true
+
 # ml/ (dev/CI-only, never in the wheel) imports hangarfit, which ships no
 # py.typed marker, so mypy raises import-untyped on those imports. Scope the
 # suppression to ONLY the hangarfit submodules ml/ actually imports — NOT a

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -372,7 +372,7 @@ def build_parser() -> argparse.ArgumentParser:
         dest="weights",
         help=(
             "Path to the learned backend's ONNX weights (only with --backend learned). "
-            "No default ships yet (#6); omitting it with --backend learned exits cleanly."
+            "No default weights ship yet; omitting it with --backend learned exits cleanly."
         ),
     )
 

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -361,8 +361,9 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Solver backend. 'rrmc' (default) is the shipped deterministic "
             "random-restart min-conflicts solver (ADR-0003). 'learned' selects the "
-            "opt-in neural backend (epic #607) — not yet available, so it exits "
-            "cleanly with a message; the deterministic path is unchanged (ADR-0027)."
+            "opt-in neural backend (epic #607); it requires --weights PATH and the "
+            "[learned-infer] extra, else it exits cleanly with a message. The "
+            "deterministic path is unchanged (ADR-0027)."
         ),
     )
     solve.add_argument(
@@ -728,8 +729,8 @@ def cmd_solve(args: argparse.Namespace) -> int:
 
     # Backend dispatch (#607 / ADR-0027). The default deterministic RR-MC path is
     # unchanged and byte-identical; `--backend learned` routes to the opt-in learned
-    # proposer, which returns the same SolveResult shape. It is not yet implemented,
-    # so it surfaces a clean exit-2 error rather than a traceback.
+    # proposer (#706), which returns the same SolveResult shape. A missing --weights /
+    # [learned-infer] extra surfaces a clean exit-2 error rather than a traceback.
     if args.backend == "learned":
         try:
             result = solve_learned(

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -365,6 +365,16 @@ def build_parser() -> argparse.ArgumentParser:
             "cleanly with a message; the deterministic path is unchanged (ADR-0027)."
         ),
     )
+    solve.add_argument(
+        "--weights",
+        type=str,
+        default=None,
+        dest="weights",
+        help=(
+            "Path to the learned backend's ONNX weights (only with --backend learned). "
+            "No default ships yet (#6); omitting it with --backend learned exits cleanly."
+        ),
+    )
 
     view = sub.add_parser(
         "view",
@@ -724,6 +734,7 @@ def cmd_solve(args: argparse.Namespace) -> int:
         try:
             result = solve_learned(
                 scenario,
+                weights_path=args.weights,
                 budget_s=args.budget,
                 alternatives=args.alternatives,
                 seed=args.seed,

--- a/src/hangarfit/learned.py
+++ b/src/hangarfit/learned.py
@@ -6,9 +6,12 @@ that returns the same :class:`~hangarfit.models.SolveResult`
 shape, so every downstream consumer (render / ``view`` / ``--write-yaml``) stays
 backend-agnostic.
 
-It is **not yet implemented**. Calling :func:`solve_learned` always raises
-:class:`LearnedBackendUnavailableError`; the learned policy, its training, and the
-``[learned-infer]`` runtime extra arrive in later rungs of #607.
+Calling :func:`solve_learned` without a ``weights_path``, with a missing weights
+file, or without the ``[learned-infer]`` / ``ml/`` dependencies installed raises
+:class:`LearnedBackendUnavailableError` with an actionable message. When a valid
+weights path is provided and the inference dependencies are present, the call
+delegates to :func:`ml.infer.solve_learned_impl` (lazy-imported inside the
+function body so the wheel never drags in ``ml``/``onnxruntime`` at module load).
 
 Determinism: the learned proposer is **not** under the ADR-0003 byte-identical
 contract — that contract stays on the verifier (``collisions.check`` + ``towplanner``),
@@ -18,6 +21,7 @@ which remains the sole arbiter of validity and routability. The learned path's o
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -27,34 +31,54 @@ if TYPE_CHECKING:
 class LearnedBackendUnavailableError(RuntimeError):
     """Raised when the learned backend is requested but cannot run.
 
-    Today this is *always* raised: the learned backend (epic #607) is not yet
-    implemented. Once it ships, this will instead signal a missing optional
-    ``[learned-infer]`` runtime dependency or absent model weights — letting the
-    CLI surface a clean, actionable error rather than an import traceback.
+    Signals a missing optional ``[learned-infer]`` runtime dependency, absent
+    model weights, or a bare wheel distribution that does not include the ``ml/``
+    package — letting the CLI surface a clean, actionable error rather than an
+    import traceback.
     """
 
 
 def solve_learned(
     scenario: Scenario,
     *,
+    weights_path: str | Path | None = None,
     budget_s: float = 30.0,
     alternatives: int = 1,
     seed: int | None = None,
     plan_paths: bool = True,
 ) -> SolveResult:
-    """Learned-backend counterpart to :func:`hangarfit.solver.solve`.
+    """Learned-backend counterpart to :func:`hangarfit.solver.solve` (epic #607).
 
-    Intended contract (once implemented): propose poses **and** the place-and-tow
-    sequence with a learned policy, then return the same
-    :class:`~hangarfit.models.SolveResult` shape (poses + tow ``MovesPlan``) as the
-    deterministic backend, with the verifier accepting/rejecting every layout. The
-    signature mirrors the user-facing knobs of :func:`solve` so the CLI can dispatch
-    on ``--backend`` without reshaping the call.
-
-    **Not yet implemented** (epic #607): always raises
-    :class:`LearnedBackendUnavailableError`.
+    Lazy-imports the torch-free ``ml.infer`` inference path (onnxruntime). Raises
+    :class:`LearnedBackendUnavailableError` with an actionable message when the backend
+    cannot run: no ``--weights`` given, the ``ml`` package is absent (a bare wheel — see
+    #6), ``onnxruntime`` (the ``[learned-infer]`` extra) is missing, or the weights file
+    does not exist. The deterministic verifier remains the sole arbiter of validity
+    (ADR-0027); an invalid proposal returns a no-layout ``SolveResult``, not an error.
     """
-    raise LearnedBackendUnavailableError(
-        "the learned solver backend is not yet available (tracked in #607); "
-        "use the default --backend rrmc"
+    if weights_path is None:
+        raise LearnedBackendUnavailableError(
+            "the learned backend needs trained weights: pass --weights PATH "
+            "(no default weights ship yet; tracked in #6)"
+        )
+    if not Path(weights_path).is_file():
+        raise LearnedBackendUnavailableError(
+            f"learned-backend weights not found at {weights_path!r}"
+        )
+    try:
+        from ml.infer import solve_learned_impl
+    except ImportError as exc:
+        raise LearnedBackendUnavailableError(
+            "the learned backend requires the inference dependencies: install the "
+            "'[learned-infer]' extra (onnxruntime) in a source checkout that includes "
+            "the 'ml/' package (wheel distribution is tracked in #6). "
+            f"(import failed: {exc})"
+        ) from exc
+    return solve_learned_impl(
+        scenario,
+        weights_path=weights_path,
+        budget_s=budget_s,
+        alternatives=alternatives,
+        seed=seed,
+        plan_paths=plan_paths,
     )

--- a/tests/ml/test_export.py
+++ b/tests/ml/test_export.py
@@ -1,0 +1,76 @@
+"""ONNX export of HangarFitPolicy (sub-project #5, #607). Needs the [train] extra
+(torch) to export and the [learned-infer] extra (onnxruntime) to run the round-trip."""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+ort = pytest.importorskip("onnxruntime")
+
+import numpy as np  # noqa: E402
+
+from ml.encoding import EncoderConfig, encode  # noqa: E402
+from ml.export import ONNX_INPUT_NAMES, ONNX_OUTPUT_NAMES, export_onnx  # noqa: E402
+from ml.policy import HangarFitPolicy, to_batch  # noqa: E402
+from ml.train import build_trivial_env  # noqa: E402
+
+
+def _example_obs():
+    env = build_trivial_env()
+    obs = env.reset()
+    return encode(obs, env.hangar, {**env.fleet, **env.ground_objects}, EncoderConfig())
+
+
+def test_export_argmax_parity(tmp_path):
+    torch.manual_seed(0)
+    policy = HangarFitPolicy()
+    policy.eval()
+    obs_t = _example_obs()
+    out_path = tmp_path / "policy.onnx"
+    export_onnx(policy, out_path)
+
+    batch = to_batch([obs_t])
+    # The ONNX graph traces the STANDARD attention path: export disables the fused/nested
+    # TransformerEncoder fast paths (they emit ops with no ONNX symbolic). Those paths are a
+    # numerically-equivalent optimization, but on an UNTRAINED near-tie policy the tiny
+    # fast-vs-standard delta can still flip an argmax. Compute the torch reference on the
+    # SAME standard path so the comparison is apples-to-apples (a trained policy's decisive
+    # logits make this distinction moot).
+    prev_fastpath = torch.backends.mha.get_fastpath_enabled()
+    torch.backends.mha.set_fastpath_enabled(False)
+    try:
+        with torch.no_grad():
+            torch_out = policy(batch)
+    finally:
+        torch.backends.mha.set_fastpath_enabled(prev_fastpath)
+    feed = {
+        "raster": batch["raster"].numpy(),
+        "tokens": batch["tokens"].numpy(),
+        "token_mask": batch["token_mask"].numpy(),
+        "active_index": batch["active_index"].numpy(),
+        "legal_action_mask": batch["legal_action_mask"].numpy(),
+    }
+    sess = ort.InferenceSession(str(out_path), providers=["CPUExecutionProvider"])
+    kind_logits, mag_logits = sess.run(list(ONNX_OUTPUT_NAMES), feed)
+
+    assert tuple(ONNX_INPUT_NAMES) == (
+        "raster",
+        "tokens",
+        "token_mask",
+        "active_index",
+        "legal_action_mask",
+    )
+    # Faithful export: the legal (finite) logits match within float tolerance. Illegal slots
+    # are -inf in both (the masked_fill is inside the graph), so compare only finite entries.
+    kt = torch_out.kind_gear_logits[0].numpy()
+    finite = np.isfinite(kt)
+    np.testing.assert_allclose(kind_logits[0][finite], kt[finite], atol=1e-3, rtol=1e-3)
+    np.testing.assert_allclose(
+        mag_logits[0], torch_out.magnitude_bin_logits[0].numpy(), atol=1e-3, rtol=1e-3
+    )
+    # The inference-relevant invariant: argmax of each head agrees.
+    onnx_kind = int(np.argmax(kind_logits, axis=-1)[0])
+    onnx_mag = int(np.argmax(mag_logits, axis=-1)[0])
+    assert onnx_kind == int(torch_out.kind_gear_logits.argmax(-1)[0])
+    assert onnx_mag == int(torch_out.magnitude_bin_logits.argmax(-1)[0])

--- a/tests/ml/test_export.py
+++ b/tests/ml/test_export.py
@@ -74,3 +74,11 @@ def test_export_argmax_parity(tmp_path):
     onnx_mag = int(np.argmax(mag_logits, axis=-1)[0])
     assert onnx_kind == int(torch_out.kind_gear_logits.argmax(-1)[0])
     assert onnx_mag == int(torch_out.magnitude_bin_logits.argmax(-1)[0])
+
+
+def test_train_save_onnx_writes_file(tmp_path):
+    from ml.train import train
+
+    onnx_path = tmp_path / "trivial.onnx"
+    train(iterations=1, rollout_len=16, save_onnx=str(onnx_path))
+    assert onnx_path.exists() and onnx_path.stat().st_size > 0

--- a/tests/ml/test_infer.py
+++ b/tests/ml/test_infer.py
@@ -111,3 +111,40 @@ def test_rollout_builds_moves_plan(tmp_path):
     # Every parked object has a Move; every Move targets a real slot pose.
     assert len(plan.moves) == len(driven)
     assert all(m.target_slot is not None for m in plan.moves)
+
+
+def test_build_moves_plan_maps_primitives_to_dubins_arc():
+    """Direct coverage of the core Primitive->Segment->DubinsArc mapping (the rollout
+    integration test parks 0 objects under an untrained policy, so it cannot exercise this
+    path). Handcraft driven objects and assert the arc mirrors the primitives 1:1, plus the
+    zero-primitive -> Move(path=None) best-effort edge case."""
+    from hangarfit.towplanner import Pose
+    from ml.infer import _DrivenObject, build_moves_plan
+
+    env = build_trivial_env()
+    env.reset()
+    layout = env._layout()
+    start = Pose(x_m=11.0, y_m=-4.0, heading_deg=0.0)
+    end = Pose(x_m=11.0, y_m=6.0, heading_deg=0.0)
+    prims = [Primitive(kind="S", magnitude=2.0, gear=1), Primitive(kind="L", magnitude=1.0, gear=1)]
+    driven = [
+        _DrivenObject(object_id="fuji", start_pose=start, end_pose=end, primitives=list(prims)),
+        _DrivenObject(object_id="fuji", start_pose=start, end_pose=end, primitives=[]),
+    ]
+    plan = build_moves_plan(layout, driven, env)
+    assert len(plan.moves) == 2
+
+    # Object with primitives -> a DubinsArc whose segments mirror them 1:1.
+    arc = plan.moves[0].path
+    assert arc is not None
+    assert [(s.kind, s.length_m, s.gear) for s in arc.segments] == [
+        (p.kind, p.magnitude, p.gear) for p in prims
+    ]
+    assert arc.start == start
+    assert arc.end == end
+    assert arc.turn_radius_m == env._body("fuji").effective_turn_radius_m()
+    assert plan.moves[0].target_slot == end
+
+    # Zero-primitive object (parked at spawn) -> best-effort Move(path=None).
+    assert plan.moves[1].path is None
+    assert plan.moves[1].target_slot == end

--- a/tests/ml/test_infer.py
+++ b/tests/ml/test_infer.py
@@ -1,0 +1,42 @@
+"""Torch-free onnxruntime inference for the learned backend (sub-project #5, #607)."""
+
+from __future__ import annotations
+
+import pytest
+
+ort = pytest.importorskip("onnxruntime")
+torch = pytest.importorskip("torch")  # OrtPolicy is torch-free, but we export with torch here
+
+from ml.encoding import EncoderConfig, encode  # noqa: E402
+from ml.export import export_onnx  # noqa: E402
+from ml.infer import OrtPolicy  # noqa: E402
+from ml.policy import HangarFitPolicy  # noqa: E402
+from ml.train import build_trivial_env  # noqa: E402
+
+
+def test_ortpolicy_matches_torch_act(tmp_path):
+    torch.manual_seed(0)
+    policy = HangarFitPolicy()
+    policy.eval()
+    env = build_trivial_env()
+    obs = env.reset()
+    obs_t = encode(obs, env.hangar, {**env.fleet, **env.ground_objects}, EncoderConfig())
+    tr = obs.active.body.effective_turn_radius_m()
+
+    onnx_path = tmp_path / "p.onnx"
+    export_onnx(policy, onnx_path, example=obs_t)
+    ort_pol = OrtPolicy(onnx_path)
+
+    # OrtPolicy runs the ONNX graph (standard attention path). `policy.act` uses the fused
+    # fast path by default, which on an UNTRAINED near-tie policy can flip the argmax. Compute
+    # the torch reference on the same standard path so the comparison is apples-to-apples (a
+    # trained policy's decisive logits make this moot). Discovered in Task 1.
+    prev_fastpath = torch.backends.mha.get_fastpath_enabled()
+    torch.backends.mha.set_fastpath_enabled(False)
+    try:
+        (_k, _m), _lp, torch_action = policy.act(obs_t, turn_radius_m=tr, deterministic=True)
+    finally:
+        torch.backends.mha.set_fastpath_enabled(prev_fastpath)
+    ort_action = ort_pol.act(obs_t, turn_radius_m=tr)
+    assert type(ort_action) is type(torch_action)
+    assert ort_action == torch_action

--- a/tests/ml/test_infer.py
+++ b/tests/ml/test_infer.py
@@ -150,6 +150,68 @@ def test_build_moves_plan_maps_primitives_to_dubins_arc():
     assert plan.moves[1].target_slot == end
 
 
+def test_learned_within_build_bit_identity(tmp_path):
+    """ADR-0027 tier-1: same weights + seed + pinned CPU EP -> bit-identical SolveResult
+    (poses + plan), within a single build. Cross-machine validity-only equivalence is a
+    separate (deferred) canary.
+
+    Two assertions:
+    1. SolveResult equality — the spec's stated canary (status/layouts/plans).
+    2. Rollout-trajectory equality — the meaningful determinism check: two independent
+       rollouts over fresh envs with the same OrtPolicy must produce identical driven
+       trajectories (same sequence of parked objects, same primitives, same poses).
+       This catches non-deterministic ONNX forward passes even when the terminal layout
+       is empty (which would make assertion 1 vacuously true with an untrained policy)."""
+    import pathlib
+
+    from ml.infer import OrtPolicy, env_from_scenario, rollout, solve_learned_impl
+
+    torch.manual_seed(0)
+    policy = HangarFitPolicy()
+    policy.eval()
+    onnx_path = tmp_path / "p.onnx"
+    export_onnx(policy, onnx_path)
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    scenario = load_scenario(str(root / "tests/fixtures/scenario_minimal.yaml"))
+
+    # --- Assertion 1: SolveResult equality ---
+    kw = dict(weights_path=onnx_path, budget_s=30.0, alternatives=1, seed=0, plan_paths=True)
+    r1 = solve_learned_impl(scenario, **kw)
+    r2 = solve_learned_impl(scenario, **kw)
+
+    assert r1.status == r2.status
+    assert r1.layouts == r2.layouts  # Layout is a frozen dataclass: structural equality
+    assert r1.plans == r2.plans
+
+    # --- Assertion 2: Rollout-trajectory equality ---
+    # Use a single OrtPolicy (deterministic argmax) and two fresh envs. Identical
+    # (object_id, [(kind, magnitude, gear)]) sequences prove the ONNX forward is
+    # bit-identical across calls, regardless of whether any objects are actually parked.
+    ort_pol = OrtPolicy(onnx_path)
+
+    env_a = env_from_scenario(scenario)
+    _, driven_a, _ = rollout(env_a, ort_pol)
+
+    env_b = env_from_scenario(scenario)
+    _, driven_b, _ = rollout(env_b, ort_pol)
+
+    def trajectory_key(driven):  # type: ignore[no-untyped-def]
+        return [
+            (d.object_id, [(p.kind, p.magnitude, p.gear) for p in d.primitives]) for d in driven
+        ]
+
+    assert trajectory_key(driven_a) == trajectory_key(driven_b), (
+        "OrtPolicy rollout is non-deterministic: driven trajectories differ between two runs "
+        "with identical weights and fresh envs. This violates the ADR-0027 tier-1 contract."
+    )
+    # Also verify start/end poses are identical for each driven object.
+    assert len(driven_a) == len(driven_b)
+    for da, db in zip(driven_a, driven_b, strict=True):
+        assert da.start_pose == db.start_pose
+        assert da.end_pose == db.end_pose
+
+
 def test_solve_learned_impl_returns_well_formed_result(tmp_path):
     import pathlib
 

--- a/tests/ml/test_infer.py
+++ b/tests/ml/test_infer.py
@@ -148,3 +148,34 @@ def test_build_moves_plan_maps_primitives_to_dubins_arc():
     # Zero-primitive object (parked at spawn) -> best-effort Move(path=None).
     assert plan.moves[1].path is None
     assert plan.moves[1].target_slot == end
+
+
+def test_solve_learned_impl_returns_well_formed_result(tmp_path):
+    import pathlib
+
+    from ml.infer import solve_learned_impl
+
+    torch.manual_seed(0)
+    policy = HangarFitPolicy()
+    policy.eval()
+    onnx_path = tmp_path / "p.onnx"
+    export_onnx(policy, onnx_path)
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    scenario = load_scenario(str(root / "tests/fixtures/scenario_minimal.yaml"))
+    result = solve_learned_impl(
+        scenario, weights_path=onnx_path, budget_s=30.0, alternatives=1, seed=0, plan_paths=True
+    )
+    # SolveResult.__post_init__ enforces status/layouts/plans coherence; construction
+    # succeeding is the structural assertion. An untrained policy almost always fails to
+    # park the whole set validly, so expect a no-layout status here.
+    assert result.status in ("found", "exhausted_budget")
+    assert len(result.plans) == len(result.layouts)
+    from ml.geometry_oracle import layout_valid
+
+    if result.status == "found":
+        assert layout_valid(result.layouts[0])
+        assert len(result.plans) == 1
+    else:
+        assert result.layouts == ()
+        assert result.plans == ()

--- a/tests/ml/test_infer.py
+++ b/tests/ml/test_infer.py
@@ -42,7 +42,39 @@ def test_ortpolicy_matches_torch_act(tmp_path):
     assert ort_action == torch_action
 
 
+import math  # noqa: E402
+
 from hangarfit.loader import load_scenario  # noqa: E402
+from hangarfit.towplanner import DubinsArc, Segment  # noqa: E402
+from ml.geometry_oracle import apply_primitive  # noqa: E402
+from ml.types import Primitive  # noqa: E402
+
+
+def test_primitive_sequence_dubinsarc_endpoint_parity():
+    """A multi-segment DubinsArc built from a primitive sequence integrates to the same
+    pose as chaining apply_primitive — the guarantee build_moves_plan relies on."""
+    from hangarfit.towplanner import Pose
+
+    start = Pose(x_m=5.0, y_m=-4.0, heading_deg=0.0)
+    prims = [
+        Primitive(kind="S", magnitude=2.0, gear=1),
+        Primitive(kind="L", magnitude=3.0, gear=1),
+        Primitive(kind="S", magnitude=1.0, gear=1),
+    ]
+    tr = 4.0
+    pose = start
+    for p in prims:
+        pose, _ = apply_primitive(pose, p, turn_radius_m=tr)
+    arc = DubinsArc(
+        start=start,
+        end=pose,
+        turn_radius_m=tr,
+        segments=tuple(Segment(kind=p.kind, length_m=p.magnitude, gear=p.gear) for p in prims),
+    )
+    integrated = arc.pose_at(arc.length_m)
+    assert math.isclose(integrated.x_m, pose.x_m, abs_tol=1e-6)
+    assert math.isclose(integrated.y_m, pose.y_m, abs_tol=1e-6)
+    assert math.isclose(integrated.heading_deg, pose.heading_deg, abs_tol=1e-6)
 
 
 def test_env_from_scenario_queues_placeables(tmp_path):
@@ -57,3 +89,25 @@ def test_env_from_scenario_queues_placeables(tmp_path):
     assert obs.active is not None
     assert set(env.requested_ids) == set(scenario.placeable_ids)
     assert env.hangar.apron_depth_m == 8.0
+
+
+def test_rollout_builds_moves_plan(tmp_path):
+    import pathlib
+
+    from ml.infer import OrtPolicy, build_moves_plan, env_from_scenario, rollout
+
+    torch.manual_seed(0)
+    policy = HangarFitPolicy()
+    policy.eval()
+    onnx_path = tmp_path / "p.onnx"
+    export_onnx(policy, onnx_path)
+    ort_pol = OrtPolicy(onnx_path)
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    scenario = load_scenario(str(root / "tests/fixtures/scenario_minimal.yaml"))
+    env = env_from_scenario(scenario)
+    layout, driven, info = rollout(env, ort_pol)
+    plan = build_moves_plan(layout, driven, env)
+    # Every parked object has a Move; every Move targets a real slot pose.
+    assert len(plan.moves) == len(driven)
+    assert all(m.target_slot is not None for m in plan.moves)

--- a/tests/ml/test_infer.py
+++ b/tests/ml/test_infer.py
@@ -7,8 +7,10 @@ import pytest
 ort = pytest.importorskip("onnxruntime")
 torch = pytest.importorskip("torch")  # OrtPolicy is torch-free, but we export with torch here
 
+import numpy as np  # noqa: E402
+
 from ml.encoding import EncoderConfig, encode  # noqa: E402
-from ml.export import export_onnx  # noqa: E402
+from ml.export import ONNX_OUTPUT_NAMES, export_onnx  # noqa: E402
 from ml.infer import OrtPolicy  # noqa: E402
 from ml.policy import HangarFitPolicy  # noqa: E402
 from ml.train import build_trivial_env  # noqa: E402
@@ -151,20 +153,24 @@ def test_build_moves_plan_maps_primitives_to_dubins_arc():
 
 
 def test_learned_within_build_bit_identity(tmp_path):
-    """ADR-0027 tier-1: same weights + seed + pinned CPU EP -> bit-identical SolveResult
-    (poses + plan), within a single build. Cross-machine validity-only equivalence is a
-    separate (deferred) canary.
+    """ADR-0027 tier-1: same weights + seed + pinned CPU EP -> bit-identical learned output
+    within a single build. Cross-machine validity-only equivalence is a separate (deferred)
+    canary.
 
     Two assertions:
-    1. SolveResult equality — the spec's stated canary (status/layouts/plans).
-    2. Rollout-trajectory equality — the meaningful determinism check: two independent
-       rollouts over fresh envs with the same OrtPolicy must produce identical driven
-       trajectories (same sequence of parked objects, same primitives, same poses).
-       This catches non-deterministic ONNX forward passes even when the terminal layout
-       is empty (which would make assertion 1 vacuously true with an untrained policy)."""
+    1. SolveResult equality — the spec's stated canary (status/layouts/plans). NOTE: under an
+       UNTRAINED policy this is vacuous (both runs park nothing -> empty layouts/plans -> equal
+       trivially), so it cannot stand alone — assertion 2 is the meaningful check.
+    2. Byte-identical ONNX forward — the real tier-1 bit-identity: the source of any
+       nondeterminism is the onnxruntime forward, so drive ONE fixed observation through two
+       FRESH single-threaded CPU-EP sessions (same weights) and assert the raw logits are
+       BYTE-identical (np.array_equal, not approximate), and the decoded action matches. This
+       is non-vacuous regardless of whether any object parks. (The earlier rollout-trajectory
+       form was vacuous: ``rollout`` records only PARKED objects, so an untrained policy that
+       parks nothing yields ``[] == []``.)"""
     import pathlib
 
-    from ml.infer import OrtPolicy, env_from_scenario, rollout, solve_learned_impl
+    from ml.infer import OrtPolicy, env_from_scenario, solve_learned_impl
 
     torch.manual_seed(0)
     policy = HangarFitPolicy()
@@ -184,32 +190,44 @@ def test_learned_within_build_bit_identity(tmp_path):
     assert r1.layouts == r2.layouts  # Layout is a frozen dataclass: structural equality
     assert r1.plans == r2.plans
 
-    # --- Assertion 2: Rollout-trajectory equality ---
-    # Use a single OrtPolicy (deterministic argmax) and two fresh envs. Identical
-    # (object_id, [(kind, magnitude, gear)]) sequences prove the ONNX forward is
-    # bit-identical across calls, regardless of whether any objects are actually parked.
-    ort_pol = OrtPolicy(onnx_path)
+    # --- Assertion 2: byte-identical ONNX forward (the real tier-1 bit-identity check) ---
+    # Build one fixed observation and run it through two FRESH single-threaded CPU-EP
+    # sessions (same weights). The raw logits must be BYTE-identical — this exercises the
+    # actual source of nondeterminism (the onnxruntime forward) and is non-vacuous even
+    # though the untrained policy parks nothing.
+    env = env_from_scenario(scenario)
+    obs = env.reset()
+    assert obs.active is not None
+    obs_t = encode(obs, env.hangar, {**env.fleet, **env.ground_objects}, EncoderConfig())
+    feed = {
+        "raster": obs_t.raster[None].astype(np.float32),
+        "tokens": obs_t.tokens[None].astype(np.float32),
+        "token_mask": obs_t.token_mask[None].astype(np.bool_),
+        "active_index": np.asarray([obs_t.active_index], dtype=np.int64),
+        "legal_action_mask": obs_t.legal_action_mask[None].astype(np.bool_),
+    }
 
-    env_a = env_from_scenario(scenario)
-    _, driven_a, _ = rollout(env_a, ort_pol)
+    def _fresh_session_logits():  # type: ignore[no-untyped-def]
+        opts = ort.SessionOptions()
+        opts.intra_op_num_threads = 1
+        opts.inter_op_num_threads = 1
+        sess = ort.InferenceSession(
+            str(onnx_path), sess_options=opts, providers=["CPUExecutionProvider"]
+        )
+        return sess.run(list(ONNX_OUTPUT_NAMES), feed)
 
-    env_b = env_from_scenario(scenario)
-    _, driven_b, _ = rollout(env_b, ort_pol)
-
-    def trajectory_key(driven):  # type: ignore[no-untyped-def]
-        return [
-            (d.object_id, [(p.kind, p.magnitude, p.gear) for p in d.primitives]) for d in driven
-        ]
-
-    assert trajectory_key(driven_a) == trajectory_key(driven_b), (
-        "OrtPolicy rollout is non-deterministic: driven trajectories differ between two runs "
-        "with identical weights and fresh envs. This violates the ADR-0027 tier-1 contract."
+    kind1, mag1 = _fresh_session_logits()
+    kind2, mag2 = _fresh_session_logits()
+    assert np.array_equal(kind1, kind2), (
+        "ONNX kind-head logits differ across builds (ADR-0027 tier-1)"
     )
-    # Also verify start/end poses are identical for each driven object.
-    assert len(driven_a) == len(driven_b)
-    for da, db in zip(driven_a, driven_b, strict=True):
-        assert da.start_pose == db.start_pose
-        assert da.end_pose == db.end_pose
+    assert np.array_equal(mag1, mag2), "ONNX mag-head logits differ across builds (ADR-0027 tier-1)"
+
+    # The public OrtPolicy.act (argmax + decode) is likewise identical across two fresh sessions.
+    tr = obs.active.body.effective_turn_radius_m()
+    act1 = OrtPolicy(onnx_path).act(obs_t, turn_radius_m=tr)
+    act2 = OrtPolicy(onnx_path).act(obs_t, turn_radius_m=tr)
+    assert act1 == act2
 
 
 def test_solve_learned_impl_returns_well_formed_result(tmp_path):

--- a/tests/ml/test_infer.py
+++ b/tests/ml/test_infer.py
@@ -40,3 +40,20 @@ def test_ortpolicy_matches_torch_act(tmp_path):
     ort_action = ort_pol.act(obs_t, turn_radius_m=tr)
     assert type(ort_action) is type(torch_action)
     assert ort_action == torch_action
+
+
+from hangarfit.loader import load_scenario  # noqa: E402
+
+
+def test_env_from_scenario_queues_placeables(tmp_path):
+    import pathlib
+
+    from ml.infer import env_from_scenario
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    scenario = load_scenario(str(root / "tests/fixtures/scenario_minimal.yaml"))
+    env = env_from_scenario(scenario)
+    obs = env.reset()
+    assert obs.active is not None
+    assert set(env.requested_ids) == set(scenario.placeable_ids)
+    assert env.hangar.apron_depth_m == 8.0

--- a/tests/test_cli_backend.py
+++ b/tests/test_cli_backend.py
@@ -1,7 +1,8 @@
 """CLI surface for the ``solve --backend`` switch (epic #607 rung 1, ADR-0027).
 
 The default ``rrmc`` path is the unchanged deterministic solver; ``learned`` is the
-opt-in neural backend, not yet implemented, which must fail cleanly (exit 2).
+opt-in neural backend (#706), which without ``--weights`` / the ``[learned-infer]``
+extra must fail cleanly (exit 2).
 """
 
 from __future__ import annotations

--- a/tests/test_cli_backend.py
+++ b/tests/test_cli_backend.py
@@ -31,9 +31,19 @@ class TestBackendFlag:
             build_parser().parse_args(["solve", SMOKE_FIXTURE, "--backend", "bogus"])
 
     def test_backend_learned_exits_2_cleanly(self, capsys):
-        # Not implemented yet (#607): a clean exit-2 error, not a traceback.
+        # Without --weights the backend raises LearnedBackendUnavailableError with a
+        # weights-related message (Task 8 wired weights_path=None → that branch).
         code = main(["solve", SMOKE_FIXTURE, "--backend", "learned"])
         assert code == 2
         err = capsys.readouterr().err
-        assert "learned" in err.lower()
-        assert "#607" in err
+        assert "weights" in err.lower()
+
+
+def test_backend_learned_without_weights_exits_2(capsys, tmp_path):
+    from hangarfit.cli import main
+
+    # a minimal valid solve scenario fixture
+    code = main(["solve", "tests/fixtures/scenario_minimal.yaml", "--backend", "learned"])
+    assert code == 2
+    err = capsys.readouterr().err
+    assert "weights" in err.lower()

--- a/tests/test_learned.py
+++ b/tests/test_learned.py
@@ -1,15 +1,25 @@
 """Unit tests for the learned-backend seam (epic #607 rung 1, ADR-0027).
 
-The learned backend is a stub until #607 lands: :func:`solve_learned` must raise
-the documented :class:`LearnedBackendUnavailableError` so the CLI can surface a
-clean, actionable message instead of a traceback.
+The learned backend raises :class:`LearnedBackendUnavailableError` with actionable
+messages when weights are absent, the file is missing, or the ml/onnxruntime
+dependencies are not installed — so the CLI surfaces a clean error instead of a
+traceback.
 """
 
 from __future__ import annotations
 
+import pathlib
+
 import pytest
 
 from hangarfit.learned import LearnedBackendUnavailableError, solve_learned
+
+
+def _minimal_scenario():
+    from hangarfit.loader import load_scenario
+
+    root = pathlib.Path(__file__).resolve().parent.parent
+    return load_scenario(str(root / "tests/fixtures/scenario_minimal.yaml"))
 
 
 def test_unavailable_error_is_runtime_error():
@@ -19,9 +29,20 @@ def test_unavailable_error_is_runtime_error():
 
 
 def test_solve_learned_raises_unavailable():
-    # The stub raises before touching the scenario, so a sentinel is fine here.
+    # Calling without weights raises LearnedBackendUnavailableError before
+    # touching the scenario, so a sentinel None is fine here.
     with pytest.raises(LearnedBackendUnavailableError) as exc:
         solve_learned(None)
     msg = str(exc.value)
-    assert "#607" in msg
-    assert "rrmc" in msg  # points the user at the working default
+    assert "--weights" in msg  # actionable: tells the user what to pass
+
+
+def test_solve_learned_no_weights_is_clean_error():
+    with pytest.raises(LearnedBackendUnavailableError, match="--weights"):
+        solve_learned(_minimal_scenario(), weights_path=None)
+
+
+def test_solve_learned_missing_weights_file_is_clean_error(tmp_path):
+    missing = tmp_path / "nope.onnx"
+    with pytest.raises(LearnedBackendUnavailableError, match="weights"):
+        solve_learned(_minimal_scenario(), weights_path=str(missing))

--- a/tests/test_learned.py
+++ b/tests/test_learned.py
@@ -44,5 +44,7 @@ def test_solve_learned_no_weights_is_clean_error():
 
 def test_solve_learned_missing_weights_file_is_clean_error(tmp_path):
     missing = tmp_path / "nope.onnx"
-    with pytest.raises(LearnedBackendUnavailableError, match="weights"):
+    # "not found" pins the missing-FILE branch specifically; a loose "weights" match would
+    # also pass on the weights_path-is-None branch's message.
+    with pytest.raises(LearnedBackendUnavailableError, match="not found"):
         solve_learned(_minimal_scenario(), weights_path=str(missing))


### PR DESCRIPTION
Closes #706 (epic #607 sub-project #5).

## What

Makes `solve --backend learned --weights PATH` actually run: a trained RL policy is exported to ONNX, run **torch-free** via onnxruntime, and returns a `SolveResult` (valid layout + the policy's own drive-in tow plan) **behind the unchanged deterministic verifier**. RR-MC stays the default; nothing about the deterministic path changes.

This rung is **weights-agnostic** — the export round-trip, inference rollout, `SolveResult` adapter, and clean fallbacks are all testable against the tiny untrained checkpoint. Only the *acceptance verdict* (#7) gates on a converged model (#698); the *plumbing* does not.

## How it's wired

- **`ml/export.py`** — exports the policy `forward` (value head dropped) to ONNX. Disables the TransformerEncoder/Layer sparsity fast paths for the trace (the fused/nested ops have no ONNX symbolic at any opset) and restores both that global flag and the module training mode (the legacy exporter leaks `train()`). `train --save-onnx` exports alongside the state_dict.
- **`ml/infer.py`** (torch-free runtime) — `OrtPolicy` (pinned single-thread `CPUExecutionProvider`) → `env_from_scenario` → `rollout` (records each parked object's drive-in primitives) → `build_moves_plan` (1:1 `Primitive`→`Segment`→`DubinsArc`; endpoint parity by construction via the shared integrator) → `solve_learned_impl` (verifier-gated `SolveResult`).
- **`src/hangarfit/learned.py`** — thin wheel-shipped seam: lazy-imports `ml.infer`, raises a clean `LearnedBackendUnavailableError` when `--weights`/the `[learned-infer]` extra/the `ml/` package is absent. No `ml`/torch/onnxruntime at module load.
- **`src/hangarfit/cli.py`** — `solve --weights PATH` (no default weights ship yet — that's #6).
- **`pyproject.toml`** — `learned-infer = [onnxruntime]` extra; `onnx>=1.16` added to `[train]` (export proto serialization); `mypy ml.* follow_imports=skip` so the `src/hangarfit/` pass doesn't bleed `ml/` internals while `mypy ml/` still fully checks.

## Contracts honored

- **Verifier is the sole arbiter** (Prime Directive / ADR-0027): validity is `collisions.check` + Caddy egress (`go.layout_valid`), never an env/learned oracle. An invalid/incomplete proposal → no-layout `SolveResult` (`exhausted_budget`), never an invalid layout and never a crash. Degenerate-*input* errors propagate loudly (not masked — silent-failure avoidance).
- **Determinism (ADR-0027)**: the verifier/solver stay strict and `determinism-guard`-bound (this branch does **not** touch `solver.py`/`towplanner.py`). The learned proposer gets the weaker **tier-1 within-build bit-identity canary** (`tests/ml/test_infer.py::test_learned_within_build_bit_identity` — byte-identical ONNX logits across two fresh single-thread CPU-EP sessions). Tier-2 (cross-machine validity-only) deferred to #7.

## Verification

- **Whole-branch review (opus): READY TO MERGE — 0 Critical / 0 Important.**
- **ml-rl-guard: PASS** — all four RL invariants intact (validity = product checker #694, determinism, silent-failure guards, knob default-neutrality orthogonal).
- `make test` green: **1939 passed + 1 skipped** (bulk) + **7 passed** (serial canaries); `ruff` + `mypy src/hangarfit/` + `mypy ml/` clean. Each task landed via a TDD inline-review cycle.

## Deferred (non-blocking follow-ups)

- Wheel-shippable inference, a CI lane for the extras, and signed Release-asset weights → **#6**.
- The reach-not-beat acceptance run against a converged model → **#7** / #698.
- DRY between `env_from_scenario` and `ml.benchmark.build_scenario_env`; coverage for the `found`+`plan_paths=False` branch (needs a trained checkpoint — rides with #698/#7).

Design spec + implementation plan are committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
