### PR TITLE
feat(607): statistical reach-rate harness (#711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#711, epic #607): statistical reach-rate harness (`python -m ml.reach_rate`).**
+  Lifts the #695 reach benchmark from a 4-row binary existence table to a reproducible
+  reach-**rate** over a **sampled population**: reach-rate ± **Wilson** CI per scenario-kind,
+  for both **multi-alternative RR-MC** (`rrmc_reach_multi` solves for N alternatives and counts
+  reached if *any* is valid + fully routable — strictly stronger than the #695 `alternatives=1`
+  best-spread-only check) and a trained policy (`--policy`, multi-sample stochastic rollouts for
+  variance). Both arms judge reach by the same product-checker predicate (`geometry_oracle.layout_valid`
+  + routable-by-construction, #694), never the env oracle. `sample_population` draws fleet-subset
+  fill scenarios deterministic in `seed`. Per the issue's cost caveat, the RR-MC arm defaults to a
+  small population at a modest restart budget (a large baseline is meant to be recorded once and
+  frozen, mirroring the `bench_baseline.json` freeze). The RR-MC + stats arms are torch-free;
+  `--policy` needs `[train]`. `ml/` is dev/CI-only (never shipped in the wheel).
+
 ### Changed
 
 ### Fixed

--- a/ml/README.md
+++ b/ml/README.md
@@ -17,6 +17,11 @@ environment + reward (`HangarFitEnv`), reusing `hangarfit`'s geometry oracle.
   above) across the frozen reach-not-beat benchmark set and print the
   side-by-side both-rates table against the recorded RR-MC baseline (needs the
   `[train]` extra / torch).
+- `python -m ml.reach_rate [--policy P]` — the **statistical reach-rate harness**
+  (#711): sample a population of fill scenarios and report **reach-rate ± Wilson CI**
+  per scenario-kind for multi-alternative RR-MC and (with `--policy P`) a trained
+  policy. The RR-MC arm is torch-free; `--policy` needs `[train]`. See "Statistical
+  reach-rate (#711)" below for the methodology + budget.
 
 ### Vectorized training (#708)
 
@@ -71,6 +76,43 @@ oracle — the single shared `layout_valid` oracle is now used by both the env
 reward and `ml/eval` (the prior over-enforcement of the inert maintenance bay
 was fixed in 4c-ii, #694). Fixed-obstacle pre-placements from
 `Scenario.fixed_obstacle_placements` are honoured by the env since 4c-ii (#693).
+
+## Statistical reach-rate (#711)
+
+`ml/benchmark.py` + `ml/eval.py` answer a **binary** question on **4 frozen** scenarios:
+"does RR-MC / the policy reach *these*?" `ml/reach_rate.py` lifts that to a **rate** over a
+**sampled population**: reach-rate ± **Wilson** CI per scenario-kind, for both arms. Both
+arms judge reach by the **same** predicate the bench uses — the product checker
+(`geometry_oracle.layout_valid` = `collisions.check` + Caddy egress, #694) **and**
+routable-by-construction (`plan_fill` gives every placeable body a real tow path) — never
+the env oracle's parked-score validity.
+
+- **Population (v1):** `sample_population` draws fill scenarios that vary the **fleet subset**
+  (`k ∈ [k_min, k_max]` aircraft from a pool) on a fixed roomy hangar, deterministic in `seed`.
+  Varying hangar geometry / GO placements (the issue's other axes) is a documented extension.
+- **Multi-alternative RR-MC:** `rrmc_reach_multi` solves for `--alternatives N` and counts
+  RR-MC-reached if **any** candidate is valid + fully routable — strictly stronger than
+  `benchmark.rrmc_reach` (`alternatives=1`, best-spread only). Load-bearing the moment the
+  solver yields valid-but-**un**routable dense layouts.
+- **Multi-sample policy:** `policy_reach_count` rolls the policy out `--samples M` times per
+  scenario (stochastic, seeded per sample) so its rate carries variance for the CI.
+- **Wilson CI** (not normal-approx) because a reach-rate sits at the 0/1 extremes, where the
+  normal interval gives negative / zero-width bounds.
+
+```bash
+# RR-MC reach-rate over a small sampled population (torch-free).
+python -m ml.reach_rate --scenarios 8 --k-min 2 --k-max 4 --alternatives 4 --max-restarts 16
+# …plus the policy arm from a trained checkpoint (needs [train]).
+python -m ml.reach_rate --scenarios 8 --policy model.pt --samples 16
+```
+
+**Budget (the issue's cost caveat).** RR-MC reach is the expensive arm (a `solve` + `plan_fill`
+per scenario, ≈10 s/restart on dense anchors — 200 restarts was "unrunnable", ≈30–50 min/anchor).
+So the harness defaults to a **small** population at a **modest** restart budget, and a
+large-population RR-MC baseline is meant to be recorded once and **frozen** (mirroring the
+`bench_baseline.json` freeze, spec D4); pre-register the population `seed` + budgets before
+measuring so the policy-vs-RR-MC comparison can't go circular. The policy arm is cheap (rollouts,
+no solver), so it affords a larger population × more samples.
 
 ## Training knobs (4c-ii)
 

--- a/ml/reach_rate.py
+++ b/ml/reach_rate.py
@@ -1,0 +1,360 @@
+"""Statistical reach-rate harness (#711, epic #607) — DEV/CI-ONLY.
+
+Lifts the #695 reach benchmark from a 4-row existence table to a reproducible
+reach-**rate** over a sampled population: N scenarios × M samples, reported as
+reach-rate ± Wilson CI per scenario-kind, for both RR-MC (multi-alternative) and a
+trained policy. ``ml/benchmark.py`` answers "does RR-MC/the policy reach THESE four
+frozen scenarios"; this answers "what FRACTION of a population does each reach".
+
+Both arms judge reach by the **same** predicate the #695 bench uses — the product
+checker (``geometry_oracle.layout_valid`` = ``collisions.check`` + Caddy egress, #694)
+**and** routable-by-construction (``plan_fill`` routes every placeable body with a real
+path) — never the env oracle's parked-score validity.
+
+**Multi-alternative RR-MC.** ``rrmc_reach_multi`` solves for ``alternatives`` candidate
+layouts and counts RR-MC-reached if **any** is valid + fully routable — strictly stronger
+than the #695 ``rrmc_reach`` (``alternatives=1``), which only routes the single best-spread
+layout. Load-bearing the moment the solver yields valid-but-unroutable dense layouts.
+
+**Budget (the #711 caveat).** RR-MC reach is the expensive arm (a ``solve`` + ``plan_fill``
+per scenario), so the CLI defaults to a SMALL population at a MODEST restart budget; a
+large-population RR-MC baseline is meant to be recorded once and frozen, mirroring the
+#695 ``bench_baseline.json`` freeze (spec D4). The policy arm is cheap (rollouts, no
+solver), so it affords more stochastic samples per scenario.
+
+The sampled population (v1) varies the **fleet subset** (k aircraft drawn from a pool) on a
+fixed roomy hangar — a clean fill with no ground objects / pins. Varying hangar geometry and
+GO placements (issue subtask 1's other axes) is a documented extension.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from hangarfit.loader import load_fleet, load_hangar
+from hangarfit.models import Scenario, SearchConfig
+from hangarfit.solver import solve
+from hangarfit.towplanner import NoFeasiblePlanError, plan_fill
+from ml import geometry_oracle as go
+
+_ROOT = Path(__file__).resolve().parent.parent  # repo root (ml/ sits at the root)
+
+
+# ── pure statistics ──────────────────────────────────────────────────────────
+
+
+def wilson_ci(successes: int, n: int, *, z: float = 1.96) -> tuple[float, float]:
+    """Wilson score interval for a binomial proportion. Preferred over the normal
+    approximation because a reach-rate routinely sits at the 0/1 extremes, where the
+    normal interval misbehaves (negative bounds / zero width). ``z=1.96`` ⇒ 95% CI.
+    ``n == 0`` ⇒ ``(0.0, 1.0)`` (no information). Raises if ``successes`` ∉ ``0..n``."""
+    if successes < 0 or successes > n:
+        raise ValueError(f"wilson_ci: successes {successes} out of range 0..{n}")
+    if n == 0:
+        return (0.0, 1.0)
+    p = successes / n
+    z2 = z * z
+    denom = 1.0 + z2 / n
+    centre = (p + z2 / (2 * n)) / denom
+    half = (z / denom) * math.sqrt(p * (1 - p) / n + z2 / (4 * n * n))
+    return (max(0.0, centre - half), min(1.0, centre + half))
+
+
+@dataclass(frozen=True, slots=True)
+class ReachRate:
+    """A reach-rate over ``n`` Bernoulli trials of one scenario-kind, with a Wilson CI."""
+
+    kind: str
+    n: int
+    reached: int
+    rate: float
+    ci_lo: float
+    ci_hi: float
+
+
+def reach_rate(kind: str, reached: int, n: int) -> ReachRate:
+    lo, hi = wilson_ci(reached, n)
+    return ReachRate(
+        kind=kind, n=n, reached=reached, rate=(reached / n if n else 0.0), ci_lo=lo, ci_hi=hi
+    )
+
+
+def aggregate(pairs: Iterable[tuple[str, bool]]) -> dict[str, ReachRate]:
+    """Aggregate ``(kind, reached)`` trials into a ``{kind: ReachRate}`` map plus an
+    ``"overall"`` row pooling every trial. Pure — the statistics layer the issue notes
+    neither ``eval.py`` nor ``benchmark.py`` provides."""
+    by_kind: dict[str, list[bool]] = {}
+    all_trials: list[bool] = []
+    for kind, reached in pairs:
+        by_kind.setdefault(kind, []).append(bool(reached))
+        all_trials.append(bool(reached))
+    out = {k: reach_rate(k, sum(v), len(v)) for k, v in sorted(by_kind.items())}
+    if all_trials:
+        out["overall"] = reach_rate("overall", sum(all_trials), len(all_trials))
+    return out
+
+
+# ── sampled population ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class SampledScenario:
+    """One member of the reach-rate population: an in-memory fill Scenario + its kind
+    label (the fleet-subset size stratum, e.g. ``"k3"``)."""
+
+    name: str
+    kind: str
+    scenario: Scenario
+
+
+def sample_population(
+    *,
+    n: int,
+    k_min: int = 2,
+    k_max: int = 4,
+    seed: int,
+    fleet_path: str = "data/fleet.yaml",
+    hangar_path: str = "tests/fixtures/test_hangar_large.yaml",
+) -> list[SampledScenario]:
+    """Sample ``n`` aircraft-subset fill scenarios on a fixed hangar — the reach-rate
+    population. Each draws ``k ∈ [k_min, k_max]`` aircraft from the fleet pool (no ground
+    objects, no maintenance, no pins). Deterministic in ``seed`` (its sole RNG), so the
+    population — and thus the baseline — is reproducible."""
+    if not 1 <= k_min <= k_max:
+        raise ValueError(f"sample_population: need 1 <= k_min <= k_max, got {k_min}, {k_max}")
+    fleet = load_fleet(str(_ROOT / fleet_path))
+    hangar = load_hangar(str(_ROOT / hangar_path), fleet=fleet)
+    pool = sorted(fleet)  # aircraft ids, sorted for a deterministic draw
+    if k_max > len(pool):
+        raise ValueError(f"sample_population: k_max {k_max} exceeds fleet pool size {len(pool)}")
+    rng = random.Random(seed)
+    out: list[SampledScenario] = []
+    for i in range(n):
+        k = rng.randint(k_min, k_max)
+        subset = tuple(sorted(rng.sample(pool, k)))
+        sc = Scenario(
+            fleet=fleet,
+            hangar=hangar,
+            fleet_in=subset,
+            constraints={},
+            ground_object_defs={},
+            region_preferences={},
+        )
+        out.append(SampledScenario(name=f"sample{i:03d}_k{k}", kind=f"k{k}", scenario=sc))
+    return out
+
+
+# ── reach predicates (the #695 product-checker predicate, both arms) ─────────
+
+
+def rrmc_reach_multi(
+    scenario: Scenario,
+    *,
+    alternatives: int,
+    max_restarts: int,
+    tow_max_expansions: int,
+    seed: int = 0,
+) -> bool:
+    """Multi-alternative RR-MC reach: solve for up to ``alternatives`` diverse layouts and
+    return True if **any** is valid (product checker) AND fully routable-by-construction
+    (``plan_fill`` gives every placeable body a real tow path). ``budget_s=inf`` so
+    ``max_restarts`` is the only bound (a wall-clock budget would make the verdict
+    machine-dependent — spec D4). Torch-free."""
+    result = solve(
+        scenario,
+        budget_s=float("inf"),
+        seed=seed,
+        search=SearchConfig(spread=True, max_restarts=max_restarts),
+        alternatives=alternatives,
+        plan_paths=False,
+    )
+    n_total = len(scenario.placeable_ids)
+    for layout in result.layouts:
+        if not go.layout_valid(layout):
+            continue
+        try:
+            plan = plan_fill(layout, heuristic="grid", max_total_expansions=tow_max_expansions)
+        except NoFeasiblePlanError:
+            continue
+        if sum(1 for m in plan.moves if m.path is not None) == n_total:
+            return True
+    return False
+
+
+def _build_env(scenario: Scenario):  # noqa: ANN202 (HangarFitEnv imported lazily)
+    """A driven-fill HangarFitEnv for a sampled (no-GO) Scenario — the no-ground-object
+    case of ``benchmark.build_scenario_env``, built from an in-memory Scenario. Torch-free
+    (HangarFitEnv carries no torch)."""
+    from ml.env import HangarFitEnv
+    from ml.types import DifficultyConfig
+
+    placeable = scenario.placeable_ids
+    per = 120
+    difficulty = DifficultyConfig(
+        max_objects=len(placeable),
+        per_object_step_budget=per,
+        total_step_budget=per * max(1, len(placeable)),
+    )
+    hangar = replace(scenario.hangar, apron_depth_m=8.0)
+    return HangarFitEnv(
+        hangar=hangar, fleet=scenario.fleet, requested_ids=placeable, difficulty=difficulty
+    )
+
+
+def policy_reach_count(scenario: Scenario, policy, *, samples: int, seed: int = 0) -> int:
+    """Roll ``policy`` out ``samples`` times on ``scenario`` and count the reaches under the
+    SAME product-checker predicate (parked == total AND ``go.layout_valid`` AND zero swept
+    intrusion). ``samples == 1`` ⇒ a single deterministic (argmax) pass; ``samples > 1`` ⇒
+    stochastic sampling (seeded per sample) so the rate has variance for a CI. Needs torch
+    (imported lazily)."""
+    import torch
+
+    from ml.encoding import EncoderConfig, encode
+
+    enc = EncoderConfig()
+    env = _build_env(scenario)
+    bodies = {**env.fleet, **env.ground_objects}
+    deterministic = samples == 1
+    policy.eval()
+    reached = 0
+    for s in range(samples):
+        torch.manual_seed(seed * 100003 + s)
+        obs = env.reset()
+        max_swept = 0.0
+        info = None
+        done = False
+        with torch.no_grad():
+            while not done and obs.active is not None:
+                obs_t = encode(obs, env.hangar, bodies, enc)
+                tr = obs.active.body.effective_turn_radius_m()
+                _idx, _logprob, action = policy.act(
+                    obs_t, turn_radius_m=tr, deterministic=deterministic
+                )
+                obs, _reward, done, info = env.step(action)
+                max_swept = max(max_swept, info.terms.get("hard_swept", 0.0))
+        if (
+            info is not None
+            and done
+            and info.placed == info.total
+            and max_swept == 0.0
+            and go.layout_valid(env._layout())
+        ):
+            reached += 1
+    return reached
+
+
+# ── population aggregation ───────────────────────────────────────────────────
+
+
+def rrmc_population_rates(
+    population: Sequence[SampledScenario],
+    *,
+    alternatives: int,
+    max_restarts: int,
+    tow_max_expansions: int,
+    seed: int = 0,
+) -> dict[str, ReachRate]:
+    """RR-MC reach-rate ± CI per kind over the population (one Bernoulli trial per scenario)."""
+    pairs = [
+        (
+            ss.kind,
+            rrmc_reach_multi(
+                ss.scenario,
+                alternatives=alternatives,
+                max_restarts=max_restarts,
+                tow_max_expansions=tow_max_expansions,
+                seed=seed,
+            ),
+        )
+        for ss in population
+    ]
+    return aggregate(pairs)
+
+
+def policy_population_rates(
+    population: Sequence[SampledScenario], policy, *, samples: int, seed: int = 0
+) -> dict[str, ReachRate]:
+    """Policy reach-rate ± CI per kind: each scenario contributes ``samples`` Bernoulli
+    trials (stochastic rollouts) to its kind's rate."""
+    pairs: list[tuple[str, bool]] = []
+    for ss in population:
+        r = policy_reach_count(ss.scenario, policy, samples=samples, seed=seed)
+        pairs.extend((ss.kind, True) for _ in range(r))
+        pairs.extend((ss.kind, False) for _ in range(samples - r))
+    return aggregate(pairs)
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def _print_rates(title: str, rates: dict[str, ReachRate]) -> None:
+    print(f"\n{title}")
+    print(f"  {'kind':10}  {'reach-rate':>10}  {'95% CI':>16}  {'n':>5}")
+    for kind, r in rates.items():
+        ci = f"[{r.ci_lo:.2f}, {r.ci_hi:.2f}]"
+        print(f"  {kind:10}  {r.rate:>10.3f}  {ci:>16}  {r.n:>5}")
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    p = argparse.ArgumentParser(
+        description="Statistical reach-rate harness (#711): reach-rate ± CI over a sampled "
+        "population, for multi-alternative RR-MC and (optionally) a trained policy."
+    )
+    p.add_argument("--scenarios", type=int, default=8, help="population size N (default: 8)")
+    p.add_argument("--k-min", type=int, default=2, help="min aircraft per scenario (default: 2)")
+    p.add_argument("--k-max", type=int, default=4, help="max aircraft per scenario (default: 4)")
+    p.add_argument("--seed", type=int, default=0, help="population + RR-MC seed (default: 0)")
+    p.add_argument("--alternatives", type=int, default=4, help="RR-MC alternatives (default: 4)")
+    p.add_argument("--max-restarts", type=int, default=16, help="RR-MC restarts (default: 16)")
+    p.add_argument(
+        "--tow-max-expansions", type=int, default=8000, help="tow budget (default: 8000)"
+    )
+    p.add_argument("--fleet", default="data/fleet.yaml")
+    p.add_argument("--hangar", default="tests/fixtures/test_hangar_large.yaml")
+    p.add_argument(
+        "--policy",
+        default=None,
+        help="path to a torch state_dict .pt — adds the policy reach-rate arm ([train] extra)",
+    )
+    p.add_argument(
+        "--samples", type=int, default=8, help="stochastic rollouts per scenario, policy arm"
+    )
+    args = p.parse_args(argv)
+
+    population = sample_population(
+        n=args.scenarios,
+        k_min=args.k_min,
+        k_max=args.k_max,
+        seed=args.seed,
+        fleet_path=args.fleet,
+        hangar_path=args.hangar,
+    )
+    print(
+        f"population: {len(population)} fill scenarios (k {args.k_min}..{args.k_max}) on "
+        f"{args.hangar}, seed {args.seed}"
+    )
+    rrmc = rrmc_population_rates(
+        population,
+        alternatives=args.alternatives,
+        max_restarts=args.max_restarts,
+        tow_max_expansions=args.tow_max_expansions,
+        seed=args.seed,
+    )
+    _print_rates(
+        f"RR-MC reach-rate (alternatives={args.alternatives}, restarts={args.max_restarts})", rrmc
+    )
+    if args.policy is not None:
+        from ml.eval import load_policy
+
+        policy = load_policy(args.policy)
+        pol = policy_population_rates(population, policy, samples=args.samples, seed=args.seed)
+        _print_rates(f"policy reach-rate ({args.samples} samples/scenario)", pol)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/reach_rate.py
+++ b/ml/reach_rate.py
@@ -214,6 +214,7 @@ def policy_reach_count(scenario: Scenario, policy, *, samples: int, seed: int = 
     (imported lazily)."""
     import torch
 
+    from ml.benchmark import _verdict_from  # single-source the spec §4 reach predicate
     from ml.encoding import EncoderConfig, encode
 
     enc = EncoderConfig()
@@ -237,13 +238,20 @@ def policy_reach_count(scenario: Scenario, policy, *, samples: int, seed: int = 
                 )
                 obs, _reward, done, info = env.step(action)
                 max_swept = max(max_swept, info.terms.get("hard_swept", 0.0))
-        if (
-            info is not None
-            and done
-            and info.placed == info.total
-            and max_swept == 0.0
-            and go.layout_valid(env._layout())
-        ):
+        if info is None:
+            continue  # a 0-step episode (no placeable bodies) never reaches
+        # Build the verdict via the bench's predicate (NOT an inline copy) so the env-oracle-
+        # vs-product-checker contract (#694) stays single-sourced: final_valid is the PRODUCT
+        # checker on the terminal layout, never info.valid.
+        final_valid = go.layout_valid(env._layout()) if done else False
+        verdict = _verdict_from(
+            parked=info.placed,
+            total=info.total,
+            done=done,
+            final_valid=final_valid,
+            max_swept=max_swept,
+        )
+        if verdict.reached:
             reached += 1
     return reached
 
@@ -280,10 +288,12 @@ def policy_population_rates(
     population: Sequence[SampledScenario], policy, *, samples: int, seed: int = 0
 ) -> dict[str, ReachRate]:
     """Policy reach-rate ± CI per kind: each scenario contributes ``samples`` Bernoulli
-    trials (stochastic rollouts) to its kind's rate."""
+    trials (stochastic rollouts) to its kind's rate. The per-scenario seed folds in the
+    scenario index, so two scenarios with an identical fleet subset still draw independent
+    rollout noise (while staying fully reproducible in ``seed``)."""
     pairs: list[tuple[str, bool]] = []
-    for ss in population:
-        r = policy_reach_count(ss.scenario, policy, samples=samples, seed=seed)
+    for idx, ss in enumerate(population):
+        r = policy_reach_count(ss.scenario, policy, samples=samples, seed=seed + idx)
         pairs.extend((ss.kind, True) for _ in range(r))
         pairs.extend((ss.kind, False) for _ in range(samples - r))
     return aggregate(pairs)
@@ -324,6 +334,11 @@ def main(argv: Sequence[str] | None = None) -> None:
     p.add_argument(
         "--samples", type=int, default=8, help="stochastic rollouts per scenario, policy arm"
     )
+    # Policy architecture (must match the checkpoint's), mirroring ml.eval's flags so a
+    # checkpoint trained at a non-default size loads instead of failing load_state_dict.
+    p.add_argument("--d-model", type=int, default=128)
+    p.add_argument("--n-layers", type=int, default=2)
+    p.add_argument("--n-heads", type=int, default=4)
     args = p.parse_args(argv)
 
     population = sample_population(
@@ -351,7 +366,14 @@ def main(argv: Sequence[str] | None = None) -> None:
     if args.policy is not None:
         from ml.eval import load_policy
 
-        policy = load_policy(args.policy)
+        policy = load_policy(
+            args.policy,
+            policy_kwargs={
+                "d_model": args.d_model,
+                "n_layers": args.n_layers,
+                "n_heads": args.n_heads,
+            },
+        )
         pol = policy_population_rates(population, policy, samples=args.samples, seed=args.seed)
         _print_rates(f"policy reach-rate ({args.samples} samples/scenario)", pol)
 

--- a/tests/ml/test_reach_rate.py
+++ b/tests/ml/test_reach_rate.py
@@ -1,0 +1,153 @@
+"""Tests for the statistical reach-rate harness (#711). The stats / sampling / RR-MC
+arm is torch-free; the policy arm importorskips torch per-test."""
+
+from __future__ import annotations
+
+import pytest
+
+from ml.reach_rate import (
+    ReachRate,
+    SampledScenario,
+    aggregate,
+    reach_rate,
+    rrmc_reach_multi,
+    sample_population,
+    wilson_ci,
+)
+
+# ── pure statistics ──────────────────────────────────────────────────────────
+
+
+def test_wilson_ci_all_success_is_below_one_and_brackets_one():
+    lo, hi = wilson_ci(10, 10)
+    assert hi == pytest.approx(1.0, abs=1e-9)  # clamped at 1
+    assert 0.0 < lo < 1.0  # ...but the lower bound pulls in (the Wilson virtue vs normal)
+
+
+def test_wilson_ci_all_failure_is_above_zero():
+    lo, hi = wilson_ci(0, 10)
+    assert lo == pytest.approx(0.0, abs=1e-9)
+    assert 0.0 < hi < 1.0
+
+
+def test_wilson_ci_brackets_the_point_estimate():
+    lo, hi = wilson_ci(5, 10)
+    assert lo < 0.5 < hi
+
+
+def test_wilson_ci_zero_n_is_full_uncertainty():
+    assert wilson_ci(0, 0) == (0.0, 1.0)
+
+
+def test_wilson_ci_narrows_with_n():
+    _, hi_small = wilson_ci(5, 10)
+    _, hi_big = wilson_ci(50, 100)
+    assert (hi_big - 0.5) < (hi_small - 0.5)  # same rate, more data ⇒ tighter
+
+
+def test_wilson_ci_rejects_out_of_range():
+    with pytest.raises(ValueError, match="out of range"):
+        wilson_ci(11, 10)
+
+
+def test_reach_rate_fields():
+    r = reach_rate("k3", 3, 4)
+    assert (r.kind, r.reached, r.n) == ("k3", 3, 4)
+    assert r.rate == pytest.approx(0.75)
+    assert r.ci_lo < 0.75 < r.ci_hi
+
+
+def test_aggregate_groups_by_kind_and_adds_overall():
+    rates = aggregate([("k2", True), ("k2", False), ("k3", True), ("k3", True)])
+    assert rates["k2"].reached == 1 and rates["k2"].n == 2
+    assert rates["k3"].reached == 2 and rates["k3"].n == 2
+    assert rates["overall"].reached == 3 and rates["overall"].n == 4
+    assert all(isinstance(v, ReachRate) for v in rates.values())
+
+
+def test_aggregate_empty_is_empty():
+    assert aggregate([]) == {}
+
+
+# ── sampled population ───────────────────────────────────────────────────────
+
+
+def test_sample_population_is_deterministic_in_seed():
+    a = sample_population(n=5, seed=7)
+    b = sample_population(n=5, seed=7)
+    assert [s.name for s in a] == [s.name for s in b]
+    assert [tuple(s.scenario.fleet_in) for s in a] == [tuple(s.scenario.fleet_in) for s in b]
+
+
+def test_sample_population_varies_with_seed():
+    a = [tuple(s.scenario.fleet_in) for s in sample_population(n=6, seed=1)]
+    b = [tuple(s.scenario.fleet_in) for s in sample_population(n=6, seed=2)]
+    assert a != b
+
+
+def test_sample_population_respects_k_bounds_and_kind_label():
+    pop = sample_population(n=12, k_min=2, k_max=3, seed=0)
+    for ss in pop:
+        k = len(ss.scenario.fleet_in)
+        assert 2 <= k <= 3
+        assert ss.kind == f"k{k}"
+        assert len(set(ss.scenario.fleet_in)) == k  # distinct ids
+    assert isinstance(pop[0], SampledScenario)
+
+
+def test_sample_population_rejects_bad_k_bounds():
+    with pytest.raises(ValueError, match="k_min <= k_max"):
+        sample_population(n=1, k_min=3, k_max=2, seed=0)
+
+
+def test_sample_population_rejects_k_over_pool():
+    with pytest.raises(ValueError, match="exceeds fleet pool"):
+        sample_population(n=1, k_min=2, k_max=999, seed=0)
+
+
+# ── multi-alternative RR-MC ──────────────────────────────────────────────────
+
+
+def test_rrmc_reach_multi_reaches_an_easy_two_plane_fill():
+    # A 2-plane fill on the roomy test hangar is trivially valid+routable; RR-MC reaches it
+    # at a small budget. (Fast: 2 planes, few restarts.)
+    ss = sample_population(n=1, k_min=2, k_max=2, seed=0)[0]
+    reached = rrmc_reach_multi(
+        ss.scenario, alternatives=2, max_restarts=4, tow_max_expansions=2000, seed=0
+    )
+    assert reached is True
+
+
+def test_rrmc_reach_multi_is_deterministic():
+    ss = sample_population(n=1, k_min=2, k_max=2, seed=3)[0]
+    kw = dict(alternatives=2, max_restarts=4, tow_max_expansions=2000, seed=0)
+    assert rrmc_reach_multi(ss.scenario, **kw) == rrmc_reach_multi(ss.scenario, **kw)
+
+
+# ── policy arm (torch-gated) ─────────────────────────────────────────────────
+
+
+def test_policy_reach_count_runs_end_to_end():
+    pytest.importorskip("torch")
+    from ml.policy import HangarFitPolicy
+    from ml.reach_rate import policy_reach_count
+
+    policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2)
+    ss = sample_population(n=1, k_min=2, k_max=2, seed=0)[0]
+    # An untrained policy may or may not reach; assert it runs and returns a valid count.
+    count = policy_reach_count(ss.scenario, policy, samples=3, seed=0)
+    assert isinstance(count, int)
+    assert 0 <= count <= 3
+
+
+def test_policy_population_rates_shape():
+    pytest.importorskip("torch")
+    from ml.policy import HangarFitPolicy
+    from ml.reach_rate import policy_population_rates
+
+    policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2)
+    pop = sample_population(n=2, k_min=2, k_max=2, seed=0)
+    rates = policy_population_rates(pop, policy, samples=2, seed=0)
+    assert "overall" in rates
+    assert rates["overall"].n == 4  # 2 scenarios × 2 samples
+    assert 0.0 <= rates["overall"].rate <= 1.0

--- a/tests/ml/test_reach_rate.py
+++ b/tests/ml/test_reach_rate.py
@@ -108,6 +108,7 @@ def test_sample_population_rejects_k_over_pool():
 # ── multi-alternative RR-MC ──────────────────────────────────────────────────
 
 
+@pytest.mark.slow
 def test_rrmc_reach_multi_reaches_an_easy_two_plane_fill():
     # A 2-plane fill on the roomy test hangar is trivially valid+routable; RR-MC reaches it
     # at a small budget. (Fast: 2 planes, few restarts.)
@@ -118,6 +119,7 @@ def test_rrmc_reach_multi_reaches_an_easy_two_plane_fill():
     assert reached is True
 
 
+@pytest.mark.slow
 def test_rrmc_reach_multi_is_deterministic():
     ss = sample_population(n=1, k_min=2, k_max=2, seed=3)[0]
     kw = dict(alternatives=2, max_restarts=4, tow_max_expansions=2000, seed=0)


### PR DESCRIPTION
## What & why

Closes **#711**. `ml/benchmark.py` + `ml/eval.py` answer a **binary** reach question on **4 frozen** scenarios. This adds `ml/reach_rate.py`: reach as a **rate ± Wilson CI** over a **sampled population**, for both arms.

## What it adds

- **`sample_population`** — fleet-subset fill scenarios (`k ∈ [k_min,k_max]` aircraft from a pool on a roomy hangar), deterministic in `seed`. (Varying hangar geometry / GO placements — the issue's other axes — is a documented extension.)
- **`rrmc_reach_multi`** — **multi-alternative RR-MC**: solve for `N` alternatives, reached if **any** is valid (product checker) + fully routable-by-construction. Strictly stronger than #695's `alternatives=1` best-spread-only check.
- **`policy_reach_count`** — multi-sample stochastic policy rollouts (seeded per sample → variance for the CI), same product-checker predicate.
- **`wilson_ci` + `aggregate`** — reach-rate ± Wilson CI per kind + an `overall` row (the stats layer neither `eval.py` nor `benchmark.py` had).
- **`python -m ml.reach_rate`** CLI — RR-MC arm torch-free; `--policy P` adds the policy arm (`[train]`).

## Predicate & determinism (ml-rl-guard)

Both arms judge reach by the **same** predicate the #695 bench uses — the product checker (`geometry_oracle.layout_valid` = `collisions.check` + Caddy egress, #694) **and** routable-by-construction — never the env oracle's parked-score validity (the issue's subtask 3). `sample_population` and the RR-MC arm are deterministic in `seed`. New code is additive and torch-free except the policy arm; no training/curriculum/reward surfaces touched.

## Budget (the issue's cost caveat — addressed)

RR-MC reach is the expensive arm (`solve` + `plan_fill` per scenario; ≈10 s/restart on dense anchors, 200 restarts "unrunnable"). So the CLI **defaults to a small population at a modest restart budget**, and a large-population RR-MC baseline is meant to be **recorded once and frozen** (mirroring the `bench_baseline.json` freeze, spec D4); pre-register the population `seed` + budgets so the policy-vs-RR-MC comparison can't go circular. The policy arm is cheap, so it affords a larger population × more samples. Documented in `ml/README`.

## Tests

18 tests: stats (Wilson extremes/0-n/narrowing/raise), `aggregate`, `sample_population` (determinism / k-bounds / kind labels / pool-guard), multi-alt RR-MC (reaches an easy 2-plane fill, deterministic), and the policy arm (importorskip torch, untrained-policy plumbing). `mypy ml/` clean.

## Note

This pairs with the #736 witness-anchored lever (PR #794) — it's the instrumentation to measure whether a trained policy's reach-rate beats RR-MC's, most useful once a lever shows lift. `ml/` is dev/CI-only (never in the wheel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDna3UbHRUueri81HPXHoz