### PR TITLE
perf(752): shrink rollout IPC payload — uint8 raster + drop static channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#752, epic #607 Wave 2 / #759): shrink the rollout IPC payload —
+  uint8 raster + drop the re-shipped static channels (byte-identical).** Every vectorized
+  training step pickles each worker's 7×192×96 float32 raster over a Pipe, but two-thirds of
+  that traffic is waste: the raster is binary occupancy shipped at 4 bytes/cell, and 4 of the 7
+  channels (`oob`/`bay`/`apron`/`door`) depend only on `(hangar, config)` yet were recomputed
+  *and* re-shipped byte-identically by every worker every step. The encoder now splits into a
+  **static block** (`encoding.static_block(hangar, config)` — the 4 hangar-fixed channels) and
+  `encode_dynamic` (the 3 observation-dependent channels as **uint8** 0/1); the worker ships only
+  the dynamic block, and the parent re-prepends the rung's cached static block in `to_batch`
+  (`encoding.reassemble_raster`), rehydrating the full 7-channel float32 raster. This cuts the
+  per-step worker→parent payload ~57% **and** deletes the 3 static `shapely.contains_xy` calls
+  from every worker step (computed once per rung instead). **Byte-identical** (ADR-0003): the
+  dynamic block is binary, so float32(0/1)→uint8→float32 is lossless and `reassemble_raster`
+  reproduces `encode()`'s raster bit-for-bit (`test_reassemble_raster_equals_full_encode_bitwise`);
+  `to_batch` keys on the uint8 dtype, so every non-vectorized caller (full float32 obs) passes
+  straight through, and Sync still equals Subproc byte-for-byte. Dev/CI-only (`ml/`); no
+  shipped-wheel surface.
+
 - **Learned backend (#751, epic #607 Wave 1 / #758): opt-in `--vec-start-method`
   {spawn,forkserver,fork} to cut per-worker training RAM.** RAM — not cores or GPU — is the
   ceiling for both `--n-envs auto` (#747) and the concurrent sweep runner (#749): `spawn`

--- a/bench/train_throughput.py
+++ b/bench/train_throughput.py
@@ -85,7 +85,7 @@ def run_throughput(
 
     import torch
 
-    from ml.encoding import EncoderConfig
+    from ml.encoding import EncoderConfig, static_block
     from ml.policy import HangarFitPolicy
     from ml.ppo import PPOConfig, ppo_update
     from ml.train import build_trivial_env, collect_rollout_vec
@@ -97,6 +97,9 @@ def run_throughput(
     # benchmark measures throughput, not learning, so a fixed env set is exactly what we want).
     workers = [_EnvWorker(build_trivial_env(seed), enc, None) for _ in range(n_envs)]
     vec_env = SyncVectorEnv(workers)
+    # #752: the workers ship only the dynamic raster channels (uint8); re-prepend the trivial
+    # stage's cached static block (same hangar+config for every worker) in to_batch.
+    rung_static_block = static_block(build_trivial_env(seed).hangar, enc)
     policy = HangarFitPolicy(d_model=d_model, n_layers=n_layers, n_heads=n_heads)
     cfg = PPOConfig(minibatch_size=min(PPOConfig().minibatch_size, rollout_len * n_envs))
     optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.lr)
@@ -106,7 +109,9 @@ def run_throughput(
     for it in range(warmup_iters + iterations):
         timed = it >= warmup_iters
         t0 = time.perf_counter()
-        buf, _ = collect_rollout_vec(vec_env, policy, enc, rollout_len)
+        buf, _ = collect_rollout_vec(
+            vec_env, policy, enc, rollout_len, static_block=rung_static_block
+        )
         t1 = time.perf_counter()
         ppo_update(policy, optimizer, buf, cfg)
         t2 = time.perf_counter()

--- a/ml/encoding.py
+++ b/ml/encoding.py
@@ -37,6 +37,13 @@ ACTION_DIM = len(_CANONICAL_ACTIONS) + 1  # + PARK
 PARK_INDEX = ACTION_DIM - 1
 TOKEN_DIM = 24
 RASTER_CHANNELS = 7
+# #752: the 7 raster channels split into a STATIC block (depends only on hangar+config)
+# and a DYNAMIC block (depends on the observation). The vectorized rollout ships only the
+# dynamic block (as uint8) from each worker and re-prepends a cached static block parent-
+# side, so the redundant-every-step static channels are neither re-encoded nor re-shipped.
+STATIC_CHANNELS = 4  # oob, bay, apron, door
+DYNAMIC_CHANNELS = 3  # parked-low, parked-wing, active
+assert STATIC_CHANNELS + DYNAMIC_CHANNELS == RASTER_CHANNELS
 
 
 @dataclass(frozen=True, slots=True)
@@ -337,21 +344,40 @@ def _legal_action_mask(obs: Observation) -> np.ndarray:
 _DEFAULT_CONFIG = EncoderConfig()
 
 
-def encode(
-    obs: Observation,
-    hangar: Hangar,
-    bodies: Mapping[str, Aircraft | GroundObject],
-    config: EncoderConfig = _DEFAULT_CONFIG,
-) -> ObservationTensors:
-    """Tensorize a semantic Observation. Pure + deterministic (no RNG).
+def static_block(hangar: Hangar, config: EncoderConfig = _DEFAULT_CONFIG) -> np.ndarray:
+    """The (STATIC_CHANNELS, H, W) float32 raster block that depends ONLY on
+    (hangar, config) — oob/bay/apron/door. It is identical for every step of a rung, so
+    the vectorized rollout computes it ONCE per rung and re-prepends it (:func:`reassemble_raster`)
+    instead of re-encoding + re-shipping it from every worker every step (#752). Returns a
+    fresh array per call (no module cache → no stale-hangar trap); the caller owns caching it
+    for a rung and MUST treat the result read-only."""
+    return _static_channels(hangar, config)
 
-    ``bodies`` is fleet ∪ ground_objects (Observation.parked carries only
-    id+Placement, so the encoder looks each body up for its polygons and features).
-    ``meta`` is a read-only mapping of floats for debugging / un-normalization."""
-    static = _static_channels(hangar, config)  # (4, H, W)
+
+def _dynamic_channels(
+    obs: Observation, bodies: Mapping[str, Aircraft | GroundObject], config: EncoderConfig
+) -> np.ndarray:
+    """(DYNAMIC_CHANNELS, H, W) float32: [parked-low, parked-wing, active]. The part of the
+    raster that depends on the observation; the only block the worker path needs to ship."""
     low, wing = _parked_occupancy(obs, bodies, config)
     active_occ = _active_occupancy(obs, config)
-    raster = np.concatenate([static, np.stack([low, wing, active_occ])], axis=0).astype(np.float32)
+    return np.stack([low, wing, active_occ]).astype(np.float32)
+
+
+def reassemble_raster(static: np.ndarray, dynamic: np.ndarray) -> np.ndarray:
+    """Re-prepend a cached static block onto a (uint8) dynamic block → the full
+    (RASTER_CHANNELS, H, W) float32 raster, **bit-for-bit equal to** :func:`encode`'s raster.
+    The dynamic block is binary (0/1), so the uint8→float32 widening is lossless — only the
+    transport encoding changed, never a value. This is the byte-identity seam of #752."""
+    return np.concatenate([static, dynamic.astype(np.float32)], axis=0).astype(np.float32)
+
+
+def _encode_common(
+    obs: Observation, bodies: Mapping[str, Aircraft | GroundObject], config: EncoderConfig
+) -> tuple[np.ndarray, np.ndarray, int, np.ndarray, Mapping[str, float]]:
+    """The non-raster fields shared by :func:`encode` and :func:`encode_dynamic` — tokens,
+    token mask, active index, legal-action mask, and meta. Identical code path, so the two
+    encoders agree bit-for-bit on everything but the raster."""
     tokens, token_mask, active_index = _tokens(obs, bodies, config)
     legal = _legal_action_mask(obs)
     meta: dict[str, float] = {
@@ -363,12 +389,62 @@ def encode(
         "steps_this_object": float(obs.steps_this_object),
         "steps_total": float(obs.steps_total),
     }
+    return tokens, token_mask, active_index, legal, MappingProxyType(meta)
+
+
+def encode(
+    obs: Observation,
+    hangar: Hangar,
+    bodies: Mapping[str, Aircraft | GroundObject],
+    config: EncoderConfig = _DEFAULT_CONFIG,
+) -> ObservationTensors:
+    """Tensorize a semantic Observation. Pure + deterministic (no RNG).
+
+    ``bodies`` is fleet ∪ ground_objects (Observation.parked carries only
+    id+Placement, so the encoder looks each body up for its polygons and features).
+    ``meta`` is a read-only mapping of floats for debugging / un-normalization.
+
+    The (RASTER_CHANNELS, H, W) float32 raster is the full static∥dynamic concatenation;
+    this is the reference all non-vectorized callers use. The vectorized rollout instead
+    pairs :func:`encode_dynamic` + :func:`reassemble_raster`, which reproduce this raster
+    bit-for-bit (#752)."""
+    raster = np.concatenate(
+        [static_block(hangar, config), _dynamic_channels(obs, bodies, config)], axis=0
+    ).astype(np.float32)
+    tokens, token_mask, active_index, legal, meta = _encode_common(obs, bodies, config)
     return ObservationTensors(
         raster=raster,
         tokens=tokens,
         token_mask=token_mask,
         active_index=active_index,
         legal_action_mask=legal,
-        meta=MappingProxyType(meta),
+        meta=meta,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+def encode_dynamic(
+    obs: Observation,
+    hangar: Hangar,  # noqa: ARG001 — kept for signature parity with encode(); static is skipped
+    bodies: Mapping[str, Aircraft | GroundObject],
+    config: EncoderConfig = _DEFAULT_CONFIG,
+) -> ObservationTensors:
+    """Like :func:`encode` but the raster is ONLY the DYNAMIC_CHANNELS, as **uint8** 0/1.
+
+    The static block (oob/bay/apron/door) depends only on (hangar, config), so the
+    vectorized worker skips it entirely — neither encoding its 3 ``shapely.contains_xy``
+    channels nor shipping them — and the parent re-prepends a cached :func:`static_block`
+    via :func:`reassemble_raster` (#752). All non-raster fields are bit-identical to
+    :func:`encode`. ``hangar`` is unused (the static block is the caller's job) but kept in
+    the signature so the worker can swap ``encode``↔``encode_dynamic`` with one call shape."""
+    dynamic = _dynamic_channels(obs, bodies, config).astype(np.uint8)
+    tokens, token_mask, active_index, legal, meta = _encode_common(obs, bodies, config)
+    return ObservationTensors(
+        raster=dynamic,
+        tokens=tokens,
+        token_mask=token_mask,
+        active_index=active_index,
+        legal_action_mask=legal,
+        meta=meta,
         schema_version=SCHEMA_VERSION,
     )

--- a/ml/encoding.py
+++ b/ml/encoding.py
@@ -368,7 +368,21 @@ def reassemble_raster(static: np.ndarray, dynamic: np.ndarray) -> np.ndarray:
     """Re-prepend a cached static block onto a (uint8) dynamic block → the full
     (RASTER_CHANNELS, H, W) float32 raster, **bit-for-bit equal to** :func:`encode`'s raster.
     The dynamic block is binary (0/1), so the uint8→float32 widening is lossless — only the
-    transport encoding changed, never a value. This is the byte-identity seam of #752."""
+    transport encoding changed, never a value. This is the byte-identity seam of #752.
+
+    Validates the leading (channel) dim of both blocks: a wrong-sized static block would
+    otherwise concatenate to the wrong channel count and surface only as a cryptic Conv2d
+    in-channel mismatch deep in the policy forward — far from the cause."""
+    if static.shape[0] != STATIC_CHANNELS:
+        raise ValueError(
+            f"reassemble_raster: static block has {static.shape[0]} channels, expected "
+            f"STATIC_CHANNELS={STATIC_CHANNELS} (a static_block for a different config?)"
+        )
+    if dynamic.shape[0] != DYNAMIC_CHANNELS:
+        raise ValueError(
+            f"reassemble_raster: dynamic block has {dynamic.shape[0]} channels, expected "
+            f"DYNAMIC_CHANNELS={DYNAMIC_CHANNELS} (not an encode_dynamic raster?)"
+        )
     return np.concatenate([static, dynamic.astype(np.float32)], axis=0).astype(np.float32)
 
 

--- a/ml/policy.py
+++ b/ml/policy.py
@@ -14,7 +14,13 @@ from torch import Tensor, nn
 
 from ml import action_space
 from ml.action_space import MAGNITUDE_DIM
-from ml.encoding import ACTION_DIM, RASTER_CHANNELS, TOKEN_DIM, ObservationTensors
+from ml.encoding import (
+    ACTION_DIM,
+    RASTER_CHANNELS,
+    TOKEN_DIM,
+    ObservationTensors,
+    reassemble_raster,
+)
 from ml.types import Park, Primitive
 
 
@@ -39,11 +45,31 @@ class PolicyOutput:
         assert self.kind_gear_logits.shape[0] == self.value.shape[0]
 
 
-def to_batch(obs: Sequence[ObservationTensors]) -> dict[str, Tensor]:
+def to_batch(
+    obs: Sequence[ObservationTensors], *, static_block: np.ndarray | None = None
+) -> dict[str, Tensor]:
     """Stack a list of ObservationTensors into batched torch tensors. The only
-    torch seam on the input side (ml/encoding.py stays numpy)."""
+    torch seam on the input side (ml/encoding.py stays numpy).
+
+    #752: vectorized-rollout obs carry ONLY the DYNAMIC raster channels, as uint8 — the
+    worker drops the static block (oob/bay/apron/door) from the wire. The dtype is the
+    discriminator: when the rasters are uint8 we re-prepend the rung's cached ``static_block``
+    (shape ``(STATIC_CHANNELS, H, W)``) and widen to float32 via :func:`reassemble_raster`,
+    reproducing the full :func:`encode` raster bit-for-bit. Full float32 obs — every
+    non-vectorized caller — pass straight through, so ``static_block`` is required ONLY for
+    trimmed obs (and is harmlessly ignored otherwise)."""
+    if obs[0].raster.dtype == np.uint8:
+        if static_block is None:
+            raise ValueError(
+                "to_batch got uint8 (dynamic-only) rasters but no static_block to re-prepend "
+                "— the vectorized rollout must pass the rung's cached static block "
+                "(encoding.static_block / reassemble_raster, #752)."
+            )
+        raster = np.stack([reassemble_raster(static_block, o.raster) for o in obs])
+    else:
+        raster = np.stack([o.raster for o in obs])
     return {
-        "raster": torch.from_numpy(np.stack([o.raster for o in obs])),
+        "raster": torch.from_numpy(raster),
         "tokens": torch.from_numpy(np.stack([o.tokens for o in obs])),
         "token_mask": torch.from_numpy(np.stack([o.token_mask for o in obs])),
         "active_index": torch.tensor([o.active_index for o in obs], dtype=torch.long),

--- a/ml/policy.py
+++ b/ml/policy.py
@@ -58,7 +58,15 @@ def to_batch(
     reproducing the full :func:`encode` raster bit-for-bit. Full float32 obs — every
     non-vectorized caller — pass straight through, so ``static_block`` is required ONLY for
     trimmed obs (and is harmlessly ignored otherwise)."""
-    if obs[0].raster.dtype == np.uint8:
+    trimmed = obs[0].raster.dtype == np.uint8
+    if any((o.raster.dtype == np.uint8) != trimmed for o in obs):
+        raise ValueError(
+            "to_batch received a mix of full (float32) and trimmed (uint8) rasters; a batch "
+            "must be uniformly one or the other (the vec rollout is all-trimmed, every other "
+            "caller all-full). A mixed batch would reassemble a full obs into a wrong-shaped "
+            "raster."
+        )
+    if trimmed:
         if static_block is None:
             raise ValueError(
                 "to_batch got uint8 (dynamic-only) rasters but no static_block to re-prepend "

--- a/ml/ppo.py
+++ b/ml/ppo.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+import numpy as np
 import torch
 from torch import Tensor
 
@@ -424,6 +425,11 @@ class VecRolloutBuffer:
         self.reward: list[list[float]] = []
         self.done: list[list[bool]] = []
         self.last_value: list[float] = [0.0] * num_envs
+        # #752: the rung's cached static raster block (oob/bay/apron/door). The vec workers
+        # ship only the dynamic channels (uint8), so batch() re-prepends this to rehydrate
+        # the full 7ch float32 raster. collect_rollout_vec sets it; None means the obs are
+        # full (the non-vectorized path) and need no reassembly.
+        self.static_block: np.ndarray | None = None
 
     def add_step(
         self,
@@ -451,7 +457,7 @@ class VecRolloutBuffer:
 
     def batch(self) -> dict[str, Tensor]:
         flat_obs = [o for row in self.obs for o in row]
-        data = dict(to_batch(flat_obs))
+        data = dict(to_batch(flat_obs, static_block=self.static_block))
         data["kind_idx"] = torch.tensor([x for row in self.kind_idx for x in row], dtype=torch.long)
         data["mag_idx"] = torch.tensor([x for row in self.mag_idx for x in row], dtype=torch.long)
         data["old_logprob"] = torch.tensor(self._flat(self.logprob), dtype=torch.float32)

--- a/ml/train.py
+++ b/ml/train.py
@@ -18,6 +18,7 @@ from functools import partial
 from pathlib import Path
 from typing import Literal
 
+import numpy as np
 import torch
 from torch import Tensor
 
@@ -46,7 +47,7 @@ from ml.curriculum import (
     with_promotion_overrides,
     with_solo_box_rung,
 )
-from ml.encoding import EncoderConfig, encode
+from ml.encoding import EncoderConfig, encode, static_block
 from ml.env import HangarFitEnv
 from ml.export import export_onnx
 from ml.policy import HangarFitPolicy, to_batch
@@ -183,19 +184,29 @@ def collect_rollout_vec(
     policy: HangarFitPolicy,
     encoder: EncoderConfig,
     rollout_len: int,
+    *,
+    static_block: np.ndarray,
 ) -> tuple[VecRolloutBuffer, list[EpisodeStat]]:
     """Drive `vec_env` for `rollout_len` steps (rollout_len * num_envs transitions),
     batching the N observations through one policy forward per step. Returns the
-    (T, N) buffer + the per-completed-episode stats (with the per-env reward sum)."""
+    (T, N) buffer + the per-completed-episode stats (with the per-env reward sum).
+
+    `static_block` (#752) is the rung's cached (STATIC_CHANNELS, H, W) raster block
+    (`encoding.static_block(hangar, encoder)`). The vec workers ship only the dynamic
+    channels (uint8); this block is re-prepended in `to_batch` (and stored on the buffer for
+    the PPO minibatch reassembly) to rehydrate the full 7ch float32 raster byte-identically.
+    It is the SAME for every step of a rung (one hangar+config), so the caller computes it
+    once per rung."""
     n = vec_env.num_envs
     buf = VecRolloutBuffer(num_envs=n)
+    buf.static_block = static_block
     device = next(policy.parameters()).device
     obs = vec_env.reset()
     ep_reward = [0.0] * n
     ep_stats: list[EpisodeStat] = []
     with torch.no_grad():
         for _ in range(rollout_len):
-            out = policy(_to_device(to_batch(obs), device))
+            out = policy(_to_device(to_batch(obs, static_block=static_block), device))
             kind, mag = sample_action(out)
             logprob, _ = factored_logprob_entropy(out, kind, mag)
             actions = [(int(kind[i]), int(mag[i])) for i in range(n)]
@@ -225,7 +236,7 @@ def collect_rollout_vec(
                     ep_reward[i] = 0.0
             obs = step.obs
         # per-env bootstrap value for non-done tails
-        tail = policy(_to_device(to_batch(obs), device))
+        tail = policy(_to_device(to_batch(obs, static_block=static_block), device))
         buf.last_value = [float(tail.value[i]) for i in range(n)]
     return buf, ep_stats
 
@@ -511,6 +522,10 @@ def train_curriculum(
                 vec_cm = SubprocVectorEnv(worker_fns, start_method=vec_start_method)
             else:
                 vec_cm = SyncVectorEnv([fn() for fn in worker_fns])
+            # #752: the static raster block (oob/bay/apron/door) depends only on this rung's
+            # (hangar, config), so compute it ONCE here; the vec workers ship only the dynamic
+            # channels (uint8) and collect_rollout_vec re-prepends this block in to_batch.
+            rung_static_block = static_block(env.hangar, enc)
             with vec_cm as vec:
                 for it in range(ceiling):
                     it_cfg = replace(
@@ -523,7 +538,9 @@ def train_curriculum(
                             anneal_iters=cfg.entropy_anneal_iters,
                         ),
                     )
-                    buf_vec, ep_stats = collect_rollout_vec(vec, policy, enc, rollout_len)
+                    buf_vec, ep_stats = collect_rollout_vec(
+                        vec, policy, enc, rollout_len, static_block=rung_static_block
+                    )
                     ppo_update(policy, optimizer, buf_vec, it_cfg, normalizer=normalizer)
                     history.record(stage.name, it, ep_stats)
                     if log:

--- a/ml/vector_env.py
+++ b/ml/vector_env.py
@@ -21,7 +21,7 @@ from typing import Any, NamedTuple, cast
 from hangarfit.geometry import pose_cache_scope
 from ml.action_space import decode
 from ml.curriculum import EpisodeStart, EpisodeStat
-from ml.encoding import EncoderConfig, ObservationTensors, encode
+from ml.encoding import EncoderConfig, ObservationTensors, encode_dynamic
 from ml.env import HangarFitEnv
 from ml.types import Observation, StepInfo
 
@@ -56,7 +56,12 @@ class _EnvWorker:
         return pose_cache_scope() if self._pose_cache else contextlib.nullcontext()
 
     def _encode(self, obs: Observation) -> ObservationTensors:
-        return encode(obs, self._env.hangar, self._bodies, self._enc)
+        # #752: ship only the DYNAMIC raster channels (uint8); the parent re-prepends a
+        # cached static block (encoding.static_block) and rehydrates to float32 in to_batch.
+        # Both Sync and Subproc workers emit this identical trimmed form, so Sync still
+        # equals Subproc byte-for-byte; the static channels are neither re-encoded nor
+        # re-shipped every step.
+        return encode_dynamic(obs, self._env.hangar, self._bodies, self._enc)
 
     def reset(self) -> ObservationTensors:
         with self._scope():

--- a/tests/ml/test_encoding.py
+++ b/tests/ml/test_encoding.py
@@ -455,3 +455,19 @@ def test_reassemble_raster_equals_full_encode_bitwise():
     assert reassembled.shape == (RASTER_CHANNELS, 192, 96) and reassembled.dtype == np.float32
     assert np.array_equal(reassembled, full)
     assert reassembled.tobytes() == full.tobytes()
+
+
+def test_reassemble_raster_rejects_wrong_channel_counts():
+    """A wrong-sized static or dynamic block must fail loudly in reassemble_raster, not
+    silently concat to the wrong channel count and surface as a cryptic conv error far
+    downstream (silent-failure review of #752)."""
+    from ml.encoding import DYNAMIC_CHANNELS, STATIC_CHANNELS, reassemble_raster
+
+    good_static = np.zeros((STATIC_CHANNELS, 8, 8), np.float32)
+    good_dyn = np.zeros((DYNAMIC_CHANNELS, 8, 8), np.uint8)
+    # sanity: the well-formed pair reassembles
+    assert reassemble_raster(good_static, good_dyn).shape[0] == STATIC_CHANNELS + DYNAMIC_CHANNELS
+    with pytest.raises(ValueError, match="static"):
+        reassemble_raster(np.zeros((STATIC_CHANNELS + 1, 8, 8), np.float32), good_dyn)
+    with pytest.raises(ValueError, match="dynamic"):
+        reassemble_raster(good_static, np.zeros((DYNAMIC_CHANNELS + 1, 8, 8), np.uint8))

--- a/tests/ml/test_encoding.py
+++ b/tests/ml/test_encoding.py
@@ -382,3 +382,76 @@ def test_tokens_ground_object_type_and_flags():
     assert tokens[0, 17] == 0.0 and tokens[1, 17] == 1.0
     # wing (8..10) and movement (11..13) one-hots are all-zero for ground objects
     assert tokens[0, 8:14].sum() == 0.0 and tokens[1, 8:14].sum() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# #752: static/dynamic raster split + uint8 dynamic block, for the IPC trim.
+# The full encode() stays the 7-channel float32 reference (above); the worker
+# path ships only the 3 dynamic channels as uint8 and the parent re-prepends a
+# cached static block. The contract: reassemble(static_block, encode_dynamic) is
+# bit-for-bit equal to encode(). (Local imports keep these RED scoped to the new
+# symbols until they exist.)
+# ---------------------------------------------------------------------------
+
+
+def test_static_block_equals_full_static_channels_bitwise():
+    """static_block(hangar, config) is the (4,H,W) float32 block encode() prepends —
+    bit-for-bit equal to the first STATIC_CHANNELS channels of the full raster."""
+    from ml.encoding import STATIC_CHANNELS, static_block
+
+    c = EncoderConfig()
+    fleet = _fuji()
+    h = empty_hangar()
+    sb = static_block(h, c)
+    assert sb.shape == (STATIC_CHANNELS, 192, 96) and sb.dtype == np.float32
+    full = encode(_two_body_obs(fleet), h, fleet, c).raster
+    assert np.array_equal(sb, full[:STATIC_CHANNELS])
+
+
+def test_encode_dynamic_raster_is_binary_uint8():
+    """encode_dynamic ships ONLY the dynamic channels (low/wing/active) as uint8 0/1 —
+    4x smaller on the wire, and provably binary so float32(0/1)->uint8 is lossless."""
+    from ml.encoding import DYNAMIC_CHANNELS, encode_dynamic
+
+    c = EncoderConfig()
+    fleet = _fuji()
+    h = empty_hangar()
+    dyn = encode_dynamic(_two_body_obs(fleet), h, fleet, c).raster
+    assert dyn.shape == (DYNAMIC_CHANNELS, 192, 96) and dyn.dtype == np.uint8
+    assert set(np.unique(dyn)).issubset({0, 1})
+
+
+def test_encode_dynamic_nonraster_fields_match_full_encode():
+    """encode_dynamic differs from encode ONLY in the raster; tokens/mask/active_index/
+    legal/meta are produced by the same code, so they are bit-identical."""
+    from ml.encoding import encode_dynamic
+
+    c = EncoderConfig()
+    fleet = _fuji()
+    h = empty_hangar()
+    obs = _two_body_obs(fleet)
+    full = encode(obs, h, fleet, c)
+    dyn = encode_dynamic(obs, h, fleet, c)
+    assert np.array_equal(dyn.tokens, full.tokens)
+    assert np.array_equal(dyn.token_mask, full.token_mask)
+    assert np.array_equal(dyn.legal_action_mask, full.legal_action_mask)
+    assert dyn.active_index == full.active_index
+    assert dyn.meta == full.meta
+    assert dyn.schema_version == full.schema_version
+
+
+def test_reassemble_raster_equals_full_encode_bitwise():
+    """The byte-identity heart of #752: re-prepending the cached static_block onto the
+    uint8 dynamic block reproduces encode()'s (7,H,W) float32 raster bit-for-bit."""
+    from ml.encoding import RASTER_CHANNELS, encode_dynamic, reassemble_raster, static_block
+
+    c = EncoderConfig()
+    fleet = _fuji()
+    h = empty_hangar()
+    obs = _two_body_obs(fleet)
+    full = encode(obs, h, fleet, c).raster
+    dyn = encode_dynamic(obs, h, fleet, c).raster
+    reassembled = reassemble_raster(static_block(h, c), dyn)
+    assert reassembled.shape == (RASTER_CHANNELS, 192, 96) and reassembled.dtype == np.float32
+    assert np.array_equal(reassembled, full)
+    assert reassembled.tobytes() == full.tobytes()

--- a/tests/ml/test_policy.py
+++ b/tests/ml/test_policy.py
@@ -143,3 +143,69 @@ def test_act_on_terminal_observation_raises():
     assert obs_t.active_index < 0  # precondition: this really is a terminal obs
     with pytest.raises(ValueError, match="terminal"):
         m.act(obs_t, turn_radius_m=8.0)
+
+
+# ---------------------------------------------------------------------------
+# #752: to_batch discriminator — a trimmed (uint8/3ch) worker obs is rehydrated
+# with a cached static block; a full (float32/7ch) obs passes straight through.
+# ---------------------------------------------------------------------------
+
+
+def _obs_full_and_dynamic():
+    """The SAME observation, encoded both ways: encode (full 7ch f32) + encode_dynamic
+    (3ch uint8). Returns (full, dynamic, hangar, config)."""
+    from ml.encoding import encode_dynamic
+
+    fleet = _fuji()
+    pl = Placement(plane_id="fuji", x_m=11.0, y_m=12.0, heading_deg=0.0, on_carts=False)
+    active = ActiveObject(
+        object_id="aviat_husky",
+        body=fleet["aviat_husky"],
+        pose=Pose(x_m=11.0, y_m=-4.0, heading_deg=0.0),
+        on_carts=False,
+    )
+    obs = Observation(
+        active=active,
+        parked=(ParkedObject(object_id="fuji", placement=pl),),
+        unplaced_ids=("cessna_150",),
+        steps_this_object=0,
+        steps_total=0,
+    )
+    h, c = empty_hangar(), EncoderConfig()
+    return encode(obs, h, fleet, c), encode_dynamic(obs, h, fleet, c), h, c
+
+
+def test_to_batch_reassembles_trimmed_with_static_block():
+    """A trimmed (3ch uint8) worker obs + the cached static block rehydrates to the SAME
+    batched raster as the full (7ch f32) obs — bit-for-bit (the #752 byte-identity seam)."""
+    from ml.encoding import static_block
+
+    full, dyn, h, c = _obs_full_and_dynamic()
+    sb = static_block(h, c)
+    full_batch = to_batch([full, full])
+    trimmed_batch = to_batch([dyn, dyn], static_block=sb)
+    assert trimmed_batch["raster"].shape == (2, 7, 192, 96)
+    assert trimmed_batch["raster"].dtype == torch.float32
+    assert torch.equal(trimmed_batch["raster"], full_batch["raster"])
+    # the discriminator only touches the raster; the rest is unchanged
+    assert torch.equal(trimmed_batch["tokens"], full_batch["tokens"])
+    assert torch.equal(trimmed_batch["legal_action_mask"], full_batch["legal_action_mask"])
+    assert torch.equal(trimmed_batch["active_index"], full_batch["active_index"])
+
+
+def test_to_batch_trimmed_without_static_block_raises():
+    """A trimmed obs with no static block is a programming error, not a silent wrong path:
+    to_batch must raise rather than hand the policy a 3-channel raster."""
+    _full, dyn, _h, _c = _obs_full_and_dynamic()
+    with pytest.raises((ValueError, RuntimeError)):
+        to_batch([dyn])  # uint8/3ch but no static_block supplied
+
+
+def test_to_batch_full_obs_ignores_static_block():
+    """The discriminator keys on the uint8 dtype, so a full float32 obs passes straight
+    through even if a static_block is supplied — full obs never need reassembly."""
+    from ml.encoding import static_block
+
+    full, _dyn, h, c = _obs_full_and_dynamic()
+    sb = static_block(h, c)
+    assert torch.equal(to_batch([full], static_block=sb)["raster"], to_batch([full])["raster"])

--- a/tests/ml/test_policy.py
+++ b/tests/ml/test_policy.py
@@ -209,3 +209,15 @@ def test_to_batch_full_obs_ignores_static_block():
     full, _dyn, h, c = _obs_full_and_dynamic()
     sb = static_block(h, c)
     assert torch.equal(to_batch([full], static_block=sb)["raster"], to_batch([full])["raster"])
+
+
+def test_to_batch_rejects_mixed_full_and_trimmed_rasters():
+    """A batch mixing full (float32/7ch) and trimmed (uint8/3ch) obs is a wiring error;
+    to_batch must reject it rather than reassemble a full obs into a wrong-shaped raster
+    (silent-failure + ml-rl-guard review of #752)."""
+    from ml.encoding import static_block
+
+    full, dyn, h, c = _obs_full_and_dynamic()
+    sb = static_block(h, c)
+    with pytest.raises(ValueError, match="mix"):
+        to_batch([dyn, full], static_block=sb)  # obs[0] trimmed, obs[1] full

--- a/tests/ml/test_ppo.py
+++ b/tests/ml/test_ppo.py
@@ -721,3 +721,54 @@ def test_ppo_update_target_kl_early_stops_epochs():
 
     assert epochs_run(None) == 4  # no early stop -> all epochs run
     assert epochs_run(0.0) == 1  # any positive KL after epoch 1 trips the stop
+
+
+# ---------------------------------------------------------------------------
+# #752: VecRolloutBuffer holds TRIMMED (uint8/3ch) worker obs; batch() rehydrates
+# them to the full 7ch float32 batch using a cached static_block.
+# ---------------------------------------------------------------------------
+
+
+def test_vec_buffer_batch_reassembles_trimmed_obs_with_static_block():
+    """A buffer of trimmed worker obs + its cached static_block rehydrates in batch() to the
+    full 7ch float32 raster, bit-matching encode() of the same observation (#752)."""
+    from ml.encoding import EncoderConfig, encode, static_block
+    from ml.ppo import VecRolloutBuffer
+    from ml.train import build_trivial_env
+    from ml.vector_env import _EnvWorker
+
+    enc = EncoderConfig()
+    env = build_trivial_env()
+    dyn = _EnvWorker(env, enc, None).reset()  # trimmed (uint8/3ch)
+    obs = env._observe()
+    buf = VecRolloutBuffer(num_envs=1)
+    buf.static_block = static_block(env.hangar, enc)
+    buf.add_step([dyn], [1], [0], [0.0], [0.0], [1.0], [False])
+    buf.last_value = [0.0]
+    data = buf.batch()
+    assert data["raster"].shape == (1, 7, 192, 96) and data["raster"].dtype == torch.float32
+    full = encode(obs, env.hangar, {**env.fleet, **env.ground_objects}, enc)
+    assert torch.equal(data["raster"][0], torch.from_numpy(full.raster))
+
+
+def test_vec_buffer_batch_raises_for_trimmed_obs_without_static_block():
+    """Trimmed obs with no cached static block is a wiring error, not a silent wrong path:
+    batch() must surface the to_batch failure rather than feed a 3-channel raster."""
+    from ml.encoding import EncoderConfig
+    from ml.ppo import VecRolloutBuffer
+    from ml.train import build_trivial_env
+    from ml.vector_env import _EnvWorker
+
+    buf = VecRolloutBuffer(num_envs=1)
+    buf.add_step(
+        [_EnvWorker(build_trivial_env(), EncoderConfig(), None).reset()],
+        [1],
+        [0],
+        [0.0],
+        [0.0],
+        [1.0],
+        [False],
+    )
+    buf.last_value = [0.0]
+    with pytest.raises((ValueError, RuntimeError)):
+        buf.batch()

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -388,7 +388,7 @@ def test_train_curriculum_weights_default_neutral():
 def test_collect_rollout_vec_fills_buffer_and_stats():
     import torch
 
-    from ml.encoding import EncoderConfig
+    from ml.encoding import EncoderConfig, static_block
     from ml.policy import HangarFitPolicy
     from ml.train import build_trivial_env, collect_rollout_vec
     from ml.vector_env import SyncVectorEnv, _EnvWorker
@@ -397,7 +397,9 @@ def test_collect_rollout_vec_fills_buffer_and_stats():
     enc = EncoderConfig()
     vec = SyncVectorEnv([_EnvWorker(build_trivial_env(), enc, None) for _ in range(2)])
     policy = HangarFitPolicy()
-    buf, stats = collect_rollout_vec(vec, policy, enc, rollout_len=8)
+    # #752: the rung's cached static block is re-prepended to the trimmed worker obs.
+    sb = static_block(build_trivial_env().hangar, enc)
+    buf, stats = collect_rollout_vec(vec, policy, enc, rollout_len=8, static_block=sb)
     vec.close()
     assert len(buf) == 8 and buf.num_envs == 2
     assert len(buf.last_value) == 2

--- a/tests/ml/test_vector_env.py
+++ b/tests/ml/test_vector_env.py
@@ -501,3 +501,36 @@ def test_subproc_faster_than_sync_on_multiobject_stage():
     print(f"\n  sync={sync_s:.3f}s  subproc={sub_s:.3f}s  ratio={ratio:.2f}x")
     # subproc has spawn overhead; require it to be no worse than 2.5x sync (loose smoke).
     assert sub_s < sync_s * 2.5, f"subproc {sub_s:.2f}s vs sync {sync_s:.2f}s (ratio {ratio:.2f}x)"
+
+
+# ---------------------------------------------------------------------------
+# #752: the worker ships only the DYNAMIC raster channels (uint8); the parent
+# re-prepends a cached static block. Both backends emit the identical trimmed
+# form (so Sync still equals Subproc), and trimmed + static == full encode().
+# ---------------------------------------------------------------------------
+
+
+def test_envworker_encodes_trimmed_dynamic_uint8_raster():
+    """The worker raster is the 3 dynamic channels as uint8 — 4x smaller on the wire and
+    free of the redundant-every-step static channels (#752)."""
+    from ml.encoding import DYNAMIC_CHANNELS
+
+    w = _EnvWorker(build_trivial_env(), EncoderConfig(), next_request=None)
+    obs = w.reset()
+    assert obs.raster.shape[0] == DYNAMIC_CHANNELS and obs.raster.dtype == np.uint8
+
+
+def test_envworker_trimmed_plus_static_reassembles_to_full_encode():
+    """Byte-identity: the worker's trimmed raster + the env's cached static block
+    reassembles to the full encode() raster bit-for-bit, so the policy input is unchanged."""
+    from ml.encoding import encode, reassemble_raster, static_block
+
+    enc = EncoderConfig()
+    env = build_trivial_env()
+    w = _EnvWorker(env, enc, next_request=None)
+    trimmed = w.reset()
+    obs = env._observe()  # post-reset state the worker just encoded
+    bodies = {**env.fleet, **env.ground_objects}
+    full = encode(obs, env.hangar, bodies, enc)
+    reassembled = reassemble_raster(static_block(env.hangar, enc), trimmed.raster)
+    assert np.array_equal(reassembled, full.raster)


### PR DESCRIPTION
Closes #752. Part of epic #607 Wave 2 (#759).

## What
Split the encoder raster into a **static block** (`oob`/`bay`/`apron`/`door` — depends only on `(hangar, config)`) and a **dynamic block** (parked-low / parked-wing / active). The vectorized workers now ship only the 3 dynamic channels as **uint8** (`encode_dynamic`); the parent re-prepends the rung's cached `static_block` in `to_batch` (`reassemble_raster`), rehydrating the full 7-channel float32 raster.

- ~57% smaller worker→parent IPC payload, **and** the 3 static `shapely.contains_xy` calls are computed once per rung instead of every worker step.
- The cached static block also travels on `VecRolloutBuffer` so the PPO minibatch reassembly works.

## Byte-identity (ADR-0003)
The dynamic block is binary, so `float32(0/1)→uint8→float32` is lossless and `reassemble_raster(static_block, encode_dynamic) == encode().raster` bit-for-bit (`test_reassemble_raster_equals_full_encode_bitwise`). `to_batch` keys on the **uint8 dtype**, so every non-vectorized caller (full float32 obs) passes straight through, and Sync still equals Subproc byte-for-byte. `static_block` is required only for trimmed obs — `to_batch` raises loudly otherwise (no silent wrong-path).

## Tests
- `test_encoding.py`: static/dynamic split, binary-uint8 dynamic, reassembly == encode bit-for-bit.
- `test_policy.py`: `to_batch` discriminator (trimmed+static == full; raises without static_block; full obs ignore static_block).
- `test_vector_env.py`: worker emits trimmed uint8; trimmed + static reassembles to full encode.
- `test_ppo.py`: `VecRolloutBuffer.batch()` reassembles with its cached static block; raises without it.
- Updated `collect_rollout_vec` + `bench/train_throughput.py` to thread the rung static block.

Dev/CI-only (`ml/`); no shipped-wheel surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)