### PR TITLE
perf(751): opt-in `--vec-start-method` (forkserver cuts per-worker RAM ~4.6x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#751, epic #607 Wave 1 / #758): opt-in `--vec-start-method`
+  {spawn,forkserver,fork} to cut per-worker training RAM.** RAM — not cores or GPU — is the
+  ceiling for both `--n-envs auto` (#747) and the concurrent sweep runner (#749): `spawn`
+  re-imports torch + shapely *privately* in every worker (~327 MiB PSS/worker measured). Since
+  the workers are torch-free in their *ops*, `--vec-start-method forkserver` forks them from a
+  shared server that preloads those modules once, so all workers share the pages copy-on-write —
+  **measured ~327 → ~71 MiB PSS/worker (~4.6×)**, which raises the achievable `--n-envs`/sweep
+  concurrency. **Default stays `spawn`** (the byte-identity reference); `forkserver` is verified
+  **byte-identical** to it (the worker's `stage_rng` is `worker_index`-keyed, so the start method
+  can't perturb the trajectory — pinned by `test_subproc_forkserver_byte_identical_to_sync` +
+  `test_sync_equals_subproc_byte_identical`). `fork` is an explicit escape hatch that warns loudly
+  (copying a torch-loaded / CUDA-holding parent can deadlock — `forkserver` is the safe path).
+  Dev/CI-only (`ml/`); no shipped-wheel surface.
+
 - **Learned backend (#750, epic #607, throughput Wave 1): a transitions/sec training-loop canary
   + a vectorized width-N GAE scan.** Two dev/CI-only changes so the rest of the throughput work is
   measured, not eyeballed. (1) `python -m bench.train_throughput` is the `ml/` twin of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
   re-imports torch + shapely *privately* in every worker (~327 MiB PSS/worker measured). Since
   the workers are torch-free in their *ops*, `--vec-start-method forkserver` forks them from a
   shared server that preloads those modules once, so all workers share the pages copy-on-write —
-  **measured ~327 → ~71 MiB PSS/worker (~4.6×)**, which raises the achievable `--n-envs`/sweep
+  **measured ~327 → ~71 MiB PSS/worker (~4.6×; CPU-only, Linux/Py3.12, N=4)**, which raises the achievable `--n-envs`/sweep
   concurrency. **Default stays `spawn`** (the byte-identity reference); `forkserver` is verified
   **byte-identical** to it (the worker's `stage_rng` is `worker_index`-keyed, so the start method
   can't perturb the trajectory — pinned by `test_subproc_forkserver_byte_identical_to_sync` +

--- a/ml/train.py
+++ b/ml/train.py
@@ -363,6 +363,7 @@ def train_curriculum(
     save_onnx: str | None = None,
     n_envs: int = 1,
     vec_backend: Literal["sync", "subproc"] = "subproc",
+    vec_start_method: Literal["spawn", "forkserver", "fork"] = "spawn",
     device: str = "cpu",
     load: str | None = None,
     checkpoint_out: str | None = None,
@@ -507,7 +508,7 @@ def train_curriculum(
             ]
             vec_cm: SyncVectorEnv | SubprocVectorEnv
             if vec_backend == "subproc":
-                vec_cm = SubprocVectorEnv(worker_fns)
+                vec_cm = SubprocVectorEnv(worker_fns, start_method=vec_start_method)
             else:
                 vec_cm = SyncVectorEnv([fn() for fn in worker_fns])
             with vec_cm as vec:
@@ -918,6 +919,14 @@ def build_argparser() -> argparse.ArgumentParser:
         help="vectorized env backend: sync (in-process, CI-safe) or subproc (parallel workers)",
     )
     p.add_argument(
+        "--vec-start-method",
+        choices=["spawn", "forkserver", "fork"],
+        default="spawn",
+        help="subproc worker start method (#751): spawn (default, byte-identical) or "
+        "forkserver (shares the parent's imported pages, cutting per-worker RAM). fork is "
+        "an explicit escape hatch — unsafe if the parent holds a CUDA context.",
+    )
+    p.add_argument(
         "--device",
         choices=["cpu", "cuda"],
         default="cpu",
@@ -1060,6 +1069,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             save_onnx=args.save_onnx,
             n_envs=args.n_envs,
             vec_backend=args.vec_backend,
+            vec_start_method=args.vec_start_method,
             device=args.device,
             load=args.load,
             checkpoint_out=args.checkpoint_out,

--- a/ml/train.py
+++ b/ml/train.py
@@ -923,7 +923,7 @@ def build_argparser() -> argparse.ArgumentParser:
         choices=["spawn", "forkserver", "fork"],
         default="spawn",
         help="subproc worker start method (#751): spawn (default, byte-identical) or "
-        "forkserver (shares the parent's imported pages, cutting per-worker RAM). fork is "
+        "forkserver (forks from a shared preloaded server, cutting per-worker RAM). fork is "
         "an explicit escape hatch — unsafe if the parent holds a CUDA context.",
     )
     p.add_argument(

--- a/ml/vector_env.py
+++ b/ml/vector_env.py
@@ -266,8 +266,9 @@ class SubprocVectorEnv:
     """N _EnvWorkers, each in its own worker process. Parallelizes the per-env shapely
     geometry + encoding. Workers are torch-free, so output is byte-identical to
     SyncVectorEnv on the same action stream — independent of the start method (#751):
-    ``spawn`` (default, the byte-identity reference), ``forkserver`` (shares the parent's
-    imported pages, cutting per-worker RAM), or ``fork`` (explicit, parent-must-be-fork-safe)."""
+    ``spawn`` (default, the byte-identity reference), ``forkserver`` (forks workers from a
+    shared server that preloads the heavy modules, so they share its pages copy-on-write —
+    cutting per-worker RAM), or ``fork`` (explicit, parent-must-be-fork-safe)."""
 
     def __init__(
         self,

--- a/ml/vector_env.py
+++ b/ml/vector_env.py
@@ -13,6 +13,7 @@ import contextlib
 import multiprocessing as mp
 import os
 import sys
+import warnings
 from collections.abc import Callable, Iterator, Sequence
 from multiprocessing.connection import wait
 from typing import Any, NamedTuple, cast
@@ -250,15 +251,57 @@ def _worker_loop(remote: mp.connection.Connection, worker_fn: Callable[[], _EnvW
             remote.close()
 
 
-class SubprocVectorEnv:
-    """N _EnvWorkers, each in its own spawn process. Parallelizes the per-env shapely
-    geometry + encoding. Workers are torch-free, so output is byte-identical to
-    SyncVectorEnv on the same action stream."""
+_VALID_START_METHODS = ("spawn", "forkserver", "fork")
 
-    def __init__(self, worker_fns: Sequence[Callable[[], _EnvWorker]]) -> None:
+# Modules whose import dominates a worker's resident memory. Preloading them in the
+# forkserver server (#751) means every forked worker SHARES these pages copy-on-write
+# instead of re-importing torch + shapely privately as it does under spawn — the
+# per-worker PSS cut that raises the achievable --n-envs (#747) and sweep concurrency.
+# ml.train transitively pulls torch / numpy / shapely / hangarfit; ml.vector_env is the
+# worker target module.
+_FORKSERVER_PRELOAD = ("ml.vector_env", "ml.train")
+
+
+class SubprocVectorEnv:
+    """N _EnvWorkers, each in its own worker process. Parallelizes the per-env shapely
+    geometry + encoding. Workers are torch-free, so output is byte-identical to
+    SyncVectorEnv on the same action stream — independent of the start method (#751):
+    ``spawn`` (default, the byte-identity reference), ``forkserver`` (shares the parent's
+    imported pages, cutting per-worker RAM), or ``fork`` (explicit, parent-must-be-fork-safe)."""
+
+    def __init__(
+        self,
+        worker_fns: Sequence[Callable[[], _EnvWorker]],
+        *,
+        start_method: str = "spawn",
+    ) -> None:
         if not worker_fns:
             raise ValueError("SubprocVectorEnv needs at least one worker_fn")
-        ctx = mp.get_context("spawn")
+        if start_method not in _VALID_START_METHODS:
+            raise ValueError(
+                f"start_method must be one of {_VALID_START_METHODS}, got {start_method!r}"
+            )
+        self._start_method = start_method
+        # get_context(str) is typed BaseContext (no .Process/.Pipe); the concrete
+        # Spawn/ForkServer/Fork context is runtime-dynamic, so widen to Any.
+        ctx: Any = mp.get_context(start_method)
+        if start_method == "forkserver":
+            # Set BEFORE the server is started (first Process.start, inside the thread-cap
+            # window below) so the preloaded torch reads the 1-thread cap. The preload list
+            # is global to the process's single forkserver; idempotent across instances.
+            mp.set_forkserver_preload(list(_FORKSERVER_PRELOAD))
+        elif start_method == "fork":
+            # fork copies the (torch-loaded, possibly multi-threaded) parent. If the parent
+            # holds a CUDA context or live threads this can deadlock or corrupt — forkserver
+            # is the safe path to the RAM cut; fork is the explicit "my parent is fork-safe"
+            # escape hatch, so surface the risk loudly rather than silently.
+            warnings.warn(
+                "SubprocVectorEnv start_method='fork' copies the torch-loaded parent; if it "
+                "holds a CUDA context or live threads this can deadlock/corrupt — prefer "
+                "'forkserver'.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         self._n = len(worker_fns)
         self._parents: list[mp.connection.Connection] = []
         self._procs: list[Any] = []  # SpawnProcess is not mp.Process in typeshed
@@ -292,6 +335,10 @@ class SubprocVectorEnv:
     @property
     def num_envs(self) -> int:
         return self._n
+
+    @property
+    def start_method(self) -> str:
+        return self._start_method
 
     def _recv(self, parent: mp.connection.Connection, worker_idx: int) -> object:
         try:
@@ -363,8 +410,6 @@ class SubprocVectorEnv:
             if proc.is_alive():  # pragma: no cover
                 proc.terminate()
             elif proc.exitcode not in (0, None):
-                import warnings
-
                 warnings.warn(
                     f"SubprocVectorEnv worker {i} exited with code {proc.exitcode} — "
                     f"training data from this worker may be incomplete.",

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -247,6 +247,17 @@ def test_argparser_n_envs_default_is_one_byte_identity_floor():
     assert build_argparser().parse_args([]).n_envs == 1
 
 
+def test_argparser_vec_start_method_defaults_to_spawn():
+    """#751: the default stays `spawn` (the byte-identity reference); forkserver/fork are
+    opt-in. A bad value is rejected by argparse choices."""
+    parser = build_argparser()
+    assert parser.parse_args([]).vec_start_method == "spawn"
+    assert parser.parse_args(["--vec-start-method", "forkserver"]).vec_start_method == "forkserver"
+    assert parser.parse_args(["--vec-start-method", "fork"]).vec_start_method == "fork"
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--vec-start-method", "bogus"])
+
+
 def test_argparser_n_envs_auto_resolves_to_positive_int(monkeypatch):
     import ml.train as t
 

--- a/tests/ml/test_vector_env.py
+++ b/tests/ml/test_vector_env.py
@@ -225,11 +225,20 @@ def test_subproc_rejects_unknown_start_method():
         SubprocVectorEnv([_trivial_worker_fn], start_method="bogus")
 
 
+import multiprocessing as _mp_test  # noqa: E402
+
+_FORKSERVER_AVAILABLE = "forkserver" in _mp_test.get_all_start_methods()
+_needs_forkserver = pytest.mark.skipif(
+    not _FORKSERVER_AVAILABLE, reason="forkserver start method is Unix-only"
+)
+
+
+@_needs_forkserver
 def test_subproc_forkserver_byte_identical_to_sync():
-    """#751 acceptance: forkserver forks workers from a shared server (cutting per-worker
-    PSS) but MUST stay byte-identical to the spawn/Sync reference — the worker's stage_rng
-    is `worker_index`-keyed, so the start method can't perturb it. A fixed action stream
-    (incl. a PARK -> auto-reset) yields the same reward + done + encoded-obs as Sync."""
+    """#751 acceptance (quick): forkserver forks workers from a shared server (cutting
+    per-worker PSS) but MUST stay byte-identical to the spawn/Sync reference — the worker's
+    stage_rng is `worker_index`-keyed, so the start method can't perturb it. A fixed action
+    stream (incl. a PARK -> auto-reset) yields the same reward + done + encoded-obs as Sync."""
     from ml.action_space import PARK_INDEX
 
     actions = [(1, 1), (1, 2)]
@@ -252,6 +261,56 @@ def test_subproc_forkserver_byte_identical_to_sync():
         assert np.array_equal(a.raster, b.raster) and np.array_equal(a.tokens, b.tokens)
     for a, b in zip(ss2.obs, bs2.obs, strict=True):
         assert np.array_equal(a.raster, b.raster) and np.array_equal(a.tokens, b.tokens)
+
+
+@_needs_forkserver
+def test_subproc_forkserver_byte_identical_across_resampling_resets():
+    """#751 DEEP byte-identity: the quick test above uses `next_request=None`, so it never
+    draws from `stage_rng`. This drives SAMPLER-backed workers (real per-worker `stage_rng`)
+    over many PARK-driven auto-resets — each reset RESAMPLES the next episode's object set —
+    so the worker_index-keyed RNG resample path is genuinely exercised. forkserver must
+    reproduce each worker's stream exactly, and the workers must be MUTUALLY DISTINCT (so the
+    match is not a vacuous all-clones artifact)."""
+    from functools import partial
+
+    from ml.action_space import PARK_INDEX
+    from ml.curriculum import CurriculumSchedule
+    from ml.stage_builder import effective_fleet_ids
+    from ml.train import _build_stage_worker
+
+    sched = CurriculumSchedule.default()
+    stage = next(s for s in sched.stages if (s.difficulty.max_objects or 1) >= 2)
+    enc = EncoderConfig()
+    pool = effective_fleet_ids(stage)
+    nobj = stage.difficulty.max_objects or len(pool)
+    n_workers, steps = 3, 24
+    # partial over the MODULE-LEVEL _build_stage_worker is picklable under spawn AND
+    # forkserver; worker_index (the last arg) keys each worker's stage_rng stream.
+    worker_fns = [
+        partial(_build_stage_worker, stage, 0, pool, nobj, 0, None, enc, wi)
+        for wi in range(n_workers)
+    ]
+
+    def _drive(vec):
+        out = []
+        vec.reset()
+        for _ in range(steps):
+            # PARK completes the set -> done -> auto-reset -> resample next episode
+            s = vec.step([(PARK_INDEX, 0)] * n_workers)
+            out.append((tuple(s.rewards), tuple(s.dones), tuple(o.raster.tobytes() for o in s.obs)))
+        return out
+
+    sync = SyncVectorEnv([fn() for fn in worker_fns])
+    sync_rec = _drive(sync)
+    sync.close()
+    with SubprocVectorEnv(worker_fns, start_method="forkserver") as sub:
+        fs_rec = _drive(sub)
+
+    assert any(any(d) for _r, d, _o in sync_rec), "no auto-reset fired — test is vacuous"
+    assert fs_rec == sync_rec  # forkserver reproduces every worker's resample stream exactly
+    # non-vacuity: the workers are genuinely different streams (worker_index-keyed rng)
+    per_worker_rasters = [tuple(rec[2][w] for rec in sync_rec) for w in range(n_workers)]
+    assert len(set(per_worker_rasters)) == n_workers, "workers are not distinct (vacuous match)"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ml/test_vector_env.py
+++ b/tests/ml/test_vector_env.py
@@ -206,6 +206,55 @@ def test_subproc_worker_failure_is_loud():
 
 
 # ---------------------------------------------------------------------------
+# #751: opt-in --vec-start-method (spawn/forkserver/fork). spawn stays the default
+# byte-identity reference; forkserver shares the parent's imported pages (RAM cut).
+# ---------------------------------------------------------------------------
+
+
+def test_subproc_default_start_method_is_spawn():
+    """The default stays `spawn` — the #708/#747/#748 byte-identity reference. The opt-in
+    methods are #751; the floor must not silently change."""
+    with SubprocVectorEnv([_trivial_worker_fn]) as sub:
+        assert sub.start_method == "spawn"
+
+
+def test_subproc_rejects_unknown_start_method():
+    import pytest
+
+    with pytest.raises(ValueError, match=r"start_method"):
+        SubprocVectorEnv([_trivial_worker_fn], start_method="bogus")
+
+
+def test_subproc_forkserver_byte_identical_to_sync():
+    """#751 acceptance: forkserver forks workers from a shared server (cutting per-worker
+    PSS) but MUST stay byte-identical to the spawn/Sync reference — the worker's stage_rng
+    is `worker_index`-keyed, so the start method can't perturb it. A fixed action stream
+    (incl. a PARK -> auto-reset) yields the same reward + done + encoded-obs as Sync."""
+    from ml.action_space import PARK_INDEX
+
+    actions = [(1, 1), (1, 2)]
+    sync = SyncVectorEnv([_trivial_worker_fn(), _trivial_worker_fn()])
+    sync.reset()
+    ss = sync.step(actions)
+    ss2 = sync.step([(PARK_INDEX, 0), (PARK_INDEX, 0)])
+    sync.close()
+
+    with SubprocVectorEnv(
+        [_trivial_worker_fn, _trivial_worker_fn], start_method="forkserver"
+    ) as sub:
+        sub.reset()
+        bs = sub.step(actions)
+        bs2 = sub.step([(PARK_INDEX, 0), (PARK_INDEX, 0)])
+
+    assert bs.rewards == ss.rewards and bs.dones == ss.dones
+    assert bs2.dones == ss2.dones
+    for a, b in zip(ss.obs, bs.obs, strict=True):
+        assert np.array_equal(a.raster, b.raster) and np.array_equal(a.tokens, b.tokens)
+    for a, b in zip(ss2.obs, bs2.obs, strict=True):
+        assert np.array_equal(a.raster, b.raster) and np.array_equal(a.tokens, b.tokens)
+
+
+# ---------------------------------------------------------------------------
 # #747: per-worker BLAS/OMP thread cap (the prerequisite that makes raising
 # --n-envs toward the core count safe — one worker per core, no oversubscription)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of **epic #758 (Wave 1)** under #607 — the **last** Wave-1 sub-issue. Cuts per-worker training RAM so `--n-envs auto` (#747) and the sweep runner (#749) can pack more workers.

## Problem
RAM — not cores or GPU — is the ceiling. `spawn` re-imports torch + shapely **privately** in every worker (**~327 MiB PSS/worker measured**, N=4). Workers are torch-free in their *ops*, so they don't need a private torch — they just pay for it.

## Change
Opt-in `--vec-start-method {spawn,forkserver,fork}` (default **`spawn`** = current behavior) on `SubprocVectorEnv`:
- **`forkserver`** forks workers from a shared server that **preloads** the heavy modules (`ml.train` → torch/numpy/shapely, `ml.vector_env`) once; all workers then share those pages copy-on-write. **Measured ~327 → ~71 MiB PSS/worker (~4.6×).** The preload is set before the server starts (inside the #747 thread-cap window, so its torch reads the 1-thread cap).
- **`fork`** is an explicit escape hatch that **warns loudly** — copying a torch-loaded / CUDA-holding parent can deadlock; `forkserver` is the safe path.

Plumbed through `SubprocVectorEnv(start_method=...)` → `train_curriculum(vec_start_method=...)` → `--vec-start-method` CLI.

## Determinism: default spawn byte-identical; forkserver verified byte-identical
The worker's `stage_rng` is `worker_index`-keyed and rebuilt inside `_build_stage_worker` (post-fork, in the child), so the start method **cannot** perturb the trajectory. Pinned by:
- `test_subproc_forkserver_byte_identical_to_sync` — forkserver subproc ≡ Sync over a fixed action stream (incl. a PARK→auto-reset): same reward + done + encoded obs.
- `test_sync_equals_subproc_byte_identical` (spawn) unchanged + green.
- End-to-end: a `--vec-start-method forkserver` curriculum rung produced the **same** `mean_ep_reward=-2529.216` as the spawn run.

## PSS measurement (the acceptance criterion)
```
spawn      : per-worker PSS avg = 327.1 MiB   (1308.2 MiB over N=4)
forkserver : per-worker PSS avg =  71.1 MiB   ( 284.3 MiB over N=4)
```

## Tests
`tests/ml/test_vector_env.py`: default-is-spawn, rejects-unknown-method, forkserver-byte-identical. `tests/ml/test_train_curriculum.py`: `--vec-start-method` default spawn + accepts forkserver/fork. Full `tests/ml/test_vector_env.py` + `test_train_curriculum.py` green; `ruff` + `mypy ml/` (full package) clean.

## Stacking note
Branched off #764's tip so it carries everything (#747/#748/#749 via develop + #750), per request. The diff therefore includes #750's changes until **#764 merges** — **merge #764 (#750) first**, then I'll merge develop to drop the overlap. #751's own changes are confined to `ml/vector_env.py` + `ml/train.py` (start-method plumbing).

Closes #751