### PR TITLE
feat(728): default the #720 L4 trust-region clipping bundle in ml.train

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,7 +359,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
   argparse **and** `PPOConfig` dataclass defaults (kept in sync). New paired `--no-reward-clip` /
   `--no-value-clip-eps` / `--no-target-kl` off-switches restore the disabled (`None`) behavior —
   the only way to reach it, since there is no in-band "off" value (`--reward-clip 0` zeroes all
-  rewards; `--target-kl 0` stops after one epoch) — for A/B controls such as the seed-1 clip-OFF
+  rewards; `--target-kl 0` stops after the first epoch) — for A/B controls such as the seed-1 clip-OFF
   run. This is a deliberate training-default **re-baseline**: an unflagged run is no longer
   byte-identical to a pre-#720 run, but reproducibility (same seed → same stream) is unchanged. The
   four 4c-ii basin-escape knobs (`--r-valid-park`, `--dense-slot-potential`, entropy, `--normalize-returns`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,11 @@ All notable changes to this project are documented here. Format follows [Keep a 
   `--valid-park-grade-scale` grades the `r_valid_park` bonus by near-miss misfit
   (`r_valid_park·exp(−misfit/scale)`) into an uphill gradient toward the witness slot;
   `--r-first-valid` is a one-time breakthrough bonus on an episode's first valid placement;
-  `--w-col` exposes the collision weight. **L4** (PPO, default-neutral): `--reward-clip`,
+  `--w-col` exposes the collision weight. **L4** (PPO): `--reward-clip`,
   `--value-clip-eps` (PPO2 clipped value loss), and `--target-kl` (epoch early-stop) tame the
   unclipped collision spike that drove the gate's −5000…−12000 sawtooth; `ppo_update` now also
-  reports `approx_kl`/`epochs_run`. All knobs 0/None ⇒ byte-identical training. The refuted
+  reports `approx_kl`/`epochs_run`. As shipped in #720 all knobs were 0/None ⇒ byte-identical
+  training; the L4 trio later graduated to default-on (#728 — see Changed). The refuted
   continuous-k-anneal lever is **not** added (policy-invariant on the empty-start sub-MDP).
 
 - **Mixed-start anchor curriculum rung (`--mixed-anchor`, #712 follow-up).** An opt-in
@@ -350,6 +351,19 @@ All notable changes to this project are documented here. Format follows [Keep a 
   backend (epic #607).
 
 ### Changed
+
+- **Learned backend (#728, epic #607): the #720 L4 trust-region clipping bundle is now the
+  `ml.train` default.** `--reward-clip 50` / `--value-clip-eps 0.2` / `--target-kl 0.03` — the
+  values confirmed load-bearing by the two-seed #720/#722 `pair-box` gate (a controlled A/B showed
+  clip-off collapses to place-nothing, clip-on masters) — graduated from opt-in flags to the
+  argparse **and** `PPOConfig` dataclass defaults (kept in sync). New paired `--no-reward-clip` /
+  `--no-value-clip-eps` / `--no-target-kl` off-switches restore the disabled (`None`) behavior —
+  the only way to reach it, since there is no in-band "off" value (`--reward-clip 0` zeroes all
+  rewards; `--target-kl 0` stops after one epoch) — for A/B controls such as the seed-1 clip-OFF
+  run. This is a deliberate training-default **re-baseline**: an unflagged run is no longer
+  byte-identical to a pre-#720 run, but reproducibility (same seed → same stream) is unchanged. The
+  four 4c-ii basin-escape knobs (`--r-valid-park`, `--dense-slot-potential`, entropy, `--normalize-returns`)
+  remain default-neutral. `ml/README.md` recipe prose updated.
 
 - **Herrenteich dataset realism pass (#657/#658/#659).** Tightened the real
   Airfield Herrenteich dataset to how the club actually parks (user on-site facts):

--- a/ml/README.md
+++ b/ml/README.md
@@ -259,7 +259,8 @@ The three **L4 trust-region** knobs **graduated to the default in #728** (`--rew
 carries them, so they are shown explicitly in the recipe below only for reproducibility. Pass
 `--no-reward-clip` / `--no-value-clip-eps` / `--no-target-kl` to disable any of them — that is the
 only way to reach the unclipped behavior (e.g. the seed-1 clip-OFF A/B control), since there is no
-in-band "off" value (`--reward-clip 0` zeroes all rewards; `--target-kl 0` stops after one epoch).
+in-band "off" value (`--reward-clip 0` zeroes all rewards; `--target-kl 0` stops after the first
+epoch).
 
 ```bash
 # Above mixed-anchor config, plus the #720 L5 economics + L4 PPO trust-region knobs.

--- a/ml/README.md
+++ b/ml/README.md
@@ -251,8 +251,15 @@ to `valid_placed 0.000`). A multi-agent diagnosis root-caused the cliff as *econ
 discoverability*: from empty, do-nothing is a small bounded loss (≈−8 observed on the failed seed-0
 gate run) while any exploratory mis-Park books the **unclipped** `−w_col·overlap` (−5000…−12000),
 so place-nothing is the genuine reward argmax.
-The #720 levers shift that argmax (L5) and tame the resulting sawtooth (L4); all knobs are
-default-neutral (0/None ⇒ byte-identical), so they layer onto the recipe above.
+The #720 levers shift that argmax (L5) and tame the resulting sawtooth (L4). The **L5 economics**
+knobs (`--r-valid-park`, `--r-unplaced-penalty`, `--w-col`, `--valid-park-grade-scale`,
+`--r-first-valid`) stay default-neutral (0/None ⇒ byte-identical) and layer onto the recipe above.
+The three **L4 trust-region** knobs **graduated to the default in #728** (`--reward-clip 50`,
+`--value-clip-eps 0.2`, `--target-kl 0.03` — the two-seed-validated values): an unflagged run now
+carries them, so they are shown explicitly in the recipe below only for reproducibility. Pass
+`--no-reward-clip` / `--no-value-clip-eps` / `--no-target-kl` to disable any of them — that is the
+only way to reach the unclipped behavior (e.g. the seed-1 clip-OFF A/B control), since there is no
+in-band "off" value (`--reward-clip 0` zeroes all rewards; `--target-kl 0` stops after one epoch).
 
 ```bash
 # Above mixed-anchor config, plus the #720 L5 economics + L4 PPO trust-region knobs.

--- a/ml/ppo.py
+++ b/ml/ppo.py
@@ -33,10 +33,11 @@ class PPOConfig:
     normalize_returns: bool = False  # std-only reward normalization before GAE
     return_norm_eps: float = 1e-8  # numerical floor on the running std
     # #720 (L4) PPO trust-region hardening, default-ON since #728 (the two-seed-validated #720
-    # bundle). Set any to None to disable (byte-identical to the pre-#720 update) — the CLI exposes
-    # --no-reward-clip / --no-value-clip-eps / --no-target-kl for that. The reward_clip value is
-    # tuned to the RewardWeights magnitudes (45 = r_valid_park 30 + r_first_valid 15 graded bonus,
-    # ~50 terminal credit), so a reward-scale change should revisit it.
+    # bundle). Set any to None to disable it — that knob's update-step path is then byte-identical
+    # to the pre-#720 loop, though an unflagged *run* is the deliberate #728 default re-baseline.
+    # The CLI exposes --no-reward-clip / --no-value-clip-eps / --no-target-kl for that. The
+    # reward_clip value is tuned to the RewardWeights magnitudes (45 = r_valid_park 30 +
+    # r_first_valid 15 graded bonus, ~50 terminal credit) — revisit on a reward-scale change.
     reward_clip: float | None = 50.0  # clamp RAW rewards to [-c, c] before normalize/GAE; tames
     # the unclipped -w_col collision spike (-12000 batches) that drove the gate sawtooth.
     value_clip_eps: float | None = 0.2  # PPO2 clipped value loss; caps per-update critic movement.

--- a/ml/ppo.py
+++ b/ml/ppo.py
@@ -32,11 +32,15 @@ class PPOConfig:
     entropy_anneal_iters: int = 0  # iters over which to anneal; 0 = no schedule
     normalize_returns: bool = False  # std-only reward normalization before GAE
     return_norm_eps: float = 1e-8  # numerical floor on the running std
-    # #720 (L4) PPO trust-region hardening — all None/off => byte-identical to the pre-#720 update.
-    reward_clip: float | None = None  # clamp RAW rewards to [-c, c] before normalize/GAE; tames
+    # #720 (L4) PPO trust-region hardening, default-ON since #728 (the two-seed-validated #720
+    # bundle). Set any to None to disable (byte-identical to the pre-#720 update) — the CLI exposes
+    # --no-reward-clip / --no-value-clip-eps / --no-target-kl for that. The reward_clip value is
+    # tuned to the RewardWeights magnitudes (45 = r_valid_park 30 + r_first_valid 15 graded bonus,
+    # ~50 terminal credit), so a reward-scale change should revisit it.
+    reward_clip: float | None = 50.0  # clamp RAW rewards to [-c, c] before normalize/GAE; tames
     # the unclipped -w_col collision spike (-12000 batches) that drove the gate sawtooth.
-    value_clip_eps: float | None = None  # PPO2 clipped value loss; caps per-update critic movement.
-    target_kl: float | None = None  # early-stop the epoch loop once a full epoch's mean approx-KL
+    value_clip_eps: float | None = 0.2  # PPO2 clipped value loss; caps per-update critic movement.
+    target_kl: float | None = 0.03  # early-stop the epoch loop once a full epoch's mean approx-KL
     # exceeds this (a per-update trust region), so one catastrophic batch cannot over-rotate.
 
 

--- a/ml/train.py
+++ b/ml/train.py
@@ -695,27 +695,54 @@ def build_argparser() -> argparse.ArgumentParser:
         action="store_true",
         help="std-only Welford return normalization before GAE",
     )
+    # #720 L4 trust-region bundle, default-ON since #728 (the two-seed-validated config). Each
+    # value flag is paired with a --no-* off-switch sharing its dest; the value flag is defined
+    # FIRST so argparse's first-default-wins rule makes the bundle value the namespace default,
+    # and last-on-the-CLI-wins lets a later --no-* (or explicit value) override. The off-switch is
+    # the only way to reach the disabled (None) behavior — there is no in-band "off" value
+    # (--reward-clip 0 zeroes all rewards; --target-kl 0 stops after one epoch).
     p.add_argument(
         "--reward-clip",
         type=float,
-        default=None,
+        default=50.0,
         help="clamp RAW rewards to [-c, c] before normalize/GAE (tames the -w_col collision "
-        "spike that drove the gate sawtooth); None = off (byte-identical); #720 L4",
+        "spike that drove the gate sawtooth); default 50 (#720/#728); --no-reward-clip disables",
+    )
+    p.add_argument(
+        "--no-reward-clip",
+        action="store_const",
+        const=None,
+        dest="reward_clip",
+        help="disable L4 reward clipping (reward_clip=None) — for the clip-OFF A/B control",
     )
     p.add_argument(
         "--value-clip-eps",
         type=float,
-        default=None,
+        default=0.2,
         help="PPO2 clipped value loss epsilon — caps how far one update moves the critic; "
-        "None = plain MSE (byte-identical); #720 L4",
+        "default 0.2 (#720/#728); --no-value-clip-eps disables (plain MSE)",
+    )
+    p.add_argument(
+        "--no-value-clip-eps",
+        action="store_const",
+        const=None,
+        dest="value_clip_eps",
+        help="disable L4 clipped value loss (value_clip_eps=None, plain MSE)",
     )
     p.add_argument(
         "--target-kl",
         type=float,
-        default=None,
+        default=0.03,
         help="early-stop the PPO epoch loop once a full epoch's mean approx-KL exceeds this "
-        "(per-update trust region); None/omitted = off, run all epochs (byte-identical). Note "
-        "0.0 is NOT 'off' — it stops after the first epoch (mean-KL > 0 almost always); #720 L4",
+        "(per-update trust region); default 0.03 (#720/#728); --no-target-kl disables (run all "
+        "epochs). Note 0.0 is NOT 'off' — it stops after epoch 1 (mean-KL > 0 almost always)",
+    )
+    p.add_argument(
+        "--no-target-kl",
+        action="store_const",
+        const=None,
+        dest="target_kl",
+        help="disable L4 target-KL early-stop (target_kl=None) — run all PPO epochs",
     )
     p.add_argument(
         "--n-envs",

--- a/ml/train.py
+++ b/ml/train.py
@@ -700,7 +700,7 @@ def build_argparser() -> argparse.ArgumentParser:
     # FIRST so argparse's first-default-wins rule makes the bundle value the namespace default,
     # and last-on-the-CLI-wins lets a later --no-* (or explicit value) override. The off-switch is
     # the only way to reach the disabled (None) behavior — there is no in-band "off" value
-    # (--reward-clip 0 zeroes all rewards; --target-kl 0 stops after one epoch).
+    # (--reward-clip 0 zeroes all rewards; --target-kl 0 stops after the first epoch).
     p.add_argument(
         "--reward-clip",
         type=float,
@@ -735,7 +735,7 @@ def build_argparser() -> argparse.ArgumentParser:
         default=0.03,
         help="early-stop the PPO epoch loop once a full epoch's mean approx-KL exceeds this "
         "(per-update trust region); default 0.03 (#720/#728); --no-target-kl disables (run all "
-        "epochs). Note 0.0 is NOT 'off' — it stops after epoch 1 (mean-KL > 0 almost always)",
+        "epochs). Note 0.0 is NOT 'off' — it stops after the first epoch (mean-KL > 0)",
     )
     p.add_argument(
         "--no-target-kl",

--- a/tests/ml/test_ppo.py
+++ b/tests/ml/test_ppo.py
@@ -580,15 +580,16 @@ def test_ppo_update_minibatches_all_TN_vec_transitions(monkeypatch):
 
 # ---------------------------------------------------------------------------
 # #720 (L4) — PPO trust-region hardening: raw-reward clip, clipped value loss, target-KL
-# early-stop. All three default None -> byte-identical to the pre-#720 update. These tame the
-# unclipped -w_col collision spike that drove the gate's -5000..-12000 sawtooth.
+# early-stop. Default-ON since #728 (the validated #720 bundle 50/0.2/0.03); pass None to disable.
+# These tame the unclipped -w_col collision spike that drove the gate's -5000..-12000 sawtooth.
 # ---------------------------------------------------------------------------
 from ml.ppo import value_loss_term  # noqa: E402
 
 
-def test_ppo_config_l4_knobs_default_none():
+def test_ppo_config_l4_knobs_default_on():
+    # #728: the validated #720 L4 trust-region bundle is now the PPOConfig default.
     c = PPOConfig()
-    assert c.reward_clip is None and c.value_clip_eps is None and c.target_kl is None
+    assert c.reward_clip == 50.0 and c.value_clip_eps == 0.2 and c.target_kl == 0.03
 
 
 def test_value_loss_term_unclipped_is_plain_mse():

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -1130,7 +1130,8 @@ def test_train_curriculum_anchored_rung_runs_vectorized(backend):
 
 # ---------------------------------------------------------------------------
 # #720 (L5+L4) — graded-economics weights + PPO trust-region knobs thread through main().
-# All default to neutral so an unflagged run is byte-identical to the pre-#720 CLI.
+# The L5 economics knobs stay default-neutral; the three L4 trust-region knobs are default-ON
+# since #728 (graduated to the validated #720 bundle 50/0.2/0.03), with --no-* off-switches.
 # ---------------------------------------------------------------------------
 
 
@@ -1142,13 +1143,14 @@ def test_argparser_l5_l4_knobs_defaults():
     assert a.w_col == RewardWeights().w_col  # default 100.0, read from the dataclass not hardcoded
     assert a.valid_park_grade_scale == 0.0
     assert a.r_first_valid == 0.0
-    assert a.reward_clip is None
-    assert a.value_clip_eps is None
-    assert a.target_kl is None
-    # The PPOConfig dataclass agrees the L4 knobs are off by default.
-    assert PPOConfig().reward_clip is None
-    assert PPOConfig().value_clip_eps is None
-    assert PPOConfig().target_kl is None
+    # #728: the L4 trust-region knobs default to the validated #720 bundle.
+    assert a.reward_clip == 50.0
+    assert a.value_clip_eps == 0.2
+    assert a.target_kl == 0.03
+    # The PPOConfig dataclass agrees (argparse default == dataclass default).
+    assert PPOConfig().reward_clip == 50.0
+    assert PPOConfig().value_clip_eps == 0.2
+    assert PPOConfig().target_kl == 0.03
 
 
 def _capture_main(monkeypatch, argv: list[str]) -> dict:
@@ -1186,7 +1188,33 @@ def test_main_threads_l4_knobs_into_ppo(monkeypatch):
     assert ppo.target_kl == 0.03
 
 
-def test_main_no_l5_l4_flags_default_neutral(monkeypatch):
+def test_argparser_l4_off_switches_disable():
+    # #728: the three --no-* off-switches restore the disabled (None) behavior — the seed-1
+    # clip-OFF A/B control needs this, since there is no in-band "off" value.
+    a = build_argparser().parse_args(["--no-reward-clip", "--no-value-clip-eps", "--no-target-kl"])
+    assert a.reward_clip is None
+    assert a.value_clip_eps is None
+    assert a.target_kl is None
+
+
+def test_argparser_l4_off_switch_last_wins():
+    # An explicit value then --no-* disables (argparse last-wins on the shared dest).
+    a = build_argparser().parse_args(["--reward-clip", "30.0", "--no-reward-clip"])
+    assert a.reward_clip is None
+
+
+def test_main_threads_l4_off_switches_into_ppo(monkeypatch):
+    ppo = _capture_main(monkeypatch, ["--no-reward-clip", "--no-value-clip-eps", "--no-target-kl"])[
+        "ppo"
+    ]
+    assert ppo.reward_clip is None
+    assert ppo.value_clip_eps is None
+    assert ppo.target_kl is None
+
+
+def test_main_no_flags_l5_neutral_l4_default_on(monkeypatch):
+    # #728: an unflagged run keeps the L5 economics weights neutral but now carries the
+    # default-ON L4 trust-region bundle through to PPOConfig.
     from ml.types import RewardWeights
 
     captured = _capture_main(monkeypatch, [])
@@ -1195,6 +1223,6 @@ def test_main_no_l5_l4_flags_default_neutral(monkeypatch):
     assert w.valid_park_grade_scale == 0.0
     assert w.r_first_valid == 0.0
     ppo = captured["ppo"]
-    assert ppo.reward_clip is None
-    assert ppo.value_clip_eps is None
-    assert ppo.target_kl is None
+    assert ppo.reward_clip == 50.0
+    assert ppo.value_clip_eps == 0.2
+    assert ppo.target_kl == 0.03


### PR DESCRIPTION
## What & why

Graduates the #720 **L4 trust-region clipping** bundle from opt-in flags to the **default** for `python -m ml.train`. The bundle — `--reward-clip 50` / `--value-clip-eps 0.2` / `--target-kl 0.03` — was confirmed **load-bearing** by the two-seed #720/#722 `pair-box` gate (controlled seed-0 A/B: clip-off collapses to place-nothing, clip-on masters). No more hand-pasting it on every gate run.

Closes #728.

## Design decisions (settled via brainstorming)

- **Scope:** all three L4 knobs (the exact bundle the A/B toggled), not reward-clip alone.
- **Where the value lives:** **sync both** — the argparse defaults *and* the `PPOConfig` dataclass defaults flip to `50.0 / 0.2 / 0.03`, kept identical (so the argparse-default == dataclass-default coherence holds).
- **Off-switches:** new paired `--no-reward-clip` / `--no-value-clip-eps` / `--no-target-kl` (`store_const, const=None`, shared `dest`, value-flag-first so argparse's first-default-wins makes the bundle the namespace default). These are the **only** way to reach the disabled (`None`) behavior — there is no in-band "off" value (`--reward-clip 0` zeroes all rewards; `--target-kl 0` stops after one epoch). The future **seed-1 clip-OFF A/B control** depends on them; explicit overrides (`--reward-clip 30`) still work via last-wins.

## Re-baseline, not a contract break

This is a **deliberate, documented training-default re-baseline**. An unflagged run is no longer byte-identical to a pre-#720 run — but the property that must survive, **reproducibility** (same seed → same stream), is untouched. The three default-assertion tests are *rewritten* (not deleted) to assert the new defaults. The four genuine **4c-ii** basin-escape knobs (`--r-valid-park`, `--dense-slot-potential`, entropy, `--normalize-returns`) stay default-neutral; `ml-rl-guard` Invariant 2 names those four, so this breaks no named contract.

## Changes

- `ml/ppo.py` — `PPOConfig` defaults → `50.0 / 0.2 / 0.03`; comment notes the value is tuned to the `RewardWeights` magnitudes (revisit on a reward-scale change).
- `ml/train.py` — argparse defaults flipped; three `--no-*` off-switches added (with the ordering rationale in a comment).
- `tests/ml/` — three default-assertion tests rewritten to the new defaults (keeping every L5-neutral assertion); three off-switch tests added; `test_main_no_l5_l4_flags_default_neutral` → `test_main_no_flags_l5_neutral_l4_default_on`.
- `ml/README.md` — split the now-false blanket "all default-neutral" claim; document the off-switches.
- `CHANGELOG.md` — `### Changed` entry; softened the #720 entry's absolute claim.

## Verification

- `pytest tests/ml/` — **387 passed, 2 deselected** (zero collateral shift from the dataclass default flip; the audit hypothesis held).
- `ruff check ml/ tests/ml/` clean; `ruff format` clean; `mypy ml/` — success, 18 files.

## Out of scope

No re-gate / GPU run — the bundle is already gate-validated on the harder empty-start `pair-box` rung. The trivial-rung byte stream re-bases (clip=50 is tuned inert on legitimate rewards, so this is neutral-to-beneficial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
