### PR TITLE
feat(712): seed-anchor start-state curriculum graft (--seed-anchor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#712, epic #607): seed-anchor start-state curriculum graft
+  (`--seed-anchor`) — the 2-object joint-discovery scaffold.** The #714 re-gate confirmed a
+  genuine joint-discovery wall (`trivial` + `solo-box` master, but `pair-box` stalls at
+  `valid_placed ≈ 0.05`, and the `--normalize-returns`-off control is strictly worse, so the
+  residual is discovery, not the normalizer). `--seed-anchor` (curriculum-only) inserts an
+  opt-in `pair-anchored` rung before `pair-box` that **pre-parks a k-prefix of a committed
+  witness layout** (`tests/fixtures/ml/witness_box.yaml`) and drives only the remaining N−k
+  objects in, so 2-object discovery is scaffolded by a guaranteed-valid 1-object start.
+  Correctness rests on one property — a k-prefix of a valid layout is itself valid (removing
+  objects cannot create conflicts) — so the partial start needs **no runtime solver / search**
+  (the env stays solver-free). `DifficultyConfig.seed_anchor` (an unwired stub) is replaced by
+  `seed_anchor_k: int = 0`; `HangarFitEnv` gains an `anchor_placements` arg and pre-parks the
+  request **prefix** at reset, which composes with the curriculum's existing seeded
+  per-episode permutation into a **seeded-random k-subset** anchor (so the choice is
+  deterministic + Sync≡Subproc byte-identical). `Stage.anchor_layout_path` + `stage_builder`
+  load the witness (single source of truth for the rung's object set and poses). All
+  default-neutral: `seed_anchor_k=0` / `--seed-anchor` absent → CPU byte-identical to prior
+  runs; `--seed-anchor` fails loud under `--schedule trivial`.
+
 - **Learned backend (#710, epic #607): opt-in CUDA training (`--device cuda`).**
   `ml.train` / `train_curriculum` / `train` gain a `--device {cpu,cuda}` knob. `cpu`
   (the default) is unchanged and **byte-identical** to prior runs — every device move is

--- a/ml/README.md
+++ b/ml/README.md
@@ -139,9 +139,10 @@ per-step active-overlap gradient) and, being potential-based shaping, is **polic
 | `--metrics-out PATH` | off | Per-iter per-rung JSONL incl. the `valid_placed` curve. |
 | `--validity-conditional-terminal` | off | Terminal credits the **valid** placed fraction (invalid layout → 0), so an overlapping pile no longer books `+r_terminal`. The #714 multi-object fix; also closes the budget-exhaustion branch. |
 | `--solo-box-rung` | off | Insert an opt-in `solo-box` rung (1 object, **whole fleet**) after `trivial` so single-object competency transfers before the 2-object jump (#714). Curriculum-only. |
+| `--seed-anchor` | off | Insert an opt-in `pair-anchored` rung **before** `pair-box`: one of its 2 objects is pre-parked at a committed-witness pose (`seed_anchor_k=1`) and the agent only drives the other in — scaffolding 2-object joint discovery with a valid 1-object start (#712). Curriculum-only. |
 
-`--load`/`--checkpoint-out`/`--metrics-out`/`--promotion-*`/`--solo-box-rung` are
-curriculum-only (fail loud under `--schedule trivial`). The resume checkpoint
+`--load`/`--checkpoint-out`/`--metrics-out`/`--promotion-*`/`--solo-box-rung`/`--seed-anchor`
+are curriculum-only (fail loud under `--schedule trivial`). The resume checkpoint
 (`ml/checkpoint.py`) is distinct from `--save` (a bare `state_dict` for the ONNX/`ml.eval`
 consumer) and loads with `weights_only=True`.
 
@@ -156,9 +157,16 @@ reward spikes of −9k to −37k). Root cause: the terminal credited `fraction_p
 **regardless of validity** — invisible at N=1 (fraction is 0/1) but a free `+r_terminal` for
 invalid piles at N≥2. The #714 fix is two default-neutral levers: `--validity-conditional-terminal`
 (credit only the *valid* fraction) and `--solo-box-rung` (decouple the count jump from the
-sampling-pool jump). #712 (`seed_anchor` start-state graft) is **not** the binding lever here
-— it is an unwired stub, and the box rungs *do* reach valid joint poses briefly before
-abandoning them.
+sampling-pool jump).
+
+The #714 re-gate then **confirmed the 2-object joint-discovery wall**: `trivial` and `solo-box`
+master by competency (single-object whole-fleet transfer works), but `pair-box` stalls at
+`valid_placed ≈ 0.054` and the `--normalize-returns`-off control is strictly worse (so the
+normalizer is load-bearing, not the blocker — the residual is genuine joint discovery). That
+result satisfied the documented trigger for **#712 (`--seed-anchor` start-state graft)**, now
+wired: pre-park a k-prefix of a committed witness layout (a k-prefix of a valid layout is
+provably valid, so no runtime solver), drive the remaining N−k in, anneal k→0. See the
+pair-anchored gate recipe below.
 
 ### Box-rung mastery gate recipe (#714 re-gate)
 
@@ -181,6 +189,32 @@ further lever (#712 start-state graft / a pose-curriculum). **Kill-criterion:** 
 ~iter 20 a rung still produces commit-everything spikes (reward < −3000 with
 `fraction_placed` > 0.5 and `valid_rate` < 0.1), the terminal fix did not bite — re-open
 toward the return-normalizer (run with `--normalize-returns` off) before more discovery work.
+
+### Pair-anchored gate recipe (#712 seed-anchor, step 1)
+
+The proof-first step of #712: insert the single `pair-anchored` (k=1) rung before `pair-box`
+and check whether a valid 1-object start lets the agent learn to place the **second** object.
+
+```bash
+# Same #714 economics as above, plus --seed-anchor (the pair-anchored rung before pair-box).
+python -u -m ml.train --schedule curriculum --device cuda --n-envs 16 \
+  --rollout-len 512 --max-iters-per-stage 25 \
+  --promotion-metric valid_placed --promotion-threshold 0.9 \
+  --r-valid-park 30.0 --r-unplaced-penalty 8.0 --dense-slot-potential \
+  --entropy-start 0.05 --entropy-end 0.005 --entropy-anneal-iters 40 \
+  --normalize-returns --validity-conditional-terminal --solo-box-rung --seed-anchor \
+  --metrics-out metrics-seed0-anchor.jsonl --checkpoint-out ck-seed0-anchor.pt --seed 0
+```
+
+The `pair-anchored` rung pre-parks 1 object and drives 1, so its `valid_placed` **floor is
+~0.5** (sit still with the anchor → a valid 1-object layout). The **win condition** is the
+rung *lifting above 0.5* toward 0.9 — i.e. the agent learning to place object 2 *given* object
+1 — and ideally that competency transferring so the downstream empty-start `pair-box` lifts off
+its place-nothing pole too. **If pair-anchored cannot exceed its 0.5 floor**, a valid start
+alone is insufficient and the next lever is the full k=2→1→0 anneal (more scaffolding) or a
+pose-curriculum. Read `valid_placed`, not `valid_rate`. The witness is
+`tests/fixtures/ml/witness_box.yaml` (a committed valid 2-object box layout; every k-prefix is
+validated by `tests/ml/test_stage_builder.py::test_witness_box_*`).
 
 ## Design
 See `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`

--- a/ml/README.md
+++ b/ml/README.md
@@ -165,8 +165,9 @@ master by competency (single-object whole-fleet transfer works), but `pair-box` 
 normalizer is load-bearing, not the blocker — the residual is genuine joint discovery). That
 result satisfied the documented trigger for **#712 (`--seed-anchor` start-state graft)**, now
 wired: pre-park a k-prefix of a committed witness layout (a k-prefix of a valid layout is
-provably valid, so no runtime solver), drive the remaining N−k in, anneal k→0. See the
-pair-anchored gate recipe below.
+provably valid, so no runtime solver) and drive the remaining N−k in. Step 1 ships a single
+k=1 rung (`pair-anchored`); later rungs can anneal k→0. See the pair-anchored gate recipe
+below.
 
 ### Box-rung mastery gate recipe (#714 re-gate)
 
@@ -206,11 +207,14 @@ python -u -m ml.train --schedule curriculum --device cuda --n-envs 16 \
   --metrics-out metrics-seed0-anchor.jsonl --checkpoint-out ck-seed0-anchor.pt --seed 0
 ```
 
-The `pair-anchored` rung pre-parks 1 object and drives 1, so its `valid_placed` **floor is
-~0.5** (sit still with the anchor → a valid 1-object layout). The **win condition** is the
-rung *lifting above 0.5* toward 0.9 — i.e. the agent learning to place object 2 *given* object
-1 — and ideally that competency transferring so the downstream empty-start `pair-box` lifts off
-its place-nothing pole too. **If pair-anchored cannot exceed its 0.5 floor**, a valid start
+The `pair-anchored` rung pre-parks 1 object and drives 1. An agent that **keeps the valid
+1-object partial** (parks nothing, or parks object 2 validly) scores `valid_placed ≥ ~0.5`
+(the anchor is a valid 1-object layout, counted in the denominator); committing object 2
+*invalidly* still scores 0 for that episode, so the rung average only settles at ~0.5 once the
+place-nothing behavior dominates. The **win condition** is the rung average *lifting above 0.5*
+toward 0.9 — i.e. the agent learning to place object 2 *validly given* object 1 — and ideally
+that competency transferring so the downstream empty-start `pair-box` lifts off its
+place-nothing pole too. **If pair-anchored cannot exceed its 0.5 floor**, a valid start
 alone is insufficient and the next lever is the full k=2→1→0 anneal (more scaffolding) or a
 pose-curriculum. Read `valid_placed`, not `valid_rate`. The witness is
 `tests/fixtures/ml/witness_box.yaml` (a committed valid 2-object box layout; every k-prefix is

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -158,10 +158,9 @@ def sample_request(pool: Sequence[str], n: int, rng: random.Random) -> tuple[str
 
 @dataclass(frozen=True, slots=True)
 class Stage:
-    """One rung of the ladder. Holds fleet/hangar as repo-relative PATH STRINGS +
-    scalar overrides — no loading happens here (that is stage_builder.py's job),
-    so this module stays disk-free. DifficultyConfig.seed_anchor is left False;
-    anchored spawning is a later rung, out of 4b scope."""
+    """One rung of the ladder. Holds fleet/hangar (and, for a #712 seed-anchor rung, the
+    witness layout) as repo-relative PATH STRINGS + scalar overrides — no loading happens
+    here (that is stage_builder.py's job), so this module stays disk-free."""
 
     name: str
     difficulty: DifficultyConfig
@@ -172,6 +171,11 @@ class Stage:
     clearance_m: float | None = None  # override on the loaded hangar; None = file value
     wing_layer_clearance_m: float | None = None  # override; None = file value
     apron_depth_m: float = 8.0  # override; gives the env a spawn region (matches 4a)
+    # #712 seed-anchor rung: repo-relative path to a committed witness layout. When set, the
+    # rung's sampling pool IS the witness's objects (Q2) and the env pre-parks a
+    # ``difficulty.seed_anchor_k``-prefix of them at their witness poses. None (default) =>
+    # no anchoring (an empty-start rung) => byte-identical to the pre-#712 ladder.
+    anchor_layout_path: str | None = None
 
     def __post_init__(self) -> None:
         # Disk-free scalar invariants (the disk-needing max_objects <= len(pool) check
@@ -230,6 +234,10 @@ class CurriculumSchedule:
 
 _BOX_HANGAR = "data/hangar.yaml"
 _BOX_FLEET = "data/fleet.yaml"
+# Committed seed-anchor witness for the box rungs (#712). A valid 2-object box layout; the
+# pair-anchored rung pre-parks a k-prefix of it. A dev/CI-only fixture (all of ml/ is
+# dev/CI-only, never shipped), validated by tests/ml/test_stage_builder.py::test_witness_box_*.
+_WITNESS_BOX = "tests/fixtures/ml/witness_box.yaml"
 _NOTCH_HANGAR = "examples/herrenteich/hangar.yaml"
 _NOTCH_FLEET = "examples/herrenteich/fleet.yaml"
 _LENIENT_CLEARANCE = (
@@ -245,6 +253,23 @@ _SOLO_BOX_STAGE = Stage(
     difficulty=DifficultyConfig(max_objects=1, per_object_step_budget=60, total_step_budget=60),
     hangar_path=_BOX_HANGAR,
     fleet_path=_BOX_FLEET,
+    clearance_m=_LENIENT_CLEARANCE,
+)
+
+# Opt-in #712 rung (wired via with_pair_anchored_rung / --seed-anchor), NOT in DEFAULT_LADDER.
+# Two objects, but ONE is pre-parked at a committed-witness pose (seed_anchor_k=1) and the agent
+# only drives the other in — scaffolding 2-object joint discovery with a valid 1-object start
+# before the empty-start pair-box (k=0). The pool IS the witness's objects (anchor_layout_path
+# set => stage_builder pins it), so the per-episode seeded permutation makes k=1 a seeded-random
+# single-object anchor. Only one object is driven, so the budget matches solo-box's 60/60.
+_PAIR_ANCHORED_STAGE = Stage(
+    name="pair-anchored",
+    difficulty=DifficultyConfig(
+        max_objects=2, seed_anchor_k=1, per_object_step_budget=60, total_step_budget=60
+    ),
+    hangar_path=_BOX_HANGAR,
+    fleet_path=_BOX_FLEET,
+    anchor_layout_path=_WITNESS_BOX,
     clearance_m=_LENIENT_CLEARANCE,
 )
 
@@ -311,3 +336,20 @@ def with_solo_box_rung(schedule: CurriculumSchedule) -> CurriculumSchedule:
             "with_solo_box_rung: schedule has no 'trivial' rung to insert after"
         ) from None
     return replace(schedule, stages=stages[:after] + (_SOLO_BOX_STAGE,) + stages[after:])
+
+
+def with_pair_anchored_rung(schedule: CurriculumSchedule) -> CurriculumSchedule:
+    """Return ``schedule`` with the opt-in ``pair-anchored`` rung inserted immediately BEFORE
+    the ``pair-box`` rung — the #712 ``--seed-anchor`` lever. pair-anchored pre-parks 1 of its
+    2 objects at a committed-witness pose (k=1) and the agent drives the other in, so 2-object
+    joint discovery is scaffolded by a valid 1-object start before the empty-start pair-box
+    (k=0). Only the ladder changes (the promotion policy is preserved). The default ladder is
+    left untouched, so default runs stay byte-identical (this is opt-in)."""
+    stages = schedule.stages
+    try:
+        before = next(i for i, s in enumerate(stages) if s.name == "pair-box")
+    except StopIteration:
+        raise ValueError(
+            "with_pair_anchored_rung: schedule has no 'pair-box' rung to insert before"
+        ) from None
+    return replace(schedule, stages=stages[:before] + (_PAIR_ANCHORED_STAGE,) + stages[before:])

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -203,6 +203,16 @@ def validate_ladder(ladder: Sequence[Stage], *, encoder_max_objects: int) -> Non
             raise ValueError(
                 f"stage {s.name!r}: max_objects {n} exceeds encoder capacity {encoder_max_objects}"
             )
+        # #712 seed-anchor: catch a misconfigured anchored rung here (the pre-flight gate)
+        # rather than lazily at the first env reset, deep inside the training loop.
+        k = s.difficulty.seed_anchor_k
+        if k < 0:
+            raise ValueError(f"stage {s.name!r}: seed_anchor_k must be >= 0, got {k}")
+        if k >= n:
+            raise ValueError(
+                f"stage {s.name!r}: seed_anchor_k {k} must be < max_objects {n} "
+                f"(at least one object must be left to drive in)"
+            )
 
 
 @dataclass(slots=True)

--- a/ml/env.py
+++ b/ml/env.py
@@ -50,6 +50,13 @@ class HangarFitEnv:
         # valid witness layout is provably valid). Empty by default => the anchor mechanism is
         # inert (k stays 0) and reset is byte-identical to the empty-start env.
         self._anchor_by_id: dict[str, Placement] = {p.plane_id: p for p in anchor_placements}
+        if len(self._anchor_by_id) != len(anchor_placements):
+            ids = [p.plane_id for p in anchor_placements]
+            dupes = sorted({i for i in ids if ids.count(i) > 1})
+            raise ValueError(
+                f"anchor_placements has duplicate object ids {dupes} (each anchored id needs "
+                f"exactly one witness pose, else the anchor map desyncs from the pool)"
+            )
         self.difficulty = difficulty or DifficultyConfig()
         self.weights = weights or RewardWeights()
         self._reset_state()
@@ -65,10 +72,10 @@ class HangarFitEnv:
         # seeded-random k-subset" (#712 Q1). k=0 => _parked empty, _queue full => byte-identical.
         k = self.difficulty.seed_anchor_k
         if k:
-            if k >= len(requested):
+            if k < 0 or k >= len(requested):
                 raise ValueError(
-                    f"seed_anchor_k={k} must be < the requested set size {len(requested)} "
-                    f"(at least one object must be left to drive in)"
+                    f"seed_anchor_k={k} must satisfy 0 <= k < the requested set size "
+                    f"{len(requested)} (at least one object must be left to drive in)"
                 )
             missing = [i for i in requested[:k] if i not in self._anchor_by_id]
             if missing:

--- a/ml/env.py
+++ b/ml/env.py
@@ -32,6 +32,7 @@ class HangarFitEnv:
         requested_ids: tuple[str, ...],
         ground_objects: Mapping[str, GroundObject] | None = None,
         fixed_placements: tuple[Placement, ...] = (),
+        anchor_placements: tuple[Placement, ...] = (),
         difficulty: DifficultyConfig | None = None,
         weights: RewardWeights | None = None,
     ) -> None:
@@ -44,14 +45,39 @@ class HangarFitEnv:
         # denominator stays the requested/driven set). Set here (scenario-level) rather
         # than in ``_reset_state`` so it survives ``reset()``.
         self._fixed: list[Placement] = list(fixed_placements)
+        # #712 seed-anchor witness poses, keyed by object id. At reset, the first
+        # ``difficulty.seed_anchor_k`` requested objects are pre-parked here (a k-prefix of a
+        # valid witness layout is provably valid). Empty by default => the anchor mechanism is
+        # inert (k stays 0) and reset is byte-identical to the empty-start env.
+        self._anchor_by_id: dict[str, Placement] = {p.plane_id: p for p in anchor_placements}
         self.difficulty = difficulty or DifficultyConfig()
         self.weights = weights or RewardWeights()
         self._reset_state()
 
     def _reset_state(self) -> None:
         n = self.difficulty.max_objects
-        self._queue: list[str] = list(self.requested_ids if n is None else self.requested_ids[:n])
-        self._parked: list[Placement] = []
+        requested = list(self.requested_ids if n is None else self.requested_ids[:n])
+        # #712 seed-anchor: pre-park the first ``k`` requested objects at their committed-witness
+        # poses and drive only the remaining N-k. A k-prefix of a valid witness layout is provably
+        # valid (removing objects cannot create overlap/intrusion/egress conflicts), so the partial
+        # start is collision-free with NO runtime search. The per-episode request order is a fresh
+        # seeded permutation (curriculum sample_request), so "anchor the prefix" == "anchor a
+        # seeded-random k-subset" (#712 Q1). k=0 => _parked empty, _queue full => byte-identical.
+        k = self.difficulty.seed_anchor_k
+        if k:
+            if k >= len(requested):
+                raise ValueError(
+                    f"seed_anchor_k={k} must be < the requested set size {len(requested)} "
+                    f"(at least one object must be left to drive in)"
+                )
+            missing = [i for i in requested[:k] if i not in self._anchor_by_id]
+            if missing:
+                raise ValueError(
+                    f"seed_anchor_k={k} but no witness pose for anchored ids {missing} "
+                    f"(known witness ids: {sorted(self._anchor_by_id)})"
+                )
+        self._parked: list[Placement] = [self._anchor_by_id[i] for i in requested[:k]]
+        self._queue: list[str] = requested[k:]
         self._parked_version = 0
         self._score_cache: tuple[int, go.LayoutScore] | None = None
         self._obstacles_cache: tuple[int, str, go.ObstaclesT] | None = None

--- a/ml/stage_builder.py
+++ b/ml/stage_builder.py
@@ -29,7 +29,12 @@ def witness_placements(stage: Stage) -> tuple[Placement, ...]:
     fleet = load_fleet(str(_ROOT / stage.fleet_path))
     hangar = load_hangar(str(_ROOT / stage.hangar_path), fleet=fleet)
     layout = load_layout(str(_ROOT / stage.anchor_layout_path), fleet=fleet, hangar=hangar)
-    return layout.placements + (layout.ground_object_placements or ())
+    # NOTE: anchor poses are taken from the witness VERBATIM (incl. ``on_carts``), then frozen
+    # into ``_parked``. The committed box witness is taildraggers (``on_carts=False``, matching
+    # both the loader default and ``env._on_carts``). A future witness anchoring an
+    # ``always_cart``/towed body must author ``on_carts: true`` so the anchored pose is scored
+    # identically to how the env flags that body when it is driven+parked.
+    return layout.placements + layout.ground_object_placements
 
 
 def effective_fleet_ids(stage: Stage) -> tuple[str, ...]:
@@ -75,6 +80,13 @@ def build_stage_env(stage: Stage, *, weights: RewardWeights | None = None) -> Ha
     if n > len(pool):
         raise ValueError(
             f"stage {stage.name!r}: max_objects {n} exceeds fleet pool size {len(pool)}"
+        )
+    if stage.anchor_layout_path is not None and n != len(pool):
+        # The anchored pool IS the witness set (Q2), so max_objects must equal the witness
+        # object count — else the rung silently drives a truncated subset of the witness.
+        raise ValueError(
+            f"stage {stage.name!r}: anchored rung max_objects {n} must equal its witness "
+            f"object count {len(pool)} (the pool is pinned to the witness set)"
         )
     return HangarFitEnv(
         hangar=hangar,

--- a/ml/stage_builder.py
+++ b/ml/stage_builder.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from dataclasses import replace
 from pathlib import Path
 
-from hangarfit.loader import load_fleet, load_hangar
+from hangarfit.loader import load_fleet, load_hangar, load_layout
+from hangarfit.models import Placement
 from ml.curriculum import Stage
 from ml.env import HangarFitEnv
 from ml.types import RewardWeights
@@ -15,11 +16,31 @@ from ml.types import RewardWeights
 _ROOT = Path(__file__).resolve().parent.parent  # repo root (ml/ sits at the root)
 
 
+def witness_placements(stage: Stage) -> tuple[Placement, ...]:
+    """Load an anchored rung's committed witness layout and return its placements (aircraft
+    + any ground objects). The poses are hangar-independent, so this loads against the rung's
+    own hangar/fleet purely to PARSE the YAML (load_layout validates id references but not
+    geometry — the witness's validity is pinned by tests/ml/test_stage_builder.py). Raises if
+    ``stage.anchor_layout_path`` is None (call only for an anchored rung)."""
+    if stage.anchor_layout_path is None:
+        raise ValueError(
+            f"stage {stage.name!r}: witness_placements called but anchor_layout_path is None"
+        )
+    fleet = load_fleet(str(_ROOT / stage.fleet_path))
+    hangar = load_hangar(str(_ROOT / stage.hangar_path), fleet=fleet)
+    layout = load_layout(str(_ROOT / stage.anchor_layout_path), fleet=fleet, hangar=hangar)
+    return layout.placements + (layout.ground_object_placements or ())
+
+
 def effective_fleet_ids(stage: Stage) -> tuple[str, ...]:
-    """The stage's sampling pool: its explicit ``fleet_ids`` if set, else the keys of
-    ``load_fleet(stage.fleet_path)`` (aircraft only — a manifest's ground_objects load
-    via a separate path and are never returned by load_fleet). The ONLY disk touch in
-    the sampling chain; resolved once per rung by train_curriculum."""
+    """The stage's sampling pool. For a #712 anchored rung it is EXACTLY the witness's objects
+    (Q2 — requested_ids pinned to the witness set, so every episode's seeded permutation draws
+    the same N ids and the env anchors a k-prefix of them). Otherwise: the explicit
+    ``fleet_ids`` if set, else the keys of ``load_fleet(stage.fleet_path)`` (aircraft only — a
+    manifest's ground_objects load via a separate path and are never returned by load_fleet).
+    The ONLY disk touch in the sampling chain; resolved once per rung by train_curriculum."""
+    if stage.anchor_layout_path is not None:
+        return tuple(p.plane_id for p in witness_placements(stage))
     if stage.fleet_ids is not None:
         return stage.fleet_ids
     return tuple(load_fleet(str(_ROOT / stage.fleet_path)).keys())
@@ -42,7 +63,14 @@ def build_stage_env(stage: Stage, *, weights: RewardWeights | None = None) -> Ha
     hangar = replace(hangar, **overrides)
 
     fleet = load_fleet(str(_ROOT / stage.fleet_path))
-    pool = effective_fleet_ids(stage)
+    # #712 anchored rung: load the witness once and derive BOTH the pool (its object ids) and
+    # the env's anchor poses from it (single source of truth). Else: no anchoring.
+    if stage.anchor_layout_path is not None:
+        anchors = witness_placements(stage)
+        pool: tuple[str, ...] = tuple(p.plane_id for p in anchors)
+    else:
+        anchors = ()
+        pool = effective_fleet_ids(stage)
     n = stage.difficulty.max_objects if stage.difficulty.max_objects is not None else len(pool)
     if n > len(pool):
         raise ValueError(
@@ -52,6 +80,7 @@ def build_stage_env(stage: Stage, *, weights: RewardWeights | None = None) -> Ha
         hangar=hangar,
         fleet=fleet,
         requested_ids=tuple(pool[:n]),
+        anchor_placements=anchors,
         difficulty=stage.difficulty,
         weights=weights,
     )

--- a/ml/train.py
+++ b/ml/train.py
@@ -34,6 +34,7 @@ from ml.curriculum import (
     should_promote,
     stage_rng,
     validate_ladder,
+    with_pair_anchored_rung,
     with_promotion_overrides,
     with_solo_box_rung,
 )
@@ -592,6 +593,13 @@ def build_argparser() -> argparse.ArgumentParser:
         "trivial, so single-object competency transfers before the 2-object jump",
     )
     p.add_argument(
+        "--seed-anchor",
+        action="store_true",
+        help="curriculum: insert the opt-in #712 'pair-anchored' rung before pair-box (1 object "
+        "pre-parked at a committed-witness pose, the other driven in), scaffolding 2-object "
+        "joint discovery before the empty-start pair-box",
+    )
+    p.add_argument(
         "--r-valid-park",
         type=float,
         default=0.0,
@@ -703,6 +711,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             parser.error("--load/--checkpoint-out require --schedule curriculum")
         if args.solo_box_rung:
             parser.error("--solo-box-rung requires --schedule curriculum")
+        if args.seed_anchor:
+            parser.error("--seed-anchor requires --schedule curriculum")
         train(
             seed=args.seed,
             iterations=args.iterations,
@@ -728,6 +738,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         )
         if args.solo_box_rung:
             sched = with_solo_box_rung(sched)
+        if args.seed_anchor:
+            sched = with_pair_anchored_rung(sched)
         history = train_curriculum(
             seed=args.seed,
             schedule=sched,

--- a/ml/types.py
+++ b/ml/types.py
@@ -81,7 +81,12 @@ class DifficultyConfig:
     max_objects: int | None = None  # cap the requested set size (None = all)
     per_object_step_budget: int = 60  # primitives before an object is "unplaceable"
     total_step_budget: int = 600  # global per-episode primitive cap
-    seed_anchor: bool = False  # spawn near a known-valid anchor (curriculum, NOT BC)
+    # #712 seed-anchor start-state graft: pre-park the first ``seed_anchor_k`` requested
+    # objects at their committed-witness poses (a k-prefix of a valid witness layout is
+    # provably valid), drive the remaining N-k in, anneal k->0 across the curriculum. 0 =>
+    # no anchored objects => byte-identical to the empty-start env. The env reads the witness
+    # poses from its ``anchor_placements`` (threaded by stage_builder from the rung's witness).
+    seed_anchor_k: int = 0
 
 
 @dataclass(frozen=True, slots=True)

--- a/ml/types.py
+++ b/ml/types.py
@@ -83,9 +83,10 @@ class DifficultyConfig:
     total_step_budget: int = 600  # global per-episode primitive cap
     # #712 seed-anchor start-state graft: pre-park the first ``seed_anchor_k`` requested
     # objects at their committed-witness poses (a k-prefix of a valid witness layout is
-    # provably valid), drive the remaining N-k in, anneal k->0 across the curriculum. 0 =>
-    # no anchored objects => byte-identical to the empty-start env. The env reads the witness
-    # poses from its ``anchor_placements`` (threaded by stage_builder from the rung's witness).
+    # provably valid), drive the remaining N-k in. (Step 1 wires a single k=1 rung; later
+    # rungs can anneal k->0 across the curriculum.) 0 => no anchored objects => byte-identical
+    # to the empty-start env. The env reads the witness poses from its ``anchor_placements``
+    # (threaded by stage_builder from the rung's witness).
     seed_anchor_k: int = 0
 
 

--- a/tests/fixtures/ml/witness_box.yaml
+++ b/tests/fixtures/ml/witness_box.yaml
@@ -1,0 +1,17 @@
+# Committed seed-anchor witness for the #712 box rung (pair-anchored).
+#
+# A VALID 2-object layout on the synthetic box hangar (data/hangar.yaml). The seed-anchor
+# curriculum graft (#712) pre-parks a k-prefix of this layout at reset and drives the rest
+# in, annealing k->0. Correctness rests on one property: a k-prefix of a valid layout is
+# itself valid, so any anchored subset is a guaranteed-valid partial start with NO runtime
+# solver / search call.
+#
+# No `fleet:` / `hangar:` fields on purpose: the env + stage_builder load this with
+# fleet=/hangar= OVERRIDES (the rung's box fleet + box hangar at clearance 0.05), and the
+# loader rejects a file that sets those AND takes overrides. Poses were found offline and are
+# validated by the PRODUCT checker (collisions.check + Caddy egress) at the rung's 0.05 m
+# clearance — and at the strict 0.3 m clearance for margin — by tests/ml/test_stage_builder.py
+# (test_witness_box_*). Do not hand-edit the poses without re-running those tests.
+placements:
+  - {plane: fuji, x_m: 5.5, y_m: 8.0, heading_deg: 0.0}
+  - {plane: aviat_husky, x_m: 16.5, y_m: 8.0, heading_deg: 0.0}

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -18,6 +18,7 @@ from ml.curriculum import (
     should_promote,
     stage_rng,
     validate_ladder,
+    with_pair_anchored_rung,
     with_promotion_overrides,
     with_solo_box_rung,
 )
@@ -364,3 +365,71 @@ def test_with_solo_box_rung_raises_without_trivial_rung():
     )
     with pytest.raises(ValueError, match="trivial"):
         with_solo_box_rung(no_trivial)
+
+
+# ---------------------------------------------------------------------------
+# #712 — seed-anchor start-state curriculum graft: DifficultyConfig.seed_anchor_k
+# ---------------------------------------------------------------------------
+
+
+def test_difficulty_config_seed_anchor_k_defaults_zero():
+    # #712: replaces the unwired seed_anchor:bool stub. 0 => no anchored objects
+    # => byte-identical to the pre-#712 env reset.
+    assert DifficultyConfig().seed_anchor_k == 0
+
+
+def test_difficulty_config_seed_anchor_k_is_settable():
+    assert DifficultyConfig(seed_anchor_k=1).seed_anchor_k == 1
+    assert DifficultyConfig(seed_anchor_k=2).seed_anchor_k == 2
+
+
+# ---------------------------------------------------------------------------
+# #712 — the opt-in 'pair-anchored' rung (--seed-anchor)
+# ---------------------------------------------------------------------------
+
+
+def test_default_ladder_has_no_pair_anchored_rung():
+    # Byte-identity guard: pair-anchored is opt-in; the default ladder is unchanged.
+    assert all(s.name != "pair-anchored" for s in DEFAULT_LADDER)
+
+
+def test_with_pair_anchored_rung_inserts_before_pair_box():
+    sched = with_pair_anchored_rung(CurriculumSchedule.default())
+    names = [s.name for s in sched.stages]
+    assert names[:3] == ["trivial", "pair-anchored", "pair-box"]
+
+
+def test_pair_anchored_rung_is_two_object_k1_with_a_witness():
+    sched = with_pair_anchored_rung(CurriculumSchedule.default())
+    rung = next(s for s in sched.stages if s.name == "pair-anchored")
+    assert rung.difficulty.max_objects == 2  # two objects in the set...
+    assert rung.difficulty.seed_anchor_k == 1  # ...one pre-parked, one driven in
+    assert rung.anchor_layout_path is not None  # the committed witness layout
+
+
+def test_with_pair_anchored_rung_preserves_policy_and_validates():
+    base = CurriculumSchedule.default()
+    sched = with_pair_anchored_rung(base)
+    assert sched.policy == base.policy  # only the ladder changes, not the promotion gate
+    validate_ladder(sched.stages, encoder_max_objects=EncoderConfig().max_objects)  # no raise
+
+
+def test_with_pair_anchored_rung_does_not_mutate_the_default_ladder():
+    with_pair_anchored_rung(CurriculumSchedule.default())
+    assert all(s.name != "pair-anchored" for s in DEFAULT_LADDER)  # default still pristine
+
+
+def test_with_pair_anchored_rung_raises_without_pair_box():
+    no_pair_box = CurriculumSchedule(
+        stages=tuple(s for s in DEFAULT_LADDER if s.name != "pair-box"),
+        policy=PromotionPolicy(),
+    )
+    with pytest.raises(ValueError, match="pair-box"):
+        with_pair_anchored_rung(no_pair_box)
+
+
+def test_seed_anchor_composes_with_solo_box_rung():
+    # The two opt-in levers stack: solo-box after trivial, pair-anchored before pair-box.
+    sched = with_pair_anchored_rung(with_solo_box_rung(CurriculumSchedule.default()))
+    names = [s.name for s in sched.stages]
+    assert names[:4] == ["trivial", "solo-box", "pair-anchored", "pair-box"]

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -433,3 +433,30 @@ def test_seed_anchor_composes_with_solo_box_rung():
     sched = with_pair_anchored_rung(with_solo_box_rung(CurriculumSchedule.default()))
     names = [s.name for s in sched.stages]
     assert names[:4] == ["trivial", "solo-box", "pair-anchored", "pair-box"]
+
+
+def _anchored_test_stage(*, max_objects: int, seed_anchor_k: int) -> Stage:
+    return Stage(
+        name="bad",
+        difficulty=DifficultyConfig(max_objects=max_objects, seed_anchor_k=seed_anchor_k),
+        hangar_path="data/hangar.yaml",
+        fleet_path="data/fleet.yaml",
+    )
+
+
+def test_validate_ladder_rejects_negative_seed_anchor_k():
+    bad = (_anchored_test_stage(max_objects=2, seed_anchor_k=-1),)
+    with pytest.raises(ValueError, match="seed_anchor_k"):
+        validate_ladder(bad, encoder_max_objects=EncoderConfig().max_objects)
+
+
+def test_validate_ladder_rejects_seed_anchor_k_ge_max_objects():
+    # k must leave >=1 object to drive; a pre-flight catch (not a mid-training reset failure).
+    bad = (_anchored_test_stage(max_objects=2, seed_anchor_k=2),)
+    with pytest.raises(ValueError, match="seed_anchor_k"):
+        validate_ladder(bad, encoder_max_objects=EncoderConfig().max_objects)
+
+
+def test_validate_ladder_accepts_valid_seed_anchor_k():
+    ok = (_anchored_test_stage(max_objects=2, seed_anchor_k=1),)
+    validate_ladder(ok, encoder_max_objects=EncoderConfig().max_objects)  # no raise

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -580,3 +580,88 @@ def test_validity_conditional_terminal_multiobject_full_invalid_park_drops_credi
     on_r, on_i, _ = run(validity_conditional=True)
     assert off_i.valid is False and on_i.valid is False  # overlapping pile -> invalid
     assert off_r - on_r == pytest.approx(w.r_terminal + w.r_unplaced_penalty)
+
+
+# ---------------------------------------------------------------------------
+# #712 — seed-anchor start-state graft: env pre-parks the requested PREFIX at
+# committed-witness poses and drives only the remaining N-k objects.
+# ---------------------------------------------------------------------------
+_WITNESS_ANCHORS = (
+    Placement(plane_id="fuji", x_m=5.0, y_m=8.0, heading_deg=0.0, on_carts=False),
+    Placement(plane_id="aviat_husky", x_m=16.0, y_m=8.0, heading_deg=0.0, on_carts=False),
+)
+
+
+def _anchor_env(seed_anchor_k):
+    return HangarFitEnv(
+        hangar=empty_hangar(),
+        fleet=_fuji(),
+        requested_ids=("fuji", "aviat_husky"),
+        anchor_placements=_WITNESS_ANCHORS,
+        difficulty=DifficultyConfig(
+            max_objects=2,
+            seed_anchor_k=seed_anchor_k,
+            per_object_step_budget=60,
+            total_step_budget=60,
+        ),
+    )
+
+
+def test_seed_anchor_pre_parks_prefix_and_drives_the_rest():
+    env = _anchor_env(seed_anchor_k=1)
+    obs = env.reset(requested_ids=("fuji", "aviat_husky"))
+    # the prefix object (fuji) is pre-parked at its committed-witness pose...
+    assert [p.plane_id for p in env._parked] == ["fuji"]
+    assert env._parked[0] == _WITNESS_ANCHORS[0]
+    # ...and the remaining object (aviat_husky) is the one driven in this episode.
+    assert env._active_id == "aviat_husky"
+    assert env._queue == []  # husky was the only queued id; _spawn popped it
+    assert obs.active is not None and obs.active.object_id == "aviat_husky"
+    assert [pk.object_id for pk in obs.parked] == ["fuji"]
+
+
+def test_seed_anchor_subset_follows_request_order():
+    # The anchored subset is the request PREFIX, so a different request order anchors a
+    # different object -> "anchor the prefix" composes with the curriculum's seeded
+    # per-episode permutation into a seeded-random k-subset (#712 Q1).
+    env = _anchor_env(seed_anchor_k=1)
+    env.reset(requested_ids=("aviat_husky", "fuji"))
+    assert [p.plane_id for p in env._parked] == ["aviat_husky"]
+    assert env._active_id == "fuji"
+
+
+def test_seed_anchor_k_zero_reset_is_byte_identical_to_no_anchor():
+    # k=0 with anchors supplied must reproduce the no-anchor reset exactly (default-neutral:
+    # the #712 lever is inert until a rung sets seed_anchor_k>0).
+    anchored = _anchor_env(seed_anchor_k=0)
+    plain = HangarFitEnv(
+        hangar=empty_hangar(),
+        fleet=_fuji(),
+        requested_ids=("fuji", "aviat_husky"),
+        difficulty=DifficultyConfig(max_objects=2, per_object_step_budget=60, total_step_budget=60),
+    )
+    obs_a = anchored.reset(requested_ids=("fuji", "aviat_husky"))
+    obs_p = plain.reset(requested_ids=("fuji", "aviat_husky"))
+    assert anchored._parked == [] == plain._parked
+    assert anchored._queue == plain._queue
+    assert obs_a == obs_p
+
+
+def test_seed_anchor_terminal_fraction_counts_anchored_objects():
+    # Anchors live in _parked (counted in the denominator N), so parking the one driven
+    # object completes the set: placed==total==2 (#712 denominator semantics).
+    env = _anchor_env(seed_anchor_k=1)
+    env.reset(requested_ids=("fuji", "aviat_husky"))
+    for _ in range(20):
+        if env._active_pose is not None and env._active_pose.y_m >= 1.0:
+            break
+        env.step(Primitive(kind="S", magnitude=1.0, gear=1))
+    _, _, done, info = env.step(Park())
+    assert done is True
+    assert info.placed == 2 and info.total == 2
+
+
+def test_seed_anchor_rejects_k_not_less_than_requested():
+    # k must leave at least one object to drive; k>=N is a misconfigured rung -> loud error.
+    with pytest.raises(ValueError, match="seed_anchor_k"):
+        _anchor_env(seed_anchor_k=2)

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -656,6 +656,9 @@ def test_seed_anchor_terminal_fraction_counts_anchored_objects():
         if env._active_pose is not None and env._active_pose.y_m >= 1.0:
             break
         env.step(Primitive(kind="S", magnitude=1.0, gear=1))
+    # Guard the premise: the driven object actually advanced inside before we Park (so this
+    # tests "drove in + parked", not an accidental park-from-the-apron if primitives rescale).
+    assert env._active_pose is not None and env._active_pose.y_m >= 1.0
     _, _, done, info = env.step(Park())
     assert done is True
     assert info.placed == 2 and info.total == 2
@@ -665,3 +668,41 @@ def test_seed_anchor_rejects_k_not_less_than_requested():
     # k must leave at least one object to drive; k>=N is a misconfigured rung -> loud error.
     with pytest.raises(ValueError, match="seed_anchor_k"):
         _anchor_env(seed_anchor_k=2)
+
+
+def test_seed_anchor_rejects_negative_k():
+    # A negative k must fail loud, NOT silently slice requested[:k] (anchor all-but-|k|).
+    with pytest.raises(ValueError, match="seed_anchor_k"):
+        _anchor_env(seed_anchor_k=-1)
+
+
+def test_seed_anchor_rejects_duplicate_witness_ids():
+    # Two placements with the same id would silently overwrite in _anchor_by_id, desyncing the
+    # anchor map from the pool -> loud error instead.
+    dupes = (
+        Placement(plane_id="fuji", x_m=5.0, y_m=8.0, heading_deg=0.0, on_carts=False),
+        Placement(plane_id="fuji", x_m=10.0, y_m=8.0, heading_deg=0.0, on_carts=False),
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        HangarFitEnv(
+            hangar=empty_hangar(),
+            fleet=_fuji(),
+            requested_ids=("fuji", "aviat_husky"),
+            anchor_placements=dupes,
+            difficulty=DifficultyConfig(max_objects=2, seed_anchor_k=1),
+        )
+
+
+def test_seed_anchor_rejects_requested_prefix_without_a_witness_pose():
+    # If the anchored prefix references an id with no witness pose, fail loud (covers the
+    # env.py "no witness pose for anchored ids" branch) rather than KeyError.
+    env = HangarFitEnv(
+        hangar=empty_hangar(),
+        fleet=_fuji(),
+        requested_ids=("fuji", "aviat_husky"),
+        anchor_placements=(_WITNESS_ANCHORS[0],),  # only fuji has a witness pose
+        difficulty=DifficultyConfig(max_objects=2, seed_anchor_k=1),
+    )
+    # Request husky FIRST: the k=1 prefix is now husky, which has no witness pose.
+    with pytest.raises(ValueError, match="no witness pose"):
+        env.reset(requested_ids=("aviat_husky", "fuji"))

--- a/tests/ml/test_stage_builder.py
+++ b/tests/ml/test_stage_builder.py
@@ -194,6 +194,21 @@ def test_build_stage_env_without_anchor_layout_has_empty_anchor_map():
     assert env._anchor_by_id == {}
 
 
+def test_build_stage_env_anchored_requires_max_objects_equals_witness():
+    # An anchored rung pins its pool to the witness set, so max_objects must equal the witness
+    # object count — else the rung silently trains a truncated objective. Fail loud.
+    s = Stage(
+        name="mismatch",
+        difficulty=DifficultyConfig(max_objects=1),  # the box witness has 2 objects
+        hangar_path="data/hangar.yaml",
+        fleet_path="data/fleet.yaml",
+        anchor_layout_path=_WITNESS_BOX,
+        clearance_m=0.05,
+    )
+    with pytest.raises(ValueError, match="witness"):
+        build_stage_env(s)
+
+
 def test_committed_pair_anchored_rung_builds_and_resets_from_a_valid_partial():
     # End-to-end on the REAL rung: the committed pair-anchored rung's witness path resolves
     # and its env starts from a valid 1-object partial. Catches drift between the rung's
@@ -205,3 +220,28 @@ def test_committed_pair_anchored_rung_builds_and_resets_from_a_valid_partial():
     env.reset(requested_ids=env.requested_ids)
     assert len(env._parked) == 1  # k=1 prefix pre-parked
     assert env._layout_valid()  # the partial start is collision-free
+
+
+def test_anchored_subset_varies_across_episodes_and_is_reproducible():
+    # The seeded-random k-subset claim, end-to-end: driving the env through the curriculum's
+    # seeded per-episode sampler, the ANCHORED object varies episode-to-episode (it is not
+    # pinned to one object) AND the sequence is reproducible for a fixed seed.
+    from ml.curriculum import sample_request, stage_rng
+
+    sched = with_pair_anchored_rung(CurriculumSchedule.default())
+    rung = next(s for s in sched.stages if s.name == "pair-anchored")
+    env = build_stage_env(rung)
+    pool = effective_fleet_ids(rung)
+    n = len(pool)  # anchored rung: max_objects == witness object count (enforced in build)
+
+    def anchored_object_sequence(seed: int) -> list[str]:
+        rng = stage_rng(seed, 0)
+        seq = []
+        for _ in range(12):
+            env.reset(requested_ids=sample_request(pool, n, rng))
+            seq.append(env._parked[0].plane_id)
+        return seq
+
+    seq = anchored_object_sequence(0)
+    assert len(set(seq)) > 1, "the anchored object should vary across episodes (random k-subset)"
+    assert seq == anchored_object_sequence(0), "the anchored sequence must be seed-reproducible"

--- a/tests/ml/test_stage_builder.py
+++ b/tests/ml/test_stage_builder.py
@@ -3,11 +3,27 @@ runs in the no-torch CI."""
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 
-from ml.curriculum import DEFAULT_LADDER, Stage
+from hangarfit.loader import load_fleet, load_hangar, load_layout
+from ml import geometry_oracle as go
+from ml.curriculum import DEFAULT_LADDER, CurriculumSchedule, Stage, with_pair_anchored_rung
 from ml.stage_builder import build_stage_env, effective_fleet_ids
 from ml.types import DifficultyConfig
+
+_WITNESS_BOX = "tests/fixtures/ml/witness_box.yaml"
+
+
+def _load_witness_box(clearance_m: float = 0.05):
+    """Load the committed box witness layout against the box rung's hangar (clearance
+    override) + fleet — the same hangar/fleet the pair-anchored rung trains on."""
+    hangar = dataclasses.replace(
+        load_hangar("data/hangar.yaml"), clearance_m=clearance_m, apron_depth_m=8.0
+    )
+    fleet = load_fleet("data/fleet.yaml")
+    return load_layout(_WITNESS_BOX, fleet=fleet, hangar=hangar)
 
 
 def test_effective_fleet_ids_returns_explicit_pool_verbatim():
@@ -93,3 +109,99 @@ def test_build_stage_env_every_default_rung_constructs():
     for s in DEFAULT_LADDER:
         env = build_stage_env(s)
         assert len(env.requested_ids) == s.difficulty.max_objects
+
+
+# ---------------------------------------------------------------------------
+# #712 — the committed box witness layout (seed-anchor start-state graft)
+# ---------------------------------------------------------------------------
+
+
+def test_witness_box_is_a_valid_two_object_layout():
+    # The committed witness is a valid N-object layout under the box rung's clearance
+    # (0.05) — validated by the PRODUCT checker (collisions.check + Caddy egress), no solver.
+    lay = _load_witness_box()
+    assert len(lay.placements) == 2
+    assert go.layout_valid(lay)
+
+
+def test_witness_box_every_prefix_is_valid():
+    # The #712 correctness property: a k-prefix of a valid witness is itself valid (removing
+    # objects cannot create overlap/intrusion/egress conflicts), so any anchored subset is a
+    # guaranteed-valid partial start with no per-reset validity search.
+    lay = _load_witness_box()
+    for k in range(len(lay.placements) + 1):
+        prefix = dataclasses.replace(lay, placements=lay.placements[:k])
+        assert go.layout_valid(prefix), f"witness prefix k={k} is invalid"
+
+
+def test_witness_box_has_margin_at_strict_clearance():
+    # Robustness: the witness is valid even at the file's strict 0.3 m clearance, so it has
+    # real geometric margin at the rung's lenient 0.05 m (not a borderline wing-graze).
+    assert go.layout_valid(_load_witness_box(clearance_m=0.3))
+
+
+# ---------------------------------------------------------------------------
+# #712 — stage_builder threads the witness into an anchored rung's env
+# ---------------------------------------------------------------------------
+
+
+def _anchored_stage(k: int = 1) -> Stage:
+    return Stage(
+        name="pair-anchored-test",
+        difficulty=DifficultyConfig(
+            max_objects=2, seed_anchor_k=k, per_object_step_budget=60, total_step_budget=60
+        ),
+        hangar_path="data/hangar.yaml",
+        fleet_path="data/fleet.yaml",
+        anchor_layout_path=_WITNESS_BOX,
+        clearance_m=0.05,
+    )
+
+
+def test_stage_anchor_layout_path_defaults_none():
+    s = Stage(
+        name="x",
+        difficulty=DifficultyConfig(max_objects=1),
+        hangar_path="data/hangar.yaml",
+        fleet_path="data/fleet.yaml",
+    )
+    assert s.anchor_layout_path is None
+
+
+def test_effective_fleet_ids_is_the_witness_set_when_anchored():
+    # Q2: an anchored rung pins the pool to the witness's objects (so each episode's seeded
+    # permutation draws exactly that set and the env anchors a k-prefix of it).
+    assert set(effective_fleet_ids(_anchored_stage())) == {"fuji", "aviat_husky"}
+
+
+def test_build_stage_env_threads_witness_placements_and_k():
+    env = build_stage_env(_anchored_stage(k=1))
+    assert set(env._anchor_by_id) == {"fuji", "aviat_husky"}
+    assert env.difficulty.seed_anchor_k == 1
+    assert set(env.requested_ids) == {"fuji", "aviat_husky"}
+
+
+def test_build_stage_env_anchored_reset_starts_from_a_valid_partial():
+    env = build_stage_env(_anchored_stage(k=1))
+    env.reset(requested_ids=("fuji", "aviat_husky"))
+    assert [p.plane_id for p in env._parked] == ["fuji"]  # k=1 prefix pre-parked
+    assert env._layout_valid()  # the pre-parked partial is collision-free at reset
+
+
+def test_build_stage_env_without_anchor_layout_has_empty_anchor_map():
+    # Default-neutral: a rung with no anchor_layout_path builds an anchor-free env.
+    env = build_stage_env(DEFAULT_LADDER[1])  # pair-box
+    assert env._anchor_by_id == {}
+
+
+def test_committed_pair_anchored_rung_builds_and_resets_from_a_valid_partial():
+    # End-to-end on the REAL rung: the committed pair-anchored rung's witness path resolves
+    # and its env starts from a valid 1-object partial. Catches drift between the rung's
+    # anchor_layout_path and the witness fixture.
+    sched = with_pair_anchored_rung(CurriculumSchedule.default())
+    rung = next(s for s in sched.stages if s.name == "pair-anchored")
+    env = build_stage_env(rung)
+    assert set(env._anchor_by_id) == set(env.requested_ids)
+    env.reset(requested_ids=env.requested_ids)
+    assert len(env._parked) == 1  # k=1 prefix pre-parked
+    assert env._layout_valid()  # the partial start is collision-free

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -887,3 +887,81 @@ def test_main_without_solo_box_rung_keeps_default_ladder(monkeypatch):
     monkeypatch.setattr(train_mod, "train_curriculum", fake)
     train_mod.main(["--schedule", "curriculum"])
     assert "solo-box" not in [s.name for s in captured["schedule"].stages]
+
+
+# ---------------------------------------------------------------------------
+# #712 — --seed-anchor CLI wiring (the pair-anchored start-state graft).
+# ---------------------------------------------------------------------------
+
+
+def test_argparser_seed_anchor_defaults_false():
+    assert build_argparser().parse_args([]).seed_anchor is False
+
+
+def test_main_seed_anchor_requires_curriculum_schedule(monkeypatch):
+    # --seed-anchor is a curriculum ladder edit; under --schedule trivial it fails LOUD.
+    import ml.train as train_mod
+
+    ran = {"train": False}
+
+    def guard(**kw):
+        ran["train"] = True
+        return []
+
+    monkeypatch.setattr(train_mod, "train", guard)
+    with pytest.raises(SystemExit):
+        train_mod.main(["--schedule", "trivial", "--seed-anchor"])
+    assert ran["train"] is False
+
+
+def test_main_seed_anchor_inserts_rung_into_schedule(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum", "--seed-anchor"])
+    assert "pair-anchored" in [s.name for s in captured["schedule"].stages]
+
+
+def test_main_without_seed_anchor_keeps_default_ladder(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum"])
+    assert "pair-anchored" not in [s.name for s in captured["schedule"].stages]
+
+
+def test_train_curriculum_trains_an_anchored_rung_end_to_end():
+    # End-to-end smoke: train_curriculum runs an anchored rung without crashing — the witness
+    # pool feeds sample_request, the env pre-parks the k=1 prefix, and collect_rollout +
+    # ppo_update consume the partial-start episodes. Tiny budget for speed.
+    anchored = Stage(
+        name="pair-anchored-smoke",
+        difficulty=DifficultyConfig(
+            max_objects=2, seed_anchor_k=1, per_object_step_budget=30, total_step_budget=30
+        ),
+        hangar_path="data/hangar.yaml",
+        fleet_path="data/fleet.yaml",
+        anchor_layout_path="tests/fixtures/ml/witness_box.yaml",
+        clearance_m=0.05,
+    )
+    sched = CurriculumSchedule(
+        stages=(anchored,),
+        # threshold>1 => never promote by competency => the rung runs its single capped iter.
+        policy=PromotionPolicy(metric="fraction_placed", window=1, threshold=2.0, max_iters=1),
+    )
+    hist = train_curriculum(seed=0, schedule=sched, rollout_len=32)
+    assert any(name == "pair-anchored-smoke" for name, _, _ in hist.iterations)

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -944,12 +944,9 @@ def test_main_without_seed_anchor_keeps_default_ladder(monkeypatch):
     assert "pair-anchored" not in [s.name for s in captured["schedule"].stages]
 
 
-def test_train_curriculum_trains_an_anchored_rung_end_to_end():
-    # End-to-end smoke: train_curriculum runs an anchored rung without crashing — the witness
-    # pool feeds sample_request, the env pre-parks the k=1 prefix, and collect_rollout +
-    # ppo_update consume the partial-start episodes. Tiny budget for speed.
+def _anchored_smoke_schedule(name: str = "pair-anchored-smoke"):
     anchored = Stage(
-        name="pair-anchored-smoke",
+        name=name,
         difficulty=DifficultyConfig(
             max_objects=2, seed_anchor_k=1, per_object_step_budget=30, total_step_budget=30
         ),
@@ -958,10 +955,43 @@ def test_train_curriculum_trains_an_anchored_rung_end_to_end():
         anchor_layout_path="tests/fixtures/ml/witness_box.yaml",
         clearance_m=0.05,
     )
-    sched = CurriculumSchedule(
+    return CurriculumSchedule(
         stages=(anchored,),
         # threshold>1 => never promote by competency => the rung runs its single capped iter.
         policy=PromotionPolicy(metric="fraction_placed", window=1, threshold=2.0, max_iters=1),
     )
-    hist = train_curriculum(seed=0, schedule=sched, rollout_len=32)
+
+
+def test_train_curriculum_trains_an_anchored_rung_end_to_end():
+    # End-to-end: train_curriculum runs an anchored rung — the witness pool feeds sample_request,
+    # the env pre-parks the k=1 prefix, and collect_rollout + ppo_update consume the partial-start
+    # episodes. Every completed episode must report fraction_placed >= 0.5 (the k=1 anchor is
+    # counted in the denominator), which only holds if the anchor was actually pre-parked —
+    # without it a place-nothing episode would be 0/2 = 0.0.
+    hist = train_curriculum(seed=0, schedule=_anchored_smoke_schedule(), rollout_len=32)
+    eps = [s for _, _, eps in hist.iterations for s in eps]
     assert any(name == "pair-anchored-smoke" for name, _, _ in hist.iterations)
+    assert eps, "the smoke must complete at least one episode"
+    assert all(s.fraction_placed >= 0.5 for s in eps)  # anchor counted -> floor 1/2
+
+
+def test_train_curriculum_anchored_rung_is_deterministic():
+    # Anchoring adds no RNG, so the same seed reproduces the anchored run bit-for-bit (the
+    # determinism contract, mirrored from test_train_curriculum_is_deterministic).
+    h1 = train_curriculum(seed=0, schedule=_anchored_smoke_schedule("pa-det"), rollout_len=32)
+    h2 = train_curriculum(seed=0, schedule=_anchored_smoke_schedule("pa-det"), rollout_len=32)
+    assert h1.iterations == h2.iterations
+
+
+@pytest.mark.parametrize("backend", ["sync", "subproc"])
+def test_train_curriculum_anchored_rung_runs_vectorized(backend):
+    # The anchored Stage (now carrying anchor_layout_path) must pickle across the spawn
+    # boundary and the witness must reload IN the worker — exercise both vec backends.
+    hist = train_curriculum(
+        seed=0,
+        schedule=_anchored_smoke_schedule(f"pa-vec-{backend}"),
+        rollout_len=32,
+        n_envs=2,
+        vec_backend=backend,
+    )
+    assert any(name == f"pa-vec-{backend}" for name, _, _ in hist.iterations)


### PR DESCRIPTION
Closes #712

## What & why

Step 1 (proof-first) of the #712 seed-anchor start-state curriculum graft, epic #607. The #714 re-gate confirmed a genuine **2-object joint-discovery wall** (`trivial` + `solo-box` master, but `pair-box` stalls at `valid_placed ≈ 0.054`; the `--normalize-returns`-off control is *strictly worse*, so the normalizer is load-bearing and the residual is discovery, not optimization). That satisfied this issue's documented trigger.

**The lever:** pre-park a `k`-prefix of a committed witness layout, drive the remaining `N−k` objects in, anneal `k→0` across the curriculum. Correctness rests on one property: **a k-prefix of a valid layout is itself valid** (removing objects cannot create overlap/intrusion/egress conflicts), so the partial start is guaranteed-valid with **no runtime solver/search** — the env stays solver-free.

This PR ships the mechanism + a committed witness fixture + **one** `pair-anchored` (k=1) rung, so the lever can be gated before building the full anneal.

## Design notes

- **Seeded-random k-subset (Q1) for free.** The env anchors the request **prefix** `requested_ids[:k]`. The curriculum's existing `sample_request` already returns a fresh *seeded permutation* each episode, so "anchor the prefix" composes into "anchor a seeded-random k-subset" — deterministic and Sync≡Subproc byte-identical, with **zero new RNG** and an RNG-free env.
- **Witness = single source of truth (Q2).** `Stage.anchor_layout_path` → `stage_builder` loads the witness once and derives both the rung's object pool (its ids) and the env's anchor poses. Pool pinned to the witness set.
- **Denominator semantics.** Anchors live in `_parked` (counted in `N`), so mastering `k=N−1` == placing the one remaining object validly → `valid_placed → 1.0`. The free `k/N` credit vanishes as `k` anneals.
- **Default-neutral.** `seed_anchor_k=0` / `--seed-anchor` absent → CPU **byte-identical** to prior runs (guarded by tests); `--seed-anchor` fails loud under `--schedule trivial` (mirrors `--solo-box-rung`).

## Changes

| File | Change |
|---|---|
| `ml/types.py` | `seed_anchor: bool` stub → `seed_anchor_k: int = 0` |
| `ml/env.py` | `anchor_placements` arg; `_reset_state` pre-parks the prefix, validates `k < N` + witness coverage |
| `ml/curriculum.py` | `Stage.anchor_layout_path`; `pair-anchored` rung + `with_pair_anchored_rung` |
| `ml/stage_builder.py` | `witness_placements`; `effective_fleet_ids`/`build_stage_env` witness branches |
| `ml/train.py` | `--seed-anchor` (curriculum-only) |
| `tests/fixtures/ml/witness_box.yaml` | valid 2-object box layout (margin at strict 0.3 m clearance) |
| `ml/README.md`, `CHANGELOG.md` | docs + the pair-anchored step-1 gate recipe |

## Tests

28 new `ml/` tests (TDD, RED-first): env mechanism + k=0 byte-identity, witness validity + every-k-prefix validity + strict-clearance margin, stage_builder witness threading, ladder wiring (incl. composes-with-solo-box), CLI gating, and an end-to-end anchored-rung training smoke. Full `ml/` suite green (mypy + ruff clean).

## Next (not in this PR)
Gate the lever: does `pair-anchored` lift above its ~0.5 sit-still floor toward 0.9 (place object 2 given object 1), and does it transfer to `pair-box`? If yes → full `k=2→1→0` anneal + a notch witness in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8i5zdZf6APfwGMqBg3MSW