### PR TITLE
feat(ml): opt-in spatial-token cross-attention policy (#809, #736 lever)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#809, epic #607): opt-in spatial-token cross-attention policy (`--spatial-tokens`).**
+  Replaces the spatially-blind global-average-pool — which collapsed the CNN occupancy feature map
+  to a single vector broadcast to every object token, so the policy knew *how full* the hangar was
+  but never *where* the free gaps were (the dense trio-notch plateau lever, #736). With
+  `--spatial-tokens` the CNN feature map becomes per-cell **spatial tokens** (fixed sin/cos 2D
+  positional encoding) that the object tokens **cross-attend** to, plus a spatial summary fed to the
+  critic. Default off ⇒ **byte-identical** to the prior net (zero new parameters; a deliberate
+  new-architecture re-baseline when on, persisted in the checkpoint's `policy_kwargs`). `ml/` is
+  dev/CI-only (never shipped in the wheel).
 - **Learned backend (#711, epic #607): statistical reach-rate harness (`python -m ml.reach_rate`).**
   Lifts the #695 reach benchmark from a 4-row binary existence table to a reproducible
   reach-**rate** over a **sampled population**: reach-rate ± **Wilson** CI per scenario-kind,

--- a/docs/superpowers/plans/2026-06-23-spatial-token-policy.md
+++ b/docs/superpowers/plans/2026-06-23-spatial-token-policy.md
@@ -1,0 +1,565 @@
+# Spatial-token cross-attention policy — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the spatially-blind global-average-pool in `ml/policy.py` with an opt-in spatial-token cross-attention path so object tokens attend to free-space cells instead of one broadcast global summary (#809, the #736 plateau lever).
+
+**Architecture:** A new `spatial_tokens: bool = False` constructor flag on `HangarFitPolicy`. OFF builds and runs today's exact net (byte-identical, 0 new params). ON keeps the CNN feature map `(B, C, 24, 12)`, projects each cell to a spatial token (+ fixed sin/cos 2D PE), concatenates the 288 spatial tokens with the 16 object tokens into one transformer sequence, and feeds a spatial summary into a widened value head. Pure `ml/policy.py` + `tests/ml/` change; no `encoding.py` / `SCHEMA_VERSION` / `#752` impact.
+
+**Tech Stack:** Python 3.12, PyTorch (the `[train]` extra; tests `importorskip("torch")`), pytest. Spec: `docs/superpowers/specs/2026-06-23-spatial-token-policy-design.md`.
+
+## Global Constraints
+
+- **Default-neutrality (4c-ii).** `spatial_tokens=False` (the default) MUST register **zero** new parameters, in the **same module-registration order** as today, and run today's exact `forward()` → byte-identical. Existing determinism/byte-identity canaries must not need re-baseline.
+- **`ml-rl-guard` invariants.** No new RNG in `forward()`; the fixed sin/cos PE is computed deterministically (not learned). Validity = the product checker (untouched — observation-consumption only). No new silent-failure surface.
+- **Scope:** `ml/policy.py`, `tests/ml/`, and a thin `ml/train.py` CLI wire only. No `ml/encoding.py`, no `SCHEMA_VERSION` bump, no scene/v2 contact.
+- **Resolution:** v1 uses the 2 m (`24×12`) feature-map tap. A 1 m (`48×24`) tap is pre-registered as a follow-up lever, NOT built here.
+- **`d_model` divisibility:** the 2D sin/cos PE requires `d_model % 4 == 0` (default 128, test dims 64/32 all satisfy it).
+- **Commits:** TDD, one logical change per commit. The repo runs a PostToolUse ruff+pytest hook after `ml/*.py` edits; let it pass before committing.
+- **Branch:** `feature/809-spatial-token-policy` (already created off develop; the design spec is already committed on it).
+
+---
+
+### Task 1: Fixed sin/cos 2D positional-encoding helper
+
+**Files:**
+- Modify: `ml/policy.py` (add module-level helper + `import math`)
+- Test: `tests/ml/test_policy.py`
+
+**Interfaces:**
+- Produces: `_sincos_pos_2d(h: int, w: int, d_model: int) -> torch.Tensor` returning `(h*w, d_model)` float32, **row-major** over the `h×w` grid (cell index `= row*w + col`, matching `Tensor.flatten(2)`), deterministic, no RNG. Requires `d_model % 4 == 0`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/ml/test_policy.py` (after the imports; `_sincos_pos_2d` is imported from `ml.policy`):
+
+```python
+import math  # noqa: E402  (top of file, with the other stdlib imports)
+from ml.policy import _sincos_pos_2d  # noqa: E402  (add to the existing ml.policy import line or its own)
+
+
+def test_sincos_pos_2d_shape_finite_deterministic():
+    pe = _sincos_pos_2d(24, 12, 64)
+    assert pe.shape == (24 * 12, 64)
+    assert pe.dtype == torch.float32
+    assert torch.isfinite(pe).all()
+    assert torch.equal(pe, _sincos_pos_2d(24, 12, 64))  # no RNG -> identical
+
+
+def test_sincos_pos_2d_row_major_distinct_cells():
+    pe = _sincos_pos_2d(24, 12, 64)
+    # row-major: index = row*w + col. (0,0)=0, (0,1)=1, (1,0)=12 must all differ.
+    assert not torch.equal(pe[0], pe[1])
+    assert not torch.equal(pe[0], pe[12])
+
+
+def test_sincos_pos_2d_requires_d_model_div4():
+    with pytest.raises((AssertionError, ValueError)):
+        _sincos_pos_2d(24, 12, 66)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/ml/test_policy.py::test_sincos_pos_2d_shape_finite_deterministic -v`
+Expected: FAIL — `ImportError: cannot import name '_sincos_pos_2d'`.
+
+- [ ] **Step 3: Implement the helper**
+
+Add `import math` to the top of `ml/policy.py` (with the stdlib imports), and add this module-level function (e.g. just below the imports, above `to_batch`):
+
+```python
+def _sincos_pos_2d(h: int, w: int, d_model: int) -> Tensor:
+    """Fixed (non-learned) 2D sin/cos positional encoding for an ``h × w`` grid,
+    flattened ROW-MAJOR to ``(h*w, d_model)`` so cell index ``row*w + col`` matches
+    ``Tensor.flatten(2)``. The first ``d_model/2`` channels encode the row, the second
+    half the column. Deterministic (no RNG). Requires ``d_model % 4 == 0``."""
+    if d_model % 4 != 0:
+        raise ValueError(f"_sincos_pos_2d needs d_model % 4 == 0, got {d_model}")
+    d_half = d_model // 2
+
+    def _1d(length: int, dim: int) -> Tensor:
+        pos = torch.arange(length, dtype=torch.float32).unsqueeze(1)  # (length, 1)
+        idx = torch.arange(0, dim, 2, dtype=torch.float32)  # (dim/2,)
+        div = torch.exp(-math.log(10000.0) * idx / dim)  # (dim/2,)
+        out = torch.zeros(length, dim, dtype=torch.float32)
+        out[:, 0::2] = torch.sin(pos * div)
+        out[:, 1::2] = torch.cos(pos * div)
+        return out
+
+    row_pe = _1d(h, d_half)  # (h, d_half)
+    col_pe = _1d(w, d_half)  # (w, d_half)
+    grid = torch.zeros(h, w, d_model, dtype=torch.float32)
+    grid[:, :, :d_half] = row_pe.unsqueeze(1)  # row varies along dim 0
+    grid[:, :, d_half:] = col_pe.unsqueeze(0)  # col varies along dim 1
+    return grid.reshape(h * w, d_model)  # row-major flatten
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/ml/test_policy.py -k sincos -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/policy.py tests/ml/test_policy.py
+git commit -m "feat(ml): fixed sin/cos 2D positional-encoding helper (#809)"
+```
+
+---
+
+### Task 2: `spatial_tokens` flag — ON-branch `__init__` + `forward()`
+
+**Files:**
+- Modify: `ml/policy.py:92-142` (`HangarFitPolicy.__init__` and `forward`)
+- Test: `tests/ml/test_policy.py`
+
+**Interfaces:**
+- Consumes: `_sincos_pos_2d` (Task 1); `RASTER_CHANNELS`, `TOKEN_DIM`, `ACTION_DIM`, `MAGNITUDE_DIM`, `PolicyOutput`, `to_batch`, `_obs` (existing).
+- Produces: `HangarFitPolicy(..., spatial_tokens: bool = False)`; with `spatial_tokens=True`, `forward(batch)` returns a `PolicyOutput` over the `16 + H*W` sequence, with `value_head` consuming `cat(pooled_obj, g, pooled_spatial)`.
+
+- [ ] **Step 1: Write the failing ON-path tests**
+
+Add to `tests/ml/test_policy.py`:
+
+```python
+def _model_spatial(seed=0, d_model=64):
+    torch.manual_seed(seed)
+    return HangarFitPolicy(d_model=d_model, n_layers=2, n_heads=4, spatial_tokens=True).eval()
+
+
+def test_spatial_on_forward_output_shapes():
+    out = _model_spatial()(to_batch([_obs(), _obs()]))
+    assert isinstance(out, PolicyOutput)
+    assert out.kind_gear_logits.shape == (2, 9)
+    assert out.magnitude_bin_logits.shape == (2, 5)
+    assert out.value.shape == (2,)
+
+
+def test_spatial_on_forward_deterministic_and_finite():
+    m = _model_spatial(seed=5)
+    batch = to_batch([_obs()])
+    a, b = m(batch), m(batch)
+    assert torch.isfinite(a.value).all()
+    assert torch.isfinite(a.kind_gear_logits.nan_to_num(neginf=0.0)).all()
+    assert torch.equal(a.value, b.value)
+    assert torch.equal(a.kind_gear_logits, b.kind_gear_logits)
+
+
+def test_spatial_on_still_masks_illegal_kinds():
+    batch = to_batch([_obs()])
+    out = _model_spatial()(batch)
+    legal = batch["legal_action_mask"][0]
+    probs = out.kind_gear_logits.softmax(-1)[0]
+    assert torch.all(probs[~legal] == 0.0)
+
+
+def test_feat_mean_equals_adaptive_avgpool():
+    # The ON branch computes g = cnn_proj(feat.mean((2,3))); this must equal the old
+    # AdaptiveAvgPool2d(1)+Flatten so the global pathway is preserved exactly.
+    from torch import nn
+    feat = torch.randn(2, 64, 24, 12)
+    via_mean = feat.mean(dim=(2, 3))
+    via_pool = nn.Flatten()(nn.AdaptiveAvgPool2d(1)(feat))
+    assert torch.allclose(via_mean, via_pool, atol=1e-6)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/ml/test_policy.py -k spatial_on -v`
+Expected: FAIL — `HangarFitPolicy.__init__() got an unexpected keyword argument 'spatial_tokens'`.
+
+- [ ] **Step 3: Update `__init__`**
+
+In `ml/policy.py`, change the `HangarFitPolicy.__init__` signature and body. Replace the current signature line and the `self.cnn = ...` / `self.value_head = ...` blocks:
+
+```python
+    def __init__(
+        self,
+        *,
+        d_model: int = 128,
+        n_layers: int = 2,
+        n_heads: int = 4,
+        cnn_channels: tuple[int, ...] = (16, 32, 64),
+        spatial_tokens: bool = False,
+    ) -> None:
+        super().__init__()
+        self.spatial_tokens = spatial_tokens
+        convs: list[nn.Module] = []
+        in_ch = RASTER_CHANNELS
+        for ch in cnn_channels:
+            convs += [nn.Conv2d(in_ch, ch, kernel_size=3, stride=2, padding=1), nn.ReLU()]
+            in_ch = ch
+        if spatial_tokens:
+            # keep the feature MAP (B, C, H, W); the spatial path consumes it directly
+            self.cnn = nn.Sequential(*convs)
+        else:
+            self.cnn = nn.Sequential(*convs, nn.AdaptiveAvgPool2d(1), nn.Flatten())
+        self.cnn_proj = nn.Linear(cnn_channels[-1], d_model)  # g: -> D
+        self.token_proj = nn.Linear(TOKEN_DIM, d_model)  # tokens 24 -> D
+        self.fuse = nn.Linear(2 * d_model, d_model)  # concat(token, g) 2D -> D
+        layer = nn.TransformerEncoderLayer(
+            d_model, n_heads, dim_feedforward=4 * d_model, batch_first=True
+        )
+        self.encoder = nn.TransformerEncoder(layer, n_layers)
+        self.kind_head = nn.Sequential(
+            nn.Linear(d_model, d_model), nn.ReLU(), nn.Linear(d_model, ACTION_DIM)
+        )
+        self.mag_head = nn.Sequential(
+            nn.Linear(d_model, d_model), nn.ReLU(), nn.Linear(d_model, MAGNITUDE_DIM)
+        )
+        value_in = 3 * d_model if spatial_tokens else 2 * d_model
+        self.value_head = nn.Sequential(
+            nn.Linear(value_in, d_model), nn.ReLU(), nn.Linear(d_model, 1)
+        )
+        # ON-only modules are registered LAST so the OFF branch's module-registration order
+        # (and therefore its param-init RNG stream + state_dict keys) is byte-identical to today.
+        if spatial_tokens:
+            self.spatial_proj = nn.Linear(cnn_channels[-1], d_model)  # per-cell -> D
+```
+
+- [ ] **Step 4: Branch `forward()` and add the spatial forward**
+
+In `ml/policy.py`, at the top of `forward`, dispatch to the spatial path; leave the existing OFF body unchanged below it:
+
+```python
+    def forward(self, batch: dict[str, Tensor]) -> PolicyOutput:
+        if self.spatial_tokens:
+            return self._forward_spatial(batch)
+        raster, tokens = batch["raster"], batch["tokens"]
+        token_mask, active_index = batch["token_mask"], batch["active_index"]
+        legal = batch["legal_action_mask"]
+        g = self.cnn_proj(self.cnn(raster))  # (B, D)
+        tok = self.token_proj(tokens)  # (B, N, D)
+        g_b = g.unsqueeze(1).expand(-1, tok.shape[1], -1)  # (B, N, D)
+        fused = self.fuse(torch.cat([tok, g_b], dim=-1))  # (B, N, D)
+        emb = self.encoder(fused, src_key_padding_mask=~token_mask)  # (B, N, D)
+        idx = active_index.clamp(min=0).view(-1, 1, 1).expand(-1, 1, emb.shape[-1])
+        active_emb = emb.gather(1, idx).squeeze(1)  # (B, D)
+        m = token_mask.unsqueeze(-1).to(emb.dtype)  # (B, N, 1)
+        pooled = (emb * m).sum(1) / m.sum(1).clamp(min=1.0)  # (B, D)
+        kind_logits = self.kind_head(active_emb).masked_fill(~legal, float("-inf"))
+        mag_logits = self.mag_head(active_emb)
+        value = self.value_head(torch.cat([pooled, g], dim=-1)).squeeze(-1)
+        return PolicyOutput(kind_logits, mag_logits, value)
+
+    def _forward_spatial(self, batch: dict[str, Tensor]) -> PolicyOutput:
+        """ON-branch forward: object tokens cross-attend to per-cell spatial tokens.
+        ``g = feat.mean((2,3))`` reproduces the old AdaptiveAvgPool2d(1)+Flatten exactly;
+        the spatial tokens + a critic spatial summary are purely additive."""
+        raster, tokens = batch["raster"], batch["tokens"]
+        token_mask, active_index = batch["token_mask"], batch["active_index"]
+        legal = batch["legal_action_mask"]
+        feat = self.cnn(raster)  # (B, C, H, W) — no pool/flatten on this branch
+        h, w = feat.shape[2], feat.shape[3]
+        g = self.cnn_proj(feat.mean(dim=(2, 3)))  # (B, D) == AdaptiveAvgPool2d(1)+Flatten
+        pos = _sincos_pos_2d(h, w, g.shape[-1]).to(feat.device, feat.dtype)  # (H*W, D)
+        sp = self.spatial_proj(feat.flatten(2).mT) + pos  # (B, H*W, D)
+        tok = self.token_proj(tokens)  # (B, N, D)
+        n_obj = tok.shape[1]
+        g_b = g.unsqueeze(1).expand(-1, n_obj, -1)  # (B, N, D)
+        fused_obj = self.fuse(torch.cat([tok, g_b], dim=-1))  # (B, N, D)
+        seq = torch.cat([fused_obj, sp], dim=1)  # (B, N + H*W, D)
+        sp_pad = torch.zeros(sp.shape[0], sp.shape[1], dtype=torch.bool, device=sp.device)
+        pad = torch.cat([~token_mask, sp_pad], dim=1)  # (B, N + H*W); spatial rows valid
+        emb = self.encoder(seq, src_key_padding_mask=pad)  # (B, N + H*W, D)
+        emb_obj = emb[:, :n_obj, :]  # (B, N, D)
+        idx = active_index.clamp(min=0).view(-1, 1, 1).expand(-1, 1, emb_obj.shape[-1])
+        active_emb = emb_obj.gather(1, idx).squeeze(1)  # (B, D)
+        m = token_mask.unsqueeze(-1).to(emb.dtype)  # (B, N, 1)
+        pooled_obj = (emb_obj * m).sum(1) / m.sum(1).clamp(min=1.0)  # (B, D)
+        pooled_spatial = emb[:, n_obj:, :].mean(dim=1)  # (B, D) — all spatial rows valid
+        kind_logits = self.kind_head(active_emb).masked_fill(~legal, float("-inf"))
+        mag_logits = self.mag_head(active_emb)
+        value = self.value_head(
+            torch.cat([pooled_obj, g, pooled_spatial], dim=-1)
+        ).squeeze(-1)
+        return PolicyOutput(kind_logits, mag_logits, value)
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `pytest tests/ml/test_policy.py -k "spatial_on or feat_mean" -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Run the whole policy suite (catch OFF regressions)**
+
+Run: `pytest tests/ml/test_policy.py -v`
+Expected: PASS (all existing + new). The existing OFF tests must be green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ml/policy.py tests/ml/test_policy.py
+git commit -m "feat(ml): opt-in spatial-token cross-attention forward path (#809)"
+```
+
+---
+
+### Task 3: Default-neutrality guards (OFF byte-identical, ON adds exactly the expected params)
+
+**Files:**
+- Test: `tests/ml/test_policy.py`
+
+**Interfaces:**
+- Consumes: `HangarFitPolicy` with the `spatial_tokens` flag (Task 2).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_spatial_off_is_byte_identical_to_default():
+    # spatial_tokens=False (the default) must reproduce today's net exactly: same params,
+    # same module order (same seed -> identical weights), same forward.
+    torch.manual_seed(7)
+    a = HangarFitPolicy(d_model=64, n_layers=2, n_heads=4, spatial_tokens=False).eval()
+    torch.manual_seed(7)
+    b = HangarFitPolicy(d_model=64, n_layers=2, n_heads=4).eval()  # default
+    sa, sb = a.state_dict(), b.state_dict()
+    assert set(sa) == set(sb)
+    for k in sa:
+        assert torch.equal(sa[k], sb[k]), k
+    oa, ob = a(to_batch([_obs()])), b(to_batch([_obs()]))
+    assert torch.equal(oa.kind_gear_logits, ob.kind_gear_logits)
+    assert torch.equal(oa.magnitude_bin_logits, ob.magnitude_bin_logits)
+    assert torch.equal(oa.value, ob.value)
+
+
+def test_spatial_off_registers_no_spatial_params():
+    m = HangarFitPolicy(d_model=64, spatial_tokens=False)
+    assert not any("spatial_proj" in k for k in m.state_dict())
+    assert m.value_head[0].weight.shape == (64, 128)  # 2*d_model input
+
+
+def test_spatial_on_adds_spatial_proj_and_widens_value_head():
+    m = HangarFitPolicy(d_model=64, spatial_tokens=True)
+    assert any("spatial_proj" in k for k in m.state_dict())
+    assert m.value_head[0].weight.shape == (64, 192)  # 3*d_model input
+```
+
+- [ ] **Step 2: Run to verify (these should PASS immediately — they pin Task 2's contract)**
+
+Run: `pytest tests/ml/test_policy.py -k "spatial_off or spatial_on_adds" -v`
+Expected: PASS. If `test_spatial_off_is_byte_identical_to_default` FAILS, the OFF branch perturbed the module-registration order — fix `__init__` so ON-only modules are registered strictly last and OFF builds the identical set.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/ml/test_policy.py
+git commit -m "test(ml): pin spatial_tokens default-neutrality (OFF byte-identical) (#809)"
+```
+
+---
+
+### Task 4: Checkpoint-flag guard + terminal-observation contract
+
+**Files:**
+- Test: `tests/ml/test_policy.py`
+
+**Interfaces:**
+- Consumes: `HangarFitPolicy` (both flag values), `_terminal_obs` (existing in the test file).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_state_dict_does_not_cross_load_across_flag():
+    # The two branches have different state_dict key-sets; a strict load must raise rather
+    # than silently partial-load (the checkpoint persists policy_kwargs incl. spatial_tokens).
+    off = HangarFitPolicy(d_model=64, spatial_tokens=False)
+    on = HangarFitPolicy(d_model=64, spatial_tokens=True)
+    with pytest.raises(RuntimeError):
+        on.load_state_dict(off.state_dict())
+    with pytest.raises(RuntimeError):
+        off.load_state_dict(on.state_dict())
+
+
+@pytest.mark.parametrize("spatial", [False, True])
+def test_act_on_terminal_observation_raises_both_branches(spatial):
+    # PPO never value-forwards a terminal obs (compute_gae zeroes last_value via 1-dones[-1]);
+    # act() is the public guard and must reject a terminal obs on BOTH branches, so the
+    # 288 always-valid spatial tokens never turn a terminal forward into finite garbage.
+    torch.manual_seed(2)
+    m = HangarFitPolicy(d_model=64, n_layers=2, n_heads=4, spatial_tokens=spatial).eval()
+    obs_t = _terminal_obs()
+    assert obs_t.active_index < 0
+    with pytest.raises(ValueError, match="terminal"):
+        m.act(obs_t, turn_radius_m=8.0)
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `pytest tests/ml/test_policy.py -k "cross_load or terminal_observation_raises_both" -v`
+Expected: PASS (3 cases: cross-load + terminal×2). `act()`'s existing `active_index < 0` guard (`ml/policy.py`) already rejects terminal before any forward, so both branches pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/ml/test_policy.py
+git commit -m "test(ml): checkpoint-flag guard + terminal contract for spatial_tokens (#809)"
+```
+
+---
+
+### Task 5: Thread `--spatial-tokens` through the train CLI
+
+**Files:**
+- Modify: `ml/train.py:822-839` (add the argparse flag near `--d-model`) and `ml/train.py:1090-1098` (the `policy_kwargs` assembly)
+- Test: manual `--help` check (the smoke in Task 6 exercises the `policy_kwargs → policy` path)
+
+**Interfaces:**
+- Consumes: the `policy_kwargs` dict already threaded into `HangarFitPolicy(**policy_kwargs)` and persisted in the checkpoint.
+- Produces: a `--spatial-tokens` store_true flag that adds `spatial_tokens=True` to `policy_kwargs` only when set (absent ⇒ default-neutral).
+
+- [ ] **Step 1: Add the argparse flag**
+
+In `ml/train.py`, immediately after the `--n-heads` argument block (around line 839), add:
+
+```python
+    p.add_argument(
+        "--spatial-tokens",
+        action="store_true",
+        help="opt-in spatial-token cross-attention policy (#809): object tokens attend to "
+        "free-space cells instead of one global-pool summary. Default off = byte-identical net "
+        "(a deliberate new-architecture re-baseline when on; the flag is persisted in the "
+        "checkpoint's policy_kwargs)",
+    )
+```
+
+- [ ] **Step 2: Thread it into `policy_kwargs`**
+
+In `ml/train.py`, change the `policy_kwargs` assembly (around line 1090) to include the flag only when set, preserving the default-neutral `or None` fallback:
+
+```python
+    policy_kwargs = {
+        k: v
+        for k, v in (
+            ("d_model", args.d_model),
+            ("n_layers", args.n_layers),
+            ("n_heads", args.n_heads),
+            ("spatial_tokens", True if args.spatial_tokens else None),
+        )
+        if v is not None
+    } or None
+```
+
+- [ ] **Step 3: Verify the flag is wired**
+
+Run: `python -m ml.train --help 2>&1 | grep -- "--spatial-tokens"`
+Expected: the flag's help line prints (non-empty).
+
+- [ ] **Step 4: Lint + type-check the change**
+
+Run: `ruff check ml/train.py && mypy ml/`
+Expected: no errors. (Run `mypy` over the whole `ml/` package, not a single file — `follow_imports = "skip"` makes a single-file run resolve cross-module imports as `Any`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/train.py
+git commit -m "feat(ml): --spatial-tokens train CLI flag, default-neutral (#809)"
+```
+
+---
+
+### Task 6: PPO smoke — the ON path trains without NaN
+
+**Files:**
+- Test: `tests/ml/test_train_curriculum.py` (alongside the existing `train(...)` smoke at line ~43)
+
+**Interfaces:**
+- Consumes: `ml.train.train(seed, iterations, rollout_len, policy_kwargs=…)` → `list[float]` per-iteration mean reward.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/ml/test_train_curriculum.py` (ensure `import math` is present at the top):
+
+```python
+def test_spatial_tokens_ppo_smoke_trains_without_nan():
+    # A handful of PPO iterations on the trivial rung with the ON architecture must run and
+    # return finite rewards — proves the spatial path trains end-to-end (rollout + GAE +
+    # update) with no NaN and no terminal-forward crash.
+    history = train(
+        seed=0,
+        iterations=2,
+        rollout_len=32,
+        policy_kwargs={"spatial_tokens": True, "d_model": 32, "n_layers": 1, "n_heads": 2},
+    )
+    assert len(history) == 2
+    assert all(isinstance(r, float) and math.isfinite(r) for r in history)
+```
+
+- [ ] **Step 2: Run to verify it fails first (red), then implement is N/A**
+
+Run: `pytest tests/ml/test_train_curriculum.py::test_spatial_tokens_ppo_smoke_trains_without_nan -v`
+Expected: PASS directly (Task 2 already implemented the ON path; this test is the integration gate). If it FAILS with a shape/NaN error, debug the `_forward_spatial` path (most likely the `pad` mask or `pooled_spatial` shape) before proceeding — do not weaken the assertion.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/ml/test_train_curriculum.py
+git commit -m "test(ml): PPO smoke for spatial_tokens ON path (#809)"
+```
+
+---
+
+### Task 7: CHANGELOG (conditional) + full local gate
+
+**Files:**
+- Modify (conditional): `CHANGELOG.md`
+- Verify: ruff, mypy, the `tests/ml/` suite
+
+- [ ] **Step 1: Decide on a CHANGELOG entry**
+
+`ml/` is dev/CI-only (never shipped in the wheel). Check whether recent `ml/`-only training-knob PRs added a `[Unreleased]` entry:
+
+Run: `git log --oneline -20 -- CHANGELOG.md` and inspect whether prior `--r-valid-park` / `--normalize-returns`-class knobs were logged.
+- If `ml/` training knobs are conventionally logged → add one line under `[Unreleased] → ### Added`:
+  `- \`--spatial-tokens\` opt-in policy architecture (spatial-token cross-attention) for the learned backend (#809).`
+- If they follow the dev-tooling no-entry policy → **no CHANGELOG edit**; note this in the PR body.
+
+- [ ] **Step 2: Full lint + type + test gate**
+
+Run:
+```bash
+ruff check ml/ tests/ml/ && ruff format --check ml/ tests/ml/
+mypy ml/
+pytest tests/ml/test_policy.py tests/ml/test_train_curriculum.py -v
+```
+Expected: all green.
+
+- [ ] **Step 3: Run the broader ml/ suite to confirm no determinism/byte-identity regression**
+
+Run: `pytest tests/ml/ -q`
+Expected: PASS. Pay attention to `tests/ml/test_ppo.py`, `tests/ml/test_checkpoint.py`, and any byte-identity/determinism canary — the OFF default path must be unaffected.
+
+- [ ] **Step 4: Commit (if CHANGELOG changed)**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): note --spatial-tokens learned-backend knob (#809)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage**
+
+| Spec section | Task |
+|---|---|
+| §4.1 OFF bit-identical | Task 2 (`__init__` order) + Task 3 (byte-identity guard) |
+| §4.2 ON modules (cnn_backbone, spatial_proj, fixed sin/cos PE, widened value_head) | Task 1 (PE) + Task 2 |
+| §4.3 ON forward data flow (304-seq, masks, gathers) | Task 2 |
+| §4.4 critic-summary fold-in (`cat(pooled_obj, g, pooled_spatial)`) | Task 2 |
+| §5 determinism/guard (no RNG, default-neutral, checkpoint flag) | Task 2 + Task 3 + Task 4 |
+| §6 terminal-forward obligation | Task 4 (terminal contract test; PPO live-only confirmed) |
+| §7 2 m tap first | Task 2 (consumes the default `24×12` map; no escalation built) |
+| §8 tests (shape, equivalence, g-equiv, determinism, checkpoint, terminal) | Tasks 2–4 |
+| §9 `--spatial-tokens` CLI knob | Task 5 |
+| §8 PPO smoke | Task 6 |
+| §8 CHANGELOG (conditional) | Task 7 |
+
+No gaps.
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows complete code; every run step shows an exact command + expected result.
+
+**3. Type consistency:** `spatial_tokens: bool` consistent across `__init__`/CLI/tests. `_sincos_pos_2d(h, w, d_model) -> Tensor` used identically in Task 1 and Task 2's `_forward_spatial`. `_forward_spatial(self, batch)` matches the `forward` dispatch. `value_head` input width `3*d_model` (ON) / `2*d_model` (OFF) consistent between Task 2 (`__init__`) and Task 3 (`(64,192)`/`(64,128)` assertions). `policy_kwargs` key `spatial_tokens` consistent between Task 5 and Task 6's smoke.

--- a/docs/superpowers/specs/2026-06-23-spatial-token-policy-design.md
+++ b/docs/superpowers/specs/2026-06-23-spatial-token-policy-design.md
@@ -1,0 +1,209 @@
+# Spatial-token cross-attention policy — fixing the spatially-blind global pool (#736 lever)
+
+**Status:** Draft (design under review)
+**Date:** 2026-06-23
+**Issue:** #809 (impl). Epic #607 (learned backend); tracking #736 (training-improvement backlog).
+**Scope:** `ml/policy.py` + `tests/ml/` **only**. No `ml/encoding.py`, no `SCHEMA_VERSION` bump, no `#752` wire-format change, no scene/v2 contact. `ml-rl-guard` is the reviewer.
+**Builds on:** the policy architecture (sub-project #3, spec `2026-06-16-learned-backend-policy-architecture-design.md`) and the observation tensorizer (sub-project #2). Selected by a 3-variant adversarial design panel (2026-06-23).
+
+---
+
+## 1. The flaw this fixes
+
+`HangarFitPolicy.forward()` (`ml/policy.py`) runs a 3×stride-2 CNN over the 7-channel
+occupancy raster `(B, 7, 192, 96)` → feature map `(B, 64, 24, 12)`, then
+**`AdaptiveAvgPool2d(1)` global-average-pools it to a single `(B, 64)` vector `g`**,
+projects it to `d_model`, and **broadcasts that one vector to every object token**
+before the transformer. So the only spatial signal reaching the decision heads is a
+scalar *how full is the hangar*, never *where the free gaps are*. The transformer reasons
+over per-object **tokens** (each carrying its own pose `nx, ny, sinθ, cosθ` + dims) fused
+with that broadcast global vector — it must infer free space by mentally rasterizing object
+poses.
+
+This spatial blindness is invisible on easy rungs (1–2 objects, acres of room) but is the
+**wall on dense rungs**: a 3rd object must thread a specific gap near the office notch.
+It fits the observed trio-notch plateau (dense-rung valid-placement `vp` stuck ~0.33) and
+both failure modes — piling into an unseen occupied cell, and place-nothing-new
+(no confident gap → never commits).
+
+## 2. Goals & non-goals
+
+**Goals**
+- Give the policy a **spatial** read of the raster: object tokens **cross-attend to free-space
+  cells** instead of receiving one broadcast global summary.
+- **Flag-gated, default-neutral.** With the flag off, the net is bit-identical to today
+  (0 new params, identical module-registration order) so the existing equivalence/determinism
+  canaries need no re-baseline.
+- **Critic too.** The value head must see WHERE, not only the indicted global mean.
+- Tests: shape contract on the new sequence path; flag-off byte-identity vs current
+  `HangarFitPolicy`; flag-on finite + reproducible; a short PPO smoke proving the on-path
+  trains without NaN.
+
+**Non-goals (deferred to a supervised follow-up)**
+- The **full trio-notch mastery training run** — pre-registered WIN: dense-rung `vp` clears
+  the ~0.33 ceiling. Out of scope for the implementation PR; it is a multi-hour GPU run.
+- Any **1 m (`48×24`) resolution escalation** — pre-registered as the *next* lever, taken
+  only if the 2 m tap's reach-rate stalls (§7).
+- Any `ml/encoding.py` / observation-schema change.
+
+## 3. Why spatial tokens (and not the alternatives)
+
+A 3-variant adversarial panel (2026-06-23) scored each candidate then tried to refute it.
+
+| Variant | Leverage holds after refutation? | Fatal flaws | Schema impact |
+|---|---|---|---|
+| **Spatial-token cross-attention** | **yes** | **none found** | none |
+| Per-object grid-sample | **no** (refuted) | deep 2 m/cell map + ~15–30 m receptive field can't resolve a ~1-plane-width gap; needs a *different, bigger* shallow-map design; critic stays blind; zero-init gate has zero gradient | none |
+| Numpy free-space rays | narrowly | senses current pose not post-action pose; critic gets it ~1/N diluted; between-ray false-blocked teaches avoidance; new NaN-token surface | `SCHEMA_VERSION 1→2` |
+
+Spatial tokens is the only variant that **removes the pool from the decision path** rather
+than working around it, and the only one the skeptic could not break. Full panel detail lives
+in the issue #809 thread / session transcript.
+
+## 4. Architecture — `ml/policy.py`
+
+A new constructor flag selects the path. `HangarFitPolicy.__init__` gains
+`spatial_tokens: bool = False`.
+
+### 4.1 Flag OFF — bit-identical to today
+Build today's exact modules and run today's exact `forward()`:
+`self.cnn = nn.Sequential(*convs, nn.AdaptiveAvgPool2d(1), nn.Flatten())`, `cnn_proj`,
+`token_proj`, `fuse`, `encoder`, `kind_head`, `mag_head`, `value_head` unchanged. **No new
+parameters are registered**, and module-registration order is unchanged, so the
+construction-RNG stream and every `state_dict` key match today. This is the default.
+
+### 4.2 Flag ON — spatial tokens
+`__init__` instead builds:
+- `self.cnn_backbone = nn.Sequential(*convs)` — keeps the feature **map** `(B, 64, 24, 12)`
+  (drops the pool+flatten).
+- `self.spatial_proj = nn.Linear(cnn_channels[-1], d_model)` — projects each spatial cell to D.
+- A **fixed (non-learned) sin/cos 2D positional encoding** for the `24×12` grid, registered as
+  a non-persistent buffer (zero parameters). *Chosen over a learned PE specifically so the
+  on-branch adds the minimum parameter surface and introduces no extra construction-RNG draw;
+  a learned PE would also be valid but is not needed for v1.*
+- `cnn_proj`, `token_proj`, `fuse`, `encoder`, `kind_head`, `mag_head` as today.
+- `self.value_head` widened to accept `cat(pooled_obj, g, pooled_spatial)` — input
+  `3 * d_model` instead of `2 * d_model` (§4.4).
+
+### 4.3 `forward()` data flow (flag ON)
+```
+feat   = cnn_backbone(raster)                       # (B, 64, 24, 12)
+g      = cnn_proj(feat.mean(dim=(2, 3)))            # (B, D) — == old AdaptiveAvgPool2d(1)+Flatten, exactly
+sp     = spatial_proj(feat.flatten(2).mT) + pos_2d  # (B, 288, D) spatial tokens (288 = 24*12)
+tok    = token_proj(tokens)                         # (B, 16, D)
+g_b    = g.unsqueeze(1).expand(-1, 16, -1)
+fused_obj = fuse(cat([tok, g_b], dim=-1))           # (B, 16, D) — object stream unchanged
+seq    = cat([fused_obj, sp], dim=1)                # (B, 304, D)
+pad    = cat([~token_mask, zeros(B, 288, bool)], 1) # spatial tokens always valid
+emb    = encoder(seq, src_key_padding_mask=pad)     # (B, 304, D)
+emb_obj = emb[:, :16, :]                            # object rows only
+active_emb = emb_obj.gather(1, active_index…)        # (B, D) — heads consume this
+pooled_obj  = masked_mean(emb_obj, token_mask)       # (B, D) — object-only (as today)
+pooled_spat = emb[:, 16:, :].mean(dim=1)             # (B, D) — spatial summary for the critic
+kind/mag heads on active_emb                         # unchanged
+value = value_head(cat([pooled_obj, g, pooled_spat]))# (B,) — critic now sees WHERE
+```
+`g = feat.mean(dim=(2,3))` is provably equal to `AdaptiveAvgPool2d(1)` + `Flatten` over the
+same `feat`, so the global pathway is preserved exactly; the spatial pathway is purely additive.
+
+`feat.flatten(2)` is **row-major** over the `24×12` grid (cell index `= row*12 + col`); the
+fixed `pos_2d` PE **must** be built in that same order so each spatial token's positional code
+matches the cell it carries. A shape/order test pins this (§8).
+
+### 4.4 Critic-summary fold-in (decision: included in v1)
+All three panel reviewers independently flagged that `value_head(cat(pooled, g))` leaves the
+**critic globally blind** — `g` is the indicted global mean, and the actor-only fix reaches the
+critic only indirectly. The notch wall is partly a marginal-commitment **economics** problem,
+which the critic gates, so a WHERE-blind critic under-credits the threading move. v1 therefore
+feeds `pooled_spatial` (the masked-mean of the spatial-token encoder outputs) into the on-branch
+value head. *Alternative considered: defer to a follow-up lever — rejected because it is ~3 LOC
+behind the same flag and the critic is where the economics signal must land.*
+
+## 5. Determinism & guard contract (`ml-rl-guard`)
+
+- **Reproducibility/seeding.** No new RNG in `forward()`. The fixed sin/cos PE adds no draw.
+  Within-build bit-identity holds; cross-process torch-CPU nondeterminism is pre-existing and
+  unchanged.
+- **4c-ii default-neutrality.** Flag off registers **zero** new params and runs today's exact
+  forward → byte-identical. The byte-identity oracle (Sync == Subproc) and the fixed-action
+  reward-stream diff need **no re-baseline** for the default.
+- **Flag-on is a deliberate new-architecture re-baseline** (expected for a plateau lever). The
+  flag is **persisted in the checkpoint and validated on load** — the two branches have
+  different `state_dict` key-sets, so loading a flag-off checkpoint into a flag-on policy (or
+  vice-versa) must raise loudly, not silently partial-load.
+- **Numeric silent-failure.** A NaN in `feat` would now propagate through 288 tokens; the
+  existing advantage-finiteness assert in the PPO update backstops, and the spatial path adds no
+  new division/log. The masked-mean `.clamp(min=1.0)` zero-guard stays on the **object** rows
+  (the 288 spatial rows are excluded from `pooled_obj`, so they cannot mask-leak into the value
+  semantics).
+- **Validity = the product checker.** Untouched — this is observation-consumption plumbing, no
+  reward / oracle change, so the #694 contract holds by construction.
+
+## 6. Edge cases
+
+- **Terminal-state forward (panel-flagged).** With 288 always-valid spatial rows, a fully-padded
+  object row no longer NaNs — it attends to spatial tokens and returns a *finite-but-meaningless*
+  embedding. `act()` already rejects `active_index < 0`, so sampling is safe. **Implementation
+  obligation:** verify in `ml/ppo.py` that no `forward()` is taken over a terminal observation
+  for value-bootstrap (the intrinsic-horizon bootstrap should use 0, not a forward); add a test
+  pinning that contract. If a terminal value-forward *is* taken, gate it explicitly.
+- **Padding mask shape.** `src_key_padding_mask` grows from `(B, 16)` to `(B, 304)`; the spatial
+  block is all-valid (`False` = attend). The `active_index` gather and `pooled_obj` operate on
+  `emb[:, :16]`, so they are unaffected by the appended rows.
+
+## 7. Resolution: 2 m tap first, 1 m escalation pre-registered (decision)
+
+The `24×12` feature map is **2 m per cell** (`192/24 = 8` rows, `96/12 = 8` cols, ×0.25 m).
+A ~1-plane-width notch gap (~1.5–2 m) is at/below that pitch, so the 2 m tap resolves *which
+2 m neighbourhood is free*, not *is this exact slot threadable*. The **diagnosed** failure,
+though, is coverage-minimum / abandonment — the policy not *aiming* the 3rd object at the right
+region — which the 2 m tap can plausibly fix. So:
+
+- **v1 uses the 2 m (`24×12`) tap.** Cheapest; the rollout box is shapely-bound (~61%), so the
+  ~19× sequence growth (16 → 304 tokens) is tolerable.
+- **Pre-registered escalation:** a 1 m (`48×24`, ~1152-token, ~1300× attention term) tap, taken
+  **only if** the trio-notch reach-rate stalls on the 2 m tap. Not built in v1.
+- **Pre-registered WIN (follow-up training run):** dense-rung `vp` clears the ~0.33 ceiling.
+
+## 8. Module structure & tests
+
+- **Modify** `ml/policy.py` — the flag, the on-branch `__init__` modules, the on-branch
+  `forward()`, the fixed sin/cos 2D PE helper, `import torch.nn.functional as F` if needed.
+- **Modify** `tests/ml/test_policy.py`:
+  - **Equivalence (canary-protecting):** a flag-off `HangarFitPolicy(spatial_tokens=False)`
+    forward is byte-identical to the current net given the same seed/weights.
+  - **Shape contract:** flag-on forward produces the documented `(B, ACTION_DIM)`,
+    `(B, MAGNITUDE_DIM)`, `(B,)` outputs over the 304-length sequence; `PolicyOutput`
+    asserts pass.
+  - **`g`-equivalence:** `feat.mean(dim=(2,3))` equals the old `AdaptiveAvgPool2d(1)+Flatten`
+    on a fixed `feat`.
+  - **Determinism:** flag-on forward is finite and bit-identical across two calls with a fixed
+    seed in `eval()`.
+  - **Checkpoint-flag guard:** loading a flag-off `state_dict` into a flag-on policy raises.
+  - **Terminal contract:** the §6 obligation — a test pinning that no terminal value-forward
+    is taken (or that it is explicitly gated).
+- **CHANGELOG.md** — a `[Unreleased]` entry only **if** the project conventionally logs `ml/`
+  training knobs. `ml/` is dev/CI-only (never shipped in the wheel), so this may instead follow
+  the dev-tooling no-entry policy; verify against recent `ml/` knob PRs at implementation time
+  rather than assuming an entry is required.
+- **Possibly modify** `ml/train.py` / the PPO config — thread a `--spatial-tokens` CLI flag to
+  the policy constructor (default off, per 4c-ii). Kept minimal; the A/B is flag-on vs flag-off.
+
+## 9. CLI / training-knob surface
+
+A single new **default-neutral** knob `--spatial-tokens` (off by default), threaded from the
+train CLI → `PPOConfig`/policy constructor → `HangarFitPolicy(spatial_tokens=…)`. Off reproduces
+today bit-for-bit; on selects the new architecture. This matches the existing 4c-ii knob
+convention (every knob off ⇒ byte-identical).
+
+## 10. Open questions / risks
+
+- **Does the 2 m tap actually lift abandonment?** Unknown until the follow-up training run; the
+  design is explicitly staged so a stall escalates to the 1 m tap rather than re-opening the
+  architecture choice.
+- **Spatial tokens dominating attention** (288 keys vs 16 object queries) could wash out the
+  object-token gradient. Mitigation if observed: scale or gate the spatial contribution; not
+  pre-built in v1.
+- **Critic widening** changes the value-head input width on the on-branch only; confirm the
+  GAE/value-loss path in `ml/ppo.py` is agnostic to the value-head internals (it consumes the
+  scalar value, so it should be).

--- a/ml/policy.py
+++ b/ml/policy.py
@@ -5,6 +5,7 @@ ObservationTensors -> batched-tensor adapter. Requires the [train] extra (torch)
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -43,6 +44,32 @@ class PolicyOutput:
         assert self.kind_gear_logits.shape[-1] == ACTION_DIM
         assert self.magnitude_bin_logits.shape[-1] == MAGNITUDE_DIM
         assert self.kind_gear_logits.shape[0] == self.value.shape[0]
+
+
+def _sincos_pos_2d(h: int, w: int, d_model: int) -> Tensor:
+    """Fixed (non-learned) 2D sin/cos positional encoding for an ``h × w`` grid,
+    flattened ROW-MAJOR to ``(h*w, d_model)`` so cell index ``row*w + col`` matches
+    ``Tensor.flatten(2)``. The first ``d_model/2`` channels encode the row, the second
+    half the column. Deterministic (no RNG). Requires ``d_model % 4 == 0``."""
+    if d_model % 4 != 0:
+        raise ValueError(f"_sincos_pos_2d needs d_model % 4 == 0, got {d_model}")
+    d_half = d_model // 2
+
+    def _1d(length: int, dim: int) -> Tensor:
+        pos = torch.arange(length, dtype=torch.float32).unsqueeze(1)  # (length, 1)
+        idx = torch.arange(0, dim, 2, dtype=torch.float32)  # (dim/2,)
+        div = torch.exp(-math.log(10000.0) * idx / dim)  # (dim/2,)
+        out = torch.zeros(length, dim, dtype=torch.float32)
+        out[:, 0::2] = torch.sin(pos * div)
+        out[:, 1::2] = torch.cos(pos * div)
+        return out
+
+    row_pe = _1d(h, d_half)  # (h, d_half)
+    col_pe = _1d(w, d_half)  # (w, d_half)
+    grid = torch.zeros(h, w, d_model, dtype=torch.float32)
+    grid[:, :, :d_half] = row_pe.unsqueeze(1)  # row varies along dim 0
+    grid[:, :, d_half:] = col_pe.unsqueeze(0)  # col varies along dim 1
+    return grid.reshape(h * w, d_model)  # row-major flatten
 
 
 def to_batch(

--- a/ml/policy.py
+++ b/ml/policy.py
@@ -123,16 +123,22 @@ class HangarFitPolicy(nn.Module):
         n_layers: int = 2,
         n_heads: int = 4,
         cnn_channels: tuple[int, ...] = (16, 32, 64),
+        spatial_tokens: bool = False,
     ) -> None:
         super().__init__()
+        self.spatial_tokens = spatial_tokens
         convs: list[nn.Module] = []
         in_ch = RASTER_CHANNELS
         for ch in cnn_channels:
             convs += [nn.Conv2d(in_ch, ch, kernel_size=3, stride=2, padding=1), nn.ReLU()]
             in_ch = ch
-        self.cnn = nn.Sequential(
-            *convs, nn.AdaptiveAvgPool2d(1), nn.Flatten()
-        )  # (B, cnn_channels[-1])
+        if spatial_tokens:
+            # keep the feature MAP (B, C, H, W); the spatial path consumes it directly
+            self.cnn = nn.Sequential(*convs)
+        else:
+            self.cnn = nn.Sequential(
+                *convs, nn.AdaptiveAvgPool2d(1), nn.Flatten()
+            )  # (B, cnn_channels[-1])
         self.cnn_proj = nn.Linear(cnn_channels[-1], d_model)  # g: -> D
         self.token_proj = nn.Linear(TOKEN_DIM, d_model)  # tokens 24 -> D
         self.fuse = nn.Linear(2 * d_model, d_model)  # concat(token, g) 2D -> D
@@ -146,11 +152,18 @@ class HangarFitPolicy(nn.Module):
         self.mag_head = nn.Sequential(
             nn.Linear(d_model, d_model), nn.ReLU(), nn.Linear(d_model, MAGNITUDE_DIM)
         )
+        value_in = 3 * d_model if spatial_tokens else 2 * d_model
         self.value_head = nn.Sequential(
-            nn.Linear(2 * d_model, d_model), nn.ReLU(), nn.Linear(d_model, 1)
+            nn.Linear(value_in, d_model), nn.ReLU(), nn.Linear(d_model, 1)
         )
+        # ON-only modules are registered LAST so the OFF branch's module-registration order
+        # (and therefore its param-init RNG stream + state_dict keys) is byte-identical to today.
+        if spatial_tokens:
+            self.spatial_proj = nn.Linear(cnn_channels[-1], d_model)  # per-cell -> D
 
     def forward(self, batch: dict[str, Tensor]) -> PolicyOutput:
+        if self.spatial_tokens:
+            return self._forward_spatial(batch)
         raster, tokens = batch["raster"], batch["tokens"]
         token_mask, active_index = batch["token_mask"], batch["active_index"]
         legal = batch["legal_action_mask"]
@@ -166,6 +179,37 @@ class HangarFitPolicy(nn.Module):
         kind_logits = self.kind_head(active_emb).masked_fill(~legal, float("-inf"))
         mag_logits = self.mag_head(active_emb)
         value = self.value_head(torch.cat([pooled, g], dim=-1)).squeeze(-1)
+        return PolicyOutput(kind_logits, mag_logits, value)
+
+    def _forward_spatial(self, batch: dict[str, Tensor]) -> PolicyOutput:
+        """ON-branch forward: object tokens cross-attend to per-cell spatial tokens.
+        ``g = feat.mean((2,3))`` reproduces the old AdaptiveAvgPool2d(1)+Flatten exactly;
+        the spatial tokens + a critic spatial summary are purely additive."""
+        raster, tokens = batch["raster"], batch["tokens"]
+        token_mask, active_index = batch["token_mask"], batch["active_index"]
+        legal = batch["legal_action_mask"]
+        feat = self.cnn(raster)  # (B, C, H, W) — no pool/flatten on this branch
+        h, w = feat.shape[2], feat.shape[3]
+        g = self.cnn_proj(feat.mean(dim=(2, 3)))  # (B, D) == AdaptiveAvgPool2d(1)+Flatten
+        pos = _sincos_pos_2d(h, w, g.shape[-1]).to(feat.device, feat.dtype)  # (H*W, D)
+        sp = self.spatial_proj(feat.flatten(2).mT) + pos  # (B, H*W, D)
+        tok = self.token_proj(tokens)  # (B, N, D)
+        n_obj = tok.shape[1]
+        g_b = g.unsqueeze(1).expand(-1, n_obj, -1)  # (B, N, D)
+        fused_obj = self.fuse(torch.cat([tok, g_b], dim=-1))  # (B, N, D)
+        seq = torch.cat([fused_obj, sp], dim=1)  # (B, N + H*W, D)
+        sp_pad = torch.zeros(sp.shape[0], sp.shape[1], dtype=torch.bool, device=sp.device)
+        pad = torch.cat([~token_mask, sp_pad], dim=1)  # (B, N + H*W); spatial rows valid
+        emb = self.encoder(seq, src_key_padding_mask=pad)  # (B, N + H*W, D)
+        emb_obj = emb[:, :n_obj, :]  # (B, N, D)
+        idx = active_index.clamp(min=0).view(-1, 1, 1).expand(-1, 1, emb_obj.shape[-1])
+        active_emb = emb_obj.gather(1, idx).squeeze(1)  # (B, D)
+        m = token_mask.unsqueeze(-1).to(emb.dtype)  # (B, N, 1)
+        pooled_obj = (emb_obj * m).sum(1) / m.sum(1).clamp(min=1.0)  # (B, D)
+        pooled_spatial = emb[:, n_obj:, :].mean(dim=1)  # (B, D) — all spatial rows valid
+        kind_logits = self.kind_head(active_emb).masked_fill(~legal, float("-inf"))
+        mag_logits = self.mag_head(active_emb)
+        value = self.value_head(torch.cat([pooled_obj, g, pooled_spatial], dim=-1)).squeeze(-1)
         return PolicyOutput(kind_logits, mag_logits, value)
 
     @torch.no_grad()

--- a/ml/train.py
+++ b/ml/train.py
@@ -838,6 +838,14 @@ def build_argparser() -> argparse.ArgumentParser:
         help="attention heads (None = HangarFitPolicy default, 4)",
     )
     p.add_argument(
+        "--spatial-tokens",
+        action="store_true",
+        help="opt-in spatial-token cross-attention policy (#809): object tokens attend to "
+        "free-space cells instead of one global-pool summary. Default off = byte-identical net "
+        "(a deliberate new-architecture re-baseline when on; the flag is persisted in the "
+        "checkpoint's policy_kwargs)",
+    )
+    p.add_argument(
         "--epochs",
         type=int,
         default=PPOConfig().epochs,
@@ -1093,6 +1101,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             ("d_model", args.d_model),
             ("n_layers", args.n_layers),
             ("n_heads", args.n_heads),
+            ("spatial_tokens", True if args.spatial_tokens else None),
         )
         if v is not None
     } or None

--- a/tests/ml/test_checkpoint.py
+++ b/tests/ml/test_checkpoint.py
@@ -123,6 +123,36 @@ def test_save_load_checkpoint_roundtrip(tmp_path):
     assert rn2.state_dict() == rn.state_dict()
 
 
+def test_save_load_checkpoint_roundtrip_spatial_tokens(tmp_path):
+    # The ON (spatial_tokens=True) architecture must survive save -> load -> reconstruct via the
+    # persisted policy_kwargs (the #809 "persisted in the checkpoint's policy_kwargs" contract),
+    # with forward-output identity. Mirrors test_save_load_checkpoint_roundtrip on the ON branch.
+    torch.manual_seed(0)
+    pk = {"d_model": 32, "n_layers": 1, "n_heads": 2, "spatial_tokens": True}
+    policy = HangarFitPolicy(**pk)
+    batch = _fixed_obs_batch()
+    ckpt_path = tmp_path / "ckpt_spatial.pt"
+    save_checkpoint(
+        ckpt_path,
+        policy=policy,
+        optimizer=torch.optim.Adam(policy.parameters(), lr=1e-3),
+        normalizer=ReturnNormalizer(),
+        policy_kwargs=pk,
+        completed_stages=["t0"],
+    )
+    loaded = load_checkpoint(ckpt_path)
+    assert loaded.policy_kwargs == pk
+    assert loaded.policy_kwargs["spatial_tokens"] is True
+    policy2 = HangarFitPolicy(**loaded.policy_kwargs)
+    policy2.load_state_dict(loaded.policy_state)
+    policy.eval()
+    policy2.eval()
+    with torch.no_grad():
+        a, b = policy(batch), policy2(batch)
+    assert torch.equal(a.value, b.value)
+    assert torch.equal(a.magnitude_bin_logits, b.magnitude_bin_logits)
+
+
 def test_save_load_checkpoint_normalizer_none(tmp_path):
     # normalize_returns off -> no normalizer -> the checkpoint round-trips None cleanly.
     policy = HangarFitPolicy()

--- a/tests/ml/test_policy.py
+++ b/tests/ml/test_policy.py
@@ -347,12 +347,96 @@ def test_state_dict_does_not_cross_load_across_flag():
 
 @pytest.mark.parametrize("spatial", [False, True])
 def test_act_on_terminal_observation_raises_both_branches(spatial):
-    # PPO never value-forwards a terminal obs (compute_gae zeroes last_value via 1-dones[-1]);
-    # act() is the public guard and must reject a terminal obs on BOTH branches, so the
-    # 288 always-valid spatial tokens never turn a terminal forward into finite garbage.
+    # act()'s active_index<0 guard fires BEFORE any forward on BOTH branches, and PPO never
+    # value-forwards a terminal obs (compute_gae zeroes last_value via 1-dones[-1]). So the ON
+    # path's 288 always-valid spatial tokens are simply never reached on a terminal obs — the
+    # forward is never taken, so there is no finite-garbage output to guard against. This pins
+    # act()'s public contract (it does not exercise _forward_spatial itself, by design).
     torch.manual_seed(2)
     m = HangarFitPolicy(d_model=64, n_layers=2, n_heads=4, spatial_tokens=spatial).eval()
     obs_t = _terminal_obs()
     assert obs_t.active_index < 0
     with pytest.raises(ValueError, match="terminal"):
         m.act(obs_t, turn_radius_m=8.0)
+
+
+# ---------------------------------------------------------------------------
+# #809: ON-path liveness — cross-row isolation, gradient flow, PE layout
+# ---------------------------------------------------------------------------
+
+
+def test_spatial_on_single_and_batched_consistency():
+    # Two DISTINCT obs in the batch so a per-row mask/attention cross-leak in the 304-seq path
+    # is detectable (the shape tests batch identical rows, which hide cross-row bugs). act()
+    # runs single while PPO runs batched, so a divergence here is a real train/act skew.
+    m = _model_spatial(seed=1)
+    o_a = _obs()
+    fleet = _fuji()
+    pl = Placement(plane_id="fuji", x_m=11.0, y_m=12.0, heading_deg=0.0, on_carts=False)
+    active_b = ActiveObject(
+        object_id="aviat_husky",
+        body=fleet["aviat_husky"],
+        pose=Pose(x_m=5.0, y_m=-2.0, heading_deg=30.0),
+        on_carts=False,
+    )
+    o_b = encode(
+        Observation(
+            active=active_b,
+            parked=(ParkedObject(object_id="fuji", placement=pl),),
+            unplaced_ids=("cessna_150",),
+            steps_this_object=0,
+            steps_total=0,
+        ),
+        empty_hangar(),
+        fleet,
+        EncoderConfig(),
+    )
+    sa, sb = m(to_batch([o_a])), m(to_batch([o_b]))
+    batched = m(to_batch([o_a, o_b]))
+    # value + mag logits are finite (kind logits carry -inf masked slots, so skip those).
+    assert torch.allclose(sa.value, batched.value[:1], atol=1e-5)
+    assert torch.allclose(sb.value, batched.value[1:], atol=1e-5)
+    assert torch.allclose(sa.magnitude_bin_logits, batched.magnitude_bin_logits[:1], atol=1e-5)
+    assert torch.allclose(sb.magnitude_bin_logits, batched.magnitude_bin_logits[1:], atol=1e-5)
+
+
+def test_spatial_on_gradients_reach_spatial_proj():
+    # The lever only works if the spatial path is LIVE: spatial_proj must get non-zero gradient.
+    # A finite-reward smoke would still pass if the branch were detached from the graph.
+    m = HangarFitPolicy(d_model=64, n_layers=2, n_heads=4, spatial_tokens=True)  # train mode
+    out = m(to_batch([_obs(), _obs()]))
+    (out.magnitude_bin_logits.sum() + out.value.sum()).backward()
+    grad = m.spatial_proj.weight.grad
+    assert grad is not None and torch.any(grad != 0)
+
+
+def test_spatial_on_critic_summary_is_load_bearing():
+    # pooled_spatial occupies the LAST d_model input columns of value_head[0] (cat order:
+    # pooled_obj, g, pooled_spatial). Those columns must receive gradient from value alone,
+    # proving the critic spatial summary actually influences value — a zeroed/detached
+    # pooled_spatial would pass every shape/finite test otherwise.
+    d = 64
+    m = HangarFitPolicy(d_model=d, n_layers=2, n_heads=4, spatial_tokens=True)
+    out = m(to_batch([_obs(), _obs()]))
+    out.value.sum().backward()
+    w_grad = m.value_head[0].weight.grad  # (d, 3*d)
+    assert w_grad is not None
+    assert torch.any(w_grad[:, 2 * d :] != 0)  # the pooled_spatial slice is load-bearing
+
+
+def test_sincos_pos_2d_row_major_matches_flatten_layout():
+    # The PE lays out the h*w grid ROW-MAJOR (index = row*w + col) to match feat.flatten(2),
+    # with the first d/2 channels encoding ROW and the second d/2 encoding COL. Pin that exact
+    # correspondence: a transposed/column-major PE passes the weaker "cells differ" check but
+    # fails here (and would silently feed the policy a permuted geometry).
+    h, w, d = 4, 3, 8
+    pe = _sincos_pos_2d(h, w, d).reshape(h, w, d)
+    dh = d // 2
+    for r in range(h):  # row-half: constant across a row, differs between rows
+        for c in range(1, w):
+            assert torch.equal(pe[r, c, :dh], pe[r, 0, :dh])
+    assert not torch.equal(pe[0, 0, :dh], pe[1, 0, :dh])
+    for c in range(w):  # col-half: constant down a column, differs between columns
+        for r in range(1, h):
+            assert torch.equal(pe[r, c, dh:], pe[0, c, dh:])
+    assert not torch.equal(pe[0, 0, dh:], pe[0, 1, dh:])

--- a/tests/ml/test_policy.py
+++ b/tests/ml/test_policy.py
@@ -327,3 +327,32 @@ def test_spatial_on_adds_spatial_proj_and_widens_value_head():
     m = HangarFitPolicy(d_model=64, spatial_tokens=True)
     assert any("spatial_proj" in k for k in m.state_dict())
     assert m.value_head[0].weight.shape == (64, 192)  # 3*d_model input
+
+
+# ---------------------------------------------------------------------------
+# #809: checkpoint-flag guard + terminal-observation contract
+# ---------------------------------------------------------------------------
+
+
+def test_state_dict_does_not_cross_load_across_flag():
+    # The two branches have different state_dict key-sets; a strict load must raise rather
+    # than silently partial-load (the checkpoint persists policy_kwargs incl. spatial_tokens).
+    off = HangarFitPolicy(d_model=64, spatial_tokens=False)
+    on = HangarFitPolicy(d_model=64, spatial_tokens=True)
+    with pytest.raises(RuntimeError):
+        on.load_state_dict(off.state_dict())
+    with pytest.raises(RuntimeError):
+        off.load_state_dict(on.state_dict())
+
+
+@pytest.mark.parametrize("spatial", [False, True])
+def test_act_on_terminal_observation_raises_both_branches(spatial):
+    # PPO never value-forwards a terminal obs (compute_gae zeroes last_value via 1-dones[-1]);
+    # act() is the public guard and must reject a terminal obs on BOTH branches, so the
+    # 288 always-valid spatial tokens never turn a terminal forward into finite garbage.
+    torch.manual_seed(2)
+    m = HangarFitPolicy(d_model=64, n_layers=2, n_heads=4, spatial_tokens=spatial).eval()
+    obs_t = _terminal_obs()
+    assert obs_t.active_index < 0
+    with pytest.raises(ValueError, match="terminal"):
+        m.act(obs_t, turn_radius_m=8.0)

--- a/tests/ml/test_policy.py
+++ b/tests/ml/test_policy.py
@@ -293,3 +293,37 @@ def test_feat_mean_equals_adaptive_avgpool():
     via_mean = feat.mean(dim=(2, 3))
     via_pool = nn.Flatten()(nn.AdaptiveAvgPool2d(1)(feat))
     assert torch.allclose(via_mean, via_pool, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# #809: default-neutrality — spatial_tokens=False is byte-identical to today
+# ---------------------------------------------------------------------------
+
+
+def test_spatial_off_is_byte_identical_to_default():
+    # spatial_tokens=False (the default) must reproduce today's net exactly: same params,
+    # same module order (same seed -> identical weights), same forward.
+    torch.manual_seed(7)
+    a = HangarFitPolicy(d_model=64, n_layers=2, n_heads=4, spatial_tokens=False).eval()
+    torch.manual_seed(7)
+    b = HangarFitPolicy(d_model=64, n_layers=2, n_heads=4).eval()  # default
+    sa, sb = a.state_dict(), b.state_dict()
+    assert set(sa) == set(sb)
+    for k in sa:
+        assert torch.equal(sa[k], sb[k]), k
+    oa, ob = a(to_batch([_obs()])), b(to_batch([_obs()]))
+    assert torch.equal(oa.kind_gear_logits, ob.kind_gear_logits)
+    assert torch.equal(oa.magnitude_bin_logits, ob.magnitude_bin_logits)
+    assert torch.equal(oa.value, ob.value)
+
+
+def test_spatial_off_registers_no_spatial_params():
+    m = HangarFitPolicy(d_model=64, spatial_tokens=False)
+    assert not any("spatial_proj" in k for k in m.state_dict())
+    assert m.value_head[0].weight.shape == (64, 128)  # 2*d_model input
+
+
+def test_spatial_on_adds_spatial_proj_and_widens_value_head():
+    m = HangarFitPolicy(d_model=64, spatial_tokens=True)
+    assert any("spatial_proj" in k for k in m.state_dict())
+    assert m.value_head[0].weight.shape == (64, 192)  # 3*d_model input

--- a/tests/ml/test_policy.py
+++ b/tests/ml/test_policy.py
@@ -8,7 +8,7 @@ torch = pytest.importorskip("torch")  # whole module skips without the [train] e
 
 from hangarfit.models import Placement  # noqa: E402
 from ml.encoding import EncoderConfig, encode  # noqa: E402
-from ml.policy import HangarFitPolicy, PolicyOutput, to_batch  # noqa: E402
+from ml.policy import HangarFitPolicy, PolicyOutput, _sincos_pos_2d, to_batch  # noqa: E402
 from ml.types import ActiveObject, Observation, Park, ParkedObject, Pose, Primitive  # noqa: E402
 from tests.ml.conftest import _fuji, empty_hangar  # noqa: E402
 
@@ -221,3 +221,28 @@ def test_to_batch_rejects_mixed_full_and_trimmed_rasters():
     sb = static_block(h, c)
     with pytest.raises(ValueError, match="mix"):
         to_batch([dyn, full], static_block=sb)  # obs[0] trimmed, obs[1] full
+
+
+# ---------------------------------------------------------------------------
+# #809: spatial-token cross-attention policy — fixed sin/cos 2D PE helper
+# ---------------------------------------------------------------------------
+
+
+def test_sincos_pos_2d_shape_finite_deterministic():
+    pe = _sincos_pos_2d(24, 12, 64)
+    assert pe.shape == (24 * 12, 64)
+    assert pe.dtype == torch.float32
+    assert torch.isfinite(pe).all()
+    assert torch.equal(pe, _sincos_pos_2d(24, 12, 64))  # no RNG -> identical
+
+
+def test_sincos_pos_2d_row_major_distinct_cells():
+    pe = _sincos_pos_2d(24, 12, 64)
+    # row-major: index = row*w + col. (0,0)=0, (0,1)=1, (1,0)=12 must all differ.
+    assert not torch.equal(pe[0], pe[1])
+    assert not torch.equal(pe[0], pe[12])
+
+
+def test_sincos_pos_2d_requires_d_model_div4():
+    with pytest.raises((AssertionError, ValueError)):
+        _sincos_pos_2d(24, 12, 66)

--- a/tests/ml/test_policy.py
+++ b/tests/ml/test_policy.py
@@ -246,3 +246,50 @@ def test_sincos_pos_2d_row_major_distinct_cells():
 def test_sincos_pos_2d_requires_d_model_div4():
     with pytest.raises((AssertionError, ValueError)):
         _sincos_pos_2d(24, 12, 66)
+
+
+# ---------------------------------------------------------------------------
+# #809: spatial-token ON-branch forward
+# ---------------------------------------------------------------------------
+
+
+def _model_spatial(seed=0, d_model=64):
+    torch.manual_seed(seed)
+    return HangarFitPolicy(d_model=d_model, n_layers=2, n_heads=4, spatial_tokens=True).eval()
+
+
+def test_spatial_on_forward_output_shapes():
+    out = _model_spatial()(to_batch([_obs(), _obs()]))
+    assert isinstance(out, PolicyOutput)
+    assert out.kind_gear_logits.shape == (2, 9)
+    assert out.magnitude_bin_logits.shape == (2, 5)
+    assert out.value.shape == (2,)
+
+
+def test_spatial_on_forward_deterministic_and_finite():
+    m = _model_spatial(seed=5)
+    batch = to_batch([_obs()])
+    a, b = m(batch), m(batch)
+    assert torch.isfinite(a.value).all()
+    assert torch.isfinite(a.kind_gear_logits.nan_to_num(neginf=0.0)).all()
+    assert torch.equal(a.value, b.value)
+    assert torch.equal(a.kind_gear_logits, b.kind_gear_logits)
+
+
+def test_spatial_on_still_masks_illegal_kinds():
+    batch = to_batch([_obs()])
+    out = _model_spatial()(batch)
+    legal = batch["legal_action_mask"][0]
+    probs = out.kind_gear_logits.softmax(-1)[0]
+    assert torch.all(probs[~legal] == 0.0)
+
+
+def test_feat_mean_equals_adaptive_avgpool():
+    # The ON branch computes g = cnn_proj(feat.mean((2,3))); this must equal the old
+    # AdaptiveAvgPool2d(1)+Flatten so the global pathway is preserved exactly.
+    from torch import nn
+
+    feat = torch.randn(2, 64, 24, 12)
+    via_mean = feat.mean(dim=(2, 3))
+    via_pool = nn.Flatten()(nn.AdaptiveAvgPool2d(1)(feat))
+    assert torch.allclose(via_mean, via_pool, atol=1e-6)

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -44,6 +44,21 @@ def test_trivial_train_still_runs_with_new_return_type():
     assert len(history) == 1
 
 
+def test_spatial_tokens_ppo_smoke_trains_without_nan():
+    # A handful of PPO iterations on the trivial rung with the ON architecture (#809) must run
+    # and return finite rewards — proves the spatial path trains end-to-end (rollout + GAE +
+    # update) with no NaN and no terminal-forward crash.
+    history = train(
+        seed=0,
+        iterations=2,
+        rollout_len=32,
+        policy_kwargs={"spatial_tokens": True, "d_model": 32, "n_layers": 1, "n_heads": 2},
+    )
+    assert len(history) == 2
+    # finite (no NaN/inf): r == r rejects NaN; the magnitude bound rejects inf.
+    assert all(isinstance(r, float) and r == r and abs(r) < 1e9 for r in history)
+
+
 from ml.curriculum import (  # noqa: E402
     CurriculumSchedule,
     DifficultyConfig,


### PR DESCRIPTION
## What

Replaces the spatially-blind global-average-pool in `ml/policy.py` with an **opt-in** spatial-token cross-attention path, behind `--spatial-tokens` (default off ⇒ byte-identical). The strongest untested `#736` plateau lever.

**The flaw:** `policy.py` ran a CNN over the 7-channel occupancy raster, then `AdaptiveAvgPool2d(1)` collapsed the `(B,64,24,12)` feature map to one `(B,64)` vector broadcast to every object token — so the policy knew *how full* the hangar was, never *where* the free gaps were. Invisible on easy rungs; the wall on dense rungs (trio-notch, `vp ~0.33`).

**The fix (flag ON):** keep the feature map, project each cell to a **spatial token** (+ fixed sin/cos 2D PE), concatenate the 288 spatial tokens with the 16 object tokens into one transformer sequence so object tokens **cross-attend to free-space cells**, and feed a spatial summary into a widened critic.

## Design provenance

A 3-variant adversarial design panel selected this as the only variant whose WHERE-blindness fix survived adversarial refutation with **zero fatal flaws** (per-object grid-sample was refuted on the 2 m-resolution wall; numpy rays need an L5-economics pairing + a `SCHEMA_VERSION` bump). Spec: `docs/superpowers/specs/2026-06-23-spatial-token-policy-design.md`. Plan: `docs/superpowers/plans/2026-06-23-spatial-token-policy.md`.

## Contract / safety

- **Default-neutral (4c-ii):** `spatial_tokens=False` registers **zero** new params in the **same module-registration order** → byte-identical to today (pinned by `test_spatial_off_is_byte_identical_to_default`). Flag-on is a deliberate new-arch re-baseline, persisted in the checkpoint's `policy_kwargs`.
- **No schema impact:** `ml/policy.py` + `ml/train.py` + `tests/ml/` only. No `encoding.py`, no `SCHEMA_VERSION` bump, no `#752` wire change, no scene/v2 contact. `ml-rl-guard` is the reviewer.
- **`g = feat.mean((2,3))`** is provably equal to the old `AdaptiveAvgPool2d(1)+Flatten` (pinned).
- **Terminal forward:** PPO never value-forwards a terminal obs (`compute_gae` zeroes `last_value`); `act()`'s `active_index<0` guard rejects terminal on both branches (pinned, parametrized).

## Scope

In-PR: the flag-gated implementation + unit/equivalence/determinism/checkpoint/terminal tests + a PPO smoke (ON path trains 2 iters without NaN). **Out of scope (supervised follow-up):** the full trio-notch mastery training run (pre-registered WIN: dense-rung `vp` clears ~0.33) and any 1 m-tap escalation.

## Verification

- `pytest tests/ml/` → **563 passed** (OFF default path canaries all green).
- `ruff check ml/ tests/ml/` + `ruff format --check` clean; `mypy ml/` clean.

Closes #809