### PR TITLE
perf(747): cap worker BLAS/OMP threads + add `--n-envs auto`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#747, epic #607 Wave 1 / #758): cap worker BLAS/OMP threads +
+  `--n-envs auto` to fill idle cores.** A measured `--n-envs 16` run pinned only ~5.5 of
+  32 cores, and the spawn workers ran *unconstrained* BLAS/OMP/MKL threading, so naively
+  raising `--n-envs` toward the core count would **oversubscribe** the box. Two paired,
+  byte-identical changes: (1) each `ml/vector_env.py` spawn worker now caps itself to a
+  single thread (`OMP/OPENBLAS/MKL/NUMEXPR_NUM_THREADS=1` + `torch.set_num_threads(1)`) at
+  worker-loop entry — one core per worker; (2) `--n-envs auto` sizes the worker pool to
+  `max(1, min(schedulable_cores − reserved, RAM_budget // per_worker))`, using
+  `os.sched_getaffinity` (cgroup/`taskset`-aware, unlike `cpu_count` which overcounts on
+  WSL2/containers) and `/proc/meminfo` `MemAvailable`. The argparse default stays `1`, so
+  `--n-envs 1` remains the byte-identity floor; `auto`/raised values are opt-in per run.
+  The thread cap is byte-identical (anchored on the **torch-free-worker** invariant —
+  workers run no policy ops, so a 1-thread cap can't perturb numpy/shapely reduction
+  order), proven by `test_sync_equals_subproc_byte_identical` + a fixed-action
+  reward-stream diff. `--n-envs > 1` (or `auto`) on `--schedule trivial` now fails loud
+  (the trivial path is single-env). Dev/CI-only (`ml/`); no shipped-wheel surface.
+
 - **Learned backend (#734, epic #607): slope-aware `--auto-budget` per curriculum rung.**
   A fixed `--max-iters-per-stage` cap is wrong in both directions — it truncated the trio-box
   (N=3) run while `valid_placed` was *still climbing* (peak 0.65, under-trained not collapsed),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ All notable changes to this project are documented here. Format follows [Keep a 
   raising `--n-envs` toward the core count would **oversubscribe** the box. Two paired,
   byte-identical changes: (1) each `ml/vector_env.py` spawn worker now caps itself to a
   single thread (`OMP/OPENBLAS/MKL/NUMEXPR_NUM_THREADS=1` + `torch.set_num_threads(1)`) at
-  worker-loop entry — one core per worker; (2) `--n-envs auto` sizes the worker pool to
-  `max(1, min(schedulable_cores − reserved, RAM_budget // per_worker))`, using
-  `os.sched_getaffinity` (cgroup/`taskset`-aware, unlike `cpu_count` which overcounts on
-  WSL2/containers) and `/proc/meminfo` `MemAvailable`. The argparse default stays `1`, so
+  worker-loop entry — one core per worker. The cap is set in the **parent** before
+  `spawn` so each child inherits it at interpreter startup (OpenBLAS/MKL fix their pool
+  size at numpy-import time and ignore a late env write — measured cpu/wall ≈ 31 vs 1).
+  (2) `--n-envs auto` sizes the worker pool to
+  `max(1, min(schedulable_cores − reserved, (MemAvailable − headroom) // per_worker))`,
+  using `os.sched_getaffinity` (cgroup/`taskset`-aware, unlike `cpu_count` which
+  overcounts on WSL2/containers) and `/proc/meminfo` `MemAvailable`. The default stays `1`, so
   `--n-envs 1` remains the byte-identity floor; `auto`/raised values are opt-in per run.
   The thread cap is byte-identical (anchored on the **torch-free-worker** invariant —
   workers run no policy ops, so a 1-thread cap can't perturb numpy/shapely reduction

--- a/ml/train.py
+++ b/ml/train.py
@@ -600,8 +600,9 @@ def _available_gib() -> float | None:
 
 def resolve_n_envs(value: str) -> int:
     """argparse ``type`` for ``--n-envs``: an explicit positive int passes through; the
-    literal ``auto`` resolves to ``max(1, min(cores - reserved, ram_budget // per_worker))``
-    using :func:`_available_cores` and :func:`_available_gib`. The floor of 1 keeps the
+    literal ``auto`` resolves to
+    ``max(1, min(cores - reserved, (MemAvailable_gib - headroom) // per_worker))`` using
+    :func:`_available_cores` and :func:`_available_gib`. The floor of 1 keeps the
     byte-identity reference (``--n-envs 1``) reachable even on a 1-core / tiny-RAM box.
     Raises :class:`argparse.ArgumentTypeError` (-> a clean parser error) on a non-positive
     or non-integer value."""
@@ -983,7 +984,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             parser.error("--stop-after-rung requires --schedule curriculum")
         if args.auto_budget or args.auto_budget_max_iters is not None:
             parser.error("--auto-budget/--auto-budget-max-iters require --schedule curriculum")
-        if args.n_envs != 1:
+        if args.n_envs > 1:  # resolve_n_envs floors at 1, so >1 is the only over-floor case
             # --n-envs (and 'auto') only feed the vectorized curriculum path; train() is
             # single-env. Fail LOUD so `--n-envs auto --schedule trivial` is not a silent no-op.
             parser.error("--n-envs > 1 (or 'auto') requires --schedule curriculum")

--- a/ml/train.py
+++ b/ml/train.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import os
 import sys
 from collections.abc import Callable, Sequence
 from dataclasses import replace
@@ -562,6 +563,66 @@ def train_curriculum(
     return history
 
 
+# --n-envs auto (#747): pack one spawn worker per idle core, RAM permitting. The cap
+# constants are deliberately conservative — auto picking too FEW workers wastes cores;
+# picking too many risks OOM (the issue's named risk), so the gate leans toward fewer.
+# Per-worker RAM is grounded in the measured ~0.5 GiB incremental PSS per worker (16-worker
+# trio-box run, see the throughput diagnosis) carried at ~2x for headroom; #751 (forkserver)
+# will later shrink it. These are not user knobs yet — promote to flags if a box needs it.
+_AUTO_RESERVED_CORES = 2  # learner forward/backward + the GPU-feed / main loop
+_AUTO_PER_WORKER_GIB = 1.0  # ~2x the measured ~0.5 GiB incremental PSS per spawn worker
+_AUTO_RAM_HEADROOM_GIB = 2.0  # leave room for the parent (CUDA context, larger batches) to grow
+
+
+def _available_cores() -> int:
+    """Schedulable core count. ``sched_getaffinity`` honours cgroup / ``taskset`` pinning
+    (so WSL2 / container limits are respected); ``os.cpu_count`` overcounts those. Falls
+    back to ``cpu_count`` only where affinity is unavailable (non-Linux)."""
+    getaffinity = getattr(os, "sched_getaffinity", None)
+    if getaffinity is not None:
+        return len(getaffinity(0))
+    return os.cpu_count() or 1
+
+
+def _available_gib() -> float | None:
+    """Allocatable RAM in GiB from ``/proc/meminfo`` ``MemAvailable`` (the kernel's honest
+    "without swapping" figure), or ``None`` where it cannot be read (non-Linux / sandbox).
+    ``None`` makes ``--n-envs auto`` fall back to a cores-only bound."""
+    try:
+        with open("/proc/meminfo", encoding="ascii") as fh:
+            for line in fh:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) / (1024 * 1024)  # kB -> GiB
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def resolve_n_envs(value: str) -> int:
+    """argparse ``type`` for ``--n-envs``: an explicit positive int passes through; the
+    literal ``auto`` resolves to ``max(1, min(cores - reserved, ram_budget // per_worker))``
+    using :func:`_available_cores` and :func:`_available_gib`. The floor of 1 keeps the
+    byte-identity reference (``--n-envs 1``) reachable even on a 1-core / tiny-RAM box.
+    Raises :class:`argparse.ArgumentTypeError` (-> a clean parser error) on a non-positive
+    or non-integer value."""
+    if value == "auto":
+        core_cap = max(1, _available_cores() - _AUTO_RESERVED_CORES)
+        gib = _available_gib()
+        if gib is None:
+            return core_cap
+        ram_cap = max(1, int((gib - _AUTO_RAM_HEADROOM_GIB) / _AUTO_PER_WORKER_GIB))
+        return max(1, min(core_cap, ram_cap))
+    try:
+        n = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"--n-envs must be a positive integer or 'auto', got {value!r}"
+        ) from None
+    if n < 1:
+        raise argparse.ArgumentTypeError(f"--n-envs must be >= 1, got {n}")
+    return n
+
+
 def build_argparser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         description="Train the cold-joint policy (trivial stage or curriculum)."
@@ -844,9 +905,10 @@ def build_argparser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--n-envs",
-        type=int,
+        type=resolve_n_envs,
         default=1,
-        help="number of parallel envs (1 = legacy single-stream, byte-identical)",
+        help="number of parallel envs: an integer, or 'auto' to fill idle cores "
+        "(sched_getaffinity - reserved, RAM-capped). 1 = legacy single-stream, byte-identical",
     )
     p.add_argument(
         "--vec-backend",
@@ -921,6 +983,10 @@ def main(argv: Sequence[str] | None = None) -> None:
             parser.error("--stop-after-rung requires --schedule curriculum")
         if args.auto_budget or args.auto_budget_max_iters is not None:
             parser.error("--auto-budget/--auto-budget-max-iters require --schedule curriculum")
+        if args.n_envs != 1:
+            # --n-envs (and 'auto') only feed the vectorized curriculum path; train() is
+            # single-env. Fail LOUD so `--n-envs auto --schedule trivial` is not a silent no-op.
+            parser.error("--n-envs > 1 (or 'auto') requires --schedule curriculum")
         train(
             seed=args.seed,
             iterations=args.iterations,
@@ -971,6 +1037,16 @@ def main(argv: Sequence[str] | None = None) -> None:
             verb = "requires" if len(supplied_flags) == 1 else "require"
             parser.error(f"{', '.join(supplied_flags)} {verb} --auto-budget")
         budget = BudgetController(**budget_overrides) if args.auto_budget else None
+        if args.n_envs > 1:
+            # Surface the effective parallelism + the box it was sized against, so an
+            # `auto` (or an explicit) value is visible in the run log rather than implicit.
+            gib = _available_gib()
+            mem = f"{gib:.1f} GiB" if gib is not None else "unknown"
+            print(
+                f"note: training with {args.n_envs} parallel envs "
+                f"(schedulable cores={_available_cores()}, MemAvailable={mem})",
+                file=sys.stderr,
+            )
         history = train_curriculum(
             seed=args.seed,
             schedule=sched,

--- a/ml/vector_env.py
+++ b/ml/vector_env.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import contextlib
 import multiprocessing as mp
+import os
+import sys
 from collections.abc import Callable, Sequence
 from typing import Any, NamedTuple, cast
 
@@ -138,6 +140,42 @@ class SyncVectorEnv:
         self.close()
 
 
+_WORKER_THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
+
+
+def _limit_worker_threads() -> None:
+    """Pin a spawned vec-env worker to a single BLAS/OMP/MKL thread (#747).
+
+    Raising ``--n-envs`` toward the core count is only safe once each worker is exactly
+    one core: otherwise N workers each spin a cores-wide OpenBLAS/MKL pool and the box
+    oversubscribes (the measured ~5.5/32-core run is one symptom). GEOS/shapely — the
+    ~61% rollout cost — is single-threaded regardless; this cap mainly stops an incidental
+    numpy BLAS call from fanning out across the box.
+
+    Byte-identity: workers are TORCH-FREE in their *ops* (no policy forward/backward — see
+    the module docstring), so their step+encode float reductions are numpy/shapely, not
+    multi-threaded BLAS, and a 1-thread cap cannot perturb the reduction order. This is the
+    torch-free-worker invariant the #747 byte-identity rests on — proven empirically by
+    ``test_sync_equals_subproc_byte_identical`` (Sync runs uncapped in the parent; Subproc
+    runs capped here) plus the fixed-action reward-stream diff, not asserted from theory.
+
+    The env vars are set at worker-loop entry, before the worker's first BLAS-touching
+    call, so OpenBLAS/MKL lazy-init reads the cap. torch is imported transitively in every
+    real worker (the picklable factory lives in ``ml.train``, which imports torch), so its
+    intra-op pool is capped too; the lookup is guarded so a genuinely torch-free worker is
+    not force-importing torch just to cap it."""
+    for var in _WORKER_THREAD_ENV_VARS:
+        os.environ[var] = "1"
+    torch_mod = sys.modules.get("torch")
+    if torch_mod is not None:
+        torch_mod.set_num_threads(1)
+
+
 def _obs_to_picklable(obs: ObservationTensors) -> ObservationTensors:
     """Replace MappingProxyType meta with a plain dict so pickle succeeds across Pipe."""
     if not isinstance(obs.meta, dict):
@@ -157,6 +195,7 @@ def _worker_loop(remote: mp.connection.Connection, worker_fn: Callable[[], _EnvW
     """Child process: build the env, then serve reset/step/close over the pipe. Any
     exception is sent back as ('error', repr) so the parent raises rather than hangs."""
     try:
+        _limit_worker_threads()  # #747: one core per worker, before the env's first BLAS op
         worker = worker_fn()
         remote.send(("ready", None))
         while True:

--- a/ml/vector_env.py
+++ b/ml/vector_env.py
@@ -13,7 +13,7 @@ import contextlib
 import multiprocessing as mp
 import os
 import sys
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from typing import Any, NamedTuple, cast
 
 from hangarfit.geometry import pose_cache_scope
@@ -149,7 +149,7 @@ _WORKER_THREAD_ENV_VARS = (
 
 
 @contextlib.contextmanager
-def worker_thread_cap_env() -> Any:
+def worker_thread_cap_env() -> Iterator[None]:
     """Set the single-thread BLAS/OMP/MKL caps in ``os.environ`` for the duration of the
     block, restoring prior values on exit (#747).
 

--- a/ml/vector_env.py
+++ b/ml/vector_env.py
@@ -148,27 +148,56 @@ _WORKER_THREAD_ENV_VARS = (
 )
 
 
-def _limit_worker_threads() -> None:
-    """Pin a spawned vec-env worker to a single BLAS/OMP/MKL thread (#747).
+@contextlib.contextmanager
+def worker_thread_cap_env() -> Any:
+    """Set the single-thread BLAS/OMP/MKL caps in ``os.environ`` for the duration of the
+    block, restoring prior values on exit (#747).
 
-    Raising ``--n-envs`` toward the core count is only safe once each worker is exactly
-    one core: otherwise N workers each spin a cores-wide OpenBLAS/MKL pool and the box
-    oversubscribes (the measured ~5.5/32-core run is one symptom). GEOS/shapely — the
-    ~61% rollout cost — is single-threaded regardless; this cap mainly stops an incidental
-    numpy BLAS call from fanning out across the box.
+    Why the PARENT, not the child: OpenBLAS/MKL fix their thread-pool size when the shared
+    lib is *loaded* — i.e. at ``import numpy`` — and ignore the env var afterward. Under
+    ``spawn`` the child imports numpy/torch during its bootstrap (it unpickles the worker
+    factory, which lives in ``ml.train`` → imports them) BEFORE the worker body runs, so
+    setting the env vars inside the child is *too late*: the pool is already cores-wide
+    (measured cpu/wall ≈ 31 vs 1). Setting them in the parent before ``Process.start()``
+    means each spawn child inherits the capped env at interpreter startup, so its
+    OpenBLAS/MKL read the cap. The parent's own already-loaded BLAS is unaffected (it does
+    not re-read), so the learner keeps its threads; the caps are restored after spawning so
+    no unrelated parent code sees them.
+
+    Raising ``--n-envs`` toward the core count is only safe with this cap: otherwise N
+    workers each spin a cores-wide pool and the box oversubscribes (the measured ~5.5/32
+    duty cycle is the symptom). GEOS/shapely — the dominant rollout cost — is single-
+    threaded regardless; this stops a numpy BLAS call from fanning out across the box.
 
     Byte-identity: workers are TORCH-FREE in their *ops* (no policy forward/backward — see
-    the module docstring), so their step+encode float reductions are numpy/shapely, not
-    multi-threaded BLAS, and a 1-thread cap cannot perturb the reduction order. This is the
-    torch-free-worker invariant the #747 byte-identity rests on — proven empirically by
-    ``test_sync_equals_subproc_byte_identical`` (Sync runs uncapped in the parent; Subproc
-    runs capped here) plus the fixed-action reward-stream diff, not asserted from theory.
+    the module docstring), so their step+encode float reductions are numpy indexing +
+    shapely, never multi-threaded BLAS, and the thread count cannot perturb the reduction
+    order. This is the torch-free-worker invariant the #747 byte-identity rests on — proven
+    empirically by ``test_sync_equals_subproc_byte_identical`` (Sync runs uncapped in the
+    parent; Subproc runs capped) plus the fixed-action reward-stream diff, not from theory.
+    """
+    prev = {var: os.environ.get(var) for var in _WORKER_THREAD_ENV_VARS}
+    os.environ.update({var: "1" for var in _WORKER_THREAD_ENV_VARS})
+    try:
+        yield
+    finally:
+        for var, old in prev.items():
+            if old is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = old
 
-    The env vars are set at worker-loop entry, before the worker's first BLAS-touching
-    call, so OpenBLAS/MKL lazy-init reads the cap. torch is imported transitively in every
-    real worker (the picklable factory lives in ``ml.train``, which imports torch), so its
-    intra-op pool is capped too; the lookup is guarded so a genuinely torch-free worker is
-    not force-importing torch just to cap it."""
+
+def _limit_worker_threads() -> None:
+    """Belt-and-suspenders thread cap run at spawn-worker entry (#747).
+
+    The load-bearing cap is the parent-set inherited env (see :func:`worker_thread_cap_env`);
+    this re-asserts the env vars and caps torch's intra-op pool at runtime — the one cap
+    that *is* effective from inside the child, since ``torch.set_num_threads`` resizes the
+    pool live rather than reading an env var at import. torch is imported transitively in
+    every real worker (the picklable factory lives in ``ml.train``, which imports torch), so
+    the guarded lookup finds it without force-importing torch into a genuinely torch-free
+    worker."""
     for var in _WORKER_THREAD_ENV_VARS:
         os.environ[var] = "1"
     torch_mod = sys.modules.get("torch")
@@ -232,13 +261,18 @@ class SubprocVectorEnv:
         self._n = len(worker_fns)
         self._parents: list[mp.connection.Connection] = []
         self._procs: list[Any] = []  # SpawnProcess is not mp.Process in typeshed
-        for fn in worker_fns:
-            parent, child = ctx.Pipe()
-            proc = ctx.Process(target=_worker_loop, args=(child, fn), daemon=True)
-            proc.start()
-            child.close()  # parent keeps only its end
-            self._parents.append(parent)
-            self._procs.append(proc)
+        # Cap the workers' BLAS/OMP threads via the inherited env: each spawn child reads
+        # OPENBLAS/MKL/OMP_NUM_THREADS at its OWN numpy/torch import (during bootstrap),
+        # so the cap must be in os.environ at Process.start() time — not set late inside
+        # the child, where the pool is already cores-wide. Restored once all are spawned.
+        with worker_thread_cap_env():
+            for fn in worker_fns:
+                parent, child = ctx.Pipe()
+                proc = ctx.Process(target=_worker_loop, args=(child, fn), daemon=True)
+                proc.start()
+                child.close()  # parent keeps only its end
+                self._parents.append(parent)
+                self._procs.append(proc)
         self._closed = False
         for i, (parent, proc) in enumerate(zip(self._parents, self._procs, strict=True)):
             if not parent.poll(timeout=30.0):

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -177,6 +177,100 @@ def test_argparser_schedule_defaults_to_curriculum():
     assert parser.parse_args(["--schedule", "trivial"]).schedule == "trivial"
 
 
+# ---------------------------------------------------------------------------
+# #747: --n-envs auto resolver (sched_getaffinity- and MemAvailable-bounded)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_n_envs_passes_through_explicit_int():
+    from ml.train import resolve_n_envs
+
+    assert resolve_n_envs("1") == 1
+    assert resolve_n_envs("8") == 8
+
+
+@pytest.mark.parametrize("bad", ["0", "-3", "foo", "2.5", "", "auto2"])
+def test_resolve_n_envs_rejects_non_positive_and_garbage(bad):
+    import argparse
+
+    from ml.train import resolve_n_envs
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        resolve_n_envs(bad)
+
+
+def test_resolve_n_envs_auto_is_core_bounded_when_ram_is_ample(monkeypatch):
+    import ml.train as t
+
+    monkeypatch.setattr(t, "_available_cores", lambda: 32)
+    monkeypatch.setattr(t, "_available_gib", lambda: 1000.0)  # RAM never binds
+    assert t.resolve_n_envs("auto") == 32 - t._AUTO_RESERVED_CORES
+
+
+def test_resolve_n_envs_auto_is_ram_bounded_when_memory_is_tight(monkeypatch):
+    import ml.train as t
+
+    monkeypatch.setattr(t, "_available_cores", lambda: 32)
+    monkeypatch.setattr(t, "_available_gib", lambda: 12.0)  # tight RAM binds below cores
+    n = t.resolve_n_envs("auto")
+    expected = max(1, int((12.0 - t._AUTO_RAM_HEADROOM_GIB) / t._AUTO_PER_WORKER_GIB))
+    assert n == expected
+    assert n < 32 - t._AUTO_RESERVED_CORES  # genuinely RAM-bound, not core-bound
+
+
+def test_resolve_n_envs_auto_floors_at_one(monkeypatch):
+    import ml.train as t
+
+    monkeypatch.setattr(t, "_available_cores", lambda: 1)  # cores - reserved <= 0
+    monkeypatch.setattr(t, "_available_gib", lambda: 0.1)
+    assert t.resolve_n_envs("auto") == 1
+
+
+def test_resolve_n_envs_auto_falls_back_to_cores_when_meminfo_missing(monkeypatch):
+    import ml.train as t
+
+    monkeypatch.setattr(t, "_available_cores", lambda: 8)
+    monkeypatch.setattr(t, "_available_gib", lambda: None)  # /proc/meminfo unreadable
+    assert t.resolve_n_envs("auto") == 8 - t._AUTO_RESERVED_CORES
+
+
+def test_available_cores_prefers_affinity_over_cpu_count(monkeypatch):
+    """sched_getaffinity respects cgroup/taskset pinning; os.cpu_count overcounts on
+    WSL2/containers. The resolver must use affinity when available."""
+    import ml.train as t
+
+    monkeypatch.setattr(t.os, "sched_getaffinity", lambda _pid: {0, 1, 2, 3}, raising=False)
+    assert t._available_cores() == 4
+
+
+def test_argparser_n_envs_default_is_one_byte_identity_floor():
+    assert build_argparser().parse_args([]).n_envs == 1
+
+
+def test_argparser_n_envs_auto_resolves_to_positive_int(monkeypatch):
+    import ml.train as t
+
+    monkeypatch.setattr(t, "_available_cores", lambda: 8)
+    monkeypatch.setattr(t, "_available_gib", lambda: 1000.0)
+    ns = build_argparser().parse_args(["--n-envs", "auto"])
+    assert isinstance(ns.n_envs, int) and ns.n_envs == 8 - t._AUTO_RESERVED_CORES
+
+
+def test_argparser_n_envs_rejects_garbage_with_clean_error():
+    parser = build_argparser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--n-envs", "nope"])
+
+
+def test_main_rejects_n_envs_above_one_on_trivial_schedule():
+    """--n-envs > 1 (or auto) is a curriculum-only knob; the trivial path is single-env.
+    A misdirected value must fail LOUD, not silently run serial."""
+    from ml.train import main
+
+    with pytest.raises(SystemExit):
+        main(["--schedule", "trivial", "--n-envs", "4", "--iterations", "1", "--rollout-len", "4"])
+
+
 def test_train_curriculum_validates_ladder_eagerly():
     # A rung whose max_objects exceeds the encoder token capacity must fail by name
     # BEFORE any training, not as a deep tensorizer overflow several rungs in.

--- a/tests/ml/test_vector_env.py
+++ b/tests/ml/test_vector_env.py
@@ -148,6 +148,99 @@ def test_subproc_worker_failure_is_loud():
         sub.reset()
 
 
+# ---------------------------------------------------------------------------
+# #747: per-worker BLAS/OMP thread cap (the prerequisite that makes raising
+# --n-envs toward the core count safe — one worker per core, no oversubscription)
+# ---------------------------------------------------------------------------
+
+_THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
+
+
+def test_limit_worker_threads_caps_blas_env_and_torch_pool(monkeypatch):
+    """_limit_worker_threads pins every BLAS/OMP/MKL env var to 1 and (since torch is
+    imported in this process) caps torch's intra-op pool to 1 thread."""
+    import os
+
+    from ml.vector_env import _limit_worker_threads
+
+    for var in _THREAD_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    prev_torch = torch.get_num_threads()
+    try:
+        _limit_worker_threads()
+        for var in _THREAD_ENV_VARS:
+            assert os.environ[var] == "1", var
+        assert torch.get_num_threads() == 1  # torch is imported here -> capped
+    finally:
+        torch.set_num_threads(prev_torch)
+
+
+def test_worker_loop_limits_threads_before_building_worker(monkeypatch):
+    """The cap runs at worker-loop ENTRY, before the per-worker factory builds the env —
+    so the env's first BLAS-touching numpy/torch op already sees a 1-thread pool. Driven
+    in-process over a real Pipe (no spawn): pre-queue a 'close' so the loop returns."""
+    import multiprocessing as mp
+    import os
+
+    from ml.vector_env import _worker_loop
+
+    for var in _THREAD_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    captured: dict[str, object] = {}
+
+    class _Stub:
+        pass
+
+    def fake_fn() -> _Stub:
+        # Captured AT THE MOMENT the worker is built, i.e. after _limit_worker_threads().
+        captured["omp"] = os.environ.get("OMP_NUM_THREADS")
+        captured["torch"] = torch.get_num_threads()
+        return _Stub()
+
+    prev_torch = torch.get_num_threads()
+    parent, child = mp.Pipe()
+    try:
+        parent.send(("close", None))  # queued; the loop recvs it and returns after 'ready'
+        _worker_loop(child, fake_fn)  # type: ignore[arg-type]
+        assert captured["omp"] == "1"
+        assert captured["torch"] == 1
+    finally:
+        torch.set_num_threads(prev_torch)
+        parent.close()
+
+
+def test_thread_cap_subproc_reward_stream_matches_sync():
+    """#747 byte-identity: the per-worker cap never changes a number. A fixed action
+    stream (incl. a PARK -> auto-reset) yields the same reward + done + encoded-obs
+    sequence whether stepped uncapped in the parent (Sync) or in a thread-capped spawn
+    worker (Subproc). Anchors on the torch-free-worker invariant; this is the empirical
+    proof the issue asks for."""
+    from ml.action_space import PARK_INDEX
+
+    actions_seq = [(1, 0), (0, 1), (1, 2), (PARK_INDEX, 0), (1, 0)]
+
+    sync = SyncVectorEnv([_trivial_worker_fn(), _trivial_worker_fn()])
+    sync.reset()
+    sync_rec = [sync.step([a, a]) for a in actions_seq]
+    sync.close()
+
+    with SubprocVectorEnv([_trivial_worker_fn, _trivial_worker_fn]) as sub:
+        sub.reset()
+        sub_rec = [sub.step([a, a]) for a in actions_seq]
+
+    for ss, bs in zip(sync_rec, sub_rec, strict=True):
+        assert ss.rewards == bs.rewards and ss.dones == bs.dones
+        for a, b in zip(ss.obs, bs.obs, strict=True):
+            assert np.array_equal(a.raster, b.raster)
+            assert np.array_equal(a.tokens, b.tokens)
+
+
 @pytest.mark.slow
 def test_subproc_faster_than_sync_on_multiobject_stage():
     """Subproc parallelizes the per-env geometry; on a multi-object stage it should beat

--- a/tests/ml/test_vector_env.py
+++ b/tests/ml/test_vector_env.py
@@ -215,6 +215,55 @@ def test_worker_loop_limits_threads_before_building_worker(monkeypatch):
         parent.close()
 
 
+def _env_probe_target(remote):
+    """Module-level (picklable under spawn): report the child's inherited thread-cap env."""
+    import os
+
+    remote.send({var: os.environ.get(var) for var in _THREAD_ENV_VARS})
+    remote.close()
+
+
+def test_worker_thread_cap_env_sets_then_restores(monkeypatch):
+    """worker_thread_cap_env pins every cap var to 1 inside the block and restores prior
+    state on exit — a previously-unset var goes back to absent, a set one to its value."""
+    import os
+
+    from ml.vector_env import worker_thread_cap_env
+
+    monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
+    monkeypatch.setenv("OPENBLAS_NUM_THREADS", "7")  # a pre-existing value to restore to
+    with worker_thread_cap_env():
+        assert os.environ["OMP_NUM_THREADS"] == "1"
+        assert os.environ["OPENBLAS_NUM_THREADS"] == "1"
+    assert "OMP_NUM_THREADS" not in os.environ  # restored to absent
+    assert os.environ["OPENBLAS_NUM_THREADS"] == "7"  # restored to prior value
+
+
+def test_spawn_child_inherits_thread_cap_env():
+    """The load-bearing #747 fix: a child spawned INSIDE worker_thread_cap_env inherits the
+    cap at interpreter startup, so its OpenBLAS/MKL read OPENBLAS/MKL_NUM_THREADS=1 when
+    numpy loads (setting it later in the child is too late — measured cpu/wall ~31 vs 1)."""
+    import multiprocessing as mp
+
+    from ml.vector_env import worker_thread_cap_env
+
+    ctx = mp.get_context("spawn")
+    parent, child = ctx.Pipe()
+    with worker_thread_cap_env():
+        proc = ctx.Process(target=_env_probe_target, args=(child,), daemon=True)
+        proc.start()  # env must be set at start() time -> inherited by the child
+    child.close()
+    try:
+        assert parent.poll(timeout=30.0), "spawn child did not report its env"
+        got = parent.recv()
+    finally:
+        proc.join(timeout=5.0)
+        parent.close()
+    assert got["OMP_NUM_THREADS"] == "1"
+    assert got["OPENBLAS_NUM_THREADS"] == "1"
+    assert got["MKL_NUM_THREADS"] == "1"
+
+
 def test_thread_cap_subproc_reward_stream_matches_sync():
     """#747 byte-identity: the per-worker cap never changes a number. A fixed action
     stream (incl. a PARK -> auto-reset) yields the same reward + done + encoded-obs


### PR DESCRIPTION
Part of **epic #758 (Wave 1)** under #607. Fills idle cores during `ml/` curriculum training, **byte-identical at the floor**.

## Problem
A measured `--n-envs 16 --device cuda` trio-box run pinned only ~5.5 of 32 cores, and each spawn worker (`ml/vector_env.py`) ran **unconstrained** BLAS/OMP/MKL threading (there was zero `*_NUM_THREADS` / `torch.set_num_threads` in the training path). So naively raising `--n-envs` toward the core count would **oversubscribe** the box (N workers × cores-wide BLAS pools).

## Changes (two paired, byte-identical)
1. **Per-worker thread cap** — `ml/vector_env._limit_worker_threads()` runs at `_worker_loop` entry (before the env's first BLAS-touching call) and pins `OMP/OPENBLAS/MKL/NUMEXPR_NUM_THREADS=1` + `torch.set_num_threads(1)`. One core per worker. GEOS/shapely (the ~61% rollout cost) is single-threaded anyway; this stops an incidental numpy/torch op from fanning out.
2. **`--n-envs auto`** — `resolve_n_envs()` sizes the pool to `max(1, min(cores − reserved, (MemAvailable − headroom) // per_worker))` using `os.sched_getaffinity` (cgroup/`taskset`-aware, unlike `cpu_count` which overcounts on WSL2/containers) and `/proc/meminfo MemAvailable`. The argparse default stays **`1`** (the byte-identity floor); `auto`/raised values are opt-in. On the dev box `auto → 26` (RAM-bound).
3. `--n-envs > 1` (or `auto`) on `--schedule trivial` now **fails loud** (the trivial path is single-env), matching the file's existing misdirected-flag guards.

## Determinism
The thread cap is **byte-identical**, anchored on the **torch-free-worker invariant** (workers run no policy forward/backward, so their step+encode float reductions are numpy/shapely, not multi-threaded BLAS — a 1-thread cap can't perturb reduction order). Proven empirically, not from theory:
- `tests/ml/test_vector_env.py::test_sync_equals_subproc_byte_identical` (Sync runs **uncapped** in the parent; Subproc runs **capped** in the child) stays green.
- New `test_thread_cap_subproc_reward_stream_matches_sync` — fixed action stream (incl. a PARK→auto-reset) → identical reward + done + encoded-obs sequence.

`--n-envs` itself is opt-in-nondeterministic (each value already yields a different trajectory via more `worker_index` `stage_rng` streams); the byte-identity floor stays `--n-envs 1`.

## Tests
- `_limit_worker_threads` caps env + torch pool; `_worker_loop` applies the cap **before** building the worker (driven in-process over a real Pipe); real-spawn child confirmed to see `('1','1','1', 1)`.
- `resolve_n_envs`: explicit-int passthrough, garbage/non-positive rejection, core-bound / RAM-bound / floor-at-1 / missing-`/proc/meminfo` fallback, affinity-over-`cpu_count`, argparse integration, and the trivial-schedule fail-loud guard.
- Full `tests/ml/` green; `ruff` + `mypy ml/` (full package) clean.

## Out of scope (later in Wave 1)
The transitions/sec throughput probe that quantifies the lift lands with **#750** (the throughput guard); this PR is the safety prerequisite + the `auto` sizing.

Closes #747