### PR TITLE
fix(607): force Φ(terminal)=0 in PBRS — remove spurious −Φ(terminal) return bias (#732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -445,6 +445,18 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Fixed
 
+- **Learned backend (#732, epic #607): PBRS now forces Φ(terminal) = 0 — removes a
+  spurious −Φ(terminal) return bias.** The potential-based reward shaping added
+  `γ·Φ(s′) − Φ(s)` every step but computed the terminal step's `Φ(s′)` from the live
+  potential instead of forcing 0, so the undiscounted episode return picked up a
+  constant `−Φ(terminal)` term — provably policy-invariant (Ng–Harada–Russell) only when
+  `Φ(terminal) = 0`. `Φ` is ~0 on a *clean valid* completion but **nonzero** on exactly
+  the non-clean terminals the curriculum must distinguish (budget-exhaustion stops with an
+  object still unplaced; invalid/piled completions with residual overlap). `HangarFitEnv`
+  now sets `Φ(s′) = 0` on both terminal paths (the terminal Park and the budget-exhaustion
+  movement), so the terminal shaping reduces to `−Φ(prev)`. **Deliberate re-baseline:** this
+  changes reward values on non-clean terminal episodes (clean completions are unaffected).
+
 - **Learned backend env validity now matches `collisions.check` (#694).** The
   `HangarFitEnv` oracle no longer over-enforces the inert placeholder maintenance
   bay (the bay is only active when an aircraft is explicitly placed there; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,7 +452,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
   constant `−Φ(terminal)` term — provably policy-invariant (Ng–Harada–Russell) only when
   `Φ(terminal) = 0`. `Φ` is ~0 on a *clean valid* completion but **nonzero** on exactly
   the non-clean terminals the curriculum must distinguish (budget-exhaustion stops with an
-  object still unplaced; invalid/piled completions with residual overlap). `HangarFitEnv`
+  object still unplaced; invalid/piled completions with residual overlap and/or an object
+  still unplaced). `HangarFitEnv`
   now sets `Φ(s′) = 0` on both terminal paths (the terminal Park and the budget-exhaustion
   movement), so the terminal shaping reduces to `−Φ(prev)`. **Deliberate re-baseline:** this
   changes reward values on non-clean terminal episodes (clean completions are unaffected).

--- a/ml/env.py
+++ b/ml/env.py
@@ -286,7 +286,8 @@ class HangarFitEnv:
                 self._spawn()
             # #732: PBRS requires Φ(terminal)=0 so the undiscounted return carries no
             # spurious −Φ(terminal) bias; on the terminal Park the shaping reduces to
-            # −Φ(prev). Φ happens to be ~0 only on a clean valid completion, so this is
+            # −Φ(prev). Φ is ~0 on a clean valid completion but nonzero on the non-clean
+            # terminals (an object still unplaced, or residual overlap), so this is
             # load-bearing for the invalid/piled completions the curriculum distinguishes.
             new_phi = 0.0 if done else self._potential()
             ctx = RewardContext(

--- a/ml/env.py
+++ b/ml/env.py
@@ -284,7 +284,11 @@ class HangarFitEnv:
             terminal_fraction = len(self._parked) / len(self.requested_ids) if done else None
             if not done:
                 self._spawn()
-            new_phi = self._potential()
+            # #732: PBRS requires Φ(terminal)=0 so the undiscounted return carries no
+            # spurious −Φ(terminal) bias; on the terminal Park the shaping reduces to
+            # −Φ(prev). Φ happens to be ~0 only on a clean valid completion, so this is
+            # load-bearing for the invalid/piled completions the curriculum distinguishes.
+            new_phi = 0.0 if done else self._potential()
             ctx = RewardContext(
                 overlap_m2=overlap,
                 intrusion_m2=intrusion,
@@ -329,13 +333,16 @@ class HangarFitEnv:
         )
         self._active_pose = end
         self._prev_gear = primitive.gear
-        new_phi = self._potential()
 
         # Termination: per-object budget exhausted (unplaceable) or global budget hit.
         # Compute it BEFORE the reward so a budget-driven stop still earns the
         # "best partial" terminal fraction (spec §4.5) — the active object stays
         # unparked, so the fraction is over already-PARKED objects only.
         done, reason = self._check_budget()
+        # #732: PBRS requires Φ(terminal)=0 — on a terminal (budget-exhaustion) step the
+        # shaping reduces to −Φ(prev), no spurious −Φ(terminal) return bias. Φ(prev) is
+        # genuinely nonzero here (an object remains unplaced), so this is load-bearing.
+        new_phi = 0.0 if done else self._potential()
         terminal_fraction = len(self._parked) / len(self.requested_ids) if done else None
         # Validity of the already-PARKED set at a budget-exhaustion stop. This branch carried
         # no validity signal, so the #714 validity-conditional terminal would have treated even

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -134,10 +134,13 @@ def test_partial_budget_stop_includes_terminal_fraction_reward():
     _, reward_no_term, done_b, _ = env_b.step(pivot)
     assert done_b is False
 
-    # The only reward difference between the two identical steps is the terminal
-    # term r_terminal * 0.5 — present in A, absent in B. It must be measurably added.
+    # The terminal term r_terminal * 0.5 is present in A, absent in B. #732 re-baseline:
+    # the terminal step now also forces Φ(s′)=0, so A drops the γ·Φ(s′) shaping term that
+    # the identical NON-terminal step B retains. The reward difference is therefore the
+    # terminal term MINUS that retained γ·Φ_B (B set _prev_potential = its new Φ(s′)).
     w = env_a.weights
-    assert reward_term - reward_no_term == w.r_terminal * 0.5
+    phi_b = env_b._prev_potential  # the Φ(s′) B kept; A forced its Φ(s′) to 0 (#732)
+    assert reward_term - reward_no_term == pytest.approx(w.r_terminal * 0.5 - w.gamma * phi_b)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ml/test_terminal_phi.py
+++ b/tests/ml/test_terminal_phi.py
@@ -1,0 +1,71 @@
+"""#732: PBRS must force Φ(terminal) = 0 so the undiscounted return carries no spurious
+−Φ(terminal) bias (Ng–Harada–Russell policy-invariance).
+
+`StepInfo.terms["shaping"]` is the undiscounted `ctx.potential − ctx.prev_potential`
+the env feeds the reward. With the fix, the terminal step sets `ctx.potential = 0`, so
+that term must equal `−Φ(prev)` on *both* terminal paths — and it must be non-vacuous:
+Φ(prev) is genuinely nonzero on the non-clean terminals (budget exhaustion / invalid
+completion) that the curriculum cares about distinguishing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ml.env import HangarFitEnv
+from ml.types import DifficultyConfig, Park, Primitive
+from tests.ml.conftest import _fuji, empty_hangar
+
+
+def test_terminal_phi_zeroed_on_budget_exhaustion():
+    """A movement that exhausts the per-object budget terminates with an object still
+    pending (Φ(prev) ≠ 0); the terminal shaping must be exactly −Φ(prev)."""
+    diff = DifficultyConfig(max_objects=1, per_object_step_budget=1, total_step_budget=10)
+    env = HangarFitEnv(
+        hangar=empty_hangar(), fleet=_fuji(), requested_ids=("fuji",), difficulty=diff
+    )
+    env.reset()
+    phi_prev = env._prev_potential
+    assert phi_prev != 0.0  # active object pending → Φ ≠ 0 (non-vacuous)
+
+    _obs, _r, done, info = env.step(Primitive(kind="S", magnitude=1.0, gear=1))
+
+    assert done and "budget" in info.reason
+    assert info.terms["shaping"] == pytest.approx(-phi_prev)
+
+
+def test_terminal_phi_zeroed_on_invalid_completion():
+    """Parking the last object onto the first (a piled, invalid completion) leaves
+    residual overlap → without the fix Φ(terminal) ≠ 0. The terminal shaping must still
+    be exactly −Φ(prev)."""
+    diff = DifficultyConfig(max_objects=2, per_object_step_budget=20, total_step_budget=40)
+    env = HangarFitEnv(
+        hangar=empty_hangar(),
+        fleet=_fuji(),
+        requested_ids=("fuji", "aviat_husky"),
+        difficulty=diff,
+    )
+    env.reset()
+    env.step(Park())  # park object 1 at the door spawn → not done, spawn object 2
+    phi_prev = env._prev_potential
+    assert phi_prev != 0.0  # object 2 still active → Φ ≠ 0
+
+    _obs, _r, done, info = env.step(Park())  # park object 2 onto object 1 → done, invalid
+
+    assert done and not info.valid  # piled completion is invalid
+    assert info.terms["shaping"] == pytest.approx(-phi_prev)
+
+
+def test_clean_valid_completion_shaping_unchanged():
+    """A clean valid completion already has Φ(terminal) ≈ 0, so forcing it to 0 leaves the
+    terminal shaping ≈ −Φ(prev) just as before (the fix is a no-op on the clean path)."""
+    diff = DifficultyConfig(max_objects=1, per_object_step_budget=20, total_step_budget=40)
+    env = HangarFitEnv(
+        hangar=empty_hangar(), fleet=_fuji(), requested_ids=("fuji",), difficulty=diff
+    )
+    env.reset()
+    phi_prev = env._prev_potential
+    _obs, _r, done, info = env.step(Park())
+    assert done
+    # Φ(terminal)=0 either way on a clean completion, so the identity holds exactly.
+    assert info.terms["shaping"] == pytest.approx(-phi_prev)

--- a/tests/ml/test_terminal_phi.py
+++ b/tests/ml/test_terminal_phi.py
@@ -26,7 +26,7 @@ def test_terminal_phi_zeroed_on_budget_exhaustion():
     )
     env.reset()
     phi_prev = env._prev_potential
-    assert phi_prev != 0.0  # active object pending → Φ ≠ 0 (non-vacuous)
+    assert abs(phi_prev) > 1e-9  # active object pending → Φ ≠ 0 (non-vacuous)
 
     _obs, _r, done, info = env.step(Primitive(kind="S", magnitude=1.0, gear=1))
 
@@ -48,7 +48,7 @@ def test_terminal_phi_zeroed_on_invalid_completion():
     env.reset()
     env.step(Park())  # park object 1 at the door spawn → not done, spawn object 2
     phi_prev = env._prev_potential
-    assert phi_prev != 0.0  # object 2 still active → Φ ≠ 0
+    assert abs(phi_prev) > 1e-9  # object 2 still active → Φ ≠ 0
 
     _obs, _r, done, info = env.step(Park())  # park object 2 onto object 1 → done, invalid
 
@@ -56,16 +56,19 @@ def test_terminal_phi_zeroed_on_invalid_completion():
     assert info.terms["shaping"] == pytest.approx(-phi_prev)
 
 
-def test_clean_valid_completion_shaping_unchanged():
-    """A clean valid completion already has Φ(terminal) ≈ 0, so forcing it to 0 leaves the
-    terminal shaping ≈ −Φ(prev) just as before (the fix is a no-op on the clean path)."""
-    diff = DifficultyConfig(max_objects=1, per_object_step_budget=20, total_step_budget=40)
+def test_clean_valid_completion_phi_zero_is_a_noop():
+    """On a genuinely VALID in-hangar completion Φ(terminal) = 0 *naturally* (no active
+    object, nothing unplaced, no overlap), so forcing it to 0 is a true no-op: the terminal
+    shaping is −Φ(prev) exactly as it would be without the fix. Contrast the two non-clean
+    terminals above, where Φ(terminal) was nonzero pre-fix."""
+    diff = DifficultyConfig(max_objects=1, per_object_step_budget=40, total_step_budget=80)
     env = HangarFitEnv(
         hangar=empty_hangar(), fleet=_fuji(), requested_ids=("fuji",), difficulty=diff
     )
     env.reset()
+    for _ in range(10):  # drive the object in past the door (y >= 0) so the parked layout is valid
+        env.step(Primitive(kind="S", magnitude=1.0, gear=1))
     phi_prev = env._prev_potential
     _obs, _r, done, info = env.step(Park())
-    assert done
-    # Φ(terminal)=0 either way on a clean completion, so the identity holds exactly.
+    assert done and info.valid  # the point: a genuinely clean, valid completion
     assert info.terms["shaping"] == pytest.approx(-phi_prev)


### PR DESCRIPTION
Closes #732.

## Problem

The PBRS shaping in the learned-backend RL env adds `γ·Φ(s′) − Φ(s)` each step but computed the **terminal** step's `Φ(s′)` from the live potential instead of forcing 0. PBRS is provably policy-invariant (Ng–Harada–Russell) **only** when `Φ(terminal) = 0`; otherwise the undiscounted episode return picks up a constant `−Φ(terminal)` bias. `Φ` is ~0 for a *clean valid* completion but **nonzero** on exactly the non-clean terminals the curriculum must distinguish — budget-exhaustion stops (an object remains unplaced) and invalid/piled completions (residual overlap).

## Fix

`HangarFitEnv` now sets `Φ(s′) = 0` on **both** terminal paths:
- the terminal **Park** branch (`done` already known) — `new_phi = 0.0 if done else self._potential()`;
- the **budget-exhaustion movement** branch — reordered so `done = self._check_budget()` is computed *before* `new_phi`, then the same conditional.

So the terminal shaping reduces to `−Φ(prev)`, restoring the invariance guarantee.

## Deliberate re-baseline

This **changes reward values on non-clean terminal episodes** (clean completions are unaffected — `Φ` was already ~0 there). One existing test pinned the old behaviour — `test_partial_budget_stop_includes_terminal_fraction_reward`, whose premise *"the only reward difference is the terminal term"* is now false **by design** (the terminal step also drops the `γ·Φ(s′)` the identical non-terminal step retains). It is updated to the corrected identity (`r_terminal·0.5 − γ·Φ_B`).

## Verification

- New `tests/ml/test_terminal_phi.py`: terminal shaping `== −Φ(prev)` on a budget-exhaustion stop + an invalid completion (both with non-vacuous `Φ(prev) ≠ 0`), plus a clean-completion no-op control.
- Full `pytest tests/ml/` → **413 passed**, 2 deselected (one re-baselined). `ruff` + `mypy ml/` clean.

Stacked on #733 (now merged to `develop`); diffs cleanly against `develop`. Dev/CI-only (`ml/`); no shipped-wheel surface. ml-rl-guard pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)