### PR TITLE
feat(722): --stop-after-rung to truncate the curriculum ladder for sweep cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#722, epic #607): `--stop-after-rung NAME` truncates the curriculum
+  ladder for sweep cells.** The #720 economics re-gate runs as a checkpoint-resume sweep — train
+  the ladder once through `pair-mixed`, then `--load` and sweep only the `pair-box` rung across a
+  grid of `--w-col`/`--valid-park-grade-scale` cells. Previously each resumed cell, after
+  mastering/capping `pair-box`, ground on into `trio-box`/`trio-notch`/`trio-notch-strict`
+  (~3×80 wasted PPO iters per cell), with manual `Ctrl-C` the only workaround. `--stop-after-rung`
+  (curriculum-only) drops every rung after the named one — `--stop-after-rung pair-mixed` for the
+  upstream train, `--stop-after-rung pair-box` for each cell — so the sweep runs unattended. A
+  pure `truncate_after_rung` schedule transform (`ml/curriculum.py`) mirroring the `with_*_rung`
+  grafts; the `train_curriculum` loop is untouched. A name (not a count) because resume *skips*
+  completed rungs, making a count ambiguous; a typo'd rung fails loud. Absent ⇒ byte-identical.
+
 - **Learned backend (#720, epic #607): graded-economics + PPO trust-region levers to break
   the empty-start place-nothing cliff.** A multi-agent diagnosis of the `--mixed-anchor` gate
   failure (seed-0: `pair-mixed` capped oscillating ~0.2, `pair-box` collapsed to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
   the ladder once through `pair-mixed`, then `--load` and sweep only the `pair-box` rung across a
   grid of `--w-col`/`--valid-park-grade-scale` cells. Previously each resumed cell, after
   mastering/capping `pair-box`, ground on into `trio-box`/`trio-notch`/`trio-notch-strict`
-  (~3×80 wasted PPO iters per cell), with manual `Ctrl-C` the only workaround. `--stop-after-rung`
+  (≈3 extra `trio-*` rungs, each to the per-stage cap, of wasted PPO iters per cell), with
+  manual `Ctrl-C` the only workaround. `--stop-after-rung`
   (curriculum-only) drops every rung after the named one — `--stop-after-rung pair-mixed` for the
   upstream train, `--stop-after-rung pair-box` for each cell — so the sweep runs unattended. A
   pure `truncate_after_rung` schedule transform (`ml/curriculum.py`) mirroring the `with_*_rung`

--- a/ml/README.md
+++ b/ml/README.md
@@ -141,8 +141,9 @@ per-step active-overlap gradient) and, being potential-based shaping, is **polic
 | `--solo-box-rung` | off | Insert an opt-in `solo-box` rung (1 object, **whole fleet**) after `trivial` so single-object competency transfers before the 2-object jump (#714). Curriculum-only. |
 | `--seed-anchor` | off | Insert an opt-in `pair-anchored` rung **before** `pair-box`: one of its 2 objects is pre-parked at a committed-witness pose (`seed_anchor_k=1`) and the agent only drives the other in — scaffolding 2-object joint discovery with a valid 1-object start (#712). Curriculum-only. |
 | `--mixed-anchor` | off | Insert an opt-in `pair-mixed` rung **before** `pair-box`: each episode randomly starts anchored (k=1) or empty (k=0) with probability `anchor_prob=0.5`, drawn from the curriculum's seeded stream. Keeps empty-start episodes in the training mix so the policy does not collapse to the place-nothing pole on the empty-start `pair-box`. Pair with `--seed-anchor` so `pair-mixed` lands between `pair-anchored` and `pair-box` (not required — `--mixed-anchor` alone inserts it directly before `pair-box`). Curriculum-only. (#712 follow-up) |
+| `--stop-after-rung NAME` | off | Truncate the ladder after `NAME` (that rung is the last trained; every rung after it is dropped). Applied **after** the graft flags above, so a name they introduce (`pair-mixed`) is valid. The #722 sweep lever: `--stop-after-rung pair-box` lets a resumed cell stop cleanly instead of grinding on into `trio-*`. Unknown rung → loud `ValueError`. Curriculum-only; absent ⇒ byte-identical. |
 
-`--load`/`--checkpoint-out`/`--metrics-out`/`--promotion-*`/`--solo-box-rung`/`--seed-anchor`/`--mixed-anchor`
+`--load`/`--checkpoint-out`/`--metrics-out`/`--promotion-*`/`--solo-box-rung`/`--seed-anchor`/`--mixed-anchor`/`--stop-after-rung`
 are curriculum-only (fail loud under `--schedule trivial`). The resume checkpoint
 (`ml/checkpoint.py`) is distinct from `--save` (a bare `state_dict` for the ONNX/`ml.eval`
 consumer) and loads with `weights_only=True`.

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -472,3 +472,24 @@ def with_mixed_anchor_rung(schedule: CurriculumSchedule) -> CurriculumSchedule:
             "with_mixed_anchor_rung: schedule has no 'pair-box' rung to insert before"
         ) from None
     return replace(schedule, stages=stages[:before] + (_PAIR_MIXED_STAGE,) + stages[before:])
+
+
+def truncate_after_rung(schedule: CurriculumSchedule, rung_name: str) -> CurriculumSchedule:
+    """Return ``schedule`` with every rung AFTER ``rung_name`` dropped (the named rung is kept
+    as the last stage) — the #722 ``--stop-after-rung`` lever. A pure ``stages[:idx+1]``
+    truncation that mirrors the ``with_*_rung`` grafts: only the ladder changes (the promotion
+    policy is preserved), so a sweep can train just up to (and including) a chosen rung instead
+    of grinding on through the rest of the ladder. Truncating at the LAST rung is a no-op on the
+    stages, so a run that names the final rung stays byte-identical to no truncation. Raises
+    ValueError (loud, not a leaked StopIteration) when ``rung_name`` is not in the schedule, so a
+    typo'd rung fails before the run rather than silently disabling the cap. Apply AFTER the
+    ``with_*_rung`` grafts so a name they introduce (e.g. ``pair-mixed``) is in scope."""
+    stages = schedule.stages
+    try:
+        idx = next(i for i, s in enumerate(stages) if s.name == rung_name)
+    except StopIteration:
+        raise ValueError(
+            f"truncate_after_rung: schedule has no rung named {rung_name!r} "
+            f"(have {[s.name for s in stages]})"
+        ) from None
+    return replace(schedule, stages=stages[: idx + 1])

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -480,7 +480,8 @@ def truncate_after_rung(schedule: CurriculumSchedule, rung_name: str) -> Curricu
     truncation that mirrors the ``with_*_rung`` grafts: only the ladder changes (the promotion
     policy is preserved), so a sweep can train just up to (and including) a chosen rung instead
     of grinding on through the rest of the ladder. Truncating at the LAST rung is a no-op on the
-    stages, so a run that names the final rung stays byte-identical to no truncation. Raises
+    stages, so a run that names the final rung stays byte-identical (in training output) to no
+    truncation. Raises
     ValueError (loud, not a leaked StopIteration) when ``rung_name`` is not in the schedule, so a
     typo'd rung fails before the run rather than silently disabling the cap. Apply AFTER the
     ``with_*_rung`` grafts so a name they introduce (e.g. ``pair-mixed``) is in scope."""

--- a/ml/train.py
+++ b/ml/train.py
@@ -34,6 +34,7 @@ from ml.curriculum import (
     make_episode_sampler,
     should_promote,
     stage_rng,
+    truncate_after_rung,
     validate_ladder,
     with_mixed_anchor_rung,
     with_pair_anchored_rung,
@@ -616,6 +617,16 @@ def build_argparser() -> argparse.ArgumentParser:
         "and pair-box.",
     )
     p.add_argument(
+        "--stop-after-rung",
+        type=str,
+        default=None,
+        help="curriculum: truncate the ladder after this rung (the named rung is the last "
+        "trained), dropping every rung after it. Default = run the whole ladder "
+        "(byte-identical). The #722 sweep lever: stop after pair-box so a resumed cell does "
+        "not grind on into trio-*. Applied after the --solo-box-rung/--seed-anchor/"
+        "--mixed-anchor grafts, so a name they introduce (pair-mixed) is valid.",
+    )
+    p.add_argument(
         "--r-valid-park",
         type=float,
         default=0.0,
@@ -781,6 +792,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             parser.error("--seed-anchor requires --schedule curriculum")
         if args.mixed_anchor:
             parser.error("--mixed-anchor requires --schedule curriculum")
+        if args.stop_after_rung is not None:
+            parser.error("--stop-after-rung requires --schedule curriculum")
         train(
             seed=args.seed,
             iterations=args.iterations,
@@ -810,6 +823,9 @@ def main(argv: Sequence[str] | None = None) -> None:
             sched = with_pair_anchored_rung(sched)
         if args.mixed_anchor:
             sched = with_mixed_anchor_rung(sched)
+        # Truncate LAST, after the grafts, so a name they introduce (pair-mixed) is in scope.
+        if args.stop_after_rung is not None:
+            sched = truncate_after_rung(sched, args.stop_after_rung)
         history = train_curriculum(
             seed=args.seed,
             schedule=sched,

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -28,6 +28,7 @@ from ml.curriculum import (
     sample_request,
     should_promote,
     stage_rng,
+    truncate_after_rung,
     validate_ladder,
     with_mixed_anchor_rung,
     with_pair_anchored_rung,
@@ -632,3 +633,66 @@ def test_make_episode_sampler_mixed_for_mixed_stage_varies_k():
     sampler = make_episode_sampler(_PAIR_MIXED_STAGE, pool, 2, rng)
     ks = {sampler().seed_anchor_k for _ in range(200)}
     assert ks == {0, 1}  # mixture draws both
+
+
+# ---------------------------------------------------------------------------
+# #722 — truncate_after_rung: stop the ladder after a named rung (sweep tooling)
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_after_rung_drops_later_stages():
+    # Truncating the default ladder at 'pair-box' keeps trivial+pair-box and drops the
+    # trio-* rungs after it — the #722 lever that lets a resumed sweep cell stop cleanly.
+    sched = truncate_after_rung(CurriculumSchedule.default(), "pair-box")
+    names = [s.name for s in sched.stages]
+    assert names == ["trivial", "pair-box"]
+
+
+def test_truncate_after_rung_keeps_named_rung_last():
+    sched = truncate_after_rung(CurriculumSchedule.default(), "trio-notch")
+    names = [s.name for s in sched.stages]
+    assert names[-1] == "trio-notch"
+    assert "trio-notch-strict" not in names  # the rung after it is dropped
+
+
+def test_truncate_after_rung_at_last_rung_is_a_noop_on_stages():
+    base = CurriculumSchedule.default()
+    sched = truncate_after_rung(base, "trio-notch-strict")  # the last rung
+    assert [s.name for s in sched.stages] == [s.name for s in base.stages]
+
+
+def test_truncate_after_rung_preserves_policy_and_validates():
+    base = CurriculumSchedule.default()
+    sched = truncate_after_rung(base, "pair-box")
+    assert sched.policy == base.policy  # only the ladder changes, not the promotion gate
+    validate_ladder(sched.stages, encoder_max_objects=EncoderConfig().max_objects)  # no raise
+
+
+def test_truncate_after_rung_does_not_mutate_the_default_ladder():
+    truncate_after_rung(CurriculumSchedule.default(), "pair-box")
+    assert [s.name for s in DEFAULT_LADDER][-1] == "trio-notch-strict"  # default still full
+
+
+def test_truncate_after_rung_raises_on_unknown_rung():
+    with pytest.raises(ValueError, match="no-such-rung"):
+        truncate_after_rung(CurriculumSchedule.default(), "no-such-rung")
+
+
+def test_truncate_after_rung_composes_with_grafts():
+    # The intended #722 sweep shape: graft the opt-in rungs, then truncate at 'pair-box'
+    # so the resumed cell trains only up to (and including) pair-box.
+    sched = with_mixed_anchor_rung(
+        with_pair_anchored_rung(with_solo_box_rung(CurriculumSchedule.default()))
+    )
+    truncated = truncate_after_rung(sched, "pair-box")
+    names = [s.name for s in truncated.stages]
+    assert names == ["trivial", "solo-box", "pair-anchored", "pair-mixed", "pair-box"]
+
+
+def test_truncate_after_rung_at_pair_mixed_for_upstream_train():
+    # The upstream train stops after pair-mixed (before the empty-start pair-box).
+    sched = with_mixed_anchor_rung(
+        with_pair_anchored_rung(with_solo_box_rung(CurriculumSchedule.default()))
+    )
+    names = [s.name for s in truncate_after_rung(sched, "pair-mixed").stages]
+    assert names == ["trivial", "solo-box", "pair-anchored", "pair-mixed"]

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -982,6 +982,99 @@ def test_mixed_anchor_flag_inserts_pair_mixed(monkeypatch):
     assert names.index("pair-anchored") < names.index("pair-mixed") < names.index("pair-box")
 
 
+# ---------------------------------------------------------------------------
+# #722 — --stop-after-rung CLI wiring (truncate the ladder for sweep cells).
+# ---------------------------------------------------------------------------
+
+
+def test_argparser_stop_after_rung_defaults_none():
+    assert build_argparser().parse_args([]).stop_after_rung is None
+
+
+def test_main_stop_after_rung_requires_curriculum_schedule(monkeypatch):
+    # --stop-after-rung is a curriculum ladder edit; under --schedule trivial it fails LOUD.
+    import ml.train as train_mod
+
+    ran = {"train": False}
+
+    def guard(**kw):
+        ran["train"] = True
+        return []
+
+    monkeypatch.setattr(train_mod, "train", guard)
+    with pytest.raises(SystemExit):
+        train_mod.main(["--schedule", "trivial", "--stop-after-rung", "pair-box"])
+    assert ran["train"] is False
+
+
+def test_main_stop_after_rung_truncates_schedule(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum", "--stop-after-rung", "pair-box"])
+    names = [s.name for s in captured["schedule"].stages]
+    assert names == ["trivial", "pair-box"]  # trio-* dropped
+
+
+def test_main_without_stop_after_rung_keeps_full_ladder(monkeypatch):
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum"])
+    assert captured["schedule"].stages[-1].name == "trio-notch-strict"  # full ladder
+
+
+def test_main_stop_after_rung_composes_with_grafts(monkeypatch):
+    # The intended sweep shape: graft the opt-in rungs, then stop after pair-box.
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(**kw):
+        captured.update(kw)
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(
+        [
+            "--schedule",
+            "curriculum",
+            "--solo-box-rung",
+            "--seed-anchor",
+            "--mixed-anchor",
+            "--stop-after-rung",
+            "pair-box",
+        ]
+    )
+    names = [s.name for s in captured["schedule"].stages]
+    assert names == ["trivial", "solo-box", "pair-anchored", "pair-mixed", "pair-box"]
+
+
+def test_main_stop_after_rung_unknown_rung_errors(monkeypatch):
+    # A typo'd rung name fails LOUD (the truncate_after_rung ValueError surfaces) rather than
+    # silently disabling the cap and grinding the whole ladder.
+    import ml.train as train_mod
+
+    monkeypatch.setattr(train_mod, "train_curriculum", lambda **kw: None)
+    with pytest.raises(ValueError, match="no-such-rung"):
+        train_mod.main(["--schedule", "curriculum", "--stop-after-rung", "no-such-rung"])
+
+
 def _anchored_smoke_schedule(name: str = "pair-anchored-smoke"):
     anchored = Stage(
         name=name,


### PR DESCRIPTION
Closes #722

## What

Adds a **default-neutral** `--stop-after-rung NAME` flag that truncates the curriculum ladder after the named rung (that rung is the last trained; every rung after it is dropped).

## Why

The #720 economics re-gate runs as a **checkpoint-resume sweep**: train the ladder once through `pair-mixed`, then `--load` and sweep only the `pair-box` rung across a grid of `--w-col`/`--valid-park-grade-scale` cells. Without a stop, each resumed cell — after mastering/capping `pair-box` — ground on into `trio-box` → `trio-notch` → `trio-notch-strict` (~3×80 wasted PPO iters per cell, ×6+ cells). Manual `Ctrl-C` per cell was the only workaround, which made the sweep impossible to run unattended.

With this flag: `--stop-after-rung pair-mixed` for the upstream train, `--stop-after-rung pair-box` for each cell.

## How

- **Pure transform** `truncate_after_rung(schedule, rung_name)` in `ml/curriculum.py` — a `stages[:idx+1]` slice mirroring the existing `with_solo_box_rung` / `with_pair_anchored_rung` / `with_mixed_anchor_rung` grafts. Preserves the promotion policy; doesn't mutate `DEFAULT_LADDER`; raises `ValueError` (loud) on an unknown rung.
- Wired in `main()` **after** the `with_*_rung` grafts so a name they introduce (`pair-mixed`) is in scope. The determinism-sensitive `train_curriculum` loop is **completely untouched** — the schedule is simply shorter.
- `--stop-after-rung` is curriculum-only (`parser.error` under `--schedule trivial`, matching the other ladder flags).

### Design note: name, not count
A `--max-stages N` count is brittle here: under resume, completed rungs are *skipped* (`train.py:395`), so a count interacts confusingly with what actually runs, and the right `N` shifts with which optional rungs (`--solo-box-rung`/`--seed-anchor`/`--mixed-anchor`) are enabled. A rung *name* is unambiguous and self-documenting in every sweep command.

## Byte-identity

Absent (`--stop-after-rung` default `None`) ⇒ the schedule is unchanged ⇒ **byte-identical** to current behavior. The truncate helper is only called when the flag is passed.

## Tests (TDD)

- 8 pure-transform tests (`tests/ml/test_curriculum.py`): truncate, keep-named-last, no-op-at-last-rung, preserve-policy+validate, no-mutate-default, raises-unknown, composes-with-grafts, stop-at-pair-mixed.
- 6 CLI-wiring tests (`tests/ml/test_train_curriculum.py`): default-none, requires-curriculum, truncates-schedule, keeps-full-ladder, composes-with-grafts, unknown-rung-errors.
- Full `tests/ml/` green (384 passed); `ruff` + `ruff format` + `mypy ml/` (full package) clean.

## Docs

- `CHANGELOG.md` `[Unreleased]` entry.
- `ml/README.md` flag table row + curriculum-only flag list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)