### PR TITLE
feat(749): concurrent multi-seed sweep runner (python -m ml.sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#749, epic #607, throughput Wave 1): concurrent multi-seed sweep runner
+  `python -m ml.sweep`.** The mastery deliverable is the two/three-seed gate (the `ml/README`
+  trio-box recipe), run **serially** today — one launch per seed, babysat by hand. One on-policy
+  run is throughput-capped by its synchronous step-dependency, so the box sits idle (~26 cores,
+  ~10% GPU). `ml/sweep.py` is a **torch-free** orchestrator that spawns K **unmodified**
+  `python -m ml.train` subprocesses (one per `--seed`), each with a distinct `--seed` +
+  per-cell `--metrics-out`/`--checkpoint-out`/`--save` path, runs them **concurrently** up to
+  `--max-concurrency` (default **2**, documented **RAM-bound** — ~10 GB/run → K=3 risks OOM on a
+  31 GB box, *not* core-bound), and aggregates child exit codes into a single pass/fail verdict
+  in deterministic seed order. **Loud by contract** (the #749 risk): any non-zero child — or a
+  child that *crashes* — makes the runner exit non-zero, surfaced as a failed cell with its
+  error text rather than silently corrupting a 2-seed verdict. Pure orchestration, **no
+  training-loop edits** — each child is byte-identical to running it alone, so co-locating cells
+  on one GPU adds nothing beyond `--device cuda`. The job-spawning seam is injectable for fast
+  deterministic unit tests (no real multi-minute training spawned). Per-cell metrics roll up via
+  the existing torch-free `python -m ml.gate`. Expected **~2× sweep wall-clock** (not Kx —
+  aligned rollout bursts oversubscribe). Dev/CI-only (`ml/`); no shipped-wheel surface.
+
 - **Learned backend (#734, epic #607): slope-aware `--auto-budget` per curriculum rung.**
   A fixed `--max-iters-per-stage` cap is wrong in both directions — it truncated the trio-box
   (N=3) run while `valid_placed` was *still climbing* (peak 0.65, under-trained not collapsed),

--- a/ml/README.md
+++ b/ml/README.md
@@ -407,8 +407,9 @@ codes into a single pass/fail verdict — **any failed *or crashed* child → ru
 
 ```bash
 # Two-seed trio-box gate, both cells concurrent (cap 2). The args after `--` are the
-# trio-box recipe above, MINUS --seed/--metrics-out/--checkpoint-out (the sweep injects a
-# distinct one per cell); --load is shared (each seed resumes the same pair-box checkpoint).
+# trio-box recipe above, MINUS --seed/--metrics-out/--checkpoint-out/--save (the sweep
+# strips and injects a distinct one per cell, in both the `--flag value` and `--flag=value`
+# spellings); --load is shared (each seed resumes the same pair-box checkpoint).
 python -u -m ml.sweep --seeds 0,1 --out-dir sweep-trio --tag trio --max-concurrency 2 -- \
   --schedule curriculum --device cuda --n-envs 16 --rollout-len 512 \
   --max-iters-per-stage 300 --promotion-metric valid_placed --promotion-threshold 0.9 \
@@ -423,6 +424,10 @@ python -m ml.gate sweep-trio/metrics-trio-seed0.jsonl --rung trio-box
 python -m ml.gate sweep-trio/metrics-trio-seed1.jsonl --rung trio-box
 ```
 
+By default each cell also gets a distinct per-seed `--checkpoint-out` (a crash-survivable resume
+checkpoint); pass **`--no-checkpoint-out`** to skip it, or **`--save`** to additionally hand each
+cell a distinct per-seed `--save` state_dict path.
+
 **Determinism:** byte-identical (no flag) — each child is bit-identical to running it alone, so
 co-locating cells on one GPU adds nothing beyond `--device cuda`.
 
@@ -431,7 +436,8 @@ bursty run, so K aligned rollout bursts oversubscribe. `--max-concurrency` (defa
 **RAM-bound, not core-bound**: ~10 GB/run → **K=3 risks OOM on a 31 GB box**. Disjoint core
 blocks + per-child thread caps (`OMP_NUM_THREADS`, `taskset`, `sched_setaffinity`) are an operator
 concern set in the launching env; the orchestrator inherits the env into each child unchanged
-(pairs with #747's worker thread-cap so aligned bursts don't oversubscribe the GEOS GIL).
+(pairs with #747's per-worker BLAS/OMP thread cap so aligned rollout bursts don't oversubscribe
+cores).
 
 ## Design
 See `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`

--- a/ml/README.md
+++ b/ml/README.md
@@ -395,6 +395,44 @@ little: committing objects invalidly, *not* a win — distrust any apparent prog
 (the four-lever ladder does *not* generalize to N=3 → pose-scaffold). A `piling` verdict means the
 ladder is unstable at N=3 and needs the economics re-tuned before re-gating.
 
+### Concurrent sweep runner (#749 — run the two/three-seed gate in one launch)
+
+The gate recipes above are **per-seed** (`--seed 0`, then `--seed 1`), run serially today — one
+launch per seed, babysat by hand. `python -m ml.sweep` is a **torch-free orchestrator** that
+spawns the K `python -m ml.train` cells **concurrently** (one per seed, each with a distinct
+`--seed` + per-cell `--metrics-out`/`--checkpoint-out`/`--save` path) and aggregates their exit
+codes into a single pass/fail verdict — **any failed *or crashed* child → runner exit non-zero**
+(a silently-swallowed crash would corrupt a 2-seed verdict). The per-cell `ml.train` args go
+**after a `--` separator**; everything before it is the sweep's own options:
+
+```bash
+# Two-seed trio-box gate, both cells concurrent (cap 2). The args after `--` are the
+# trio-box recipe above, MINUS --seed/--metrics-out/--checkpoint-out (the sweep injects a
+# distinct one per cell); --load is shared (each seed resumes the same pair-box checkpoint).
+python -u -m ml.sweep --seeds 0,1 --out-dir sweep-trio --tag trio --max-concurrency 2 -- \
+  --schedule curriculum --device cuda --n-envs 16 --rollout-len 512 \
+  --max-iters-per-stage 300 --promotion-metric valid_placed --promotion-threshold 0.9 \
+  --r-valid-park 30.0 --r-unplaced-penalty 25.0 --dense-slot-potential \
+  --w-col 20.0 --valid-park-grade-scale 4.0 --r-first-valid 15.0 \
+  --entropy-start 0.05 --entropy-end 0.005 --entropy-anneal-iters 40 \
+  --normalize-returns --validity-conditional-terminal --solo-box-rung \
+  --seed-anchor --mixed-anchor --stop-after-rung trio-box --load ck-pairbox.pt
+
+# Then roll up each cell's metrics with the same torch-free gate (exit 0=mastered, 1=not, 2=no-data):
+python -m ml.gate sweep-trio/metrics-trio-seed0.jsonl --rung trio-box
+python -m ml.gate sweep-trio/metrics-trio-seed1.jsonl --rung trio-box
+```
+
+**Determinism:** byte-identical (no flag) — each child is bit-identical to running it alone, so
+co-locating cells on one GPU adds nothing beyond `--device cuda`.
+
+**Expect ~2× sweep wall-clock, NOT Kx** — 5.5 cores is the time-averaged busy fraction of one
+bursty run, so K aligned rollout bursts oversubscribe. `--max-concurrency` (default 2) is
+**RAM-bound, not core-bound**: ~10 GB/run → **K=3 risks OOM on a 31 GB box**. Disjoint core
+blocks + per-child thread caps (`OMP_NUM_THREADS`, `taskset`, `sched_setaffinity`) are an operator
+concern set in the launching env; the orchestrator inherits the env into each child unchanged
+(pairs with #747's worker thread-cap so aligned bursts don't oversubscribe the GEOS GIL).
+
 ## Design
 See `docs/superpowers/specs/2026-06-12-learned-backend-cold-joint-rl-env-design.md`
 and ADR-0027 (learned-path determinism scope).

--- a/ml/sweep.py
+++ b/ml/sweep.py
@@ -144,17 +144,22 @@ def build_train_argv(cell: CellSpec, base_argv: Sequence[str]) -> list[str]:
 
 
 def _strip_flags(argv: Sequence[str], flags: set[str]) -> list[str]:
-    """Drop each ``--flag VALUE`` pair whose flag is in ``flags`` (these are
-    cell-owned). Assumes each is a value-taking option (matches the four cell-owned
-    flags); leaves all other tokens untouched."""
+    """Drop each cell-owned flag (and its value) whose flag name is in ``flags``, in
+    BOTH argparse spellings: the space-separated ``--flag VALUE`` pair and the inline
+    ``--flag=VALUE`` form. Assumes each is a value-taking option (matches the four
+    cell-owned flags); leaves all other tokens untouched."""
     out: list[str] = []
     skip_next = False
     for tok in argv:
         if skip_next:
             skip_next = False  # this token is a stripped flag's value — drop it
             continue
-        if tok in flags:
-            skip_next = True  # also drop its value
+        # tok.split("=", 1)[0] is the flag name for both `--seed 0` and `--seed=0`.
+        name = tok.split("=", 1)[0]
+        if name in flags:
+            # The inline `--flag=value` carries its own value; the bare `--flag` does not,
+            # so only the bare form consumes the next token.
+            skip_next = "=" not in tok
             continue
         out.append(tok)
     return out
@@ -168,6 +173,9 @@ def _default_run_cell(cell: CellSpec, argv: Sequence[str]) -> int:
     cmd = [sys.executable, *argv]
     sys.stderr.write(f"[sweep] seed {cell.seed}: launching {' '.join(cmd)}\n")
     sys.stderr.flush()
+    # No timeout= is deliberate: a hung trainer should be VISIBLY stuck (operator-killable),
+    # not silently SIGKILL'd mid-rung into a half-written metrics file that the gate then
+    # misreads as a clean negative.
     completed = subprocess.run(cmd, check=False)  # noqa: S603 — argv is built, not shell
     sys.stderr.write(f"[sweep] seed {cell.seed}: exited {completed.returncode}\n")
     sys.stderr.flush()
@@ -230,10 +238,16 @@ def _summary(result: SweepResult) -> str:
 
 
 def _parse_seeds(spec: str) -> list[int]:
-    """Parse a comma-separated seed list (e.g. ``0,1,3``) into ints, preserving order."""
+    """Parse a comma-separated seed list (e.g. ``0,1,3``) into ints, preserving order.
+
+    Rejects **duplicate** seeds loudly: two cells with the same seed would share the same
+    per-seed metrics/checkpoint/save paths, so concurrent children would race-corrupt the
+    shared gate input — silently producing one usable cell instead of the requested K."""
     seeds = [int(tok) for tok in spec.split(",") if tok.strip()]
     if not seeds:
         raise ValueError(f"--seeds parsed to no seeds: {spec!r}")
+    if len(set(seeds)) != len(seeds):
+        raise ValueError(f"--seeds has duplicates: {spec!r}")
     return seeds
 
 

--- a/ml/sweep.py
+++ b/ml/sweep.py
@@ -1,0 +1,334 @@
+"""ml/sweep.py — a concurrent multi-seed gate/sweep runner (#749, throughput Wave 1).
+
+Pure ORCHESTRATION over the existing torch-free building blocks: it spawns K
+**unmodified** ``python -m ml.train`` subprocesses (one per seed/cell), each with its
+own ``--seed`` plus distinct ``--metrics-out`` / ``--checkpoint-out`` / ``--save``
+paths, runs them concurrently up to a cap, collects their exit codes, and emits an
+aggregated pass/fail verdict. No training-loop edits — every child is **byte-identical**
+to running it alone (the #749 determinism note: co-locating cells on one GPU adds
+nothing beyond ``--device cuda``).
+
+WHY a thin orchestrator (not a richer harness): the mastery deliverable is the two/three
+-seed gate (the ``ml/README`` trio-box recipe), run serially today. One on-policy run is
+throughput-capped by its synchronous step-dependency, so the ~26-core box sits idle.
+Running K seeds **concurrently** cuts the whole-sweep wall-clock ~**2×** (NOT 3×: 5.5
+cores is the time-averaged busy fraction of one bursty run, so K aligned rollout bursts
+oversubscribe). ``--max-concurrency`` defaults to **2** and is **RAM-bound** (~10 GB/run
+→ K=3 risks OOM on a 31 GB box), not core-bound.
+
+LOUD by contract (the #749 risk): any non-zero child — *or a child that crashes* — makes
+the runner exit non-zero. A silently-swallowed crash would corrupt a 2-seed verdict, so a
+crashed cell is surfaced as a failed :class:`CellResult` with its error text, never hidden.
+
+PURE: stdlib only (``argparse`` / ``subprocess`` / ``concurrent.futures`` /
+``dataclasses``), **no torch** — so it runs under the ``[dev]``-only CI and collects on
+the torch-free subset. The spawned children need ``[train]`` (torch); the orchestrator
+does not.
+
+Entry point::
+
+    # Two-seed trio-box gate, two cells concurrently (cap 2), trio-box train args after `--`:
+    python -m ml.sweep --seeds 0,1 --out-dir sweep-out --tag trio -- \
+        --schedule curriculum --device cuda --n-envs 16 --rollout-len 512 \
+        --max-iters-per-stage 300 --stop-after-rung trio-box --load ck-pairbox.pt ...
+
+    python -m ml.gate sweep-out/metrics-trio-seed0.jsonl --rung trio-box   # torch-free roll-up
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# A cell-runner takes a cell + its fully-built argv and returns the child's exit code. The
+# default spawns a real subprocess; tests inject a fake so no torch/training is spawned.
+RunCell = Callable[["CellSpec", "Sequence[str]"], int]
+
+
+@dataclass(frozen=True, slots=True)
+class CellSpec:
+    """One sweep cell: a single ``ml.train`` run with a distinct ``--seed`` and distinct
+    output paths so concurrent cells never clobber each other's artifacts."""
+
+    seed: int
+    metrics_out: str | None = None
+    checkpoint_out: str | None = None
+    save: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CellResult:
+    """The outcome of one cell. ``exit_code`` is the child's exit status (0 = the rung
+    ran cleanly to the trainer's own verdict — NOT the gate verdict, which ``ml.gate``
+    reads post-hoc from ``metrics_out``). ``error`` is non-None only when the cell
+    *crashed* (the runner raised) rather than exiting non-zero normally."""
+
+    seed: int
+    exit_code: int
+    error: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        """A cell passes iff it exited zero and did not crash."""
+        return self.exit_code == 0 and self.error is None
+
+
+@dataclass(frozen=True, slots=True)
+class SweepResult:
+    """The aggregated verdict. ``cells`` is in deterministic seed order (NOT finish
+    order). ``ok`` iff every cell passed; ``exit_code`` is 0 iff ``ok``."""
+
+    cells: list[CellResult] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return all(c.passed for c in self.cells)
+
+    @property
+    def exit_code(self) -> int:
+        return 0 if self.ok else 1
+
+
+def cells_for_seeds(
+    seeds: Sequence[int],
+    *,
+    out_dir: str,
+    tag: str,
+    checkpoint_out: bool = True,
+    save: bool = False,
+) -> list[CellSpec]:
+    """Build one :class:`CellSpec` per seed with distinct per-seed output paths under
+    ``out_dir`` (the independent-outputs contract: no two cells share a metrics /
+    checkpoint / save path). ``metrics_out`` is always set (it is what ``ml.gate`` reads
+    to roll up the verdict); ``checkpoint_out`` is on by default (crash-survivable resume
+    cells), ``save`` off (state_dict export is opt-in)."""
+    out = Path(out_dir)
+    cells: list[CellSpec] = []
+    for seed in seeds:
+        cells.append(
+            CellSpec(
+                seed=seed,
+                metrics_out=str(out / f"metrics-{tag}-seed{seed}.jsonl"),
+                checkpoint_out=str(out / f"ck-{tag}-seed{seed}.pt") if checkpoint_out else None,
+                save=str(out / f"policy-{tag}-seed{seed}.pt") if save else None,
+            )
+        )
+    return cells
+
+
+def build_train_argv(cell: CellSpec, base_argv: Sequence[str]) -> list[str]:
+    """Map one cell 1:1 to a ``python -m ml.train`` argv (the ``-m`` invocation prefix
+    is the caller's; this returns the ``["-m", "ml.train", *args]`` tail).
+
+    The cell's ``--seed`` and distinct output paths are injected; any ``--seed`` /
+    ``--metrics-out`` / ``--checkpoint-out`` / ``--save`` already present in ``base_argv``
+    is **stripped** first so the cell's values are the only ones the child sees (a
+    surviving base ``--seed`` would mean two conflicting flags, where last-wins is luck,
+    not contract)."""
+    cell_owned = {"--seed", "--metrics-out", "--checkpoint-out", "--save"}
+    filtered = _strip_flags(base_argv, cell_owned)
+
+    argv: list[str] = ["-m", "ml.train", *filtered, "--seed", str(cell.seed)]
+    if cell.metrics_out is not None:
+        argv += ["--metrics-out", cell.metrics_out]
+    if cell.checkpoint_out is not None:
+        argv += ["--checkpoint-out", cell.checkpoint_out]
+    if cell.save is not None:
+        argv += ["--save", cell.save]
+    return argv
+
+
+def _strip_flags(argv: Sequence[str], flags: set[str]) -> list[str]:
+    """Drop each ``--flag VALUE`` pair whose flag is in ``flags`` (these are
+    cell-owned). Assumes each is a value-taking option (matches the four cell-owned
+    flags); leaves all other tokens untouched."""
+    out: list[str] = []
+    skip_next = False
+    for tok in argv:
+        if skip_next:
+            skip_next = False  # this token is a stripped flag's value — drop it
+            continue
+        if tok in flags:
+            skip_next = True  # also drop its value
+            continue
+        out.append(tok)
+    return out
+
+
+def _default_run_cell(cell: CellSpec, argv: Sequence[str]) -> int:
+    """Spawn ``python <argv>`` (i.e. ``python -m ml.train ...``) as a subprocess and
+    return its exit code, tee'ing the child's stderr through this process's stderr so a
+    crashed/failing cell is loud. Inherits cwd (must be the repo root so the top-level
+    ``ml`` package resolves) and the env (so a local CUDA torch / thread caps apply)."""
+    cmd = [sys.executable, *argv]
+    sys.stderr.write(f"[sweep] seed {cell.seed}: launching {' '.join(cmd)}\n")
+    sys.stderr.flush()
+    completed = subprocess.run(cmd, check=False)  # noqa: S603 — argv is built, not shell
+    sys.stderr.write(f"[sweep] seed {cell.seed}: exited {completed.returncode}\n")
+    sys.stderr.flush()
+    return completed.returncode
+
+
+def _run_one(cell: CellSpec, argv: list[str], run_cell: RunCell) -> CellResult:
+    """Run a single cell, converting a *crash* (the runner raising) into a loud failed
+    :class:`CellResult` rather than letting it escape and abort the whole sweep — a
+    crashed child must fail loud, not silently corrupt the verdict (#749)."""
+    try:
+        code = run_cell(cell, argv)
+    except Exception as exc:  # noqa: BLE001 — a crashing child must surface, not propagate
+        sys.stderr.write(f"[sweep] seed {cell.seed}: CRASHED — {exc!r}\n")
+        sys.stderr.flush()
+        return CellResult(seed=cell.seed, exit_code=1, error=f"{type(exc).__name__}: {exc}")
+    return CellResult(seed=cell.seed, exit_code=code)
+
+
+def run_sweep(
+    cells: Sequence[CellSpec],
+    *,
+    base_argv: Sequence[str],
+    max_concurrency: int = 2,
+    run_cell: RunCell | None = None,
+) -> SweepResult:
+    """Run every cell concurrently, at most ``max_concurrency`` at a time, and aggregate.
+
+    Each cell's argv is built via :func:`build_train_argv` from the shared ``base_argv``
+    plus the cell's seed/paths. Results are returned in **deterministic seed order** (the
+    cells' input order), regardless of which child finished first, so the aggregated
+    summary is reproducible. ``run_cell`` is the injectable job-spawning seam (default:
+    :func:`_default_run_cell`, a real subprocess)."""
+    if max_concurrency < 1:
+        raise ValueError(f"max_concurrency must be >= 1, got {max_concurrency}")
+    runner = run_cell if run_cell is not None else _default_run_cell
+
+    workers = min(max_concurrency, len(cells)) or 1
+    # Submit in input order and read the futures back in the SAME order, so `results` is
+    # seed-ordered (the deterministic-aggregation contract) even though completion is not.
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [
+            pool.submit(_run_one, cell, build_train_argv(cell, base_argv), runner) for cell in cells
+        ]
+        results = [f.result() for f in futures]
+    return SweepResult(cells=results)
+
+
+def _summary(result: SweepResult) -> str:
+    """A scannable per-cell + headline pass/fail block."""
+    lines = [
+        f"  seed {r.seed:>3}: {'PASS' if r.passed else 'FAIL'} "
+        f"(exit {r.exit_code}{f', {r.error}' if r.error else ''})"
+        for r in result.cells
+    ]
+    headline = "SWEEP PASS" if result.ok else "SWEEP FAIL"
+    n_pass = sum(1 for r in result.cells if r.passed)
+    lines.append(f"{headline} — {n_pass}/{len(result.cells)} cells passed")
+    return "\n".join(lines)
+
+
+def _parse_seeds(spec: str) -> list[int]:
+    """Parse a comma-separated seed list (e.g. ``0,1,3``) into ints, preserving order."""
+    seeds = [int(tok) for tok in spec.split(",") if tok.strip()]
+    if not seeds:
+        raise ValueError(f"--seeds parsed to no seeds: {spec!r}")
+    return seeds
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m ml.sweep",
+        description=(
+            "Concurrent multi-seed sweep of `python -m ml.train` cells (#749). One cell per "
+            "--seed, run up to --max-concurrency at once; any failed/crashed child -> non-zero. "
+            "Pass per-cell train args after a `--` separator."
+        ),
+        epilog=(
+            "--max-concurrency is RAM-bound (~10 GB/run -> K=3 risks OOM on a 31 GB box), "
+            "not core-bound; expect ~2x sweep wall-clock, not Kx (aligned rollout bursts "
+            "oversubscribe). Roll up the per-seed metrics with `python -m ml.gate`."
+        ),
+    )
+    p.add_argument(
+        "--seeds",
+        required=True,
+        help="comma-separated seed list, one cell per seed (e.g. 0,1 for the two-seed gate)",
+    )
+    p.add_argument(
+        "--out-dir",
+        required=True,
+        help="directory for per-cell --metrics-out/--checkpoint-out/--save artifacts",
+    )
+    p.add_argument(
+        "--tag",
+        default="sweep",
+        help="filename tag for per-cell artifacts (metrics-<tag>-seed<N>.jsonl etc.)",
+    )
+    p.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=2,
+        help="max cells in flight at once (default 2; RAM-bound, NOT core-bound)",
+    )
+    p.add_argument(
+        "--save",
+        action="store_true",
+        help="also pass a distinct per-cell --save state_dict path to each ml.train cell",
+    )
+    p.add_argument(
+        "--no-checkpoint-out",
+        action="store_true",
+        help="do not pass a per-cell --checkpoint-out (default: a crash-survivable resume "
+        "checkpoint per cell)",
+    )
+    return p
+
+
+def main(argv: Sequence[str] | None = None, *, run_cell: RunCell | None = None) -> int:
+    """``python -m ml.sweep --seeds 0,1 --out-dir D --tag trio -- <train args...>``.
+
+    Splits argv on the first ``--`` into the sweep's own options and the pass-through
+    ``ml.train`` args, builds one cell per seed, runs them concurrently, prints the
+    aggregated summary, and returns the runner exit code (0 iff every cell passed).
+    ``run_cell`` is the injectable seam (tests pass a fake; default = real subprocess)."""
+    raw = list(sys.argv[1:] if argv is None else argv)
+    sweep_args, base_argv = _split_on_separator(raw)
+
+    args = build_argparser().parse_args(sweep_args)
+    seeds = _parse_seeds(args.seeds)
+    Path(args.out_dir).mkdir(parents=True, exist_ok=True)
+
+    cells = cells_for_seeds(
+        seeds,
+        out_dir=args.out_dir,
+        tag=args.tag,
+        checkpoint_out=not args.no_checkpoint_out,
+        save=args.save,
+    )
+    result = run_sweep(
+        cells,
+        base_argv=base_argv,
+        max_concurrency=args.max_concurrency,
+        run_cell=run_cell,
+    )
+    print(_summary(result))
+    return result.exit_code
+
+
+def _split_on_separator(argv: Sequence[str]) -> tuple[list[str], list[str]]:
+    """Split argv on the first ``--`` into (sweep options, pass-through train args). No
+    ``--`` => everything is a sweep option and the pass-through is empty."""
+    argv = list(argv)
+    if "--" in argv:
+        i = argv.index("--")
+        return argv[:i], argv[i + 1 :]
+    return argv, []
+
+
+if __name__ == "__main__":
+    # Disjoint core blocks + per-child thread caps are an operator concern (set
+    # OMP_NUM_THREADS / taskset / sched_setaffinity in the launching env); the
+    # orchestrator inherits the env into each child unchanged.
+    raise SystemExit(main())

--- a/tests/ml/test_sweep.py
+++ b/tests/ml/test_sweep.py
@@ -1,0 +1,239 @@
+"""Tests for ml/sweep.py — the torch-free concurrent multi-seed gate/sweep runner (#749).
+
+PURE: stdlib only, no torch import/skip — the runner is pure orchestration over
+``python -m ml.train`` / ``python -m ml.gate`` subprocesses, so it is exercised under
+the [dev]-only CI. Every test injects a FAKE cell-runner via the ``run_cell`` seam, so
+no real multi-minute training (and no torch) is ever spawned.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Sequence
+
+from ml.sweep import (
+    CellResult,
+    CellSpec,
+    build_train_argv,
+    cells_for_seeds,
+    main,
+    run_sweep,
+)
+
+# --------------------------------------------------------------------------------------
+# CellSpec -> ml.train argv mapping (1:1, distinct paths per cell)
+# --------------------------------------------------------------------------------------
+
+
+def test_build_train_argv_injects_seed_and_distinct_paths():
+    base = ["--schedule", "curriculum", "--max-iters-per-stage", "30"]
+    cell = CellSpec(
+        seed=2,
+        metrics_out="out/metrics-seed2.jsonl",
+        checkpoint_out="out/ck-seed2.pt",
+        save="out/policy-seed2.pt",
+    )
+    argv = build_train_argv(cell, base)
+    # The runner spawns `python -m ml.train ...` — the module invocation is the prefix.
+    assert argv[:3] == ["-m", "ml.train"] or argv[:1] == ["ml.train"] or "ml.train" in argv
+    # Base args are passed through unchanged.
+    for tok in base:
+        assert tok in argv
+    # The cell's seed + distinct paths are present exactly once each.
+    assert argv.count("--seed") == 1
+    assert argv[argv.index("--seed") + 1] == "2"
+    assert argv[argv.index("--metrics-out") + 1] == "out/metrics-seed2.jsonl"
+    assert argv[argv.index("--checkpoint-out") + 1] == "out/ck-seed2.pt"
+    assert argv[argv.index("--save") + 1] == "out/policy-seed2.pt"
+
+
+def test_build_train_argv_omits_unset_optional_paths():
+    cell = CellSpec(seed=0, metrics_out="m0.jsonl")  # no checkpoint_out / save
+    argv = build_train_argv(cell, [])
+    assert "--checkpoint-out" not in argv
+    assert "--save" not in argv
+    assert argv[argv.index("--metrics-out") + 1] == "m0.jsonl"
+
+
+def test_build_train_argv_does_not_duplicate_a_base_seed():
+    # A --seed in the base args must not survive next to the cell's injected --seed,
+    # or ml.train would see a conflicting double flag (last-wins is luck, not contract).
+    cell = CellSpec(seed=7, metrics_out="m7.jsonl")
+    argv = build_train_argv(cell, ["--seed", "0", "--rollout-len", "512"])
+    assert argv.count("--seed") == 1
+    assert argv[argv.index("--seed") + 1] == "7"
+    assert "--rollout-len" in argv
+
+
+def test_cells_for_seeds_maps_one_cell_per_seed_with_distinct_paths(tmp_path):
+    cells = cells_for_seeds([0, 1, 3], out_dir=str(tmp_path), tag="trio")
+    assert [c.seed for c in cells] == [0, 1, 3]
+    # Distinct metrics paths per seed — the independent-outputs acceptance criterion.
+    paths = [c.metrics_out for c in cells]
+    assert len(set(paths)) == len(paths)
+    for c in cells:
+        assert str(c.seed) in (c.metrics_out or "")
+
+
+# --------------------------------------------------------------------------------------
+# Concurrent orchestration + aggregation
+# --------------------------------------------------------------------------------------
+
+
+def _fake_runner(exit_by_seed: dict[int, int], *, record: list[int] | None = None):
+    """A fake ``run_cell`` that returns a per-seed canned exit code (no subprocess)."""
+
+    def run_cell(cell: CellSpec, argv: Sequence[str]) -> int:
+        if record is not None:
+            record.append(cell.seed)
+        return exit_by_seed.get(cell.seed, 0)
+
+    return run_cell
+
+
+def test_run_sweep_all_pass_aggregates_to_zero():
+    cells = cells_for_seeds([0, 1], out_dir="/tmp/x", tag="t")
+    result = run_sweep(cells, base_argv=[], max_concurrency=2, run_cell=_fake_runner({0: 0, 1: 0}))
+    assert result.ok is True
+    assert result.exit_code == 0
+    assert [r.exit_code for r in result.cells] == [0, 0]
+    assert all(r.passed for r in result.cells)
+
+
+def test_run_sweep_one_seed_fails_aggregates_to_nonzero():
+    cells = cells_for_seeds([0, 1], out_dir="/tmp/x", tag="t")
+    result = run_sweep(cells, base_argv=[], max_concurrency=2, run_cell=_fake_runner({0: 0, 1: 1}))
+    assert result.ok is False
+    assert result.exit_code != 0
+    # The failing cell is identifiable.
+    failed = [r for r in result.cells if not r.passed]
+    assert [r.seed for r in failed] == [1]
+
+
+def test_run_sweep_crashed_cell_is_loud_nonzero():
+    # A child that raises (crash) MUST surface as a non-zero cell, not be swallowed —
+    # a silent crash would corrupt a 2-seed verdict (the #749 risk).
+    def crashing_runner(cell: CellSpec, argv: Sequence[str]) -> int:
+        if cell.seed == 1:
+            raise RuntimeError("boom in seed 1")
+        return 0
+
+    cells = cells_for_seeds([0, 1], out_dir="/tmp/x", tag="t")
+    result = run_sweep(cells, base_argv=[], max_concurrency=2, run_cell=crashing_runner)
+    assert result.ok is False
+    assert result.exit_code != 0
+    crashed = [r for r in result.cells if r.seed == 1][0]
+    assert crashed.passed is False
+    assert crashed.error is not None
+    assert "boom" in crashed.error
+
+
+def test_run_sweep_results_are_in_deterministic_seed_order_regardless_of_finish_order():
+    # Seed 0 finishes LAST (sleeps), seed 1 finishes first — results must still be
+    # ordered by seed, so the aggregated summary is reproducible.
+    def staggered_runner(cell: CellSpec, argv: Sequence[str]) -> int:
+        time.sleep(0.05 if cell.seed == 0 else 0.0)
+        return 0
+
+    cells = cells_for_seeds([0, 1], out_dir="/tmp/x", tag="t")
+    result = run_sweep(cells, base_argv=[], max_concurrency=2, run_cell=staggered_runner)
+    assert [r.seed for r in result.cells] == [0, 1]
+
+
+def test_run_sweep_honors_concurrency_cap():
+    # Track concurrent in-flight cells; with cap=2 it must never exceed 2.
+    lock = threading.Lock()
+    state = {"in_flight": 0, "max_seen": 0}
+
+    def counting_runner(cell: CellSpec, argv: Sequence[str]) -> int:
+        with lock:
+            state["in_flight"] += 1
+            state["max_seen"] = max(state["max_seen"], state["in_flight"])
+        time.sleep(0.05)
+        with lock:
+            state["in_flight"] -= 1
+        return 0
+
+    cells = cells_for_seeds([0, 1, 2, 3], out_dir="/tmp/x", tag="t")
+    result = run_sweep(cells, base_argv=[], max_concurrency=2, run_cell=counting_runner)
+    assert result.ok is True
+    assert state["max_seen"] <= 2
+
+
+def test_run_sweep_passes_base_argv_and_per_cell_argv_to_runner():
+    seen: list[tuple[int, list[str]]] = []
+
+    def capturing_runner(cell: CellSpec, argv: Sequence[str]) -> int:
+        seen.append((cell.seed, list(argv)))
+        return 0
+
+    cells = cells_for_seeds([0, 1], out_dir="/tmp/x", tag="t")
+    base = ["--schedule", "curriculum", "--rollout-len", "512"]
+    run_sweep(cells, base_argv=base, max_concurrency=2, run_cell=capturing_runner)
+    seen.sort()
+    for seed, argv in seen:
+        assert "ml.train" in argv
+        assert "--rollout-len" in argv
+        assert argv[argv.index("--seed") + 1] == str(seed)
+
+
+# --------------------------------------------------------------------------------------
+# main() entry point
+# --------------------------------------------------------------------------------------
+
+
+def test_main_returns_zero_when_all_cells_pass(capsys):
+    code = main(
+        ["--seeds", "0,1", "--out-dir", "/tmp/sweep-x", "--tag", "t", "--"],
+        run_cell=_fake_runner({0: 0, 1: 0}),
+    )
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "PASS" in out.upper()
+
+
+def test_main_returns_nonzero_when_any_cell_fails(capsys):
+    code = main(
+        ["--seeds", "0,1", "--out-dir", "/tmp/sweep-x", "--tag", "t"],
+        run_cell=_fake_runner({0: 0, 1: 1}),
+    )
+    out = capsys.readouterr().out
+    assert code != 0
+    assert "FAIL" in out.upper()
+
+
+def test_main_parses_seed_list_into_one_cell_each(capsys):
+    record: list[int] = []
+    code = main(
+        ["--seeds", "0,1,2", "--out-dir", "/tmp/sweep-x", "--tag", "t"],
+        run_cell=_fake_runner({0: 0, 1: 0, 2: 0}, record=record),
+    )
+    assert code == 0
+    assert sorted(record) == [0, 1, 2]
+
+
+def test_main_forwards_extra_train_args_after_separator():
+    seen: list[list[str]] = []
+
+    def capturing_runner(cell: CellSpec, argv: Sequence[str]) -> int:
+        seen.append(list(argv))
+        return 0
+
+    code = main(
+        ["--seeds", "0", "--out-dir", "/tmp/sweep-x", "--tag", "t", "--", "--rollout-len", "512"],
+        run_cell=capturing_runner,
+    )
+    assert code == 0
+    assert "--rollout-len" in seen[0]
+    assert seen[0][seen[0].index("--rollout-len") + 1] == "512"
+
+
+def test_cell_result_is_immutable():
+    r = CellResult(seed=0, exit_code=0)
+    assert r.passed is True
+    try:
+        r.exit_code = 1  # type: ignore[misc]
+    except (AttributeError, Exception):
+        return
+    raise AssertionError("CellResult should be frozen")

--- a/tests/ml/test_sweep.py
+++ b/tests/ml/test_sweep.py
@@ -8,9 +8,12 @@ no real multi-minute training (and no torch) is ever spawned.
 
 from __future__ import annotations
 
+import dataclasses
 import threading
 import time
 from collections.abc import Sequence
+
+import pytest
 
 from ml.sweep import (
     CellResult,
@@ -64,6 +67,27 @@ def test_build_train_argv_does_not_duplicate_a_base_seed():
     assert argv.count("--seed") == 1
     assert argv[argv.index("--seed") + 1] == "7"
     assert "--rollout-len" in argv
+
+
+def test_build_train_argv_strips_argparse_equals_form_of_cell_owned_flags():
+    # argparse also accepts --flag=value; that inline form must be stripped too, or a base
+    # `--seed=0` survives next to the cell's `--seed 7` (last-wins is luck, not contract).
+    cell = CellSpec(seed=7, metrics_out="m7.jsonl", checkpoint_out="ck7.pt")
+    argv = build_train_argv(
+        cell,
+        ["--seed=0", "--metrics-out=base.jsonl", "--checkpoint-out=base.pt", "--rollout-len=512"],
+    )
+    # No surviving equals-form of a cell-owned flag.
+    assert not any(tok.startswith("--seed=") for tok in argv)
+    assert not any(tok.startswith("--metrics-out=") for tok in argv)
+    assert not any(tok.startswith("--checkpoint-out=") for tok in argv)
+    # The cell's values are the only ones present, exactly once each.
+    assert argv.count("--seed") == 1
+    assert argv[argv.index("--seed") + 1] == "7"
+    assert argv[argv.index("--metrics-out") + 1] == "m7.jsonl"
+    assert argv[argv.index("--checkpoint-out") + 1] == "ck7.pt"
+    # A non-cell-owned equals-form flag is left untouched.
+    assert "--rollout-len=512" in argv
 
 
 def test_cells_for_seeds_maps_one_cell_per_seed_with_distinct_paths(tmp_path):
@@ -203,6 +227,16 @@ def test_main_returns_nonzero_when_any_cell_fails(capsys):
     assert "FAIL" in out.upper()
 
 
+def test_main_rejects_duplicate_seeds_loudly(capsys):
+    # Duplicate seeds would build two cells with the SAME metrics/checkpoint/save paths,
+    # so concurrent children race-corrupt the shared gate input — reject it loudly.
+    with pytest.raises(ValueError, match="duplicate"):
+        main(
+            ["--seeds", "0,1,1", "--out-dir", "/tmp/sweep-x", "--tag", "t"],
+            run_cell=_fake_runner({0: 0, 1: 0}),
+        )
+
+
 def test_main_parses_seed_list_into_one_cell_each(capsys):
     record: list[int] = []
     code = main(
@@ -232,8 +266,5 @@ def test_main_forwards_extra_train_args_after_separator():
 def test_cell_result_is_immutable():
     r = CellResult(seed=0, exit_code=0)
     assert r.passed is True
-    try:
+    with pytest.raises(dataclasses.FrozenInstanceError):
         r.exit_code = 1  # type: ignore[misc]
-    except (AttributeError, Exception):
-        return
-    raise AssertionError("CellResult should be frozen")


### PR DESCRIPTION
Closes #749

Part of epic #607, **throughput Wave 1**.

> ⚠ **Merge order:** this PR is `blocked_by #747` (PR #762, **not yet merged**). It develops off `develop` and does **not** import #747 code, but the runner's correctness at runtime depends on #747's worker thread-cap so K concurrent cells don't oversubscribe the GEOS GIL. **Merge this AFTER #762.**

## What

Adds **`ml/sweep.py`** — a torch-free concurrent multi-seed gate/sweep runner that runs the two/three-seed gate (the `ml/README` trio-box recipe) **concurrently** instead of serially, cutting sweep wall-clock ~2× vs a serial loop.

- Spawns K **unmodified** `python -m ml.train` subprocesses (one per `--seed`), each with a distinct `--seed` + per-cell `--metrics-out`/`--checkpoint-out`/`--save` path (the independent-outputs contract — concurrent cells never clobber each other's artifacts).
- `--max-concurrency` (default **2**) runs cells concurrently up to the cap; documented **RAM-bound** (~10 GB/run → K=3 risks OOM on a 31 GB box), *not* core-bound.
- **Loud by contract** (the #749 risk): any non-zero child — *or a child that crashes* — makes the runner exit non-zero, surfaced as a failed `CellResult` with its error text. A silently-swallowed crash would corrupt a 2-seed verdict.
- Results aggregated in **deterministic seed order** (not finish order), so the summary is reproducible.
- Pure orchestration, **no training-loop edits** — each child is byte-identical to running it alone (the #749 determinism note: co-locating cells on one GPU adds nothing beyond `--device cuda`).
- Clean entry point: `python -m ml.sweep --seeds 0,1 --out-dir D --tag trio -- <train args...>`; per-cell metrics roll up via the existing torch-free `python -m ml.gate`.

The job-spawning seam (`run_cell`) is **injectable** so unit tests stay fast + deterministic (no real multi-minute training spawned).

## Key files

- `ml/sweep.py` — `CellSpec` / `CellResult` / `SweepResult`, `cells_for_seeds`, `build_train_argv` (1:1 argv mapping, strips a base `--seed` so the cell's is the only one), `run_sweep` (ThreadPoolExecutor, capped, seed-ordered), `main` (`--`-split pass-through + aggregated summary).
- `tests/ml/test_sweep.py` — 15 tests: argv 1:1 mapping, all-pass / one-seed-fail / crash-is-loud aggregation, concurrency-cap honored, deterministic seed-order regardless of finish order, the `main()` entry point.
- `ml/README.md` — concurrent-sweep recipe + honest ~2× / RAM-ceiling docs.
- `CHANGELOG.md` — `[Unreleased] ### Added` entry.

## Tests / checks

- `pytest tests/ml/test_sweep.py` → 15 passed; full `tests/ml/` → 459 passed.
- `ruff check ml/ tests/ml/test_sweep.py` clean; `ruff format --check` clean.
- `mypy ml/` (full package) clean.

Dev/CI-only (`ml/`); no shipped-wheel surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
