### PR TITLE
feat(750): GAE width-N scan + ml/ throughput canary (Wave 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#750, epic #607, throughput Wave 1): a transitions/sec training-loop canary
+  + a vectorized width-N GAE scan.** Two dev/CI-only changes so the rest of the throughput work is
+  measured, not eyeballed. (1) `python -m bench.train_throughput` is the `ml/` twin of
+  `bench.profile_pipeline`: it runs a small, fixed, deterministic CPU training loop (`SyncVectorEnv`)
+  and reports **transitions/sec** + **iters/sec** with the per-phase rollout-vs-update split as a
+  table or `--json`, **bound on a fixed step COUNT** (`iterations × rollout_len × n_envs`, mirroring
+  the #381 `max_restarts` binding) so only machine speed varies run-to-run. It confirms the Wave 1
+  premise — ~85% of per-iteration wall-clock is the shapely-bound rollout. No `--gate`: a throughput
+  ceiling is jitter-prone on shared runners, so it reports, never enforces. (2) `compute_gae_vec`
+  (`ml/ppo.py`) is rewritten from a `for env in range(N)` wrapper around the scalar reverse-scan into
+  a single width-N reverse scan, removing the last O(T·N) pure-Python loop so GAE stops scaling with
+  `n_envs`. **Byte-identical** (ADR-0003): the scalar loop boxes every term via `float()` → a float64
+  accumulator, so the vector scan runs its `delta`/`last_gae` accumulator in float64 (`.double()`) and
+  casts back to float32 only at each `adv[t]` write — a naive float32 scan diverges by ~2.4e-6 (a
+  determinism break that fails the `n_envs=1` / Sync≡Subproc byte-identity oracle). Verified by
+  `torch.equal` against the per-env `compute_gae` over mid-rollout / all-done / no-done patterns
+  (`test_compute_gae_vec_byte_identical_to_per_env_loop`). Dev/CI-only (`ml/` + `bench/`); no
+  shipped-wheel surface. The torch-CI hook stays scoped out of v1 (CI installs only `[dev]`, no torch).
+
 - **Learned backend (#734, epic #607): slope-aware `--auto-budget` per curriculum rung.**
   A fixed `--max-iters-per-stage` cap is wrong in both directions — it truncated the trio-box
   (N=3) run while `valid_placed` was *still climbing* (peak 0.65, under-trained not collapsed),

--- a/bench/train_throughput.py
+++ b/bench/train_throughput.py
@@ -1,0 +1,185 @@
+"""python -m bench.train_throughput — a transitions/sec canary for the ml/ training loop (#750).
+
+`bench/profile_pipeline` measures only the **solver** pipeline; this module is its twin for the
+dev/CI-only `ml/` RL training loop (epic #607). It runs a small, fixed, deterministic training
+loop on a CPU `SyncVectorEnv` and reports **transitions/sec** (steps/sec) and **iters/sec** with
+the per-phase split — rollout collection (`collect_rollout_vec`) vs the PPO update (`ppo_update`)
+— so the rest of throughput Wave 1 (#735 geometry, IPC/cache work) is measured, not eyeballed,
+and a silent per-iteration regression is catchable.
+
+Like `profile_pipeline`, this **binds on a fixed step COUNT** (``iterations × rollout_len ×
+n_envs`` transitions, mirroring the #381 `max_restarts` binding), NOT a wall-clock budget — so the
+*work* is fixed and only machine speed varies run-to-run. It needs the `[train]` extra (torch);
+`bench/` is dev/CI-only and never shipped in the wheel.
+
+Examples::
+
+    python -m bench.train_throughput                       # default fixed loop, table to stdout
+    python -m bench.train_throughput --json                # machine-readable JSON
+    python -m bench.train_throughput --iters 10 --rollout-len 128 --n-envs 4
+    python -m bench.train_throughput --warmup-iters 1      # discard cold-start iters from the rate
+
+NOT a CI gate. A throughput *ceiling* is jitter-prone on shared runners (see the #750 risk note),
+so — unlike `profile_pipeline --gate` — there is no `--gate` here: it reports numbers, never
+enforces them. The smoke test (`tests/ml/test_train_throughput_smoke.py`) asserts it RUNS and
+emits the expected JSON keys with a positive rate, not a timing threshold.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import asdict, dataclass
+
+
+@dataclass
+class ThroughputResult:
+    """One fixed-loop throughput measurement (timed phases + derived rates).
+
+    All ``*_s`` are summed wall-clock seconds over the *timed* iterations (the warmup iterations
+    are excluded from both the timings and the transition count, so the rates reflect the
+    steady state, not the cold start)."""
+
+    iterations: int  # timed iterations (after warmup)
+    warmup_iters: int
+    rollout_len: int
+    n_envs: int
+    transitions: int  # timed transitions = iterations * rollout_len * n_envs
+    rollout_s: float  # summed collect_rollout_vec wall-clock
+    update_s: float  # summed ppo_update wall-clock
+    total_s: float  # rollout_s + update_s
+    transitions_per_s: float  # transitions / total_s
+    iters_per_s: float  # iterations / total_s
+    rollout_frac: float  # rollout_s / total_s (the share spent collecting rollouts)
+
+
+def run_throughput(
+    *,
+    seed: int = 0,
+    iterations: int = 5,
+    warmup_iters: int = 1,
+    rollout_len: int = 128,
+    n_envs: int = 2,
+    d_model: int = 32,
+    n_layers: int = 1,
+    n_heads: int = 2,
+) -> ThroughputResult:
+    """Run a fixed deterministic training loop on CPU and time the two phases separately.
+
+    Drives ``n_envs`` trivial-stage envs (the easiest curriculum rung) through a
+    ``SyncVectorEnv`` — in-process, no multiprocessing, so it runs anywhere torch imports — for
+    ``warmup_iters + iterations`` PPO iterations. Each iteration is one ``collect_rollout_vec``
+    (``rollout_len * n_envs`` transitions) followed by one ``ppo_update``. The first
+    ``warmup_iters`` iterations are run but EXCLUDED from the timings and the transition count, so
+    the reported rates reflect the steady state (torch lazily allocates on the first forward).
+
+    Imports torch transitively (via ``ml.train`` / ``ml.ppo``), so it raises ``ImportError``
+    without the ``[train]`` extra — the smoke test ``importorskip('torch')``s accordingly."""
+    if iterations < 1:
+        raise ValueError(f"iterations must be >= 1, got {iterations}")
+    if warmup_iters < 0:
+        raise ValueError(f"warmup_iters must be >= 0, got {warmup_iters}")
+    if rollout_len < 1 or n_envs < 1:
+        raise ValueError(f"rollout_len and n_envs must be >= 1, got {rollout_len}, {n_envs}")
+
+    import torch
+
+    from ml.encoding import EncoderConfig
+    from ml.policy import HangarFitPolicy
+    from ml.ppo import PPOConfig, ppo_update
+    from ml.train import build_trivial_env, collect_rollout_vec
+    from ml.vector_env import SyncVectorEnv, _EnvWorker
+
+    torch.manual_seed(seed)
+    enc = EncoderConfig()
+    # n_envs identical trivial-stage workers (the trivial env has no RNG, so they are clones; the
+    # benchmark measures throughput, not learning, so a fixed env set is exactly what we want).
+    workers = [_EnvWorker(build_trivial_env(seed), enc, None) for _ in range(n_envs)]
+    vec_env = SyncVectorEnv(workers)
+    policy = HangarFitPolicy(d_model=d_model, n_layers=n_layers, n_heads=n_heads)
+    cfg = PPOConfig(minibatch_size=min(PPOConfig().minibatch_size, rollout_len * n_envs))
+    optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.lr)
+
+    rollout_s = 0.0
+    update_s = 0.0
+    for it in range(warmup_iters + iterations):
+        timed = it >= warmup_iters
+        t0 = time.perf_counter()
+        buf, _ = collect_rollout_vec(vec_env, policy, enc, rollout_len)
+        t1 = time.perf_counter()
+        ppo_update(policy, optimizer, buf, cfg)
+        t2 = time.perf_counter()
+        if timed:
+            rollout_s += t1 - t0
+            update_s += t2 - t1
+
+    total_s = rollout_s + update_s
+    transitions = iterations * rollout_len * n_envs
+    # total_s is wall-clock over real torch work, so it is > 0; guard the division defensively
+    # rather than risk a ZeroDivisionError masking a degenerate (e.g. zero-iteration) config.
+    if total_s <= 0.0:
+        raise RuntimeError(f"non-positive timed wall-clock ({total_s} s) — measurement failed")
+    return ThroughputResult(
+        iterations=iterations,
+        warmup_iters=warmup_iters,
+        rollout_len=rollout_len,
+        n_envs=n_envs,
+        transitions=transitions,
+        rollout_s=rollout_s,
+        update_s=update_s,
+        total_s=total_s,
+        transitions_per_s=transitions / total_s,
+        iters_per_s=iterations / total_s,
+        rollout_frac=rollout_s / total_s,
+    )
+
+
+def _print_table(r: ThroughputResult) -> None:
+    print("── ml/ training-loop throughput canary (#750) ──")
+    print(
+        f"  config        : n_envs={r.n_envs} rollout_len={r.rollout_len} "
+        f"iters={r.iterations} (+{r.warmup_iters} warmup)"
+    )
+    print(f"  transitions   : {r.transitions:,}")
+    print(f"  rollout       : {r.rollout_s:8.3f} s  ({100.0 * r.rollout_frac:5.1f}%)")
+    print(f"  update        : {r.update_s:8.3f} s  ({100.0 * (1.0 - r.rollout_frac):5.1f}%)")
+    print(f"  total         : {r.total_s:8.3f} s")
+    print(f"  throughput    : {r.transitions_per_s:10.1f} transitions/s")
+    print(f"  iters/s       : {r.iters_per_s:10.3f} iters/s")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="ml/ training-loop transitions/sec canary (#750; needs the [train] extra)"
+    )
+    ap.add_argument("--seed", type=int, default=0, help="torch + env seed (default 0)")
+    ap.add_argument("--iters", type=int, default=5, help="timed PPO iterations (default 5)")
+    ap.add_argument(
+        "--warmup-iters",
+        type=int,
+        default=1,
+        help="iterations run but excluded from the rate (cold-start; default 1)",
+    )
+    ap.add_argument("--rollout-len", type=int, default=128, help="steps per env per iter (def 128)")
+    ap.add_argument("--n-envs", type=int, default=2, help="SyncVectorEnv width (default 2)")
+    ap.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = ap.parse_args(argv)
+
+    result = run_throughput(
+        seed=args.seed,
+        iterations=args.iters,
+        warmup_iters=args.warmup_iters,
+        rollout_len=args.rollout_len,
+        n_envs=args.n_envs,
+    )
+
+    if args.json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        _print_table(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ml/ppo.py
+++ b/ml/ppo.py
@@ -378,23 +378,34 @@ def compute_gae_vec(
     gamma: float = 0.99,
     lam: float = 0.95,
 ) -> tuple[Tensor, Tensor]:
-    """Per-env GAE: run the single-stream ``compute_gae`` on each env column (each env's
-    ``done`` resets its own λ-recursion + bootstrap), then flatten row-major ``(t, env) ->
-    t*N + env`` to match ``VecRolloutBuffer.batch()``."""
+    """Width-N GAE: a single reverse scan over the (T, N) buffer, vectorized across the N
+    envs at each timestep (each env's ``done`` resets its own λ-recursion + bootstrap),
+    flattened row-major ``(t, env) -> t*N + env`` to match ``VecRolloutBuffer.batch()``.
+
+    BYTE-IDENTITY (#750): the equivalent per-env scalar ``compute_gae`` boxes every term via
+    ``float()`` → a Python-float (float64) accumulator. A naive float32 tensor scan diverges
+    by ~2.4e-6 — a determinism break that fails the n_envs=1 / Sync≡Subproc byte-identity
+    oracle. So the ``delta`` / ``last_gae`` accumulator runs in float64 (``.double()``) and is
+    cast back to float32 ONLY when writing each ``adv[t]`` row — mirroring the scalar loop's
+    per-step ``advantages[t] = last_gae`` assignment, which is the single float64→float32
+    rounding point. This makes the vectorized scan bit-identical to the old per-env loop
+    (verified by ``test_compute_gae_vec_byte_identical_to_per_env_loop``)."""
     t_len, n = rewards.shape
-    adv = torch.zeros(t_len, n)
-    ret = torch.zeros(t_len, n)
-    for env in range(n):
-        a, r = compute_gae(
-            rewards[:, env],
-            values[:, env],
-            dones[:, env],
-            float(last_values[env]),
-            gamma=gamma,
-            lam=lam,
-        )
-        adv[:, env] = a
-        ret[:, env] = r
+    # float64 intermediates: the accumulator and its inputs match the scalar loop's
+    # float(...) boxing; only the per-row adv[t] write rounds back to float32.
+    rewards64 = rewards.double()
+    values64 = values.double()
+    nonterminal64 = (~dones).double()  # (T, N): 1.0 where not done, 0.0 on a terminal
+    last_values64 = torch.as_tensor([float(lv) for lv in last_values], dtype=torch.float64)  # (N,)
+    adv = torch.zeros(t_len, n)  # float32 output, written per-row from the float64 scan
+    last_gae = torch.zeros(n, dtype=torch.float64)
+    for t in reversed(range(t_len)):
+        nonterminal = nonterminal64[t]
+        next_value = (last_values64 if t == t_len - 1 else values64[t + 1]) * nonterminal
+        delta = rewards64[t] + gamma * next_value - values64[t]
+        last_gae = delta + gamma * lam * nonterminal * last_gae
+        adv[t] = last_gae.float()  # the lone float64 -> float32 rounding point per step
+    ret = adv + values  # returns = advantages + values, float32 (matches the scalar path)
     return adv.reshape(-1), ret.reshape(-1)
 
 

--- a/tests/ml/test_ppo.py
+++ b/tests/ml/test_ppo.py
@@ -487,6 +487,55 @@ def test_compute_gae_vec_matches_per_env_compute_gae():
             assert torch.allclose(ret_vec[t * N + env], r[t])
 
 
+def test_compute_gae_vec_byte_identical_to_per_env_loop():
+    """#750: the width-N reverse scan must stay BYTE-identical to the per-env scalar loop.
+
+    The pre-#750 ``compute_gae_vec`` ran the float64-intermediate scalar ``compute_gae`` on
+    each env column. The vectorized rewrite folds those N columns into one reverse scan; it
+    is only byte-identical if the delta / last_gae accumulator runs in float64 (``.double()``)
+    and casts to float32 ONLY at the ``adv[t]`` write — a naive float32 tensor scan diverges
+    by ~2.4e-6, which is a determinism break (Sync≡Subproc + n_envs=1 byte-identity).
+
+    We assert EXACT equality (``torch.equal`` on the float32 result, not ``allclose``) over
+    random rewards/values/last_values across several done patterns: mid-rollout dones, an
+    all-done column, and a no-done (bootstrap-tail) column — the three regimes
+    ``test_compute_gae_done_zeroes_bootstrap_and_resets`` pins for the scalar path.
+    """
+    import torch
+
+    from ml.ppo import compute_gae, compute_gae_vec
+
+    torch.manual_seed(12345)
+    T, N = 9, 5
+    rewards = torch.randn(T, N)
+    values = torch.randn(T, N)
+    last_values = torch.randn(N).tolist()
+
+    # Hand-construct contrasting done patterns per env column.
+    dones = torch.zeros(T, N, dtype=torch.bool)
+    dones[3, 0] = True  # env 0: a single mid-rollout terminal
+    dones[2, 1] = dones[6, 1] = True  # env 1: two mid-rollout terminals
+    dones[:, 2] = True  # env 2: every step is a terminal (all-done)
+    # env 3: no dones at all (bootstrap-tail uses last_values[3])
+    dones[T - 1, 4] = True  # env 4: terminal exactly on the final step (zeros the tail bootstrap)
+
+    adv_vec, ret_vec = compute_gae_vec(rewards, values, dones, last_values, gamma=0.99, lam=0.95)
+
+    # Reference: the per-env scalar loop, flattened row-major (t, env) -> t*N + env.
+    ref_adv = torch.zeros(T, N)
+    ref_ret = torch.zeros(T, N)
+    for env in range(N):
+        a, r = compute_gae(
+            rewards[:, env], values[:, env], dones[:, env], last_values[env], gamma=0.99, lam=0.95
+        )
+        ref_adv[:, env] = a
+        ref_ret[:, env] = r
+
+    assert torch.equal(adv_vec, ref_adv.reshape(-1)), "advantages diverged from per-env loop"
+    assert torch.equal(ret_vec, ref_ret.reshape(-1)), "returns diverged from per-env loop"
+    assert adv_vec.dtype == torch.float32 and ret_vec.dtype == torch.float32
+
+
 def test_vecrolloutbuffer_batch_shape_matches_flat():
 
     from ml.encoding import ACTION_DIM, RASTER_CHANNELS, TOKEN_DIM, ObservationTensors

--- a/tests/ml/test_train_throughput_smoke.py
+++ b/tests/ml/test_train_throughput_smoke.py
@@ -1,0 +1,60 @@
+"""Smoke test for the ml/ training-loop throughput canary (#750).
+
+Asserts ``bench.train_throughput`` RUNS and emits the expected JSON keys with a positive
+transitions/sec — NOT a timing threshold (a throughput ceiling is jitter-prone on shared
+runners; see the #750 risk note). Torch-gated like the rest of the train-loop tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")  # noqa: F841  (bench imports torch transitively)
+
+from bench.train_throughput import ThroughputResult, main, run_throughput  # noqa: E402
+
+# A tiny fixed loop: enough to drive both phases (rollout + update) without being slow.
+_SMOKE = dict(iterations=2, warmup_iters=1, rollout_len=16, n_envs=2)
+
+
+def test_run_throughput_reports_positive_rate():
+    r = run_throughput(seed=0, **_SMOKE)
+    assert isinstance(r, ThroughputResult)
+    # Bound on a fixed step COUNT: transitions = timed iters * rollout_len * n_envs.
+    assert r.transitions == _SMOKE["iterations"] * _SMOKE["rollout_len"] * _SMOKE["n_envs"]
+    assert r.transitions_per_s > 0.0
+    assert r.iters_per_s > 0.0
+    assert r.total_s > 0.0
+    # The phase split is consistent: rollout + update == total, and the fraction is in [0, 1].
+    assert r.rollout_s + r.update_s == pytest.approx(r.total_s)
+    assert 0.0 <= r.rollout_frac <= 1.0
+
+
+def test_main_json_emits_expected_keys(capsys):
+    rc = main(
+        ["--json", "--iters", "2", "--warmup-iters", "1", "--rollout-len", "16", "--n-envs", "2"]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    expected = {
+        "iterations",
+        "warmup_iters",
+        "rollout_len",
+        "n_envs",
+        "transitions",
+        "rollout_s",
+        "update_s",
+        "total_s",
+        "transitions_per_s",
+        "iters_per_s",
+        "rollout_frac",
+    }
+    assert set(payload) == expected
+    assert payload["transitions_per_s"] > 0.0
+    assert payload["transitions"] == 2 * 16 * 2
+
+
+def test_run_throughput_rejects_zero_iterations():
+    with pytest.raises(ValueError, match="iterations must be >= 1"):
+        run_throughput(iterations=0)


### PR DESCRIPTION
Closes #750

Part of epic #607, throughput **Wave 1** (byte-identical). Two dev/CI-only changes so the rest of Wave 1 (#735 geometry, IPC/cache) is **measured, not eyeballed**.

## What changed

### 1. `bench/train_throughput.py` — a transitions/sec canary (`bench/train_throughput.py`)
The `ml/` twin of `bench.profile_pipeline`. Runs a small, fixed, deterministic CPU training loop (`SyncVectorEnv`) and reports **transitions/sec** + **iters/sec** with the per-phase **rollout (`collect_rollout_vec`) vs update (`ppo_update`)** split, as a table or `--json`. Runnable as `python -m bench.train_throughput`.

- **Bound on a fixed step COUNT** (`iterations × rollout_len × n_envs`), mirroring the #381 `max_restarts` binding — so the *work* is fixed and only machine speed varies run-to-run. Warmup iterations are run but excluded from the rate (torch cold-start).
- **No `--gate`.** A throughput ceiling is jitter-prone on shared runners (the #750 risk note), so it reports, never enforces.
- Confirms the Wave 1 premise: a local run lands **~85% of per-iteration wall-clock in the shapely-bound rollout**, ~15% in the PPO update.

### 2. Vectorized `compute_gae_vec` (`ml/ppo.py:372`)
Rewrites the `for env in range(N)` wrapper around the scalar reverse-scan into a **single width-N reverse scan**, removing the last O(T·N) pure-Python loop so GAE stops scaling with `n_envs`.

## Byte-identity argument (the whole risk of #750)
The pre-#750 path ran the scalar `compute_gae` on each env column; that loop boxes every term via `float()` → a **float64** Python accumulator. A naive **float32** tensor reverse scan **diverges by ~2.4e-6** — a determinism break that fails the `n_envs=1` and Sync≡Subproc byte-identity oracle (ADR-0003).

So the vector scan runs its `delta` / `last_gae` accumulator in **float64 (`.double()`)** — `rewards`, `values`, `last_values`, and `nonterminal` all promoted — and casts back to **float32 only at each `adv[t]` row write**, mirroring the scalar loop's single per-step `advantages[t] = last_gae` rounding point. `returns = adv + values` then runs in float32, exactly as the scalar path does.

Verified at `max abs diff = 0.0` / `torch.equal == True` vs the per-env loop (the naive f32 version measured at `4.77e-7` max diff, byte-equal `False`).

## Tests
- `test_compute_gae_vec_byte_identical_to_per_env_loop` — `torch.equal` (exact, not `allclose`) vs the per-env `compute_gae` over **mid-rollout dones, two-terminal, all-done, no-done bootstrap-tail, and terminal-on-final-step** patterns, on random rewards/values/last_values. Asserts float32 output dtype.
- The pre-existing `test_compute_gae_vec_matches_per_env_compute_gae` + all `compute_gae` done-edge-case tests stay green.
- `tests/ml/test_train_throughput_smoke.py` — `importorskip('torch')`; asserts the harness **runs**, emits the expected JSON keys with a **positive** transitions/sec, the phase split sums to total, and rejects a zero-iteration config. **Not a timing assertion.**

## Verification
- `ruff check ml/ bench/ tests/` + `ruff format --check` — clean
- `mypy ml/` (full package) — `Success: no issues found in 19 source files`
- `tests/ml/` — **448 passed, 2 deselected**

## Scope notes
Dev/CI-only (`ml/` + `bench/`); `bench/` is top-level outside `src/`, never discovered by `packages.find where=["src"]`, so it is never in the wheel. The torch-CI hook stays scoped **out of v1** (CI installs only `[dev]`, no torch); landed as a dev/local tool now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)