### PR TITLE
docs(CLAUDE.md): scratch-gitignore is per-branch (git add -A gotcha)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,14 @@ banner right after a merge/push clears on recompute — `mergeable=MERGEABLE` (a
 then close+reopen the PR to trigger CI.) Wire the stack's order as native issue
 deps: `gh api -X POST repos/DocGerd/hangarfit/issues/<n>/dependencies/blocked_by -F issue_id=<numeric id>`.
 
+**Scratch-gitignore is per-branch.** A `.gitignore` rule added on one branch does NOT
+protect a sibling cut from `develop` before it merged — a `git add -A` there sweeps the
+still-untracked scratch (`train-*.log` / `ck-*.pt` / `metrics-*.jsonl`) into the commit and
+pollutes `develop` (a tracked file is never re-ignored; the fix is a `git rm --cached` PR,
+e.g. #786). Prefer **explicit `git add <paths>`** when reproducible gate scratch sits in the
+tree, or merge `develop` in / land the ignore first. Spot a leak with `git ls-files | grep -E
+'train-|ck-|metrics-'` — `git check-ignore` returns 0 for already-tracked files, so it won't.
+
 ### Issues
 
 - Every change is tracked by a GitHub issue. No code without an issue.


### PR DESCRIPTION
## Summary

Appends a one-paragraph gotcha to the **Stacking PRs** section of CLAUDE.md, from a concrete incident this session: a `git add -A` on a sibling branch (cut from develop before the `/train-*.log` gitignore merged) committed 8 scratch logs to develop, needing a `git rm --cached` cleanup (#785/#786).

The note: a gitignore on one branch doesn't protect a sibling; prefer explicit `git add <paths>`; spot leaks with `git ls-files | grep -E 'train-|ck-|metrics-'` (not `git check-ignore`, which skips already-tracked files).

Docs only.

`Closes #787`

🤖 Generated with [Claude Code](https://claude.com/claude-code)