### PR TITLE
docs(724): #720 L4-clip gate result (two-seed pass) + recipe reward-clip 10→50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
   **L4 trust-region clipping is load-bearing, not optional**: clip-off collapses to place-nothing
   (the deep ≈−1400 collision-penalty gradient outlier drives PPO into the place-nothing absorbing
   state), clip-on masters. The recipe's `--reward-clip` is corrected `10.0 → 50.0` — sized so the
-  per-step valid-park bonus (`r_valid_park 30 + r_first_valid 15 = 45`) stays below the clip while
-  the deep spikes are clamped (`10` would clip the legit bonus and flatten the L5 gradient; `50` is
-  the validated value). `ml/README.md` recipe + WIN section updated with the confirmed result.
+  per-step **graded** valid-park bonus (`r_valid_park 30 + r_first_valid 15 = 45`) below the clip
+  (so the L5 near-miss gradient survives) while the deep spikes are clamped — the episode-completing
+  step's `r_terminal` credit does saturate the ±50 clamp, by design. `10` would clip even the graded
+  bonus and flatten the L5 gradient; `50` is the validated value. `ml/README.md` recipe + WIN section updated with the confirmed result.
   Docs-only — the L4 flags already shipped in #720.
 
 - **Learned backend (#722, epic #607): `--stop-after-rung NAME` truncates the curriculum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#724, epic #607): #720 empty-start `pair-box` gate — two-seed PASS; L4
+  clipping confirmed load-bearing; recipe `reward_clip 10 → 50`.** The #720 L5+L4 gate was run as a
+  #722 checkpoint-resume sweep on GPU. The empty-start `pair-box` rung — `valid_placed=0.000` in
+  every prior gate — now **promotes by competency on both seeds** (seed 0 iter 27 `vp` 0.80, seed 1
+  iter 19 `vp` 0.85), placing both objects validly with no piling. A controlled A/B (seed 0, same
+  upstream checkpoint, same seed, byte-identical iter 0, only the three L4 flags differing) showed
+  **L4 trust-region clipping is load-bearing, not optional**: clip-off collapses to place-nothing
+  (the deep ≈−1400 collision-penalty gradient outlier drives PPO into the place-nothing absorbing
+  state), clip-on masters. The recipe's `--reward-clip` is corrected `10.0 → 50.0` — sized so the
+  per-step valid-park bonus (`r_valid_park 30 + r_first_valid 15 = 45`) stays below the clip while
+  the deep spikes are clamped (`10` would clip the legit bonus and flatten the L5 gradient; `50` is
+  the validated value). `ml/README.md` recipe + WIN section updated with the confirmed result.
+  Docs-only — the L4 flags already shipped in #720.
+
 - **Learned backend (#722, epic #607): `--stop-after-rung NAME` truncates the curriculum
   ladder for sweep cells.** The #720 economics re-gate runs as a checkpoint-resume sweep — train
   the ladder once through `pair-mixed`, then `--load` and sweep only the `pair-box` rung across a

--- a/ml/README.md
+++ b/ml/README.md
@@ -280,19 +280,22 @@ holds).
 main-grid hypothesis that `--validity-conditional-terminal` + `--normalize-returns` would cover
 stability). A controlled A/B settled it: same upstream checkpoint, same `--seed 0`, byte-identical
 iter 0, the *only* difference the three L4 flags — clip **off** collapses to place-nothing (`vp`
-peaks 0.24 then decays to ~0 as `fraction_placed` 0.79→0.02), clip **on** masters. The deep
-`−w_col·overlap` collision spikes (≈−1400 here, the residue after L5 tamed the −5000…−12000 band)
-are a gradient outlier that drives PPO into the place-nothing absorbing state; clamping them in the
-update is what lets the policy stay in the *placing* regime long enough to learn 2-object joint
-placement. The full ladder needs all four ingredients — L5 graded economics (start off 0.000) +
+peaks 0.24 then decays to ~0 as `fraction_placed` 0.79→0.02), clip **on** masters. The residual
+deep-penalty episodes (`mean_ep_reward` ≈−1400 in the clip-off run, down from the −5000…−12000 band
+before L5) are a `−w_col·overlap` gradient outlier that drives PPO into the place-nothing absorbing
+state; clamping the per-step reward in the update is what lets the policy stay in the *placing*
+regime long enough to learn 2-object joint placement. The full ladder needs all four ingredients — L5 graded economics (start off 0.000) +
 `--seed-anchor`/`--mixed-anchor` (keep empty-start episodes in the training distribution) + **L4
 clipping** (don't flee to place-nothing) + `--validity-conditional-terminal` (place *validly*, not
 pile).
 
