### PR TITLE
feat(614): SOFT door-priority tie-breaker (Scenario.door_order)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,5 +81,6 @@ viewer/node_modules/
 /ck-*.pt
 /metrics-*.jsonl
 /gate-*.log
+/train-*.log
 /.gate-*.pid
 /.workflow-*.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,21 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
-- **Solver (#614, epic #600 / milestone #34): SOFT door-priority tie-breaker
+- **Solver (#614, epic #600 / milestone 34): SOFT door-priority tie-breaker
   (`Scenario.door_order`).** The deferred soft half of #603's HARD Caddy egress gate: a scenario
   may declare a desired door-proximity order (a top-level `door_order:` list of placeable body ids;
   the first should park nearest the door). Among the already-collision-valid candidate basins the
   solver collects, a new **lexicographically-subordinate** selection term ranks layouts by a
   Kendall-tau inversion count over the placed `door_order` bodies (door distance = the `y_m`
-  reference coordinate, consistent with the `_back_bias`/`_region` soft terms; absent bodies, e.g.
+  reference coordinate, the same idiom as the `_back_bias` soft term; absent bodies, e.g.
   a maintenance plane treated as away, are skipped). It sits **above** the ADR-0008 spread terms (a
   declared order wins over maximal spread) but strictly **below every hard rule** — consumed only
-  after the collision + egress gates pass, so it can never make an invalid layout selectable nor
-  reorder a hard rejection. **Determinism (ADR-0003):** unset (`door_order` absent, the default) ⇒
-  a constant `0.0` deviation prefix on the selection key ⇒ byte-identical solver, verified by the
-  6-plane canaries and an unset-is-zero unit. Closes the Ground-objects + Herrenteich-calibration
-  milestone (#600 epic).
+  after the collision gate passes, and it stays subordinate to the ADR-0026 egress gate (which
+  independently rejects un-routable layouts downstream), so it can never make an invalid layout
+  selectable nor reorder a hard rejection. **Determinism (ADR-0003):** unset (`door_order` absent,
+  the default) ⇒ a constant `0.0` deviation prefix on the selection key ⇒ byte-identical solver,
+  verified by the 6-plane canaries and an unset-is-zero unit. Closes #614, the last open child of
+  epic #600 / milestone 34 (Ground objects + Herrenteich calibration).
 
 - **Solver (#754, epic #607 Wave 3 / #760): Lever B — opt-in `solve --sat-collisions` numpy
   SAT box oracle for the collision narrow-phase.** The pairwise + ground-obstacle narrow-phase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Solver (#614, epic #600 / milestone #34): SOFT door-priority tie-breaker
+  (`Scenario.door_order`).** The deferred soft half of #603's HARD Caddy egress gate: a scenario
+  may declare a desired door-proximity order (a top-level `door_order:` list of placeable body ids;
+  the first should park nearest the door). Among the already-collision-valid candidate basins the
+  solver collects, a new **lexicographically-subordinate** selection term ranks layouts by a
+  Kendall-tau inversion count over the placed `door_order` bodies (door distance = the `y_m`
+  reference coordinate, consistent with the `_back_bias`/`_region` soft terms; absent bodies, e.g.
+  a maintenance plane treated as away, are skipped). It sits **above** the ADR-0008 spread terms (a
+  declared order wins over maximal spread) but strictly **below every hard rule** — consumed only
+  after the collision + egress gates pass, so it can never make an invalid layout selectable nor
+  reorder a hard rejection. **Determinism (ADR-0003):** unset (`door_order` absent, the default) ⇒
+  a constant `0.0` deviation prefix on the selection key ⇒ byte-identical solver, verified by the
+  6-plane canaries and an unset-is-zero unit. Closes the Ground-objects + Herrenteich-calibration
+  milestone (#600 epic).
+
 - **Solver (#754, epic #607 Wave 3 / #760): Lever B — opt-in `solve --sat-collisions` numpy
   SAT box oracle for the collision narrow-phase.** The pairwise + ground-obstacle narrow-phase
   (~61% of each box-rung iteration is shapely `Polygon` work, #381) now has an opt-in second path:

--- a/docs/adr/0008-inter-plane-spread-soft-preference.md
+++ b/docs/adr/0008-inter-plane-spread-soft-preference.md
@@ -383,3 +383,23 @@ re-summed in full. Measured: `roomy_three_spread_on` placement 15.04 s → 14.08
 median (~6 %) at n = 3 — baseline ~15 s, itself down from the spike's 40.6 s after
 #453/#454 landed. The saving is O(n²)→O(n) in plane count, so it grows with fleet
 size.
+
+## Amendment (#614, 2026-06-22): door-priority is the primary soft selection key
+
+`Scenario.door_order` (#614, the deferred SOFT half of #603's HARD Caddy egress
+gate) adds a second soft preference that sits **above** this spread term in the
+selection lexicographic order. `_select_spread_diverse` now ranks the
+already-collision-valid candidate pool by
+`(door_deviation, −min_gap, energy, restart_index)`: fewest door-order
+inversions first (`solver._door_order_deviation`, a Kendall-tau count over the
+placed `door_order` bodies ranked by `y_m` door-proximity), then this ADR's
+maximin spread (`−min_gap`, then `energy`), then `restart_index` for a total
+order. So a declared door order wins over maximal spread, while spread stays the
+**lower-priority tie-breaker** among layouts that satisfy the order equally — and
+because the inversion count is discrete, door-order-satisfying candidates group
+together and spread decides *within* the group. Door-priority is still strictly
+**below every hard rule** (the pool is built only from `(0, 0.0)`-valid basins),
+so it can never make an invalid layout selectable. With `door_order` unset (the
+default) every candidate's `door_deviation` is a constant `0.0`, so the key
+reduces to this ADR's original `(−min_gap, energy, restart_index)` ordering
+**byte-for-byte** (ADR-0003) — verified by the 6-plane determinism canaries.

--- a/ml/README.md
+++ b/ml/README.md
@@ -373,7 +373,8 @@ this late-climbing rung; the fixed cap stays the simplest, most reproducible def
 - **Do not `pip install .[train]`** if you have a local CUDA torch — it clobbers your `~/.local`
   build. Run `ml.train` from the repo root (the top-level `ml/` package is not on the editable
   install's path).
-- Gate scratch (`metrics-*.jsonl`, `ck-*.pt`) is gitignored (#717) — don't commit run artifacts.
+- Gate scratch (`metrics-*.jsonl`, `ck-*.pt`, and run logs redirected to `train-*.log`) is
+  gitignored (#717) — don't commit run artifacts.
 
 **Read the result with the gate harness** (torch-free, `ml/gate.py`) instead of eyeballing the
 JSONL — it headlines `valid_placed` (never `valid_rate`) and flags the piling basin. Since #742 the

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -659,7 +659,7 @@ def load_layout(
 # the too-strict direction. Per-plane ``constraints`` entries carry their own
 # allowlist (:data:`_ALLOWED_CONSTRAINT_KEYS`).
 _ALLOWED_SCENARIO_KEYS = frozenset(
-    {"fleet_in", "fleet", "hangar", "maintenance", "constraints", "ground_objects"}
+    {"fleet_in", "fleet", "hangar", "maintenance", "constraints", "ground_objects", "door_order"}
 )
 
 
@@ -915,6 +915,14 @@ def load_scenario(
                 except (ValueError, LoaderError) as e:
                     raise LoaderError(f"{path}: ground_objects[{i}] ({gid}): {e}") from e
 
+    # Door order (#614): an optional top-level list of body ids. Absent ⇒ None
+    # (inert, byte-identical). Cross-reference validation (placeable ids, no
+    # duplicates) is the Scenario's job — its ValueError is wrapped below.
+    door_order_raw = raw.get("door_order")
+    if door_order_raw is not None and not isinstance(door_order_raw, list):
+        raise LoaderError(f"{path}: 'door_order' must be a list")
+    door_order = None if door_order_raw is None else tuple(str(x) for x in door_order_raw)
+
     try:
         return Scenario(
             fleet=fleet,
@@ -926,6 +934,7 @@ def load_scenario(
             ground_object_defs=ground_objects,
             fixed_obstacle_placements=tuple(fixed_obstacle_placements),
             region_preferences=region_preferences,
+            door_order=door_order,
         )
     except ValueError as e:
         raise LoaderError(f"{path}: {e}") from e

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1201,6 +1201,7 @@ class Scenario:
       constraints (the occupant is treated as away — those constraints would be
       incoherent and would be silently ignored by the solver)
     - region_preferences.keys() ⊆ placeable bodies (fleet_in ∪ placed_routed_mover ids)
+    - door_order (if set) ⊆ placeable bodies and has no duplicate ids (#614)
     - fixed_obstacle_placements entries reference distinct fixed_obstacle ground
       objects (in ground_object_defs)
     - fleet and constraints are wrapped in MappingProxyType (same pattern as Layout)
@@ -1231,6 +1232,12 @@ class Scenario:
     region_preferences: Mapping[str, RegionPreference] = field(
         default_factory=lambda: MappingProxyType({})
     )
+    # #614 SOFT door-priority: a desired door-proximity order (the first id should
+    # park nearest the door). A lexicographically-subordinate selection term,
+    # consumed only after every hard rule passes (see ``solver._door_order_deviation``;
+    # it sits below ADR-0026's HARD egress gate). ``None`` ⇒ inert / byte-identical
+    # solver (ADR-0003). A tuple (immutable already), so no MappingProxyType wrap.
+    door_order: tuple[str, ...] | None = None
 
     # The mapping fields wrapped in MappingProxyType for immutability. This is
     # the single source of truth for both the construction-time wrap (in
@@ -1387,6 +1394,20 @@ class Scenario:
                     f"placeable body (aircraft or placed_routed_mover); "
                     f"placeable ids: {sorted(placeable)}"
                 )
+
+        # Door order (#614): every id must reference a placeable body (mirrors
+        # region_preferences) and no id may repeat (a body can't hold two
+        # door-proximity ranks). None ⇒ no constraint (inert, byte-identical).
+        if self.door_order is not None:
+            if len(set(self.door_order)) != len(self.door_order):
+                raise ValueError(f"Scenario.door_order has duplicate entries: {self.door_order}")
+            for did in self.door_order:
+                if did not in placeable:
+                    raise ValueError(
+                        f"Scenario.door_order references {did!r} which is not a "
+                        f"placeable body (aircraft or placed_routed_mover); "
+                        f"placeable ids: {sorted(placeable)}"
+                    )
         seen_fixed: set[str] = set()
         for p in self.fixed_obstacle_placements:
             if p.plane_id not in self.ground_object_defs:

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -325,6 +325,7 @@ def _run_restart(
                 restart_index=restart_index,
                 nose_out_flips=n_flips,
                 region_alignment=cand_alignment,
+                door_deviation=_door_order_deviation(placements, scenario),
             )
             break  # found a basin
 
@@ -1386,6 +1387,39 @@ def _region_alignment(
     return tuple(out)
 
 
+def _door_order_deviation(placements: Mapping[str, Placement], scenario: Scenario) -> float:
+    """Soft door-priority deviation: a Kendall-tau inversion count (#614).
+
+    ``scenario.door_order`` is a desired door-proximity sequence (the first id
+    should park nearest the door at ``y = 0``; ADR-0002 ``+y`` is deeper in).
+    For the placed door_order bodies, in request order, count the pairs that are
+    OUT of order by door distance — i.e. an earlier-requested body parked
+    *farther* from the door (larger ``y``) than a later-requested one. ``0.0`` ⇒
+    the placed bodies match the requested order exactly; higher ⇒ more inversions.
+
+    Door distance is the placement ``y_m`` reference coordinate (a soft proxy,
+    consistent with :func:`_back_bias_energy`'s ``y`` / :func:`_region_energy`'s
+    ``x``; the HARD egress geometry is ADR-0026's separate gate). Bodies absent
+    from ``placements`` (e.g. a maintenance plane treated as away) are skipped, so
+    only the realized relative order is scored ("position 2 when position 1 is
+    geometrically impossible is acceptable", #603). Strict ``>`` means equal-``y``
+    ties add no inversion either way — order-neutral and deterministic.
+
+    Returns ``0.0`` when ``door_order`` is ``None`` (inert ⇒ byte-identical
+    selection, ADR-0003) — the early return also keeps the default path free."""
+    order = scenario.door_order
+    if order is None:
+        return 0.0
+    seq = [pid for pid in order if pid in placements]
+    ys = [placements[pid].y_m for pid in seq]
+    inversions = 0
+    for i in range(len(ys)):
+        for j in range(i + 1, len(ys)):
+            if ys[i] > ys[j]:  # earlier-requested body is FARTHER from the door
+                inversions += 1
+    return float(inversions)
+
+
 def _resolve_spread_scale(scenario: Scenario, search: SearchConfig) -> float:
     """Repulsion length-scale for spread (spec §4): explicit override or
     20% of the smaller hangar dimension. Single source so ``_spread`` and
@@ -2033,6 +2067,9 @@ class _SpreadCandidate(NamedTuple):
     restart_index: int
     nose_out_flips: int = 0
     region_alignment: tuple[RegionAlignment, ...] = ()
+    # #614 soft door-priority deviation (Kendall-tau inversions; 0.0 when
+    # door_order is unset ⇒ a constant key prefix ⇒ byte-identical selection).
+    door_deviation: float = 0.0
 
 
 def _select_spread_diverse(
@@ -2042,9 +2079,12 @@ def _select_spread_diverse(
 ) -> tuple[list[_SpreadCandidate], int]:
     """Select up to ``alternatives`` best-spread, pairwise-diverse candidates.
 
-    Order the pool by ``(−min_gap, energy, restart_index)``: largest minimum
-    plan-view gap first, ties broken by lower repulsion energy, then by restart
-    order for a *total* (so deterministic — ADR-0003) ordering. Greedily accept
+    Order the pool by ``(door_deviation, −min_gap, energy, restart_index)``:
+    fewest door-order inversions first (#614 — a constant ``0.0`` when
+    ``door_order`` is unset, so the spread ordering is then byte-identical),
+    then largest minimum plan-view gap, ties broken by lower repulsion energy,
+    then by restart order for a *total* (so deterministic — ADR-0003) ordering.
+    Greedily accept
     a candidate iff it is diverse enough (ADR-0004) against everything already
     selected; the first pick is always accepted (diversity is vacuous on the
     empty selection). Returns ``(selected, diversity_rejected)`` in best-spread
@@ -2053,7 +2093,12 @@ def _select_spread_diverse(
     ``alternatives == 1`` this is always 0 — selection stops after the first,
     vacuous pick.
     """
-    ordered = sorted(pool, key=lambda c: (-c.min_gap, c.energy, c.restart_index))
+    # #614 door-priority is the PRIMARY soft key (above the ADR-0008 spread
+    # terms): fewer door-order inversions first, then maximin gap, then lower
+    # repulsion energy, then restart_index for a total (deterministic) order.
+    # With door_order unset every candidate's door_deviation is 0.0, so this
+    # constant prefix leaves the spread ordering byte-identical (ADR-0003).
+    ordered = sorted(pool, key=lambda c: (c.door_deviation, -c.min_gap, c.energy, c.restart_index))
     selected: list[_SpreadCandidate] = []
     diversity_rejected = 0
     for cand in ordered:

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -1398,12 +1398,17 @@ def _door_order_deviation(placements: Mapping[str, Placement], scenario: Scenari
     the placed bodies match the requested order exactly; higher ⇒ more inversions.
 
     Door distance is the placement ``y_m`` reference coordinate (a soft proxy,
-    consistent with :func:`_back_bias_energy`'s ``y`` / :func:`_region_energy`'s
-    ``x``; the HARD egress geometry is ADR-0026's separate gate). Bodies absent
+    the same single-reference-coordinate idiom as :func:`_back_bias_energy`'s
+    ``y``; the HARD egress geometry is ADR-0026's separate gate). Bodies absent
     from ``placements`` (e.g. a maintenance plane treated as away) are skipped, so
     only the realized relative order is scored ("position 2 when position 1 is
     geometrically impossible is acceptable", #603). Strict ``>`` means equal-``y``
     ties add no inversion either way — order-neutral and deterministic.
+
+    An order needs ≥2 *placed* bodies to express anything: an empty ``door_order``
+    ``()``, a single-element order, and a ``None`` order all have no orderable pair
+    and so all yield ``0.0`` — i.e. they are equivalent inert no-ops (the term is
+    purely *relative* ordering, never absolute door-attraction).
 
     Returns ``0.0`` when ``door_order`` is ``None`` (inert ⇒ byte-identical
     selection, ADR-0003) — the early return also keeps the default path free."""

--- a/tests/fixtures/scenario_door_order.yaml
+++ b/tests/fixtures/scenario_door_order.yaml
@@ -1,0 +1,6 @@
+# #614 door-priority demo scenario: a desired door-proximity order declared at
+# the scenario top level. ctsl should park nearest the door, then aviat_husky.
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [aviat_husky, ctsl]
+door_order: [ctsl, aviat_husky]

--- a/tests/fixtures/scenario_door_order_bad.yaml
+++ b/tests/fixtures/scenario_door_order_bad.yaml
@@ -1,0 +1,5 @@
+# #614 — door_order references an id not in the fleet: must be rejected.
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [aviat_husky, ctsl]
+door_order: [ctsl, ghost]

--- a/tests/fixtures/scenario_door_order_empty.yaml
+++ b/tests/fixtures/scenario_door_order_empty.yaml
@@ -1,0 +1,5 @@
+# #614 — an explicit empty door_order is accepted and inert (parses to ()).
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+fleet_in: [aviat_husky, ctsl]
+door_order: []

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2471,6 +2471,7 @@ maintenance_bay: {center_x_m: 13.5, width_m: 9, depth_m: 9}
             "maintenance:\n  plane: foo\n"
             "constraints:\n  foo:\n    priority: 1.0\n"
             "ground_objects:\n  - fixture_caddy\n"
+            "door_order:\n  - foo\n"
         )
         file_keys = set(yaml.safe_load(body))
         assert file_keys == _ALLOWED_SCENARIO_KEYS, (
@@ -2482,3 +2483,4 @@ maintenance_bay: {center_x_m: 13.5, width_m: 9, depth_m: 9}
         assert scn.ground_objects == ("fixture_caddy",)
         assert "fixture_caddy" in scn.ground_object_defs
         assert scn.maintenance_plane == "foo"
+        assert scn.door_order == ("foo",)

--- a/tests/test_loader_door_order.py
+++ b/tests/test_loader_door_order.py
@@ -15,6 +15,13 @@ def test_load_scenario_no_door_order_is_none():
     assert s.door_order is None  # absent ⇒ inert (byte-identical, ADR-0003)
 
 
+def test_load_scenario_empty_door_order_is_inert_tuple():
+    # An explicit `door_order: []` parses to () — accepted and inert (the lenient
+    # contract, like an empty region_preferences map); pinned so it can't drift.
+    s = load_scenario("tests/fixtures/scenario_door_order_empty.yaml")
+    assert s.door_order == ()
+
+
 def test_load_scenario_door_order_unknown_id_rejected():
     with pytest.raises(LoaderError, match="door_order"):
         load_scenario("tests/fixtures/scenario_door_order_bad.yaml")

--- a/tests/test_loader_door_order.py
+++ b/tests/test_loader_door_order.py
@@ -1,0 +1,20 @@
+"""#614 — load_scenario parses the top-level ``door_order:`` key."""
+
+import pytest
+
+from hangarfit.loader import LoaderError, load_scenario
+
+
+def test_load_scenario_door_order():
+    s = load_scenario("tests/fixtures/scenario_door_order.yaml")
+    assert s.door_order == ("ctsl", "aviat_husky")
+
+
+def test_load_scenario_no_door_order_is_none():
+    s = load_scenario("tests/fixtures/scenario_minimal.yaml")
+    assert s.door_order is None  # absent ⇒ inert (byte-identical, ADR-0003)
+
+
+def test_load_scenario_door_order_unknown_id_rejected():
+    with pytest.raises(LoaderError, match="door_order"):
+        load_scenario("tests/fixtures/scenario_door_order_bad.yaml")

--- a/tests/test_loader_scenario.py
+++ b/tests/test_loader_scenario.py
@@ -369,7 +369,8 @@ def test_load_scenario_all_allowed_top_level_keys_load(tmp_path):
         "constraints:\n"
         "  aviat_husky:\n"
         "    priority: 1.0\n"
-        "ground_objects: []\n",
+        "ground_objects: []\n"
+        "door_order: [aviat_husky]\n",
     )
     file_keys = set(yaml.safe_load(p.read_text()))
     assert file_keys == _ALLOWED_SCENARIO_KEYS, (
@@ -381,6 +382,7 @@ def test_load_scenario_all_allowed_top_level_keys_load(tmp_path):
     assert s.maintenance_plane == "ctsl"
     assert "aviat_husky" in s.constraints
     assert s.ground_objects == ()
+    assert s.door_order == ("aviat_husky",)
 
 
 def test_load_scenario_unknown_key_wins_over_missing_required(tmp_path):

--- a/tests/test_models_door_order.py
+++ b/tests/test_models_door_order.py
@@ -1,0 +1,91 @@
+"""#614 SOFT door-priority tie-breaker — Scenario.door_order model validation.
+
+``door_order`` is a scenario-level ordered sequence of placeable-body ids
+expressing a desired door-proximity (the first id should park nearest the
+door). It is the deferred SOFT half of #603's HARD Caddy egress gate: a
+lexicographically-subordinate selection term, validated like
+``region_preferences`` (ids must resolve to placeable bodies; no duplicates).
+"""
+
+import pytest
+
+from hangarfit.models import Door, GroundObject, Hangar, MaintenanceBay, Part, Scenario
+from tests.conftest import make_test_aircraft  # noqa: E402
+
+
+def _hangar() -> Hangar:
+    return Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.2,
+    )
+
+
+def _ground_part() -> Part:
+    return Part(
+        kind="ground",
+        length_m=3.0,
+        width_m=2.0,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=0.0,
+        z_top_m=1.5,
+    )
+
+
+def _towed_mover(obj_id: str = "glider_trailer_1") -> GroundObject:
+    return GroundObject(
+        id=obj_id,
+        name="Glider trailer",
+        parts=(_ground_part(),),
+        object_class="placed_routed_mover",
+        motion_mode="towed",
+    )
+
+
+def _scenario(**kwargs) -> Scenario:
+    """Valid Scenario with three aircraft (husky, fuji, scout)."""
+    fleet = {pid: make_test_aircraft(id=pid) for pid in ("husky", "fuji", "scout")}
+    return Scenario(
+        fleet=fleet,
+        hangar=_hangar(),
+        fleet_in=("husky", "fuji", "scout"),
+        **kwargs,
+    )
+
+
+def test_scenario_door_order_default_none():
+    s = _scenario()
+    assert s.door_order is None  # unset ⇒ inert (byte-identical solver, ADR-0003)
+
+
+def test_scenario_door_order_valid_aircraft_ids():
+    s = _scenario(door_order=("fuji", "husky"))
+    assert s.door_order == ("fuji", "husky")
+
+
+def test_scenario_door_order_rejects_unknown_id():
+    with pytest.raises(ValueError, match="door_order"):
+        _scenario(door_order=("husky", "ghost"))
+
+
+def test_scenario_door_order_rejects_duplicate():
+    with pytest.raises(ValueError, match="duplicate"):
+        _scenario(door_order=("husky", "husky"))
+
+
+def test_scenario_door_order_on_mover_ok():
+    mover = _towed_mover()
+    s = Scenario(
+        fleet={"husky": make_test_aircraft(id="husky")},
+        hangar=_hangar(),
+        fleet_in=("husky",),
+        ground_objects=(mover.id,),
+        ground_object_defs={mover.id: mover},
+        door_order=(mover.id, "husky"),
+    )
+    assert s.door_order == (mover.id, "husky")

--- a/tests/test_solver_door_order.py
+++ b/tests/test_solver_door_order.py
@@ -1,0 +1,168 @@
+"""#614 SOFT door-priority tie-breaker — solver selection term.
+
+``door_order`` orders otherwise-equally-valid layouts by door-proximity: the
+deviation is a Kendall-tau inversion count over the placed ``door_order`` bodies
+ranked by ``y_m`` (smaller ``y`` = nearer the door at ``y=0``). It is a
+selection-time term, lexicographically subordinate to every HARD rule (the pool
+``_select_spread_diverse`` ranks is already collision-valid) and ABOVE the
+ADR-0008 spread terms — so a door-order-matching valid layout beats a
+door-order-violating valid one, but no door order can make an invalid layout
+selectable. Unset ⇒ a constant ``0.0`` deviation ⇒ byte-identical solver (ADR-0003).
+"""
+
+from hangarfit.collisions import check
+from hangarfit.models import (
+    DiversityConfig,
+    Door,
+    Hangar,
+    MaintenanceBay,
+    Placement,
+    Scenario,
+    SearchConfig,
+)
+from hangarfit.solver import (
+    _door_order_deviation,
+    _empty_layout,
+    _select_spread_diverse,
+    _SpreadCandidate,
+    solve,
+)
+from tests.conftest import make_test_aircraft  # noqa: E402
+
+
+def _hangar() -> Hangar:
+    return Hangar(
+        length_m=40.0,
+        width_m=40.0,
+        door=Door(center_x_m=20.0, width_m=12.0),
+        maintenance_bay=MaintenanceBay(center_x_m=20.0, width_m=8.0, depth_m=6.0),
+        clearance_m=0.3,
+        wing_layer_clearance_m=0.2,
+    )
+
+
+def _scenario(**kwargs) -> Scenario:
+    fleet = {pid: make_test_aircraft(id=pid) for pid in ("a", "b", "c")}
+    return Scenario(
+        fleet=fleet,
+        hangar=_hangar(),
+        fleet_in=("a", "b", "c"),
+        **kwargs,
+    )
+
+
+def _pl(pid: str, y: float) -> Placement:
+    return Placement(pid, 10.0, y, 0.0, on_carts=False)
+
+
+# --- _door_order_deviation metric -----------------------------------------
+
+
+def test_door_order_deviation_unset_is_zero():
+    s = _scenario()  # door_order is None
+    placements = {"a": _pl("a", 5.0), "b": _pl("b", 1.0)}  # any arrangement
+    assert _door_order_deviation(placements, s) == 0.0  # inert ⇒ byte-identical
+
+
+def test_door_order_deviation_perfect_order_is_zero():
+    s = _scenario(door_order=("a", "b", "c"))
+    # a nearest the door (smallest y), then b, then c — matches the request
+    placements = {"a": _pl("a", 1.0), "b": _pl("b", 5.0), "c": _pl("c", 9.0)}
+    assert _door_order_deviation(placements, s) == 0.0
+
+
+def test_door_order_deviation_full_reversal_counts_all_pairs():
+    s = _scenario(door_order=("a", "b", "c"))
+    # exactly reversed: c nearest, a farthest ⇒ all 3 pairs inverted
+    placements = {"a": _pl("a", 9.0), "b": _pl("b", 5.0), "c": _pl("c", 1.0)}
+    assert _door_order_deviation(placements, s) == 3.0
+
+
+def test_door_order_deviation_single_inversion():
+    s = _scenario(door_order=("a", "b", "c"))
+    # a and b swapped (b before a), c correct ⇒ one inverted pair (a,b)
+    placements = {"a": _pl("a", 5.0), "b": _pl("b", 1.0), "c": _pl("c", 9.0)}
+    assert _door_order_deviation(placements, s) == 1.0
+
+
+def test_door_order_deviation_skips_absent_bodies():
+    s = _scenario(door_order=("a", "b", "c"))
+    # b absent (e.g. a maintenance plane treated as away): rank only a,c —
+    # a nearer than c matches their relative request order ⇒ 0 inversions
+    placements = {"a": _pl("a", 1.0), "c": _pl("c", 9.0)}
+    assert _door_order_deviation(placements, s) == 0.0
+
+
+# --- _select_spread_diverse ordering --------------------------------------
+
+
+def test_door_order_dominates_spread_in_selection():
+    """A door-order-matching valid candidate (lower deviation) is selected over a
+    better-spread one (larger min_gap) — door_order ranks ABOVE the spread terms."""
+    s = _scenario(door_order=("a", "b", "c"))
+    layout = _empty_layout(s)
+    # door_matching: deviation 0 but a SMALLER min_gap (worse spread)
+    door_matching = _SpreadCandidate(
+        layout=layout, min_gap=1.0, energy=9.0, restart_index=0, door_deviation=0.0
+    )
+    # better_spread: a LARGER min_gap (better spread) but violates the order
+    better_spread = _SpreadCandidate(
+        layout=layout, min_gap=8.0, energy=1.0, restart_index=1, door_deviation=2.0
+    )
+    selected, _ = _select_spread_diverse(
+        [better_spread, door_matching], alternatives=1, diversity=DiversityConfig()
+    )
+    assert selected[0] is door_matching
+
+
+def test_selection_spread_breaks_ties_within_equal_door_deviation():
+    """Among candidates with EQUAL door deviation, the larger-min_gap (better
+    spread) one still wins — spread is the lower-priority tie-breaker."""
+    s = _scenario(door_order=("a", "b", "c"))
+    layout = _empty_layout(s)
+    worse = _SpreadCandidate(
+        layout=layout, min_gap=2.0, energy=5.0, restart_index=0, door_deviation=1.0
+    )
+    better = _SpreadCandidate(
+        layout=layout, min_gap=7.0, energy=1.0, restart_index=1, door_deviation=1.0
+    )
+    selected, _ = _select_spread_diverse(
+        [worse, better], alternatives=1, diversity=DiversityConfig()
+    )
+    assert selected[0] is better
+
+
+# --- solve-level contracts -------------------------------------------------
+
+
+def _key(layouts):
+    return [
+        [(p.plane_id, p.x_m, p.y_m, p.heading_deg) for p in layout.placements] for layout in layouts
+    ]
+
+
+def test_solve_door_order_none_deterministic():
+    s = _scenario()  # door_order None
+    cfg = SearchConfig(max_restarts=4, spread=True)
+    a = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    b = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    assert _key(a.layouts) == _key(b.layouts)
+
+
+def test_solve_door_order_never_returns_invalid_layout():
+    """door_order can never make an invalid layout selectable: the returned
+    layout is always collision-valid (the pool is hard-valid by construction)."""
+    s = _scenario(door_order=("c", "b", "a"))
+    cfg = SearchConfig(max_restarts=4, spread=True)
+    res = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    assert res.status == "found"
+    for layout in res.layouts:
+        assert check(layout).conflicts == ()
+
+
+def test_solve_door_order_active_deterministic():
+    s = _scenario(door_order=("c", "a", "b"))
+    cfg = SearchConfig(max_restarts=4, spread=True)
+    a = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    b = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    assert _key(a.layouts) == _key(b.layouts)

--- a/tests/test_solver_door_order.py
+++ b/tests/test_solver_door_order.py
@@ -93,6 +93,21 @@ def test_door_order_deviation_skips_absent_bodies():
     assert _door_order_deviation(placements, s) == 0.0
 
 
+def test_door_order_deviation_empty_order_is_inert():
+    # An empty door_order () validates (no ids, no dups) and is a no-op: no
+    # orderable pair ⇒ 0.0, equivalent to None (inert, byte-identical selection).
+    s = _scenario(door_order=())
+    placements = {"a": _pl("a", 9.0), "b": _pl("b", 1.0)}
+    assert _door_order_deviation(placements, s) == 0.0
+
+
+def test_door_order_deviation_single_element_is_inert():
+    # A single-element order can never invert (Kendall-tau needs a pair): inert.
+    s = _scenario(door_order=("a",))
+    placements = {"a": _pl("a", 9.0), "b": _pl("b", 1.0)}
+    assert _door_order_deviation(placements, s) == 0.0
+
+
 # --- _select_spread_diverse ordering --------------------------------------
 
 


### PR DESCRIPTION
## Summary

Implements **#614** — the deferred **SOFT** half of #603's HARD Caddy egress gate. A scenario may declare a desired door-proximity order; the solver uses it to order otherwise-equally-valid layouts, never to override a hard rule.

`Closes #614` (the last open child of epic **#600** / milestone 34 — Ground objects + Herrenteich calibration).

## What changed

- **`models.Scenario.door_order: tuple[str, ...] | None = None`** — a top-level ordered list of placeable body ids (first = nearest the door). Validated in `__post_init__` (ids ⊆ placeable bodies, no duplicates), mirroring `region_preferences`.
- **`solver._door_order_deviation(placements, scenario)`** — a Kendall-tau inversion count over the *placed* `door_order` bodies ranked by `y_m` door-proximity (the same single-reference-coordinate idiom as `_back_bias_energy`; absent bodies — e.g. a maintenance plane treated as away — are skipped). Returns `0.0` when unset (early return ⇒ the default path pays nothing). Empty/single-element orders are inert no-ops.
- **`_SpreadCandidate.door_deviation`** (default `0.0`) computed at candidate-build, and `_select_spread_diverse` now sorts by `(door_deviation, -min_gap, energy, restart_index)` — door-priority is the **primary soft key, above the ADR-0008 spread terms**, but the pool is already collision-valid so it stays **strictly below every hard rule** (and subordinate to the ADR-0026 egress gate, which rejects un-routable layouts downstream).
- **`loader`** — parses a top-level `door_order:` key (added to `_ALLOWED_SCENARIO_KEYS`; cross-ref validation is the `Scenario`'s job, wrapped as `LoaderError`).
- **Docs** — CHANGELOG `[Unreleased]`, an ADR-0008 amendment documenting the new lexicographic selection order.

## Determinism (ADR-0003)

**Unset ⇒ byte-identical.** With `door_order` absent, every candidate's `door_deviation` is a constant `0.0`, so the sort key reduces to the original `(-min_gap, energy, restart_index)` ordering bit-for-bit. Proven by the 6-plane determinism canaries (pass) + an `unset-is-zero` unit + a `solve(door_order=None)` re-run identity test. The `determinism-guard` subagent additionally verified same-seed reproducibility and parallel≡serial on both the unset and door_order-set paths.

## Why door-priority sits *above* spread

The #614/#603 spec: a declared door order should win over maximal spread ("ADR-0008 spread stays a separate, **lower-priority** soft term"). Because the inversion count is **discrete**, door-order-satisfying candidates group together and spread (`-min_gap`, then `energy`) decides *within* the group — so spread is the lower-priority tie-breaker, never discarded.

## Tests

- `test_models_door_order.py` — field default, valid ids, unknown-id + duplicate rejection, mover ids.
- `test_solver_door_order.py` — metric units (unset/perfect/reversal/single-inversion/absent-skip/empty/single-element), selection ordering (door dominates spread; spread breaks ties within equal deviation), solve-level contracts (never returns invalid; re-run determinism with and without `door_order`).
- `test_loader_door_order.py` + completeness-guard update — parse, absent-is-None, empty-list-is-`()`, unknown-id rejection.

Local: 153 relevant tests + 6 determinism canaries pass; `ruff` + `mypy src/hangarfit/` clean.

## Note — bundled hygiene chore

A second commit (`chore(gitignore)`) adds `/train-*.log` to `.gitignore` (its `/ck-*.pt`/`/metrics-*.jsonl`/`/gate-*.log` siblings were already ignored) + a one-line ml/README note. Unrelated to door-priority; bundled as a trivial drive-by so the gate-run scratch logs stop showing in `git status`.

## Review arc

Self-review per CLAUDE.md: `determinism-guard` (**PASS** — byte-identity + parallel≡serial confirmed), `code-reviewer`, `type-design-analyzer`, `silent-failure-hunter`, `comment-analyzer`. No blocking findings; 4 threads (2 doc-accuracy should-fix + nits) all fixed in `3b87616` and resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)