### PR TITLE
feat(ml): per-commitment economics lever — banked marginal valid-coverage credit (#812)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#812, epic #607): per-commitment economics reward lever (`--r-valid-progress`).**
+  A banked marginal valid-coverage credit that targets the dense `trio-notch` plateau (#736), where the
+  policy validly parks one freebie aircraft then *abstains* on the rest because the marginal 2nd/3rd
+  commitment's expected value is negative — the **economics** argmax the spatial-token representation
+  lever (#809) was refuted as unable to move. `step_reward` gains one term
+  `r_valid_progress * max(0, valid_park_count − 1)`, paid **only on a Park where the whole layout is
+  valid** (the product checker) and scaled by the marginal valid-object count beyond the freebie — so
+  the 2nd validly-placed object banks the weight and the 3rd twice it. Banked per-step (it survives GAE
+  while the #714 terminal-validity flag collapses) and gated on `park_valid`, so an invalid pile pays
+  exactly 0. Default `0.0` ⇒ **byte-identical**. `ml/` is dev/CI-only (never shipped in the wheel).
 - **Learned backend (#809, epic #607): opt-in spatial-token cross-attention policy (`--spatial-tokens`).**
   Replaces the spatially-blind global-average-pool — which collapsed the CNN occupancy feature map
   to a single vector broadcast to every object token, so the policy knew *how full* the hangar was

--- a/docs/superpowers/plans/2026-06-23-per-commitment-economics.md
+++ b/docs/superpowers/plans/2026-06-23-per-commitment-economics.md
@@ -1,0 +1,319 @@
+# Per-commitment economics lever (`r_valid_progress`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a default-neutral, banked marginal valid-coverage reward credit (`r_valid_progress`) that pays the policy for each *new* validly-placed object, to break the `trio-notch` marginal-commitment-economics plateau.
+
+**Architecture:** One additive term in `ml/reward.py::step_reward`, gated on the existing `park_valid` product-checker bool and scaled by a new `RewardContext.valid_park_count` field the env populates from `len(self._parked)`. One new `RewardWeights` knob (`r_valid_progress`, default `0.0` → byte-identical) and one `--r-valid-progress` CLI flag. No SCHEMA / observation / policy change.
+
+**Tech Stack:** Python 3.12, the `ml/` RL workspace (torch-free for `reward.py`/`env.py`/`types.py`), pytest. Spec: `docs/superpowers/specs/2026-06-23-per-commitment-economics-design.md`.
+
+## Global Constraints
+
+- **Default-neutral (4c-ii):** `r_valid_progress` defaults `0.0`; with it 0.0 the reward stream is **byte-identical** to today. No existing determinism / byte-identity canary may need re-baselining.
+- **Determinism (ADR-0027):** the reward stays a pure function of `(ctx, weights)` — `float·int·bool` arithmetic, no RNG/clock.
+- **Must not reopen the invalid-pile basin:** the new term is gated on `park_valid is True` (the `collisions.check` + Caddy-egress product checker). An invalid/overlapping Park pays exactly `0.0`. Do not weaken `validity_conditional_terminal` or the L4 reward clip.
+- **`ml-rl-guard` applies** (touches `ml/reward.py`, `ml/types.py`, `ml/env.py`, `tests/ml/`). Run `ruff`/`mypy ml/` (whole package) + `pytest tests/ml/`.
+- **Run from the repo root** (the top-level `ml/` package is not on the editable install's path): `pytest tests/ml/...`.
+- Commit subjects end with `Part of #812`.
+
+---
+
+### Task 1: Reward term + knob + context field (`ml/reward.py`, `ml/types.py`)
+
+**Files:**
+- Modify: `ml/types.py` (add `r_valid_progress` to `RewardWeights`, after `validity_conditional_terminal` ~line 138)
+- Modify: `ml/reward.py` (add `valid_park_count` to `RewardContext` after `first_valid_now` ~line 34; add the `valid_progress` term in `step_reward` ~line 84)
+- Test: `tests/ml/test_reward.py` (append a new section)
+
+**Interfaces:**
+- Produces: `RewardWeights.r_valid_progress: float = 0.0`; `RewardContext.valid_park_count: int = 0`; `step_reward` returns `… + valid_progress` where `valid_progress = w.r_valid_progress * max(0, ctx.valid_park_count - 1)` when `ctx.park_valid` is `True`, else `0.0`.
+- Consumes: existing `RewardContext.park_valid: bool | None`.
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/ml/test_reward.py` (the file already has the `_ctx(**kw)` helper and imports `step_reward`, `RewardContext`, `RewardWeights`):
+
+```python
+# ---------------------------------------------------------------------------
+# #812 — banked marginal valid-coverage credit (r_valid_progress)
+# ---------------------------------------------------------------------------
+
+
+def test_r_valid_progress_default_zero_is_byte_identical():
+    # park_valid True with a count set, but the knob default 0.0 -> no change.
+    ctx = _ctx(park_valid=True, valid_park_count=3)
+    assert step_reward(ctx, RewardWeights()) == step_reward(
+        ctx, RewardWeights(r_valid_progress=0.0)
+    )
+
+
+def test_r_valid_progress_pays_marginal_count_beyond_the_freebie():
+    w = RewardWeights(r_valid_progress=8.0)
+    base = RewardWeights(r_valid_progress=0.0)
+    # 1st valid object (count 1) pays 0; 2nd pays 8; 3rd pays 16 (max(0, n-1) * 8).
+    for count, expected in ((1, 0.0), (2, 8.0), (3, 16.0)):
+        ctx = _ctx(park_valid=True, valid_park_count=count)
+        assert step_reward(ctx, w) - step_reward(ctx, base) == pytest.approx(expected)
+
+
+def test_r_valid_progress_not_paid_on_invalid_park():
+    # park_valid False (an overlapping pile) earns ZERO coverage credit -> firewall.
+    w = RewardWeights(r_valid_progress=8.0)
+    base = RewardWeights(r_valid_progress=0.0)
+    ctx = _ctx(park_valid=False, valid_park_count=0, overlap_m2=0.05)
+    assert step_reward(ctx, w) == step_reward(ctx, base)
+
+
+def test_r_valid_progress_not_paid_on_nonpark_step():
+    # park_valid None (a movement step) -> term structurally absent.
+    w = RewardWeights(r_valid_progress=8.0)
+    base = RewardWeights(r_valid_progress=0.0)
+    ctx = _ctx(park_valid=None)
+    assert step_reward(ctx, w) == step_reward(ctx, base)
+
+
+def test_r_valid_progress_clip_headroom_at_recipe_scale():
+    # The banked valid-Park bonus (valid_park + valid_progress + first_valid) must stay within
+    # reward_clip=50 at the recipe scale so GAE never sees it truncated:
+    # r_valid_park 30 + r_valid_progress 8*(3-1) + r_first_valid 0 = 46 <= 50.
+    REWARD_CLIP = 50.0
+    w = RewardWeights(r_valid_park=30.0, r_valid_progress=8.0, r_first_valid=0.0)
+    off = RewardWeights(r_valid_park=0.0, r_valid_progress=0.0, r_first_valid=0.0)
+    ctx = _ctx(park_valid=True, valid_park_count=3, overlap_m2=0.0, intrusion_m2=0.0)
+    bonus = step_reward(ctx, w) - step_reward(ctx, off)
+    assert bonus == pytest.approx(46.0)
+    assert bonus <= REWARD_CLIP
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/ml/test_reward.py -k r_valid_progress -v`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'r_valid_progress'` (and `valid_park_count`), because the knob and field don't exist yet.
+
+- [ ] **Step 3: Add the `valid_park_count` field to `RewardContext`** — in `ml/reward.py`, immediately after the `first_valid_now: bool = False` field (~line 34):
+
+```python
+    first_valid_now: bool = False
+    # The number of validly-co-placed objects at THIS Park step (len(_parked) on a Park where
+    # the whole layout is valid, else 0). Consumed only when RewardWeights.r_valid_progress > 0.
+    # Internal reward input — not an observation. (#812)
+    valid_park_count: int = 0
+```
+
+- [ ] **Step 4: Add the knob to `RewardWeights`** — in `ml/types.py`, immediately after the `validity_conditional_terminal: bool = False` field (~line 138):
+
+```python
+    validity_conditional_terminal: bool = False
+    # Banked per-valid-Park credit, scaled by the marginal valid-object count beyond the freebie:
+    # pays r_valid_progress * max(0, valid_park_count - 1) on a Park where the WHOLE layout is
+    # valid (valid_park_count = # driven-in objects). 0.0 -> term identically 0 -> byte-identical.
+    # The 1st valid object pays 0 (r_first_valid owns the breakthrough), the 2nd pays
+    # r_valid_progress, the 3rd 2x. Banked per-step so it survives GAE while the #714 terminal
+    # flag collapses; gated on park_valid so an invalid pile never pays. (#812)
+    r_valid_progress: float = 0.0
+```
+
+- [ ] **Step 5: Add the `valid_progress` term to `step_reward`** — in `ml/reward.py`, replace the final two lines of `step_reward` (the `first_valid = …` line and the `return …` line, ~lines 83-84):
+
+```python
+    first_valid = w.r_first_valid if ctx.first_valid_now else 0.0
+    # Banked marginal valid-coverage credit (#812): pays only on a Park where the whole layout
+    # is valid (park_valid True), scaled by the marginal valid-object count beyond the freebie.
+    # park_valid None (non-Park) and False (invalid pile) both pay 0 -> the pile firewall.
+    valid_progress = (
+        w.r_valid_progress * float(max(0, ctx.valid_park_count - 1)) if ctx.park_valid else 0.0
+    )
+    return hard + movement + soft + terminal + shaping + valid_park + first_valid + valid_progress
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pytest tests/ml/test_reward.py -k r_valid_progress -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 7: Run the full reward suite + lint/type to confirm no regression (byte-identity canaries)**
+
+Run: `pytest tests/ml/test_reward.py -v && ruff check ml/reward.py ml/types.py && mypy ml/`
+Expected: PASS; `mypy ml/` clean (run over the whole `ml/` package, not a single file).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ml/reward.py ml/types.py tests/ml/test_reward.py
+git commit -m "feat(ml): banked marginal valid-coverage reward credit (r_valid_progress)
+
+Add a default-neutral RewardWeights.r_valid_progress knob and a
+RewardContext.valid_park_count field; step_reward gains one term
+r_valid_progress*max(0, valid_park_count-1), paid only on a valid Park
+(park_valid True). 1st valid object pays 0, 2nd pays the weight, 3rd 2x.
+Knob default 0.0 -> byte-identical. Gated on the product checker so an
+invalid pile pays 0.
+
+Part of #812"
+```
+
+---
+
+### Task 2: Env wiring + `info.terms` diagnostic (`ml/env.py`)
+
+**Files:**
+- Modify: `ml/env.py` (populate `valid_park_count` in the Park-branch `RewardContext` ~line 293-310; add a `valid_park_count` key to the `_info` terms dict ~line 396)
+- Test: `tests/ml/test_env.py` (append one test)
+
+**Interfaces:**
+- Consumes: `RewardContext.valid_park_count` (from Task 1), existing `park_valid` and `len(self._parked)`.
+- Produces: on a Park step the env passes `valid_park_count = len(self._parked) if park_valid else 0`; `StepInfo.terms["valid_park_count"]` exposes `float(ctx.valid_park_count)` for diagnosis.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/ml/test_env.py` (imports already present: `HangarFitEnv`, `Park`, `Primitive`, `_env`):
+
+```python
+def test_env_threads_valid_park_count_into_info_gated_on_validity():
+    # On a Park step, valid_park_count == placed when the WHOLE layout is valid, else 0
+    # (the #812 firewall: an invalid park carries zero marginal coverage count).
+    env = _env()
+    env.reset()
+    for _ in range(20):
+        if env._active_pose is not None and env._active_pose.y_m >= 1.0:
+            break
+        env.step(Primitive(kind="S", magnitude=1.0, gear=1))
+    _, _, _, info = env.step(Park())
+    expected = info.placed if info.valid else 0
+    assert info.terms["valid_park_count"] == float(expected)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/ml/test_env.py::test_env_threads_valid_park_count_into_info_gated_on_validity -v`
+Expected: FAIL — `KeyError: 'valid_park_count'` (the `_info` terms dict has no such key yet).
+
+- [ ] **Step 3: Populate `valid_park_count` on the Park-branch context** — in `ml/env.py`, in the `RewardContext(...)` built inside the `if isinstance(action, Park):` branch, add the field right after `first_valid_now=first_valid_now,` (~line 309):
+
+```python
+                first_valid_now=first_valid_now,
+                # len(_parked) includes the just-appended pose; 0 on an invalid park so the
+                # banked coverage credit never pays a pile (#812).
+                valid_park_count=len(self._parked) if park_valid else 0,
+```
+
+- [ ] **Step 4: Surface it in `info.terms`** — in `ml/env.py::_info`, add one entry to the `terms` dict right after `"terminal_fraction": ctx.terminal_fraction or 0.0,` (~line 396):
+
+```python
+                "terminal_fraction": ctx.terminal_fraction or 0.0,
+                "valid_park_count": float(ctx.valid_park_count),
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pytest tests/ml/test_env.py::test_env_threads_valid_park_count_into_info_gated_on_validity -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full env suite + lint/type**
+
+Run: `pytest tests/ml/test_env.py -v && ruff check ml/env.py && mypy ml/`
+Expected: PASS; `mypy ml/` clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ml/env.py tests/ml/test_env.py
+git commit -m "feat(ml): env feeds valid_park_count to the reward + info.terms (#812)
+
+The Park branch sets RewardContext.valid_park_count = len(_parked) on a
+valid park (0 on an invalid one), and _info surfaces it as the
+valid_park_count term for vp-plateau diagnosis. Additive: movement steps
+and invalid parks report 0.
+
+Part of #812"
+```
+
+---
+
+### Task 3: `--r-valid-progress` CLI flag (`ml/train.py`)
+
+**Files:**
+- Modify: `ml/train.py` (add the `--r-valid-progress` argument in `build_argparser` after `--r-first-valid` ~line 957; pass `r_valid_progress=args.r_valid_progress` into the `RewardWeights(...)` construction ~line 1091)
+- Test: `tests/ml/test_train_curriculum.py` (append one test; the file already imports `build_argparser`)
+
+**Interfaces:**
+- Consumes: `RewardWeights.r_valid_progress` (Task 1).
+- Produces: `build_argparser().parse_args([...]).r_valid_progress: float` (default `0.0`), wired into the training `RewardWeights`.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/ml/test_train_curriculum.py`:
+
+```python
+def test_r_valid_progress_flag_parses_and_defaults_neutral():
+    parser = build_argparser()
+    assert parser.parse_args([]).r_valid_progress == 0.0  # default-neutral
+    assert parser.parse_args(["--r-valid-progress", "8.0"]).r_valid_progress == 8.0
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/ml/test_train_curriculum.py::test_r_valid_progress_flag_parses_and_defaults_neutral -v`
+Expected: FAIL — `AttributeError: 'Namespace' object has no attribute 'r_valid_progress'`.
+
+- [ ] **Step 3: Add the argparse argument** — in `ml/train.py::build_argparser`, immediately after the `--r-first-valid` argument block (the one ending ~line 957), add:
+
+```python
+    p.add_argument(
+        "--r-valid-progress",
+        type=float,
+        default=0.0,
+        help="banked per-valid-Park credit scaled by the marginal valid-object count beyond the "
+        "freebie (r_valid_progress*max(0, n-1) on a Park where the whole layout is valid); 0 = off "
+        "(byte-identical); the #812 per-commitment economics lever",
+    )
+```
+
+- [ ] **Step 4: Wire it into `RewardWeights`** — in `ml/train.py`, in the `weights = RewardWeights(...)` construction (~line 1087), add the field right after `r_first_valid=args.r_first_valid,` (~line 1091):
+
+```python
+        r_first_valid=args.r_first_valid,
+        r_valid_progress=args.r_valid_progress,
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pytest tests/ml/test_train_curriculum.py::test_r_valid_progress_flag_parses_and_defaults_neutral -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the ml suite + lint/type as a final gate**
+
+Run: `pytest tests/ml/ -q && ruff check ml/ && mypy ml/`
+Expected: PASS across `tests/ml/`; ruff + `mypy ml/` clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ml/train.py tests/ml/test_train_curriculum.py
+git commit -m "feat(ml): --r-valid-progress CLI flag wires the #812 lever into training
+
+Default 0.0 (byte-identical). Recipe deploys it on the trio-notch run on
+top of valid_park_grade_scale>0; the magnitude is tuned by a two-seed
+ml.gate A/B sweep (6/8/12).
+
+Part of #812"
+```
+
+---
+
+## Out of scope (deferred)
+
+- The convex-stick adjunct (`unplaced_penalty_exponent`) — spec §10. Not implemented in #812.
+- The trio-notch A/B sweep + an `ml/README` recipe note — a follow-up after the knob lands (the recipe lives there alongside the other gate recipes). Not part of this code change.
+
+## Self-Review
+
+**Spec coverage:**
+- §2 reward term → Task 1 Step 5. ✓
+- §3 knob (`r_valid_progress=0.0`) → Task 1 Step 4. ✓
+- §4 env hook (`valid_park_count`) + optional `info.terms` diagnostic → Task 2. ✓
+- §5 argmax (per-count payout 0/1×/2×) → Task 1 `test_r_valid_progress_pays_marginal_count_beyond_the_freebie`. ✓
+- §6 pile-safety → Task 1 `test_r_valid_progress_not_paid_on_invalid_park` (reward level) + Task 2 invariant (env level). ✓
+- §7 determinism → covered by the default-neutral byte-identity test + `ml-rl-guard` gate (Task 1 Step 7 / Task 3 Step 6). ✓
+- §8 tests: default-neutral byte-identity ✓, clip-headroom guard ✓ (`test_r_valid_progress_clip_headroom_at_recipe_scale`), pile-firewall ✓, positive-credit ✓, determinism ✓ (mypy/ruff + byte-identity). ✓
+- §9 recipe / CLI flag → Task 3. ✓ (the A/B run itself is out of scope, noted above.)
+- §10/§11 caveats/open-questions → documentation only; no task needed.
+
+**Placeholder scan:** none — every step has exact code, exact paths, exact commands, expected output.
+
+**Type consistency:** `r_valid_progress: float` and `valid_park_count: int` are used identically in `types.py`, `reward.py`, `env.py`, `train.py`, and all tests. The reward term `w.r_valid_progress * float(max(0, ctx.valid_park_count - 1))` matches the field types and the spec formula. `info.terms` values are `float`, so `float(ctx.valid_park_count)` matches the dict's value type.

--- a/docs/superpowers/specs/2026-06-23-per-commitment-economics-design.md
+++ b/docs/superpowers/specs/2026-06-23-per-commitment-economics-design.md
@@ -1,0 +1,141 @@
+# Per-commitment economics lever — banked marginal valid-coverage credit
+
+- **Issue:** #812 (part of the #736 training-improvement backlog)
+- **Status:** Design — approved mechanism + scope, pending spec review
+- **Provenance:** chosen by a 17-agent adversarial design panel (4 proposers × 3 skeptic lenses + synthesizer) over a per-milestone carrot (latch form), a convex abstention stick, and a commitment-insurance scheme.
+- **Scope decision (user, 2026-06-23):** carrot **alone** — the convex-stick adjunct is explicitly out of scope (deferred).
+
+---
+
+## 1. Problem
+
+The empty-start `trio-notch` curriculum rung (3 aircraft, real Herrenteich notch hangar) plateaus at `valid_placed` (vp) ~0.33 on both seeds and never masters. Two prior levers were KILLED:
+
+- **Witness-anchored start-state scaffold** (#736/#794): pre-park 1 of 3, drive 2 in → still vp 0.333.
+- **Spatial-token cross-attention representation** (#809/#810): refuted — `trio-notch-anchored` converged to vp 0.333 *exactly* = the global-pool control, confirming a **representation change cannot move a reward-economics argmax**.
+
+**Accepted root cause — marginal-commitment economics.** The policy validly parks one aircraft (the freebie; banks `r_first_valid` + `valid_park`), then **abstains** on the 2nd/3rd because the marginal economics make *place-nothing-new* the reward argmax:
+
+- Committing the 2nd/3rd object risks the hard collision penalty `w_col·overlap` (clipped to −50 by `reward_clip`) when the tight notch gap is missed, **plus** the #714 terminal collapse to `eff_fraction=0` on an invalid whole-layout.
+- The graded valid-park bonus `r_valid_park·exp(−misfit/grade_scale)` decays to ~0 when the gap is not found.
+- Abstaining (keep the freebie, drive to step-budget) is a bounded small loss.
+
+So for a modest success probability *p* on the 2nd object, **E[commit] < E[abstain]**. Signature on the plateau: `valid_rate≈1.0`, `fraction_placed≈0.33`, `vp≈0.33` (place-nothing-new). The *other* failure face is invalid-pile (`fraction` high, `valid_rate` low) — **a fix must not reopen it.**
+
+## 2. The mechanism — banked marginal valid-coverage credit
+
+Add **one** term to `step_reward` (`ml/reward.py`), appended **last** in the sum (preserving the existing trailing-`first_valid` partial-sum byte-identity):
+
+```python
+valid_progress = (
+    w.r_valid_progress * float(max(0, ctx.valid_park_count - 1))
+    if ctx.park_valid else 0.0
+)
+return hard + movement + soft + terminal + shaping + valid_park + first_valid + valid_progress
+```
+
+Semantics, keyed on the existing `ctx.park_valid` tri-state:
+
+| `park_valid` | meaning | `valid_progress` |
+|---|---|---|
+| `None` | non-Park step | `0.0` |
+| `False` | invalid Park (overlap / oob / egress) | `0.0` ← **structural pile firewall** |
+| `True` | valid whole-layout Park | `r_valid_progress · max(0, valid_park_count − 1)` |
+
+The `max(0, n−1)` offset means the **1st** valid object pays 0 (the existing `r_first_valid` owns the breakthrough kick off the place-nothing pole), the **2nd** pays `r_valid_progress`, the **3rd** pays `2·r_valid_progress`. This pays the **specific marginal objects (#2/#3)** the policy abstains on — `r_valid_park` is count-blind and `r_first_valid` fires once.
+
+### Why banked-per-step, not terminal
+
+The credit is booked at the **step the valid Park occurs**, so it enters GAE's `δ_t` at full weight. A *later* invalidating commit only discounts back in at `(γλ)^k`, so it cannot claw the banked credit away. This **decouples marginal-commit credit from the collapsible #714 terminal whole-layout flag** — which is the entire wall. (A success-only *terminal* carrot would be zeroed by the same `validity_conditional_terminal` collapse that already fails to fix this.)
+
+## 3. The knob (`ml/types.py` `RewardWeights`)
+
+```python
+r_valid_progress: float = 0.0
+# Banked per-valid-Park credit, scaled by the marginal valid-object count beyond
+# the freebie: pays r_valid_progress*(n-1) on a Park where the WHOLE layout is valid
+# (n = # driven-in objects). 0.0 -> term identically 0 -> byte-identical to today.
+# Recipe lever for the trio-notch rung; the 4c-ii default stays 0.0.
+```
+
+**Default-neutrality (4c-ii):** `0.0 · anything = 0.0` across every `ctx` state → the returned scalar is bit-identical to today; no determinism / byte-identity canary needs re-baselining (mirrors the `r_valid_park` / `r_first_valid` default-zero byte-identity tests).
+
+## 4. Env hook (`ml/env.py`)
+
+Add one **internal** `RewardContext` field (additive, not an observation/SCHEMA change):
+
+```python
+valid_park_count: int = 0   # len(_parked) on a valid Park; 0 otherwise. Internal reward input only.
+```
+
+Populate it on the Park branch where the context is built (`env.py:~293`), reusing values already in hand:
+
+```python
+valid_park_count = len(self._parked) if park_valid else 0
+```
+
+- `park_valid` is already computed at `env.py:276` (`score.collisions_valid and not score.egress_blocked` — the authoritative product checker).
+- `len(self._parked)` already includes the just-appended object at that point.
+- The movement-primitive context (`env.py:~353`) leaves `valid_park_count` at its default `0`.
+
+**No new oracle call, no new env running-state, no observation/tensor/SCHEMA change.** Optionally surface `valid_park_count` in `StepInfo.terms` as an additive, default-0 metrics key for vp-plateau diagnosis (grafted from the runner-up — diagnostic only; the reward already carries the count).
+
+## 5. Argmax-shift argument (the EV that makes it work)
+
+At the 2nd-object decision, let `p = P(2nd Park valid)`, with the recipe weights (`r_terminal=50`, `r_unplaced_penalty=25`, `r_valid_park=30`, `reward_clip=50`, `validity_conditional_terminal` ON):
+
+- **E[abstain]** (drive the 2nd to budget; freebie already valid): `eff_fraction=1/3` → `terminal = 50·(1/3) − 25·(2/3) ≈ 0`. The freebie's `first_valid`+`valid_park` are sunk.
+- **E[commit]** `= p·(valid_park≈30 + valid_progress=r_valid_progress + improved terminal eff_frac 2/3) + (1−p)·(hard≈−50 + terminal collapse → −r_unplaced_penalty≈−25)`.
+
+Break-even *p* for `E[commit] > E[abstain]` at the **2nd-object** decision (illustrative single-step sketch; `dE = p·(55 + r_valid_progress) − (1−p)·75`, where the success branch counts `valid_park≈30 + r_valid_progress·1 + a realized terminal improvement ≈+25`, and `r_valid_progress·1` because `max(0, n−1)=1` at `n=2`):
+
+| `r_valid_progress` | break-even *p* (2nd object) |
+|---|---|
+| 0 (today) | ~0.58 |
+| 8 | ~0.54 |
+| 15 | ~0.52 |
+| 25 | ~0.48 |
+
+The per-unit shift at the 2nd object is deliberately modest, but the term **compounds**: the **3rd-object** decision gets `+p·2·r_valid_progress` (twice the pull, since `max(0, n−1)=2` at `n=3`) while still staying under `reward_clip` — the clip-safe depth-targeting that beat the escalating-carrot's clip-colliding 3× payout. These figures are illustrative; the magnitude that actually moves the policy is empirical (§9's {6, 8, 12} sweep).
+
+The key property: `valid_progress` adds an **unopposed** `+p·r_valid_progress` — it is structurally 0 on the *failure* branch and on *abstain*, so unlike a success-only carrot scaling `p·big` against the `(1−p)·catastrophe`, it does not have to overcome the collision tail. **For any p>0 a finite `r_valid_progress` flips the decision.** It is not potential-based (no `γΦ(s′)−Φ(s)` telescope), so Ng–Harada–Russell policy-invariance does not apply — it genuinely moves the optimum. Advantage normalization is affine/order-preserving, so it is not washed out.
+
+## 6. Pile-safety (the firewall)
+
+Gated on `park_valid is True` (the same product checker as #714/#694) → identically `0.0` on **any** invalid/overlapping Park. Because `_parked` is append-only with frozen poses, the moment overlap exists the whole layout is invalid, `park_valid` is `False` for that Park and every later one (you cannot un-append the overlapping pose), so the count is frozen and the invalid-pile basin pays **exactly zero** coverage credit — **by construction, not by tuning**. An overlapping Park still eats the full clipped −`w_col` stick, so a pile is strictly worse than a clean valid Park. It does not weaken `validity_conditional_terminal` or the L4 trust-region clip.
+
+## 7. Determinism
+
+The reward stays a pure function of `(ctx, weights)`: `float · int · bool` arithmetic, no RNG/clock. `valid_park_count` is reset implicitly each episode (it is recomputed per step from `_parked`, which `_reset_state` clears). CPU training stays bit-identical for a fixed seed (ADR-0027).
+
+## 8. Testing
+
+1. **Default-neutral byte-identity** — with `r_valid_progress=0.0`, the reward stream is bit-identical to today across a fixed action sequence (mirror the `r_valid_park`/`r_first_valid` byte-identity tests).
+2. **Clip-headroom guard (grafted)** — a loud assertion/test that `r_valid_park + r_valid_progress·(k_max−1) + r_first_valid ≤ reward_clip`, so a future weight bump cannot *silently* clip away the banked marginal credit before GAE. For trio (`k_max=3`) at the recipe default: `30 + 8·2 + 0 = 46 < 50` ✓.
+3. **Pile-firewall regression (grafted)** — a `[valid freebie, invalid pile, invalid pile]` episode earns **exactly 0** cumulative `r_valid_progress`, and `valid_park_count == 0` on each `park_valid=False` step. Pins the `if ctx.park_valid` / `else 0.0` gate so a future refactor cannot silently let an invalid Park carry a nonzero marginal count.
+4. **Positive credit** — a `[valid, valid, valid]` trio episode banks `r_valid_progress·(0+1+2)` cumulatively (the 1st pays 0).
+5. **Determinism** — `ml-rl-guard`'s fixed-action reward-stream diff with the knob on.
+
+`ml-rl-guard` applies (touches `ml/reward.py`, `ml/types.py`, `ml/env.py`, `tests/ml/`).
+
+## 9. Recipe + success criterion (separate from the merge)
+
+The merged knob default stays `0.0`. The tuned trio-notch run sets `r_valid_progress` and runs **on top of** the existing #720 economics (do **not** drop `valid_park_grade_scale` — see §10):
+
+```
+… (the #736 notch recipe) … --r-valid-progress 8.0
+```
+
+**Success:** a two-seed `ml.gate` A/B on the `trio-notch` recipe, sweeping `r_valid_progress ∈ {6, 8, 12}` → WIN = vp clears the ~0.33 ceiling (target ≥0.6 on both seeds). The magnitude is **empirical**, not derivable a priori; this is gathered after merge, not part of the unit-tested change.
+
+## 10. Caveats & scope boundaries
+
+- **Carrot alone.** The convex-stick adjunct (`unplaced_penalty_exponent`) is **out of scope** for #812. Rationale: its own skeptic showed the terminal abstain gradient is already +25 today yet fails — deepening the *non-binding* branch is under-scaled vs the binding −50/step collision tail. Revisit only if the carrot A/B leaves a residual near-zero abstain floor.
+- **Economics, not capability.** This lowers the economic *bar* but does not grant the *search capability* to find the valid tight-notch pose. It must compose with `valid_park_grade_scale > 0` (the uphill gradient into the slot), not replace it.
+- **Easy-coverage risk.** It may move vp only *partially* — it can bank the two roomy objects while still abstaining on the genuinely tight notch pose. Every banked step is whole-layout-valid (no invalid commitment is ever paid), and the honest `valid_placed` gate still catches non-mastery, so this is a *partial-win* risk, not a correctness risk.
+
+## 11. Open questions (for the human / the A/B)
+
+1. **Magnitude:** is `r_valid_progress=8` enough to flip `E[commit]>E[abstain]` at the observed plateau *p*, yet under `reward_clip=50` alongside `r_valid_park=30`? → the {6,8,12} sweep answers it.
+2. **`r_first_valid` interaction:** keep `r_first_valid` firing at count 1 (the offset means the carrot doesn't double-pay it), or fold it in? Default: keep both independent (preserves default-neutrality and prior recipes).
+3. **Partial-win threshold:** if vp moves to e.g. 0.5 (two roomy objects) but not 0.9, is that a WIN worth shipping the knob for, or the trigger for the deferred convex-stick / a capability lever?

--- a/ml/env.py
+++ b/ml/env.py
@@ -307,6 +307,9 @@ class HangarFitEnv:
                 # bool (== _layout_valid()) for the #714 validity-conditional terminal.
                 terminal_valid=park_valid if done else None,
                 first_valid_now=first_valid_now,
+                # len(_parked) includes the just-appended pose; 0 on an invalid park so the
+                # banked coverage credit never pays a pile (#812).
+                valid_park_count=len(self._parked) if park_valid else 0,
             )
             reward = step_reward(ctx, weights)
             self._prev_potential = new_phi
@@ -394,6 +397,7 @@ class HangarFitEnv:
                 "move_cost": ctx.move_cost,
                 "shaping": ctx.potential - ctx.prev_potential,
                 "terminal_fraction": ctx.terminal_fraction or 0.0,
+                "valid_park_count": float(ctx.valid_park_count),
             },
             valid=self._layout_valid(),
             placed=len(self._parked),

--- a/ml/reward.py
+++ b/ml/reward.py
@@ -32,6 +32,10 @@ class RewardContext:
     # True on EXACTLY the one Park step where the episode first reaches a valid placement; the
     # env flips it once per episode. Consumed only when RewardWeights.r_first_valid > 0. (#720)
     first_valid_now: bool = False
+    # The number of validly-co-placed objects at THIS Park step (len(_parked) on a Park where
+    # the whole layout is valid, else 0). Consumed only when RewardWeights.r_valid_progress > 0.
+    # Internal reward input — not an observation. (#812)
+    valid_park_count: int = 0
 
 
 def potential(
@@ -81,7 +85,13 @@ def step_reward(ctx: RewardContext, w: RewardWeights) -> float:
     shaping = w.gamma * ctx.potential - ctx.prev_potential
     valid_park = _valid_park_term(ctx, w)
     first_valid = w.r_first_valid if ctx.first_valid_now else 0.0
-    return hard + movement + soft + terminal + shaping + valid_park + first_valid
+    # Banked marginal valid-coverage credit (#812): pays only on a Park where the whole layout
+    # is valid (park_valid True), scaled by the marginal valid-object count beyond the freebie.
+    # park_valid None (non-Park) and False (invalid pile) both pay 0 -> the pile firewall.
+    valid_progress = (
+        w.r_valid_progress * float(max(0, ctx.valid_park_count - 1)) if ctx.park_valid else 0.0
+    )
+    return hard + movement + soft + terminal + shaping + valid_park + first_valid + valid_progress
 
 
 def _valid_park_term(ctx: RewardContext, w: RewardWeights) -> float:

--- a/ml/train.py
+++ b/ml/train.py
@@ -956,6 +956,14 @@ def build_argparser() -> argparse.ArgumentParser:
         "off the place-nothing pole); paid once per episode, 0 = off (byte-identical); #720 L5",
     )
     p.add_argument(
+        "--r-valid-progress",
+        type=float,
+        default=0.0,
+        help="banked per-valid-Park credit scaled by the marginal valid-object count beyond the "
+        "freebie (r_valid_progress*max(0, n-1) on a Park where the whole layout is valid); 0 = off "
+        "(byte-identical); the #812 per-commitment economics lever",
+    )
+    p.add_argument(
         "--validity-conditional-terminal",
         action="store_true",
         help="terminal credits the VALID placed fraction (invalid layout -> 0), so an "
@@ -1089,6 +1097,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         r_valid_park=args.r_valid_park,
         valid_park_grade_scale=args.valid_park_grade_scale,
         r_first_valid=args.r_first_valid,
+        r_valid_progress=args.r_valid_progress,
         dense_slot_potential=args.dense_slot_potential,
         r_unplaced_penalty=args.r_unplaced_penalty,
         validity_conditional_terminal=args.validity_conditional_terminal,

--- a/ml/types.py
+++ b/ml/types.py
@@ -136,6 +136,13 @@ class RewardWeights:
     # validity-blind, invisible at N=1 where fraction is 0/1). Validity = the same whole-layout
     # product checker (collisions.check + Caddy egress) that drives the valid_placed gate.
     validity_conditional_terminal: bool = False
+    # Banked per-valid-Park credit, scaled by the marginal valid-object count beyond the freebie:
+    # pays r_valid_progress * max(0, valid_park_count - 1) on a Park where the WHOLE layout is
+    # valid (valid_park_count = # driven-in objects). 0.0 -> term identically 0 -> byte-identical.
+    # The 1st valid object pays 0 (r_first_valid owns the breakthrough), the 2nd pays
+    # r_valid_progress, the 3rd 2x. Banked per-step so it survives GAE while the #714 terminal
+    # flag collapses; gated on park_valid so an invalid pile never pays. (#812)
+    r_valid_progress: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -843,3 +843,48 @@ def test_first_valid_bonus_resets_across_episodes():
 
     assert first_valid_delta() == pytest.approx(9.0)  # episode 1
     assert first_valid_delta() == pytest.approx(9.0)  # after reset -> flag cleared, paid again
+
+
+# ---------------------------------------------------------------------------
+# #812 — env feeds valid_park_count to the banked marginal valid-coverage credit
+# ---------------------------------------------------------------------------
+
+
+def test_r_valid_progress_pays_the_marginal_valid_park_through_the_env():
+    # Park two objects at clean non-overlapping poses (A then B): the 1st valid Park (count 1)
+    # pays 0 (max(0, n-1)=0), the 2nd (count 2) banks r_valid_progress. Mirrors the r_first_valid
+    # once-per-episode test, but the per-commitment credit fires on the LATER valid Park. (#812)
+    def run(progress: float) -> tuple[float, bool, float, bool]:
+        env = HangarFitEnv(
+            hangar=empty_hangar(),
+            fleet=_fuji(),
+            requested_ids=("fuji", "aviat_husky"),
+            weights=RewardWeights(r_valid_progress=progress),
+        )
+        env.reset()
+        r1, v1 = _park_reward_at(env, _FIRST_VALID_POSE_A)
+        r2, v2 = _park_reward_at(env, _FIRST_VALID_POSE_B)
+        return r1, v1, r2, v2
+
+    r1_0, v1_0, r2_0, v2_0 = run(0.0)
+    r1_p, v1_p, r2_p, v2_p = run(8.0)
+    assert v1_0 and v2_0 and v1_p and v2_p, "fixture poses must both Park validly"
+    assert r1_p - r1_0 == pytest.approx(0.0)  # 1st valid Park: the freebie pays nothing
+    assert r2_p - r2_0 == pytest.approx(8.0)  # 2nd valid Park: banks r_valid_progress*(2-1)
+
+
+def test_env_valid_park_count_in_info_terms_gated_on_validity():
+    # The diagnostic term reflects len(_parked) on a valid Park, and 0 on an invalid one. (#812)
+    env = HangarFitEnv(hangar=empty_hangar(), fleet=_fuji(), requested_ids=("fuji", "aviat_husky"))
+    env.reset()
+    env._active_pose = _FIRST_VALID_POSE_A
+    _o, _r, _d, info1 = env.step(Park())  # 1st valid park
+    assert info1.valid is True and info1.terms["valid_park_count"] == 1.0
+    env._active_pose = _FIRST_VALID_POSE_B
+    _o, _r, _d, info2 = env.step(Park())  # 2nd valid park
+    assert info2.valid is True and info2.terms["valid_park_count"] == 2.0
+
+    bad = HangarFitEnv(hangar=empty_hangar(), fleet=_fuji(), requested_ids=("fuji", "aviat_husky"))
+    bad.reset()
+    _o, _r, _d, info_bad = bad.step(Park())  # object 1 parked on the apron -> invalid layout
+    assert info_bad.valid is False and info_bad.terms["valid_park_count"] == 0.0

--- a/tests/ml/test_env.py
+++ b/tests/ml/test_env.py
@@ -888,3 +888,31 @@ def test_env_valid_park_count_in_info_terms_gated_on_validity():
     bad.reset()
     _o, _r, _d, info_bad = bad.step(Park())  # object 1 parked on the apron -> invalid layout
     assert info_bad.valid is False and info_bad.terms["valid_park_count"] == 0.0
+
+
+def test_r_valid_progress_firewall_holds_across_a_poisoned_episode():
+    # spec §8 #3: after a valid freebie, an overlapping (invalid) park earns 0 marginal credit and
+    # reports valid_park_count 0; the poison persists, so a LATER park is still uncredited. (#812)
+    def run(progress: float):
+        env = HangarFitEnv(
+            hangar=empty_hangar(),
+            fleet=_fuji(),
+            requested_ids=("fuji", "aviat_husky", "cessna_150"),
+            weights=RewardWeights(r_valid_progress=progress),
+        )
+        env.reset()
+        _r1, v1 = _park_reward_at(env, _FIRST_VALID_POSE_A)  # freebie, valid (count 1)
+        env._active_pose = _FIRST_VALID_POSE_A  # object 2 ONTO object 1 -> overlap -> invalid
+        _o, r2, _d, info2 = env.step(Park())
+        env._active_pose = _FIRST_VALID_POSE_B  # object 3 clean pose; layout still poisoned
+        _o, r3, _d, info3 = env.step(Park())
+        return v1, r2, info2, r3, info3
+
+    v1_0, r2_0, info2_0, r3_0, info3_0 = run(0.0)
+    v1_8, r2_8, info2_8, r3_8, info3_8 = run(8.0)
+    assert v1_0 and v1_8  # the freebie parked validly in both runs
+    assert info2_0.valid is False and info3_0.valid is False  # poisoned for the rest of the episode
+    assert info2_8.terms["valid_park_count"] == 0.0  # firewall: 0 count on the poisoned parks
+    assert info3_8.terms["valid_park_count"] == 0.0
+    assert r2_8 == pytest.approx(r2_0)  # no marginal credit on the invalid 2nd park
+    assert r3_8 == pytest.approx(r3_0)  # nor on the later (still-invalid) 3rd park

--- a/tests/ml/test_reward.py
+++ b/tests/ml/test_reward.py
@@ -356,6 +356,9 @@ def test_r_valid_progress_clip_headroom_at_recipe_scale():
     # The banked valid-Park bonus (valid_park + valid_progress + first_valid) must stay within
     # reward_clip=50 at the recipe scale so GAE never sees it truncated:
     # r_valid_park 30 + r_valid_progress 8*(3-1) + r_first_valid 0 = 46 <= 50.
+    # 50.0 mirrors PPOConfig().reward_clip; that default is independently pinned by
+    # tests/ml/test_train_curriculum.py::test_main_no_flags_l5_neutral_l4_default_on, so a lowered
+    # clip default fails THERE — keeping this literal torch-free (test_reward.py stays torch-free).
     REWARD_CLIP = 50.0
     w = RewardWeights(r_valid_park=30.0, r_valid_progress=8.0, r_first_valid=0.0)
     off = RewardWeights(r_valid_park=0.0, r_valid_progress=0.0, r_first_valid=0.0)
@@ -363,3 +366,25 @@ def test_r_valid_progress_clip_headroom_at_recipe_scale():
     bonus = step_reward(ctx, w) - step_reward(ctx, off)
     assert bonus == pytest.approx(46.0)
     assert bonus <= REWARD_CLIP
+
+
+def test_r_valid_progress_count_zero_pays_nothing():
+    # Defensive: a (structurally impossible) valid Park at count 0 is clamped by max(0, n-1) to 0,
+    # so the term cannot go negative if a future refactor produced a 0 count on a valid Park.
+    w = RewardWeights(r_valid_progress=8.0)
+    base = RewardWeights(r_valid_progress=0.0)
+    ctx = _ctx(park_valid=True, valid_park_count=0)
+    assert step_reward(ctx, w) == step_reward(ctx, base)
+
+
+def test_r_valid_progress_cumulative_over_a_valid_trio():
+    # spec §8 #4: a valid 3-object episode banks r_valid_progress*(0 + 1 + 2) cumulatively
+    # (the freebie pays 0, the 2nd pays 1x, the 3rd 2x).
+    w = RewardWeights(r_valid_progress=8.0)
+    base = RewardWeights(r_valid_progress=0.0)
+    total = sum(
+        step_reward(_ctx(park_valid=True, valid_park_count=n), w)
+        - step_reward(_ctx(park_valid=True, valid_park_count=n), base)
+        for n in (1, 2, 3)
+    )
+    assert total == pytest.approx(8.0 * (0 + 1 + 2))  # 0 + 8 + 16 = 24

--- a/tests/ml/test_reward.py
+++ b/tests/ml/test_reward.py
@@ -312,3 +312,54 @@ def test_dense_slot_potential_on_lowers_potential_when_misfit_positive():
     # Only the misfit term differs between the two (same dist-to-slot, unplaced, overlap),
     # so the knob-on potential must be STRICTLY lower by exactly the misfit penalty.
     assert potential_at(dense=True) < potential_at(dense=False)
+
+
+# ---------------------------------------------------------------------------
+# #812 — banked marginal valid-coverage credit (r_valid_progress)
+# ---------------------------------------------------------------------------
+
+
+def test_r_valid_progress_default_zero_is_byte_identical():
+    # park_valid True with a count set, but the knob default 0.0 -> no change.
+    ctx = _ctx(park_valid=True, valid_park_count=3)
+    assert step_reward(ctx, RewardWeights()) == step_reward(
+        ctx, RewardWeights(r_valid_progress=0.0)
+    )
+
+
+def test_r_valid_progress_pays_marginal_count_beyond_the_freebie():
+    w = RewardWeights(r_valid_progress=8.0)
+    base = RewardWeights(r_valid_progress=0.0)
+    # 1st valid object (count 1) pays 0; 2nd pays 8; 3rd pays 16 (max(0, n-1) * 8).
+    for count, expected in ((1, 0.0), (2, 8.0), (3, 16.0)):
+        ctx = _ctx(park_valid=True, valid_park_count=count)
+        assert step_reward(ctx, w) - step_reward(ctx, base) == pytest.approx(expected)
+
+
+def test_r_valid_progress_not_paid_on_invalid_park():
+    # park_valid False (an overlapping pile) earns ZERO coverage credit -> firewall.
+    w = RewardWeights(r_valid_progress=8.0)
+    base = RewardWeights(r_valid_progress=0.0)
+    ctx = _ctx(park_valid=False, valid_park_count=0, overlap_m2=0.05)
+    assert step_reward(ctx, w) == step_reward(ctx, base)
+
+
+def test_r_valid_progress_not_paid_on_nonpark_step():
+    # park_valid None (a movement step) -> term structurally absent.
+    w = RewardWeights(r_valid_progress=8.0)
+    base = RewardWeights(r_valid_progress=0.0)
+    ctx = _ctx(park_valid=None)
+    assert step_reward(ctx, w) == step_reward(ctx, base)
+
+
+def test_r_valid_progress_clip_headroom_at_recipe_scale():
+    # The banked valid-Park bonus (valid_park + valid_progress + first_valid) must stay within
+    # reward_clip=50 at the recipe scale so GAE never sees it truncated:
+    # r_valid_park 30 + r_valid_progress 8*(3-1) + r_first_valid 0 = 46 <= 50.
+    REWARD_CLIP = 50.0
+    w = RewardWeights(r_valid_park=30.0, r_valid_progress=8.0, r_first_valid=0.0)
+    off = RewardWeights(r_valid_park=0.0, r_valid_progress=0.0, r_first_valid=0.0)
+    ctx = _ctx(park_valid=True, valid_park_count=3, overlap_m2=0.0, intrusion_m2=0.0)
+    bonus = step_reward(ctx, w) - step_reward(ctx, off)
+    assert bonus == pytest.approx(46.0)
+    assert bonus <= REWARD_CLIP

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -1489,3 +1489,16 @@ def test_main_no_flags_l5_neutral_l4_default_on(monkeypatch):
     assert ppo.reward_clip == 50.0
     assert ppo.value_clip_eps == 0.2
     assert ppo.target_kl == 0.03
+
+
+def test_r_valid_progress_flag_defaults_neutral():
+    # #812: the per-commitment economics knob defaults 0.0 (byte-identical) and parses a value.
+    parser = build_argparser()
+    assert parser.parse_args([]).r_valid_progress == 0.0
+    assert parser.parse_args(["--r-valid-progress", "8.0"]).r_valid_progress == 8.0
+
+
+def test_main_threads_r_valid_progress_into_weights(monkeypatch):
+    # #812: --r-valid-progress flows all the way into the RewardWeights used for training.
+    w = _capture_main(monkeypatch, ["--r-valid-progress", "8.0"])["weights"]
+    assert w.r_valid_progress == 8.0


### PR DESCRIPTION
## What

The **per-commitment economics lever** for the #736 `trio-notch` plateau: a default-neutral, banked marginal valid-coverage reward credit (`r_valid_progress`). Reward-only, no SCHEMA / observation / policy change.

## Why

The dense `trio-notch` rung stalls at `valid_placed`≈0.33 on both seeds. Two prior levers were KILLED — the witness-anchored scaffold (#794) and the spatial-token **representation** change (#810, which converged to vp 0.333 *exactly* = control, proving a representation change can't move a reward-economics argmax). The accepted root cause is **marginal-commitment economics**: the policy validly parks one freebie aircraft, then *abstains* on the 2nd/3rd because committing risks the clipped hard collision penalty while abstaining is a bounded loss.

## The mechanism

One term in `step_reward`, gated on the existing `park_valid` product-checker bool:

```python
valid_progress = r_valid_progress * max(0, valid_park_count - 1)  if park_valid else 0.0
```

- Pays the **specific marginal objects** the policy abstains on: 1st valid park 0 (the existing `r_first_valid` owns the breakthrough), **2nd banks the weight, 3rd 2×**.
- **Unopposed argmax shift** (structurally 0 on the failure branch and on abstain) — not potential-based, so it genuinely moves the optimum.
- **Banked per-step**, so it survives GAE while the #714 terminal-validity flag collapses.
- **Pile firewall is structural:** an invalid/overlapping Park pays exactly 0 and still eats the full clipped −`w_col` stick.

Chosen by a 17-agent adversarial design panel over a per-milestone carrot (latch form), a convex abstention stick, and a commitment-insurance scheme. Full provenance + EV arithmetic + caveats: `docs/superpowers/specs/2026-06-23-per-commitment-economics-design.md`; the TDD plan: `docs/superpowers/plans/2026-06-23-per-commitment-economics.md`.

## Changes (TDD, 3 tasks)

| Commit | What |
|---|---|
| `bb22fd1` | reward term + `RewardWeights.r_valid_progress` knob + `RewardContext.valid_park_count` field (5 reward tests) |
| `53d3ca5` | env feeds `valid_park_count` (Park branch) + `info.terms` diagnostic (2 env tests) |
| `ef5d240` | `--r-valid-progress` CLI flag + `RewardWeights` wiring (2 train tests) |

## Verification

- `pytest tests/ml/` → **577 passed**; `ruff check ml/ tests/ml/` + `mypy ml/` clean.
- **Default-neutral (4c-ii):** knob default `0.0` ⇒ byte-identical; pinned by `test_r_valid_progress_default_zero_is_byte_identical`.
- **Pile firewall:** `test_r_valid_progress_not_paid_on_invalid_park` (reward) + the env apron-park count-0 assertion.
- **Clip-headroom guard:** `r_valid_park 30 + r_valid_progress 8·(3−1) + r_first_valid 0 = 46 ≤ reward_clip 50`.

## Out of scope

The convex-stick adjunct (`unplaced_penalty_exponent`) and the two-seed `ml.gate` A/B sweep on `trio-notch` (sweep `r_valid_progress ∈ {6,8,12}`, WIN = vp clears ~0.33) — a follow-up after this knob lands; the recipe note goes in `ml/README` then.

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)
