### PR TITLE
fix(742/743): honest per-iteration competency gate + auto-budget floor-guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -460,6 +460,28 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Fixed
 
+- **Learned backend (#742/#743, epic #607): the curriculum competency gate and
+  `--auto-budget` now read the honest per-iteration metric, not a noisy 20-episode tail.**
+  The promotion gate (`should_promote`) and the #734 auto-budget slope-fit both watched a
+  per-episode `deque(maxlen=window)`; after `window.extend(ep_stats)` that retained only the
+  **last ~20 episodes of the latest rollout** (out of ~250), a far noisier estimator than the
+  per-iteration `valid_placed` the `--metrics-out` JSONL and `ml.gate` report. Two symptoms:
+  **(#742)** a rung false-promoted `by competency` on a lucky autocorrelated 20-episode streak
+  while its honest per-iteration mean was well below threshold (observed on `trio-box`: trainer
+  said mastered at iter 136, `ml.gate` reported peak `valid_placed` 0.709 / `never` competent,
+  still climbing); **(#743)** `--auto-budget` plateau-stopped a hard rung **during its flat
+  pre-climb warmup** (`trio-box` stopped at iter 29, `valid_placed` ~0.04 — the climb only
+  started ~iter 50). The fix unifies both decisions onto a single per-iteration honest series
+  (`window_score` over the whole rollout, skipping no-episode iterations), so `PromotionPolicy.window`
+  now counts **iterations** (default 3, was 20 episodes) and `should_promote` thresholds their
+  mean — the trainer's verdict is now as trustworthy as `ml.gate`'s. A new `BudgetController`
+  **floor-guard** (`min_level`, default 0.05) refuses to read a flat-at-floor warmup as a
+  converged plateau (slope alone cannot tell floor-flat from ceiling-flat). New default-neutral
+  CLI levers: `--promotion-window`, `--auto-budget-min-iters`, `--auto-budget-min-level`.
+  **Deliberate re-baseline:** the gate now advances rungs at different iterations than the
+  buggy per-episode tail did (run-twice determinism and `--auto-budget`-off byte-identity are
+  preserved). Dev/CI-only (`ml/`); no shipped-wheel surface.
+
 - **Learned backend (#732, epic #607): PBRS now forces Φ(terminal) = 0 — removes a
   spurious −Φ(terminal) return bias.** The potential-based reward shaping added
   `γ·Φ(s′) − Φ(s)` every step but computed the terminal step's `Φ(s′)` from the live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -479,8 +479,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
   converged plateau (slope alone cannot tell floor-flat from ceiling-flat). New default-neutral
   CLI levers: `--promotion-window`, `--auto-budget-min-iters`, `--auto-budget-min-level`.
   **Deliberate re-baseline:** the gate now advances rungs at different iterations than the
-  buggy per-episode tail did (run-twice determinism and `--auto-budget`-off byte-identity are
-  preserved). Dev/CI-only (`ml/`); no shipped-wheel surface.
+  buggy per-episode tail did, so trained policies differ from pre-#742 runs. Run-twice
+  determinism is preserved, and the `--auto-budget` flag stays default-neutral (toggling it off
+  adds no controller call) — the re-baseline lives in the gate itself, not the auto-budget
+  machinery. Dev/CI-only (`ml/`); no shipped-wheel surface.
 
 - **Learned backend (#732, epic #607): PBRS now forces Φ(terminal) = 0 — removes a
   spurious −Φ(terminal) return bias.** The potential-based reward shaping added

--- a/ml/README.md
+++ b/ml/README.md
@@ -142,12 +142,21 @@ per-step active-overlap gradient) and, being potential-based shaping, is **polic
 | `--seed-anchor` | off | Insert an opt-in `pair-anchored` rung **before** `pair-box`: one of its 2 objects is pre-parked at a committed-witness pose (`seed_anchor_k=1`) and the agent only drives the other in — scaffolding 2-object joint discovery with a valid 1-object start (#712). Curriculum-only. |
 | `--mixed-anchor` | off | Insert an opt-in `pair-mixed` rung **before** `pair-box`: each episode randomly starts anchored (k=1) or empty (k=0) with probability `anchor_prob=0.5`, drawn from the curriculum's seeded stream. Keeps empty-start episodes in the training mix so the policy does not collapse to the place-nothing pole on the empty-start `pair-box`. Pair with `--seed-anchor` so `pair-mixed` lands between `pair-anchored` and `pair-box` (not required — `--mixed-anchor` alone inserts it directly before `pair-box`). Curriculum-only. (#712 follow-up) |
 | `--stop-after-rung NAME` | off | Truncate the ladder after `NAME` (that rung is the last trained; every rung after it is dropped). Applied **after** the graft flags above, so a name they introduce (`pair-mixed`) is valid. The #722 sweep lever: `--stop-after-rung pair-box` lets a resumed cell stop cleanly instead of grinding on into `trio-*`. Unknown rung → loud `ValueError`. Curriculum-only; absent ⇒ byte-identical. |
-| `--auto-budget` (+ `--auto-budget-max-iters N`, default 1000) | off | Slope-aware per-rung budget (#734): replace the fixed `--max-iters-per-stage` cap with a closed loop — a Theil–Sen slope over the windowed-mean promotion-metric series (default `valid_placed`) **extends** the rung while it climbs and **stops early** on a plateau (or the ceiling `N`). Fixes the trio-box "truncated while still climbing" waste. Distinct from the manual `--stop-after-rung`. Curriculum-only; absent ⇒ the fixed cap, byte-identical. |
+| `--promotion-metric` / `--promotion-threshold` / `--promotion-window` | schedule policy (`valid_placed` / `0.9` / `3`) | Competency-gate overrides. A rung promotes when the mean of the last `--promotion-window` **iterations'** honest per-rollout `--promotion-metric` (the same `valid_placed` the `--metrics-out` JSONL and `ml.gate` report) clears `--promotion-threshold`. `--promotion-window` counts **iterations**, not episodes — the #742 fix: the gate previously thresholded only the last ~20 *episodes* of the latest rollout (a `deque(maxlen=window)` tail), a noisy estimator that false-promoted `by competency` on a lucky autocorrelated streak while the honest per-iteration mean was well below threshold. Curriculum-only. |
+| `--auto-budget` (+ `--auto-budget-max-iters N` ⌀1000, `--auto-budget-min-iters N` ⌀30, `--auto-budget-min-level L` ⌀0.05) | off | Slope-aware per-rung budget (#734): replace the fixed `--max-iters-per-stage` cap with a closed loop — a Theil–Sen slope over the **honest per-iteration** promotion-metric series (the same `valid_placed` the gate reads, #742) **extends** the rung while it climbs and **stops early** on a plateau (or the ceiling `N`). The `--auto-budget-min-level` **floor-guard** (#743) refuses to plateau-stop while the recent level is below `L` — a flat-at-floor *warmup* is not convergence, and slope alone cannot tell the two apart (both ~0); `0` disables it. Raise `--auto-budget-min-iters` for a hard rung with a long pre-climb. Distinct from the manual `--stop-after-rung`. Curriculum-only; absent ⇒ the fixed cap, byte-identical. |
 
 `--load`/`--checkpoint-out`/`--metrics-out`/`--promotion-*`/`--solo-box-rung`/`--seed-anchor`/`--mixed-anchor`/`--stop-after-rung`/`--auto-budget`
 are curriculum-only (fail loud under `--schedule trivial`). The resume checkpoint
 (`ml/checkpoint.py`) is distinct from `--save` (a bare `state_dict` for the ONNX/`ml.eval`
 consumer) and loads with `weights_only=True`.
+
+**Honest competency gate (#742/#743).** The trainer's `promoted by competency` and the
+`--auto-budget` slope are now fit on **one** per-iteration series — each rung iteration
+contributes its full-rollout `valid_placed` mean, the exact signal `ml.gate` re-reads from the
+JSONL — instead of a per-episode `deque` tail. The trainer's verdict is therefore as trustworthy
+as `ml.gate`'s (still re-grade with `python -m ml.gate` as a torch-free cross-check, but the two
+no longer disagree by construction). The companion `--auto-budget` floor-guard stops a hard rung
+from being truncated during its flat pre-climb warmup.
 
 ### What the #710 levers achieved, and the #714 multi-object fix
 

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -32,7 +32,10 @@ class PromotionPolicy:
     # the set AND validly. "fraction_placed" ignores validity (can promote on overlapping
     # parks); "valid_rate" ignores how much got placed. See should_promote.
     metric: Literal["fraction_placed", "valid_rate", "valid_placed"] = "valid_placed"
-    window: int = 20  # most-recent completed episodes to average
+    # most-recent ITERATIONS to average (each one rollout's honest full-rollout metric mean).
+    # NOT episodes — the #742 fix; see should_promote. A small window suffices because the
+    # per-iteration mean is already low-variance (it averages a whole rollout's episodes).
+    window: int = 3
     # advance when mean(metric over window) >= threshold. The metric is a rate in
     # [0, 1], so threshold > 1 means "never promote by competency" (always cap) and
     # threshold <= 0 means "promote as soon as the window fills" — both are valid levers.
@@ -62,12 +65,22 @@ def window_score(window: Sequence[EpisodeStat], metric: str) -> float:
     return sum(s.fraction_placed for s in window) / len(window)  # fraction_placed
 
 
-def should_promote(window: Sequence[EpisodeStat], policy: PromotionPolicy) -> bool:
-    """Pure gate: True when the last ``policy.window`` episodes meet the threshold."""
-    if len(window) < policy.window:
+def should_promote(history: Sequence[float], policy: PromotionPolicy) -> bool:
+    """Pure competency gate over the per-ITERATION honest-metric series. True when the mean of
+    the last ``policy.window`` iteration scores meets ``policy.threshold``.
+
+    Each element of ``history`` is one PPO iteration's full-rollout metric mean —
+    ``window_score(ep_stats, policy.metric)`` over the WHOLE rollout, the same honest
+    ``valid_placed`` signal the ``--metrics-out`` JSONL and ``ml.gate`` report. This is the
+    #742 fix: the gate previously thresholded the last ``policy.window`` *episodes* of a
+    ``deque(maxlen=window)`` — i.e. only the tail of the latest rollout (~20 of ~250 episodes),
+    a far noisier estimator that false-positive-promoted on a lucky autocorrelated streak.
+    Reading the per-iteration mean over a window of iterations removes that bias. ``policy.metric``
+    is applied upstream when the series is built, so this gate consults only window + threshold."""
+    if len(history) < policy.window:
         return False
-    recent = list(window)[-policy.window :]
-    return window_score(recent, policy.metric) >= policy.threshold
+    recent = list(history)[-policy.window :]
+    return sum(recent) / len(recent) >= policy.threshold
 
 
 def theil_sen_slope(values: Sequence[float]) -> float:
@@ -90,7 +103,9 @@ class BudgetController:
 
     ``should_stop`` is True once the rung has PLATEAUED: the trend over each of the last
     ``plateau_patience`` trailing ``slope_window``-sized windows is non-positive
-    (slope <= ``eps``). The caller separately enforces the competency gate
+    (slope <= ``eps``) AND the recent level has cleared ``min_level`` (the #743 floor-guard —
+    a curve flat at the FLOOR is a warmup, not a converged plateau, and slope alone cannot tell
+    the two apart since both are ~0). The caller separately enforces the competency gate
     (``should_promote``) and the hard ceiling (the loop bound ``max_iters``). Wired into
     train.py behind ``--auto-budget`` (default off), so the fixed-``max_iters`` path stays
     byte-identical (4c-ii default-neutrality)."""
@@ -100,6 +115,11 @@ class BudgetController:
     plateau_patience: int = 4  # consecutive non-positive-slope windows => plateau
     max_iters: int = 1000  # hard ceiling (the loop bound when auto-budget is on)
     eps: float = 1e-4  # slope <= eps counts as flat/non-positive
+    # #743 floor-guard: the recent slope_window's mean must clear this before any plateau-stop —
+    # distinguishes flat-at-floor (warmup, not started) from flat-at-ceiling (converged below the
+    # competency threshold). 0.0 disables the guard (pure slope-only stopping). The default is a
+    # small valid_placed level: below it the rung has effectively not begun to learn.
+    min_level: float = 0.05
 
     def __post_init__(self) -> None:
         if self.min_iters < 1:
@@ -112,15 +132,22 @@ class BudgetController:
             )
         if self.max_iters < 1:
             raise ValueError(f"BudgetController.max_iters must be >= 1, got {self.max_iters}")
+        if self.min_level < 0:
+            raise ValueError(f"BudgetController.min_level must be >= 0, got {self.min_level}")
 
     def should_stop(self, history: Sequence[float]) -> bool:
         """True iff the rung has plateaued: every one of the last ``plateau_patience``
-        trailing ``slope_window``-sized windows has slope <= ``eps``. False until there are
+        trailing ``slope_window``-sized windows has slope <= ``eps`` AND the most recent
+        ``slope_window``'s mean is >= ``min_level`` (the floor-guard). False until there are
         enough points (>= ``min_iters``, and enough to form the trailing windows)."""
         n = len(history)
         if n < self.min_iters:
             return False
         if n < self.slope_window + self.plateau_patience - 1:
+            return False
+        # Floor-guard: a flat curve still near the floor is a warmup, not a converged plateau.
+        recent = history[-self.slope_window :]
+        if sum(recent) / len(recent) < self.min_level:
             return False
         for k in range(self.plateau_patience):
             end = n - k
@@ -136,17 +163,21 @@ def with_promotion_overrides(
     metric: Literal["fraction_placed", "valid_rate", "valid_placed"] | None = None,
     threshold: float | None = None,
     max_iters: int | None = None,
+    window: int | None = None,
 ) -> PromotionPolicy:
     """Return ``policy`` with each non-None field overridden — the CLI plumbing for the
     #710 promotion-gate study (``--promotion-metric`` / ``--promotion-threshold`` /
-    ``--max-iters-per-stage``). All-None returns an equal policy, so the CLI stays
-    default-neutral when no override flag is passed."""
+    ``--max-iters-per-stage``) and the #742 ``--promotion-window`` (recent ITERATIONS to
+    average). All-None returns an equal policy, so the CLI stays default-neutral when no
+    override flag is passed."""
     if metric is not None:
         policy = replace(policy, metric=metric)
     if threshold is not None:
         policy = replace(policy, threshold=threshold)
     if max_iters is not None:
         policy = replace(policy, max_iters=max_iters)
+    if window is not None:
+        policy = replace(policy, window=window)
     return policy
 
 

--- a/ml/train.py
+++ b/ml/train.py
@@ -11,7 +11,6 @@ import argparse
 import contextlib
 import json
 import sys
-from collections import deque
 from collections.abc import Callable, Sequence
 from dataclasses import replace
 from functools import partial
@@ -31,6 +30,7 @@ from ml.curriculum import (
     CurriculumSchedule,
     EpisodeStart,
     EpisodeStat,
+    PromotionPolicy,
     Stage,
     format_iter_log,
     history_metric_records,
@@ -320,6 +320,34 @@ def train(
     return history
 
 
+def _rung_stop_reason(
+    promo_history: list[float],
+    ep_stats: Sequence[EpisodeStat],
+    pol: PromotionPolicy,
+    auto_budget: BudgetController | None,
+) -> str | None:
+    """Append this iteration's HONEST per-iteration metric mean to ``promo_history`` — the
+    ``window_score`` over the WHOLE rollout's episodes, the same ``valid_placed`` the
+    ``--metrics-out`` JSONL and ``ml.gate`` report — then decide whether the rung stops THIS
+    iteration. Returns the promotion reason (``"competency"`` | ``"budget-plateau"``) or None
+    to keep training. The #742 fix routes BOTH the competency gate (``should_promote``) and the
+    #734 auto-budget slope-fit through this single honest series, replacing the old per-episode
+    ``deque(maxlen=window)`` tail that each read separately.
+
+    Only an iteration that completed >= 1 episode contributes a score: an empty rollout carries
+    no competency signal (matching ``episode_metrics``' None-when-empty convention and
+    ``ml.gate``'s None-row filter), so it neither advances the gate nor injects a phantom-flat
+    point that could trip the auto-budget plateau detector. Competency wins over a budget
+    plateau when both fire in the same iteration."""
+    if ep_stats:
+        promo_history.append(window_score(ep_stats, pol.metric))
+    if should_promote(promo_history, pol):
+        return "competency"
+    if auto_budget is not None and auto_budget.should_stop(promo_history):
+        return "budget-plateau"
+    return None
+
+
 def train_curriculum(
     *,
     seed: int = 0,
@@ -421,20 +449,22 @@ def train_curriculum(
         pool = effective_fleet_ids(stage)
         n = stage.difficulty.max_objects if stage.difficulty.max_objects is not None else len(pool)
         rng = stage_rng(seed, stage_index)
-        # The window holds the last `pol.window` COMPLETED EPISODES (not iterations): one
-        # rollout can complete many episodes, so a rung the transferred policy already
-        # masters can legitimately promote on its first iteration. That is intended — the
-        # curriculum advances as soon as competent, it does not "serve time" per rung.
-        window: deque[EpisodeStat] = deque(maxlen=pol.window)
+        # promo_history holds ONE honest score per ITERATION — window_score over the WHOLE
+        # rollout's episodes (the same valid_placed the JSONL/ml.gate report), NOT the last
+        # `pol.window` completed episodes (the #742 fix). should_promote thresholds its windowed
+        # mean and the #734 auto-budget controller fits its slope on the SAME series, so the gate
+        # and the budget watch one honest trajectory. A rung the transferred policy already
+        # masters can still promote on its first competent iteration — the curriculum advances as
+        # soon as competent, it does not "serve time" per rung.
+        promo_history: list[float] = []
         # partial binds THIS stage's pool/n/rng by value (so the per-iteration closure
         # is not the flake8-bugbear B023 late-binding trap) and stays mypy-inferrable
         # where a default-arg lambda would not be.
         next_request = make_episode_sampler(stage, pool, n, rng)
         # #734 auto-budget: with a controller, each rung runs up to its hard ceiling and
         # stops early on a valid_placed plateau; without one, the fixed pol.max_iters cap.
-        # auto_budget is None (default) => same bound + no controller calls => byte-identical.
+        # auto_budget is None (default) => same loop bound + no controller calls.
         ceiling = auto_budget.max_iters if auto_budget is not None else pol.max_iters
-        metric_history: list[float] = []
         # n_envs == 1: the single-stream path (byte-identical when auto_budget is None).
         if n_envs == 1:
             for it in range(ceiling):
@@ -454,18 +484,13 @@ def train_curriculum(
                     env, policy, enc, rollout_len, sample_request=next_request
                 )
                 ppo_update(policy, optimizer, buf, it_cfg, normalizer=normalizer)
-                window.extend(ep_stats)
                 history.record(stage.name, it, ep_stats)
                 if log:
                     print(format_iter_log(stage.name, it, ep_stats), flush=True)
-                if should_promote(list(window), pol):
-                    history.note_promotion(stage.name, it, by="competency")
+                reason = _rung_stop_reason(promo_history, ep_stats, pol, auto_budget)
+                if reason is not None:
+                    history.note_promotion(stage.name, it, by=reason)
                     break
-                if auto_budget is not None:
-                    metric_history.append(window_score(list(window), pol.metric))
-                    if auto_budget.should_stop(metric_history):
-                        history.note_promotion(stage.name, it, by="budget-plateau")
-                        break
             else:
                 history.note_promotion(stage.name, ceiling - 1, by="cap")
         else:
@@ -497,18 +522,13 @@ def train_curriculum(
                     )
                     buf_vec, ep_stats = collect_rollout_vec(vec, policy, enc, rollout_len)
                     ppo_update(policy, optimizer, buf_vec, it_cfg, normalizer=normalizer)
-                    window.extend(ep_stats)
                     history.record(stage.name, it, ep_stats)
                     if log:
                         print(format_iter_log(stage.name, it, ep_stats), flush=True)
-                    if should_promote(list(window), pol):
-                        history.note_promotion(stage.name, it, by="competency")
+                    reason = _rung_stop_reason(promo_history, ep_stats, pol, auto_budget)
+                    if reason is not None:
+                        history.note_promotion(stage.name, it, by=reason)
                         break
-                    if auto_budget is not None:
-                        metric_history.append(window_score(list(window), pol.metric))
-                        if auto_budget.should_stop(metric_history):
-                            history.note_promotion(stage.name, it, by="budget-plateau")
-                            break
                 else:
                     history.note_promotion(stage.name, ceiling - 1, by="cap")
         if log:
@@ -570,6 +590,22 @@ def build_argparser() -> argparse.ArgumentParser:
         "1000). Ignored without --auto-budget.",
     )
     p.add_argument(
+        "--auto-budget-min-iters",
+        type=int,
+        default=None,
+        help="curriculum: --auto-budget no-stop floor — no plateau-stop decision before this many "
+        "iterations (default = BudgetController default, 30). Raise it for a hard rung with a long "
+        "pre-climb warmup. Requires --auto-budget.",
+    )
+    p.add_argument(
+        "--auto-budget-min-level",
+        type=float,
+        default=None,
+        help="curriculum: --auto-budget floor-guard (#743) — the recent metric level must clear "
+        "this before any plateau-stop, so a flat-at-floor WARMUP is not mistaken for convergence "
+        "(default = BudgetController default, 0.05; 0 disables the guard). Requires --auto-budget.",
+    )
+    p.add_argument(
         "--promotion-metric",
         choices=["fraction_placed", "valid_rate", "valid_placed"],
         default=None,
@@ -582,6 +618,15 @@ def build_argparser() -> argparse.ArgumentParser:
         default=None,
         help="curriculum: PromotionPolicy.threshold override in [0,1] "
         "(default = schedule policy, 0.9); lower it so the easy rungs reveal the ladder",
+    )
+    p.add_argument(
+        "--promotion-window",
+        type=int,
+        default=None,
+        help="curriculum: PromotionPolicy.window override — recent ITERATIONS to average for the "
+        "competency gate (default = schedule policy, 3). Each iteration contributes its honest "
+        "full-rollout valid_placed mean (the #742 fix), NOT a per-episode tail; raise it to "
+        "require sustained competency over more iterations before promoting.",
     )
     p.add_argument(
         "--metrics-out",
@@ -896,6 +941,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                 metric=args.promotion_metric,
                 threshold=args.promotion_threshold,
                 max_iters=args.max_iters_per_stage,
+                window=args.promotion_window,
             ),
         )
         if args.solo_box_rung:
@@ -907,18 +953,23 @@ def main(argv: Sequence[str] | None = None) -> None:
         # Truncate LAST, after the grafts, so a name they introduce (pair-mixed) is in scope.
         if args.stop_after_rung is not None:
             sched = truncate_after_rung(sched, args.stop_after_rung)
-        # #734: build the slope-aware controller only when --auto-budget is set; None keeps
-        # the fixed per-rung cap (byte-identical default). Fail LOUD on a ceiling without the
-        # switch rather than silently dropping a typed numeric flag.
-        if args.auto_budget_max_iters is not None and not args.auto_budget:
-            parser.error("--auto-budget-max-iters requires --auto-budget")
-        budget = None
-        if args.auto_budget:
-            budget = (
-                BudgetController(max_iters=args.auto_budget_max_iters)
-                if args.auto_budget_max_iters is not None
-                else BudgetController()
+        # #734/#743: build the slope-aware controller only when --auto-budget is set; None keeps
+        # the fixed per-rung cap (byte-identical default). Each per-knob override (max-iters /
+        # min-iters / min-level) is inert without the switch, so fail LOUD rather than silently
+        # dropping a typed numeric flag. Unsupplied knobs fall back to the BudgetController default.
+        budget_overrides = {
+            k: v
+            for k, v in (
+                ("max_iters", args.auto_budget_max_iters),
+                ("min_iters", args.auto_budget_min_iters),
+                ("min_level", args.auto_budget_min_level),
             )
+            if v is not None
+        }
+        if budget_overrides and not args.auto_budget:
+            flags = ", ".join("--auto-budget-" + k.replace("_", "-") for k in budget_overrides)
+            parser.error(f"{flags} require --auto-budget")
+        budget = BudgetController(**budget_overrides) if args.auto_budget else None
         history = train_curriculum(
             seed=args.seed,
             schedule=sched,

--- a/ml/train.py
+++ b/ml/train.py
@@ -454,8 +454,8 @@ def train_curriculum(
         # `pol.window` completed episodes (the #742 fix). should_promote thresholds its windowed
         # mean and the #734 auto-budget controller fits its slope on the SAME series, so the gate
         # and the budget watch one honest trajectory. A rung the transferred policy already
-        # masters can still promote on its first competent iteration — the curriculum advances as
-        # soon as competent, it does not "serve time" per rung.
+        # masters can promote as soon as `pol.window` consecutive iterations are competent (3 by
+        # default) — the curriculum advances on sustained competency, it does not "serve time".
         promo_history: list[float] = []
         # partial binds THIS stage's pool/n/rng by value (so the per-iteration closure
         # is not the flake8-bugbear B023 late-binding trap) and stays mypy-inferrable
@@ -465,7 +465,8 @@ def train_curriculum(
         # stops early on a valid_placed plateau; without one, the fixed pol.max_iters cap.
         # auto_budget is None (default) => same loop bound + no controller calls.
         ceiling = auto_budget.max_iters if auto_budget is not None else pol.max_iters
-        # n_envs == 1: the single-stream path (byte-identical when auto_budget is None).
+        # n_envs == 1: the legacy single-stream path — byte-identical to the pre-#708 loop (the
+        # #708 contract); it shares the #742 per-iteration gate with the vectorized path below.
         if n_envs == 1:
             for it in range(ceiling):
                 # Per-rung entropy schedule: `it` resets to 0 each stage, so each rung
@@ -957,18 +958,18 @@ def main(argv: Sequence[str] | None = None) -> None:
         # the fixed per-rung cap (byte-identical default). Each per-knob override (max-iters /
         # min-iters / min-level) is inert without the switch, so fail LOUD rather than silently
         # dropping a typed numeric flag. Unsupplied knobs fall back to the BudgetController default.
-        budget_overrides = {
-            k: v
-            for k, v in (
-                ("max_iters", args.auto_budget_max_iters),
-                ("min_iters", args.auto_budget_min_iters),
-                ("min_level", args.auto_budget_min_level),
-            )
-            if v is not None
-        }
-        if budget_overrides and not args.auto_budget:
-            flags = ", ".join("--auto-budget-" + k.replace("_", "-") for k in budget_overrides)
-            parser.error(f"{flags} require --auto-budget")
+        # (field, user-facing flag, value) — the flag string is explicit, not derived from the
+        # field name, so a future knob whose flag diverges from its dataclass field can't desync.
+        budget_specs = (
+            ("max_iters", "--auto-budget-max-iters", args.auto_budget_max_iters),
+            ("min_iters", "--auto-budget-min-iters", args.auto_budget_min_iters),
+            ("min_level", "--auto-budget-min-level", args.auto_budget_min_level),
+        )
+        budget_overrides = {field: v for field, _flag, v in budget_specs if v is not None}
+        supplied_flags = [flag for _field, flag, v in budget_specs if v is not None]
+        if supplied_flags and not args.auto_budget:
+            verb = "requires" if len(supplied_flags) == 1 else "require"
+            parser.error(f"{', '.join(supplied_flags)} {verb} --auto-budget")
         budget = BudgetController(**budget_overrides) if args.auto_budget else None
         history = train_curriculum(
             seed=args.seed,

--- a/tests/ml/test_budget_controller.py
+++ b/tests/ml/test_budget_controller.py
@@ -100,6 +100,36 @@ def test_stop_on_plateau():
     assert c.should_stop(history) is True
 
 
+def test_no_stop_while_flat_at_floor():
+    # #743 regression: a curve flat at ~0 is a WARMUP (not started), not a converged plateau.
+    # Slope alone cannot tell floor-flat from ceiling-flat (both are ~0). The floor-guard keeps
+    # training while the recent level is below min_level, so --auto-budget no longer truncates a
+    # hard rung's flat pre-climb warmup (the trio-box failure: plateau-stopped at iter 29, ~0.04).
+    c = _ctrl(min_level=0.05)
+    assert c.should_stop([0.0] * 15) is False
+
+
+def test_stop_when_plateaued_above_floor():
+    # flat at a MEANINGFUL level (converged below the competency threshold) still stops — the
+    # floor-guard only blocks floor-flat, not a genuine ceiling-plateau.
+    c = _ctrl(min_level=0.05)
+    assert c.should_stop([0.7] * 15) is True
+
+
+def test_floor_guard_uses_recent_level_not_early_floor():
+    # warm up at the floor, then climb to a flat plateau: the early floor iterations must not
+    # veto the genuine late plateau — the guard reads the RECENT slope_window's level.
+    c = _ctrl(min_level=0.05, min_iters=10, slope_window=5, plateau_patience=2)
+    history = [0.0] * 8 + [0.6] * 7  # floor warmup then flat at 0.6
+    assert c.should_stop(history) is True
+
+
+def test_min_level_zero_disables_floor_guard():
+    # min_level=0 restores pure slope-only stopping — the isolation lever for the wiring test.
+    c = _ctrl(min_level=0.0)
+    assert c.should_stop([0.0] * 15) is True
+
+
 def test_stop_on_decline():
     c = _ctrl()
     history = [1.0 - 0.01 * i for i in range(15)]  # slowly declining
@@ -136,6 +166,8 @@ def test_invalid_config_rejected():
         BudgetController(plateau_patience=0)
     with pytest.raises(ValueError):
         BudgetController(max_iters=0)
+    with pytest.raises(ValueError):
+        BudgetController(min_level=-0.1)  # the floor must be a non-negative metric level
 
 
 # ---------------------------------------------------------------------------
@@ -189,13 +221,15 @@ def test_auto_budget_ceiling_replaces_fixed_cap():
 
 def test_auto_budget_stops_early_on_plateau():
     """A controller with a huge eps treats every slope as non-positive, so it plateau-stops
-    as soon as it has min_iters points — well before the high fixed cap."""
+    as soon as it has min_iters points — well before the high fixed cap. min_level=0 isolates
+    the slope-plateau wiring from the #743 floor-guard (separately unit-tested above); without
+    it the floor-guard would keep an early flat-at-floor trivial rung training past min_iters."""
     pytest.importorskip("torch")
     from ml.train import train_curriculum
 
     sched = _one_stage_sched(threshold=2.0, max_iters=100)
     budget = BudgetController(
-        min_iters=2, slope_window=2, plateau_patience=1, max_iters=100, eps=1e9
+        min_iters=2, slope_window=2, plateau_patience=1, max_iters=100, eps=1e9, min_level=0.0
     )
     hist = train_curriculum(
         seed=0, schedule=sched, rollout_len=8, policy_kwargs=_SMALL_NET, auto_budget=budget

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -39,38 +39,38 @@ from ml.encoding import EncoderConfig
 from ml.types import DifficultyConfig
 
 
-def test_should_promote_fires_when_windowed_mean_meets_threshold():
-    pol = PromotionPolicy(metric="fraction_placed", window=2, threshold=0.5)
-    window = [EpisodeStat(0.4, False, -1.0), EpisodeStat(0.8, True, 1.0)]  # mean 0.6 >= 0.5
-    assert should_promote(window, pol) is True
+def test_should_promote_fires_when_iteration_mean_meets_threshold():
+    # should_promote reads the per-ITERATION honest-metric series — each element is one PPO
+    # iteration's full-rollout metric mean — NOT a per-episode tail (the #742 fix). The metric
+    # credit rule (valid_placed/valid_rate/fraction_placed) is applied upstream when the series
+    # is built, so the gate itself only thresholds the windowed mean of those iteration scores.
+    pol = PromotionPolicy(window=2, threshold=0.5)
+    assert should_promote([0.4, 0.8], pol) is True  # mean 0.6 >= 0.5
 
 
 def test_should_promote_false_below_threshold():
-    pol = PromotionPolicy(metric="fraction_placed", window=2, threshold=0.9)
-    window = [EpisodeStat(0.4, False, -1.0), EpisodeStat(0.8, True, 1.0)]  # mean 0.6 < 0.9
-    assert should_promote(window, pol) is False
+    pol = PromotionPolicy(window=2, threshold=0.9)
+    assert should_promote([0.4, 0.8], pol) is False  # mean 0.6 < 0.9
 
 
 def test_should_promote_waits_for_full_window():
     pol = PromotionPolicy(window=3, threshold=0.0)
-    assert should_promote([EpisodeStat(1.0, True, 1.0)], pol) is False  # only 1 < window 3
+    assert should_promote([1.0], pol) is False  # only 1 iteration < window 3
 
 
 def test_should_promote_uses_last_window_only():
-    pol = PromotionPolicy(metric="fraction_placed", window=2, threshold=0.95)
-    # old low episodes must NOT drag down a recently-mastered window
-    window = [
-        EpisodeStat(0.0, False, 0.0),
-        EpisodeStat(1.0, True, 0.0),
-        EpisodeStat(1.0, True, 0.0),
-    ]
-    assert should_promote(window, pol) is True  # last 2 both 1.0
+    # old low iterations must NOT drag down a recently-mastered window
+    pol = PromotionPolicy(window=2, threshold=0.95)
+    assert should_promote([0.0, 1.0, 1.0], pol) is True  # last 2 both 1.0
 
 
-def test_should_promote_valid_rate_metric():
-    pol = PromotionPolicy(metric="valid_rate", window=2, threshold=1.0)
-    assert should_promote([EpisodeStat(1.0, True, 0.0), EpisodeStat(0.5, False, 0.0)], pol) is False
-    assert should_promote([EpisodeStat(0.1, True, 0.0), EpisodeStat(0.2, True, 0.0)], pol) is True
+def test_should_promote_does_not_fire_on_subthreshold_iteration_mean():
+    # THE #742 regression: a rung whose honest per-iteration mean sits ~0.65 must NOT promote
+    # at threshold 0.9, however noisy the underlying per-episode tail is — the gate now reads
+    # the full-rollout per-iteration mean, not a lucky last-20-episode spike that read >= 0.9.
+    history = [0.62, 0.71, 0.65, 0.68, 0.64]  # every iteration's honest mean ~0.65, all < 0.9
+    pol = PromotionPolicy(window=3, threshold=0.9)
+    assert should_promote(history, pol) is False
 
 
 def test_sample_request_is_deterministic_for_equal_rngs():
@@ -216,14 +216,11 @@ def test_default_promotion_metric_is_valid_placed():
     assert PromotionPolicy().metric == "valid_placed"
 
 
-def test_should_promote_valid_placed_credits_only_valid_episodes():
-    pol = PromotionPolicy(metric="valid_placed", window=2, threshold=0.5)
-    # both fully placed, but only one valid -> mean(1.0, 0.0) = 0.5 >= 0.5
-    assert should_promote([EpisodeStat(1.0, True, 0.0), EpisodeStat(1.0, False, 0.0)], pol) is True
-    # both fully placed but BOTH invalid -> mean(0.0, 0.0) = 0.0 < 0.5
-    assert (
-        should_promote([EpisodeStat(1.0, False, 0.0), EpisodeStat(1.0, False, 0.0)], pol) is False
-    )
+def test_default_promotion_window_counts_iterations_not_episodes():
+    # #742: the window is now a count of recent ITERATIONS (each an honest full-rollout mean),
+    # not the last-N completed episodes. The default is a small smoothing window because the
+    # per-iteration mean is already low-variance (it averages a whole rollout's episodes).
+    assert PromotionPolicy().window == 3
 
 
 def test_stage_rng_worker_index_zero_is_legacy_and_distinct():
@@ -268,18 +265,17 @@ def test_episode_metrics_empty_is_n0_with_none_rates():
     assert m["valid_placed"] is None
 
 
-def test_episode_metrics_valid_placed_matches_should_promote_scoring():
-    # the per-iter valid_placed must use the SAME credit rule as the promotion gate
+def test_episode_metrics_valid_placed_feeds_should_promote_as_one_iteration_score():
+    # episode_metrics(...)["valid_placed"] IS one element of the honest series the gate reads:
+    # feed it as a 1-element history and the window=1 gate fires exactly at that value. This
+    # pins the contract that the metric the JSONL/ml.gate report is the metric the gate uses.
     stats = [EpisodeStat(0.8, True, 0.0), EpisodeStat(0.9, False, 0.0), EpisodeStat(0.4, True, 0.0)]
+    score = episode_metrics(stats)["valid_placed"]
     expected = (0.8 + 0.0 + 0.4) / 3
-    assert episode_metrics(stats)["valid_placed"] == pytest.approx(expected)
-    # and the gate fires exactly when that mean meets threshold
-    assert should_promote(
-        stats, PromotionPolicy(metric="valid_placed", window=3, threshold=expected)
-    )
-    assert not should_promote(
-        stats, PromotionPolicy(metric="valid_placed", window=3, threshold=expected + 0.01)
-    )
+    assert score == pytest.approx(expected)
+    assert isinstance(score, float)
+    assert should_promote([score], PromotionPolicy(window=1, threshold=expected))
+    assert not should_promote([score], PromotionPolicy(window=1, threshold=expected + 0.01))
 
 
 def test_history_metric_records_one_record_per_recorded_iteration():
@@ -332,6 +328,13 @@ def test_with_promotion_overrides_sets_only_given_fields():
     assert got.threshold == pytest.approx(0.3)
     assert got.max_iters == 120
     assert got.window == 20  # untouched field preserved
+
+
+def test_with_promotion_overrides_sets_window():
+    # #742: --promotion-window threads through with_promotion_overrides like the other levers.
+    base = PromotionPolicy(window=3)
+    assert with_promotion_overrides(base, window=8).window == 8
+    assert with_promotion_overrides(base).window == 3  # None -> unchanged (default-neutral)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -93,6 +93,84 @@ def test_train_curriculum_promotes_by_cap_when_unreachable():
     assert all(p[2] == "cap" for p in h.promotions)
 
 
+def test_train_curriculum_competency_reads_honest_per_iteration_mean_not_episode_tail(monkeypatch):
+    # #742 regression: the competency gate must threshold the HONEST per-iteration mean over the
+    # WHOLE rollout, not the last-N-episode tail. Feed a rollout whose full-iteration mean is 0.2
+    # (below threshold 0.9) but whose trailing 20 episodes spike to 1.0; the rung must CAP, never
+    # promote by competency. The pre-#742 last-20-episode deque would have read the 1.0 tail and
+    # false-promoted — this test fails loudly if anyone reintroduces a per-episode window.
+    import ml.train as train_mod
+    from ml.ppo import RolloutBuffer
+
+    ep_stats = [EpisodeStat(0.0, True, 0.0)] * 80 + [EpisodeStat(1.0, True, 0.0)] * 20  # mean 0.2
+
+    def biased_rollout(env, policy, enc, rollout_len, *, sample_request=None):
+        return RolloutBuffer(), list(ep_stats)
+
+    monkeypatch.setattr(train_mod, "collect_rollout", biased_rollout)
+    monkeypatch.setattr(
+        train_mod,
+        "ppo_update",
+        lambda *a, **k: {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0, "loss": 0.0},
+    )
+
+    sched = CurriculumSchedule.default()
+    sched = replace(
+        sched,
+        stages=(sched.stages[0],),  # one rung keeps the run tiny
+        policy=PromotionPolicy(metric="fraction_placed", window=1, threshold=0.9, max_iters=2),
+    )
+    h = train_curriculum(
+        seed=0,
+        schedule=sched,
+        rollout_len=8,
+        policy_kwargs={"d_model": 32, "n_layers": 1, "n_heads": 2},
+    )
+    _name, _it, by = h.promotions[-1]
+    assert by == "cap"  # honest mean 0.2 < 0.9 -> never competency, despite the 1.0 episode tail
+
+
+@pytest.mark.parametrize("min_level,expected_by", [(0.0, "budget-plateau"), (0.05, "cap")])
+def test_auto_budget_floor_guard_blocks_premature_stop_in_loop(monkeypatch, min_level, expected_by):
+    # #743 wiring: a rung whose honest valid_placed is flat AT THE FLOOR (every rollout places
+    # but INVALIDLY -> valid_placed 0.0) must NOT budget-plateau early. With the floor-guard on
+    # (min_level=0.05) the rung trains to its cap; with it off (min_level=0.0) the same flat-at-0
+    # series early-stops — the contrast proves the loop routes the honest series through the guard.
+    import ml.train as train_mod
+    from ml.curriculum import BudgetController
+    from ml.ppo import RolloutBuffer
+
+    flat_floor = [EpisodeStat(1.0, False, 0.0)] * 30  # placed but invalid -> valid_placed = 0.0
+
+    def floor_rollout(env, policy, enc, rollout_len, *, sample_request=None):
+        return RolloutBuffer(), list(flat_floor)
+
+    monkeypatch.setattr(train_mod, "collect_rollout", floor_rollout)
+    monkeypatch.setattr(
+        train_mod,
+        "ppo_update",
+        lambda *a, **k: {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0, "loss": 0.0},
+    )
+
+    sched = CurriculumSchedule.default()
+    sched = replace(
+        sched,
+        stages=(sched.stages[0],),
+        policy=PromotionPolicy(metric="valid_placed", window=1, threshold=2.0, max_iters=5),
+    )
+    budget = BudgetController(
+        min_iters=2, slope_window=2, plateau_patience=1, max_iters=5, eps=1e9, min_level=min_level
+    )
+    h = train_curriculum(
+        seed=0,
+        schedule=sched,
+        rollout_len=8,
+        policy_kwargs={"d_model": 32, "n_layers": 1, "n_heads": 2},
+        auto_budget=budget,
+    )
+    assert h.promotions[-1][2] == expected_by
+
+
 def test_argparser_schedule_defaults_to_curriculum():
     parser = build_argparser()
     assert parser.parse_args([]).schedule == "curriculum"
@@ -312,6 +390,69 @@ def test_main_no_override_flags_keeps_default_policy(monkeypatch):
     monkeypatch.setattr(train_mod, "train_curriculum", fake)
     train_mod.main(["--schedule", "curriculum"])
     assert captured["schedule"].policy == PromotionPolicy()
+
+
+def test_argparser_promotion_window_and_auto_budget_floor_default_none():
+    a = build_argparser().parse_args([])
+    assert a.promotion_window is None
+    assert a.auto_budget_min_iters is None
+    assert a.auto_budget_min_level is None
+
+
+def test_main_threads_promotion_window_into_policy(monkeypatch):
+    # #742: --promotion-window overrides PromotionPolicy.window (recent ITERATIONS to average).
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(*, schedule, **kw):
+        captured["schedule"] = schedule
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum", "--promotion-window", "5"])
+    assert captured["schedule"].policy.window == 5
+
+
+def test_main_threads_auto_budget_floor_knobs(monkeypatch):
+    # #743: --auto-budget-min-iters / --auto-budget-min-level build the BudgetController.
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(*, auto_budget, **kw):
+        captured["auto_budget"] = auto_budget
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(
+        [
+            "--schedule",
+            "curriculum",
+            "--auto-budget",
+            "--auto-budget-min-iters",
+            "50",
+            "--auto-budget-min-level",
+            "0.1",
+        ]
+    )
+    b = captured["auto_budget"]
+    assert b is not None
+    assert b.min_iters == 50
+    assert b.min_level == pytest.approx(0.1)
+
+
+def test_main_auto_budget_floor_knobs_require_auto_budget():
+    # the floor knobs are inert without --auto-budget: fail LOUD (like --auto-budget-max-iters),
+    # never silently drop a typed numeric flag.
+    import ml.train as train_mod
+
+    with pytest.raises(SystemExit):
+        train_mod.main(["--schedule", "curriculum", "--auto-budget-min-iters", "50"])
+    with pytest.raises(SystemExit):
+        train_mod.main(["--schedule", "curriculum", "--auto-budget-min-level", "0.1"])
 
 
 def test_main_writes_metrics_jsonl(monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #742
Closes #743

## Problem

The curriculum competency gate (`should_promote`) and the #734 `--auto-budget` slope-fit both
watched a **per-episode** `deque(maxlen=window)`. After `window.extend(ep_stats)` that deque
retained only the **last ~20 episodes of the latest rollout** (out of ~250) — a far noisier
estimator than the per-iteration `valid_placed` the `--metrics-out` JSONL and `ml.gate` report.

Two symptoms, one root cause:

- **#742** — a rung false-promoted `by competency` on a lucky autocorrelated 20-episode streak
  while its honest per-iteration mean was well below threshold. Caught red-handed in the prior
  `trio-box` run: the trainer printed `promoted by competency` at **iter 136 with the honest
  `valid_placed=0.655`** (and `ml.gate` reported peak 0.709 / `never` competent, **still climbing**).
- **#743** — `--auto-budget` plateau-stopped a hard rung **during its flat pre-climb warmup**
  (`trio-box` stopped at iter 29, `valid_placed` ~0.04 — the climb only started ~iter 50). A
  flat-at-floor warmup is not a converged plateau, but slope alone (Theil–Sen) cannot tell the
  two apart since both are ~0.

## Fix

Unify both decisions onto a **single honest per-iteration series** — `window_score` over the
*whole* rollout's episodes, skipping no-episode iterations — extracted into `_rung_stop_reason`
(which also DRYs the duplicated single-stream and vectorized loop blocks).

- `should_promote(history: Sequence[float], policy)` now thresholds the mean of the last
  `PromotionPolicy.window` **iterations** (each an honest full-rollout mean). `window` default
  3 (was 20 episodes); it now counts iterations.
- `BudgetController` gains a **floor-guard** `min_level` (default 0.05): no plateau-stop until
  the recent slope-window's mean clears the floor. `0` disables it.
- New default-neutral CLI levers: `--promotion-window`, `--auto-budget-min-iters`,
  `--auto-budget-min-level` (the last two fail loud without `--auto-budget`, like
  `--auto-budget-max-iters`).

**Deliberate re-baseline:** the gate now advances rungs at different iterations than the buggy
per-episode tail did. Run-twice determinism (`test_train_curriculum_is_deterministic`) and
`--auto-budget`-off byte-identity are preserved (the new logic is itself deterministic). Dev/CI-only
(`ml/`); no shipped-wheel surface.

## Tests (TDD, red→green)

- `should_promote` rewritten to a float-series gate; **#742 regression**:
  `test_should_promote_does_not_fire_on_subthreshold_iteration_mean` and the loop-level
  `test_train_curriculum_competency_reads_honest_per_iteration_mean_not_episode_tail` (a rollout
  whose full mean is 0.2 but whose trailing 20 episodes spike to 1.0 must **cap**, not promote).
- **#743**: `BudgetController` floor-guard unit tests (`flat_at_floor` → no stop;
  `plateaued_above_floor` → stop; recent-level not early-floor; `min_level=0` disables) plus a
  parametrized loop-wiring test proving the guard is consulted both ways.
- CLI threading + loud-fail tests for the three new flags.
- Full `tests/ml/` suite: **444 passed**.

## Docs

CHANGELOG `[Unreleased] → Fixed`; ml/README flag table (`--promotion-*` row + updated
`--auto-budget` row) and a new "Honest competency gate" note. The stale **trio-box recipe**
itself (`--load` name + `--auto-budget`-ignored flag) is fixed separately in #744.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Tt77ncHetTe85ee9J7NKm