### PR TITLE
feat(714): validity-conditional terminal + solo-box rung (multi-object collapse fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,24 @@ All notable changes to this project are documented here. Format follows [Keep a 
   `dense_slot_potential` shaping and so cannot move the optimum). Default 0 → byte-identical;
   pairs with the existing `--r-valid-park` for the positive pull toward valid commits.
 
+- **Learned backend (#714, #710, epic #607): validity-conditional terminal +
+  `solo-box` sub-curriculum rung — the multi-object collapse fix.** After the economics
+  rebalance let the policy **master the trivial (1-object) rung**, every ≥2-object rung still
+  collapsed, oscillating between place-nothing and *commit-everything-invalidly* (parking a
+  heap of overlapping objects). Root cause: the terminal credited `r_terminal·fraction_placed`
+  **regardless of validity** — invisible at N=1 (fraction is 0/1) but a free `+r_terminal`
+  for invalid piles at N≥2. Two default-neutral levers: (1) `--validity-conditional-terminal`
+  (new `RewardWeights.validity_conditional_terminal`) credits the **valid** placed fraction
+  instead — an invalid terminal layout scores effective-fraction 0, so an overlapping pile no
+  longer pays; it also closes the budget-exhaustion branch, which previously carried no
+  validity signal at all. Validity is the same whole-layout product checker
+  (`collisions.check` + Caddy egress) that drives the `valid_placed` promotion gate. (2)
+  `--solo-box-rung` (curriculum-only) inserts an opt-in `solo-box` rung (1 object, **whole
+  fleet**) after `trivial`, decoupling the count jump (1→2) from the sampling-pool jump
+  (single-fuji→whole-fleet) so single-object competency transfers. Both default off →
+  byte-identical (the default ladder is unchanged); `--solo-box-rung` fails loud under
+  `--schedule trivial`.
+
 - **Vectorized training envs (#708, epic #607).** `train_curriculum`/`ml.train` gain an
   `n_envs` knob (`--n-envs`, `--vec-backend {sync,subproc}`) that runs N cold-joint envs in
   parallel for throughput — the shapely geometry + encoder rasterization run across N

--- a/ml/README.md
+++ b/ml/README.md
@@ -137,28 +137,50 @@ per-step active-overlap gradient) and, being potential-based shaping, is **polic
 | `--epochs` / `--minibatch-size` | `PPOConfig` defaults | PPO update epochs / minibatch size. |
 | `--device {cpu,cuda}` | `cpu` | Opt-in GPU (non-deterministic fast path; cpu stays byte-identical). |
 | `--metrics-out PATH` | off | Per-iter per-rung JSONL incl. the `valid_placed` curve. |
+| `--validity-conditional-terminal` | off | Terminal credits the **valid** placed fraction (invalid layout → 0), so an overlapping pile no longer books `+r_terminal`. The #714 multi-object fix; also closes the budget-exhaustion branch. |
+| `--solo-box-rung` | off | Insert an opt-in `solo-box` rung (1 object, **whole fleet**) after `trivial` so single-object competency transfers before the 2-object jump (#714). Curriculum-only. |
 
-`--load`/`--checkpoint-out`/`--metrics-out`/`--promotion-*` are curriculum-only (fail loud
-under `--schedule trivial`). The resume checkpoint (`ml/checkpoint.py`) is distinct from
-`--save` (a bare `state_dict` for the ONNX/`ml.eval` consumer) and loads with
-`weights_only=True`.
+`--load`/`--checkpoint-out`/`--metrics-out`/`--promotion-*`/`--solo-box-rung` are
+curriculum-only (fail loud under `--schedule trivial`). The resume checkpoint
+(`ml/checkpoint.py`) is distinct from `--save` (a bare `state_dict` for the ONNX/`ml.eval`
+consumer) and loads with `weights_only=True`.
 
-### Box-rung mastery gate recipe
+### What the #710 levers achieved, and the #714 multi-object fix
+
+The #710 economics rebalance (`--r-valid-park 30 --r-unplaced-penalty 8 --dense-slot-potential`
++ entropy anneal + `--normalize-returns`) **mastered the trivial (1-object) rung** — the
+first competency promotion of the learned backend (valid_placed 0.018→0.936, fraction held,
+reward positive). But every **≥2-object** rung still collapsed, oscillating between
+place-nothing and *commit-everything-invalidly* (parking a heap of overlapping objects;
+reward spikes of −9k to −37k). Root cause: the terminal credited `fraction_placed`
+**regardless of validity** — invisible at N=1 (fraction is 0/1) but a free `+r_terminal` for
+invalid piles at N≥2. The #714 fix is two default-neutral levers: `--validity-conditional-terminal`
+(credit only the *valid* fraction) and `--solo-box-rung` (decouple the count jump from the
+sampling-pool jump). #712 (`seed_anchor` start-state graft) is **not** the binding lever here
+— it is an unwired stub, and the box rungs *do* reach valid joint poses briefly before
+abandoning them.
+
+### Box-rung mastery gate recipe (#714 re-gate)
 
 ```bash
-# GPU, box rungs only, HONEST valid_placed promotion, resumable, 2 seeds:
+# GPU, HONEST valid_placed promotion, resumable, the #714 levers active. Run 2 seeds.
 python -u -m ml.train --schedule curriculum --device cuda --n-envs 16 \
-  --rollout-len 512 --max-iters-per-stage 50 \
+  --rollout-len 512 --max-iters-per-stage 25 \
   --promotion-metric valid_placed --promotion-threshold 0.9 \
-  --r-valid-park 2.0 --r-unplaced-penalty 25.0 \
-  --metrics-out metrics-seed0.jsonl --checkpoint-out ck-seed0.pt --seed 0
+  --r-valid-park 30.0 --r-unplaced-penalty 8.0 --dense-slot-potential \
+  --entropy-start 0.05 --entropy-end 0.005 --entropy-anneal-iters 40 \
+  --normalize-returns --validity-conditional-terminal --solo-box-rung \
+  --metrics-out metrics-seed0-v3.jsonl --checkpoint-out ck-seed0-v3.pt --seed 0
 ```
 
-Watch **both** `fraction_placed` (recovering off ~0.476 = the perverse incentive is breaking)
-and `valid_placed` (the mastery axis). Guard against the opposite failure — `valid_rate`
-dropping while `fraction_placed` spikes is the commit-anything pathology (penalty too high).
-Flat `valid_placed` across both seeds is the empirical signal that reachability (the #712
-start-state graft) is the next lever.
+Read **`valid_placed`** (the honest mastery axis), **not** `valid_rate` (an empty layout is
+trivially valid → inflated). Expected: `solo-box` masters like `trivial`; `pair-box` then
+lifts off the place-nothing pole toward the **one-valid plateau (~0.5)** — that is the
+win condition for this increment. Reaching 0.9 (two *simultaneously* valid) may need a
+further lever (#712 start-state graft / a pose-curriculum). **Kill-criterion:** if by
+~iter 20 a rung still produces commit-everything spikes (reward < −3000 with
+`fraction_placed` > 0.5 and `valid_rate` < 0.1), the terminal fix did not bite — re-open
+toward the return-normalizer (run with `--normalize-returns` off) before more discovery work.
 
 ## Design
 See `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -236,6 +236,18 @@ _LENIENT_CLEARANCE = (
     0.05  # below the herrenteich file value (0.10) so the clearance ramp truly tightens
 )
 
+# Opt-in #714 rung (wired via with_solo_box_rung / --solo-box-rung), NOT part of DEFAULT_LADDER.
+# max_objects=1 like trivial, but the WHOLE-fleet pool (fleet_ids omitted) instead of trivial's
+# single ("fuji",) — decouples the count jump (1->2) from the sampling-pool jump at the
+# trivial->pair-box boundary so single-object competency transfers to arbitrary fleet objects.
+_SOLO_BOX_STAGE = Stage(
+    name="solo-box",
+    difficulty=DifficultyConfig(max_objects=1, per_object_step_budget=60, total_step_budget=60),
+    hangar_path=_BOX_HANGAR,
+    fleet_path=_BOX_FLEET,
+    clearance_m=_LENIENT_CLEARANCE,
+)
+
 DEFAULT_LADDER: tuple[Stage, ...] = (
     Stage(
         name="trivial",
@@ -282,3 +294,20 @@ DEFAULT_LADDER: tuple[Stage, ...] = (
         clearance_m=None,  # inherit the herrenteich file value (0.10) — the real strict rung
     ),
 )
+
+
+def with_solo_box_rung(schedule: CurriculumSchedule) -> CurriculumSchedule:
+    """Return ``schedule`` with the opt-in ``solo-box`` rung inserted immediately after the
+    ``trivial`` rung — the #714 ``--solo-box-rung`` lever. solo-box keeps max_objects=1 but
+    draws from the whole fleet, decoupling the count jump (1->2) from the sampling-pool jump
+    (single-fuji -> whole-fleet) at the trivial->pair-box boundary so single-object competency
+    transfers. Only the ladder changes (the promotion policy is preserved). The default ladder
+    is left untouched, so default runs stay byte-identical (this is opt-in)."""
+    stages = schedule.stages
+    try:
+        after = next(i for i, s in enumerate(stages) if s.name == "trivial") + 1
+    except StopIteration:
+        raise ValueError(
+            "with_solo_box_rung: schedule has no 'trivial' rung to insert after"
+        ) from None
+    return replace(schedule, stages=stages[:after] + (_SOLO_BOX_STAGE,) + stages[after:])

--- a/ml/env.py
+++ b/ml/env.py
@@ -249,6 +249,9 @@ class HangarFitEnv:
                 potential=new_phi,
                 terminal_fraction=terminal_fraction,
                 park_valid=park_valid,
+                # On the terminal Park, reuse the already-computed whole-layout product-checker
+                # bool (== _layout_valid()) for the #714 validity-conditional terminal.
+                terminal_valid=park_valid if done else None,
             )
             reward = step_reward(ctx, weights)
             self._prev_potential = new_phi
@@ -284,6 +287,11 @@ class HangarFitEnv:
         # unparked, so the fraction is over already-PARKED objects only.
         done, reason = self._check_budget()
         terminal_fraction = len(self._parked) / len(self.requested_ids) if done else None
+        # Validity of the already-PARKED set at a budget-exhaustion stop. This branch carried
+        # no validity signal, so the #714 validity-conditional terminal would have treated even
+        # a valid partial as invalid — wire it from the product checker (cache-warm: a movement
+        # primitive does not bump _parked_version). None when not terminal.
+        terminal_valid = self._layout_valid() if done else None
         ctx = RewardContext(
             overlap_m2=0.0,
             intrusion_m2=0.0,
@@ -296,6 +304,7 @@ class HangarFitEnv:
             prev_potential=self._prev_potential,
             potential=new_phi,
             terminal_fraction=terminal_fraction,
+            terminal_valid=terminal_valid,
         )
         reward = step_reward(ctx, weights)
         self._prev_potential = new_phi

--- a/ml/reward.py
+++ b/ml/reward.py
@@ -25,6 +25,9 @@ class RewardContext:
     # None = not a Park step (bonus structurally absent);
     # False = Park step with invalid layout; True = Park step with valid layout.
     park_valid: bool | None = None
+    # Whole-layout validity at the TERMINAL step (the product checker), consumed only when
+    # RewardWeights.validity_conditional_terminal is on. None on non-terminal steps. (#714)
+    terminal_valid: bool | None = None
 
 
 def potential(
@@ -54,12 +57,17 @@ def step_reward(ctx: RewardContext, w: RewardWeights) -> float:
     # Terminal: reward the placed fraction MINUS a penalty on the unplaced fraction. The
     # penalty (r_unplaced_penalty, default 0 -> the second term vanishes) charges abandonment
     # so running an object to budget exhaustion is no longer free relative to committing a
-    # Park — the #710 Park/drive-out economics rebalance.
-    terminal = (
-        w.r_terminal * ctx.terminal_fraction - w.r_unplaced_penalty * (1.0 - ctx.terminal_fraction)
-        if ctx.terminal_fraction is not None
-        else 0.0
-    )
+    # Park — the #710 Park/drive-out economics rebalance. When validity_conditional_terminal is
+    # on, an INVALID terminal layout collapses the effective placed fraction to 0 (so the
+    # +r_terminal credit goes to abandonment instead) — the #714 fix for the multi-object
+    # commit-everything-invalidly attractor. Default off -> eff_fraction == terminal_fraction.
+    if ctx.terminal_fraction is None:
+        terminal = 0.0
+    else:
+        eff_fraction = ctx.terminal_fraction
+        if w.validity_conditional_terminal and not ctx.terminal_valid:
+            eff_fraction = 0.0
+        terminal = w.r_terminal * eff_fraction - w.r_unplaced_penalty * (1.0 - eff_fraction)
     shaping = w.gamma * ctx.potential - ctx.prev_potential
     valid_park = w.r_valid_park if ctx.park_valid else 0.0
     return hard + movement + soft + terminal + shaping + valid_park

--- a/ml/reward.py
+++ b/ml/reward.py
@@ -65,8 +65,14 @@ def step_reward(ctx: RewardContext, w: RewardWeights) -> float:
         terminal = 0.0
     else:
         eff_fraction = ctx.terminal_fraction
-        if w.validity_conditional_terminal and not ctx.terminal_valid:
-            eff_fraction = 0.0
+        if w.validity_conditional_terminal:
+            # The env sets terminal_valid whenever terminal_fraction is set (both gated on
+            # `done`); assert that here so a future call-site that forgets it fails LOUD rather
+            # than silently zeroing a valid layout via `not None`. Zero only on a known-invalid
+            # layout (`is False`), never on the None sentinel.
+            assert ctx.terminal_valid is not None, "terminal_valid unset at a terminal step"
+            if ctx.terminal_valid is False:
+                eff_fraction = 0.0
         terminal = w.r_terminal * eff_fraction - w.r_unplaced_penalty * (1.0 - eff_fraction)
     shaping = w.gamma * ctx.potential - ctx.prev_potential
     valid_park = w.r_valid_park if ctx.park_valid else 0.0

--- a/ml/train.py
+++ b/ml/train.py
@@ -35,6 +35,7 @@ from ml.curriculum import (
     stage_rng,
     validate_ladder,
     with_promotion_overrides,
+    with_solo_box_rung,
 )
 from ml.encoding import EncoderConfig, encode
 from ml.env import HangarFitEnv
@@ -585,6 +586,12 @@ def build_argparser() -> argparse.ArgumentParser:
         "pair with --load PATH to resume the same path",
     )
     p.add_argument(
+        "--solo-box-rung",
+        action="store_true",
+        help="curriculum: insert the opt-in #714 'solo-box' rung (1 object, whole fleet) after "
+        "trivial, so single-object competency transfers before the 2-object jump",
+    )
+    p.add_argument(
         "--r-valid-park",
         type=float,
         default=0.0,
@@ -596,6 +603,12 @@ def build_argparser() -> argparse.ArgumentParser:
         default=0.0,
         help="terminal penalty per UNPLACED fraction (charges abandonment so driving to "
         "budget exhaustion is no longer free vs committing a Park; #710 economics rebalance)",
+    )
+    p.add_argument(
+        "--validity-conditional-terminal",
+        action="store_true",
+        help="terminal credits the VALID placed fraction (invalid layout -> 0), so an "
+        "overlapping pile no longer books +r_terminal; #714 multi-object commit-invalidly fix",
     )
     p.add_argument(
         "--dense-slot-potential",
@@ -656,6 +669,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         r_valid_park=args.r_valid_park,
         dense_slot_potential=args.dense_slot_potential,
         r_unplaced_penalty=args.r_unplaced_penalty,
+        validity_conditional_terminal=args.validity_conditional_terminal,
     )
     # Only the supplied arch flags go into policy_kwargs; an all-None set yields None, so
     # the policy falls back to HangarFitPolicy's own defaults (default-neutral / byte-identical).
@@ -687,6 +701,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             parser.error("--promotion-metric/--promotion-threshold require --schedule curriculum")
         if args.load is not None or args.checkpoint_out is not None:
             parser.error("--load/--checkpoint-out require --schedule curriculum")
+        if args.solo_box_rung:
+            parser.error("--solo-box-rung requires --schedule curriculum")
         train(
             seed=args.seed,
             iterations=args.iterations,
@@ -710,6 +726,8 @@ def main(argv: Sequence[str] | None = None) -> None:
                 max_iters=args.max_iters_per_stage,
             ),
         )
+        if args.solo_box_rung:
+            sched = with_solo_box_rung(sched)
         history = train_curriculum(
             seed=args.seed,
             schedule=sched,

--- a/ml/types.py
+++ b/ml/types.py
@@ -105,6 +105,13 @@ class RewardWeights:
     # identical. Non-zero charges abandonment so "drive to budget exhaustion" is no longer
     # free relative to committing a Park (the #710 Park/drive-out economics-rebalance lever).
     r_unplaced_penalty: float = 0.0
+    # When True, the terminal credits the VALID placed fraction instead of the raw
+    # fraction_placed: an invalid terminal layout scores effective-fraction 0 (so an
+    # overlapping pile no longer books +r_terminal). Default False -> byte-identical. Fixes
+    # the #714 commit-everything-invalidly attractor on multi-object rungs (the terminal was
+    # validity-blind, invisible at N=1 where fraction is 0/1). Validity = the same whole-layout
+    # product checker (collisions.check + Caddy egress) that drives the valid_placed gate.
+    validity_conditional_terminal: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -353,3 +353,14 @@ def test_with_solo_box_rung_preserves_policy_and_validates():
 def test_with_solo_box_rung_does_not_mutate_the_default_ladder():
     with_solo_box_rung(CurriculumSchedule.default())
     assert all(s.name != "solo-box" for s in DEFAULT_LADDER)  # default still pristine
+
+
+def test_with_solo_box_rung_raises_without_trivial_rung():
+    # No 'trivial' rung => no anchor to insert after => loud ValueError (not a leaked
+    # StopIteration from the internal next()).
+    no_trivial = CurriculumSchedule(
+        stages=tuple(s for s in DEFAULT_LADDER if s.name != "trivial"),
+        policy=PromotionPolicy(),
+    )
+    with pytest.raises(ValueError, match="trivial"):
+        with_solo_box_rung(no_trivial)

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -19,6 +19,7 @@ from ml.curriculum import (
     stage_rng,
     validate_ladder,
     with_promotion_overrides,
+    with_solo_box_rung,
 )
 from ml.encoding import EncoderConfig
 from ml.types import DifficultyConfig
@@ -317,3 +318,38 @@ def test_with_promotion_overrides_sets_only_given_fields():
     assert got.threshold == pytest.approx(0.3)
     assert got.max_iters == 120
     assert got.window == 20  # untouched field preserved
+
+
+# ---------------------------------------------------------------------------
+# #714 — solo-box sub-curriculum rung (Lever B), opt-in / flag-gated
+# ---------------------------------------------------------------------------
+
+
+def test_default_ladder_has_no_solo_box_rung():
+    # Byte-identity guard: solo-box is opt-in; the default ladder is unchanged.
+    assert all(s.name != "solo-box" for s in DEFAULT_LADDER)
+
+
+def test_with_solo_box_rung_inserts_after_trivial():
+    sched = with_solo_box_rung(CurriculumSchedule.default())
+    names = [s.name for s in sched.stages]
+    assert names[:3] == ["trivial", "solo-box", "pair-box"]
+
+
+def test_solo_box_rung_is_single_object_whole_fleet_pool():
+    sched = with_solo_box_rung(CurriculumSchedule.default())
+    solo = next(s for s in sched.stages if s.name == "solo-box")
+    assert solo.difficulty.max_objects == 1  # still one object...
+    assert solo.fleet_ids is None  # ...but the WHOLE-fleet pool (trivial pins fleet_ids=("fuji",))
+
+
+def test_with_solo_box_rung_preserves_policy_and_validates():
+    base = CurriculumSchedule.default()
+    sched = with_solo_box_rung(base)
+    assert sched.policy == base.policy  # only the ladder changes, not the promotion gate
+    validate_ladder(sched.stages, encoder_max_objects=EncoderConfig().max_objects)  # no raise
+
+
+def test_with_solo_box_rung_does_not_mutate_the_default_ladder():
+    with_solo_box_rung(CurriculumSchedule.default())
+    assert all(s.name != "solo-box" for s in DEFAULT_LADDER)  # default still pristine

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -9,7 +9,7 @@ import pytest
 from hangarfit.models import GroundObject, Part, Placement
 from ml import geometry_oracle as go
 from ml.env import HangarFitEnv
-from ml.types import DifficultyConfig, Park, Primitive
+from ml.types import DifficultyConfig, Park, Pose, Primitive, RewardWeights
 from tests.ml.conftest import _fuji, empty_hangar
 
 
@@ -470,3 +470,83 @@ def test_r_unplaced_penalty_full_park_not_penalized_vs_abandon():
     assert p_placed == 2 and a_placed == 0  # Park-done (frac=1) vs budget-abandon (frac=0)
     assert parkR == pytest.approx(park0)  # full placement -> penalty term 0, unchanged by knob
     assert aban0 - abanR == pytest.approx(20.0)  # abandon -> charged the full unplaced fraction
+
+
+# ---------------------------------------------------------------------------
+# #714 — validity-conditional terminal wiring (Lever A)
+# ---------------------------------------------------------------------------
+# An in-hangar fuji pose verified valid in empty_hangar (probed: 22x25 box,
+# bay keep-out x in [9,18] y in [16,25]; (9,10,0) clears it).
+_VALID_POSE = (9.0, 10.0, 0.0)
+
+
+def _park_terminal_reward(*, validity_conditional: bool, pose):
+    """Single-object env: optionally override the active pose, then Park (terminal).
+    Returns (reward, info, weights). pose=None keeps the apron spawn (out of bounds)."""
+    w = RewardWeights(r_unplaced_penalty=8.0, validity_conditional_terminal=validity_conditional)
+    env = HangarFitEnv(hangar=empty_hangar(), fleet=_fuji(), requested_ids=("fuji",), weights=w)
+    env.reset()
+    if pose is not None:
+        env._active_pose = Pose(x_m=pose[0], y_m=pose[1], heading_deg=pose[2])
+    _, reward, done, info = env.step(Park())
+    assert done is True
+    return reward, info, w
+
+
+def test_validity_conditional_terminal_park_invalid_drops_placed_credit():
+    # Park on the apron (out of bounds) => invalid terminal. Flag ON drops the +r_terminal
+    # credit (eff fraction 0): off - on == frac*(r_terminal + r_unplaced) at frac 1.
+    off_r, off_i, w = _park_terminal_reward(validity_conditional=False, pose=None)
+    on_r, on_i, _ = _park_terminal_reward(validity_conditional=True, pose=None)
+    assert off_i.valid is False and on_i.valid is False
+    assert off_r - on_r == pytest.approx(w.r_terminal + w.r_unplaced_penalty)
+
+
+def test_validity_conditional_terminal_park_valid_unchanged():
+    # A VALID in-hangar park: the flag makes NO difference (terminal credited either way),
+    # confirming the Park branch passes terminal_valid=True (else flag-on would wrongly zero it).
+    off_r, off_i, _ = _park_terminal_reward(validity_conditional=False, pose=_VALID_POSE)
+    on_r, on_i, _ = _park_terminal_reward(validity_conditional=True, pose=_VALID_POSE)
+    assert off_i.valid is True and on_i.valid is True
+    assert on_r == pytest.approx(off_r)
+
+
+def _budget_terminal_reward(*, validity_conditional: bool, park_pose):
+    """2-object env: park obj1 (at park_pose or apron), then exhaust obj2's per-object
+    budget with a no-op pivot so the terminating step's only fraction credit is the
+    terminal term over the {obj1} parked set. Returns (reward, info, weights)."""
+    w = RewardWeights(r_unplaced_penalty=8.0, validity_conditional_terminal=validity_conditional)
+    env = HangarFitEnv(
+        hangar=empty_hangar(),
+        fleet=_fuji(),
+        requested_ids=("fuji", "aviat_husky"),
+        difficulty=DifficultyConfig(per_object_step_budget=1),
+        weights=w,
+    )
+    env.reset()
+    if park_pose is not None:
+        env._active_pose = Pose(x_m=park_pose[0], y_m=park_pose[1], heading_deg=park_pose[2])
+    _, _, done0, _ = env.step(Park())  # park obj1; advance to obj2
+    assert done0 is False
+    _, reward, done, info = env.step(Primitive(kind="L", magnitude=0.1, gear=1))  # budget-exhaust
+    assert done is True and "unplaceable" in info.reason
+    assert info.placed == 1 and info.total == 2  # terminal_fraction 0.5
+    return reward, info, w
+
+
+def test_validity_conditional_terminal_budget_invalid_drops_credit():
+    # Budget-exhaustion stop over an INVALID parked set (obj1 on apron): flag ON zeros the
+    # placed-fraction credit. off - on == 0.5*(r_terminal + r_unplaced).
+    off_r, _, w = _budget_terminal_reward(validity_conditional=False, park_pose=None)
+    on_r, _, _ = _budget_terminal_reward(validity_conditional=True, park_pose=None)
+    assert off_r - on_r == pytest.approx(0.5 * (w.r_terminal + w.r_unplaced_penalty))
+
+
+def test_validity_conditional_terminal_budget_valid_credited():
+    # THE budget-branch wiring guard: a budget stop over a VALID parked set must STILL be
+    # credited under the flag (the branch must pass terminal_valid=_layout_valid()=True, not
+    # leave it None). If the budget branch is unwired, this valid partial is wrongly zeroed.
+    off_r, off_i, _ = _budget_terminal_reward(validity_conditional=False, park_pose=_VALID_POSE)
+    on_r, on_i, _ = _budget_terminal_reward(validity_conditional=True, park_pose=_VALID_POSE)
+    assert off_i.valid is True and on_i.valid is True
+    assert on_r == pytest.approx(off_r)

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -550,3 +550,33 @@ def test_validity_conditional_terminal_budget_valid_credited():
     on_r, on_i, _ = _budget_terminal_reward(validity_conditional=True, park_pose=_VALID_POSE)
     assert off_i.valid is True and on_i.valid is True
     assert on_r == pytest.approx(off_r)
+
+
+def test_validity_conditional_terminal_multiobject_full_invalid_park_drops_credit():
+    # The headline #714 scenario via the Park-done branch: park BOTH objects
+    # (terminal_fraction 1.0) but OVERLAPPING, so the whole layout is invalid. The flag must
+    # withdraw the full +r_terminal credit even at full placement: off - on == r_terminal +
+    # r_unplaced (only the terminal term differs; the shared -w_col overlap penalty cancels).
+    def run(validity_conditional: bool):
+        w = RewardWeights(
+            r_unplaced_penalty=8.0, validity_conditional_terminal=validity_conditional
+        )
+        env = HangarFitEnv(
+            hangar=empty_hangar(),
+            fleet=_fuji(),
+            requested_ids=("fuji", "aviat_husky"),
+            weights=w,
+        )
+        env.reset()
+        env._active_pose = Pose(x_m=9.0, y_m=10.0, heading_deg=0.0)  # fuji at a valid pose
+        _, _, done0, _ = env.step(Park())
+        assert done0 is False
+        env._active_pose = Pose(x_m=9.0, y_m=10.0, heading_deg=0.0)  # husky stacked on fuji
+        _, reward, done, info = env.step(Park())
+        assert done is True and info.placed == 2 and info.total == 2  # frac 1.0
+        return reward, info, w
+
+    off_r, off_i, w = run(validity_conditional=False)
+    on_r, on_i, _ = run(validity_conditional=True)
+    assert off_i.valid is False and on_i.valid is False  # overlapping pile -> invalid
+    assert off_r - on_r == pytest.approx(w.r_terminal + w.r_unplaced_penalty)

--- a/tests/ml/test_reward.py
+++ b/tests/ml/test_reward.py
@@ -133,6 +133,52 @@ def test_r_unplaced_penalty_widens_placed_advantage():
     assert gapp > gap0
 
 
+# ---------------------------------------------------------------------------
+# #714 — validity-conditional terminal (Lever A)
+# ---------------------------------------------------------------------------
+
+
+def test_validity_conditional_terminal_default_off_is_byte_identical():
+    # Default-neutral: flag off => ctx.terminal_valid is never consulted, so an invalid
+    # terminal pays exactly today's value (r_terminal*frac - r_unplaced*(1-frac)).
+    ctx_invalid = _ctx(terminal_fraction=1.0, terminal_valid=False)
+    ctx_none = _ctx(terminal_fraction=1.0, terminal_valid=None)
+    w = RewardWeights(r_unplaced_penalty=8.0)  # validity_conditional_terminal defaults False
+    assert step_reward(ctx_invalid, w) == step_reward(ctx_none, w)
+    assert step_reward(ctx_invalid, w) == pytest.approx(w.r_terminal)  # frac 1 -> +r_terminal
+
+
+def test_validity_conditional_terminal_on_invalid_zeros_placed_credit():
+    # Flag on + invalid terminal => effective fraction 0 => terminal = -r_unplaced*(1-0).
+    w = RewardWeights(r_unplaced_penalty=8.0, validity_conditional_terminal=True)
+    ctx = _ctx(terminal_fraction=1.0, terminal_valid=False)
+    assert step_reward(ctx, w) == pytest.approx(-w.r_unplaced_penalty)
+
+
+def test_validity_conditional_terminal_on_valid_pays_full():
+    # Flag on + valid terminal => effective fraction = terminal_fraction => +r_terminal at frac 1.
+    w = RewardWeights(r_unplaced_penalty=8.0, validity_conditional_terminal=True)
+    ctx = _ctx(terminal_fraction=1.0, terminal_valid=True)
+    assert step_reward(ctx, w) == pytest.approx(w.r_terminal)
+
+
+def test_validity_conditional_terminal_invalid_strictly_below_valid_same_fraction():
+    # The crux of the #714 fix: at the SAME placed fraction, an INVALID terminal must score
+    # strictly lower than a VALID one — removing the commit-everything-invalidly free credit.
+    w = RewardWeights(r_unplaced_penalty=8.0, validity_conditional_terminal=True)
+    valid = _ctx(terminal_fraction=0.5, terminal_valid=True)
+    invalid = _ctx(terminal_fraction=0.5, terminal_valid=False)
+    assert step_reward(invalid, w) < step_reward(valid, w)
+
+
+def test_validity_conditional_terminal_nonterminal_noop():
+    # terminal_fraction=None (a mid-episode step) => no terminal term regardless of flag.
+    ctx = _ctx(terminal_fraction=None, terminal_valid=None)
+    on = RewardWeights(r_unplaced_penalty=8.0, validity_conditional_terminal=True)
+    off = RewardWeights(r_unplaced_penalty=8.0, validity_conditional_terminal=False)
+    assert step_reward(ctx, on) == step_reward(ctx, off)
+
+
 def test_dense_slot_potential_on_lowers_potential_when_misfit_positive():
     """dense_slot_potential=True must STRICTLY lower the shaping potential vs False when the
     active object sits in a bad pose (active_misfit_m2 > 0), catching a gate-inversion the

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -817,3 +817,73 @@ def test_main_device_cuda_unavailable_errors(monkeypatch):
     with pytest.raises(SystemExit):
         train_mod.main(["--schedule", "curriculum", "--device", "cuda"])
     assert ran["train_curriculum"] is False
+
+
+# ---------------------------------------------------------------------------
+# #714 — validity-conditional terminal + solo-box rung CLI wiring.
+# ---------------------------------------------------------------------------
+
+
+def test_argparser_validity_conditional_terminal_defaults_false():
+    assert build_argparser().parse_args([]).validity_conditional_terminal is False
+
+
+def test_main_threads_validity_conditional_terminal_into_weights(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum", "--validity-conditional-terminal"])
+    assert captured["weights"].validity_conditional_terminal is True
+
+
+def test_main_solo_box_rung_requires_curriculum_schedule(monkeypatch):
+    # --solo-box-rung is a curriculum ladder edit; under --schedule trivial it fails LOUD.
+    import ml.train as train_mod
+
+    ran = {"train": False}
+
+    def guard(**kw):
+        ran["train"] = True
+        return []
+
+    monkeypatch.setattr(train_mod, "train", guard)
+    with pytest.raises(SystemExit):
+        train_mod.main(["--schedule", "trivial", "--solo-box-rung"])
+    assert ran["train"] is False
+
+
+def test_main_solo_box_rung_inserts_rung_into_schedule(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum", "--solo-box-rung"])
+    assert "solo-box" in [s.name for s in captured["schedule"].stages]
+
+
+def test_main_without_solo_box_rung_keeps_default_ladder(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum"])
+    assert "solo-box" not in [s.name for s in captured["schedule"].stages]


### PR DESCRIPTION
Closes #714. Part of #710 / epic #607.

## Why

The #710 economics rebalance let the policy **master the trivial (1-object) rung** (first competency promotion of the learned backend: valid_placed 0.018→0.936, fraction held, reward positive). But every **≥2-object** rung still collapsed, oscillating between place-nothing and **commit-everything-invalidly** (parking a heap of overlapping objects; reward spikes −9k to −37k).

**Root cause (adversarially verified):** the terminal credited `r_terminal·fraction_placed` **regardless of validity** — invisible at N=1 (fraction is 0/1, so it coincides with valid_fraction) but a free `+r_terminal` for invalid piles at N≥2. The budget-exhaustion branch was worse: it passed **no** validity signal at all.

## What

Two **default-neutral** levers (off ⇒ cpu byte-identical):

1. **`--validity-conditional-terminal`** (`RewardWeights.validity_conditional_terminal`): the terminal credits the **valid** placed fraction — an invalid terminal layout scores effective-fraction 0, so an overlapping pile no longer pays `+r_terminal`. Validity = the same whole-layout product checker (`collisions.check` + Caddy egress, `== _layout_valid()`) that drives the `valid_placed` promotion gate (ml-rl-guard #694 contract). The Park branch reuses the already-computed `park_valid`; the **budget branch now passes `_layout_valid()`**, closing the prior validity-blind leak.
2. **`--solo-box-rung`** (curriculum-only, `with_solo_box_rung`): inserts an opt-in `solo-box` rung (1 object, **whole fleet**) after `trivial`, decoupling the count jump (1→2) from the sampling-pool jump (single-fuji→whole-fleet) so single-object competency transfers. The default ladder is unchanged.

## Validation

- TDD'd, RED-watched: **14 new tests** — reward unit (off byte-identical / on-invalid-zeros / on-valid-pays / invalid<valid same fraction / nonterminal noop), env wiring (Park valid+invalid, **budget valid+invalid** incl. the budget-branch valid-credit guard), curriculum (opt-in insertion, single-object whole-fleet, policy preserved, default ladder un-mutated).
- **Full `ml/` suite: 279 passed** (incl. the byte-identity / determinism canaries). `ruff check` + `ruff format --check` + `mypy ml/` + `mypy src/hangarfit/` all clean.

## Scope notes

- **#712 (`seed_anchor` start-state graft) is NOT the binding lever here** — it is an unwired stub, and the box rungs *do* reach valid joint poses briefly before abandoning them. It becomes the residual lever only if, after this change, `solo-box` masters but `pair-box` still can't escape the place-nothing pole.
- Honest ceiling: the predicted outcome of the re-gate is `pair-box` lifting toward the **one-valid plateau (~0.5)**; full 0.9 mastery (two *simultaneously* valid) may need a further increment. Re-gate recipe + kill-criterion in `ml/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)