### PR TITLE
test(735): @slow-gate heavy SAT-equivalence test + make the 200k claim auditable

### DIFF
--- a/docs/spikes/sat-geos-equivalence.md
+++ b/docs/spikes/sat-geos-equivalence.md
@@ -22,7 +22,7 @@
 
 Float numpy SAT reproduces the GEOS oriented-rectangle collision surface **to
 float-noise (~5e-15)** — small enough that it **never observably flips a verdict
-on random or realistic geometry** (0 flips across a 200 000-pair random corpus).
+on random or realistic geometry** (0 flips across the committed 20 000-pair random corpus; a 200 000-pair ad-hoc run, not committed, likewise showed 0).
 It is therefore safe to ship Lever B **as an opt-in** `--sat-collisions` backend
 for the box-curriculum rungs.
 
@@ -37,7 +37,7 @@ validity/determinism authority**:
    take this branch.
 2. **`clearance == 0.05` (`distance < clearance`) — the live box-rung branch —
    is GO on real geometry, with one documented caveat.** **0** verdict flips on
-   the 20 000- *and* 200 000-pair random corpora. A flip is only producible by a
+   the committed 20 000-pair random corpus (a 200 000-pair ad-hoc run, not committed, likewise showed 0). A flip is only producible by a
    **surgically constructed** pair whose *true* separation lands within ~5e-16 m
    of exactly `0.05 m` (3 633 flips / 105 000 such adversarial pairs). The flip
    band is ~1 part in 1e14 of the clearance — random/real geometry never hits
@@ -132,7 +132,7 @@ world direction and sweeps the gap through `nextafter`-scale neighbours of
 | (a) overlap-verdict mismatch, **clearance 0.05** | **0** |
 | (b) max abs distance delta | `3.55e-15 m` |
 | (b) max distance ULP delta (separated pairs, d > 1e-9) | `2241` (≈ `5e-19` relative) |
-| (b) **clearance-0.05 boundary flips (random corpus)** | **0** (also 0 at 200 000 pairs) |
+| (b) **clearance-0.05 boundary flips (random corpus)** | **0** on the committed 20 000-pair corpus (a 200 000-pair ad-hoc run also showed 0) |
 | (c) overlapping pairs measured | 7 279 |
 | (c) max abs area delta | `5.33e-15 m²` |
 | (c) max relative area delta | `3.14e-10` |
@@ -153,7 +153,7 @@ bit-identity on the `clearance == 0` branch**, but **the box rungs run at
 
 The live box-rung branch. Distance agrees to **float noise** (`≤ 3.55e-15 m`
 absolute; ≤ 2241 ULP on genuinely separated pairs). On the random corpus —
-even at 200 000 pairs — there are **zero** `< 0.05` verdict flips.
+even on a 200 000-pair ad-hoc run (the committed corpus is 20 000) — there are **zero** `< 0.05` verdict flips.
 
 The honest caveat: the surgical probe **proves a flip is possible**. When the
 true separation is constructed to within a ULP of exactly `0.05 m`, GEOS rounds

--- a/tests/spikes/test_sat_geos_equivalence.py
+++ b/tests/spikes/test_sat_geos_equivalence.py
@@ -52,6 +52,7 @@ import math
 from dataclasses import dataclass
 
 import numpy as np