-**`--reward-clip 50` (not 10):** sized so the per-step valid-park bonus
-(`r_valid_park 30 + r_first_valid 15 = 45`) stays below the clip while the deep collision spikes are
-clamped to −50. `reward_clip 10` would clip the legit valid-park bonus (45 > 10), flattening the
-very L5 gradient the recipe creates; `50` is the validated value (two-seed mastery). The
+**`--reward-clip 50` (not 10):** `reward_clip` clamps the *total* per-step reward to ±50. `50` keeps
+the per-step **graded** valid-park bonus (`r_valid_park 30 + r_first_valid 15 = 45`) below the clip
+so the L5 near-miss gradient survives, while clamping the deep `−w_col·overlap` spikes to −50. (The
+episode-*completing* valid park step also books `r_terminal·fraction ≈ 50`, so that one step does
+saturate the clamp — the intent is preserving the graded near-miss gradient, not the terminal
+credit.) `reward_clip 10` would clip even the graded bonus (45 > 10), flattening the L5 gradient;
+`50` is the validated value (two-seed mastery). The
 no-upstream-regression check still holds (`trivial`/`solo-box`/`pair-anchored` all promote by
 competency at `w_col=20`). Read `valid_placed`, NOT `valid_rate` (an empty layout is vacuously
 "valid", so `valid_rate→1` under place-nothing is the *failure* signature).

--- a/ml/README.md
+++ b/ml/README.md
@@ -261,21 +261,41 @@ python -u -m ml.train --schedule curriculum --device cuda --n-envs 16 \
   --promotion-metric valid_placed --promotion-threshold 0.9 \
   --r-valid-park 30.0 --r-unplaced-penalty 25.0 --dense-slot-potential \
   --w-col 20.0 --valid-park-grade-scale 4.0 --r-first-valid 15.0 \
