### PR TITLE
feat(730): trio-box training-gate harness + launch recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#730, epic #607): trio-box training-gate harness + launch recipe.**
+  No-GPU prep for the #698 train-to-mastery frontier — does the #720/#728 four-lever ladder
+  generalize past the 2-object `pair-box` to the 3-object `trio-box` rung (the historical
+  ≥2-object wall)? Adds `ml/gate.py` (`python -m ml.gate METRICS.jsonl --rung trio-box`), a
+  **torch-free** reader for the `--metrics-out` JSONL that emits a per-rung verdict headlining
+  `valid_placed` (never `valid_rate` — vacuously 1.0 under place-nothing) with a **piling
+  watchdog** (`fraction_placed` high while `valid_placed` low = committing objects invalidly).
+  Verdicts: `mastered` / `piling` / `place-nothing` / `in-progress` / `no-data`, with exit
+  codes (0/1/2) for unattended sweeps. `ml/README.md` gains the two-seed `--stop-after-rung
+  trio-box` checkpoint-resume launch recipe + resume gotchas; a curriculum smoke test guards the
+  exact truncated sweep-shape ladder. Does not run the sweep itself (needs the GPU).
+
 - **Learned backend (#724, epic #607): #720 empty-start `pair-box` gate — two-seed PASS; L4
   clipping confirmed load-bearing; recipe `reward_clip 10 → 50`.** The #720 L5+L4 gate was run as a
   #722 checkpoint-resume sweep on GPU. The empty-start `pair-box` rung — `valid_placed=0.000` in

--- a/ml/README.md
+++ b/ml/README.md
@@ -308,6 +308,58 @@ no-upstream-regression check still holds (`trivial`/`solo-box`/`pair-anchored` a
 competency at `w_col=20`). Read `valid_placed`, NOT `valid_rate` (an empty layout is vacuously
 "valid", so `valid_rate→1` under place-nothing is the *failure* signature).
 
+### Trio-box gate recipe (#730 — does the four-lever ladder generalize past N=2?)
+
+The two-seed `pair-box` PASS above broke the *2-object* cliff. The open question is whether the
+same four-lever ladder clears the **3-object** `trio-box` rung (`max_objects=3`, already in
+`DEFAULT_LADDER`) — historically every ≥2-object rung collapsed, and `trio-box` is the first
+untested one past the fix. This is a **checkpoint-resume sweep**: take a checkpoint whose
+`completed_stages` already include `pair-box` (the `--checkpoint-out` from the pair-box gate above),
+then train **only** `trio-box` with `--stop-after-rung trio-box`. The L4 clip knobs are now the
+default (#728) but are kept explicit below for reproducibility.
+
+```bash
+# Per seed (run twice, --seed 0 and --seed 1, with the matching pair-box checkpoint).
+# --load resumes; the loop SKIPS trivial…pair-box (already in completed_stages) and trains trio-box.
+python -u -m ml.train --schedule curriculum --device cuda --n-envs 16 \
+  --rollout-len 512 --max-iters-per-stage 80 \
+  --promotion-metric valid_placed --promotion-threshold 0.9 \
+  --r-valid-park 30.0 --r-unplaced-penalty 25.0 --dense-slot-potential \
+  --w-col 20.0 --valid-park-grade-scale 4.0 --r-first-valid 15.0 \
+  --reward-clip 50.0 --value-clip-eps 0.2 --target-kl 0.03 \
+  --entropy-start 0.05 --entropy-end 0.005 --entropy-anneal-iters 40 \
+  --normalize-returns --validity-conditional-terminal --solo-box-rung \
+  --seed-anchor --mixed-anchor --stop-after-rung trio-box \
+  --load ck-seed0-l5l4.pt \
+  --metrics-out metrics-seed0-trio.jsonl --checkpoint-out ck-seed0-trio.pt --seed 0
+```
+
+**Resume gotchas (the single most likely way to corrupt the gate):**
+- **Re-pass `--solo-box-rung --seed-anchor --mixed-anchor` on every resumed cell.** The checkpoint
+  stores completed rung *names*, not the schedule shape — omit a graft and the rebuilt ladder no
+  longer matches, so the skip-completed logic silently re-trains or reshapes rungs.
+- **Do not `pip install .[train]`** if you have a local CUDA torch — it clobbers your `~/.local`
+  build. Run `ml.train` from the repo root (the top-level `ml/` package is not on the editable
+  install's path).
+- Gate scratch (`metrics-*.jsonl`, `ck-*.pt`) is gitignored (#717) — don't commit run artifacts.
+
+**Read the result with the gate harness** (torch-free, `ml/gate.py`) instead of eyeballing the
+JSONL — it headlines `valid_placed` (never `valid_rate`) and flags the piling basin:
+
+```bash
+python -m ml.gate metrics-seed0-trio.jsonl --rung trio-box   # exit 0=mastered, 1=not, 2=no-data
+python -m ml.gate metrics-seed1-trio.jsonl --rung trio-box
+```
+
+Outcomes: **`mastered`** (`valid_placed ≥ 0.9` — the WIN) · **`piling`** (placed much but validly
+little: committing objects invalidly, *not* a win — distrust any apparent progress) · **`place-nothing`**
+(fled to do-nothing: a *clean* collapse that routes to an L6a pose-scaffold rung) · **`in-progress`**
+(placing validly and climbing, just under threshold — give it more iters).
+
+**WIN = `trio-box` mastered on BOTH seeds.** A clean two-seed `place-nothing` is a valid negative
+(the four-lever ladder does *not* generalize to N=3 → pose-scaffold). A `piling` verdict means the
+ladder is unstable at N=3 and needs the economics re-tuned before re-gating.
+
 ## Design
 See `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`
 and ADR-0027 (learned-path determinism scope).

--- a/ml/README.md
+++ b/ml/README.md
@@ -313,7 +313,7 @@ competency at `w_col=20`). Read `valid_placed`, NOT `valid_rate` (an empty layou
 The two-seed `pair-box` PASS above broke the *2-object* cliff. The open question is whether the
 same four-lever ladder clears the **3-object** `trio-box` rung (`max_objects=3`, already in
 `DEFAULT_LADDER`) — historically every ≥2-object rung collapsed, and `trio-box` is the first
-untested one past the fix. This is a **checkpoint-resume sweep**: take a checkpoint whose
+≥2-object rung after the validated `pair-box`. This is a **checkpoint-resume sweep**: take a checkpoint whose
 `completed_stages` already include `pair-box` (the `--checkpoint-out` from the pair-box gate above),
 then train **only** `trio-box` with `--stop-after-rung trio-box`. The L4 clip knobs are now the
 default (#728) but are kept explicit below for reproducibility.

--- a/ml/gate.py
+++ b/ml/gate.py
@@ -1,0 +1,167 @@
+"""ml/gate.py — read a ``--metrics-out`` JSONL training curve and emit a per-rung
+gate verdict (#730, towards the #698 train-to-mastery frontier).
+
+PURE: stdlib only (``json`` / ``dataclasses``), **no torch** — so it runs under the
+``[dev]``-only CI and can be invoked post-hoc on any run's metrics file via
+``python -m ml.gate METRICS.jsonl --rung trio-box``.
+
+Reads ``valid_placed`` (the #710 compound mastery axis: ``fraction_placed`` credited
+only on collision-free episodes), NOT ``valid_rate`` — an empty layout is vacuously
+"valid", so ``valid_rate -> 1`` under place-nothing is the *failure* signature, not a
+win. The piling watchdog flags the other failure mode: ``valid_placed`` low while
+``fraction_placed`` high = the policy commits objects *invalidly* (piling), distinct
+from fleeing to place-nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+
+@dataclass(frozen=True, slots=True)
+class GateVerdict:
+    """The verdict for one rung's ``valid_placed`` learning curve."""
+
+    rung: str
+    outcome: str  # "mastered" | "piling" | "place-nothing" | "in-progress" | "no-data"
+    n_iters: int  # iterations with at least one completed episode
+    peak_valid_placed: float | None
+    peak_valid_placed_iter: int | None
+    final_valid_placed: float | None
+    competency_iter: int | None  # first iter with valid_placed >= threshold, else None
+    peak_fraction_placed: float | None = None
+    piling_iters: int = 0  # iters that placed much (fraction high) but validly little
+
+
+def gate_verdict(
+    records: list[dict[str, object]],
+    rung: str,
+    *,
+    threshold: float = 0.9,
+    piling_floor: float = 0.2,
+    piling_fraction: float = 0.5,
+) -> GateVerdict:
+    """Reduce ``records`` (history_metric_records()-shaped) for ``rung`` to a verdict.
+
+    An iteration is a *piling* iteration when it placed much (``fraction_placed >=
+    piling_fraction``) but validly little (``valid_placed <= piling_floor``) — the policy
+    is committing objects invalidly. The headline ``outcome`` when not yet mastered:
+    ``piling`` if any piling iter occurred, ``place-nothing`` if it never placed much
+    (peak ``fraction_placed < piling_fraction``: fled to do-nothing), else ``in-progress``
+    (placing validly and climbing, just below ``threshold``)."""
+    rows = [r for r in records if r.get("stage") == rung and r.get("valid_placed") is not None]
+    # JSON values are typed `object`; the emitter (history_metric_records) guarantees iter:int
+    # and the rates:float, and the filter above drops the n_eps==0 rows where the rates are None
+    # (fraction_placed is None iff valid_placed is None), so the casts are sound.
+    curve: list[tuple[int, float, float]] = [
+        (
+            cast("int", r["iter"]),
+            cast("float", r["valid_placed"]),
+            cast("float", r["fraction_placed"]),
+        )
+        for r in rows
+    ]
+
+    if not curve:
+        return GateVerdict(
+            rung=rung,
+            outcome="no-data",
+            n_iters=0,
+            peak_valid_placed=None,
+            peak_valid_placed_iter=None,
+            final_valid_placed=None,
+            competency_iter=None,
+        )
+
+    peak_iter, peak_vp, _ = max(curve, key=lambda ivf: ivf[1])
+    peak_fp = max(fp for _, _, fp in curve)
+    competency_iter = next((it for it, vp, _ in curve if vp >= threshold), None)
+    piling_iters = sum(1 for _, vp, fp in curve if fp >= piling_fraction and vp <= piling_floor)
+
+    if peak_vp >= threshold:
+        outcome = "mastered"
+    elif piling_iters > 0:
+        outcome = "piling"
+    elif peak_fp < piling_fraction:
+        outcome = "place-nothing"
+    else:
+        outcome = "in-progress"
+
+    return GateVerdict(
+        rung=rung,
+        outcome=outcome,
+        n_iters=len(curve),
+        peak_valid_placed=peak_vp,
+        peak_valid_placed_iter=peak_iter,
+        final_valid_placed=curve[-1][1],
+        competency_iter=competency_iter,
+        peak_fraction_placed=peak_fp,
+        piling_iters=piling_iters,
+    )
+
+
+def read_metric_records(path: str | Path) -> list[dict[str, object]]:
+    """Parse a ``--metrics-out`` JSONL file into the record list ``gate_verdict`` wants
+    (one JSON object per non-blank line)."""
+    text = Path(path).read_text()
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+_OUTCOME_GLOSS = {
+    "mastered": "valid_placed crossed the threshold — the WIN.",
+    "piling": "placed much but validly little — committing objects invalidly, NOT a win.",
+    "place-nothing": "fled to do-nothing — clean collapse, routes to a pose-scaffold rung.",
+    "in-progress": "placing validly and climbing, but below the threshold — not yet mastered.",
+    "no-data": "no completed-episode iteration recorded for this rung.",
+}
+
+
+def render_verdict(v: GateVerdict) -> str:
+    """A human-readable multi-line verdict. Headlines ``valid_placed`` (the mastery axis),
+    never ``valid_rate`` (vacuously 1.0 under place-nothing — the documented trap)."""
+    if v.outcome == "no-data":
+        return f"[{v.rung}] NO-DATA — {_OUTCOME_GLOSS['no-data']}"
+    comp = f"iter {v.competency_iter}" if v.competency_iter is not None else "never"
+    return (
+        f"[{v.rung}] {v.outcome.upper()} — {_OUTCOME_GLOSS[v.outcome]}\n"
+        f"  peak valid_placed  = {v.peak_valid_placed:.3f} (iter {v.peak_valid_placed_iter})\n"
+        f"  final valid_placed = {v.final_valid_placed:.3f}\n"
+        f"  competency (vp>=thr): {comp}\n"
+        f"  peak fraction_placed = {v.peak_fraction_placed:.3f}   piling iters = {v.piling_iters}\n"
+        f"  iters with episodes  = {v.n_iters}"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """``python -m ml.gate METRICS.jsonl --rung trio-box``. Prints the verdict and returns
+    an exit code: ``0`` mastered, ``1`` ran but did not reach competency (piling /
+    place-nothing / in-progress — all valid *results*, just not the WIN), ``2`` no data
+    for the rung."""
+    p = argparse.ArgumentParser(
+        prog="python -m ml.gate",
+        description="Read a --metrics-out JSONL training curve and emit a per-rung gate verdict.",
+    )
+    p.add_argument("metrics", help="path to the --metrics-out JSONL file")
+    p.add_argument("--rung", default="trio-box", help="curriculum rung to gate (default: trio-box)")
+    p.add_argument(
+        "--threshold",
+        type=float,
+        default=0.9,
+        help="valid_placed competency threshold (default: 0.9, matching PromotionPolicy)",
+    )
+    args = p.parse_args(argv)
+
+    verdict = gate_verdict(read_metric_records(args.metrics), args.rung, threshold=args.threshold)
+    print(render_verdict(verdict))
+    if verdict.outcome == "no-data":
+        return 2
+    return 0 if verdict.outcome == "mastered" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ml/gate.py
+++ b/ml/gate.py
@@ -6,7 +6,8 @@ PURE: stdlib only (``json`` / ``dataclasses``), **no torch** — so it runs unde
 ``python -m ml.gate METRICS.jsonl --rung trio-box``.
 
 Reads ``valid_placed`` (the #710 compound mastery axis: ``fraction_placed`` credited
-only on collision-free episodes), NOT ``valid_rate`` — an empty layout is vacuously
+only on **valid** episodes — the #694 product checker, ``collisions.check`` *plus* Caddy
+egress, not merely collision-free), NOT ``valid_rate`` — an empty layout is vacuously
 "valid", so ``valid_rate -> 1`` under place-nothing is the *failure* signature, not a
 win. The piling watchdog flags the other failure mode: ``valid_placed`` low while
 ``fraction_placed`` high = the policy commits objects *invalidly* (piling), distinct
@@ -54,18 +55,30 @@ def gate_verdict(
     ``piling`` if any piling iter occurred, ``place-nothing`` if it never placed much
     (peak ``fraction_placed < piling_fraction``: fled to do-nothing), else ``in-progress``
     (placing validly and climbing, just below ``threshold``)."""
-    rows = [r for r in records if r.get("stage") == rung and r.get("valid_placed") is not None]
-    # JSON values are typed `object`; the emitter (history_metric_records) guarantees iter:int
-    # and the rates:float, and the filter above drops the n_eps==0 rows where the rates are None
-    # (fraction_placed is None iff valid_placed is None), so the casts are sound.
-    curve: list[tuple[int, float, float]] = [
-        (
-            cast("int", r["iter"]),
-            cast("float", r["valid_placed"]),
-            cast("float", r["fraction_placed"]),
-        )
-        for r in rows
+    rows = [
+        r
+        for r in records
+        if r.get("stage") == rung
+        and r.get("iter") is not None
+        and r.get("valid_placed") is not None
+        and r.get("fraction_placed") is not None
     ]
+    # JSON values are typed `object`; the filter above guarantees the three keys are present
+    # and numeric (the emitter writes the rates as None together for n_eps==0 iterations, and
+    # a hand-rolled file with a partial row is skipped here rather than crashing on a None
+    # comparison), so the casts are sound. Sort by iter so `final_*` is the last *iteration*,
+    # not merely the last line of a possibly out-of-order or concatenated file.
+    curve: list[tuple[int, float, float]] = sorted(
+        (
+            (
+                cast("int", r["iter"]),
+                cast("float", r["valid_placed"]),
+                cast("float", r["fraction_placed"]),
+            )
+            for r in rows
+        ),
+        key=lambda ivf: ivf[0],
+    )
 
     if not curve:
         return GateVerdict(
@@ -122,8 +135,8 @@ _OUTCOME_GLOSS = {
 
 
 def render_verdict(v: GateVerdict) -> str:
-    """A human-readable multi-line verdict. Headlines ``valid_placed`` (the mastery axis),
-    never ``valid_rate`` (vacuously 1.0 under place-nothing — the documented trap)."""
+    """A human-readable multi-line verdict, headlining ``valid_placed`` (see the module
+    docstring for why never ``valid_rate``)."""
     if v.outcome == "no-data":
         return f"[{v.rung}] NO-DATA — {_OUTCOME_GLOSS['no-data']}"
     comp = f"iter {v.competency_iter}" if v.competency_iter is not None else "never"

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -696,3 +696,18 @@ def test_truncate_after_rung_at_pair_mixed_for_upstream_train():
     )
     names = [s.name for s in truncate_after_rung(sched, "pair-mixed").stages]
     assert names == ["trivial", "solo-box", "pair-anchored", "pair-mixed"]
+
+
+def test_truncate_after_rung_at_trio_box_is_the_gate_sweep_shape():
+    # #730: the trio-box gate-sweep cell resumes the grafted ladder and stops AFTER
+    # trio-box — dropping trio-notch/-strict so a resumed cell does not grind on past the
+    # rung under test. This is the exact ladder shape the GPU sweep launch produces.
+    sched = with_mixed_anchor_rung(
+        with_pair_anchored_rung(with_solo_box_rung(CurriculumSchedule.default()))
+    )
+    truncated = truncate_after_rung(sched, "trio-box")
+    names = [s.name for s in truncated.stages]
+    assert names == ["trivial", "solo-box", "pair-anchored", "pair-mixed", "pair-box", "trio-box"]
+    trio = truncated.stages[-1]
+    assert trio.name == "trio-box"
+    assert trio.difficulty.max_objects == 3  # the ≥2-object rung the four-lever ladder must clear

--- a/tests/ml/test_gate.py
+++ b/tests/ml/test_gate.py
@@ -149,3 +149,18 @@ def test_main_defaults_rung_to_trio_box(tmp_path, capsys):
     path = _write(tmp_path, [_rec("trio-box", 0, vp=0.95, fp=0.97)])
     assert main([str(path)]) == 0
     assert "trio-box" in capsys.readouterr().out
+
+
+def test_gate_verdict_skips_rows_with_partial_metrics():
+    # A post-hoc run on an arbitrary metrics file may carry a row with valid_placed
+    # present but fraction_placed missing/None (asymmetric to the emitter contract). The
+    # harness must skip such a row, not crash with an opaque None-comparison TypeError.
+    records = [
+        {"stage": "trio-box", "iter": 0, "valid_placed": 0.5, "fraction_placed": None},
+        {"stage": "trio-box", "iter": 1, "valid_placed": 0.6},  # fraction_placed key absent
+        _rec("trio-box", 2, vp=0.92, fp=0.95),
+    ]
+    v = gate_verdict(records, "trio-box", threshold=0.9)
+    assert v.outcome == "mastered"
+    assert v.n_iters == 1  # only the well-formed row counts
+    assert v.peak_valid_placed == 0.92

--- a/tests/ml/test_gate.py
+++ b/tests/ml/test_gate.py
@@ -1,0 +1,151 @@
+"""Tests for ml/gate.py — the torch-free `--metrics-out` JSONL gate reader (#730).
+
+PURE: no torch import/skip — the gate harness reads the per-iteration metric records
+that `history_metric_records()` emits, so it is exercised under the [dev]-only CI.
+"""
+
+from __future__ import annotations
+
+import json
+
+from ml.gate import gate_verdict, main, read_metric_records, render_verdict
+
+
+def _rec(stage, it, *, vp, fp, vr=None, reward=0.0, n_eps=8):
+    """A `history_metric_records()`-shaped per-iteration record."""
+    return {
+        "stage": stage,
+        "iter": it,
+        "n_eps": n_eps,
+        "mean_ep_reward": reward,
+        "fraction_placed": fp,
+        "valid_rate": vr if vr is not None else (vp / fp if fp else 0.0),
+        "valid_placed": vp,
+    }
+
+
+def test_verdict_is_mastered_when_valid_placed_crosses_threshold():
+    records = [
+        _rec("trio-box", 0, vp=0.0, fp=0.1),
+        _rec("trio-box", 1, vp=0.45, fp=0.6),
+        _rec("trio-box", 2, vp=0.92, fp=0.95),
+    ]
+    v = gate_verdict(records, "trio-box", threshold=0.9)
+    assert v.outcome == "mastered"
+    assert v.competency_iter == 2
+    assert v.peak_valid_placed == 0.92
+
+
+def test_verdict_is_no_data_when_rung_absent_or_all_empty_iters():
+    records = [
+        _rec("pair-box", 0, vp=0.9, fp=0.95),  # different rung
+        {
+            "stage": "trio-box",
+            "iter": 0,
+            "n_eps": 0,
+            "valid_placed": None,
+            "fraction_placed": None,
+            "valid_rate": None,
+            "mean_ep_reward": None,
+        },
+    ]
+    v = gate_verdict(records, "trio-box", threshold=0.9)
+    assert v.outcome == "no-data"
+    assert v.n_iters == 0
+    assert v.peak_valid_placed is None
+    assert v.competency_iter is None
+
+
+def test_verdict_is_piling_when_fraction_high_but_valid_placed_low():
+    # Commits objects invalidly: fraction_placed >= 0.5 while valid_placed <= 0.2.
+    records = [
+        _rec("trio-box", 0, vp=0.05, fp=0.70),
+        _rec("trio-box", 1, vp=0.10, fp=0.85),
+        _rec("trio-box", 2, vp=0.08, fp=0.66),
+    ]
+    v = gate_verdict(records, "trio-box", threshold=0.9)
+    assert v.outcome == "piling"
+    assert v.piling_iters == 3
+    assert v.competency_iter is None
+
+
+def test_verdict_is_place_nothing_when_fraction_stays_low():
+    # Flees to do-nothing: never places much, so never piles either.
+    records = [
+        _rec("trio-box", 0, vp=0.0, fp=0.10),
+        _rec("trio-box", 1, vp=0.0, fp=0.05),
+        _rec("trio-box", 2, vp=0.0, fp=0.02),
+    ]
+    v = gate_verdict(records, "trio-box", threshold=0.9)
+    assert v.outcome == "place-nothing"
+    assert v.piling_iters == 0
+
+
+def test_verdict_is_in_progress_when_placing_validly_but_below_threshold():
+    # Genuine partial progress: places most of the set validly, climbing, not yet mastered.
+    records = [
+        _rec("trio-box", 0, vp=0.30, fp=0.55),
+        _rec("trio-box", 1, vp=0.55, fp=0.70),
+        _rec("trio-box", 2, vp=0.72, fp=0.80),
+    ]
+    v = gate_verdict(records, "trio-box", threshold=0.9)
+    assert v.outcome == "in-progress"
+    assert v.piling_iters == 0
+    assert v.peak_valid_placed == 0.72
+
+
+def test_read_metric_records_parses_jsonl_round_trip(tmp_path):
+    records = [_rec("trio-box", 0, vp=0.1, fp=0.2), _rec("trio-box", 1, vp=0.9, fp=0.95)]
+    path = tmp_path / "metrics.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    assert read_metric_records(path) == records
+
+
+def test_read_metric_records_skips_blank_lines(tmp_path):
+    path = tmp_path / "metrics.jsonl"
+    path.write_text(json.dumps(_rec("trio-box", 0, vp=0.5, fp=0.6)) + "\n\n")
+    assert len(read_metric_records(path)) == 1
+
+
+def test_render_verdict_reports_valid_placed_not_valid_rate():
+    v = gate_verdict([_rec("trio-box", 2, vp=0.92, fp=0.95)], "trio-box", threshold=0.9)
+    text = render_verdict(v)
+    assert "MASTERED" in text
+    assert "trio-box" in text
+    assert "valid_placed" in text
+    assert "valid_rate" not in text  # the documented trap — never headline valid_rate
+
+
+def _write(tmp_path, records):
+    path = tmp_path / "metrics.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return path
+
+
+def test_main_exits_zero_and_prints_mastered_on_win(tmp_path, capsys):
+    path = _write(
+        tmp_path, [_rec("trio-box", 0, vp=0.3, fp=0.5), _rec("trio-box", 1, vp=0.91, fp=0.95)]
+    )
+    code = main([str(path), "--rung", "trio-box"])
+    assert code == 0
+    assert "MASTERED" in capsys.readouterr().out
+
+
+def test_main_exits_one_when_not_mastered(tmp_path, capsys):
+    path = _write(
+        tmp_path, [_rec("trio-box", 0, vp=0.05, fp=0.8), _rec("trio-box", 1, vp=0.1, fp=0.85)]
+    )
+    code = main([str(path), "--rung", "trio-box"])
+    assert code == 1
+    assert "PILING" in capsys.readouterr().out
+
+
+def test_main_exits_two_on_no_data(tmp_path):
+    path = _write(tmp_path, [_rec("pair-box", 0, vp=0.9, fp=0.95)])
+    assert main([str(path), "--rung", "trio-box"]) == 2
+
+
+def test_main_defaults_rung_to_trio_box(tmp_path, capsys):
+    path = _write(tmp_path, [_rec("trio-box", 0, vp=0.95, fp=0.97)])
+    assert main([str(path)]) == 0
+    assert "trio-box" in capsys.readouterr().out


### PR DESCRIPTION
Closes #730. Part of the #698 train-to-mastery frontier (epic #607).

## Why
The two-seed `pair-box` competency gate passed under the #720/#728 four-lever ladder (L5 graded economics + L4 PPO trust-region clipping, now default-on). The open question is empirical: **does that ladder generalize past N=2** — the historical ≥2-object wall — to the `trio-box` rung (`max_objects=3`, already in `DEFAULT_LADDER`)?

This is the **no-GPU prep** so the eventual two-seed serial-4090 sweep is a single supervised launch. It does **not** run the sweep (needs the GPU) and does not close #698.

## What
- **`ml/gate.py`** — a **torch-free** reader for the `--metrics-out` JSONL that emits a per-rung `GateVerdict`. It headlines `valid_placed` (the #710 compound mastery axis), **never** `valid_rate` (vacuously 1.0 under place-nothing — the documented trap), and runs a **piling watchdog** (`fraction_placed` high while `valid_placed` low = committing objects invalidly). Verdicts: `mastered` / `piling` / `place-nothing` / `in-progress` / `no-data`. CLI `python -m ml.gate METRICS.jsonl --rung trio-box` with exit codes **0** (mastered) / **1** (ran, not mastered) / **2** (no data) for unattended sweeps. Torch-free ⇒ exercised under the `[dev]`-only CI.
- **`ml/README.md`** — the two-seed `--load <pair-box ckpt> --stop-after-rung trio-box` checkpoint-resume launch recipe, derived from the validated #720/#728 recipe, plus the resume gotchas (re-pass `--solo-box-rung --seed-anchor --mixed-anchor`; don't `pip install .[train]`; gate scratch is gitignored) and the gate-harness reading instructions + WIN criteria.
- **`tests/ml/test_curriculum.py`** — a smoke test guarding the exact truncated sweep-shape ladder (`truncate_after_rung(grafted, "trio-box")` → `[trivial, solo-box, pair-anchored, pair-mixed, pair-box, trio-box]`, `max_objects=3`).

## Tests
TDD'd: 12 new `tests/ml/test_gate.py` (each behaviour watched fail first) + 1 curriculum smoke test. Full `ml/` tree: **400 passed, 2 deselected (slow), 0 failures**. `ruff` + `ruff format` + `mypy ml/` (whole package) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)