### PR TITLE
perf(755): opt-in --pipeline-update — overlap CPU rollout with GPU PPO update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#755, epic #607 Wave 4 / #761): opt-in `--pipeline-update` — overlap the
+  CPU rollout with the GPU PPO update (one-iteration-stale pipeline).** In the vectorized
+  curriculum path, while `ppo_update` runs on the live policy the workers collect the NEXT rollout
+  under a frozen `deepcopy` snapshot of the **pre-update** policy (exactly one iteration stale),
+  recovering the GPU/worker idle time during the otherwise strictly-sequential rollout↔update
+  phases. The rollout runs on a single background thread; the live policy and the snapshot share no
+  mutable state (separate module objects; the env is touched only by the rollout thread, serialized
+  across iterations by `future.result()`). The next rollout is launched only when another iteration
+  will consume it (never on the stop/final iteration), so no speculative rollout is wasted and there
+  is nothing to drain. **Default off = byte-identical** sequential training (the existing loop is
+  left untouched in the `else` branch). **On is NON-deterministic by design** — the one-iteration
+  staleness AND the background rollout sharing the global torch RNG with the update's minibatch
+  shuffle (a safe, mutex-guarded race) perturb the learning curve — so it is re-gated on a two-seed
+  `ml.gate` valid_placed delta, NOT a byte-diff (that re-gate is a follow-up long-run). No effect
+  with `--schedule trivial` or `--n-envs 1`. Dev/CI-only (`ml/`); no shipped-wheel surface.
+
 - **Learned backend (#754, epic #607 Wave 3 / #760): Lever A — whole-leg swept-envelope AABB
   early-out for the rollout's swept-clearance oracle (byte-identical).** `swept_intrusion_m2`
   (`ml/geometry_oracle.py`) sampled a tow leg at 0.05 m / 1° and ran the per-pose `_motion_clear`

--- a/ml/train.py
+++ b/ml/train.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import copy
 import json
 import os
 import sys
 from collections.abc import Callable, Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import replace
 from functools import partial
 from pathlib import Path
@@ -332,6 +334,17 @@ def train(
     return history
 
 
+def _clone_policy(policy: HangarFitPolicy) -> HangarFitPolicy:
+    """A frozen deep copy of ``policy`` for the #755 ``--pipeline-update`` rollout.
+
+    The pipelined rollout reads the **pre-update** weights on a background thread
+    while ``ppo_update`` mutates the live policy in place on the main thread, so the
+    snapshot must be an independent module (params + buffers), not an aliasing view.
+    ``deepcopy`` clones onto the same device; the copy is used only for
+    ``torch.no_grad()`` forward passes in :func:`collect_rollout_vec`."""
+    return copy.deepcopy(policy)
+
+
 def _rung_stop_reason(
     promo_history: list[float],
     ep_stats: Sequence[EpisodeStat],
@@ -379,6 +392,7 @@ def train_curriculum(
     load: str | None = None,
     checkpoint_out: str | None = None,
     auto_budget: BudgetController | None = None,
+    pipeline_update: bool = False,
 ) -> CurriculumHistory:
     """Climb the ladder: one policy/optimizer across rungs (transfer); per rung, run
     PPO until the competency gate fires or the per-stage cap is hit, then advance.
@@ -527,8 +541,9 @@ def train_curriculum(
             # channels (uint8) and collect_rollout_vec re-prepends this block in to_batch.
             rung_static_block = static_block(env.hangar, enc)
             with vec_cm as vec:
-                for it in range(ceiling):
-                    it_cfg = replace(
+
+                def _it_cfg(it: int) -> PPOConfig:
+                    return replace(
                         cfg,
                         entropy_coef=entropy_coef_at(
                             it,
@@ -538,19 +553,83 @@ def train_curriculum(
                             anneal_iters=cfg.entropy_anneal_iters,
                         ),
                     )
-                    buf_vec, ep_stats = collect_rollout_vec(
-                        vec, policy, enc, rollout_len, static_block=rung_static_block
-                    )
-                    ppo_update(policy, optimizer, buf_vec, it_cfg, normalizer=normalizer)
-                    history.record(stage.name, it, ep_stats)
-                    if log:
-                        print(format_iter_log(stage.name, it, ep_stats), flush=True)
-                    reason = _rung_stop_reason(promo_history, ep_stats, pol, auto_budget)
-                    if reason is not None:
-                        history.note_promotion(stage.name, it, by=reason)
-                        break
+
+                if pipeline_update:
+                    # #755 (Wave 4, opt-in, NON-deterministic): overlap the next
+                    # rollout — collected under a frozen snapshot of the PRE-update
+                    # policy, exactly one iteration stale — with this iteration's
+                    # ppo_update. The rollout runs on a single background thread while
+                    # the live policy is updated on the main thread; they share no
+                    # mutable state (separate module objects; the env is touched only
+                    # by the rollout thread, serialized across iterations by
+                    # future.result()). The next rollout is launched ONLY when another
+                    # iteration will consume it (never on the stop / final iteration),
+                    # so no speculative rollout is ever wasted and there is nothing to
+                    # drain. Re-gated on a two-seed ml.gate valid_placed delta, NOT a
+                    # byte-diff (the staleness perturbs the learning curve).
+                    #
+                    # Non-determinism is two-fold and DELIBERATE: (1) the one-iteration
+                    # stale policy snapshot, and (2) the background rollout's action
+                    # sampling shares the GLOBAL torch RNG with the main thread's
+                    # ppo_update (minibatch shuffle), so the two threads' draws
+                    # interleave by timing. torch's generator is mutex-guarded, so this
+                    # is a SAFE race (no state corruption) — but the run is not
+                    # reproducible, which is exactly why this path is gated on a
+                    # learning-metric delta rather than byte-identity.
+                    executor = ThreadPoolExecutor(max_workers=1)
+                    pending: Future[tuple[VecRolloutBuffer, list[EpisodeStat]]] | None = None
+                    try:
+                        for it in range(ceiling):
+                            if pending is None:
+                                # Iteration 0 primes on-policy under the current weights.
+                                buf_vec, ep_stats = collect_rollout_vec(
+                                    vec, policy, enc, rollout_len, static_block=rung_static_block
+                                )
+                            else:
+                                buf_vec, ep_stats = pending.result()
+                                pending = None
+                            history.record(stage.name, it, ep_stats)
+                            reason = _rung_stop_reason(promo_history, ep_stats, pol, auto_budget)
+                            if reason is None and it < ceiling - 1:
+                                snapshot = _clone_policy(policy)
+                                pending = executor.submit(
+                                    collect_rollout_vec,
+                                    vec,
+                                    snapshot,
+                                    enc,
+                                    rollout_len,
+                                    static_block=rung_static_block,
+                                )
+                            ppo_update(
+                                policy, optimizer, buf_vec, _it_cfg(it), normalizer=normalizer
+                            )
+                            if log:
+                                print(format_iter_log(stage.name, it, ep_stats), flush=True)
+                            if reason is not None:
+                                history.note_promotion(stage.name, it, by=reason)
+                                break
+                        else:
+                            history.note_promotion(stage.name, ceiling - 1, by="cap")
+                    finally:
+                        # pending is always None here (never launched on the stop/last
+                        # iteration), so this just releases the worker thread.
+                        executor.shutdown(wait=True)
                 else:
-                    history.note_promotion(stage.name, ceiling - 1, by="cap")
+                    for it in range(ceiling):
+                        it_cfg = _it_cfg(it)
+                        buf_vec, ep_stats = collect_rollout_vec(
+                            vec, policy, enc, rollout_len, static_block=rung_static_block
+                        )
+                        ppo_update(policy, optimizer, buf_vec, it_cfg, normalizer=normalizer)
+                        history.record(stage.name, it, ep_stats)
+                        if log:
+                            print(format_iter_log(stage.name, it, ep_stats), flush=True)
+                        reason = _rung_stop_reason(promo_history, ep_stats, pol, auto_budget)
+                        if reason is not None:
+                            history.note_promotion(stage.name, it, by=reason)
+                            break
+                    else:
+                        history.note_promotion(stage.name, ceiling - 1, by="cap")
         if log:
             by = history.promotions[-1][2]
             print(f"[{stage.name}] promoted by {by}")
@@ -950,6 +1029,16 @@ def build_argparser() -> argparse.ArgumentParser:
         help="compute device: cpu (default — deterministic / byte-identical) or cuda "
         "(opt-in GPU fast path; ~5-6x on the PPO update, non-deterministic)",
     )
+    p.add_argument(
+        "--pipeline-update",
+        action="store_true",
+        help="(#755, opt-in, vectorized path only) overlap the next rollout — under a "
+        "frozen snapshot of the pre-update policy, one iteration stale — with this "
+        "iteration's ppo_update, recovering the GPU/worker idle during the non-overlapping "
+        "phases. Default off = byte-identical sequential training. On is NON-deterministic "
+        "(the staleness perturbs the learning curve) and must be re-gated on a two-seed "
+        "ml.gate valid_placed delta. No effect with --schedule trivial or --n-envs 1.",
+    )
     return p
 
 
@@ -1091,6 +1180,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             load=args.load,
             checkpoint_out=args.checkpoint_out,
             auto_budget=budget,
+            pipeline_update=args.pipeline_update,
         )
         if args.metrics_out is not None:
             records = history_metric_records(history)

--- a/ml/train.py
+++ b/ml/train.py
@@ -13,6 +13,7 @@ import copy
 import json
 import os
 import sys
+import traceback
 from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import replace
@@ -589,6 +590,12 @@ def train_curriculum(
                                 buf_vec, ep_stats = pending.result()
                                 pending = None
                             history.record(stage.name, it, ep_stats)
+                            # Evaluate the stop gate BEFORE launching the next rollout (and
+                            # before this update) so a stop suppresses the otherwise-wasted
+                            # speculative rollout. Equivalent to the sequential branch's
+                            # post-update gate: the decision reads only this rollout's
+                            # ep_stats + promo_history, never this iteration's ppo_update —
+                            # keep that true if _rung_stop_reason ever grows new inputs.
                             reason = _rung_stop_reason(promo_history, ep_stats, pol, auto_budget)
                             if reason is None and it < ceiling - 1:
                                 snapshot = _clone_policy(policy)
@@ -611,8 +618,21 @@ def train_curriculum(
                         else:
                             history.note_promotion(stage.name, ceiling - 1, by="cap")
                     finally:
-                        # pending is always None here (never launched on the stop/last
-                        # iteration), so this just releases the worker thread.
+                        # On NORMAL exit (break/cap) pending is None — the next rollout
+                        # is never launched on the stop/last iteration. On an EXCEPTIONAL
+                        # exit (e.g. ppo_update raised mid-iteration) pending may still be
+                        # in flight: drain it so a concurrent rollout failure surfaces on
+                        # stderr instead of being silently dropped by shutdown() (which
+                        # joins the thread but never retrieves the future's result). We
+                        # print rather than re-raise so the primary exception that
+                        # triggered this unwind still propagates. shutdown(wait=True) then
+                        # blocks until the rollout finishes stepping `vec`, so the env is
+                        # never torn down under an in-flight step.
+                        if pending is not None:
+                            try:
+                                pending.result()
+                            except Exception:
+                                traceback.print_exc(file=sys.stderr)
                         executor.shutdown(wait=True)
                 else:
                     for it in range(ceiling):

--- a/tests/ml/test_pipeline_update.py
+++ b/tests/ml/test_pipeline_update.py
@@ -1,0 +1,148 @@
+"""Wave 4 (#755): the opt-in one-iteration-stale ``--pipeline-update`` pipeline.
+
+While ``ppo_update`` runs on the live policy, the vectorized workers begin the
+NEXT rollout under a frozen snapshot of the **pre-update** policy — overlapping
+the CPU rollout with the (GPU) update. The flag defaults off (byte-identical
+sequential training); on, it is a one-iteration-stale-policy departure that is
+**re-gated on a two-seed ``ml.gate`` valid_placed delta** (a follow-up long-run,
+NOT byte-identity).
+
+These tests pin the MECHANISM (not the learning outcome): the snapshot is an
+independent frozen copy, the flag genuinely gates the concurrent path, and the
+pipeline preserves the rung run-structure (ceiling + gate) of the sequential path.
+The exact per-iteration stats are NON-deterministic by design — the background
+rollout and the main-thread update both draw from torch's global RNG, so their
+interleaving is a (safe, mutex-guarded) race — which is why #755 is re-gated on a
+two-seed valid_placed delta, never a byte-diff.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import ml.train as train_mod  # noqa: E402
+from ml.curriculum import (  # noqa: E402
+    CurriculumSchedule,
+    DifficultyConfig,
+    PromotionPolicy,
+    Stage,
+)
+from ml.policy import HangarFitPolicy  # noqa: E402
+from ml.train import _clone_policy, build_argparser, train_curriculum  # noqa: E402
+
+
+def _tiny_schedule(threshold: float = -1.0) -> CurriculumSchedule:
+    """A single tiny rung so a vectorized run finishes in a few seconds."""
+    stage = Stage(
+        name="t0",
+        difficulty=DifficultyConfig(max_objects=1, per_object_step_budget=12, total_step_budget=12),
+        hangar_path="data/hangar.yaml",
+        fleet_path="data/fleet.yaml",
+        fleet_ids=("fuji",),
+        clearance_m=0.05,
+    )
+    pol = PromotionPolicy(metric="fraction_placed", window=1, threshold=threshold, max_iters=3)
+    return CurriculumSchedule(stages=(stage,), policy=pol)
+
+
+_TINY_POLICY = {"d_model": 32, "n_layers": 1, "n_heads": 2}
+
+
+def test_cli_pipeline_update_flag_defaults_off():
+    """``--pipeline-update`` parses to ``args.pipeline_update`` (default off)."""
+    parser = build_argparser()
+    assert parser.parse_args(["--schedule", "curriculum"]).pipeline_update is False
+    assert (
+        parser.parse_args(["--schedule", "curriculum", "--pipeline-update"]).pipeline_update is True
+    )
+
+
+def test_clone_policy_is_independent_frozen_snapshot():
+    """``_clone_policy`` returns a deep copy whose params do NOT alias the live
+    policy — so the concurrent rollout reads pre-update weights while ``ppo_update``
+    mutates the original in place."""
+    policy = HangarFitPolicy(**_TINY_POLICY)
+    snapshot = _clone_policy(policy)
+    # Same values at snapshot time...
+    p_live = next(policy.parameters())
+    p_snap = next(snapshot.parameters())
+    assert torch.equal(p_live, p_snap)
+    assert p_live is not p_snap  # distinct storage
+    # ...and mutating the live policy must NOT bleed into the snapshot.
+    with torch.no_grad():
+        p_live.add_(1.0)
+    assert not torch.equal(p_live, p_snap)
+
+
+def test_pipeline_update_off_does_not_spawn_executor(monkeypatch):
+    """Flag OFF must never touch the concurrent machinery — proving the default
+    path is the untouched sequential loop (byte-identical)."""
+
+    def _boom(*_a, **_k):
+        raise AssertionError("ThreadPoolExecutor created with --pipeline-update OFF")
+
+    monkeypatch.setattr(train_mod, "ThreadPoolExecutor", _boom)
+    # n_envs=2 sync exercises the vectorized loop; OFF must not create the executor.
+    history = train_curriculum(
+        seed=0,
+        schedule=_tiny_schedule(),
+        rollout_len=16,
+        n_envs=2,
+        vec_backend="sync",
+        policy_kwargs=_TINY_POLICY,
+        pipeline_update=False,
+    )
+    assert history.promotions  # ran to completion on the sequential path
+
+
+def test_pipeline_update_on_uses_executor(monkeypatch):
+    """Flag ON must route through the concurrent executor — proving the lever
+    actually fires (not a silent no-op)."""
+    sentinel = {"created": False}
+    real_executor = train_mod.ThreadPoolExecutor
+
+    def _spy(*a, **k):
+        sentinel["created"] = True
+        return real_executor(*a, **k)
+
+    monkeypatch.setattr(train_mod, "ThreadPoolExecutor", _spy)
+    train_curriculum(
+        seed=0,
+        schedule=_tiny_schedule(),
+        rollout_len=16,
+        n_envs=2,
+        vec_backend="sync",
+        policy_kwargs=_TINY_POLICY,
+        pipeline_update=True,
+    )
+    assert sentinel["created"] is True
+
+
+def test_pipeline_preserves_sequential_run_structure():
+    """The pipeline must respect the rung ceiling + gate exactly like the sequential
+    path: an unreachable threshold runs all ``max_iters`` iterations and promotes by
+    ``"cap"``, recording one row per iteration. Only the run STRUCTURE is asserted —
+    the exact ep_stats are non-deterministic by design (racy concurrent RNG + stale
+    policy), so this never asserts float reproducibility."""
+    sched = _tiny_schedule(threshold=2.0)  # unreachable -> cap at max_iters=3
+
+    def _run(*, pipeline_update: bool):
+        return train_curriculum(
+            seed=0,
+            schedule=sched,
+            rollout_len=16,
+            n_envs=2,
+            vec_backend="sync",
+            policy_kwargs=_TINY_POLICY,
+            pipeline_update=pipeline_update,
+        )
+
+    seq = _run(pipeline_update=False)
+    pipe = _run(pipeline_update=True)
+    # Same promotion mechanics (stage + reason) and same number of recorded iterations
+    # — the pipeline neither drops, duplicates, nor over-runs the ceiling.
+    assert [(s, by) for s, _it, by in pipe.promotions] == [(s, by) for s, _it, by in seq.promotions]
+    assert pipe.promotions[-1][2] == "cap"
+    assert len(pipe.iterations) == len(seq.iterations) == 3


### PR DESCRIPTION
Closes #755.

**Wave 4 (#761) — opt-in, non-deterministic, gate-deferred.** The cheaper, lower-risk half of the phase-overlap wave (the XL async run-ahead, #756, stays deferred/spike-gated).

## What
In the **vectorized** curriculum path, while `ppo_update` runs on the live policy the workers collect the **next** rollout under a frozen `deepcopy` snapshot of the **pre-update** policy — exactly one iteration stale — on a single background thread. This overlaps the CPU rollout with the (GPU) update, recovering the idle time in the otherwise strictly-sequential `rollout → update` cadence.

- Live policy and snapshot are **separate module objects** (no shared mutable state); the env is touched **only** by the rollout thread, serialized across iterations by `future.result()`.
- The next rollout is launched **only when another iteration will consume it** (never on the stop/final iteration) → no speculative rollout is ever wasted, nothing to drain.
- Plumbed `--pipeline-update` (argparse) → `train_curriculum(pipeline_update=...)`.

## Determinism
- **Off (default) = byte-identical** sequential training — the existing loop is left **verbatim** in the `else` branch.
- **On = NON-deterministic by design.** Two sources: the one-iteration staleness, AND the background rollout sharing the **global torch RNG** with the update's minibatch shuffle (a *safe, mutex-guarded* race — no state corruption, just non-reproducible interleaving). Per the #755/#761 design this is re-gated on a **two-seed `ml.gate` valid_placed delta, NOT a byte-diff**.

## Deferred (per design)
The two-seed learning-regression re-gate is a follow-up long-run (hours of training); it is **not** run in this PR. This PR delivers the mechanism + the byte-identical off-switch + the mechanism tests. #756 (async run-ahead) stays deferred.

## Tests (`tests/ml/test_pipeline_update.py`)
- `_clone_policy` snapshot independence (mutating the live policy doesn't bleed into the snapshot).
- Flag **gates the executor**: off never creates it (proves the default path is the untouched sequential loop); on does (proves the lever fires, not a silent no-op).
- The pipeline **preserves the sequential run structure** (ceiling + gate: same promotion mechanics, same iteration count) — float reproducibility is deliberately NOT asserted.

Scope note: no effect with `--schedule trivial` or `--n-envs 1` (nothing to overlap). Dev/CI-only (`ml/`); no shipped-wheel surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6RKpCmrDtmSzekFrbcRjr