### PR TITLE
perf(748): out-of-order (as-completed) vec-env fan-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#748, epic #607 Wave 1 / #758): out-of-order (as-completed) vec-env
+  fan-in.** `SubprocVectorEnv` collected each step's N worker replies with a strict in-order
+  blocking recv (`worker 0`, then `1`, …), so the single slowest shapely worker stalled the
+  whole batch every step (head-of-line blocking) — worsening as `--n-envs` and per-rung
+  shapely-cost variance grow. It now drains workers **as they complete**
+  (`multiprocessing.connection.wait`) and **re-indexes by worker** before batching, so the
+  per-index payloads and the policy input are unchanged — only the pipe read order differs.
+  **Byte-identical, no flag** (pinned by `test_sync_equals_subproc_byte_identical` + a new
+  reversed-completion-order test proving index alignment is preserved). Recovers the
+  worst-case-worker stall; the win grows with `n_envs`. Dev/CI-only (`ml/`); no shipped-wheel surface.
+
 - **Learned backend (#734, epic #607): slope-aware `--auto-budget` per curriculum rung.**
   A fixed `--max-iters-per-stage` cap is wrong in both directions — it truncated the trio-box
   (N=3) run while `valid_placed` was *still climbing* (peak 0.65, under-trained not collapsed),

--- a/ml/vector_env.py
+++ b/ml/vector_env.py
@@ -201,6 +201,9 @@ class SubprocVectorEnv:
             child.close()  # parent keeps only its end
             self._parents.append(parent)
             self._procs.append(proc)
+        # Parent connections are fixed for the env's lifetime, so map each to its worker
+        # index once here — the as-completed fan-in (#748) reuses it every step/reset.
+        self._index_of = {p: i for i, p in enumerate(self._parents)}
         self._closed = False
         for i, (parent, proc) in enumerate(zip(self._parents, self._procs, strict=True)):
             if not parent.poll(timeout=30.0):
@@ -238,14 +241,13 @@ class SubprocVectorEnv:
         read order changes, pinned by ``test_sync_equals_subproc_byte_identical``). Each
         worker sends exactly one reply per command, so one recv drains a ready connection."""
         results: list[object] = [None] * self._n
-        index_of = {p: i for i, p in enumerate(self._parents)}
         pending = list(self._parents)
         while pending:
             # wait() is typed to also accept sockets/fds, so it returns a wider union; we
             # only ever pass our own Connections, so each ready object is one of them.
             for ready in wait(pending):
                 conn = cast("mp.connection.Connection", ready)
-                i = index_of[conn]
+                i = self._index_of[conn]
                 results[i] = self._recv(conn, i)
                 pending.remove(conn)
         return results

--- a/ml/vector_env.py
+++ b/ml/vector_env.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import contextlib
 import multiprocessing as mp
 from collections.abc import Callable, Sequence
+from multiprocessing.connection import wait
 from typing import Any, NamedTuple, cast
 
 from hangarfit.geometry import pose_cache_scope
@@ -228,19 +229,40 @@ class SubprocVectorEnv:
             raise RuntimeError(f"SubprocVectorEnv worker {worker_idx} failed: {payload}")
         return payload
 
+    def _recv_all(self) -> list[object]:
+        """Drain all N workers' replies AS THEY COMPLETE (``multiprocessing.connection.wait``),
+        returning the payloads in WORKER-INDEX order. The read order is non-deterministic
+        (fastest worker first), which removes the slowest-worker head-of-line stall of a
+        strict in-order recv (#748); re-indexing by worker keeps the per-index payloads and
+        the downstream batch assembly — and thus the policy input — byte-identical (only the
+        read order changes, pinned by ``test_sync_equals_subproc_byte_identical``). Each
+        worker sends exactly one reply per command, so one recv drains a ready connection."""
+        results: list[object] = [None] * self._n
+        index_of = {p: i for i, p in enumerate(self._parents)}
+        pending = list(self._parents)
+        while pending:
+            # wait() is typed to also accept sockets/fds, so it returns a wider union; we
+            # only ever pass our own Connections, so each ready object is one of them.
+            for ready in wait(pending):
+                conn = cast("mp.connection.Connection", ready)
+                i = index_of[conn]
+                results[i] = self._recv(conn, i)
+                pending.remove(conn)
+        return results
+
     def reset(self) -> list[ObservationTensors]:
         for p in self._parents:
             p.send(("reset", None))
-        # _recv returns the (untyped) pipe payload; for reset it is always an
+        # _recv_all returns payloads in worker-index order; for reset each is an
         # ObservationTensors (the worker's encoded obs). Narrow it for mypy.
-        return [cast(ObservationTensors, self._recv(p, i)) for i, p in enumerate(self._parents)]
+        return [cast(ObservationTensors, r) for r in self._recv_all()]
 
     def step(self, actions: Sequence[tuple[int, int]]) -> VecStep:
         if len(actions) != self._n:
             raise ValueError(f"expected {self._n} actions, got {len(actions)}")
         for p, (k, m) in zip(self._parents, actions, strict=True):
             p.send(("step", (int(k), int(m))))
-        results = [self._recv(p, i) for i, p in enumerate(self._parents)]
+        results = self._recv_all()
         obs = [r[0] for r in results]  # type: ignore[index]
         return VecStep(
             obs,

--- a/tests/ml/test_vector_env.py
+++ b/tests/ml/test_vector_env.py
@@ -134,6 +134,63 @@ def test_sync_equals_subproc_byte_identical():
     sync.close()
 
 
+# ---------------------------------------------------------------------------
+# #748: out-of-order (as-completed) fan-in — drain workers as they finish, but
+# re-index by worker so batch assembly is byte-identical to a strict in-order recv.
+# ---------------------------------------------------------------------------
+
+
+def test_subproc_step_reindexes_out_of_order_completions(monkeypatch):
+    """The fan-in drains workers as they complete (multiprocessing.connection.wait), so the
+    READ order is non-deterministic. Forcing wait() to surface them in REVERSE order must
+    NOT scramble the batch: each worker's payload still lands at its own index, matching the
+    in-order Sync reference. A re-sort bug (append-in-arrival-order) would fail this."""
+    import ml.vector_env as ve
+
+    real_wait = ve.wait
+
+    def reversed_wait(conns, *args, **kwargs):
+        return list(reversed(real_wait(conns, *args, **kwargs)))
+
+    monkeypatch.setattr(ve, "wait", reversed_wait)
+
+    # Distinct per-worker actions -> distinct rewards/obs, so a mis-indexing is observable.
+    actions = [(1, 1), (1, 2), (1, 3)]
+    sync = SyncVectorEnv([_trivial_worker_fn() for _ in range(3)])
+    sync.reset()
+    ss = sync.step(actions)
+    sync.close()
+    assert len(set(ss.rewards)) > 1, "actions must yield distinct per-worker rewards (non-vacuous)"
+
+    with SubprocVectorEnv([_trivial_worker_fn, _trivial_worker_fn, _trivial_worker_fn]) as sub:
+        sub.reset()
+        bs = sub.step(actions)
+
+    assert bs.rewards == ss.rewards  # index alignment preserved despite reversed completion
+    assert bs.dones == ss.dones
+    for a, b in zip(ss.obs, bs.obs, strict=True):
+        assert np.array_equal(a.raster, b.raster)
+        assert np.array_equal(a.tokens, b.tokens)
+
+
+def test_subproc_reset_reindexes_out_of_order_completions(monkeypatch):
+    """reset() shares the as-completed drain; its encoded obs must also stay index-aligned
+    under reversed completion order."""
+    import ml.vector_env as ve
+
+    real_wait = ve.wait
+    monkeypatch.setattr(ve, "wait", lambda c, *a, **k: list(reversed(real_wait(c, *a, **k))))
+
+    sync = SyncVectorEnv([_trivial_worker_fn() for _ in range(3)])
+    sref = sync.reset()
+    sync.close()
+    with SubprocVectorEnv([_trivial_worker_fn, _trivial_worker_fn, _trivial_worker_fn]) as sub:
+        sb = sub.reset()
+    for a, b in zip(sref, sb, strict=True):
+        assert np.array_equal(a.raster, b.raster)
+        assert b.active_index == a.active_index
+
+
 def _broken_worker_fn():
     raise ValueError("boom in child")
 


### PR DESCRIPTION
Part of **epic #758 (Wave 1)** under #607. Removes the slowest-worker head-of-line stall in vec-env training, **byte-identical, no flag**.

## Problem
`SubprocVectorEnv` collected each step's N worker replies with a strict **in-order blocking recv** (`worker 0`, then `1`, …). The single slowest shapely worker therefore stalls the whole batch every step (head-of-line blocking) — and it worsens as `--n-envs` (#747) and per-rung shapely-cost variance grow.

## Change
A new `_recv_all()` drains workers **as they complete** via `multiprocessing.connection.wait()` and writes each payload to `results[worker_index]`, so the returned list is **worker-index-ordered** regardless of arrival order. `step()` and `reset()` both route through it. Only the pipe *read* order changes; per-index payloads, batch/stack order, and the policy input are identical.

## Determinism: byte-identical (no flag)
Action stream, per-worker results, and batch assembly are unchanged — only read order differs. Pinned by:
- `test_sync_equals_subproc_byte_identical` (unchanged oracle) stays green.
- **New** `test_subproc_step_reindexes_out_of_order_completions` / `..._reset_...`: force `wait()` to surface completions in **reverse** order and assert the result still matches the in-order Sync reference per index (with distinct per-worker actions, asserted non-vacuous). A naive append-in-arrival-order impl would fail these.

## Tests
Full `tests/ml/test_vector_env.py` green (incl. the loud-worker-failure path — `_recv_all` raises with the right worker index on a crashed pipe). `ruff` + `mypy ml/` (full package) clean.

## Relationship to #747 / #762
Independent of #747 (different methods of the same file): #747 edits `__init__`/`_worker_loop`, #748 edits `step`/`reset`. Both base on `develop`; whichever merges second needs only a trivial import-block rebase. Acceptance's transitions/sec variance probe is provided by #750's throughput harness.

Closes #748