+import pytest
 from shapely.geometry import Polygon
 
 from hangarfit.geometry import (
@@ -556,7 +557,16 @@ def _corpus_stats(n: int = 6000) -> EquivStats:
     return measure_equivalence(pairs)
 
 
-def test_clearance_zero_mismatches_are_only_the_exact_touch_boundary() -> None:
+@pytest.fixture(scope="module")
+def corpus_stats() -> EquivStats:
+    """The 6000-pair equivalence stats, computed ONCE per module — the four
+    clearance/distance/area tests below share it instead of rebuilding it 4x."""
+    return _corpus_stats()
+
+
+def test_clearance_zero_mismatches_are_only_the_exact_touch_boundary(
+    corpus_stats: EquivStats,
+) -> None:
     """The c=0 ``intersects and not touches`` verdict diverges ONLY at exact touch.
 
     This is the documented NO-GO-for-c=0 finding (see the write-up): float SAT
@@ -568,7 +578,7 @@ def test_clearance_zero_mismatches_are_only_the_exact_touch_boundary() -> None:
     Note this branch is NOT what the box rungs use — they run at clearance 0.05
     (``test_clearance_005_verdict_matches_geos``), which is bit-safe.
     """
-    stats = _corpus_stats()
+    stats = corpus_stats
     # There ARE mismatches here — that is the finding, not a failure.
     assert stats.max_c0_mismatch_distance <= _C0_TOUCH_BOUNDARY_FLOOR_M, (
         f"a c=0 verdict mismatch occurred at distance "
@@ -578,14 +588,14 @@ def test_clearance_zero_mismatches_are_only_the_exact_touch_boundary() -> None:
     )
 
 
-def test_clearance_005_verdict_matches_geos() -> None:
+def test_clearance_005_verdict_matches_geos(corpus_stats: EquivStats) -> None:
     """SAT (distance < 0.05) == GEOS polygon_overlap at clearance 0.05 — no flips.
 
     This is the load-bearing assertion for Lever B: the box rungs evaluate
     ``distance < clearance`` at clearance 0.05, so any boundary flip here is a
     hard NO-GO for the whole lever.
     """
-    stats = _corpus_stats()
+    stats = corpus_stats
     assert stats.boundary_flips_c005 == 0, (
         f"{stats.boundary_flips_c005}/{stats.n_pairs} pairs FLIPPED the "
         f"`distance < {CLEARANCE_M}` clearance boundary vs GEOS. "
@@ -597,18 +607,18 @@ def test_clearance_005_verdict_matches_geos() -> None:
     )
 
 
-def test_min_separation_distance_matches_geos() -> None:
+def test_min_separation_distance_matches_geos(corpus_stats: EquivStats) -> None:
     """SAT/GJK closest distance == shapely ``Polygon.distance`` within float noise."""
-    stats = _corpus_stats()
+    stats = corpus_stats
     assert stats.max_abs_dist_delta <= _MAX_DIST_DELTA, (
         f"max abs distance delta {stats.max_abs_dist_delta:.3e} exceeded "
         f"{_MAX_DIST_DELTA:.3e}; worst pair {stats.worst_dist_example}"
     )
 
 
-def test_intersection_area_matches_geos() -> None:
+def test_intersection_area_matches_geos(corpus_stats: EquivStats) -> None:
     """Sutherland–Hodgman clip area == GEOS ``intersection().area`` within noise."""
-    stats = _corpus_stats()
+    stats = corpus_stats
     assert stats.n_overlapping > 0, "corpus produced no overlapping pairs — bug"
     assert stats.max_abs_area_delta <= _MAX_AREA_DELTA, (
         f"max abs area delta {stats.max_abs_area_delta:.3e} exceeded "
@@ -693,6 +703,7 @@ def _surgical_boundary_flip_census(n_per_heading: int = 1500) -> tuple[int, int,
     return checked, flips, max_delta
 
 
+@pytest.mark.slow
 def test_surgical_clearance_boundary_flips_are_ulp_scale_only() -> None:
     """DOCUMENTED finding: SAT vs GEOS CAN flip ``< 0.05`` at the exact ULP boundary.
 
@@ -705,8 +716,9 @@ def test_surgical_clearance_boundary_flips_are_ulp_scale_only() -> None:
 
     It is acceptable for an *opt-in* Lever B ONLY because (1) the flip band is
     ~5e-16 m wide — a true separation must coincide with 0.05 m to ~1 part in
-    1e14, which random/real geometry never hits (the 200k-pair random corpus
-    shows zero flips), and (2) at that separation GEOS's own verdict is
+    1e14, which random/real geometry never hits (the committed 20k-pair random
+    corpus — and a 200k-pair ad-hoc run — show zero flips), and (2) at that
+    separation GEOS's own verdict is
     float-arbitrary. CPU shapely remains the determinism + validity authority
     regardless (#694), so Lever B is ``--sat-collisions`` opt-in, not a silent
     swap. This test PINS that the flip is confined to the ULP boundary and that


### PR DESCRIPTION
Part of #735 (Wave 3 epic #760). Post-merge follow-up to PR #772's review.

#772 merged before its review findings were addressed; this lands them on develop.

## Fixes (rev772 review of #772)
- **[MAJOR] auditable evidence:** the write-up + a test docstring cited a "200 000-pair random corpus, 0 flips" that the committed harness never generates (pytest runs 6000, standalone 20000). Reworded every occurrence to the **committed 20k corpus**, noting the 200k was an ad-hoc, uncommitted run. The conditional-GO verdict now rests only on auditable evidence (the kernels + the 20k census + the reproducible 105k surgical probe are unchanged).
- **[MINOR] CI-time regression:** the 105k-pair `test_surgical_…` ran in **every** default CI pytest (~21s). Marked `@pytest.mark.slow` (runs in the `-m slow` pass). The five kernel-equivalence tests stay non-slow (coverage preserved) but now share a `scope="module"` corpus fixture instead of rebuilding the 6000-pair corpus 5×. **Default-CI spike-suite cost: ~29s → ~2.5s.**

No kernel or verdict change. Verified: `pytest tests/spikes/ -m ""` → 6 passed; default `pytest tests/spikes/` → 5 passed, 1 deselected, 2.5s; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)