### PR TITLE
feat(710): resume + arch/PPO knobs + Park/drive-out economics rebalance (mastery-run enablement)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#710, epic #607): opt-in CUDA training (`--device cuda`).**
+  `ml.train` / `train_curriculum` / `train` gain a `--device {cpu,cuda}` knob. `cpu`
+  (the default) is unchanged and **byte-identical** to prior runs — every device move is
+  gated behind `device.type != 'cpu'`, so the ADR-0027 / determinism contract holds for the
+  CPU path. `cuda` moves the policy + the PPO-update minibatch tensors to the GPU (GAE stays
+  on CPU, a per-step scalar loop); it is an **explicitly non-deterministic** fast path
+  (GPU RNG / kernels), validated loud if `torch.cuda.is_available()` is `False`. Measured
+  ~5.8x on the PPO update on an RTX 4090; the shapely-geometry rollout stays CPU-bound, so
+  the net per-iter gain is bounded by the update's share.
+
+- **Learned backend (#710, epic #607): per-rung training-metric dump + promotion-gate
+  CLI levers for the mastery study.** `ml.train --schedule curriculum` gains
+  `--metrics-out PATH` (writes one JSONL record per PPO iteration —
+  `stage`/`iter`/`n_eps`/`mean_ep_reward`/`fraction_placed`/`valid_rate`/`valid_placed`),
+  exposing the compound `valid_placed` learning curve the CLI previously discarded (it
+  logged only `mean_ep_reward`). Two new `PromotionPolicy` overrides — `--promotion-metric
+  {fraction_placed,valid_rate,valid_placed}` and `--promotion-threshold` — let a run
+  advance the easy rungs on `valid_rate` (or a lowered threshold) while `valid_placed` is
+  still pinned at 0. All three are default-neutral (omitting them is byte-identical to
+  prior runs); `--metrics-out`/`--promotion-*` are curriculum-only and fail loud under
+  `--schedule trivial`. The per-iter metric helpers (`episode_metrics`,
+  `history_metric_records`, `with_promotion_overrides`) are pure/torch-free in
+  `ml/curriculum.py`.
+
 - **Vectorized training envs (#708, epic #607).** `train_curriculum`/`ml.train` gain an
   `n_envs` knob (`--n-envs`, `--vec-backend {sync,subproc}`) that runs N cold-joint envs in
   parallel for throughput — the shapely geometry + encoder rasterization run across N

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
   gated behind `device.type != 'cpu'`, so the ADR-0027 / determinism contract holds for the
   CPU path. `cuda` moves the policy + the PPO-update minibatch tensors to the GPU (GAE stays
   on CPU, a per-step scalar loop); it is an **explicitly non-deterministic** fast path
-  (GPU RNG / kernels), validated loud if `torch.cuda.is_available()` is `False`. Measured
+  (GPU RNG / kernels). The `ml.train` **CLI** rejects `--device cuda` loudly when
+  `torch.cuda.is_available()` is `False` (library callers own device selection). Measured
   ~5.8x on the PPO update on an RTX 4090; the shapely-geometry rollout stays CPU-bound, so
   the net per-iter gain is bounded by the update's share.
 
@@ -54,7 +55,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
   r_unplaced_penalty·(1−frac)`), so running an object to budget exhaustion is no longer free
   relative to committing a Park. This targets the diagnosed cause of `valid_placed=0` (the
   agent learned to avoid committing a Park to dodge the one-shot `−w_col` collision cliff —
-  the `fraction_placed` 0.991→0.476 collapse), which the originally-planned "dense
+  the `fraction_placed` 0.991→0.476 collapse measured in the #697 baseline), which the originally-planned "dense
   collision-progress reward" could **not** fix (it duplicates the policy-invariant
   `dense_slot_potential` shaping and so cannot move the optimum). Default 0 → byte-identical;
   pairs with the existing `--r-valid-park` for the positive pull toward valid commits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,35 @@ All notable changes to this project are documented here. Format follows [Keep a 
   `history_metric_records`, `with_promotion_overrides`) are pure/torch-free in
   `ml/curriculum.py`.
 
+- **Learned backend (#710, epic #607): resume checkpoints (`--load` / `--checkpoint-out`).**
+  `ml.train --schedule curriculum` gains `--checkpoint-out PATH` (writes a rich resume
+  checkpoint after **each rung** — policy + Adam optimizer + return-normalizer state +
+  architecture + completed-rung position, via the new `ml/checkpoint.py`) and `--load PATH`
+  (restores all of it and **skips already-completed rungs**), so a long box-rung mastery run
+  survives a crash. Distinct from `--save` (still a bare `state_dict` for the ONNX/`ml.eval`
+  consumer); the resume checkpoint loads with `weights_only=True` (no arbitrary-code
+  deserialization). The checkpoint's architecture is authoritative — a conflicting
+  `policy_kwargs` raises. Both flags default off → the legacy path is byte-identical;
+  curriculum-only (fail loud under `--schedule trivial`).
+
+- **Learned backend (#710, epic #607): policy-architecture + PPO CLI knobs.** `ml.train`
+  gains `--d-model` / `--n-layers` / `--n-heads` (policy size; omitting them keeps
+  `HangarFitPolicy`'s own defaults) and `--epochs` / `--minibatch-size` (`PPOConfig`),
+  so the mastery run can scale net size / update epochs without code edits. Default-neutral:
+  omitting the arch flags yields `policy_kwargs=None` (own defaults) and the PPO flags
+  default to the `PPOConfig` dataclass values — byte-identical to prior runs.
+
+- **Learned backend (#710, epic #607): Park/drive-out economics rebalance
+  (`--r-unplaced-penalty`).** A new default-0 `RewardWeights.r_unplaced_penalty` adds a
+  terminal penalty per **unplaced** fraction (`terminal = r_terminal·frac −
+  r_unplaced_penalty·(1−frac)`), so running an object to budget exhaustion is no longer free
+  relative to committing a Park. This targets the diagnosed cause of `valid_placed=0` (the
+  agent learned to avoid committing a Park to dodge the one-shot `−w_col` collision cliff —
+  the `fraction_placed` 0.991→0.476 collapse), which the originally-planned "dense
+  collision-progress reward" could **not** fix (it duplicates the policy-invariant
+  `dense_slot_potential` shaping and so cannot move the optimum). Default 0 → byte-identical;
+  pairs with the existing `--r-valid-park` for the positive pull toward valid commits.
+
 - **Vectorized training envs (#708, epic #607).** `train_curriculum`/`ml.train` gain an
   `n_envs` knob (`--n-envs`, `--vec-backend {sync,subproc}`) that runs N cold-joint envs in
   parallel for throughput — the shapely geometry + encoder rasterization run across N

--- a/ml/README.md
+++ b/ml/README.md
@@ -114,6 +114,52 @@ against the benchmark are deferred to the second half of #693. The knobs are
 wired, unit-tested, and default-neutral; the A/B here is a smoke-level
 demonstration that they move the easy-rung metric in the expected direction.
 
+## Mastery-run levers (#710)
+
+The #710 train-to-mastery work added run-enablement knobs and one reward fix. **Why a
+reward fix and not the originally-planned "dense collision-progress reward":** a code-level
+diagnosis found `valid_placed=0` is a **Park/drive-out economics** problem, not a
+sparse-reward one. The `−w_col` collision penalty is charged **only** at a Park, while a
+budget-exhaustion stop still pays `terminal_fraction` over already-parked objects with **no**
+penalty on the abandoned one — so "drive until the step budget runs out" dodges the cliff
+nearly free, which is the `fraction_placed` 0.991→0.476 collapse seen in the #697 baseline. A
+new dense overlap reward would **not** fix this: it duplicates the already-shipped
+`--dense-slot-potential` (its `active_misfit_m2` already enters Φ, so `γΦ(s′)−Φ(s)` *is* a
+per-step active-overlap gradient) and, being potential-based shaping, is **policy-invariant**
+(Ng–Harada–Russell) — it cannot move the optimum. So item 4 was **skipped** in favour of:
+
+| Flag | Default (neutral) | Effect |
+|---|---|---|
+| `--r-unplaced-penalty R` | `0.0` | Terminal penalty per **unplaced** fraction: `terminal = r_terminal·frac − R·(1−frac)`. Charges abandonment so a valid Park out-earns driving to budget exhaustion. Pair with `--r-valid-park` for the positive pull. |
+| `--checkpoint-out PATH` | off | Write a resume checkpoint after each rung (policy + optimizer + return-normalizer + architecture + completed rungs). |
+| `--load PATH` | off | Resume: restore the above and **skip completed rungs**. Reuses the checkpoint's architecture (a conflicting `--d-model`/etc. raises). |
+| `--d-model` / `--n-layers` / `--n-heads` | own defaults | Policy size (omitting keeps `HangarFitPolicy` defaults 128/2/4). |
+| `--epochs` / `--minibatch-size` | `PPOConfig` defaults | PPO update epochs / minibatch size. |
+| `--device {cpu,cuda}` | `cpu` | Opt-in GPU (non-deterministic fast path; cpu stays byte-identical). |
+| `--metrics-out PATH` | off | Per-iter per-rung JSONL incl. the `valid_placed` curve. |
+
+`--load`/`--checkpoint-out`/`--metrics-out`/`--promotion-*` are curriculum-only (fail loud
+under `--schedule trivial`). The resume checkpoint (`ml/checkpoint.py`) is distinct from
+`--save` (a bare `state_dict` for the ONNX/`ml.eval` consumer) and loads with
+`weights_only=True`.
+
+### Box-rung mastery gate recipe
+
+```bash
+# GPU, box rungs only, HONEST valid_placed promotion, resumable, 2 seeds:
+python -u -m ml.train --schedule curriculum --device cuda --n-envs 16 \
+  --rollout-len 512 --max-iters-per-stage 50 \
+  --promotion-metric valid_placed --promotion-threshold 0.9 \
+  --r-valid-park 2.0 --r-unplaced-penalty 25.0 \
+  --metrics-out metrics-seed0.jsonl --checkpoint-out ck-seed0.pt --seed 0
+```
+
+Watch **both** `fraction_placed` (recovering off ~0.476 = the perverse incentive is breaking)
+and `valid_placed` (the mastery axis). Guard against the opposite failure — `valid_rate`
+dropping while `fraction_placed` spikes is the commit-anything pathology (penalty too high).
+Flat `valid_placed` across both seeds is the empirical signal that reachability (the #712
+start-state graft) is the next lever.
+
 ## Design
 See `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`
 and ADR-0027 (learned-path determinism scope).

--- a/ml/checkpoint.py
+++ b/ml/checkpoint.py
@@ -1,0 +1,109 @@
+"""Resume checkpoint for curriculum training (#710). A rich, ``weights_only``-safe artifact
+carrying the policy, Adam optimizer, and return-normalizer state PLUS the policy architecture
+and the curriculum position (which rungs are already done), so a long box-rung gate run can
+survive a crash and resume from the next unfinished rung. Requires the [train] extra (torch).
+
+Distinct from ``--save`` (ml/train.py), which writes a BARE ``state_dict`` for the ONNX-export
+/ ml.eval consumer (loaded there with ``weights_only=True``): that path must stay a plain
+state_dict, so resume gets its OWN richer format here. The payload is a plain dict of tensors +
+Python scalars/strings (no custom classes), so it likewise loads under ``weights_only=True`` —
+the same arbitrary-code-execution-safe posture ml.eval uses."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import torch
+
+from ml.policy import HangarFitPolicy
+from ml.ppo import ReturnNormalizer
+
+# Bump when the on-disk payload shape changes incompatibly; load refuses a mismatch (loud).
+CHECKPOINT_VERSION = 1
+
+# Keys every v1 payload must carry; load fails loud (not a bare KeyError) if any is absent.
+_REQUIRED_KEYS = (
+    "policy_kwargs",
+    "policy_state",
+    "optimizer_state",
+    "normalizer_state",
+    "completed_stages",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingCheckpoint:
+    """Decoded resume checkpoint. ``policy_kwargs`` reconstructs a same-shaped policy before
+    ``load_state_dict`` (a shape mismatch would otherwise raise); ``completed_stages`` are the
+    rung names already fully trained, so a resumed run skips them."""
+
+    # policy_kwargs stays a bare dict deliberately: it is ``**``-splatted into HangarFitPolicy,
+    # whose params are heterogeneously typed (e.g. cnn_channels: tuple[int, ...]), so any value
+    # type narrower than Any fails the splat. policy_state/optimizer_state are torch state_dicts.
+    policy_kwargs: dict
+    policy_state: dict
+    optimizer_state: dict
+    normalizer_state: dict[str, float | int] | None
+    completed_stages: list[str] = field(default_factory=list)
+    version: int = CHECKPOINT_VERSION
+
+
+def save_checkpoint(
+    path: str | Path,
+    *,
+    policy: HangarFitPolicy,
+    optimizer: torch.optim.Optimizer,
+    normalizer: ReturnNormalizer | None,
+    policy_kwargs: dict | None,
+    completed_stages: Sequence[str],
+) -> None:
+    """Write a resume checkpoint to ``path`` ATOMICALLY (temp file + ``os.replace``), so a
+    crash mid-write can never corrupt an existing checkpoint — the whole point of the per-rung
+    ``--checkpoint-out``. (Plain ``torch.save`` truncate-then-writes in place, which would
+    leave a corrupt file on an ill-timed crash.)
+
+    ``policy_kwargs`` MUST be the kwargs the policy was constructed with (the architecture) so
+    a resume rebuilds a matching-shape policy; ``None`` is stored as ``{}`` (own defaults).
+    ``completed_stages`` is the ordered list of rung names already fully trained this ladder."""
+    payload = {
+        "version": CHECKPOINT_VERSION,
+        "policy_kwargs": dict(policy_kwargs or {}),
+        "policy_state": policy.state_dict(),
+        "optimizer_state": optimizer.state_dict(),
+        "normalizer_state": normalizer.state_dict() if normalizer is not None else None,
+        "completed_stages": list(completed_stages),
+    }
+    target = str(path)
+    tmp = target + ".tmp"  # same directory -> os.replace is atomic (same filesystem)
+    torch.save(payload, tmp)
+    os.replace(tmp, target)
+
+
+def load_checkpoint(path: str | Path) -> TrainingCheckpoint:
+    """Read a resume checkpoint written by :func:`save_checkpoint`. Loaded with
+    ``weights_only=True`` (no arbitrary-code deserialization) onto CPU; the caller moves the
+    reconstructed policy to its device. Raises ValueError on a version mismatch."""
+    payload = torch.load(str(path), map_location="cpu", weights_only=True)
+    version = payload.get("version")
+    if version != CHECKPOINT_VERSION:
+        raise ValueError(
+            f"checkpoint version {version!r} != supported {CHECKPOINT_VERSION} "
+            f"(re-run from scratch or migrate the checkpoint)"
+        )
+    missing = [k for k in _REQUIRED_KEYS if k not in payload]
+    if missing:
+        raise ValueError(
+            f"checkpoint {path!s} is missing required keys {missing} "
+            f"(corrupt or truncated resume checkpoint — re-run from scratch)"
+        )
+    return TrainingCheckpoint(
+        policy_kwargs=dict(payload["policy_kwargs"]),
+        policy_state=payload["policy_state"],
+        optimizer_state=payload["optimizer_state"],
+        normalizer_state=payload["normalizer_state"],
+        completed_stages=list(payload["completed_stages"]),
+        version=version,
+    )

--- a/ml/checkpoint.py
+++ b/ml/checkpoint.py
@@ -15,6 +15,7 @@ import os
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import torch
 
@@ -40,14 +41,17 @@ class TrainingCheckpoint:
     ``load_state_dict`` (a shape mismatch would otherwise raise); ``completed_stages`` are the
     rung names already fully trained, so a resumed run skips them."""
 
-    # policy_kwargs stays a bare dict deliberately: it is ``**``-splatted into HangarFitPolicy,
-    # whose params are heterogeneously typed (e.g. cnn_channels: tuple[int, ...]), so any value
-    # type narrower than Any fails the splat. policy_state/optimizer_state are torch state_dicts.
-    policy_kwargs: dict
-    policy_state: dict
-    optimizer_state: dict
+    # str-keyed dicts; values stay Any because policy_kwargs is ``**``-splatted into
+    # HangarFitPolicy (heterogeneous params, e.g. cnn_channels: tuple[int, ...]) and
+    # policy_state/optimizer_state are torch state_dicts — any narrower value type would
+    # break the splat / the state_dict round-trip.
+    policy_kwargs: dict[str, Any]
+    policy_state: dict[str, Any]
+    optimizer_state: dict[str, Any]
     normalizer_state: dict[str, float | int] | None
     completed_stages: list[str] = field(default_factory=list)
+    # Round-trip field; on any successfully loaded instance it is always == CHECKPOINT_VERSION
+    # (the loader is the enforcement point — a constructed mismatch is never returned by load).
     version: int = CHECKPOINT_VERSION
 
 
@@ -77,9 +81,18 @@ def save_checkpoint(
         "completed_stages": list(completed_stages),
     }
     target = str(path)
-    tmp = target + ".tmp"  # same directory -> os.replace is atomic (same filesystem)
-    torch.save(payload, tmp)
-    os.replace(tmp, target)
+    # tmp MUST stay in target's directory so os.replace is a same-filesystem atomic rename;
+    # the pid suffix avoids two concurrent writers clobbering each other's in-flight temp.
+    tmp = f"{target}.{os.getpid()}.tmp"
+    try:
+        torch.save(payload, tmp)
+        os.replace(tmp, target)
+    except BaseException:
+        # A failed write must not corrupt the existing checkpoint (os.replace never ran) nor
+        # leave stray temp litter that masks the real cause (disk full / permission).
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        raise
 
 
 def load_checkpoint(path: str | Path) -> TrainingCheckpoint:
@@ -87,6 +100,11 @@ def load_checkpoint(path: str | Path) -> TrainingCheckpoint:
     ``weights_only=True`` (no arbitrary-code deserialization) onto CPU; the caller moves the
     reconstructed policy to its device. Raises ValueError on a version mismatch."""
     payload = torch.load(str(path), map_location="cpu", weights_only=True)
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f"checkpoint {path!s} is not a resume checkpoint (got {type(payload).__name__}); "
+            f"did you pass a bare --save state_dict? Use the file written by --checkpoint-out"
+        )
     version = payload.get("version")
     if version != CHECKPOINT_VERSION:
         raise ValueError(

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import random
 from collections.abc import Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Literal
 
 from ml.types import DifficultyConfig
@@ -59,6 +59,82 @@ def should_promote(window: Sequence[EpisodeStat], policy: PromotionPolicy) -> bo
     else:  # fraction_placed
         score = sum(s.fraction_placed for s in recent) / len(recent)
     return score >= policy.threshold
+
+
+def with_promotion_overrides(
+    policy: PromotionPolicy,
+    *,
+    metric: Literal["fraction_placed", "valid_rate", "valid_placed"] | None = None,
+    threshold: float | None = None,
+    max_iters: int | None = None,
+) -> PromotionPolicy:
+    """Return ``policy`` with each non-None field overridden — the CLI plumbing for the
+    #710 promotion-gate study (``--promotion-metric`` / ``--promotion-threshold`` /
+    ``--max-iters-per-stage``). All-None returns an equal policy, so the CLI stays
+    default-neutral when no override flag is passed."""
+    if metric is not None:
+        policy = replace(policy, metric=metric)
+    if threshold is not None:
+        policy = replace(policy, threshold=threshold)
+    if max_iters is not None:
+        policy = replace(policy, max_iters=max_iters)
+    return policy
+
+
+def episode_metrics(ep_stats: Sequence[EpisodeStat]) -> dict[str, float | int | None]:
+    """Per-iteration scalar metrics over one PPO iteration's COMPLETED episodes. The three
+    rates mirror ``should_promote`` exactly: ``valid_placed`` credits ``fraction_placed``
+    only on episodes whose final layout is valid (the #710 compound mastery axis),
+    ``valid_rate`` is the validity fraction, ``fraction_placed`` ignores validity. An empty
+    iteration (no episode finished within the rollout) reports ``n_eps=0`` with ``None``
+    rates — NOT 0.0 — so a short rollout is never mistaken for a genuine zero in the curve
+    (mirrors train.py's NaN-when-empty ``mean_ep_reward`` convention)."""
+    n = len(ep_stats)
+    if n == 0:
+        return {
+            "n_eps": 0,
+            "mean_ep_reward": None,
+            "fraction_placed": None,
+            "valid_rate": None,
+            "valid_placed": None,
+        }
+    return {
+        "n_eps": n,
+        "mean_ep_reward": sum(s.total_reward for s in ep_stats) / n,
+        "fraction_placed": sum(s.fraction_placed for s in ep_stats) / n,
+        "valid_rate": sum(1.0 for s in ep_stats if s.valid) / n,
+        "valid_placed": sum(s.fraction_placed if s.valid else 0.0 for s in ep_stats) / n,
+    }
+
+
+def format_iter_log(stage_name: str, it: int, ep_stats: Sequence[EpisodeStat]) -> str:
+    """One-line per-iteration progress log carrying the full ``episode_metrics`` — in
+    particular ``valid_placed``, the #710 mastery axis — so a ``python -u`` curriculum run
+    is monitorable mid-flight (the CLI previously logged only ``mean_ep_reward``). An empty
+    iteration reports ``n_eps=0`` with no rates, so a no-episode rollout is not misread as a
+    genuine zero."""
+    m = episode_metrics(ep_stats)
+    if m["n_eps"] == 0:
+        return f"[{stage_name}] iter {it:4d}  n_eps=0 (no episode completed)"
+    return (
+        f"[{stage_name}] iter {it:4d}  "
+        f"mean_ep_reward={m['mean_ep_reward']:+.3f}  "
+        f"valid_placed={m['valid_placed']:.3f}  "
+        f"valid_rate={m['valid_rate']:.3f}  "
+        f"fraction_placed={m['fraction_placed']:.3f}  "
+        f"n_eps={m['n_eps']}"
+    )
+
+
+def history_metric_records(history: CurriculumHistory) -> list[dict[str, object]]:
+    """One JSONL-ready record per recorded training iteration: ``stage``, ``iter`` index,
+    and the ``episode_metrics`` over that iteration's completed episodes. Pure over the
+    history — the #710 per-rung ``valid_placed`` learning curve the CLI dumps via
+    ``--metrics-out``."""
+    return [
+        {"stage": stage, "iter": it, **episode_metrics(ep_stats)}
+        for stage, it, ep_stats in history.iterations
+    ]
 
 
 _STAGE_RNG_STRIDE = 100003  # a prime, so (seed, stage_index) pairs don't collide

--- a/ml/ppo.py
+++ b/ml/ppo.py
@@ -84,6 +84,27 @@ class ReturnNormalizer:
         std = max(var, 0.0) ** 0.5
         return rewards / (std + self.eps)
 
+    def state_dict(self) -> dict[str, float | int]:
+        """Plain-scalar state for the #710 resume checkpoint (no tensors, so it round-trips
+        through torch.save/load weights_only=True cleanly). Captures the Welford running stats
+        AND the eps/warmup config, so a reloaded normalizer scales the next batch identically."""
+        return {
+            "count": self._count,
+            "mean": self._mean,
+            "m2": self._m2,
+            "eps": self.eps,
+            "warmup": self.warmup,
+        }
+
+    def load_state_dict(self, state: dict[str, float | int]) -> None:
+        """Restore the exact running stats + config saved by ``state_dict`` (overwrites the
+        constructor's eps/warmup, so a resumed normalizer matches the saved one bit-for-bit)."""
+        self._count = int(state["count"])
+        self._mean = float(state["mean"])
+        self._m2 = float(state["m2"])
+        self.eps = float(state["eps"])
+        self.warmup = int(state["warmup"])
+
 
 def factored_logprob_entropy(
     out: PolicyOutput, kind_idx: Tensor, mag_idx: Tensor

--- a/ml/ppo.py
+++ b/ml/ppo.py
@@ -242,6 +242,15 @@ def ppo_update(
         advantages = advantages / std
     if not torch.isfinite(advantages).all():
         raise RuntimeError("advantages contain NaN/inf after normalization")
+    # Move the minibatch-loop tensors to the policy's device (CUDA opt-in). GAE + advantage
+    # math above stays on CPU: it is a per-step scalar loop (`float(...)` per step), so doing
+    # it on GPU would force a host sync every step. For a CPU policy every `.to()` is a no-op
+    # that returns the same tensor, so the default path is byte-identical (the determinism
+    # contract holds only for device='cpu'; CUDA is an explicitly non-deterministic fast path).
+    device = next(policy.parameters()).device
+    data = {k: (v.to(device) if torch.is_tensor(v) else v) for k, v in data.items()}
+    advantages = advantages.to(device)
+    returns = returns.to(device)
     # Number of FLAT transitions to shuffle/minibatch over. For a VecRolloutBuffer this is
     # T*N (advantages is length T*N), NOT len(buffer)==T — using len(buffer) would silently
     # train on only the first T of T*N rows and drop (N-1)/N of every rollout (#708). For the
@@ -254,7 +263,8 @@ def ppo_update(
         "loss": [],
     }
     for _ in range(config.epochs):
-        perm = torch.randperm(n)
+        # device=cpu reproduces torch.randperm(n) exactly (same default generator).
+        perm = torch.randperm(n, device=device)
         for start in range(0, n, config.minibatch_size):
             mb = perm[start : start + config.minibatch_size]
             mb_obs = {k: data[k][mb] for k in _OBS_KEYS}

--- a/ml/reward.py
+++ b/ml/reward.py
@@ -51,7 +51,15 @@ def step_reward(ctx: RewardContext, w: RewardWeights) -> float:
     )
     movement = -w.w_move * ctx.move_cost
     soft = w.w_gap * ctx.min_gap_m - w.w_seq * ctx.seq_deviation + w.w_region * ctx.region_match
-    terminal = w.r_terminal * ctx.terminal_fraction if ctx.terminal_fraction is not None else 0.0
+    # Terminal: reward the placed fraction MINUS a penalty on the unplaced fraction. The
+    # penalty (r_unplaced_penalty, default 0 -> the second term vanishes) charges abandonment
+    # so running an object to budget exhaustion is no longer free relative to committing a
+    # Park — the #710 Park/drive-out economics rebalance.
+    terminal = (
+        w.r_terminal * ctx.terminal_fraction - w.r_unplaced_penalty * (1.0 - ctx.terminal_fraction)
+        if ctx.terminal_fraction is not None
+        else 0.0
+    )
     shaping = w.gamma * ctx.potential - ctx.prev_potential
     valid_park = w.r_valid_park if ctx.park_valid else 0.0
     return hard + movement + soft + terminal + shaping + valid_park

--- a/ml/train.py
+++ b/ml/train.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections import deque
 from collections.abc import Callable, Sequence
 from dataclasses import replace
@@ -21,6 +22,7 @@ from torch import Tensor
 
 from hangarfit.loader import load_fleet, load_hangar
 from ml.action_space import decode
+from ml.checkpoint import load_checkpoint, save_checkpoint
 from ml.curriculum import (
     CurriculumHistory,
     CurriculumSchedule,
@@ -301,6 +303,8 @@ def train_curriculum(
     n_envs: int = 1,
     vec_backend: Literal["sync", "subproc"] = "subproc",
     device: str = "cpu",
+    load: str | None = None,
+    checkpoint_out: str | None = None,
 ) -> CurriculumHistory:
     """Climb the ladder: one policy/optimizer across rungs (transfer); per rung, run
     PPO until the competency gate fires or the per-stage cap is hit, then advance.
@@ -309,7 +313,12 @@ def train_curriculum(
     ``ppo.entropy_coef_start/end/anneal_iters``: per-rung entropy schedule; the iteration
     index resets to 0 at each new stage, so each rung re-warms from the high start.
     ``ppo.normalize_returns``: std-only Welford return normalizer (single run-level
-    normalizer shared across all rungs; identity until warmed up)."""
+    normalizer shared across all rungs; identity until warmed up).
+    ``load``: resume from a #710 checkpoint — restore the policy, Adam optimizer, return
+    normalizer, and curriculum position (already-completed rungs are skipped). The
+    checkpoint's architecture is authoritative; a conflicting ``policy_kwargs`` raises.
+    ``checkpoint_out``: write a resume checkpoint after EACH rung completes, so a long run
+    survives a crash. Both default None (no IO) -> the legacy path is byte-identical."""
     torch.manual_seed(seed)
     cfg = ppo or PPOConfig()
     enc = encoder or EncoderConfig()
@@ -319,11 +328,57 @@ def train_curriculum(
     # tensorizer overflow several rungs in.
     validate_ladder(sched.stages, encoder_max_objects=enc.max_objects)
     pol = sched.policy
-    policy = HangarFitPolicy(**(policy_kwargs or {})).to(torch.device(device))
-    optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.lr)
-    normalizer = ReturnNormalizer(eps=cfg.return_norm_eps) if cfg.normalize_returns else None
+    dev = torch.device(device)
+    # Resume (#710): restore the policy + optimizer + normalizer + curriculum position from a
+    # checkpoint, else build them fresh. The default path (load is None) is unchanged and
+    # byte-identical. ``saved_policy_kwargs`` is the architecture the checkpoint records, so a
+    # per-rung ``checkpoint_out`` write stores the EXACT kwargs the weights were built with.
+    completed_stages: list[str] = []
+    if load is not None:
+        ckpt = load_checkpoint(load)
+        if policy_kwargs is not None and dict(policy_kwargs) != dict(ckpt.policy_kwargs):
+            raise ValueError(
+                f"train_curriculum: --load architecture (policy_kwargs) {ckpt.policy_kwargs} "
+                f"!= passed policy_kwargs {policy_kwargs}; resume must reuse the checkpoint's "
+                f"architecture (a shape mismatch would break load_state_dict)"
+            )
+        saved_policy_kwargs = dict(ckpt.policy_kwargs)
+        policy = HangarFitPolicy(**saved_policy_kwargs).to(dev)
+        policy.load_state_dict(ckpt.policy_state)
+        optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.lr)
+        # load_state_dict overwrites param_groups (lr included), so resume INHERITS the
+        # checkpoint's optimizer hyperparameters — --lr is intentionally not re-applied here.
+        optimizer.load_state_dict(ckpt.optimizer_state)
+        normalizer = ReturnNormalizer(eps=cfg.return_norm_eps) if cfg.normalize_returns else None
+        if normalizer is not None and ckpt.normalizer_state is not None:
+            normalizer.load_state_dict(ckpt.normalizer_state)
+        completed_stages = list(ckpt.completed_stages)
+        # Resume sanity warnings (stderr; the resume path is never the byte-identical default).
+        foreign = [s for s in completed_stages if s not in {st.name for st in sched.stages}]
+        if foreign:
+            print(
+                f"warning: --load checkpoint marks rungs {foreign} complete, but they are not "
+                f"in the current schedule (resuming a different ladder?)",
+                file=sys.stderr,
+            )
+        if (ckpt.normalizer_state is not None) != cfg.normalize_returns:
+            print(
+                f"warning: --load checkpoint normalizer presence "
+                f"({ckpt.normalizer_state is not None}) disagrees with "
+                f"normalize_returns={cfg.normalize_returns}; the saved return-normalizer state "
+                f"is dropped / re-initialized mid-run",
+                file=sys.stderr,
+            )
+    else:
+        saved_policy_kwargs = dict(policy_kwargs or {})
+        policy = HangarFitPolicy(**saved_policy_kwargs).to(dev)
+        optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.lr)
+        normalizer = ReturnNormalizer(eps=cfg.return_norm_eps) if cfg.normalize_returns else None
+    completed_set = set(completed_stages)
     history = CurriculumHistory()
     for stage_index, stage in enumerate(sched.stages):
+        if stage.name in completed_set:
+            continue  # already fully trained in a prior run (resume) — skip this rung
         env = build_stage_env(stage, weights=weights)
         pool = effective_fleet_ids(stage)
         n = stage.difficulty.max_objects if stage.difficulty.max_objects is not None else len(pool)
@@ -406,6 +461,20 @@ def train_curriculum(
         if log:
             by = history.promotions[-1][2]
             print(f"[{stage.name}] promoted by {by}")
+        # Mark this rung done and (if requested) checkpoint, so a crash resumes at the next
+        # rung with the policy/optimizer/normalizer this rung produced. No-op when
+        # checkpoint_out is None -> the default path stays byte-identical.
+        completed_stages.append(stage.name)
+        completed_set.add(stage.name)
+        if checkpoint_out is not None:
+            save_checkpoint(
+                checkpoint_out,
+                policy=policy,
+                optimizer=optimizer,
+                normalizer=normalizer,
+                policy_kwargs=saved_policy_kwargs,
+                completed_stages=completed_stages,
+            )
     if save is not None:
         torch.save(policy.state_dict(), save)
     if save_onnx is not None:
@@ -451,6 +520,36 @@ def build_argparser() -> argparse.ArgumentParser:
     p.add_argument("--rollout-len", type=int, default=1024)
     p.add_argument("--lr", type=float, default=3e-4)
     p.add_argument(
+        "--d-model",
+        type=int,
+        default=None,
+        help="policy embedding dim (None = HangarFitPolicy default, 128)",
+    )
+    p.add_argument(
+        "--n-layers",
+        type=int,
+        default=None,
+        help="transformer encoder layers (None = HangarFitPolicy default, 2)",
+    )
+    p.add_argument(
+        "--n-heads",
+        type=int,
+        default=None,
+        help="attention heads (None = HangarFitPolicy default, 4)",
+    )
+    p.add_argument(
+        "--epochs",
+        type=int,
+        default=PPOConfig().epochs,
+        help="PPO epochs per update (default = PPOConfig.epochs)",
+    )
+    p.add_argument(
+        "--minibatch-size",
+        type=int,
+        default=PPOConfig().minibatch_size,
+        help="PPO minibatch size (default = PPOConfig.minibatch_size)",
+    )
+    p.add_argument(
         "--save", type=str, default=None, help="write the trained policy state_dict to this path"
     )
     p.add_argument(
@@ -460,10 +559,31 @@ def build_argparser() -> argparse.ArgumentParser:
         help="also export the trained policy forward to this ONNX path (inference)",
     )
     p.add_argument(
+        "--load",
+        type=str,
+        default=None,
+        help="curriculum: resume from a #710 checkpoint (policy + optimizer + normalizer + "
+        "completed rungs); reuses the checkpoint's architecture",
+    )
+    p.add_argument(
+        "--checkpoint-out",
+        type=str,
+        default=None,
+        help="curriculum: write a resume checkpoint after each rung (crash-survivable run); "
+        "pair with --load PATH to resume the same path",
+    )
+    p.add_argument(
         "--r-valid-park",
         type=float,
         default=0.0,
         help="bonus per Park action when the full layout is valid (basin-escape shaping)",
+    )
+    p.add_argument(
+        "--r-unplaced-penalty",
+        type=float,
+        default=0.0,
+        help="terminal penalty per UNPLACED fraction (charges abandonment so driving to "
+        "budget exhaustion is no longer free vs committing a Park; #710 economics rebalance)",
     )
     p.add_argument(
         "--dense-slot-potential",
@@ -523,9 +643,23 @@ def main(argv: Sequence[str] | None = None) -> None:
     weights = RewardWeights(
         r_valid_park=args.r_valid_park,
         dense_slot_potential=args.dense_slot_potential,
+        r_unplaced_penalty=args.r_unplaced_penalty,
     )
+    # Only the supplied arch flags go into policy_kwargs; an all-None set yields None, so
+    # the policy falls back to HangarFitPolicy's own defaults (default-neutral / byte-identical).
+    policy_kwargs = {
+        k: v
+        for k, v in (
+            ("d_model", args.d_model),
+            ("n_layers", args.n_layers),
+            ("n_heads", args.n_heads),
+        )
+        if v is not None
+    } or None
     ppo_cfg = PPOConfig(
         lr=args.lr,
+        epochs=args.epochs,
+        minibatch_size=args.minibatch_size,
         entropy_coef_start=args.entropy_start,
         entropy_coef_end=args.entropy_end,
         entropy_anneal_iters=args.entropy_anneal_iters,
@@ -539,11 +673,14 @@ def main(argv: Sequence[str] | None = None) -> None:
             parser.error("--metrics-out requires --schedule curriculum")
         if args.promotion_metric is not None or args.promotion_threshold is not None:
             parser.error("--promotion-metric/--promotion-threshold require --schedule curriculum")
+        if args.load is not None or args.checkpoint_out is not None:
+            parser.error("--load/--checkpoint-out require --schedule curriculum")
         train(
             seed=args.seed,
             iterations=args.iterations,
             rollout_len=args.rollout_len,
             ppo=ppo_cfg,
+            policy_kwargs=policy_kwargs,
             weights=weights,
             log=True,
             save=args.save,
@@ -566,6 +703,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             schedule=sched,
             rollout_len=args.rollout_len,
             ppo=ppo_cfg,
+            policy_kwargs=policy_kwargs,
             weights=weights,
             log=True,
             save=args.save,
@@ -573,6 +711,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             n_envs=args.n_envs,
             vec_backend=args.vec_backend,
             device=args.device,
+            load=args.load,
+            checkpoint_out=args.checkpoint_out,
         )
         if args.metrics_out is not None:
             records = history_metric_records(history)

--- a/ml/train.py
+++ b/ml/train.py
@@ -8,14 +8,16 @@ sub-project #4b; the reach-not-beat benchmark is #4c."""
 from __future__ import annotations
 
 import argparse
+import json
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import replace
 from functools import partial
 from pathlib import Path
 from typing import Literal
 
 import torch
+from torch import Tensor
 
 from hangarfit.loader import load_fleet, load_hangar
 from ml.action_space import decode
@@ -24,10 +26,13 @@ from ml.curriculum import (
     CurriculumSchedule,
     EpisodeStat,
     Stage,
+    format_iter_log,
+    history_metric_records,
     sample_request,
     should_promote,
     stage_rng,
     validate_ladder,
+    with_promotion_overrides,
 )
 from ml.encoding import EncoderConfig, encode
 from ml.env import HangarFitEnv
@@ -50,6 +55,15 @@ from ml.vector_env import VecStep, _EnvWorker
 _TRIVIAL_DIFFICULTY = DifficultyConfig(
     max_objects=1, per_object_step_budget=40, total_step_budget=40
 )
+
+
+def _to_device(batch: dict[str, Tensor], device: torch.device) -> dict[str, Tensor]:
+    """Move a batched-observation dict to the policy's device for the forward. A no-op for
+    a CPU device (returns the SAME dict — no copy), so the CUDA path is fully opt-in and the
+    default CPU rollout is byte-identical."""
+    if device.type == "cpu":
+        return batch
+    return {k: v.to(device) for k, v in batch.items()}
 
 
 def build_trivial_env(seed: int = 0, *, weights: RewardWeights | None = None) -> HangarFitEnv:
@@ -93,12 +107,13 @@ def collect_rollout(
     the env's fixed requested set (the 4a trivial path)."""
     buf = RolloutBuffer()
     bodies = _bodies(env)
+    device = next(policy.parameters()).device
     obs = env.reset()
     ep_reward, ep_stats = 0.0, []
     with torch.no_grad():
         while len(buf) < rollout_len:
             obs_t = encode(obs, env.hangar, bodies, encoder)
-            out = policy(to_batch([obs_t]))
+            out = policy(_to_device(to_batch([obs_t]), device))
             kind, mag = sample_action(out)
             logprob, _ = factored_logprob_entropy(out, kind, mag)
             tr = obs.active.body.effective_turn_radius_m()  # type: ignore[union-attr]
@@ -130,7 +145,7 @@ def collect_rollout(
         # bootstrap value for a non-done tail
         if not buf.done[-1]:
             tail = encode(obs, env.hangar, bodies, encoder)
-            buf.last_value = float(policy(to_batch([tail])).value)
+            buf.last_value = float(policy(_to_device(to_batch([tail]), device)).value)
     return buf, ep_stats
 
 
@@ -145,12 +160,13 @@ def collect_rollout_vec(
     (T, N) buffer + the per-completed-episode stats (with the per-env reward sum)."""
     n = vec_env.num_envs
     buf = VecRolloutBuffer(num_envs=n)
+    device = next(policy.parameters()).device
     obs = vec_env.reset()
     ep_reward = [0.0] * n
     ep_stats: list[EpisodeStat] = []
     with torch.no_grad():
         for _ in range(rollout_len):
-            out = policy(to_batch(obs))
+            out = policy(_to_device(to_batch(obs), device))
             kind, mag = sample_action(out)
             logprob, _ = factored_logprob_entropy(out, kind, mag)
             actions = [(int(kind[i]), int(mag[i])) for i in range(n)]
@@ -180,7 +196,7 @@ def collect_rollout_vec(
                     ep_reward[i] = 0.0
             obs = step.obs
         # per-env bootstrap value for non-done tails
-        tail = policy(to_batch(obs))
+        tail = policy(_to_device(to_batch(obs), device))
         buf.last_value = [float(tail.value[i]) for i in range(n)]
     return buf, ep_stats
 
@@ -218,6 +234,7 @@ def train(
     log: bool = False,
     save: str | None = None,
     save_onnx: str | None = None,
+    device: str = "cpu",
 ) -> list[float]:
     """Train on the trivial stage; return the per-iteration mean episode reward.
 
@@ -232,7 +249,7 @@ def train(
     cfg = ppo or PPOConfig()
     enc = encoder or EncoderConfig()
     env = build_trivial_env(seed, weights=weights)
-    policy = HangarFitPolicy(**(policy_kwargs or {}))
+    policy = HangarFitPolicy(**(policy_kwargs or {})).to(torch.device(device))
     optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.lr)
     normalizer = ReturnNormalizer(eps=cfg.return_norm_eps) if cfg.normalize_returns else None
     history: list[float] = []
@@ -283,6 +300,7 @@ def train_curriculum(
     save_onnx: str | None = None,
     n_envs: int = 1,
     vec_backend: Literal["sync", "subproc"] = "subproc",
+    device: str = "cpu",
 ) -> CurriculumHistory:
     """Climb the ladder: one policy/optimizer across rungs (transfer); per rung, run
     PPO until the competency gate fires or the per-stage cap is hit, then advance.
@@ -301,7 +319,7 @@ def train_curriculum(
     # tensorizer overflow several rungs in.
     validate_ladder(sched.stages, encoder_max_objects=enc.max_objects)
     pol = sched.policy
-    policy = HangarFitPolicy(**(policy_kwargs or {}))
+    policy = HangarFitPolicy(**(policy_kwargs or {})).to(torch.device(device))
     optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.lr)
     normalizer = ReturnNormalizer(eps=cfg.return_norm_eps) if cfg.normalize_returns else None
     history = CurriculumHistory()
@@ -341,15 +359,7 @@ def train_curriculum(
                 window.extend(ep_stats)
                 history.record(stage.name, it, ep_stats)
                 if log:
-                    mean_r = (
-                        sum(s.total_reward for s in ep_stats) / len(ep_stats)
-                        if ep_stats
-                        else float("nan")
-                    )
-                    print(
-                        f"[{stage.name}] iter {it:4d}  mean_ep_reward={mean_r:+.3f}  "
-                        f"n_eps={len(ep_stats)}"
-                    )
+                    print(format_iter_log(stage.name, it, ep_stats), flush=True)
                 if should_promote(list(window), pol):
                     history.note_promotion(stage.name, it, by="competency")
                     break
@@ -387,15 +397,7 @@ def train_curriculum(
                     window.extend(ep_stats)
                     history.record(stage.name, it, ep_stats)
                     if log:
-                        mean_r = (
-                            sum(s.total_reward for s in ep_stats) / len(ep_stats)
-                            if ep_stats
-                            else float("nan")
-                        )
-                        print(
-                            f"[{stage.name}] iter {it:4d}  mean_ep_reward={mean_r:+.3f}  "
-                            f"n_eps={len(ep_stats)}"
-                        )
+                        print(format_iter_log(stage.name, it, ep_stats), flush=True)
                     if should_promote(list(window), pol):
                         history.note_promotion(stage.name, it, by="competency")
                         break
@@ -423,6 +425,28 @@ def build_argparser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="curriculum: per-rung safety cap (default = schedule policy)",
+    )
+    p.add_argument(
+        "--promotion-metric",
+        choices=["fraction_placed", "valid_rate", "valid_placed"],
+        default=None,
+        help="curriculum: PromotionPolicy.metric override (default = schedule policy, "
+        "valid_placed); use valid_rate to advance easy rungs while valid_placed is still 0",
+    )
+    p.add_argument(
+        "--promotion-threshold",
+        type=float,
+        default=None,
+        help="curriculum: PromotionPolicy.threshold override in [0,1] "
+        "(default = schedule policy, 0.9); lower it so the easy rungs reveal the ladder",
+    )
+    p.add_argument(
+        "--metrics-out",
+        type=str,
+        default=None,
+        help="curriculum: write per-iter per-rung metrics JSONL "
+        "(stage/iter/n_eps/mean_ep_reward/fraction_placed/valid_rate/valid_placed) to this "
+        "path — the #710 valid_placed learning curves",
     )
     p.add_argument("--rollout-len", type=int, default=1024)
     p.add_argument("--lr", type=float, default=3e-4)
@@ -481,11 +505,21 @@ def build_argparser() -> argparse.ArgumentParser:
         default="subproc",
         help="vectorized env backend: sync (in-process, CI-safe) or subproc (parallel workers)",
     )
+    p.add_argument(
+        "--device",
+        choices=["cpu", "cuda"],
+        default="cpu",
+        help="compute device: cpu (default — deterministic / byte-identical) or cuda "
+        "(opt-in GPU fast path; ~5-6x on the PPO update, non-deterministic)",
+    )
     return p
 
 
-def main() -> None:
-    args = build_argparser().parse_args()
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = build_argparser()
+    args = parser.parse_args(argv)
+    if args.device == "cuda" and not torch.cuda.is_available():
+        parser.error("--device cuda requested but torch.cuda.is_available() is False")
     weights = RewardWeights(
         r_valid_park=args.r_valid_park,
         dense_slot_potential=args.dense_slot_potential,
@@ -498,6 +532,13 @@ def main() -> None:
         normalize_returns=args.normalize_returns,
     )
     if args.schedule == "trivial":
+        # --metrics-out / --promotion-* are curriculum-only; the trivial path has no
+        # CurriculumHistory and no PromotionPolicy. Fail LOUD (not silent-ignore) so a
+        # misdirected sweep flag is caught before the run, not after.
+        if args.metrics_out is not None:
+            parser.error("--metrics-out requires --schedule curriculum")
+        if args.promotion_metric is not None or args.promotion_threshold is not None:
+            parser.error("--promotion-metric/--promotion-threshold require --schedule curriculum")
         train(
             seed=args.seed,
             iterations=args.iterations,
@@ -507,12 +548,20 @@ def main() -> None:
             log=True,
             save=args.save,
             save_onnx=args.save_onnx,
+            device=args.device,
         )
     else:
         sched = CurriculumSchedule.default()
-        if args.max_iters_per_stage is not None:
-            sched = replace(sched, policy=replace(sched.policy, max_iters=args.max_iters_per_stage))
-        train_curriculum(
+        sched = replace(
+            sched,
+            policy=with_promotion_overrides(
+                sched.policy,
+                metric=args.promotion_metric,
+                threshold=args.promotion_threshold,
+                max_iters=args.max_iters_per_stage,
+            ),
+        )
+        history = train_curriculum(
             seed=args.seed,
             schedule=sched,
             rollout_len=args.rollout_len,
@@ -523,7 +572,13 @@ def main() -> None:
             save_onnx=args.save_onnx,
             n_envs=args.n_envs,
             vec_backend=args.vec_backend,
+            device=args.device,
         )
+        if args.metrics_out is not None:
+            records = history_metric_records(history)
+            Path(args.metrics_out).write_text(
+                "".join(json.dumps(r) + "\n" for r in records), encoding="utf-8"
+            )
 
 
 if __name__ == "__main__":

--- a/ml/train.py
+++ b/ml/train.py
@@ -281,6 +281,12 @@ def train(
                 f"iter {it:4d}  {reward_str}  "
                 f"loss={metrics['loss']:+.3f}  entropy={metrics['entropy']:.3f}"
             )
+    # Move the (possibly CUDA) policy to CPU before persisting: --save writes a state_dict the
+    # CPU ml.eval / ONNX consumer loads, and export_onnx traces CPU dummy inputs against it (a
+    # CUDA-resident policy would device-mismatch). Training is finished here, so the in-place
+    # move is harmless; it is a no-op (byte-identical) for an already-CPU policy.
+    if save is not None or save_onnx is not None:
+        policy = policy.to("cpu")
     if save is not None:
         torch.save(policy.state_dict(), save)
     if save_onnx is not None:
@@ -475,6 +481,12 @@ def train_curriculum(
                 policy_kwargs=saved_policy_kwargs,
                 completed_stages=completed_stages,
             )
+    # Move the (possibly CUDA) policy to CPU before persisting: --save writes a state_dict the
+    # CPU ml.eval / ONNX consumer loads, and export_onnx traces CPU dummy inputs against it (a
+    # CUDA-resident policy would device-mismatch). Training is finished here, so the in-place
+    # move is harmless; it is a no-op (byte-identical) for an already-CPU policy.
+    if save is not None or save_onnx is not None:
+        policy = policy.to("cpu")
     if save is not None:
         torch.save(policy.state_dict(), save)
     if save_onnx is not None:

--- a/ml/types.py
+++ b/ml/types.py
@@ -101,6 +101,10 @@ class RewardWeights:
     gamma: float = 0.99  # shaping discount
     r_valid_park: float = 0.0  # bonus paid in Park ONLY when the layout is valid (basin escape)
     dense_slot_potential: bool = False  # add an in-hangar nearest-free-pocket shaping term
+    # terminal: penalty per UNPLACED fraction (1 - terminal_fraction). Default 0.0 -> byte-
+    # identical. Non-zero charges abandonment so "drive to budget exhaustion" is no longer
+    # free relative to committing a Park (the #710 Park/drive-out economics-rebalance lever).
+    r_unplaced_penalty: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/ml/test_checkpoint.py
+++ b/tests/ml/test_checkpoint.py
@@ -1,0 +1,189 @@
+"""Torch-gated tests for the #710 resume checkpoint (ml/checkpoint.py) + the
+ReturnNormalizer state round-trip it depends on.
+
+The contract proven here is CHECKPOINT ROUND-TRIP equivalence: --load restores EXACTLY
+what was saved (forward-output identity + optimizer state + normalizer stats + curriculum
+position). It deliberately does NOT assert whole-run fresh==resume byte-identity — torch CPU
+is nondeterministic across processes, and the resume re-seeds the global RNG stream at a
+different point (see the auto-memory note on ml byte-identity)."""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from ml.checkpoint import load_checkpoint, save_checkpoint  # noqa: E402
+from ml.policy import HangarFitPolicy, to_batch  # noqa: E402
+from ml.ppo import ReturnNormalizer  # noqa: E402
+
+
+def _fixed_obs_batch() -> dict:
+    """A single deterministic observation batch from the trivial env (for forward-identity)."""
+    from ml.encoding import EncoderConfig, encode
+    from ml.train import build_trivial_env
+
+    env = build_trivial_env()
+    obs = env.reset()
+    bodies = {**env.fleet, **env.ground_objects}
+    obs_t = encode(obs, env.hangar, bodies, EncoderConfig())
+    return to_batch([obs_t])
+
+
+def _opt_state_equal(a: dict, b: dict) -> bool:
+    if a["param_groups"] != b["param_groups"]:
+        return False
+    sa, sb = a["state"], b["state"]
+    if set(sa) != set(sb):
+        return False
+    for k in sa:
+        if set(sa[k]) != set(sb[k]):
+            return False
+        for name in sa[k]:
+            va, vb = sa[k][name], sb[k][name]
+            if torch.is_tensor(va):
+                if not torch.equal(va, vb):
+                    return False
+            elif va != vb:
+                return False
+    return True
+
+
+# --- Cycle A: ReturnNormalizer state round-trip ----------------------------------
+
+
+def test_return_normalizer_state_dict_roundtrip():
+    rn = ReturnNormalizer(eps=1e-6, warmup=4)
+    for _ in range(10):
+        rn.normalize(torch.tensor([1.0, 2.0, 3.0]))
+    state = rn.state_dict()
+    rn2 = ReturnNormalizer()  # different eps/warmup defaults — load must overwrite them
+    rn2.load_state_dict(state)
+    assert rn2.state_dict() == state
+    # Behavioral: identical running stats -> identical scaling AND identical post-state.
+    x = torch.tensor([1.5, -2.5, 0.25])
+    out1 = rn.normalize(x.clone())
+    out2 = rn2.normalize(x.clone())
+    assert torch.equal(out1, out2)
+    assert rn.state_dict() == rn2.state_dict()
+
+
+# --- Cycle B: checkpoint save/load round-trip ------------------------------------
+
+
+def test_save_load_checkpoint_roundtrip(tmp_path):
+    torch.manual_seed(0)
+    pk = {"d_model": 32, "n_layers": 1, "n_heads": 2}
+    policy = HangarFitPolicy(**pk)
+    opt = torch.optim.Adam(policy.parameters(), lr=1e-3)
+    batch = _fixed_obs_batch()
+    out = policy(batch)
+    # A finite loss (kind_gear_logits carry -inf masked slots, so exclude them) that
+    # populates real Adam state for the shared trunk + value/mag heads.
+    opt.zero_grad()
+    loss = (out.value**2).sum() + out.magnitude_bin_logits.pow(2).sum()
+    loss.backward()
+    opt.step()
+    rn = ReturnNormalizer()
+    rn.normalize(torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0]))
+
+    ckpt_path = tmp_path / "ckpt.pt"
+    save_checkpoint(
+        ckpt_path,
+        policy=policy,
+        optimizer=opt,
+        normalizer=rn,
+        policy_kwargs=pk,
+        completed_stages=["t0"],
+    )
+    loaded = load_checkpoint(ckpt_path)
+    assert loaded.policy_kwargs == pk
+    assert loaded.completed_stages == ["t0"]
+
+    # Forward-output identity (the handoff's preferred assertion, not a checkpoint hash).
+    policy2 = HangarFitPolicy(**loaded.policy_kwargs)
+    policy2.load_state_dict(loaded.policy_state)
+    policy.eval()
+    policy2.eval()
+    with torch.no_grad():
+        a, b = policy(batch), policy2(batch)
+    assert torch.equal(a.value, b.value)
+    assert torch.equal(a.magnitude_bin_logits, b.magnitude_bin_logits)
+    assert torch.equal(a.kind_gear_logits, b.kind_gear_logits)
+
+    # Optimizer state restoration (Adam moments + step).
+    opt2 = torch.optim.Adam(policy2.parameters(), lr=1e-3)
+    opt2.load_state_dict(loaded.optimizer_state)
+    assert _opt_state_equal(opt.state_dict(), opt2.state_dict())
+
+    # Normalizer stats restoration.
+    assert loaded.normalizer_state is not None
+    rn2 = ReturnNormalizer()
+    rn2.load_state_dict(loaded.normalizer_state)
+    assert rn2.state_dict() == rn.state_dict()
+
+
+def test_save_load_checkpoint_normalizer_none(tmp_path):
+    # normalize_returns off -> no normalizer -> the checkpoint round-trips None cleanly.
+    policy = HangarFitPolicy()
+    opt = torch.optim.Adam(policy.parameters(), lr=1e-3)
+    ckpt_path = tmp_path / "ckpt.pt"
+    save_checkpoint(
+        ckpt_path,
+        policy=policy,
+        optimizer=opt,
+        normalizer=None,
+        policy_kwargs=None,
+        completed_stages=[],
+    )
+    loaded = load_checkpoint(ckpt_path)
+    assert loaded.normalizer_state is None
+    assert loaded.policy_kwargs == {}
+    assert loaded.completed_stages == []
+
+
+def test_load_checkpoint_version_mismatch_raises(tmp_path):
+    ckpt_path = tmp_path / "bad.pt"
+    torch.save({"version": 999, "policy_state": {}}, str(ckpt_path))
+    with pytest.raises(ValueError, match="version"):
+        load_checkpoint(ckpt_path)
+
+
+def test_load_checkpoint_missing_required_key_raises(tmp_path):
+    # A correct-version but incomplete payload (e.g. a truncated/hand-built file) must fail
+    # LOUD with a corrupt-checkpoint message, not a bare KeyError deep in a stack trace.
+    ckpt_path = tmp_path / "incomplete.pt"
+    torch.save({"version": 1, "policy_kwargs": {}}, str(ckpt_path))  # missing the rest
+    with pytest.raises(ValueError, match="missing|corrupt"):
+        load_checkpoint(ckpt_path)
+
+
+def test_save_checkpoint_writes_atomically_via_temp(tmp_path, monkeypatch):
+    # save_checkpoint must write to a TEMP path then os.replace it onto the target, so a crash
+    # mid-write can never corrupt an existing checkpoint. Spy on torch.save to assert it never
+    # writes the final path directly, then assert the target exists with no temp left behind.
+    import ml.checkpoint as ckpt_mod
+
+    policy = HangarFitPolicy()
+    opt = torch.optim.Adam(policy.parameters(), lr=1e-3)
+    target = tmp_path / "ck.pt"
+    written: list[str] = []
+    real_save = torch.save
+
+    def spy_save(obj, path, *a, **k):
+        written.append(str(path))
+        return real_save(obj, path, *a, **k)
+
+    monkeypatch.setattr(ckpt_mod.torch, "save", spy_save)
+    save_checkpoint(
+        target,
+        policy=policy,
+        optimizer=opt,
+        normalizer=None,
+        policy_kwargs=None,
+        completed_stages=[],
+    )
+    assert written and written[0] != str(target)  # wrote a temp first, not the target
+    assert target.exists()
+    assert list(tmp_path.glob("*.tmp")) == []  # temp atomically replaced + cleaned up
+    load_checkpoint(target)  # the final file is valid

--- a/tests/ml/test_checkpoint.py
+++ b/tests/ml/test_checkpoint.py
@@ -187,3 +187,50 @@ def test_save_checkpoint_writes_atomically_via_temp(tmp_path, monkeypatch):
     assert target.exists()
     assert list(tmp_path.glob("*.tmp")) == []  # temp atomically replaced + cleaned up
     load_checkpoint(target)  # the final file is valid
+
+
+def test_load_checkpoint_non_dict_payload_raises(tmp_path):
+    # A non-dict payload (e.g. a bare tensor/list, or a --save state_dict mix-up) must fail
+    # LOUD with a clear message, not an AttributeError on `.get()` (T2).
+    bad = tmp_path / "notdict.pt"
+    torch.save([1, 2, 3], str(bad))
+    with pytest.raises(ValueError, match="checkpoint|resume"):
+        load_checkpoint(bad)
+
+
+def test_save_checkpoint_failed_write_preserves_existing_and_cleans_temp(tmp_path, monkeypatch):
+    # The invariant the atomic write EXISTS for (T3/T7): a torch.save that fails mid-write must
+    # leave the pre-existing checkpoint intact AND leave no stray temp file behind.
+    import ml.checkpoint as ckpt_mod
+
+    policy = HangarFitPolicy()
+    opt = torch.optim.Adam(policy.parameters(), lr=1e-3)
+    target = tmp_path / "ck.pt"
+    save_checkpoint(
+        target,
+        policy=policy,
+        optimizer=opt,
+        normalizer=None,
+        policy_kwargs=None,
+        completed_stages=["orig"],
+    )
+
+    def boom(obj, path, *a, **k):
+        with open(path, "w") as f:
+            f.write("partial")  # a partial temp file is created...
+        raise RuntimeError("disk full mid-write")  # ...then the write fails
+
+    monkeypatch.setattr(ckpt_mod.torch, "save", boom)
+    with pytest.raises(RuntimeError, match="disk full"):
+        save_checkpoint(
+            target,
+            policy=policy,
+            optimizer=opt,
+            normalizer=None,
+            policy_kwargs=None,
+            completed_stages=["new"],
+        )
+    # os.replace never ran -> the pre-existing checkpoint is untouched...
+    assert load_checkpoint(target).completed_stages == ["orig"]
+    # ...and the failed write left no stray temp litter.
+    assert list(tmp_path.glob("*.tmp")) == []

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -11,10 +11,14 @@ from ml.curriculum import (
     EpisodeStat,
     PromotionPolicy,
     Stage,
+    episode_metrics,
+    format_iter_log,
+    history_metric_records,
     sample_request,
     should_promote,
     stage_rng,
     validate_ladder,
+    with_promotion_overrides,
 )
 from ml.encoding import EncoderConfig
 from ml.types import DifficultyConfig
@@ -217,3 +221,99 @@ def test_stage_rng_worker_index_zero_is_legacy_and_distinct():
     w1 = stage_rng(7, 2, worker_index=1)
     w0b = stage_rng(7, 2, worker_index=0)
     assert [w0b.random() for _ in range(5)] != [w1.random() for _ in range(5)]
+
+
+# --- #710 per-iter metrics + promotion-override plumbing (all pure / torch-free) ---
+
+
+def test_episode_metrics_computes_the_four_rates():
+    # one fully-placed+valid, one half-placed+invalid, one fully-placed+valid
+    stats = [
+        EpisodeStat(1.0, True, 10.0),
+        EpisodeStat(0.5, False, -2.0),
+        EpisodeStat(1.0, True, 8.0),
+    ]
+    m = episode_metrics(stats)
+    assert m["n_eps"] == 3
+    assert m["fraction_placed"] == pytest.approx((1.0 + 0.5 + 1.0) / 3)
+    assert m["valid_rate"] == pytest.approx(2 / 3)
+    # valid_placed credits fraction_placed only on the valid episodes: (1.0 + 0 + 1.0) / 3
+    assert m["valid_placed"] == pytest.approx((1.0 + 1.0) / 3)
+    assert m["mean_ep_reward"] == pytest.approx((10.0 - 2.0 + 8.0) / 3)
+
+
+def test_episode_metrics_empty_is_n0_with_none_rates():
+    # no episode finished this iteration -> 0 episodes, None (not 0.0) rates, so a short
+    # rollout is not mistaken for a genuine zero in the learning curve.
+    m = episode_metrics([])
+    assert m["n_eps"] == 0
+    assert m["mean_ep_reward"] is None
+    assert m["fraction_placed"] is None
+    assert m["valid_rate"] is None
+    assert m["valid_placed"] is None
+
+
+def test_episode_metrics_valid_placed_matches_should_promote_scoring():
+    # the per-iter valid_placed must use the SAME credit rule as the promotion gate
+    stats = [EpisodeStat(0.8, True, 0.0), EpisodeStat(0.9, False, 0.0), EpisodeStat(0.4, True, 0.0)]
+    expected = (0.8 + 0.0 + 0.4) / 3
+    assert episode_metrics(stats)["valid_placed"] == pytest.approx(expected)
+    # and the gate fires exactly when that mean meets threshold
+    assert should_promote(
+        stats, PromotionPolicy(metric="valid_placed", window=3, threshold=expected)
+    )
+    assert not should_promote(
+        stats, PromotionPolicy(metric="valid_placed", window=3, threshold=expected + 0.01)
+    )
+
+
+def test_history_metric_records_one_record_per_recorded_iteration():
+    h = CurriculumHistory()
+    h.record("pair-box", 0, [EpisodeStat(1.0, True, 5.0), EpisodeStat(0.0, False, -1.0)])
+    h.record("pair-box", 1, [])  # an iteration with no completed episode
+    recs = history_metric_records(h)
+    assert [r["stage"] for r in recs] == ["pair-box", "pair-box"]
+    assert [r["iter"] for r in recs] == [0, 1]
+    assert recs[0]["valid_placed"] == pytest.approx(0.5)  # (1.0 + 0) / 2
+    assert recs[0]["n_eps"] == 2
+    assert recs[1]["n_eps"] == 0 and recs[1]["valid_placed"] is None
+
+
+def test_history_metric_records_empty_history_is_empty_list():
+    assert history_metric_records(CurriculumHistory()) == []
+
+
+def test_with_promotion_overrides_all_none_is_default_neutral():
+    base = PromotionPolicy()
+    assert with_promotion_overrides(base) == base  # no override -> equal policy
+
+
+def test_format_iter_log_surfaces_all_four_metrics_live():
+    # the curriculum log line must carry valid_placed so a `python -u` long run is
+    # monitorable mid-flight (the CLI used to print only mean_ep_reward).
+    stats = [EpisodeStat(1.0, True, 4.0), EpisodeStat(0.0, False, -1.0)]
+    line = format_iter_log("pair-box", 7, stats)
+    assert "[pair-box]" in line
+    assert "7" in line
+    assert "valid_placed=0.500" in line
+    assert "valid_rate=0.500" in line
+    assert "fraction_placed=0.500" in line
+    assert "mean_ep_reward=+1.500" in line  # (4.0 - 1.0) / 2
+    assert "n_eps=2" in line
+
+
+def test_format_iter_log_empty_iteration_has_no_phantom_zero():
+    # no completed episode -> report n_eps=0, NOT valid_placed=0.000 (which would read as a
+    # genuine zero rather than "no data this iteration").
+    line = format_iter_log("trio-box", 3, [])
+    assert "n_eps=0" in line
+    assert "valid_placed" not in line
+
+
+def test_with_promotion_overrides_sets_only_given_fields():
+    base = PromotionPolicy(metric="valid_placed", window=20, threshold=0.9, max_iters=200)
+    got = with_promotion_overrides(base, metric="valid_rate", threshold=0.3, max_iters=120)
+    assert got.metric == "valid_rate"
+    assert got.threshold == pytest.approx(0.3)
+    assert got.max_iters == 120
+    assert got.window == 20  # untouched field preserved

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -434,3 +434,39 @@ def test_r_unplaced_penalty_lowers_terminal_reward_on_abandonment():
     penalized = run(10.0)
     # unplaced fraction = 1 - terminal_fraction = 1.0 -> penalty term = -10.0, terminal step only.
     assert base - penalized == pytest.approx(10.0)
+
+
+def test_r_unplaced_penalty_full_park_not_penalized_vs_abandon():
+    """T5: both terminal branches feed terminal_fraction into the penalty. A FULLY-placed
+    Park episode (frac=1, via the Park-done branch) is NOT penalized — identical reward
+    with/without the knob — while an abandonment episode (frac=0, via the budget branch) is
+    charged the full unplaced fraction. Guards against the penalty being wired into only one
+    of the two terminal branches."""
+    from ml.types import DifficultyConfig, Park, Primitive, RewardWeights
+
+    diff = DifficultyConfig(max_objects=2, per_object_step_budget=2, total_step_budget=4)
+
+    def run(penalty: float, mode: str) -> tuple[float, int]:
+        env = HangarFitEnv(
+            hangar=empty_hangar(),
+            fleet=_fuji(),
+            requested_ids=("fuji", "aviat_husky"),
+            difficulty=diff,
+            weights=RewardWeights(r_unplaced_penalty=penalty),
+        )
+        env.reset()
+        total, done, info = 0.0, False, None
+        while not done:
+            act = Park() if mode == "park" else Primitive(kind="S", magnitude=1.0, gear=1)
+            _, r, done, info = env.step(act)
+            total += r
+        assert info is not None
+        return total, info.placed
+
+    park0, p_placed = run(0.0, "park")
+    parkR, _ = run(20.0, "park")
+    aban0, a_placed = run(0.0, "abandon")
+    abanR, _ = run(20.0, "abandon")
+    assert p_placed == 2 and a_placed == 0  # Park-done (frac=1) vs budget-abandon (frac=0)
+    assert parkR == pytest.approx(park0)  # full placement -> penalty term 0, unchanged by knob
+    assert aban0 - abanR == pytest.approx(20.0)  # abandon -> charged the full unplaced fraction

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -403,3 +403,34 @@ def test_fixed_obstacle_is_perceived_in_observation_and_encoding():
         i for i in range(tensors.tokens.shape[0]) if tensors.token_mask[i] and tensors.tokens[i, 4]
     ]
     assert fixed_rows, "no fixed_obstacle token row (row[4]) — keep-out is not perceived"
+
+
+def test_r_unplaced_penalty_lowers_terminal_reward_on_abandonment():
+    """End-to-end through HangarFitEnv: driving an object to budget exhaustion without ever
+    Parking it (abandonment, terminal_fraction=0) must cost exactly r_unplaced_penalty more
+    than the same trajectory with the penalty off — proving the #710 economics knob is wired
+    from RewardWeights through env.step's terminal branch (not just step_reward in isolation)."""
+    from ml.types import DifficultyConfig, Primitive, RewardWeights
+
+    diff = DifficultyConfig(max_objects=1, per_object_step_budget=2, total_step_budget=2)
+
+    def run(penalty: float) -> float:
+        env = HangarFitEnv(
+            hangar=empty_hangar(),
+            fleet=_fuji(),
+            requested_ids=("fuji",),
+            difficulty=diff,
+            weights=RewardWeights(r_unplaced_penalty=penalty),
+        )
+        env.reset()
+        total, done, info = 0.0, False, None
+        while not done:
+            _, r, done, info = env.step(Primitive(kind="S", magnitude=1.0, gear=1))
+            total += r
+        assert info is not None and info.placed == 0  # never parked -> pure abandonment
+        return total
+
+    base = run(0.0)
+    penalized = run(10.0)
+    # unplaced fraction = 1 - terminal_fraction = 1.0 -> penalty term = -10.0, terminal step only.
+    assert base - penalized == pytest.approx(10.0)

--- a/tests/ml/test_ppo.py
+++ b/tests/ml/test_ppo.py
@@ -172,6 +172,20 @@ def test_ppo_update_runs_changes_params_finite():
     assert changed
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+def test_ppo_update_runs_on_cuda_policy():
+    # ppo_update must honour the policy's device: a CUDA policy + a CPU-built buffer ->
+    # the update moves the batch to the policy device, runs, and changes params finitely.
+    torch.manual_seed(0)
+    buf = _filled_buffer(HangarFitPolicy(d_model=32, n_layers=1, n_heads=2))  # CPU obs
+    policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2).to("cuda")
+    before = [p.detach().clone() for p in policy.parameters()]
+    opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    metrics = ppo_update(policy, opt, buf, PPOConfig(minibatch_size=16))
+    assert all(math.isfinite(v) for v in metrics.values())
+    assert any(not torch.equal(b, a) for b, a in zip(before, policy.parameters(), strict=True))
+
+
 def test_ppo_update_overfits_fixed_batch():
     torch.manual_seed(1)
     policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2)

--- a/tests/ml/test_reward.py
+++ b/tests/ml/test_reward.py
@@ -94,6 +94,45 @@ def test_potential_active_misfit_lowers_potential():
 # ---------------------------------------------------------------------------
 
 
+def test_r_unplaced_penalty_default_zero_is_byte_identical():
+    # The economics-rebalance knob defaults 0.0 -> terminal reward is unchanged.
+    ctx = _ctx(terminal_fraction=0.5)
+    assert step_reward(ctx, RewardWeights()) == step_reward(
+        ctx, RewardWeights(r_unplaced_penalty=0.0)
+    )
+
+
+def test_r_unplaced_penalty_charges_unplaced_fraction():
+    # terminal_fraction=0.5 -> unplaced fraction (1-0.5)=0.5 -> penalty = 10.0 * 0.5 = 5.0.
+    ctx = _ctx(terminal_fraction=0.5)
+    base = step_reward(ctx, RewardWeights(r_unplaced_penalty=0.0))
+    penalized = step_reward(ctx, RewardWeights(r_unplaced_penalty=10.0))
+    assert base - penalized == pytest.approx(5.0)
+
+
+def test_r_unplaced_penalty_not_charged_on_nonterminal_steps():
+    # A mid-episode move (terminal_fraction=None) must not pay the abandonment penalty.
+    ctx = _ctx(terminal_fraction=None)
+    assert step_reward(ctx, RewardWeights(r_unplaced_penalty=10.0)) == step_reward(
+        ctx, RewardWeights(r_unplaced_penalty=0.0)
+    )
+
+
+def test_r_unplaced_penalty_widens_placed_advantage():
+    # The point of the knob: penalizing abandonment makes placing MORE strictly better, so
+    # the full-vs-partial terminal gap is LARGER with the penalty than without (breaks the
+    # "drive to budget exhaustion is free" leak the design panel identified).
+    w0 = RewardWeights(r_unplaced_penalty=0.0)
+    wp = RewardWeights(r_unplaced_penalty=20.0)
+    gap0 = step_reward(_ctx(terminal_fraction=1.0), w0) - step_reward(
+        _ctx(terminal_fraction=0.5), w0
+    )
+    gapp = step_reward(_ctx(terminal_fraction=1.0), wp) - step_reward(
+        _ctx(terminal_fraction=0.5), wp
+    )
+    assert gapp > gap0
+
+
 def test_dense_slot_potential_on_lowers_potential_when_misfit_positive():
     """dense_slot_potential=True must STRICTLY lower the shaping potential vs False when the
     active object sits in a bad pose (active_misfit_m2 > 0), catching a gate-inversion the

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -250,6 +250,107 @@ def test_train_curriculum_subproc_runs():
     assert hist.promotions and hist.iterations  # spawned, pickled, trained
 
 
+# ---------------------------------------------------------------------------
+# #710: --metrics-out per-iter dump + --promotion-metric/--promotion-threshold CLI
+# ---------------------------------------------------------------------------
+
+
+def test_argparser_new_flags_default_none():
+    a = build_argparser().parse_args([])
+    assert a.promotion_metric is None
+    assert a.promotion_threshold is None
+    assert a.metrics_out is None
+
+
+def test_main_applies_promotion_overrides_to_schedule(monkeypatch):
+    # main() must thread --promotion-metric/--promotion-threshold/--max-iters-per-stage
+    # into the PromotionPolicy it passes to train_curriculum (stubbed so no real training).
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(*, schedule, **kw):
+        captured["schedule"] = schedule
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(
+        [
+            "--schedule",
+            "curriculum",
+            "--promotion-metric",
+            "valid_rate",
+            "--promotion-threshold",
+            "0.3",
+            "--max-iters-per-stage",
+            "7",
+        ]
+    )
+    pol = captured["schedule"].policy
+    assert pol.metric == "valid_rate"
+    assert pol.threshold == pytest.approx(0.3)
+    assert pol.max_iters == 7
+
+
+def test_main_no_override_flags_keeps_default_policy(monkeypatch):
+    # default-neutral: with no override flag, the schedule policy is the committed default.
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory, PromotionPolicy
+
+    captured: dict = {}
+
+    def fake(*, schedule, **kw):
+        captured["schedule"] = schedule
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum"])
+    assert captured["schedule"].policy == PromotionPolicy()
+
+
+def test_main_writes_metrics_jsonl(monkeypatch, tmp_path):
+    import json
+
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory, EpisodeStat
+
+    hist = CurriculumHistory()
+    hist.record("pair-box", 0, [EpisodeStat(1.0, True, 5.0), EpisodeStat(0.0, False, -1.0)])
+    monkeypatch.setattr(train_mod, "train_curriculum", lambda **kw: hist)
+    out = tmp_path / "metrics.jsonl"
+    train_mod.main(["--schedule", "curriculum", "--metrics-out", str(out)])
+    lines = out.read_text().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["stage"] == "pair-box"
+    assert rec["iter"] == 0
+    assert rec["n_eps"] == 2
+    assert rec["fraction_placed"] == pytest.approx(0.5)
+    assert rec["valid_rate"] == pytest.approx(0.5)
+    assert rec["valid_placed"] == pytest.approx(0.5)
+    assert rec["mean_ep_reward"] == pytest.approx(2.0)
+
+
+def test_main_metrics_out_requires_curriculum_schedule(monkeypatch):
+    # --metrics-out is curriculum-only; with --schedule trivial it must fail LOUD and
+    # BEFORE any training runs (not silently ignore the flag).
+    import ml.train as train_mod
+
+    ran = {"train": False}
+
+    def guard(**kw):
+        ran["train"] = True
+        return []
+
+    monkeypatch.setattr(train_mod, "train", guard)
+    with pytest.raises(SystemExit):
+        train_mod.main(
+            ["--schedule", "trivial", "--metrics-out", "/tmp/should_not_be_written.jsonl"]
+        )
+    assert ran["train"] is False  # rejected before training
+
+
 def test_train_curriculum_n_envs_1_matches_legacy_byte_identical():
     """n_envs=1 must reproduce the legacy single-stream training history exactly."""
     from dataclasses import replace
@@ -264,3 +365,72 @@ def test_train_curriculum_n_envs_1_matches_legacy_byte_identical():
     assert any(eps for _, _, eps in legacy.iterations), "no episodes completed — vacuous equality"
     assert legacy.promotions == again.promotions
     assert legacy.iterations == again.iterations  # CurriculumHistory equality (per-iter records)
+
+
+# ---------------------------------------------------------------------------
+# CUDA opt-in (--device): default cpu must stay byte-identical; cuda is opt-in.
+# ---------------------------------------------------------------------------
+
+
+def _tiny_default_sched():
+    return replace(
+        CurriculumSchedule.default(),
+        policy=replace(CurriculumSchedule.default().policy, max_iters=1),
+    )
+
+
+def test_train_curriculum_device_cpu_is_byte_identical_to_default():
+    # device='cpu' (the default) must reproduce the no-device history exactly — the
+    # ADR-0027 / ml-rl-guard determinism contract holds for the CPU path.
+    sched = _tiny_default_sched()
+    base = train_curriculum(seed=0, schedule=sched, rollout_len=16)
+    dev = train_curriculum(seed=0, schedule=sched, rollout_len=16, device="cpu")
+    assert any(eps for _, _, eps in base.iterations), "no episodes completed — vacuous equality"
+    assert base.promotions == dev.promotions
+    assert base.iterations == dev.iterations
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+def test_train_curriculum_device_cuda_runs():
+    sched = _tiny_default_sched()
+    hist = train_curriculum(seed=0, schedule=sched, rollout_len=16, device="cuda")
+    assert hist.promotions and hist.iterations  # trained on GPU end-to-end
+
+
+def test_argparser_device_defaults_to_cpu():
+    assert build_argparser().parse_args([]).device == "cpu"
+    assert build_argparser().parse_args(["--device", "cuda"]).device == "cuda"
+
+
+def test_main_threads_device_to_train_curriculum(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum", "--device", "cpu"])
+    assert captured["device"] == "cpu"
+
+
+def test_main_device_cuda_unavailable_errors(monkeypatch):
+    # requesting --device cuda when no GPU is present must fail loud, before training.
+    import ml.train as train_mod
+
+    ran = {"train_curriculum": False}
+
+    def guard(**kw):
+        ran["train_curriculum"] = True
+        from ml.curriculum import CurriculumHistory
+
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(train_mod, "train_curriculum", guard)
+    with pytest.raises(SystemExit):
+        train_mod.main(["--schedule", "curriculum", "--device", "cuda"])
+    assert ran["train_curriculum"] is False

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -368,6 +368,313 @@ def test_train_curriculum_n_envs_1_matches_legacy_byte_identical():
 
 
 # ---------------------------------------------------------------------------
+# #710 item 2: --d-model/--n-layers/--n-heads (policy arch) + --epochs/--minibatch-size
+# (PPOConfig) CLI flags. Default-neutral: omitting them reproduces today's behaviour.
+# ---------------------------------------------------------------------------
+
+
+def test_argparser_arch_and_ppo_flags_defaults():
+    from ml.ppo import PPOConfig
+
+    a = build_argparser().parse_args([])
+    # arch flags default None -> policy_kwargs stays None -> HangarFitPolicy own defaults
+    assert a.d_model is None
+    assert a.n_layers is None
+    assert a.n_heads is None
+    # epochs/minibatch default = the PPOConfig dataclass defaults (read, not hardcoded)
+    assert a.epochs == PPOConfig().epochs
+    assert a.minibatch_size == PPOConfig().minibatch_size
+
+
+def test_main_threads_arch_and_ppo_flags_to_curriculum(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(
+        [
+            "--schedule",
+            "curriculum",
+            "--d-model",
+            "64",
+            "--n-layers",
+            "1",
+            "--n-heads",
+            "2",
+            "--epochs",
+            "6",
+            "--minibatch-size",
+            "128",
+        ]
+    )
+    assert captured["policy_kwargs"] == {"d_model": 64, "n_layers": 1, "n_heads": 2}
+    assert captured["ppo"].epochs == 6
+    assert captured["ppo"].minibatch_size == 128
+
+
+def test_main_no_arch_flags_default_neutral(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+    from ml.ppo import PPOConfig
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum"])
+    # no arch flags -> policy_kwargs None (own defaults), PPO epochs/minibatch unchanged
+    assert captured["policy_kwargs"] is None
+    assert captured["ppo"].epochs == PPOConfig().epochs
+    assert captured["ppo"].minibatch_size == PPOConfig().minibatch_size
+
+
+def test_main_threads_partial_arch_flags_to_trivial_train(monkeypatch):
+    # The arch flags apply to the trivial path too, and a PARTIAL set yields a
+    # policy_kwargs holding only the supplied keys (the rest fall back to defaults).
+    import ml.train as train_mod
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return []
+
+    monkeypatch.setattr(train_mod, "train", fake)
+    train_mod.main(["--schedule", "trivial", "--d-model", "64"])
+    assert captured["policy_kwargs"] == {"d_model": 64}
+
+
+# ---------------------------------------------------------------------------
+# #710 item 1: --load checkpoint resume (policy + optimizer + normalizer +
+# curriculum position). Default-neutral: load=None/checkpoint_out=None = no IO.
+# ---------------------------------------------------------------------------
+
+
+def test_train_curriculum_writes_checkpoint_per_stage(tmp_path):
+    from ml.checkpoint import load_checkpoint
+
+    sched = _tiny_schedule(threshold=2.0)  # always caps; max_iters=1 below = fast
+    sched = replace(sched, policy=replace(sched.policy, max_iters=1))
+    ckpt = tmp_path / "ck.pt"
+    train_curriculum(seed=0, schedule=sched, rollout_len=8, checkpoint_out=str(ckpt))
+    assert ckpt.exists()
+    loaded = load_checkpoint(ckpt)
+    # both rungs trained -> both recorded as completed, in ladder order
+    assert loaded.completed_stages == ["t0", "t1"]
+
+
+def test_train_curriculum_resume_skips_completed_stages(tmp_path):
+    sched = _tiny_schedule(threshold=2.0)
+    sched = replace(sched, policy=replace(sched.policy, max_iters=1))
+    ckpt = tmp_path / "ck.pt"
+    train_curriculum(seed=0, schedule=sched, rollout_len=8, checkpoint_out=str(ckpt))
+    # Resume from a checkpoint whose completed set covers EVERY rung -> nothing to train.
+    resumed = train_curriculum(seed=0, schedule=sched, rollout_len=8, load=str(ckpt))
+    assert resumed.iterations == []
+    assert resumed.promotions == []
+
+
+def test_train_curriculum_resume_partial_runs_only_remaining(tmp_path):
+    from ml.checkpoint import save_checkpoint
+    from ml.policy import HangarFitPolicy
+    from ml.ppo import ReturnNormalizer
+
+    sched = _tiny_schedule(threshold=2.0)
+    sched = replace(sched, policy=replace(sched.policy, max_iters=1))
+    # Hand-build a checkpoint that marks ONLY the first rung complete.
+    policy = HangarFitPolicy()
+    opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    ckpt = tmp_path / "ck.pt"
+    save_checkpoint(
+        ckpt,
+        policy=policy,
+        optimizer=opt,
+        normalizer=ReturnNormalizer(),
+        policy_kwargs=None,
+        completed_stages=["t0"],
+    )
+    resumed = train_curriculum(seed=0, schedule=sched, rollout_len=8, load=str(ckpt))
+    # only the SECOND rung ("t1") runs; "t0" is skipped.
+    assert [p[0] for p in resumed.promotions] == ["t1"]
+    assert {stage for stage, _, _ in resumed.iterations} == {"t1"}
+
+
+def test_train_curriculum_resume_arch_mismatch_raises(tmp_path):
+    from ml.checkpoint import save_checkpoint
+    from ml.policy import HangarFitPolicy
+
+    pk = {"d_model": 32, "n_layers": 1, "n_heads": 2}
+    policy = HangarFitPolicy(**pk)
+    opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    ckpt = tmp_path / "ck.pt"
+    save_checkpoint(
+        ckpt, policy=policy, optimizer=opt, normalizer=None, policy_kwargs=pk, completed_stages=[]
+    )
+    sched = _tiny_schedule(threshold=2.0)
+    sched = replace(sched, policy=replace(sched.policy, max_iters=1))
+    # resume must REUSE the checkpoint's architecture; a conflicting one fails loud.
+    with pytest.raises(ValueError, match="arch|policy_kwargs"):
+        train_curriculum(
+            seed=0,
+            schedule=sched,
+            rollout_len=8,
+            load=str(ckpt),
+            policy_kwargs={"d_model": 64},
+        )
+
+
+def test_train_curriculum_default_no_checkpoint_byte_identical():
+    # load=None + checkpoint_out=None must reproduce the no-arg history exactly (no IO path).
+    sched = _tiny_default_sched()
+    base = train_curriculum(seed=0, schedule=sched, rollout_len=16)
+    same = train_curriculum(seed=0, schedule=sched, rollout_len=16, load=None, checkpoint_out=None)
+    assert any(eps for _, _, eps in base.iterations), "no episodes completed — vacuous equality"
+    assert base.iterations == same.iterations
+    assert base.promotions == same.promotions
+
+
+def test_train_curriculum_resume_warns_on_foreign_completed_stage(tmp_path, capsys):
+    # Resuming a checkpoint whose completed rungs are not in the current schedule (a different
+    # ladder) is tolerated but must WARN — else the wrong rungs are silently (not) skipped.
+    from ml.checkpoint import save_checkpoint
+    from ml.policy import HangarFitPolicy
+
+    policy = HangarFitPolicy()
+    opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    ckpt = tmp_path / "ck.pt"
+    save_checkpoint(
+        ckpt,
+        policy=policy,
+        optimizer=opt,
+        normalizer=None,
+        policy_kwargs=None,
+        completed_stages=["ghost-rung"],
+    )
+    sched = _tiny_schedule(threshold=2.0)
+    sched = replace(sched, policy=replace(sched.policy, max_iters=1))
+    train_curriculum(seed=0, schedule=sched, rollout_len=8, load=str(ckpt))
+    assert "ghost-rung" in capsys.readouterr().err
+
+
+def test_train_curriculum_resume_warns_on_normalizer_config_mismatch(tmp_path, capsys):
+    # Checkpoint carries normalizer stats but the resume cfg has normalize_returns off -> the
+    # saved stats are dropped; that silent divergence must WARN (the multi-day-run footgun).
+    from ml.checkpoint import save_checkpoint
+    from ml.policy import HangarFitPolicy
+    from ml.ppo import PPOConfig, ReturnNormalizer
+
+    policy = HangarFitPolicy()
+    opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    ckpt = tmp_path / "ck.pt"
+    save_checkpoint(
+        ckpt,
+        policy=policy,
+        optimizer=opt,
+        normalizer=ReturnNormalizer(),
+        policy_kwargs=None,
+        completed_stages=[],
+    )
+    sched = _tiny_schedule(threshold=2.0)
+    sched = replace(sched, policy=replace(sched.policy, max_iters=1))
+    train_curriculum(
+        seed=0,
+        schedule=sched,
+        rollout_len=8,
+        load=str(ckpt),
+        ppo=PPOConfig(normalize_returns=False),
+    )
+    assert "normaliz" in capsys.readouterr().err.lower()
+
+
+def test_argparser_load_and_checkpoint_out_default_none():
+    a = build_argparser().parse_args([])
+    assert a.load is None
+    assert a.checkpoint_out is None
+
+
+def test_main_threads_load_and_checkpoint_out_to_curriculum(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(
+        ["--schedule", "curriculum", "--load", "/tmp/x.pt", "--checkpoint-out", "/tmp/y.pt"]
+    )
+    assert captured["load"] == "/tmp/x.pt"
+    assert captured["checkpoint_out"] == "/tmp/y.pt"
+
+
+def test_main_load_requires_curriculum_schedule(monkeypatch):
+    # resume needs a curriculum position; --load under --schedule trivial fails LOUD, no training.
+    import ml.train as train_mod
+
+    ran = {"train": False}
+
+    def guard(**kw):
+        ran["train"] = True
+        return []
+
+    monkeypatch.setattr(train_mod, "train", guard)
+    with pytest.raises(SystemExit):
+        train_mod.main(["--schedule", "trivial", "--load", "/tmp/x.pt"])
+    assert ran["train"] is False
+
+
+def test_main_checkpoint_out_requires_curriculum_schedule(monkeypatch):
+    import ml.train as train_mod
+
+    ran = {"train": False}
+
+    def guard(**kw):
+        ran["train"] = True
+        return []
+
+    monkeypatch.setattr(train_mod, "train", guard)
+    with pytest.raises(SystemExit):
+        train_mod.main(["--schedule", "trivial", "--checkpoint-out", "/tmp/y.pt"])
+    assert ran["train"] is False
+
+
+# ---------------------------------------------------------------------------
+# #710 economics rebalance — --r-unplaced-penalty threads into RewardWeights.
+# ---------------------------------------------------------------------------
+
+
+def test_argparser_r_unplaced_penalty_defaults_zero():
+    assert build_argparser().parse_args([]).r_unplaced_penalty == 0.0
+
+
+def test_main_threads_r_unplaced_penalty_into_weights(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum", "--r-unplaced-penalty", "12.5"])
+    assert captured["weights"].r_unplaced_penalty == 12.5
+
+
+# ---------------------------------------------------------------------------
 # CUDA opt-in (--device): default cpu must stay byte-identical; cuda is opt-in.
 # ---------------------------------------------------------------------------
 

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -595,6 +595,66 @@ def test_train_curriculum_resume_warns_on_normalizer_config_mismatch(tmp_path, c
     assert "normaliz" in capsys.readouterr().err.lower()
 
 
+def test_train_curriculum_resume_inherits_checkpoint_optimizer_lr(tmp_path, monkeypatch):
+    # T6: resume restores the optimizer via load_state_dict, which carries the checkpoint's lr
+    # (train.py documents this deliberate inheritance). A refactor re-applying cfg.lr after the
+    # load would silently violate it — pin the contract with a distinct checkpoint lr.
+    import ml.train as train_mod
+    from ml.checkpoint import save_checkpoint
+    from ml.policy import HangarFitPolicy
+    from ml.ppo import PPOConfig
+
+    policy = HangarFitPolicy()
+    opt = torch.optim.Adam(policy.parameters(), lr=0.05)  # distinct from cfg.lr below
+    ckpt = tmp_path / "ck.pt"
+    save_checkpoint(
+        ckpt,
+        policy=policy,
+        optimizer=opt,
+        normalizer=None,
+        policy_kwargs=None,
+        completed_stages=["t0"],
+    )
+    seen: dict = {}
+    real = train_mod.ppo_update
+
+    def spy(pol, optim, *a, **k):
+        seen["lr"] = optim.param_groups[0]["lr"]
+        return real(pol, optim, *a, **k)
+
+    monkeypatch.setattr(train_mod, "ppo_update", spy)
+    sched = _tiny_schedule(threshold=2.0)
+    sched = replace(sched, policy=replace(sched.policy, max_iters=1))
+    train_curriculum(seed=0, schedule=sched, rollout_len=8, load=str(ckpt), ppo=PPOConfig(lr=3e-4))
+    assert seen["lr"] == pytest.approx(0.05)  # checkpoint optimizer lr wins, not cfg.lr 3e-4
+
+
+def test_train_curriculum_resume_same_path_load_and_checkpoint_out(tmp_path):
+    # T8: the headline usage — --load PATH and --checkpoint-out PATH the SAME file (read at
+    # start, atomically overwritten per rung). Must complete and extend completed_stages.
+    from ml.checkpoint import load_checkpoint, save_checkpoint
+    from ml.policy import HangarFitPolicy
+
+    policy = HangarFitPolicy()
+    opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    ck = tmp_path / "ck.pt"
+    save_checkpoint(
+        ck,
+        policy=policy,
+        optimizer=opt,
+        normalizer=None,
+        policy_kwargs=None,
+        completed_stages=["t0"],
+    )
+    sched = _tiny_schedule(threshold=2.0)
+    sched = replace(sched, policy=replace(sched.policy, max_iters=1))
+    hist = train_curriculum(
+        seed=0, schedule=sched, rollout_len=8, load=str(ck), checkpoint_out=str(ck)
+    )
+    assert [p[0] for p in hist.promotions] == ["t1"]  # only the remaining rung ran
+    assert load_checkpoint(ck).completed_stages == ["t0", "t1"]  # same-path write extended it
+
+
 def test_argparser_load_and_checkpoint_out_default_none():
     a = build_argparser().parse_args([])
     assert a.load is None
@@ -702,6 +762,22 @@ def test_train_curriculum_device_cuda_runs():
     sched = _tiny_default_sched()
     hist = train_curriculum(seed=0, schedule=sched, rollout_len=16, device="cuda")
     assert hist.promotions and hist.iterations  # trained on GPU end-to-end
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+def test_train_curriculum_device_cuda_save_and_onnx_export_cpu(tmp_path):
+    # T1: after --device cuda training the policy is CUDA-resident; --save / --save-onnx must
+    # not crash (export traces CPU dummy inputs) and must write CPU-loadable artifacts (the
+    # eval/ONNX consumer expects CPU). Pre-fix, export_onnx raised a device-mismatch at run end.
+    sched = _tiny_default_sched()
+    save = tmp_path / "p.pt"
+    onnx = tmp_path / "p.onnx"
+    train_curriculum(
+        seed=0, schedule=sched, rollout_len=16, device="cuda", save=str(save), save_onnx=str(onnx)
+    )
+    assert onnx.exists()
+    state = torch.load(str(save), map_location="cpu", weights_only=True)
+    assert all(v.device.type == "cpu" for v in state.values())  # saved tensors are CPU
 
 
 def test_argparser_device_defaults_to_cpu():


### PR DESCRIPTION
## Summary

Mastery-run enablement for the learned backend (epic #607). Two commits: the prior
per-iter `valid_placed` metrics + opt-in CUDA (`e713c7e`), and this session's resume
checkpoints + architecture/PPO CLI knobs + the Park/drive-out **economics-rebalance**
reward fix (`7915904`).

Every new flag is **default-neutral** — omitting it reproduces prior runs byte-for-byte
on CPU (the ADR-0027 / determinism contract). All changes are TDD'd.

Closes #710

## What changed

### Resume checkpoints (`--load` / `--checkpoint-out`)
- New `ml/checkpoint.py`: a resume checkpoint carrying policy + Adam optimizer +
  `ReturnNormalizer` + architecture (`policy_kwargs`) + completed-rung position.
- `train_curriculum(load=, checkpoint_out=)`: writes after **each rung**
  (crash-survivable) and resumes by restoring all state + **skipping completed rungs**.
- **Atomic** write (temp file + `os.replace`); `weights_only=True` load with loud
  version + required-key checks; arch-mismatch raises, resume-config drift warns.
- Distinct from `--save` (still a bare `state_dict` for the ONNX / `ml.eval` consumer).

### Architecture + PPO CLI knobs
- `--d-model` / `--n-layers` / `--n-heads` (policy size) + `--epochs` /
  `--minibatch-size` (`PPOConfig`). Omitting them keeps the existing defaults.

### Park/drive-out economics rebalance (`--r-unplaced-penalty`)
- `RewardWeights.r_unplaced_penalty` (default `0.0`):
  `terminal = r_terminal·frac − r_unplaced_penalty·(1−frac)` — charges abandonment so a
  valid Park out-earns driving to budget exhaustion. Pairs with `--r-valid-park`.
- **This replaces the originally-planned "dense collision-progress reward."** An
  8-agent design panel (4 lenses + synthesis + 3 refuters, all code-confirmed) found
  that reward (a) **redundant** with `--dense-slot-potential` — its `active_misfit_m2`
  already enters Φ, so `γΦ(s′)−Φ(s)` *is* a per-step active-overlap gradient — and
  (b) **policy-invariant** (Ng–Harada–Russell) so it cannot move the optimum. The real
  bottleneck is the Park/drive-out asymmetry: `−w_col` is charged only at a Park, while a
  budget-exhaustion stop still pays `terminal_fraction` over already-parked objects for
  free → the `fraction_placed` 0.991→0.476 collapse seen in the #697 baseline.

## Review arc (this session)
- **`ml-rl-guard`: PASS** — all four RL invariants (seeding / byte-identity, knob
  default-neutrality, #694 product-checker validity, numeric + GAE) intact; the
  byte-identity canaries pass; `ruff` + `mypy ml/` clean.
- **`code-reviewer`: clean** — no blockers / majors.
- **`silent-failure-hunter`:** 2 findings → both fixed (atomic checkpoint write + loud
  corrupt/incomplete-file errors; resume sanity warnings for foreign rungs / normalizer
  drift).
- 255+ `tests/ml/` pass; `ruff` + `mypy ml/` clean.

## Not in this PR — the gate run
The box-rung mastery gate (does the economics rebalance move `valid_placed` off 0?) is a
multi-hour GPU job, run separately. Recipe: `ml/README.md` → "Box-rung mastery gate
recipe". Verdict: a non-zero `valid_placed` trend on pair/trio-box across **both** seeds
→ economics suffices; flat-zero both → **#712** (start-state graft / wire
`DifficultyConfig.seed_anchor`) is the next lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
