### PR TITLE
perf(607): activate pose_cache_scope + cached_parts_world in the ml/ rollout (#733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#733, epic #607): activate `pose_cache_scope` + `cached_parts_world`
+  in the `ml/` RL rollout — top throughput lever, closes the #453/#704 gap.** Per-iteration
+  training is ~94% CPU/shapely-bound and ~61% of the rollout is `aircraft_parts_world`
+  Polygon construction; the env was rebuilding the **same** `(body, pose)` shapely parts
+  repeatedly across the collision check, the reward oracle and the encoder rasterizer. The
+  `ml/` geometry consumers (`geometry_oracle` intrusion / swept-intrusion / active-misfit and
+  the `encoding` rasterizer) now call the pose-memoized `cached_parts_world`, and the
+  vectorized `_EnvWorker.step`/`reset` + the single-env `collect_rollout` open a per-step
+  `pose_cache_scope` spanning the env step **and** the encode, so each pose is built once
+  across all consumers. The scope is opened **per env method call** (one fixed-fleet env), so
+  the `(plane_id, x, y, heading)` key is never stale even when `SyncVectorEnv` steps workers
+  in one process. **Byte-identical** (ADR-0003): `cached_parts_world` is an inert passthrough
+  outside a scope and returns the same `WorldPart`s the pure function builds inside one, so
+  the new `pose_cache=False` toggle (on `_EnvWorker` / `collect_rollout`, default-on)
+  reproduces the un-cached run bit-for-bit — verified via the established fixed-action
+  reward-stream + encoded-observation diff, not checkpoint hashes. Folds in an additive,
+  byte-identical AABB-disjointness pre-filter on the swept-intrusion leak loop (reusing the
+  obstacles' precomputed `world_part_aabbs`). Dev/CI-only (`ml/`); no shipped-wheel surface.
+
 - **Learned backend (#730, epic #607): trio-box training-gate harness + launch recipe.**
   No-GPU prep for the #698 train-to-mastery frontier — does the #720/#728 four-lever ladder
   generalize past the 2-object `pair-box` to the 3-object `trio-box` rung (the historical

--- a/ml/encoding.py
+++ b/ml/encoding.py
@@ -13,7 +13,7 @@ from typing import Literal
 import numpy as np
 import shapely
 
-from hangarfit.geometry import aircraft_parts_world
+from hangarfit.geometry import cached_parts_world
 from hangarfit.models import Aircraft, GroundObject, Hangar, Placement
 from hangarfit.towplanner import SegmentKind
 from ml import geometry_oracle as go
@@ -153,7 +153,7 @@ def _parked_occupancy(
     wing_polys: list[shapely.Geometry] = []
     for po in obs.parked:
         body = _require_body(bodies, po.object_id)
-        for wp in aircraft_parts_world(body, po.placement):
+        for wp in cached_parts_world(body, po.placement):
             if wp.z_bottom_m < config.z_split_m:
                 low_polys.append(wp.polygon)
             if wp.z_top_m > config.z_split_m:
@@ -175,7 +175,7 @@ def _active_occupancy(obs: Observation, config: EncoderConfig) -> np.ndarray:
         heading_deg=a.pose.heading_deg,
         on_carts=a.on_carts,
     )
-    polys = [wp.polygon for wp in aircraft_parts_world(a.body, placement)]
+    polys = [wp.polygon for wp in cached_parts_world(a.body, placement)]
     if not polys:
         raise ValueError(
             f"_active_occupancy: no parts for active object {a.object_id!r} at its pose"
@@ -192,7 +192,7 @@ def _body_dims(body: Aircraft | GroundObject, config: EncoderConfig) -> tuple[fl
     """(length, width) of the body footprint in its own frame, normalized by pos_ref_m.
     At heading 0 the determinant-−1 transform maps fore-aft to world-y and lateral to
     world-x, so y-extent is length and x-extent is width."""
-    parts = aircraft_parts_world(
+    parts = cached_parts_world(
         body,
         Placement(plane_id=body.id, x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False),
     )

--- a/ml/geometry_oracle.py
+++ b/ml/geometry_oracle.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from shapely.geometry import box
 
 from hangarfit.collisions import check
-from hangarfit.geometry import aircraft_parts_world
+from hangarfit.geometry import cached_parts_world
 from hangarfit.models import Aircraft, GroundObject, Hangar, Layout, Placement
 from hangarfit.towplanner import (
     CUSP_PENALTY as _CUSP_PENALTY,
@@ -22,6 +22,7 @@ from hangarfit.towplanner import (
     DubinsArc,
     Pose,
     Segment,
+    _aabb,
     _build_obstacles,
     _motion_clear,
     _Obstacles,
@@ -88,7 +89,7 @@ def intrusion_area_m2(
             hangar.length_m,
         )
     total = 0.0
-    for wp in aircraft_parts_world(body, placement):
+    for wp in cached_parts_world(body, placement):
         poly = wp.polygon
         total += poly.difference(floor).area  # outside the floor (walls/notch)
         if bay_poly is not None:
@@ -176,9 +177,26 @@ def swept_intrusion_m2(
             on_carts=False,
         )
         # Overlap against parked obstacle parts + out-of-floor (front apron excluded).
+        # ``cached_parts_world`` reuses the mover parts ``_motion_clear`` just built for
+        # this same pose inside an active pose_cache_scope (#733). The obstacle AABBs are
+        # precomputed (static across poses), so an AABB-disjointness pre-filter skips the
+        # exact shapely intersects for pairs that cannot overlap.
         leak = 0.0
-        for wp in aircraft_parts_world(body, pl):
-            for op in obstacles.world_parts:
+        for wp in cached_parts_world(body, pl):
+            wp_xmin, wp_ymin, wp_xmax, wp_ymax = _aabb(wp.polygon)
+            for op, (op_xmin, op_ymin, op_xmax, op_ymax) in zip(
+                obstacles.world_parts, obstacles.world_part_aabbs, strict=True
+            ):
+                # Touching-inclusive (clearance 0): a STRICT AABB gap means the polygons
+                # are disjoint -> 0 intersection area, so skipping is byte-identical. A
+                # touching/overlapping AABB falls through to the exact predicate.
+                if (
+                    wp_xmin - op_xmax > 0.0
+                    or op_xmin - wp_xmax > 0.0
+                    or wp_ymin - op_ymax > 0.0
+                    or op_ymin - wp_ymax > 0.0
+                ):
+                    continue
                 if wp.polygon.intersects(op.polygon):
                     leak += wp.polygon.intersection(op.polygon).area
         worst = max(worst, leak)
@@ -275,16 +293,16 @@ def active_misfit_m2(
         for p in parked_layout.placements
         for b in [parked_layout.fleet.get(p.plane_id)]
         if b is not None
-        for wp in aircraft_parts_world(b, p)
+        for wp in cached_parts_world(b, p)
     ] + [
         wp
         for gp in parked_layout.ground_object_placements
         for b in [parked_layout.ground_objects.get(gp.plane_id)]
         if b is not None
-        for wp in aircraft_parts_world(b, gp)
+        for wp in cached_parts_world(b, gp)
     ]
     total = 0.0
-    for wp in aircraft_parts_world(body, pl):
+    for wp in cached_parts_world(body, pl):
         poly = wp.polygon
         total += poly.difference(floor).intersection(upper).area  # in-hangar wall/notch intrusion
         for op in obstacle_parts:

--- a/ml/geometry_oracle.py
+++ b/ml/geometry_oracle.py
@@ -187,9 +187,12 @@ def swept_intrusion_m2(
             for op, (op_xmin, op_ymin, op_xmax, op_ymax) in zip(
                 obstacles.world_parts, obstacles.world_part_aabbs, strict=True
             ):
-                # Touching-inclusive (clearance 0): a STRICT AABB gap means the polygons
-                # are disjoint -> 0 intersection area, so skipping is byte-identical. A
-                # touching/overlapping AABB falls through to the exact predicate.
+                # This loop measures raw overlap AREA (clearance-independent), unlike
+                # _motion_clear's clearance-INflated filter (towplanner `> clearance`) --
+                # so the gap threshold is 0.0, not clearance. A STRICT AABB gap (> 0) means
+                # the polygons are disjoint -> 0 intersection area, so skipping is
+                # byte-identical; a touching/overlapping AABB (gap <= 0) falls through to
+                # the exact predicate.
                 if (
                     wp_xmin - op_xmax > 0.0
                     or op_xmin - wp_xmax > 0.0

--- a/ml/train.py
+++ b/ml/train.py
@@ -8,6 +8,7 @@ sub-project #4b; the reach-not-beat benchmark is #4c."""
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import sys
 from collections import deque
@@ -20,6 +21,7 @@ from typing import Literal
 import torch
 from torch import Tensor
 
+from hangarfit.geometry import pose_cache_scope
 from hangarfit.loader import load_fleet, load_hangar
 from ml.action_space import decode
 from ml.checkpoint import load_checkpoint, save_checkpoint
@@ -107,26 +109,37 @@ def collect_rollout(
     rollout_len: int,
     *,
     sample_request: Callable[[], EpisodeStart] | None = None,
+    pose_cache: bool = True,
 ) -> tuple[RolloutBuffer, list[EpisodeStat]]:
     """Drive the env single-stream for `rollout_len` steps; return the buffer and the
     per-completed-episode stats (competency + reward sum). On each episode boundary,
     `sample_request()` (when given) returns an EpisodeStart that picks the next episode's
     object subset and optional seed_anchor_k; None keeps the env's fixed requested set
-    (the 4a trivial path)."""
+    (the 4a trivial path).
+
+    `pose_cache` (#733, default-on) opens a per-step `pose_cache_scope` spanning the
+    encode + env.step so the shapely parts are built once across the encoder and the
+    reward oracle. The cache is a byte-identical passthrough, so `pose_cache=False`
+    reproduces the un-cached rollout bit-for-bit."""
     buf = RolloutBuffer()
     bodies = _bodies(env)
     device = next(policy.parameters()).device
     obs = env.reset()
     ep_reward, ep_stats = 0.0, []
+
+    def _scope() -> contextlib.AbstractContextManager[None]:
+        return pose_cache_scope() if pose_cache else contextlib.nullcontext()
+
     with torch.no_grad():
         while len(buf) < rollout_len:
-            obs_t = encode(obs, env.hangar, bodies, encoder)
-            out = policy(_to_device(to_batch([obs_t]), device))
-            kind, mag = sample_action(out)
-            logprob, _ = factored_logprob_entropy(out, kind, mag)
-            tr = obs.active.body.effective_turn_radius_m()  # type: ignore[union-attr]
-            primitive = decode(int(kind), int(mag), turn_radius_m=tr)
-            nxt, reward, done, info = env.step(primitive)
+            with _scope():
+                obs_t = encode(obs, env.hangar, bodies, encoder)
+                out = policy(_to_device(to_batch([obs_t]), device))
+                kind, mag = sample_action(out)
+                logprob, _ = factored_logprob_entropy(out, kind, mag)
+                tr = obs.active.body.effective_turn_radius_m()  # type: ignore[union-attr]
+                primitive = decode(int(kind), int(mag), turn_radius_m=tr)
+                nxt, reward, done, info = env.step(primitive)
             buf.add(
                 obs_t,
                 kind_idx=int(kind),
@@ -156,8 +169,9 @@ def collect_rollout(
                 obs = nxt
         # bootstrap value for a non-done tail
         if not buf.done[-1]:
-            tail = encode(obs, env.hangar, bodies, encoder)
-            buf.last_value = float(policy(_to_device(to_batch([tail]), device)).value)
+            with _scope():
+                tail = encode(obs, env.hangar, bodies, encoder)
+                buf.last_value = float(policy(_to_device(to_batch([tail]), device)).value)
     return buf, ep_stats
 
 

--- a/ml/vector_env.py
+++ b/ml/vector_env.py
@@ -9,10 +9,12 @@ byte-identical reference / test oracle); SubprocVectorEnv runs N spawn workers."
 
 from __future__ import annotations
 
+import contextlib
 import multiprocessing as mp
 from collections.abc import Callable, Sequence
 from typing import Any, NamedTuple, cast
 
+from hangarfit.geometry import pose_cache_scope
 from ml.action_space import decode
 from ml.curriculum import EpisodeStart, EpisodeStat
 from ml.encoding import EncoderConfig, ObservationTensors, encode
@@ -30,47 +32,61 @@ class _EnvWorker:
         env: HangarFitEnv,
         encoder: EncoderConfig,
         next_request: Callable[[], EpisodeStart] | None,
+        *,
+        pose_cache: bool = True,
     ) -> None:
         self._env = env
         self._enc = encoder
         self._next_request = next_request
         self._bodies = {**env.fleet, **env.ground_objects}
+        # #733: memoize aircraft_parts_world across this worker's step+encode (one fixed
+        # fleet, so the pose key is never stale). Default-on; the cache is a byte-identical
+        # passthrough, so pose_cache=False reproduces the un-cached run bit-for-bit (the
+        # determinism reference for the byte-identity test). The scope is opened per method
+        # call, so it is per-env even when SyncVectorEnv steps workers in one process.
+        self._pose_cache = pose_cache
+
+    def _scope(self) -> contextlib.AbstractContextManager[None]:
+        return pose_cache_scope() if self._pose_cache else contextlib.nullcontext()
 
     def _encode(self, obs: Observation) -> ObservationTensors:
         return encode(obs, self._env.hangar, self._bodies, self._enc)
 
     def reset(self) -> ObservationTensors:
-        start = self._next_request() if self._next_request is not None else None
-        obs = self._env.reset(
-            requested_ids=start.requested_ids if start else None,
-            seed_anchor_k=start.seed_anchor_k if start else None,
-        )
-        return self._encode(obs)
+        with self._scope():
+            start = self._next_request() if self._next_request is not None else None
+            obs = self._env.reset(
+                requested_ids=start.requested_ids if start else None,
+                seed_anchor_k=start.seed_anchor_k if start else None,
+            )
+            return self._encode(obs)
 
     def step(
         self, kind_idx: int, mag_idx: int
     ) -> tuple[ObservationTensors, float, bool, StepInfo, EpisodeStat | None]:
-        obs = self._env._observe()
-        if obs.active is None:
-            raise RuntimeError(
-                "_EnvWorker.step called on a terminal env (auto-reset failed or step after done)"
-            )
-        tr = self._env._body(obs.active.object_id).effective_turn_radius_m()
-        action = decode(kind_idx, mag_idx, turn_radius_m=tr)
-        sem, reward, done, info = self._env.step(action)
-        ep: EpisodeStat | None = None
-        if done:
-            ep = EpisodeStat(
-                fraction_placed=info.placed / info.total,
-                valid=info.valid,
-                total_reward=0.0,  # per-episode reward sum is tracked by the collector
-            )
-            start = self._next_request() if self._next_request is not None else None
-            sem = self._env.reset(
-                requested_ids=start.requested_ids if start else None,
-                seed_anchor_k=start.seed_anchor_k if start else None,
-            )
-        return self._encode(sem), reward, done, info, ep
+        with self._scope():
+            obs = self._env._observe()
+            if obs.active is None:
+                raise RuntimeError(
+                    "_EnvWorker.step called on a terminal env (auto-reset failed or step "
+                    "after done)"
+                )
+            tr = self._env._body(obs.active.object_id).effective_turn_radius_m()
+            action = decode(kind_idx, mag_idx, turn_radius_m=tr)
+            sem, reward, done, info = self._env.step(action)
+            ep: EpisodeStat | None = None
+            if done:
+                ep = EpisodeStat(
+                    fraction_placed=info.placed / info.total,
+                    valid=info.valid,
+                    total_reward=0.0,  # per-episode reward sum is tracked by the collector
+                )
+                start = self._next_request() if self._next_request is not None else None
+                sem = self._env.reset(
+                    requested_ids=start.requested_ids if start else None,
+                    seed_anchor_k=start.seed_anchor_k if start else None,
+                )
+            return self._encode(sem), reward, done, info, ep
 
 
 class VecStep(NamedTuple):

--- a/ml/vector_env.py
+++ b/ml/vector_env.py
@@ -39,11 +39,13 @@ class _EnvWorker:
         self._enc = encoder
         self._next_request = next_request
         self._bodies = {**env.fleet, **env.ground_objects}
-        # #733: memoize aircraft_parts_world across this worker's step+encode (one fixed
-        # fleet, so the pose key is never stale). Default-on; the cache is a byte-identical
-        # passthrough, so pose_cache=False reproduces the un-cached run bit-for-bit (the
-        # determinism reference for the byte-identity test). The scope is opened per method
-        # call, so it is per-env even when SyncVectorEnv steps workers in one process.
+        # #733: route this worker's step+encode geometry through cached_parts_world
+        # (pose-memoized inside the scope; delegates to aircraft_parts_world on a miss).
+        # One fixed fleet, so the pose key is never stale. Default-on; the cache is a
+        # byte-identical passthrough, so pose_cache=False reproduces the un-cached run
+        # bit-for-bit (the determinism reference for the byte-identity test). The scope is
+        # opened per method call, so it is per-env even when SyncVectorEnv steps workers in
+        # one process.
         self._pose_cache = pose_cache
 
     def _scope(self) -> contextlib.AbstractContextManager[None]:

--- a/tests/ml/test_pose_cache.py
+++ b/tests/ml/test_pose_cache.py
@@ -6,7 +6,7 @@ Two contracts are guarded here:
   active-misfit loops and the encoder's rasterizer) goes through ``cached_parts_world``,
   so inside an active scope a *repeated* ``(body, pose)`` rebuilds zero shapely parts
   (cache hit). A worker step with ``pose_cache=True`` therefore does strictly fewer raw
-  ``aircraft_parts_world`` builds than ``pose_cache=False`` (today's passthrough).
+  ``aircraft_parts_world`` builds than ``pose_cache=False`` (the un-cached baseline).
 * **Byte-identity (ADR-0003)** — turning the cache on never changes a number: the worker
   reward stream + encoded observations and the single-env ``collect_rollout`` buffer are
   bit-identical with the cache on vs off. Verified via the established ml/ pattern (fixed
@@ -54,7 +54,7 @@ def _count_raw_builds(monkeypatch) -> dict[str, int]:
 
 
 # ---------------------------------------------------------------------------
-# Routing: each ml/ consumer goes through cached_parts_world (RED today — raw)
+# Routing: each ml/ consumer goes through cached_parts_world.
 # A repeated identical call inside a scope must rebuild ZERO parts.
 # ---------------------------------------------------------------------------
 
@@ -127,7 +127,7 @@ def test_envworker_step_with_pose_cache_builds_fewer_parts(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Byte-identity: pose_cache on vs off (RED today — kwarg does not exist)
+# Byte-identity: pose_cache on vs off produces bit-identical rewards + encoded obs
 # ---------------------------------------------------------------------------
 
 

--- a/tests/ml/test_pose_cache.py
+++ b/tests/ml/test_pose_cache.py
@@ -1,0 +1,254 @@
+"""#733: activate ``pose_cache_scope`` + ``cached_parts_world`` in the ml/ rollout.
+
+Two contracts are guarded here:
+
+* **Routing / perf** — every ml/ geometry consumer (the oracle's intrusion / swept /
+  active-misfit loops and the encoder's rasterizer) goes through ``cached_parts_world``,
+  so inside an active scope a *repeated* ``(body, pose)`` rebuilds zero shapely parts
+  (cache hit). A worker step with ``pose_cache=True`` therefore does strictly fewer raw
+  ``aircraft_parts_world`` builds than ``pose_cache=False`` (today's passthrough).
+* **Byte-identity (ADR-0003)** — turning the cache on never changes a number: the worker
+  reward stream + encoded observations and the single-env ``collect_rollout`` buffer are
+  bit-identical with the cache on vs off. Verified via the established ml/ pattern (fixed
+  action stream → reward/obs diff), NOT checkpoint hashes (torch-CPU is cross-process
+  nondeterministic). The leak-loop AABB pre-filter is pinned against a brute-force
+  reference of the exact unfiltered intersects.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import hangarfit.geometry as geo
+from hangarfit.geometry import aircraft_parts_world, pose_cache_scope
+from hangarfit.models import Placement
+from hangarfit.towplanner import Pose, _motion_clear
+from ml import geometry_oracle as go
+from ml.action_space import PARK_INDEX
+from ml.encoding import EncoderConfig, encode
+from ml.env import HangarFitEnv
+from ml.vector_env import _EnvWorker
+from tests.ml.conftest import _fuji, empty_hangar, single_object_layout, two_object_layout
+
+
+def _trivial_env() -> HangarFitEnv:
+    """A torch-free single-object env (no ml.train import, so this module collects on the
+    torch-free CI)."""
+    return HangarFitEnv(hangar=empty_hangar(), fleet=_fuji(), requested_ids=("fuji",))
+
+
+def _count_raw_builds(monkeypatch) -> dict[str, int]:
+    """Patch the underlying ``aircraft_parts_world`` (the function ``cached_parts_world``
+    delegates to on a miss, and the one collisions/encoder call) with a counter, so the
+    count == number of ACTUAL polygon builds = cache misses."""
+    seen = {"n": 0}
+    orig = geo.aircraft_parts_world
+
+    def _counting(obj, placement):
+        seen["n"] += 1
+        return orig(obj, placement)
+
+    monkeypatch.setattr(geo, "aircraft_parts_world", _counting)
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# Routing: each ml/ consumer goes through cached_parts_world (RED today — raw)
+# A repeated identical call inside a scope must rebuild ZERO parts.
+# ---------------------------------------------------------------------------
+
+
+def test_intrusion_routes_through_pose_cache(monkeypatch):
+    seen = _count_raw_builds(monkeypatch)
+    layout = single_object_layout(x_m=5.0, y_m=8.0)
+    body, pl = layout.fleet["fuji"], layout.placements[0]
+    with pose_cache_scope():
+        go.intrusion_area_m2(body, pl, layout.hangar)  # warm the cache
+        warm = seen["n"]
+        assert warm > 0  # builds went through the (patchable) cached_parts_world path
+        go.intrusion_area_m2(body, pl, layout.hangar)  # identical repeat
+        assert seen["n"] == warm  # second call was a pure cache hit
+
+
+def test_active_misfit_routes_through_pose_cache(monkeypatch):
+    seen = _count_raw_builds(monkeypatch)
+    layout, active, _id = two_object_layout(parked_y_m=12.0, active_y_m=12.2)
+    pose = Pose(x_m=5.0, y_m=12.2, heading_deg=0.0)
+    with pose_cache_scope():
+        go.active_misfit_m2(active, pose, layout, layout.hangar)  # warm
+        warm = seen["n"]
+        assert warm > 0  # builds went through the (patchable) cached_parts_world path
+        go.active_misfit_m2(active, pose, layout, layout.hangar)  # repeat
+        assert seen["n"] == warm  # parked obstacles + active all served from cache
+
+
+def test_encode_routes_through_pose_cache(monkeypatch):
+    seen = _count_raw_builds(monkeypatch)
+    enc = EncoderConfig()
+    env = _trivial_env()
+    obs = env.reset()
+    bodies = {**env.fleet, **env.ground_objects}
+    with pose_cache_scope():
+        encode(obs, env.hangar, bodies, enc)  # warm (parked + active + body-dims)
+        warm = seen["n"]
+        assert warm > 0  # builds went through the (patchable) cached_parts_world path
+        encode(obs, env.hangar, bodies, enc)  # repeat
+        assert seen["n"] == warm  # rasterizer fully served from cache
+
+
+# ---------------------------------------------------------------------------
+# Perf at the worker seam: the scope is actually opened around step + encode
+# ---------------------------------------------------------------------------
+
+
+def test_envworker_step_with_pose_cache_builds_fewer_parts(monkeypatch):
+    """One worker.step (PARK) rebuilds the active body's parts across check + intrusion +
+    encode; with the pose cache those collapse to a single build, so pose_cache=True does
+    strictly fewer raw builds than pose_cache=False."""
+    enc = EncoderConfig()
+
+    seen_off = _count_raw_builds(monkeypatch)
+    w_off = _EnvWorker(_trivial_env(), enc, next_request=None, pose_cache=False)
+    w_off.reset()
+    base = seen_off["n"]
+    w_off.step(PARK_INDEX, 0)
+    builds_off = seen_off["n"] - base
+
+    seen_on = _count_raw_builds(monkeypatch)
+    w_on = _EnvWorker(_trivial_env(), enc, next_request=None, pose_cache=True)
+    w_on.reset()
+    base = seen_on["n"]
+    w_on.step(PARK_INDEX, 0)
+    builds_on = seen_on["n"] - base
+
+    assert builds_on > 0  # sanity: the step did build geometry
+    assert builds_on < builds_off  # the cache deduplicated repeated poses
+
+
+# ---------------------------------------------------------------------------
+# Byte-identity: pose_cache on vs off (RED today — kwarg does not exist)
+# ---------------------------------------------------------------------------
+
+
+def _drive(worker: _EnvWorker, actions):
+    out = []
+    for kind, mag in actions:
+        obs, reward, done, info, _ep = worker.step(kind, mag)
+        out.append((obs, reward, done, info.placed, info.total))
+    return out
+
+
+def test_envworker_pose_cache_byte_identical_reward_and_obs():
+    """Same fixed action stream (two moves, then PARK) yields a bit-identical reward
+    stream + encoded observations with the cache on vs off (ADR-0003)."""
+    enc = EncoderConfig()
+    actions = [(0, 1), (0, 1), (PARK_INDEX, 0)]
+
+    w_off = _EnvWorker(_trivial_env(), enc, next_request=None, pose_cache=False)
+    w_off.reset()
+    rec_off = _drive(w_off, actions)
+
+    w_on = _EnvWorker(_trivial_env(), enc, next_request=None, pose_cache=True)
+    w_on.reset()
+    rec_on = _drive(w_on, actions)
+
+    for (o_off, r_off, d_off, p_off, t_off), (o_on, r_on, d_on, p_on, t_on) in zip(
+        rec_off, rec_on, strict=True
+    ):
+        assert r_on == r_off
+        assert d_on == d_off and p_on == p_off and t_on == t_off
+        assert np.array_equal(o_on.raster, o_off.raster)
+        assert np.array_equal(o_on.tokens, o_off.tokens)
+        assert np.array_equal(o_on.token_mask, o_off.token_mask)
+        assert np.array_equal(o_on.legal_action_mask, o_off.legal_action_mask)
+        assert o_on.active_index == o_off.active_index
+
+
+def test_envworker_reset_byte_identical_encoded_obs():
+    """reset()'s encoded obs is bit-identical with the cache on vs off."""
+    enc = EncoderConfig()
+    o_off = _EnvWorker(_trivial_env(), enc, next_request=None, pose_cache=False).reset()
+    o_on = _EnvWorker(_trivial_env(), enc, next_request=None, pose_cache=True).reset()
+    assert np.array_equal(o_on.raster, o_off.raster)
+    assert np.array_equal(o_on.tokens, o_off.tokens)
+    assert o_on.active_index == o_off.active_index
+
+
+# ---------------------------------------------------------------------------
+# Fold-in #3: leak-loop AABB pre-filter is byte-identical to the exact intersects
+# ---------------------------------------------------------------------------
+
+
+def _bruteforce_swept_intrusion(body, swept, *, active_id, obstacles, hangar) -> float:
+    """The exact unfiltered leak loop (no AABB pre-filter) — the byte-identity oracle."""
+    worst = 0.0
+    for pose in swept:
+        if _motion_clear(body, pose, obstacles, hangar):
+            continue
+        pl = Placement(
+            plane_id=active_id,
+            x_m=pose.x_m,
+            y_m=pose.y_m,
+            heading_deg=pose.heading_deg,
+            on_carts=False,
+        )
+        leak = 0.0
+        for wp in aircraft_parts_world(body, pl):
+            for op in obstacles.world_parts:
+                if wp.polygon.intersects(op.polygon):
+                    leak += wp.polygon.intersection(op.polygon).area
+        worst = max(worst, leak)
+    return worst
+
+
+@pytest.mark.parametrize("under_scope", [False, True])
+def test_swept_intrusion_aabb_prefilter_byte_identical(under_scope):
+    """swept_intrusion_m2 with the AABB pre-filter == the brute-force exact intersects,
+    both inside and outside a pose-cache scope, on a sweep that genuinely intrudes."""
+    layout, active, active_id = two_object_layout(parked_y_m=15.0, active_y_m=8.0)
+    obstacles = go.build_obstacles(layout, active_id)
+    # Poses placed on/around the parked fuji at (5, 15) => the husky overlaps it.
+    swept = tuple(Pose(x_m=5.0, y_m=15.0 + d, heading_deg=0.0) for d in (-0.4, 0.0, 0.4))
+
+    expected = _bruteforce_swept_intrusion(
+        active, swept, active_id=active_id, obstacles=obstacles, hangar=layout.hangar
+    )
+
+    def _call() -> float:
+        return go.swept_intrusion_m2(
+            active, swept, parked_layout=layout, active_id=active_id, obstacles=obstacles
+        )
+
+    if under_scope:
+        with pose_cache_scope():
+            actual = _call()
+    else:
+        actual = _call()
+    assert actual == expected
+    assert actual > 0.0  # the leak path actually ran (non-vacuous)
+
+
+# ---------------------------------------------------------------------------
+# Single-env collect_rollout: pose_cache toggle is byte-identical (torch path)
+# ---------------------------------------------------------------------------
+
+
+def test_collect_rollout_pose_cache_byte_identical():
+    """collect_rollout's buffer (rewards + dones) is bit-identical with the cache on vs
+    off over a fixed-seed rollout."""
+    torch = pytest.importorskip("torch")
+    from ml.policy import HangarFitPolicy
+    from ml.train import build_trivial_env, collect_rollout
+
+    enc = EncoderConfig()
+
+    def _run(pose_cache: bool):
+        torch.manual_seed(0)
+        policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2)
+        buf, stats = collect_rollout(
+            build_trivial_env(seed=0), policy, enc, rollout_len=12, pose_cache=pose_cache
+        )
+        return list(buf.reward), list(buf.done), [(s.fraction_placed, s.valid) for s in stats]
+
+    assert _run(True) == _run(False)


### PR DESCRIPTION
Closes #733.

## What

Activate the solver's existing pose-keyed geometry memo (`pose_cache_scope` + `cached_parts_world`) inside the `ml/` RL rollout — the **top throughput lever** from the training-speedup sweep, closing the **#453/#704 gap**. Per-iteration training is ~94% CPU/shapely-bound and ~61% of the rollout is `aircraft_parts_world` Polygon construction; the env rebuilt the **same** `(body, pose)` shapely parts repeatedly across the collision check, the reward oracle and the encoder rasterizer.

## Changes

1. **Route the `ml/` geometry consumers through `cached_parts_world`** (inert passthrough → pose-memoized under a scope):
   - `ml/geometry_oracle.py` — `intrusion_area_m2`, `swept_intrusion_m2` leak loop, `active_misfit_m2` (5 sites).
   - `ml/encoding.py` — `_parked_occupancy`, `_active_occupancy`, `_body_dims` (3 sites).
2. **Open a per-step `pose_cache_scope`** spanning `env.step` **and** the `encode` call, so each pose is built once across all consumers ("encoder vs oracle reusing the active pose"):
   - `ml/vector_env.py` — `_EnvWorker.step` / `reset` (vectorized path).
   - `ml/train.py` — `collect_rollout` loop body (single-env path).
   - The scope is opened **per env method call** (one fixed-fleet env), so the `(plane_id, x, y, heading)` key is never stale — safe even when `SyncVectorEnv` steps workers in one process.
3. **Fold-in (additive, byte-identical):** an AABB-disjointness pre-filter on the swept-intrusion leak loop, reusing the obstacles' precomputed `world_part_aabbs` (mirrors the towplanner pattern; skips only strictly-separated pairs that contribute 0 area).

## Determinism / byte-identity (ADR-0003)

`cached_parts_world` is an inert passthrough outside a scope and returns the same `WorldPart`s the pure function builds inside one (frozen/slots, all consumers read-only). The new **`pose_cache=False` toggle** (`_EnvWorker` / `collect_rollout`, default-on) reproduces the un-cached run **bit-for-bit**, verified via the established `ml/` pattern — fixed-action **reward-stream + encoded-observation diff**, not checkpoint hashes (torch-CPU is cross-process nondeterministic). The AABB pre-filter is pinned against a brute-force reference of the exact unfiltered `intersects`.

## Verification

- `tests/ml/test_pose_cache.py` (new, 9 tests): per-consumer routing proof, worker + reset byte-identity, `collect_rollout` byte-identity, worker build-count reduction, AABB pre-filter brute-force equivalence (under/outside a scope).
- `pytest tests/ml/` → **410 passed**, 2 deselected. `ruff check` / `ruff format --check` clean. `mypy ml/` clean.
- **Measured 1.45× (31% wall-clock cut)** on a 400-step `trio-box` rollout, cache on vs off.

Dev/CI-only (`ml/`); no shipped-wheel surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)