### PR TITLE
feat(ml): per-rung entropy floor on frontier rungs (#815)

### DIFF
--- a/ml/ppo.py
+++ b/ml/ppo.py
@@ -44,6 +44,13 @@ class PPOConfig:
     value_clip_eps: float | None = 0.2  # PPO2 clipped value loss; caps per-update critic movement.
     target_kl: float | None = 0.03  # early-stop the epoch loop once a full epoch's mean approx-KL
     # exceeds this (a per-update trust region), so one catastrophic batch cannot over-rotate.
+    # #815: per-rung entropy FLOOR. Clamp the annealed entropy coef UP to entropy_floor, but ONLY
+    # on the curriculum rungs named in entropy_floor_rungs — a frontier-scoped exploration floor
+    # that holds the high-entropy regime where the valid dense-pose basin is reachable, while the
+    # mastered lower ladder anneals normally. entropy_floor None OR a rung not in the (empty by
+    # default) tuple => byte-identical to the bare anneal (the C2 default-neutrality invariant).
+    entropy_floor: float | None = None
+    entropy_floor_rungs: tuple[str, ...] = ()
 
 
 def entropy_coef_at(
@@ -61,6 +68,32 @@ def entropy_coef_at(
         return finish
     frac = iteration / anneal_iters
     return start + (finish - start) * frac
+
+
+def entropy_coef_with_floor(value: float, *, floor: float | None, apply: bool) -> float:
+    """Clamp ``value`` UP to ``floor`` when ``apply`` and a floor is set; else identity.
+    The floor never LOWERS the coefficient (max semantics), so on a non-frontier rung
+    (``apply`` False) or with no floor (``floor`` None) it is byte-identical passthrough
+    — the #815 default-neutrality contract."""
+    return max(value, floor) if (apply and floor is not None) else value
+
+
+def iter_entropy_coef(cfg: PPOConfig, iteration: int, stage_name: str) -> float:
+    """Per-iteration entropy coefficient for a curriculum stage: the annealed schedule
+    (``entropy_coef_at``), then floored UP to ``cfg.entropy_floor`` on frontier rungs only
+    (``stage_name in cfg.entropy_floor_rungs``). #815. Off by default — floor None, or the
+    stage not a frontier rung — returns the bare anneal, so a default curriculum run is
+    byte-identical. ``train_trivial`` has no rungs and keeps the bare ``entropy_coef_at``."""
+    annealed = entropy_coef_at(
+        iteration,
+        base=cfg.entropy_coef,
+        start=cfg.entropy_coef_start,
+        end=cfg.entropy_coef_end,
+        anneal_iters=cfg.entropy_anneal_iters,
+    )
+    return entropy_coef_with_floor(
+        annealed, floor=cfg.entropy_floor, apply=stage_name in cfg.entropy_floor_rungs
+    )
 
 
 class ReturnNormalizer:

--- a/ml/train.py
+++ b/ml/train.py
@@ -62,6 +62,7 @@ from ml.ppo import (
     VecRolloutBuffer,
     entropy_coef_at,
     factored_logprob_entropy,
+    iter_entropy_coef,
     ppo_update,
     sample_action,
 )
@@ -500,16 +501,8 @@ def train_curriculum(
             for it in range(ceiling):
                 # Per-rung entropy schedule: `it` resets to 0 each stage, so each rung
                 # re-warms from entropy_coef_start (the intended high→low warmup per rung).
-                it_cfg = replace(
-                    cfg,
-                    entropy_coef=entropy_coef_at(
-                        it,
-                        base=cfg.entropy_coef,
-                        start=cfg.entropy_coef_start,
-                        end=cfg.entropy_coef_end,
-                        anneal_iters=cfg.entropy_anneal_iters,
-                    ),
-                )
+                # #815: floored UP to cfg.entropy_floor on frontier rungs only (inert OFF).
+                it_cfg = replace(cfg, entropy_coef=iter_entropy_coef(cfg, it, stage.name))
                 buf, ep_stats = collect_rollout(
                     env, policy, enc, rollout_len, sample_request=next_request
                 )
@@ -544,17 +537,11 @@ def train_curriculum(
             rung_static_block = static_block(env.hangar, enc)
             with vec_cm as vec:
 
-                def _it_cfg(it: int) -> PPOConfig:
-                    return replace(
-                        cfg,
-                        entropy_coef=entropy_coef_at(
-                            it,
-                            base=cfg.entropy_coef,
-                            start=cfg.entropy_coef_start,
-                            end=cfg.entropy_coef_end,
-                            anneal_iters=cfg.entropy_anneal_iters,
-                        ),
-                    )
+                def _it_cfg(it: int, _stage_name: str = stage.name) -> PPOConfig:
+                    # #815: anneal then frontier-rung-gated entropy floor (inert OFF).
+                    # stage.name is bound as a def-time default (B023) — the closure is
+                    # created and consumed within this stage iteration, so it stays current.
+                    return replace(cfg, entropy_coef=iter_entropy_coef(cfg, it, _stage_name))
 
                 if pipeline_update:
                     # #755 (Wave 4, opt-in, NON-deterministic): overlap the next
@@ -740,6 +727,12 @@ def resolve_n_envs(value: str) -> int:
     if n < 1:
         raise argparse.ArgumentTypeError(f"--n-envs must be >= 1, got {n}")
     return n
+
+
+def _comma_split_rungs(value: str) -> tuple[str, ...]:
+    """argparse type for --frontier-rungs: a comma-separated rung-name list → tuple,
+    whitespace-stripped, empties dropped. #815."""
+    return tuple(part.strip() for part in value.split(",") if part.strip())
 
 
 def build_argparser() -> argparse.ArgumentParser:
@@ -993,6 +986,21 @@ def build_argparser() -> argparse.ArgumentParser:
         help="number of iterations over which to anneal entropy_coef (0 = no schedule)",
     )
     p.add_argument(
+        "--entropy-floor",
+        type=float,
+        default=None,
+        help="#815: clamp the annealed entropy coef UP to this on --frontier-rungs only "
+        "(a frontier-scoped exploration floor that holds the high-entropy basin-discovery "
+        "regime). Requires --frontier-rungs and --schedule curriculum.",
+    )
+    p.add_argument(
+        "--frontier-rungs",
+        type=_comma_split_rungs,
+        default=(),
+        help="comma-separated curriculum rung names the --entropy-floor applies to "
+        "(e.g. trio-notch-anchored,trio-notch); empty default => floor inert.",
+    )
+    p.add_argument(
         "--normalize-returns",
         action="store_true",
         help="std-only Welford return normalization before GAE",
@@ -1121,6 +1129,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         entropy_coef_start=args.entropy_start,
         entropy_coef_end=args.entropy_end,
         entropy_anneal_iters=args.entropy_anneal_iters,
+        entropy_floor=args.entropy_floor,
+        entropy_floor_rungs=args.frontier_rungs,
         normalize_returns=args.normalize_returns,
         reward_clip=args.reward_clip,
         value_clip_eps=args.value_clip_eps,
@@ -1146,6 +1156,9 @@ def main(argv: Sequence[str] | None = None) -> None:
             parser.error("--anchor-trio-notch requires --schedule curriculum")
         if args.stop_after_rung is not None:
             parser.error("--stop-after-rung requires --schedule curriculum")
+        if args.entropy_floor is not None or args.frontier_rungs:
+            # The entropy floor is rung-scoped; the trivial path has no rungs.
+            parser.error("--entropy-floor/--frontier-rungs require --schedule curriculum")
         if args.auto_budget or args.auto_budget_max_iters is not None:
             parser.error("--auto-budget/--auto-budget-max-iters require --schedule curriculum")
         if args.n_envs > 1:  # resolve_n_envs floors at 1, so >1 is the only over-floor case
@@ -1165,6 +1178,10 @@ def main(argv: Sequence[str] | None = None) -> None:
             device=args.device,
         )
     else:
+        # #815: a floor with no rung to apply it to is a misconfiguration (the floor would
+        # be inert) — fail LOUD rather than silently no-op a typed flag.
+        if args.entropy_floor is not None and not args.frontier_rungs:
+            parser.error("--entropy-floor requires --frontier-rungs")
         sched = CurriculumSchedule.default()
         sched = replace(
             sched,

--- a/ml/train.py
+++ b/ml/train.py
@@ -539,8 +539,9 @@ def train_curriculum(
 
                 def _it_cfg(it: int, _stage_name: str = stage.name) -> PPOConfig:
                     # #815: anneal then frontier-rung-gated entropy floor (inert OFF).
-                    # stage.name is bound as a def-time default (B023) — the closure is
-                    # created and consumed within this stage iteration, so it stays current.
+                    # stage.name is captured as a def-time default arg (the standard B023
+                    # fix): the closure binds THIS stage's name at definition, not by late
+                    # lookup of the loop variable — correct regardless of call-site timing.
                     return replace(cfg, entropy_coef=iter_entropy_coef(cfg, it, _stage_name))
 
                 if pipeline_update:
@@ -1182,6 +1183,11 @@ def main(argv: Sequence[str] | None = None) -> None:
         # be inert) — fail LOUD rather than silently no-op a typed flag.
         if args.entropy_floor is not None and not args.frontier_rungs:
             parser.error("--entropy-floor requires --frontier-rungs")
+        # The floor RAISES the entropy coef; a non-positive value can never raise a
+        # (non-negative) coef, so it is silently inert. Reject it loud (the off state is the
+        # absent flag, not 0/negative).
+        if args.entropy_floor is not None and args.entropy_floor <= 0:
+            parser.error("--entropy-floor must be > 0")
         sched = CurriculumSchedule.default()
         sched = replace(
             sched,

--- a/tests/ml/test_ppo.py
+++ b/tests/ml/test_ppo.py
@@ -334,6 +334,72 @@ def test_entropy_coef_at_end_none_anneals_toward_base():
 
 
 # ---------------------------------------------------------------------------
+# #815: per-rung entropy FLOOR — hold the high-entropy basin-discovery regime on
+# named frontier rungs only. entropy_coef_with_floor is the pure primitive;
+# iter_entropy_coef composes the anneal with the rung-gated floor. Both must be
+# byte-identical (passthrough) when the floor is off, so a default run is unchanged.
+# ---------------------------------------------------------------------------
+from ml.ppo import entropy_coef_with_floor, iter_entropy_coef  # noqa: E402
+
+
+def test_entropy_coef_with_floor_passthrough_when_floor_none():
+    # floor None -> identity regardless of apply (off => byte-identical).
+    assert entropy_coef_with_floor(0.005, floor=None, apply=True) == 0.005
+    assert entropy_coef_with_floor(0.005, floor=None, apply=False) == 0.005
+
+
+def test_entropy_coef_with_floor_passthrough_when_not_applied():
+    # apply False -> identity even with a floor set (non-frontier rung).
+    assert entropy_coef_with_floor(0.005, floor=0.02, apply=False) == 0.005
+
+
+def test_entropy_coef_with_floor_raises_value_below_floor():
+    assert entropy_coef_with_floor(0.005, floor=0.02, apply=True) == pytest.approx(0.02)
+
+
+def test_entropy_coef_with_floor_leaves_value_above_floor():
+    # already above the floor -> unchanged (max semantics, never lowers).
+    assert entropy_coef_with_floor(0.05, floor=0.02, apply=True) == pytest.approx(0.05)
+
+
+def test_iter_entropy_coef_floors_only_on_frontier_rung():
+    # Annealed value past the window is the end (0.005), below the 0.02 floor.
+    cfg = PPOConfig(
+        entropy_coef=0.01,
+        entropy_coef_start=0.05,
+        entropy_coef_end=0.005,
+        entropy_anneal_iters=40,
+        entropy_floor=0.02,
+        entropy_floor_rungs=("trio-notch-anchored", "trio-notch"),
+    )
+    annealed_end = entropy_coef_at(100, base=0.01, start=0.05, end=0.005, anneal_iters=40)  # 0.005
+    # frontier rung: floored UP to 0.02.
+    assert iter_entropy_coef(cfg, 100, "trio-notch-anchored") == pytest.approx(0.02)
+    # non-frontier rung: bare anneal, no floor.
+    assert iter_entropy_coef(cfg, 100, "pair-box") == pytest.approx(annealed_end)
+
+
+def test_iter_entropy_coef_default_neutral_matches_bare_anneal():
+    # floor off (None) + empty rungs => iter_entropy_coef is byte-identical to
+    # entropy_coef_at across the whole iteration range, on ANY stage name.
+    cfg = PPOConfig(
+        entropy_coef=0.01,
+        entropy_coef_start=0.05,
+        entropy_coef_end=0.005,
+        entropy_anneal_iters=40,
+    )
+    for it in range(0, 60, 3):
+        bare = entropy_coef_at(it, base=0.01, start=0.05, end=0.005, anneal_iters=40)
+        assert iter_entropy_coef(cfg, it, "trio-notch-anchored") == bare
+
+
+def test_ppoconfig_entropy_floor_fields_default_off():
+    c = PPOConfig()
+    assert c.entropy_floor is None
+    assert c.entropy_floor_rungs == ()
+
+
+# ---------------------------------------------------------------------------
 # Task 4: ReturnNormalizer
 # ---------------------------------------------------------------------------
 from ml.ppo import ReturnNormalizer  # noqa: E402

--- a/tests/ml/test_ppo.py
+++ b/tests/ml/test_ppo.py
@@ -360,6 +360,8 @@ def test_entropy_coef_with_floor_raises_value_below_floor():
 def test_entropy_coef_with_floor_leaves_value_above_floor():
     # already above the floor -> unchanged (max semantics, never lowers).
     assert entropy_coef_with_floor(0.05, floor=0.02, apply=True) == pytest.approx(0.05)
+    # boundary: value == floor -> the value (max tie-break is a no-op).
+    assert entropy_coef_with_floor(0.02, floor=0.02, apply=True) == pytest.approx(0.02)
 
 
 def test_iter_entropy_coef_floors_only_on_frontier_rung():

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -1551,14 +1551,16 @@ def test_main_threads_entropy_floor_into_ppo(monkeypatch):
     assert cfg.entropy_floor_rungs == ("trio-notch-anchored", "trio-notch")
 
 
-def test_entropy_floor_applies_only_on_frontier_rung_in_train_curriculum(monkeypatch):
+@pytest.mark.parametrize("n_envs", [1, 2])
+def test_entropy_floor_applies_only_on_frontier_rung_in_train_curriculum(monkeypatch, n_envs):
     # BEHAVIORAL: prove the floor reaches the entropy_coef ppo_update actually receives, on
-    # the frontier rung ONLY. Same recorder/empty-rollout stubs as the rewarm test so the
-    # per-stage loop runs its full max_iters with no real torch training. Mirrors that test's
-    # discriminating-assertion style. _tiny_schedule stages are "t0" (non-frontier) and "t1"
+    # the frontier rung ONLY. Parametrized over BOTH curriculum call-sites: the serial
+    # n_envs==1 inline path AND the vectorized n_envs>1 `_it_cfg` closure (vec_backend=sync,
+    # in-process). Recorder/empty-rollout stubs so the per-stage loop runs its full max_iters
+    # with no real torch training. _tiny_schedule stages are "t0" (non-frontier) and "t1"
     # (the frontier rung); the floor must raise only t1's below-floor late-anneal iterations.
     import ml.train as train_mod
-    from ml.ppo import PPOConfig, RolloutBuffer
+    from ml.ppo import PPOConfig, RolloutBuffer, VecRolloutBuffer
 
     recorded: list[float] = []
 
@@ -1569,8 +1571,12 @@ def test_entropy_floor_applies_only_on_frontier_rung_in_train_curriculum(monkeyp
     def empty_rollout(env, policy, enc, rollout_len, *, sample_request=None):
         return RolloutBuffer(), []  # no completed episodes -> never promotes by competency
 
+    def empty_rollout_vec(vec, policy, enc, rollout_len, *, static_block=None):
+        return VecRolloutBuffer(num_envs=n_envs), []  # never read (ppo_update is stubbed)
+
     monkeypatch.setattr(train_mod, "ppo_update", recorder)
     monkeypatch.setattr(train_mod, "collect_rollout", empty_rollout)
+    monkeypatch.setattr(train_mod, "collect_rollout_vec", empty_rollout_vec)
 
     max_iters = 3
     sched = _tiny_schedule(threshold=2.0)  # zero episodes -> every rung caps at max_iters
@@ -1585,10 +1591,54 @@ def test_entropy_floor_applies_only_on_frontier_rung_in_train_curriculum(monkeyp
         entropy_floor=0.02,
         entropy_floor_rungs=("t1",),  # frontier = the SECOND rung only
     )
-    train_curriculum(seed=0, schedule=sched, rollout_len=8, ppo=cfg)
+    train_curriculum(
+        seed=0, schedule=sched, rollout_len=8, ppo=cfg, n_envs=n_envs, vec_backend="sync"
+    )
 
     assert len(recorded) == 2 * max_iters
     t0 = recorded[:max_iters]  # non-frontier: bare anneal, NOT floored
     t1 = recorded[max_iters:]  # frontier: floored UP where the anneal dips below 0.02
     assert t0 == pytest.approx([0.05, 0.0275, 0.005])
     assert t1 == pytest.approx([0.05, 0.0275, 0.02])  # tail raised 0.005 -> 0.02
+
+
+def test_entropy_floor_must_be_positive():
+    # The floor RAISES the coef; a non-positive value is silently inert -> fail LOUD.
+    import ml.train as train_mod
+
+    for bad in ("0", "-0.5"):
+        with pytest.raises(SystemExit):
+            train_mod.main(
+                ["--schedule", "curriculum", "--entropy-floor", bad, "--frontier-rungs", "t1"]
+            )
+
+
+def test_frontier_rungs_without_floor_is_accepted_and_inert(monkeypatch):
+    # The asymmetric-but-valid combo: rungs set, floor omitted. Accepted (no guard) and
+    # inert — entropy_floor stays None, so iter_entropy_coef is pure passthrough regardless
+    # of rung membership (the None-floor branch dominates rung membership).
+    from ml.ppo import entropy_coef_at, iter_entropy_coef
+
+    cfg = _capture_main(monkeypatch, ["--frontier-rungs", "t1"])["ppo"]
+    assert cfg.entropy_floor is None
+    assert cfg.entropy_floor_rungs == ("t1",)
+    cfg2 = replace(cfg, entropy_coef_start=0.05, entropy_coef_end=0.005, entropy_anneal_iters=2)
+    for it in range(5):
+        bare = entropy_coef_at(it, base=cfg2.entropy_coef, start=0.05, end=0.005, anneal_iters=2)
+        assert iter_entropy_coef(cfg2, it, "t1") == bare  # frontier rung, but floor None -> bare
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("a,b,", ("a", "b")),  # trailing comma dropped
+        ("a,,b", ("a", "b")),  # empty interior token dropped
+        ("a", ("a",)),  # single value
+        ("  ,  ", ()),  # all-whitespace -> empty (the load-bearing strip+filter)
+        ("trio-notch-anchored, trio-notch", ("trio-notch-anchored", "trio-notch")),
+    ],
+)
+def test_comma_split_rungs_edge_cases(raw, expected):
+    from ml.train import _comma_split_rungs
+
+    assert _comma_split_rungs(raw) == expected

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -1502,3 +1502,93 @@ def test_main_threads_r_valid_progress_into_weights(monkeypatch):
     # #812: --r-valid-progress flows all the way into the RewardWeights used for training.
     w = _capture_main(monkeypatch, ["--r-valid-progress", "8.0"])["weights"]
     assert w.r_valid_progress == 8.0
+
+
+# ---------------------------------------------------------------------------
+# #815 entropy floor on frontier rungs — flags default-neutral, comma-split rung
+# list, LOUD guards (floor requires rungs; both are curriculum-only), and the
+# flags thread into the PPOConfig handed to train_curriculum.
+# ---------------------------------------------------------------------------
+
+
+def test_entropy_floor_flags_default_off():
+    a = build_argparser().parse_args([])
+    assert a.entropy_floor is None
+    assert a.frontier_rungs == ()
+
+
+def test_frontier_rungs_comma_split_strips_whitespace():
+    a = build_argparser().parse_args(["--frontier-rungs", "trio-notch-anchored, trio-notch"])
+    assert a.frontier_rungs == ("trio-notch-anchored", "trio-notch")
+
+
+def test_entropy_floor_requires_frontier_rungs():
+    # A floor with no rung to apply it to is a misconfiguration — fail LOUD.
+    import ml.train as train_mod
+
+    with pytest.raises(SystemExit):
+        train_mod.main(["--schedule", "curriculum", "--entropy-floor", "0.02"])
+
+
+def test_entropy_floor_flags_require_curriculum():
+    # The floor is rung-scoped; the trivial path has no rungs. Fail LOUD, not silent-ignore.
+    import ml.train as train_mod
+
+    with pytest.raises(SystemExit):
+        train_mod.main(
+            ["--schedule", "trivial", "--entropy-floor", "0.02", "--frontier-rungs", "x"]
+        )
+    with pytest.raises(SystemExit):
+        train_mod.main(["--schedule", "trivial", "--frontier-rungs", "x"])
+
+
+def test_main_threads_entropy_floor_into_ppo(monkeypatch):
+    cfg = _capture_main(
+        monkeypatch,
+        ["--entropy-floor", "0.02", "--frontier-rungs", "trio-notch-anchored,trio-notch"],
+    )["ppo"]
+    assert cfg.entropy_floor == 0.02
+    assert cfg.entropy_floor_rungs == ("trio-notch-anchored", "trio-notch")
+
+
+def test_entropy_floor_applies_only_on_frontier_rung_in_train_curriculum(monkeypatch):
+    # BEHAVIORAL: prove the floor reaches the entropy_coef ppo_update actually receives, on
+    # the frontier rung ONLY. Same recorder/empty-rollout stubs as the rewarm test so the
+    # per-stage loop runs its full max_iters with no real torch training. Mirrors that test's
+    # discriminating-assertion style. _tiny_schedule stages are "t0" (non-frontier) and "t1"
+    # (the frontier rung); the floor must raise only t1's below-floor late-anneal iterations.
+    import ml.train as train_mod
+    from ml.ppo import PPOConfig, RolloutBuffer
+
+    recorded: list[float] = []
+
+    def recorder(policy, optimizer, buf, config, *, normalizer=None):
+        recorded.append(config.entropy_coef)
+        return {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0, "loss": 0.0}
+
+    def empty_rollout(env, policy, enc, rollout_len, *, sample_request=None):
+        return RolloutBuffer(), []  # no completed episodes -> never promotes by competency
+
+    monkeypatch.setattr(train_mod, "ppo_update", recorder)
+    monkeypatch.setattr(train_mod, "collect_rollout", empty_rollout)
+
+    max_iters = 3
+    sched = _tiny_schedule(threshold=2.0)  # zero episodes -> every rung caps at max_iters
+    sched = CurriculumSchedule(
+        stages=sched.stages, policy=replace(sched.policy, max_iters=max_iters)
+    )
+    # anneal: it=0->0.05, it=1->0.0275, it>=2->0.005 (below the 0.02 floor at the tail).
+    cfg = PPOConfig(
+        entropy_coef_start=0.05,
+        entropy_coef_end=0.005,
+        entropy_anneal_iters=2,
+        entropy_floor=0.02,
+        entropy_floor_rungs=("t1",),  # frontier = the SECOND rung only
+    )
+    train_curriculum(seed=0, schedule=sched, rollout_len=8, ppo=cfg)
+
+    assert len(recorded) == 2 * max_iters
+    t0 = recorded[:max_iters]  # non-frontier: bare anneal, NOT floored
+    t1 = recorded[max_iters:]  # frontier: floored UP where the anneal dips below 0.02
+    assert t0 == pytest.approx([0.05, 0.0275, 0.005])
+    assert t1 == pytest.approx([0.05, 0.0275, 0.02])  # tail raised 0.005 -> 0.02


### PR DESCRIPTION
## Per-rung entropy floor on the frontier rungs (#815)

Closes #815. Part of the #736 training-improvement backlog (epic #607).

The **#1 discovery lever** chosen by a 21-agent adversarial design panel (5 angles × 3 skeptic lenses + synthesizer) over the trio-notch wall, after **three refuted levers**: #736 k=1 start-scaffold, #809/#810 spatial-tokens, #812 economics carrot.

### Why this lever
Sharpened diagnosis of the wall: the valid 2–3-object basin **is** reached at high entropy (peak vp 0.451) but **lost** as the global anneal drives `entropy_coef` 0.05→0.005 and PPO exploits the stronger invalid-pile attractor. A **frontier-scoped entropy floor** holds only the named rungs in the high-entropy regime where the basin was empirically reachable, while the mastered lower ladder anneals normally.

This passes the panel's hard constraints:
- **C1 (discovery, not a refuted rehash):** the entropy coef is a regularizer gradient on the loss, not a reward term `F(s,s')` and not a sampling temperature — so it changes the reachable-state distribution. It is *not* policy-invariant potential shaping (Ng–Harada–Russell), which `--dense-slot-potential` already occupies.
- **C2 (default-neutral):** off (`entropy_floor` None, or stage ∉ `entropy_floor_rungs`, both default) ⇒ byte-identical to the bare anneal. Proven by an equivalence unit, not a checkpoint hash.
- **C3 (ladder safety):** inert on non-frontier rungs ⇒ cannot re-break the validated lower ladder.

### Changes
- **`ml/ppo.py`**: two pure helpers — `entropy_coef_with_floor(value, *, floor, apply)` (max-clamp primitive) and `iter_entropy_coef(cfg, it, stage_name)` (anneal ∘ frontier-rung-gated floor); two new `PPOConfig` fields `entropy_floor: float|None=None`, `entropy_floor_rungs: tuple[str,...]=()`.
- **`ml/train.py`**: the two **curriculum** per-iteration sites use `iter_entropy_coef(cfg, it, stage.name)` (the `_it_cfg` closure binds `stage.name` as a def-time default for B023); `train_trivial` has no rungs and keeps the bare `entropy_coef_at` (byte-identical). New `--entropy-floor` / `--frontier-rungs` flags (comma-split → tuple) + LOUD guards: `--entropy-floor` requires `--frontier-rungs`; both require `--schedule curriculum`.

### Tests (TDD)
- `tests/ml/test_ppo.py`: floor-primitive table (passthrough when off / not-applied; raises below; leaves above), `iter_entropy_coef` frontier-gating, the default-neutral equivalence unit (off ≡ bare anneal across the iteration range), and the config defaults.
- `tests/ml/test_train_curriculum.py`: flag defaults, comma-split, both LOUD guards, threading into the `PPOConfig`, and an integration test (mirrors the existing entropy-rewarm test) proving the floor reaches the `entropy_coef` `ppo_update` receives on the frontier rung **only**.

Full `tests/ml/` green; `ruff`/`ruff format`/`mypy ml/` clean.

### Pre-registered gate (the experiment, after merge)
- **WIN** (both seeds): trio-notch-anchored windowed-final (last-10-iter mean) vp ≥ 0.60, gate outcome ≠ piling (valid coverage, not fraction running ahead of validity — the #812-kill discriminator), directional transfer lift on empty-start trio-notch on ≥1 seed.
- **KILL**: either seed's windowed-final vp ≤ 0.40, or flips to piling.
- **Confound watch:** a higher floor raises approx-KL and can early-stop the `--target-kl 0.03` epoch loop, starving consolidation — a KILL with collapsed `epochs_run` is ambiguous ⇒ one `--no-target-kl` retune before declaring the exploration family dead. *Requires the `epochs_run` + `entropy_coef` JSONL instrumentation (follow-up #816) before the gate run.*

Dev/CI-only `ml/` workspace — no user-facing CHANGELOG entry. `ml-rl-guard` applies (4c-ii knob default-neutrality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
