### PR TITLE
chore: gitignore ml/ gate-run scratch outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,15 @@ out*.png
 # be committed or shipped; the committed bundle is src/hangarfit/_viewer_assets/
 # viewer.js, built FROM viewer/src/*.ts.
 viewer/node_modules/
+
+# Learned-backend (ml/) gate-run scratch outputs (epic #607). The dev/CI-only
+# `ml.train` gate recipes (ml/README.md) write training artifacts to the repo root:
+# resume checkpoints, per-iter metrics JSONL, and run logs, plus the gate-driver PID
+# files and diagnosis-workflow scratch. All are reproducible generated outputs, never
+# shipped in the wheel and never meant to be committed. Root-anchored so a deliberately
+# tracked file deeper in the tree is unaffected.
+/ck-*.pt
+/metrics-*.jsonl
+/gate-*.log
+/.gate-*.pid
+/.workflow-*.js


### PR DESCRIPTION
## What

Adds root-anchored `.gitignore` rules for the dev/CI-only `ml.train` gate-run artifacts that land at the repo root (epic #607):

```
/ck-*.pt
/metrics-*.jsonl
/gate-*.log
/.gate-*.pid
/.workflow-*.js
```

## Why

The `ml/README.md` gate recipes write checkpoints / metrics JSONL / run logs (plus gate-driver PID files and diagnosis-workflow scratch) to the repo root. None were ignored, so each run left untracked clutter in `git status` and a standing risk of a stray `git add -A`. These are reproducible, never-shipped generated outputs. (A prior session's ~19 MB of such scratch was just removed.)

No tracked file is affected — root-anchoring (`/`) means a deliberately tracked file deeper in the tree (e.g. a test fixture `*.pt`) stays tracked.

## Verification (review scaled to a config-only change)

```
$ git check-ignore ck-seed0-anchor.pt metrics-seed0-anchor.jsonl gate-seed0.log .gate-v4.pid .workflow-foo.js
ck-seed0-anchor.pt
metrics-seed0-anchor.jsonl
gate-seed0.log
.gate-v4.pid
.workflow-foo.js
$ git check-ignore tests/fixtures/model.pt    # -> (no output: NOT ignored, correct)
```

Patterns match the gate-run shapes (incl. the upcoming pair-anchored gate's `ck-seed0-anchor.pt` / `metrics-seed0-anchor.jsonl`) and nothing else. No code paths touched, so no subagent review panel — the verification above is the proportionate check.

_No linked issue: issue-filing was out of the requested scope for this cleanup chore._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8i5zdZf6APfwGMqBg3MSW