-  --reward-clip 10.0 --value-clip-eps 0.2 --target-kl 0.03 \
+  --reward-clip 50.0 --value-clip-eps 0.2 --target-kl 0.03 \
   --entropy-start 0.05 --entropy-end 0.005 --entropy-anneal-iters 40 \
   --normalize-returns --validity-conditional-terminal --solo-box-rung \
   --seed-anchor --mixed-anchor \
   --metrics-out metrics-seed0-l5l4.jsonl --checkpoint-out ck-seed0-l5l4.pt --seed 0
 ```
 
-WIN: `pair-box` `valid_placed` lifts decisively **off 0.000** (trending ≥0.1 within 80 iters,
-climbing — read `valid_placed` NOT `valid_rate`), the −5000…−12000 sawtooth is gone (L4 did its
-job), and `trivial`/`solo-box`/`pair-anchored` still promote-by-competency (no upstream regression
-from the lower `w_col`). The `--w-col`/`--valid-park-grade-scale`/`--r-first-valid` magnitudes
-above are a **starting point** — the open knife-edge is graded credit vs `w_col` at the near-miss
-overlap (the grade must beat the collision penalty into the slot without making piling profitable),
-so expect a short sweep. If `pair-box` stays pinned with the sawtooth gone, that isolates the
-failure to pure discoverability → escalate to a pose-scaffold rung (L6a). Run a second seed.
+**GATE RESULT (#722 checkpoint-resume sweep, 2026-06-19): two-seed PASS — the empty-start
+`pair-box` cliff is broken.** Run as a sweep with the #722 `--stop-after-rung` tooling (train the
+ladder once through `pair-mixed`, then `--load` and sweep only the empty-start `pair-box` rung).
+The empty-start `pair-box` — `valid_placed=0.000` in every prior gate — now **promotes by
+competency** on both seeds (seed 0 at iter 27, `vp` 0.80; seed 1 at iter 19, `vp` 0.85), placing
+*both* objects validly with `valid_rate` rising (no piling — `--validity-conditional-terminal`
+holds).
+
+**L4 trust-region clipping is load-bearing, not optional.** The sweep tested dropping it (the
+main-grid hypothesis that `--validity-conditional-terminal` + `--normalize-returns` would cover
+stability). A controlled A/B settled it: same upstream checkpoint, same `--seed 0`, byte-identical
+iter 0, the *only* difference the three L4 flags — clip **off** collapses to place-nothing (`vp`
+peaks 0.24 then decays to ~0 as `fraction_placed` 0.79→0.02), clip **on** masters. The deep
+`−w_col·overlap` collision spikes (≈−1400 here, the residue after L5 tamed the −5000…−12000 band)
+are a gradient outlier that drives PPO into the place-nothing absorbing state; clamping them in the
+update is what lets the policy stay in the *placing* regime long enough to learn 2-object joint
+placement. The full ladder needs all four ingredients — L5 graded economics (start off 0.000) +
+`--seed-anchor`/`--mixed-anchor` (keep empty-start episodes in the training distribution) + **L4
+clipping** (don't flee to place-nothing) + `--validity-conditional-terminal` (place *validly*, not
+pile).
+
+**`--reward-clip 50` (not 10):** sized so the per-step valid-park bonus
+(`r_valid_park 30 + r_first_valid 15 = 45`) stays below the clip while the deep collision spikes are
+clamped to −50. `reward_clip 10` would clip the legit valid-park bonus (45 > 10), flattening the
+very L5 gradient the recipe creates; `50` is the validated value (two-seed mastery). The
+no-upstream-regression check still holds (`trivial`/`solo-box`/`pair-anchored` all promote by
+competency at `w_col=20`). Read `valid_placed`, NOT `valid_rate` (an empty layout is vacuously
+"valid", so `valid_rate→1` under place-nothing is the *failure* signature).
 
 ## Design
 See `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`


### PR DESCRIPTION
Closes #724

## What
Documents the result of the #720 L5+L4 empty-start `pair-box` gate (run as a #722 checkpoint-resume sweep on GPU) and corrects the recipe's `--reward-clip` value. **Docs-only** — the L4 flags already shipped in #720.

## Result: two-seed gate PASS
The empty-start `pair-box` rung — `valid_placed=0.000` in every prior gate — now **promotes by competency on both seeds** (seed 0 iter 27 `vp` 0.80, seed 1 iter 19 `vp` 0.85), placing both objects validly with `valid_rate` rising (no piling).

## L4 clipping is load-bearing (controlled A/B)
The sweep tested the design hypothesis that L4 clipping could be dropped. A clean controlled A/B settled it:

| Run | L4 clip | Outcome |
|---|---|---|
| seed-0 recipe-center | OFF | collapse → place-nothing (`vp` 0.24→~0, `fp` 0.79→0.02) |
| seed-0 L4-clip | ON (`reward_clip 50`) | mastered — promoted by competency, iter 27 |
| seed-1 L4-clip | ON (`reward_clip 50`) | mastered — promoted by competency, iter 19 |

Same upstream checkpoint, same `--seed 0`, **byte-identical iter 0** — only the three L4 flags differ. The deep `−w_col·overlap` collision spikes (≈−1400, the residue after L5 tamed the −5000…−12000 band) are a gradient outlier that drives PPO into place-nothing; clamping them is what keeps the policy placing long enough to learn 2-object joint placement.

## Recipe value: `--reward-clip 10 → 50`
`50` is sized so the per-step valid-park bonus (`r_valid_park 30 + r_first_valid 15 = 45`) stays below the clip while the deep spikes are clamped to −50. `10` would clip the legit bonus (45 > 10), flattening the L5 gradient. `50` is the validated value (two-seed mastery); `10` was not directly tested but over-clips — documented as such, not claimed to definitively fail.

## Changes
- `ml/README.md`: recipe `--reward-clip 10.0 → 50.0`; WIN section rewritten from the speculative "expect a sweep / escalate to L6a" to the confirmed two-seed result + sizing rationale.
- `CHANGELOG.md`: `[Unreleased]` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)