### PR TITLE
feat(720): graded valid-park economics + PPO trust-region clipping (L5+L4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#720, epic #607): graded-economics + PPO trust-region levers to break
+  the empty-start place-nothing cliff.** A multi-agent diagnosis of the `--mixed-anchor` gate
+  failure (seed-0: `pair-mixed` capped oscillating ~0.2, `pair-box` collapsed to
+  `valid_placed 0.000`) root-caused it as *economics × discoverability*: from empty, do-nothing
+  is a bounded −8 loss while any exploratory mis-Park books the **unclipped** `−w_col·overlap`
+  (−5000…−12000), so place-nothing is the genuine reward argmax. **L5** (reward, default-neutral):
+  `--valid-park-grade-scale` grades the `r_valid_park` bonus by near-miss misfit
+  (`r_valid_park·exp(−misfit/scale)`) into an uphill gradient toward the witness slot;
+  `--r-first-valid` is a one-time breakthrough bonus on an episode's first valid placement;
+  `--w-col` exposes the collision weight. **L4** (PPO, default-neutral): `--reward-clip`,
+  `--value-clip-eps` (PPO2 clipped value loss), and `--target-kl` (epoch early-stop) tame the
+  unclipped collision spike that drove the gate's −5000…−12000 sawtooth; `ppo_update` now also
+  reports `approx_kl`/`epochs_run`. All knobs 0/None ⇒ byte-identical training. The refuted
+  continuous-k-anneal lever is **not** added (policy-invariant on the empty-start sub-MDP).
+
 - **Mixed-start anchor curriculum rung (`--mixed-anchor`, #712 follow-up).** An opt-in
   `pair-mixed` rung where each episode randomly starts anchored (k=1) or empty (k=0), keeping
   empty-start episodes in the training mix to bridge the k=1→k=0 start-state cliff that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
   the empty-start place-nothing cliff.** A multi-agent diagnosis of the `--mixed-anchor` gate
   failure (seed-0: `pair-mixed` capped oscillating ~0.2, `pair-box` collapsed to
   `valid_placed 0.000`) root-caused it as *economics × discoverability*: from empty, do-nothing
-  is a bounded −8 loss while any exploratory mis-Park books the **unclipped** `−w_col·overlap`
+  is a small bounded loss (≈−8 observed on the failed seed-0 gate run) while any exploratory
+  mis-Park books the **unclipped** `−w_col·overlap`
   (−5000…−12000), so place-nothing is the genuine reward argmax. **L5** (reward, default-neutral):
   `--valid-park-grade-scale` grades the `r_valid_park` bonus by near-miss misfit
   (`r_valid_park·exp(−misfit/scale)`) into an uphill gradient toward the witness slot;

--- a/ml/README.md
+++ b/ml/README.md
@@ -243,6 +243,38 @@ python -u -m ml.train --schedule curriculum --device cuda --n-envs 16 \
 WIN: `pair-mixed` lifts and ideally promotes by competency, AND the downstream all-empty
 `pair-box` no longer collapses (lifts off 0.000). Read `valid_placed`, not `valid_rate`.
 
+### Graded-economics + PPO-clipping gate recipe (#720, L5+L4)
+
+The mixed-anchor gate failed seed-0 (`pair-mixed` capped oscillating ~0.2, `pair-box` collapsed
+to `valid_placed 0.000`). A multi-agent diagnosis root-caused the cliff as *economics ×
+discoverability*: from empty, do-nothing is a bounded −8 loss while any exploratory mis-Park books
+the **unclipped** `−w_col·overlap` (−5000…−12000), so place-nothing is the genuine reward argmax.
+The #720 levers shift that argmax (L5) and tame the resulting sawtooth (L4); all knobs are
+default-neutral (0/None ⇒ byte-identical), so they layer onto the recipe above.
+
+```bash
+# Above mixed-anchor config, plus the #720 L5 economics + L4 PPO trust-region knobs.
+python -u -m ml.train --schedule curriculum --device cuda --n-envs 16 \
+  --rollout-len 512 --max-iters-per-stage 80 \
+  --promotion-metric valid_placed --promotion-threshold 0.9 \
+  --r-valid-park 30.0 --r-unplaced-penalty 25.0 --dense-slot-potential \
+  --w-col 20.0 --valid-park-grade-scale 4.0 --r-first-valid 15.0 \
+  --reward-clip 10.0 --value-clip-eps 0.2 --target-kl 0.03 \
+  --entropy-start 0.05 --entropy-end 0.005 --entropy-anneal-iters 40 \
+  --normalize-returns --validity-conditional-terminal --solo-box-rung \
+  --seed-anchor --mixed-anchor \
+  --metrics-out metrics-seed0-l5l4.jsonl --checkpoint-out ck-seed0-l5l4.pt --seed 0
+```
+
+WIN: `pair-box` `valid_placed` lifts decisively **off 0.000** (trending ≥0.1 within 80 iters,
+climbing — read `valid_placed` NOT `valid_rate`), the −5000…−12000 sawtooth is gone (L4 did its
+job), and `trivial`/`solo-box`/`pair-anchored` still promote-by-competency (no upstream regression
+from the lower `w_col`). The `--w-col`/`--valid-park-grade-scale`/`--r-first-valid` magnitudes
+above are a **starting point** — the open knife-edge is graded credit vs `w_col` at the near-miss
+overlap (the grade must beat the collision penalty into the slot without making piling profitable),
+so expect a short sweep. If `pair-box` stays pinned with the sawtooth gone, that isolates the
+failure to pure discoverability → escalate to a pose-scaffold rung (L6a). Run a second seed.
+
 ## Design
 See `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`
 and ADR-0027 (learned-path determinism scope).

--- a/ml/README.md
+++ b/ml/README.md
@@ -247,8 +247,9 @@ WIN: `pair-mixed` lifts and ideally promotes by competency, AND the downstream a
 
 The mixed-anchor gate failed seed-0 (`pair-mixed` capped oscillating ~0.2, `pair-box` collapsed
 to `valid_placed 0.000`). A multi-agent diagnosis root-caused the cliff as *economics ×
-discoverability*: from empty, do-nothing is a bounded −8 loss while any exploratory mis-Park books
-the **unclipped** `−w_col·overlap` (−5000…−12000), so place-nothing is the genuine reward argmax.
+discoverability*: from empty, do-nothing is a small bounded loss (≈−8 observed on the failed seed-0
+gate run) while any exploratory mis-Park books the **unclipped** `−w_col·overlap` (−5000…−12000),
+so place-nothing is the genuine reward argmax.
 The #720 levers shift that argmax (L5) and tame the resulting sawtooth (L4); all knobs are
 default-neutral (0/None ⇒ byte-identical), so they layer onto the recipe above.
 

--- a/ml/env.py
+++ b/ml/env.py
@@ -98,6 +98,9 @@ class HangarFitEnv:
         self._steps_this_object = 0
         self._steps_total = 0
         self._prev_potential = 0.0
+        # #720 one-shot: flipped True on the first Park that yields a valid layout, so the
+        # r_first_valid bonus is paid once per episode. Cleared here every reset.
+        self._first_valid_reached = False
 
     def _body(self, object_id: str) -> Aircraft | GroundObject:
         return self.fleet[object_id] if object_id in self.fleet else self.ground_objects[object_id]
@@ -271,6 +274,10 @@ class HangarFitEnv:
             egress = score.egress_blocked
             intrusion = go.intrusion_area_m2(body, pl, self.hangar, bay_closed=False)
             park_valid = score.collisions_valid and not score.egress_blocked
+            # First Park of the episode to reach a valid layout fires the one-time bonus.
+            first_valid_now = park_valid and not self._first_valid_reached
+            if first_valid_now:
+                self._first_valid_reached = True
             self._active_id = None
             self._active_pose = None
             done = not self._queue
@@ -294,6 +301,7 @@ class HangarFitEnv:
                 # On the terminal Park, reuse the already-computed whole-layout product-checker
                 # bool (== _layout_valid()) for the #714 validity-conditional terminal.
                 terminal_valid=park_valid if done else None,
+                first_valid_now=first_valid_now,
             )
             reward = step_reward(ctx, weights)
             self._prev_potential = new_phi

--- a/ml/ppo.py
+++ b/ml/ppo.py
@@ -135,7 +135,9 @@ def value_loss_term(
     ``v_clip = old_value + clamp(new_value - old_value, ±clip_eps)``: the clamp caps how far one
     update can move the value toward the returns and the ``max`` keeps the loss a pessimistic bound
     — a trust region on the critic so the unclipped collision spike can't yank the value head each
-    batch (the #720 L4 stabilizer for the gate's value-driven sawtooth)."""
+    batch (the #720 L4 stabilizer for the gate's value-driven sawtooth). ``old_value`` is the
+    buffer's ROLLOUT-time (pre-update) critic prediction (``data['value']``), the clip anchor — not
+    a re-forward (matches the SB3/cleanrl convention)."""
     unclipped = (new_value - returns) ** 2
     if clip_eps is None:
         return unclipped.mean()

--- a/ml/ppo.py
+++ b/ml/ppo.py
@@ -32,6 +32,12 @@ class PPOConfig:
     entropy_anneal_iters: int = 0  # iters over which to anneal; 0 = no schedule
     normalize_returns: bool = False  # std-only reward normalization before GAE
     return_norm_eps: float = 1e-8  # numerical floor on the running std
+    # #720 (L4) PPO trust-region hardening — all None/off => byte-identical to the pre-#720 update.
+    reward_clip: float | None = None  # clamp RAW rewards to [-c, c] before normalize/GAE; tames
+    # the unclipped -w_col collision spike (-12000 batches) that drove the gate sawtooth.
+    value_clip_eps: float | None = None  # PPO2 clipped value loss; caps per-update critic movement.
+    target_kl: float | None = None  # early-stop the epoch loop once a full epoch's mean approx-KL
+    # exceeds this (a per-update trust region), so one catastrophic batch cannot over-rotate.
 
 
 def entropy_coef_at(
@@ -119,6 +125,23 @@ def factored_logprob_entropy(
     logprob = kind_dist.log_prob(kind_idx) + not_park * mag_dist.log_prob(mag_idx)
     entropy = kind_dist.entropy() + not_park * mag_dist.entropy()
     return logprob, entropy
+
+
+def value_loss_term(
+    new_value: Tensor, old_value: Tensor, returns: Tensor, clip_eps: float | None
+) -> Tensor:
+    """Per-minibatch critic loss. ``clip_eps`` None → plain ``((v - R)^2).mean()`` — byte-identical
+    to the pre-#720 update. Else the PPO2 clipped form ``max((v - R)^2, (v_clip - R)^2)`` where
+    ``v_clip = old_value + clamp(new_value - old_value, ±clip_eps)``: the clamp caps how far one
+    update can move the value toward the returns and the ``max`` keeps the loss a pessimistic bound
+    — a trust region on the critic so the unclipped collision spike can't yank the value head each
+    batch (the #720 L4 stabilizer for the gate's value-driven sawtooth)."""
+    unclipped = (new_value - returns) ** 2
+    if clip_eps is None:
+        return unclipped.mean()
+    v_clipped = old_value + torch.clamp(new_value - old_value, -clip_eps, clip_eps)
+    clipped = (v_clipped - returns) ** 2
+    return torch.max(unclipped, clipped).mean()
 
 
 def compute_gae(
@@ -226,6 +249,10 @@ def ppo_update(
     GAE. Existing callers that pass no ``normalizer`` are byte-identical (default None)."""
     data = buffer.batch()
     rewards = data["reward"]
+    # Clamp the RAW reward stream first (before the Welford normalizer + GAE) so a -w_col
+    # collision spike can't blow up the running std or the returns. None => unchanged (#720 L4).
+    if config.reward_clip is not None:
+        rewards = rewards.clamp(-config.reward_clip, config.reward_clip)
     if config.normalize_returns:
         if normalizer is None:
             raise ValueError(
@@ -282,10 +309,13 @@ def ppo_update(
         "value_loss": [],
         "entropy": [],
         "loss": [],
+        "approx_kl": [],
     }
+    epochs_run = 0
     for _ in range(config.epochs):
         # device=cpu reproduces torch.randperm(n) exactly (same default generator).
         perm = torch.randperm(n, device=device)
+        epoch_kls: list[float] = []
         for start in range(0, n, config.minibatch_size):
             mb = perm[start : start + config.minibatch_size]
             mb_obs = {k: data[k][mb] for k in _OBS_KEYS}
@@ -293,13 +323,16 @@ def ppo_update(
             logprob, entropy = factored_logprob_entropy(
                 out, data["kind_idx"][mb], data["mag_idx"][mb]
             )
-            ratio = torch.exp(logprob - data["old_logprob"][mb])
+            logratio = logprob - data["old_logprob"][mb]
+            ratio = torch.exp(logratio)
             adv = advantages[mb]
             policy_loss = -torch.min(
                 ratio * adv,
                 torch.clamp(ratio, 1.0 - config.clip_eps, 1.0 + config.clip_eps) * adv,
             ).mean()
-            value_loss = ((out.value - returns[mb]) ** 2).mean()
+            value_loss = value_loss_term(
+                out.value, data["value"][mb], returns[mb], config.value_clip_eps
+            )
             entropy_bonus = entropy.mean()
             loss = (
                 policy_loss + config.value_coef * value_loss - config.entropy_coef * entropy_bonus
@@ -308,11 +341,25 @@ def ppo_update(
             loss.backward()
             torch.nn.utils.clip_grad_norm_(policy.parameters(), config.max_grad_norm)
             optimizer.step()
+            # Schulman's non-negative approx-KL estimator (cleanrl): E[(r-1) - log r], read from
+            # the pre-step forward. Pure telemetry — no grad, no RNG draw — so when target_kl is
+            # None (no early stop) the update is byte-identical to the pre-#720 loop.
+            with torch.no_grad():
+                approx_kl = ((ratio - 1.0) - logratio).mean().item()
+            epoch_kls.append(approx_kl)
             accum["policy_loss"].append(policy_loss.item())
             accum["value_loss"].append(value_loss.item())
             accum["entropy"].append(entropy_bonus.item())
             accum["loss"].append(loss.item())
-    return {k: sum(vs) / len(vs) for k, vs in accum.items()}
+            accum["approx_kl"].append(approx_kl)
+        epochs_run += 1
+        # Early-stop once a full epoch's mean approx-KL leaves the trust region (the #720 L4
+        # backstop against a single catastrophic batch over-rotating the policy).
+        if config.target_kl is not None and sum(epoch_kls) / len(epoch_kls) > config.target_kl:
+            break
+    metrics = {k: sum(vs) / len(vs) for k, vs in accum.items()}
+    metrics["epochs_run"] = float(epochs_run)
+    return metrics
 
 
 def compute_gae_vec(

--- a/ml/reward.py
+++ b/ml/reward.py
@@ -85,14 +85,22 @@ def step_reward(ctx: RewardContext, w: RewardWeights) -> float:
 
 
 def _valid_park_term(ctx: RewardContext, w: RewardWeights) -> float:
-    """The Park bonus. ``park_valid is None`` off a Park step → no bonus. With
+    """The Park bonus. When ``park_valid`` is None (not a Park step) → no bonus. With
     ``valid_park_grade_scale == 0`` the bonus is the binary all-or-nothing form (the layout is
     valid → full ``r_valid_park``, else 0 — byte-identical to the pre-#720 path). With scale > 0
-    it is GRADED by a near-miss ``misfit`` (collision overlap + out-of-bounds intrusion):
-    ``r_valid_park * exp(-misfit / scale)``, so a Park landing CLOSE to valid earns partial
-    credit and the rare near-miss pays a learnable return — the uphill gradient INTO the witness
-    slot that the flat valid-only plateau lacked. A graded Park is withheld entirely when egress
-    is blocked: egress is a binary hard failure with no graded 'near'."""
+    it is GRADED by a near-miss ``misfit`` so a Park landing CLOSE to valid earns partial credit
+    and the rare near-miss pays a learnable return — the uphill gradient INTO the witness slot
+    that the flat valid-only plateau lacked. A graded Park is withheld entirely when egress is
+    blocked: egress is a binary hard failure with no graded 'near'.
+
+    ``misfit = overlap_m2 + intrusion_m2`` — the static FINAL-POSE collision + out-of-bounds/notch
+    area. It deliberately excludes ``swept_intrusion_m2`` (the tow-sweep area the hard collision
+    term also charges): a Park is judged on its final pose, not its path, and the env sets
+    ``swept_intrusion_m2 = 0`` on a Park step anyway. INVARIANT: ``misfit`` must remain a SUPERSET
+    of every non-egress source of ``park_valid is False`` (today: overlap + bounds/notch intrusion).
+    If a future keep-out can flip validity without raising overlap/intrusion it MUST be summed in
+    here — else an invalid-but-zero-misfit Park would earn ~full credit (``exp(0) ≈ 1``) and reopen
+    a 'looks valid, isn't' reward leak."""
     if ctx.park_valid is None:
         return 0.0
     if w.valid_park_grade_scale <= 0.0:

--- a/ml/reward.py
+++ b/ml/reward.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 from ml.types import RewardWeights
@@ -28,6 +29,9 @@ class RewardContext:
     # Whole-layout validity at the TERMINAL step (the product checker), consumed only when
     # RewardWeights.validity_conditional_terminal is on. None on non-terminal steps. (#714)
     terminal_valid: bool | None = None
+    # True on EXACTLY the one Park step where the episode first reaches a valid placement; the
+    # env flips it once per episode. Consumed only when RewardWeights.r_first_valid > 0. (#720)
+    first_valid_now: bool = False
 
 
 def potential(
@@ -75,5 +79,25 @@ def step_reward(ctx: RewardContext, w: RewardWeights) -> float:
                 eff_fraction = 0.0
         terminal = w.r_terminal * eff_fraction - w.r_unplaced_penalty * (1.0 - eff_fraction)
     shaping = w.gamma * ctx.potential - ctx.prev_potential
-    valid_park = w.r_valid_park if ctx.park_valid else 0.0
-    return hard + movement + soft + terminal + shaping + valid_park
+    valid_park = _valid_park_term(ctx, w)
+    first_valid = w.r_first_valid if ctx.first_valid_now else 0.0
+    return hard + movement + soft + terminal + shaping + valid_park + first_valid
+
+
+def _valid_park_term(ctx: RewardContext, w: RewardWeights) -> float:
+    """The Park bonus. ``park_valid is None`` off a Park step → no bonus. With
+    ``valid_park_grade_scale == 0`` the bonus is the binary all-or-nothing form (the layout is
+    valid → full ``r_valid_park``, else 0 — byte-identical to the pre-#720 path). With scale > 0
+    it is GRADED by a near-miss ``misfit`` (collision overlap + out-of-bounds intrusion):
+    ``r_valid_park * exp(-misfit / scale)``, so a Park landing CLOSE to valid earns partial
+    credit and the rare near-miss pays a learnable return — the uphill gradient INTO the witness
+    slot that the flat valid-only plateau lacked. A graded Park is withheld entirely when egress
+    is blocked: egress is a binary hard failure with no graded 'near'."""
+    if ctx.park_valid is None:
+        return 0.0
+    if w.valid_park_grade_scale <= 0.0:
+        return w.r_valid_park if ctx.park_valid else 0.0
+    if ctx.egress_blocked:
+        return 0.0
+    misfit = ctx.overlap_m2 + ctx.intrusion_m2
+    return w.r_valid_park * math.exp(-misfit / w.valid_park_grade_scale)

--- a/ml/train.py
+++ b/ml/train.py
@@ -703,7 +703,8 @@ def build_argparser() -> argparse.ArgumentParser:
         type=float,
         default=None,
         help="early-stop the PPO epoch loop once a full epoch's mean approx-KL exceeds this "
-        "(per-update trust region); None = run all epochs (byte-identical); #720 L4",
+        "(per-update trust region); None/omitted = off, run all epochs (byte-identical). Note "
+        "0.0 is NOT 'off' — it stops after the first epoch (mean-KL > 0 almost always); #720 L4",
     )
     p.add_argument(
         "--n-envs",

--- a/ml/train.py
+++ b/ml/train.py
@@ -629,6 +629,28 @@ def build_argparser() -> argparse.ArgumentParser:
         "budget exhaustion is no longer free vs committing a Park; #710 economics rebalance)",
     )
     p.add_argument(
+        "--w-col",
+        type=float,
+        default=RewardWeights().w_col,
+        help="collision-overlap penalty weight (default 100.0). Lower it to shrink the unbounded "
+        "-w_col spike that makes attempting a Park dominate place-nothing; #720 L5 economics",
+    )
+    p.add_argument(
+        "--valid-park-grade-scale",
+        type=float,
+        default=0.0,
+        help="when >0, GRADE the r_valid_park bonus by near-miss misfit "
+        "(r_valid_park*exp(-misfit/scale)) so a Park landing CLOSE to valid earns partial credit "
+        "— the uphill gradient into the witness slot; 0 = binary bonus (byte-identical); #720 L5",
+    )
+    p.add_argument(
+        "--r-first-valid",
+        type=float,
+        default=0.0,
+        help="one-time bonus the first time an episode reaches a valid placement (breakthrough "
+        "off the place-nothing pole); paid once per episode, 0 = off (byte-identical); #720 L5",
+    )
+    p.add_argument(
         "--validity-conditional-terminal",
         action="store_true",
         help="terminal credits the VALID placed fraction (invalid layout -> 0), so an "
@@ -663,6 +685,27 @@ def build_argparser() -> argparse.ArgumentParser:
         help="std-only Welford return normalization before GAE",
     )
     p.add_argument(
+        "--reward-clip",
+        type=float,
+        default=None,
+        help="clamp RAW rewards to [-c, c] before normalize/GAE (tames the -w_col collision "
+        "spike that drove the gate sawtooth); None = off (byte-identical); #720 L4",
+    )
+    p.add_argument(
+        "--value-clip-eps",
+        type=float,
+        default=None,
+        help="PPO2 clipped value loss epsilon — caps how far one update moves the critic; "
+        "None = plain MSE (byte-identical); #720 L4",
+    )
+    p.add_argument(
+        "--target-kl",
+        type=float,
+        default=None,
+        help="early-stop the PPO epoch loop once a full epoch's mean approx-KL exceeds this "
+        "(per-update trust region); None = run all epochs (byte-identical); #720 L4",
+    )
+    p.add_argument(
         "--n-envs",
         type=int,
         default=1,
@@ -690,7 +733,10 @@ def main(argv: Sequence[str] | None = None) -> None:
     if args.device == "cuda" and not torch.cuda.is_available():
         parser.error("--device cuda requested but torch.cuda.is_available() is False")
     weights = RewardWeights(
+        w_col=args.w_col,
         r_valid_park=args.r_valid_park,
+        valid_park_grade_scale=args.valid_park_grade_scale,
+        r_first_valid=args.r_first_valid,
         dense_slot_potential=args.dense_slot_potential,
         r_unplaced_penalty=args.r_unplaced_penalty,
         validity_conditional_terminal=args.validity_conditional_terminal,
@@ -714,6 +760,9 @@ def main(argv: Sequence[str] | None = None) -> None:
         entropy_coef_end=args.entropy_end,
         entropy_anneal_iters=args.entropy_anneal_iters,
         normalize_returns=args.normalize_returns,
+        reward_clip=args.reward_clip,
+        value_clip_eps=args.value_clip_eps,
+        target_kl=args.target_kl,
     )
     if args.schedule == "trivial":
         # --metrics-out / --promotion-* are curriculum-only; the trivial path has no

--- a/ml/types.py
+++ b/ml/types.py
@@ -111,6 +111,18 @@ class RewardWeights:
     r_terminal: float = 50.0  # terminal: per fraction-placed
     gamma: float = 0.99  # shaping discount
     r_valid_park: float = 0.0  # bonus paid in Park ONLY when the layout is valid (basin escape)
+    # When > 0, the r_valid_park bonus is GRADED by a near-miss "misfit" (overlap + out-of-bounds
+    # intrusion) instead of paid all-or-nothing: r_valid_park * exp(-misfit / scale) on a Park
+    # step (withheld entirely on an egress-blocked Park — egress is a binary hard failure). This
+    # turns the flat valid-only plateau into an uphill gradient INTO the witness slot, so a Park
+    # that lands CLOSE to valid earns partial credit and the rare near-miss pays a learnable
+    # return. Default 0.0 -> the exact binary path -> byte-identical (#720 L5 economics lever).
+    valid_park_grade_scale: float = 0.0
+    # One-time bonus paid the FIRST time an episode reaches a valid placement (the env flips
+    # RewardContext.first_valid_now on exactly that Park step). A discrete kick that makes the
+    # breakthrough off the place-nothing pole pay a learnable return; paid once, not per Park.
+    # Default 0.0 -> the flag is never consulted -> byte-identical (#720 L5 economics lever).
+    r_first_valid: float = 0.0
     dense_slot_potential: bool = False  # add an in-hangar nearest-free-pocket shaping term
     # terminal: penalty per UNPLACED fraction (1 - terminal_fraction). Default 0.0 -> byte-
     # identical. Non-zero charges abandonment so "drive to budget exhaustion" is no longer

--- a/ml/types.py
+++ b/ml/types.py
@@ -121,7 +121,8 @@ class RewardWeights:
     # One-time bonus paid the FIRST time an episode reaches a valid placement (the env flips
     # RewardContext.first_valid_now on exactly that Park step). A discrete kick that makes the
     # breakthrough off the place-nothing pole pay a learnable return; paid once, not per Park.
-    # Default 0.0 -> the flag is never consulted -> byte-identical (#720 L5 economics lever).
+    # Default 0.0 -> the term is x0 (the env still computes first_valid_now, but it contributes
+    # nothing) -> byte-identical (#720 L5 economics lever).
     r_first_valid: float = 0.0
     dense_slot_potential: bool = False  # add an in-hangar nearest-free-pocket shaping term
     # terminal: penalty per UNPLACED fraction (1 - terminal_fraction). Default 0.0 -> byte-

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -749,3 +749,94 @@ def test_reset_without_override_uses_difficulty_default(anchored_pair_env):
     env = anchored_pair_env  # difficulty.seed_anchor_k == 1
     env.reset(requested_ids=("fuji", "aviat_husky"))
     assert len(env._parked) == 1  # regression: today's behavior unchanged
+
+
+# ---------------------------------------------------------------------------
+# #720 (L5) — one-time first-valid bonus: the env flips ctx.first_valid_now True on EXACTLY
+# the first Park that yields a valid layout, so r_first_valid is paid once per episode.
+# ---------------------------------------------------------------------------
+
+# Two side-by-side in-hangar poses inside the 22x25 hangar: each Park is valid and the pair
+# is non-overlapping (probed), asserted live below so a bad fixture fails loud, not silently.
+_FIRST_VALID_POSE_A = Pose(x_m=6.0, y_m=10.0, heading_deg=0.0)
+_FIRST_VALID_POSE_B = Pose(x_m=16.0, y_m=10.0, heading_deg=0.0)
+
+
+def _park_reward_at(env: HangarFitEnv, pose: Pose) -> tuple[float, bool]:
+    env._active_pose = pose  # override the apron spawn with the chosen in-hangar pose
+    _obs, reward, _done, info = env.step(Park())
+    return reward, info.valid
+
+
+def test_first_valid_bonus_paid_once_not_on_later_valid_parks():
+    # Park two objects validly; the bonus is added on the FIRST valid Park only.
+    def run(bonus: float) -> tuple[float, bool, float, bool]:
+        env = HangarFitEnv(
+            hangar=empty_hangar(),
+            fleet=_fuji(),
+            requested_ids=("fuji", "aviat_husky"),
+            weights=RewardWeights(r_first_valid=bonus),
+        )
+        env.reset()
+        r1, v1 = _park_reward_at(env, _FIRST_VALID_POSE_A)
+        r2, v2 = _park_reward_at(env, _FIRST_VALID_POSE_B)
+        return r1, v1, r2, v2
+
+    r1_0, v1_0, r2_0, v2_0 = run(0.0)
+    r1_b, v1_b, r2_b, v2_b = run(9.0)
+    assert v1_0 and v2_0 and v1_b and v2_b, "fixture poses must both Park validly"
+    assert r1_b - r1_0 == pytest.approx(9.0)  # first valid Park -> bonus
+    assert r2_b - r2_0 == pytest.approx(0.0)  # second valid Park -> no repeat
+
+
+def test_first_valid_bonus_tied_to_whole_layout_validity():
+    # park_valid is WHOLE-layout validity: an object committed invalidly (apron, y<0) poisons it
+    # for the rest of the episode, so no later Park yields a valid layout and the one-time bonus
+    # never fires. (It is therefore never spent prematurely on an invalid Park either.)
+    def run(bonus: float) -> tuple[float, bool, float, bool]:
+        env = HangarFitEnv(
+            hangar=empty_hangar(),
+            fleet=_fuji(),
+            requested_ids=("fuji", "aviat_husky"),
+            weights=RewardWeights(r_first_valid=bonus),
+        )
+        env.reset()
+        _obs, r_invalid, _done, info_invalid = env.step(Park())  # park object 1 on the apron
+        r_after, v_after = _park_reward_at(env, _FIRST_VALID_POSE_B)  # object 2 at a clean pose
+        return r_invalid, info_invalid.valid, r_after, v_after
+
+    r_inv_0, inv_valid_0, r_aft_0, v_aft_0 = run(0.0)
+    r_inv_b, inv_valid_b, r_aft_b, v_aft_b = run(9.0)
+    # Both Parks report an invalid whole layout (the apron object never leaves), so neither pays.
+    assert inv_valid_0 is False and v_aft_0 is False
+    assert inv_valid_b is False and v_aft_b is False
+    assert r_inv_b == pytest.approx(r_inv_0)  # invalid first Park -> no bonus
+    assert r_aft_b == pytest.approx(r_aft_0)  # layout still invalid -> bonus never fires
+
+
+def test_first_valid_bonus_resets_across_episodes():
+    # reset() must clear the one-shot, so the SAME env earns the bonus again on the first valid
+    # Park of the next episode (a leaked flag would silently starve every episode after the first).
+    env_0 = HangarFitEnv(
+        hangar=empty_hangar(),
+        fleet=_fuji(),
+        requested_ids=("fuji",),
+        weights=RewardWeights(r_first_valid=0.0),
+    )
+    env_b = HangarFitEnv(
+        hangar=empty_hangar(),
+        fleet=_fuji(),
+        requested_ids=("fuji",),
+        weights=RewardWeights(r_first_valid=9.0),
+    )
+
+    def first_valid_delta() -> float:
+        env_0.reset()
+        env_b.reset()
+        r0, v0 = _park_reward_at(env_0, _FIRST_VALID_POSE_A)
+        rb, vb = _park_reward_at(env_b, _FIRST_VALID_POSE_A)
+        assert v0 and vb
+        return rb - r0
+
+    assert first_valid_delta() == pytest.approx(9.0)  # episode 1
+    assert first_valid_delta() == pytest.approx(9.0)  # after reset -> flag cleared, paid again

--- a/tests/ml/test_ppo.py
+++ b/tests/ml/test_ppo.py
@@ -576,3 +576,98 @@ def test_ppo_update_minibatches_all_TN_vec_transitions(monkeypatch):
 
     assert captured, "ppo_update did not call torch.randperm"
     assert all(k == T * N for k in captured), f"shuffled {captured}, expected T*N={T * N}"
+
+
+# ---------------------------------------------------------------------------
+# #720 (L4) — PPO trust-region hardening: raw-reward clip, clipped value loss, target-KL
+# early-stop. All three default None -> byte-identical to the pre-#720 update. These tame the
+# unclipped -w_col collision spike that drove the gate's -5000..-12000 sawtooth.
+# ---------------------------------------------------------------------------
+from ml.ppo import value_loss_term  # noqa: E402
+
+
+def test_ppo_config_l4_knobs_default_none():
+    c = PPOConfig()
+    assert c.reward_clip is None and c.value_clip_eps is None and c.target_kl is None
+
+
+def test_value_loss_term_unclipped_is_plain_mse():
+    nv = torch.tensor([1.0, 2.0, 3.0])
+    ov = torch.tensor([0.0, 0.0, 0.0])
+    ret = torch.tensor([0.5, 0.5, 0.5])
+    assert torch.allclose(value_loss_term(nv, ov, ret, None), ((nv - ret) ** 2).mean())
+
+
+def test_value_loss_term_clip_bounds_value_movement():
+    # new value moved 3.0 from old 0.0; eps=0.5 clamps v_clip to 0.5 -> (0.5-3)^2 = 6.25, and the
+    # PPO2 max() picks it over the unclipped 0.0 -> the critic cannot chase returns past the eps.
+    nv = torch.tensor([3.0])
+    ov = torch.tensor([0.0])
+    ret = torch.tensor([3.0])
+    assert value_loss_term(nv, ov, ret, 0.5) == pytest.approx(6.25)
+    assert value_loss_term(nv, ov, ret, None) == pytest.approx(0.0)
+
+
+def test_value_loss_term_clip_noop_within_eps():
+    # value moved only 0.1 < eps 0.5 -> v_clip == new value -> identical to the unclipped MSE.
+    nv = torch.tensor([0.1])
+    ov = torch.tensor([0.0])
+    ret = torch.tensor([1.0])
+    assert value_loss_term(nv, ov, ret, 0.5) == pytest.approx(value_loss_term(nv, ov, ret, None))
+
+
+def _spy_gae(monkeypatch):
+    import ml.ppo as ppo
+
+    seen: dict[str, object] = {}
+    real = ppo.compute_gae
+
+    def spy(rewards, *a, **k):
+        seen["rewards"] = rewards.clone()
+        return real(rewards, *a, **k)
+
+    monkeypatch.setattr(ppo, "compute_gae", spy)
+    return seen
+
+
+def test_ppo_update_reward_clip_clamps_rewards_into_gae(monkeypatch):
+    seen = _spy_gae(monkeypatch)
+    torch.manual_seed(0)
+    policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2)
+    buf = _filled_buffer(policy)
+    buf.reward[0] = 100.0  # a -w_col-style spike
+    buf.reward[1] = -100.0
+    opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    ppo_update(policy, opt, buf, PPOConfig(minibatch_size=16, reward_clip=5.0))
+    r = seen["rewards"]
+    assert float(r.max()) <= 5.0 and float(r.min()) >= -5.0
+    assert float(r[0]) == pytest.approx(5.0) and float(r[1]) == pytest.approx(-5.0)
+
+
+def test_ppo_update_reward_clip_none_leaves_rewards_raw(monkeypatch):
+    seen = _spy_gae(monkeypatch)
+    torch.manual_seed(0)
+    policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2)
+    buf = _filled_buffer(policy)
+    buf.reward[0] = 100.0
+    raw = buf.batch()["reward"].clone()
+    opt = torch.optim.Adam(policy.parameters(), lr=3e-4)
+    ppo_update(policy, opt, buf, PPOConfig(minibatch_size=16, reward_clip=None))
+    assert torch.equal(seen["rewards"], raw)
+
+
+def test_ppo_update_target_kl_early_stops_epochs():
+    def epochs_run(target_kl: float | None) -> float:
+        torch.manual_seed(0)
+        policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2)
+        opt = torch.optim.Adam(policy.parameters(), lr=1e-2)  # big LR -> KL grows fast
+        m = ppo_update(
+            policy,
+            opt,
+            _filled_buffer(policy),
+            PPOConfig(minibatch_size=16, epochs=4, target_kl=target_kl),
+        )
+        return m["epochs_run"]
+
+    assert epochs_run(None) == 4  # no early stop -> all epochs run
+    assert epochs_run(0.0) == 1  # any positive KL after epoch 1 trips the stop

--- a/tests/ml/test_reward.py
+++ b/tests/ml/test_reward.py
@@ -117,6 +117,20 @@ def test_graded_valid_park_not_paid_on_nonpark_step():
     assert step_reward(_ctx(park_valid=None), w) == pytest.approx(0.0)
 
 
+def test_graded_valid_park_overlap_never_outscores_clean_valid():
+    # Knife-edge guard at a REALISTIC collision weight (not the w_col=0 the isolation tests use):
+    # a graded near-miss overlapping Park (invalid) must never out-score a clean valid Park. A clean
+    # valid Park earns full r_valid_park with no collision penalty; any overlap both shrinks the
+    # graded bonus (exp(-misfit/scale) < 1) AND adds -w_col*overlap, so it is strictly worse for
+    # every positive overlap. Pins the invariant so a future w_col/scale tweak can't silently make
+    # an overlapping pile profitable (the open knife-edge the README/PR call out).
+    w = RewardWeights(r_valid_park=10.0, valid_park_grade_scale=4.0, w_col=100.0)
+    clean_valid = _ctx(overlap_m2=0.0, park_valid=True)
+    for overlap in (0.01, 0.1, 0.5, 2.0):
+        overlapping_invalid = _ctx(overlap_m2=overlap, park_valid=False)
+        assert step_reward(overlapping_invalid, w) < step_reward(clean_valid, w)
+
+
 # ---------------------------------------------------------------------------
 # #720 (L5) — one-time first-valid bonus: a discrete positive kick the FIRST time an
 # episode reaches a valid placement, so the breakthrough from the place-nothing pole pays

--- a/tests/ml/test_reward.py
+++ b/tests/ml/test_reward.py
@@ -69,6 +69,87 @@ def test_r_valid_park_cannot_make_an_overlapping_park_profitable():
 
 
 # ---------------------------------------------------------------------------
+# #720 (L5) — graded valid_park: partial credit for a NEAR-valid Park so there is
+# an uphill gradient INTO the witness slot instead of a flat plateau-then-spike.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_park_grade_scale_default_zero_is_byte_identical():
+    # The graded knob defaults 0.0 -> the existing binary r_valid_park path, byte-identical
+    # across every park_valid state (None = not a Park step, True = valid, False = invalid).
+    for pv in (None, True, False):
+        ctx = _ctx(overlap_m2=0.03, park_valid=pv)
+        assert step_reward(ctx, RewardWeights(r_valid_park=5.0)) == step_reward(
+            ctx, RewardWeights(r_valid_park=5.0, valid_park_grade_scale=0.0)
+        )
+
+
+def test_graded_valid_park_full_credit_at_zero_misfit():
+    # A clean valid Park (overlap 0, in bounds, egress clear) pays the FULL r_valid_park even
+    # graded — exp(-0/scale) == 1 — so a valid Park is never worse off than under the binary form.
+    w = RewardWeights(r_valid_park=10.0, valid_park_grade_scale=4.0, w_col=0.0)
+    ctx = _ctx(overlap_m2=0.0, park_valid=True)
+    assert step_reward(ctx, w) == pytest.approx(10.0)
+
+
+def test_graded_valid_park_decreasing_in_overlap():
+    # The whole point: with the grade on, a SMALLER near-miss overlap earns MORE valid-park
+    # credit than a larger one (an uphill gradient toward the valid pose). w_col=0 isolates the
+    # graded term from the collision penalty so the comparison is purely the bonus.
+    w = RewardWeights(r_valid_park=10.0, valid_park_grade_scale=4.0, w_col=0.0)
+    near = _ctx(overlap_m2=0.5, park_valid=False)
+    far = _ctx(overlap_m2=3.0, park_valid=False)
+    nonpark = _ctx(overlap_m2=0.5, park_valid=None)
+    assert step_reward(near, w) > step_reward(far, w) > step_reward(nonpark, w)
+
+
+def test_graded_valid_park_withheld_when_egress_blocked():
+    # Egress is a BINARY hard failure with no "near" — a collision-clean but egress-blocked Park
+    # must earn NO graded credit despite zero overlap, else it looks as good as a valid Park.
+    w = RewardWeights(r_valid_park=10.0, valid_park_grade_scale=4.0, w_col=0.0, w_egress=0.0)
+    blocked = _ctx(overlap_m2=0.0, park_valid=False, egress_blocked=True)
+    assert step_reward(blocked, w) == pytest.approx(0.0)
+
+
+def test_graded_valid_park_not_paid_on_nonpark_step():
+    # park_valid None (a movement primitive, not a Park) earns 0 regardless of the grade scale.
+    w = RewardWeights(r_valid_park=10.0, valid_park_grade_scale=4.0, w_col=0.0)
+    assert step_reward(_ctx(park_valid=None), w) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# #720 (L5) — one-time first-valid bonus: a discrete positive kick the FIRST time an
+# episode reaches a valid placement, so the breakthrough from the place-nothing pole pays
+# a learnable return. The env flips ctx.first_valid_now True on exactly that one Park step.
+# ---------------------------------------------------------------------------
+
+
+def test_r_first_valid_default_zero_is_byte_identical():
+    # The bonus knob defaults 0.0 -> the first_valid_now flag is never consulted, byte-identical.
+    for fv in (False, True):
+        ctx = _ctx(park_valid=True, first_valid_now=fv)
+        assert step_reward(ctx, RewardWeights(r_valid_park=3.0)) == step_reward(
+            ctx, RewardWeights(r_valid_park=3.0, r_first_valid=0.0)
+        )
+
+
+def test_r_first_valid_paid_when_flag_set():
+    # On the flagged step the bonus is added on top of every other term.
+    w = RewardWeights(r_first_valid=7.0)
+    on = _ctx(park_valid=True, first_valid_now=True)
+    off = _ctx(park_valid=True, first_valid_now=False)
+    assert step_reward(on, w) - step_reward(off, w) == pytest.approx(7.0)
+
+
+def test_r_first_valid_not_paid_when_flag_unset():
+    # Default flag False (every step the env does not mark) earns no bonus.
+    w = RewardWeights(r_first_valid=7.0)
+    assert step_reward(_ctx(park_valid=True), w) == step_reward(
+        _ctx(park_valid=True), RewardWeights(r_first_valid=0.0)
+    )
+
+
+# ---------------------------------------------------------------------------
 # Task 3 — dense_slot_potential / active_misfit_m2 in potential() (Step 10)
 # ---------------------------------------------------------------------------
 

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -1033,3 +1033,75 @@ def test_train_curriculum_anchored_rung_runs_vectorized(backend):
         vec_backend=backend,
     )
     assert any(name == f"pa-vec-{backend}" for name, _, _ in hist.iterations)
+
+
+# ---------------------------------------------------------------------------
+# #720 (L5+L4) — graded-economics weights + PPO trust-region knobs thread through main().
+# All default to neutral so an unflagged run is byte-identical to the pre-#720 CLI.
+# ---------------------------------------------------------------------------
+
+
+def test_argparser_l5_l4_knobs_defaults():
+    from ml.ppo import PPOConfig
+    from ml.types import RewardWeights
+
+    a = build_argparser().parse_args([])
+    assert a.w_col == RewardWeights().w_col  # default 100.0, read from the dataclass not hardcoded
+    assert a.valid_park_grade_scale == 0.0
+    assert a.r_first_valid == 0.0
+    assert a.reward_clip is None
+    assert a.value_clip_eps is None
+    assert a.target_kl is None
+    # The PPOConfig dataclass agrees the L4 knobs are off by default.
+    assert PPOConfig().reward_clip is None
+    assert PPOConfig().value_clip_eps is None
+    assert PPOConfig().target_kl is None
+
+
+def _capture_main(monkeypatch, argv: list[str]) -> dict:
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum", *argv])
+    return captured
+
+
+def test_main_threads_l5_knobs_into_weights(monkeypatch):
+    w = _capture_main(
+        monkeypatch,
+        ["--w-col", "20.0", "--valid-park-grade-scale", "4.0", "--r-first-valid", "15.0"],
+    )["weights"]
+    assert w.w_col == 20.0
+    assert w.valid_park_grade_scale == 4.0
+    assert w.r_first_valid == 15.0
+
+
+def test_main_threads_l4_knobs_into_ppo(monkeypatch):
+    ppo = _capture_main(
+        monkeypatch,
+        ["--reward-clip", "10.0", "--value-clip-eps", "0.2", "--target-kl", "0.03"],
+    )["ppo"]
+    assert ppo.reward_clip == 10.0
+    assert ppo.value_clip_eps == 0.2
+    assert ppo.target_kl == 0.03
+
+
+def test_main_no_l5_l4_flags_default_neutral(monkeypatch):
+    from ml.types import RewardWeights
+
+    captured = _capture_main(monkeypatch, [])
+    w = captured["weights"]
+    assert w.w_col == RewardWeights().w_col
+    assert w.valid_park_grade_scale == 0.0
+    assert w.r_first_valid == 0.0
+    ppo = captured["ppo"]
+    assert ppo.reward_clip is None
+    assert ppo.value_clip_eps is None
+    assert ppo.target_kl is None


### PR DESCRIPTION
## What & why

Breaks the empty-start **place-nothing cliff** that failed the `--mixed-anchor` gate (seed-0: `pair-mixed` capped oscillating ~0.2, `pair-box` collapsed to `valid_placed 0.000`). A multi-agent diagnosis (5 lenses → 7 levers → 2 survived adversarial verification) root-caused it as **economics × discoverability**: from an empty hangar, do-nothing is a bounded −8 loss while any exploratory mis-Park books the **unclipped** `−w_col·overlap` (−5000…−12000) — so place-nothing is the genuine reward argmax, and the −w_col spike drove the −5000…−12000 PPO sawtooth. Full diagnosis in #720.

## Changes (the 2 levers that survived adversarial verification)

**L5 — Rebalance Park/abandon economics** (reward, optimum-moving):
- `valid_park_grade_scale`: grade the `r_valid_park` bonus by near-miss misfit (`r_valid_park·exp(−misfit/scale)`) → an uphill gradient *into* the witness slot. Reuses existing `overlap_m2`/`intrusion_m2`/`egress_blocked` (no new RewardContext field).
- `r_first_valid`: one-time breakthrough bonus on an episode's first valid Park (env one-shot `_first_valid_reached`, tied to whole-layout validity, cleared each `reset()`).
- `--w-col` exposes the collision weight to lower it.

**L4 — PPO trust-region hardening** (stabilizer; prerequisite, doesn't move the optimum alone):
- `reward_clip` (clamp raw rewards before normalize/GAE), `value_clip_eps` (PPO2 clipped value loss via the new `value_loss_term` helper), `target_kl` (epoch early-stop on mean approx-KL). `ppo_update` now also reports `approx_kl`/`epochs_run`.

**Default-neutrality:** every knob `0`/`None`-defaulted ⇒ byte-identical reward + training to the pre-#720 path (the 4c-ii contract). The **refuted** continuous-k-anneal lever is deliberately *not* added (policy-invariant on the empty-start sub-MDP).

## Tests (TDD, red→green per increment)

- `test_reward.py`: graded `valid_park` (full credit at 0 misfit, monotone in overlap, withheld on egress, not on non-Park) + `r_first_valid` term + default-neutral byte-identity.
- `test_env.py`: first-valid one-shot fires once, never repaid, tied to whole-layout validity, cleared across `reset()`.
- `test_ppo.py`: `value_loss_term` (MSE when unclipped, bounds value movement), reward-clip clamps/leaves-raw, `target_kl` early-stops epochs.
- `test_train_curriculum.py`: all six CLI flags thread into RewardWeights/PPOConfig; unflagged run is neutral.

Full ml suite **369 passed**; `ruff` + `mypy ml/` clean.

## Re-gate (not in this PR)

`ml/README.md` carries the L5+L4 gate recipe. WIN = `pair-box` `valid_placed` lifts decisively off 0.000 with the sawtooth gone and no upstream-rung regression. Magnitudes are a starting point (the graded-credit-vs-`w_col` knife-edge needs a short sweep).

Closes #720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
