### PR TITLE
perf(754): Lever A — whole-leg swept-envelope AABB early-out (byte-identical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#754, epic #607 Wave 3 / #760): Lever A — whole-leg swept-envelope AABB
+  early-out for the rollout's swept-clearance oracle (byte-identical).** `swept_intrusion_m2`
+  (`ml/geometry_oracle.py`) sampled a tow leg at 0.05 m / 1° and ran the per-pose `_motion_clear`
+  + overlap measurement on every sample — and #733's pose cache mostly misses for the swept mover
+  (its pose changes each sample). Lever A proves a whole clear leg in ONE test: the result is 0.0
+  iff no sampled pose's mover parts overlap a parked obstacle part (walls/notch/bay only gate
+  `_motion_clear`, never contribute leak), and every pose's footprint lies within the body's
+  footprint radius `R` of that pose's `(x, y)` — `R` is heading-independent because the
+  determinant-−1 transform preserves Euclidean norm — so the bbox of the swept `(x, y)` inflated
+  by `R` is a conservative superset of every pose's footprint. If that envelope AABB is strictly
+  separated from every precomputed obstacle-part AABB, the leg short-circuits to 0.0 with **zero
+  per-pose Polygon builds**. **Byte-identical** (ADR-0003): a conservative lower-bound filter (the
+  same logic as the per-pose AABB prefilter + `collisions._aabbs_separated_beyond_clearance`) that
+  fires only when the full loop's result is exactly 0.0 — it can never mask a real intrusion,
+  verified by an 80-leg adversarial fuzz asserting equality to the exact unfiltered reference plus
+  a zero-per-pose-build proof. (Lever B — the opt-in `--sat-collisions` numpy-SAT box oracle — is a
+  follow-up.) Dev/CI-only (`ml/`); no shipped-wheel surface.
+
 - **Learned backend (#753, epic #607 Wave 2 / #759): episode-scoped pose cache — widen
   #733 from per-step to per-episode (byte-identical).** #733's `cached_parts_world` memo was
   opened in a fresh `pose_cache_scope()` per `_EnvWorker.step`/`reset`, so it was thrown away

--- a/ml/geometry_oracle.py
+++ b/ml/geometry_oracle.py
@@ -158,6 +158,40 @@ def _footprint_radius(body: Aircraft | GroundObject) -> float:
     return math.sqrt(r2)
 
 
+def _swept_envelope_clear(
+    body: Aircraft | GroundObject, swept: tuple[Pose, ...], obstacles: ObstaclesT
+) -> bool:
+    """Lever A (#754): True iff a conservative whole-leg envelope proves NO sampled pose can
+    overlap any obstacle part — i.e. :func:`swept_intrusion_m2` is provably 0.0, so it can
+    short-circuit the per-pose loop with zero Polygon builds.
+
+    The envelope is the bbox of the swept ``(x, y)`` inflated by the body's footprint radius R
+    (:func:`_footprint_radius`, heading-independent) — a conservative SUPERSET of every sampled
+    pose's footprint. A strict (gap > 0) AABB separation from EVERY precomputed obstacle-part
+    AABB therefore means no pose footprint can overlap any obstacle part. Same conservative
+    lower-bound logic as the per-pose AABB prefilter (and
+    ``collisions._aabbs_separated_beyond_clearance``), hoisted to the whole leg: it returns True
+    only when the full loop's result is exactly 0.0, so it can never mask a real intrusion.
+    (``swept_intrusion_m2``'s leak only accumulates area against ``obstacles.world_parts``;
+    walls/notch/bay gate ``_motion_clear`` but never contribute leak.)"""
+    if not obstacles.world_parts:
+        return True  # no parked parts → the per-pose leak loop has nothing to overlap → 0.0
+    if not swept:
+        return True  # no sampled poses → the per-pose loop is empty → 0.0
+    r = _footprint_radius(body)
+    env_xmin = min(p.x_m for p in swept) - r
+    env_xmax = max(p.x_m for p in swept) + r
+    env_ymin = min(p.y_m for p in swept) - r
+    env_ymax = max(p.y_m for p in swept) + r
+    return all(
+        env_xmin - op_xmax > 0.0
+        or op_xmin - env_xmax > 0.0
+        or env_ymin - op_ymax > 0.0
+        or op_ymin - env_ymax > 0.0
+        for op_xmin, op_ymin, op_xmax, op_ymax in obstacles.world_part_aabbs
+    )
+
+
 def swept_intrusion_m2(
     body: Aircraft | GroundObject,
     swept: tuple[Pose, ...],
@@ -186,33 +220,11 @@ def swept_intrusion_m2(
     )
     hangar = parked_layout.hangar
 
-    # Lever A (#754): whole-leg swept-envelope early-out. The leak below only ever accumulates
-    # overlap AREA against parked obstacle parts (walls/notch/bay gate _motion_clear but never
-    # contribute leak), so the result is 0.0 iff no sampled pose's footprint overlaps any
-    # obstacle part. Every sampled pose's footprint lies within the body's footprint radius R
-    # of that pose's (x, y), so the bbox of the swept (x, y) inflated by R is a conservative
-    # SUPERSET of every pose's footprint. If that envelope AABB is strictly separated (gap > 0)
-    # from every precomputed obstacle-part AABB, no pose can overlap any part → the per-pose
-    # loop would return 0.0 → short-circuit with ZERO per-pose Polygon builds. This is a
-    # byte-identical conservative lower-bound filter (same logic as the per-pose AABB prefilter
-    # below and collisions._aabbs_separated_beyond_clearance), so it only ever fires when the
-    # full loop's result is exactly 0.0 — it can never mask a real intrusion.
-    if not obstacles.world_parts:
-        return 0.0  # no parked parts → no leak possible (the empty loop also returns 0.0)
-    if swept:
-        r = _footprint_radius(body)
-        env_xmin = min(p.x_m for p in swept) - r
-        env_xmax = max(p.x_m for p in swept) + r
-        env_ymin = min(p.y_m for p in swept) - r
-        env_ymax = max(p.y_m for p in swept) + r
-        if all(
-            env_xmin - op_xmax > 0.0
-            or op_xmin - env_xmax > 0.0
-            or env_ymin - op_ymax > 0.0
-            or op_ymin - env_ymax > 0.0
-            for op_xmin, op_ymin, op_xmax, op_ymax in obstacles.world_part_aabbs
-        ):
-            return 0.0
+    # Lever A (#754): a conservative whole-leg envelope short-circuits a clearly-clear leg to
+    # 0.0 with zero per-pose Polygon builds (see :func:`_swept_envelope_clear`) — a byte-
+    # identical lower-bound filter that fires only when the per-pose loop would also return 0.0.
+    if _swept_envelope_clear(body, swept, obstacles):
+        return 0.0
 
     worst = 0.0
     for pose in swept:

--- a/ml/geometry_oracle.py
+++ b/ml/geometry_oracle.py
@@ -8,6 +8,7 @@ or Hybrid-A* search. All functions are pure and RNG-free.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 from shapely.geometry import box
@@ -138,6 +139,25 @@ def build_obstacles(parked_layout: Layout, mover_id: str) -> ObstaclesT:
     return _build_obstacles(parked_layout, mover_id=mover_id)
 
 
+def _footprint_radius(body: Aircraft | GroundObject) -> float:
+    """Max distance from the placement origin to any of ``body``'s part vertices.
+
+    Heading-independent: the plane-local → world transform (:func:`local_to_world`) has
+    determinant −1 (a rotation composed with a reflection), which preserves Euclidean norm,
+    so a vertex at local ``(u, v)`` is always ``sqrt(u²+v²)`` from the pose's ``(x, y)`` at
+    ANY heading. So this radius bounds the body's footprint at every pose — the basis for
+    Lever A's conservative whole-leg envelope (#754). Built via ``cached_parts_world`` at the
+    identity placement (one build, memoized within a pose-cache scope)."""
+    parts = cached_parts_world(
+        body, Placement(plane_id=body.id, x_m=0.0, y_m=0.0, heading_deg=0.0, on_carts=False)
+    )
+    r2 = 0.0
+    for wp in parts:
+        for x, y in wp.polygon.exterior.coords:
+            r2 = max(r2, x * x + y * y)  # at identity placement the vertex IS its offset
+    return math.sqrt(r2)
+
+
 def swept_intrusion_m2(
     body: Aircraft | GroundObject,
     swept: tuple[Pose, ...],
@@ -165,6 +185,35 @@ def swept_intrusion_m2(
         obstacles if obstacles is not None else _build_obstacles(parked_layout, mover_id=active_id)
     )
     hangar = parked_layout.hangar
+
+    # Lever A (#754): whole-leg swept-envelope early-out. The leak below only ever accumulates
+    # overlap AREA against parked obstacle parts (walls/notch/bay gate _motion_clear but never
+    # contribute leak), so the result is 0.0 iff no sampled pose's footprint overlaps any
+    # obstacle part. Every sampled pose's footprint lies within the body's footprint radius R
+    # of that pose's (x, y), so the bbox of the swept (x, y) inflated by R is a conservative
+    # SUPERSET of every pose's footprint. If that envelope AABB is strictly separated (gap > 0)
+    # from every precomputed obstacle-part AABB, no pose can overlap any part → the per-pose
+    # loop would return 0.0 → short-circuit with ZERO per-pose Polygon builds. This is a
+    # byte-identical conservative lower-bound filter (same logic as the per-pose AABB prefilter
+    # below and collisions._aabbs_separated_beyond_clearance), so it only ever fires when the
+    # full loop's result is exactly 0.0 — it can never mask a real intrusion.
+    if not obstacles.world_parts:
+        return 0.0  # no parked parts → no leak possible (the empty loop also returns 0.0)
+    if swept:
+        r = _footprint_radius(body)
+        env_xmin = min(p.x_m for p in swept) - r
+        env_xmax = max(p.x_m for p in swept) + r
+        env_ymin = min(p.y_m for p in swept) - r
+        env_ymax = max(p.y_m for p in swept) + r
+        if all(
+            env_xmin - op_xmax > 0.0
+            or op_xmin - env_xmax > 0.0
+            or env_ymin - op_ymax > 0.0
+            or op_ymin - env_ymax > 0.0
+            for op_xmin, op_ymin, op_xmax, op_ymax in obstacles.world_part_aabbs
+        ):
+            return 0.0
+
     worst = 0.0
     for pose in swept:
         if _motion_clear(body, pose, obstacles, hangar):

--- a/tests/ml/test_swept_aabb_earlyout.py
+++ b/tests/ml/test_swept_aabb_earlyout.py
@@ -119,7 +119,7 @@ def test_fuzzed_legs_byte_identical_to_bruteforce():
     from ml.action_space import decode
 
     rng = random.Random(0xA1B2C3)
-    n_clear = n_intrude = 0
+    n_clear = n_intrude = n_fired = 0
     for _ in range(80):
         parked_y = rng.uniform(6.0, 24.0)
         active_x = rng.uniform(2.0, 13.0)
@@ -144,5 +144,19 @@ def test_fuzzed_legs_byte_identical_to_bruteforce():
             n_intrude += 1
         else:
             n_clear += 1
+            if go._swept_envelope_clear(active, swept, obstacles):
+                n_fired += 1  # the conservative early-out actually short-circuited this leg
     # non-vacuous: the corpus exercised BOTH the early-out (clear) and the full loop (intrude)
     assert n_clear > 0 and n_intrude > 0, f"vacuous corpus: clear={n_clear} intrude={n_intrude}"
+    # the early-out must do REAL work: a regression silently disabling it would still pass the
+    # byte-identity asserts above (the loop just runs), but n_fired would drop to 0.
+    assert n_fired > 0, "the swept-envelope early-out never fired on any clear leg"
+
+
+def test_swept_envelope_clear_predicate_fires_on_clear_not_intruding():
+    """Directly pin the early-out predicate both ways: True on a clearly-separated leg,
+    False when poses sit on the obstacle (so it cannot mask the intruding case)."""
+    _layout, active, _id, obstacles, swept = _clear_leg()
+    assert go._swept_envelope_clear(active, swept, obstacles) is True
+    _layout2, active2, _id2, obstacles2, swept2 = _intruding_leg()
+    assert go._swept_envelope_clear(active2, swept2, obstacles2) is False

--- a/tests/ml/test_swept_aabb_earlyout.py
+++ b/tests/ml/test_swept_aabb_earlyout.py
@@ -1,0 +1,148 @@
+"""#754 Lever A: whole-leg swept-envelope AABB early-out for ``swept_intrusion_m2``.
+
+``swept_intrusion_m2`` returns 0.0 iff NO sampled pose's mover parts overlap (positive
+area) any parked obstacle part (wall/notch/bay only gate ``_motion_clear``, they never
+contribute leak area). Lever A proves that for a whole leg in ONE conservative test —
+a footprint-radius-inflated bbox of the sampled poses, tested vs the precomputed obstacle
+AABBs — so a clearly-clear leg short-circuits to 0.0 with zero per-pose Polygon builds.
+
+The early-out is a conservative LOWER-BOUND filter (like the existing per-pose AABB
+prefilter), so it is byte-identical: it fires only when the per-pose loop would also
+return 0.0, and it must NEVER mask a real intrusion.
+"""
+
+from __future__ import annotations
+
+import hangarfit.geometry as geo
+from hangarfit.geometry import aircraft_parts_world, pose_cache_scope
+from hangarfit.models import Placement
+from hangarfit.towplanner import Pose, _motion_clear
+from ml import geometry_oracle as go
+from tests.ml.conftest import two_object_layout
+
+
+def _bruteforce_swept_intrusion(body, swept, *, active_id, obstacles, hangar) -> float:
+    """The exact unfiltered leak loop (no early-out, no prefilter) — the byte-identity
+    oracle Lever A must reproduce."""
+    worst = 0.0
+    for pose in swept:
+        if _motion_clear(body, pose, obstacles, hangar):
+            continue
+        pl = Placement(
+            plane_id=active_id,
+            x_m=pose.x_m,
+            y_m=pose.y_m,
+            heading_deg=pose.heading_deg,
+            on_carts=False,
+        )
+        leak = 0.0
+        for wp in aircraft_parts_world(body, pl):
+            for op in obstacles.world_parts:
+                if wp.polygon.intersects(op.polygon):
+                    leak += wp.polygon.intersection(op.polygon).area
+        worst = max(worst, leak)
+    return worst
+
+
+def _clear_leg():
+    """A straight leg in open space far from the single parked obstacle (no overlap)."""
+    layout, active, active_id = two_object_layout(parked_y_m=22.0, active_y_m=6.0)
+    obstacles = go.build_obstacles(layout, active_id)
+    swept = tuple(Pose(x_m=5.0, y_m=6.0 + d, heading_deg=0.0) for d in (0.0, 0.2, 0.4, 0.6, 0.8))
+    return layout, active, active_id, obstacles, swept
+
+
+def _intruding_leg():
+    """A leg whose poses sit on/around the parked obstacle (genuine overlap)."""
+    layout, active, active_id = two_object_layout(parked_y_m=15.0, active_y_m=8.0)
+    obstacles = go.build_obstacles(layout, active_id)
+    swept = tuple(Pose(x_m=5.0, y_m=15.0 + d, heading_deg=0.0) for d in (-0.4, 0.0, 0.4))
+    return layout, active, active_id, obstacles, swept
+
+
+def test_clear_leg_byte_identical_to_bruteforce_and_zero():
+    """A clearly-clear leg returns exactly 0.0 — identical to the unfiltered reference."""
+    layout, active, active_id, obstacles, swept = _clear_leg()
+    actual = go.swept_intrusion_m2(
+        active, swept, parked_layout=layout, active_id=active_id, obstacles=obstacles
+    )
+    expected = _bruteforce_swept_intrusion(
+        active, swept, active_id=active_id, obstacles=obstacles, hangar=layout.hangar
+    )
+    assert expected == 0.0  # sanity: the leg really is clear
+    assert actual == expected == 0.0
+
+
+def test_intruding_leg_byte_identical_to_bruteforce_nonzero():
+    """An intruding leg must NOT be masked by the early-out: the result equals the exact
+    unfiltered reference and is strictly positive (the conservative filter did not fire)."""
+    layout, active, active_id, obstacles, swept = _intruding_leg()
+    actual = go.swept_intrusion_m2(
+        active, swept, parked_layout=layout, active_id=active_id, obstacles=obstacles
+    )
+    expected = _bruteforce_swept_intrusion(
+        active, swept, active_id=active_id, obstacles=obstacles, hangar=layout.hangar
+    )
+    assert expected > 0.0  # sanity: the leg really intrudes
+    assert actual == expected
+
+
+def test_clear_leg_does_no_per_pose_builds(monkeypatch):
+    """Lever A: a clearly-clear leg short-circuits BEFORE the per-pose loop, so it builds the
+    mover's parts at most once (the heading-independent footprint radius), not ~once per pose
+    via the per-pose _motion_clear. Obstacles are pre-built so only mover builds are counted."""
+    layout, active, active_id, obstacles, swept = _clear_leg()
+    seen = {"n": 0}
+    orig = geo.aircraft_parts_world
+
+    def _counting(obj, placement):
+        if getattr(obj, "id", None) == active_id:
+            seen["n"] += 1
+        return orig(obj, placement)
+
+    monkeypatch.setattr(geo, "aircraft_parts_world", _counting)
+    with pose_cache_scope():
+        result = go.swept_intrusion_m2(
+            active, swept, parked_layout=layout, active_id=active_id, obstacles=obstacles
+        )
+    assert result == 0.0
+    assert seen["n"] <= 1, f"clear leg should skip the per-pose loop; built mover {seen['n']}x"
+
+
+def test_fuzzed_legs_byte_identical_to_bruteforce():
+    """Adversarial: across many random legs (varied start, heading, length — exercising R's
+    heading-independence) and parked positions spanning clear/near/overlapping, the Lever-A
+    result must equal the exact unfiltered reference on EVERY leg. A too-tight envelope that
+    masked an intrusion (returned 0.0 where the loop is >0) would fail here."""
+    import random
+
+    from ml.action_space import decode
+
+    rng = random.Random(0xA1B2C3)
+    n_clear = n_intrude = 0
+    for _ in range(80):
+        parked_y = rng.uniform(6.0, 24.0)
+        active_x = rng.uniform(2.0, 13.0)
+        active_y = rng.uniform(4.0, 26.0)
+        layout, active, active_id = two_object_layout(parked_y_m=parked_y, active_y_m=active_y)
+        obstacles = go.build_obstacles(layout, active_id)
+        tr = active.effective_turn_radius_m()
+        kind_idx = rng.randint(0, 5)  # L/S/R forward/back (own-gear arcs)
+        mag_idx = rng.randint(0, 4)
+        prim = decode(kind_idx, mag_idx, turn_radius_m=tr)
+        start = Pose(x_m=active_x, y_m=active_y, heading_deg=rng.uniform(0.0, 360.0))
+        _end, swept = go.apply_primitive(start, prim, turn_radius_m=tr)
+
+        actual = go.swept_intrusion_m2(
+            active, swept, parked_layout=layout, active_id=active_id, obstacles=obstacles
+        )
+        expected = _bruteforce_swept_intrusion(
+            active, swept, active_id=active_id, obstacles=obstacles, hangar=layout.hangar
+        )
+        assert actual == expected, f"diverged: {actual} != {expected} (parked_y={parked_y})"
+        if expected > 0.0:
+            n_intrude += 1
+        else:
+            n_clear += 1
+    # non-vacuous: the corpus exercised BOTH the early-out (clear) and the full loop (intrude)
+    assert n_clear > 0 and n_intrude > 0, f"vacuous corpus: clear={n_clear} intrude={n_intrude}"


### PR DESCRIPTION
Part of #754 (Wave 3 epic #760). **Lever A only** — Lever B (the opt-in `--sat-collisions` numpy-SAT box oracle) is a focused follow-up PR; #754 stays open until it lands.

## What
`swept_intrusion_m2` (`ml/geometry_oracle.py`) sampled each tow leg at 0.05 m / 1° and ran per-pose `_motion_clear` + overlap measurement on every sample — and #733's pose cache mostly *misses* for the swept mover (its pose changes each sample, the named blind spot). Lever A proves a whole clear leg in **one** test:

- `swept_intrusion_m2` returns 0.0 **iff** no sampled pose's mover parts overlap a parked obstacle part (walls/notch/bay only gate `_motion_clear`; they never contribute leak area).
- Every pose's footprint lies within the body's **footprint radius `R`** of that pose's `(x, y)`. `R` is **heading-independent** — the determinant-−1 transform is a rotation+reflection, which preserves Euclidean norm (`‖(u·sinh+v·cosh, u·cosh−v·sinh)‖² = u²+v²`). So the bbox of the swept `(x, y)` inflated by `R` is a conservative **superset** of every sampled pose's footprint, computed with zero per-pose part builds.
- If that envelope AABB is strictly separated (gap > 0) from every precomputed obstacle-part AABB → no pose can overlap → return 0.0, skipping the per-pose loop entirely.

## Byte-identity (ADR-0003)
A conservative lower-bound filter (same logic as the existing per-pose AABB prefilter + `collisions._aabbs_separated_beyond_clearance`): it fires only when the full loop's result is exactly 0.0, so it can **never mask a real intrusion**. Verified by:
- `test_fuzzed_legs_byte_identical_to_bruteforce` — 80 random legs (varied headings/positions, both clear & intruding) assert equality to the exact unfiltered reference.
- `test_clear_leg_does_no_per_pose_builds` — a clear leg builds the mover ≤1× (the footprint radius), not once per pose.
- plus explicit clear/intruding byte-identity cases.

ml-scoped reward-oracle change (byte-identical reward stream); 109 reward-path tests + ruff + mypy green. Dev/CI-only (`ml/`); no shipped-wheel surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)