### PR TITLE
feat(ml): persist epochs_run + entropy_coef to the metrics JSONL — frontier-gate instrumentation (#816)

### DIFF
--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -398,9 +398,9 @@ class CurriculumHistory:
     promotions: list[tuple[str, int, str]] = field(default_factory=list)
     # #816: per-iteration training telemetry (e.g. epochs_run, the applied entropy_coef),
     # appended in lockstep with ``iterations`` by ``record``. Kept in a PARALLEL list rather
-    # than widening the ``iterations`` 3-tuple, so every existing unpacker and the determinism
-    # canary (which compares ``iterations``) are untouched. Empty dict when a record carries
-    # no train_metrics, so the two lists stay index-aligned.
+    # than widening the ``iterations`` 3-tuple, so every existing ``iterations``-tuple unpacker
+    # and the determinism canary (which compares ``iterations``) are untouched. Empty dict when
+    # a record carries no train_metrics, so the two lists stay index-aligned.
     iter_train_metrics: list[dict[str, float]] = field(default_factory=list)
 
     def record(

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -6,7 +6,7 @@ env builder lives in ml/stage_builder.py; the torch training loop in ml/train.py
 from __future__ import annotations
 
 import random
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from functools import partial
 from typing import Literal
@@ -228,12 +228,16 @@ def format_iter_log(stage_name: str, it: int, ep_stats: Sequence[EpisodeStat]) -
 
 def history_metric_records(history: CurriculumHistory) -> list[dict[str, object]]:
     """One JSONL-ready record per recorded training iteration: ``stage``, ``iter`` index,
-    and the ``episode_metrics`` over that iteration's completed episodes. Pure over the
-    history — the #710 per-rung ``valid_placed`` learning curve the CLI dumps via
-    ``--metrics-out``."""
+    the ``episode_metrics`` over that iteration's completed episodes, and (#816) any
+    per-iteration training telemetry recorded alongside it (``epochs_run``, the applied
+    ``entropy_coef``). Pure over the history — the #710 per-rung ``valid_placed`` learning
+    curve the CLI dumps via ``--metrics-out``. Index-guards ``iter_train_metrics`` so a
+    history built without it (pre-#816 or hand-constructed) merges an empty telemetry dict
+    rather than raising — additive: no new keys when no train_metrics were recorded."""
+    tm = history.iter_train_metrics
     return [
-        {"stage": stage, "iter": it, **episode_metrics(ep_stats)}
-        for stage, it, ep_stats in history.iterations
+        {"stage": stage, "iter": it, **episode_metrics(ep_stats), **(tm[i] if i < len(tm) else {})}
+        for i, (stage, it, ep_stats) in enumerate(history.iterations)
     ]
 
 
@@ -392,9 +396,23 @@ class CurriculumHistory:
 
     iterations: list[tuple[str, int, tuple[EpisodeStat, ...]]] = field(default_factory=list)
     promotions: list[tuple[str, int, str]] = field(default_factory=list)
+    # #816: per-iteration training telemetry (e.g. epochs_run, the applied entropy_coef),
+    # appended in lockstep with ``iterations`` by ``record``. Kept in a PARALLEL list rather
+    # than widening the ``iterations`` 3-tuple, so every existing unpacker and the determinism
+    # canary (which compares ``iterations``) are untouched. Empty dict when a record carries
+    # no train_metrics, so the two lists stay index-aligned.
+    iter_train_metrics: list[dict[str, float]] = field(default_factory=list)
 
-    def record(self, stage_name: str, it: int, ep_stats: Sequence[EpisodeStat]) -> None:
+    def record(
+        self,
+        stage_name: str,
+        it: int,
+        ep_stats: Sequence[EpisodeStat],
+        *,
+        train_metrics: Mapping[str, float] | None = None,
+    ) -> None:
         self.iterations.append((stage_name, it, tuple(ep_stats)))
+        self.iter_train_metrics.append(dict(train_metrics or {}))
 
     def note_promotion(self, stage_name: str, it: int, *, by: str) -> None:
         self.promotions.append((stage_name, it, by))

--- a/ml/train.py
+++ b/ml/train.py
@@ -348,6 +348,14 @@ def _clone_policy(policy: HangarFitPolicy) -> HangarFitPolicy:
     return copy.deepcopy(policy)
 
 
+def _iter_train_metrics(metrics: dict[str, float], it_cfg: PPOConfig) -> dict[str, float]:
+    """#816: the per-iteration training telemetry recorded alongside each iteration for the
+    --metrics-out JSONL — ``epochs_run`` (the target_kl-bounded epoch count, which a higher
+    --entropy-floor can collapse toward 1) and ``entropy_coef`` (the applied coef, confirming
+    a frontier-rung floor actually bit). Pure; consumed by ``CurriculumHistory.record``."""
+    return {"epochs_run": metrics["epochs_run"], "entropy_coef": it_cfg.entropy_coef}
+
+
 def _rung_stop_reason(
     promo_history: list[float],
     ep_stats: Sequence[EpisodeStat],
@@ -506,8 +514,10 @@ def train_curriculum(
                 buf, ep_stats = collect_rollout(
                     env, policy, enc, rollout_len, sample_request=next_request
                 )
-                ppo_update(policy, optimizer, buf, it_cfg, normalizer=normalizer)
-                history.record(stage.name, it, ep_stats)
+                metrics = ppo_update(policy, optimizer, buf, it_cfg, normalizer=normalizer)
+                history.record(
+                    stage.name, it, ep_stats, train_metrics=_iter_train_metrics(metrics, it_cfg)
+                )
                 if log:
                     print(format_iter_log(stage.name, it, ep_stats), flush=True)
                 reason = _rung_stop_reason(promo_history, ep_stats, pol, auto_budget)
@@ -578,7 +588,6 @@ def train_curriculum(
                             else:
                                 buf_vec, ep_stats = pending.result()
                                 pending = None
-                            history.record(stage.name, it, ep_stats)
                             # Evaluate the stop gate BEFORE launching the next rollout (and
                             # before this update) so a stop suppresses the otherwise-wasted
                             # speculative rollout. Equivalent to the sequential branch's
@@ -596,8 +605,19 @@ def train_curriculum(
                                     rollout_len,
                                     static_block=rung_static_block,
                                 )
-                            ppo_update(
-                                policy, optimizer, buf_vec, _it_cfg(it), normalizer=normalizer
+                            it_cfg = _it_cfg(it)
+                            metrics = ppo_update(
+                                policy, optimizer, buf_vec, it_cfg, normalizer=normalizer
+                            )
+                            # #816: record AFTER the update so this iteration's epochs_run is
+                            # captured. record does not feed _rung_stop_reason (which already
+                            # ran above off ep_stats), so moving it is behavior-neutral for
+                            # promotion; this opt-in pipeline path is non-deterministic anyway.
+                            history.record(
+                                stage.name,
+                                it,
+                                ep_stats,
+                                train_metrics=_iter_train_metrics(metrics, it_cfg),
                             )
                             if log:
                                 print(format_iter_log(stage.name, it, ep_stats), flush=True)
@@ -629,8 +649,15 @@ def train_curriculum(
                         buf_vec, ep_stats = collect_rollout_vec(
                             vec, policy, enc, rollout_len, static_block=rung_static_block
                         )
-                        ppo_update(policy, optimizer, buf_vec, it_cfg, normalizer=normalizer)
-                        history.record(stage.name, it, ep_stats)
+                        metrics = ppo_update(
+                            policy, optimizer, buf_vec, it_cfg, normalizer=normalizer
+                        )
+                        history.record(
+                            stage.name,
+                            it,
+                            ep_stats,
+                            train_metrics=_iter_train_metrics(metrics, it_cfg),
+                        )
                         if log:
                             print(format_iter_log(stage.name, it, ep_stats), flush=True)
                         reason = _rung_stop_reason(promo_history, ep_stats, pol, auto_budget)

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -182,6 +182,21 @@ def test_history_metric_records_default_neutral_without_train_metrics():
     assert "epochs_run" not in rec and "entropy_coef" not in rec
 
 
+def test_history_metric_records_index_guards_short_train_metrics():
+    # Defensive (documented back-compat): a hand-built / pre-#816-deserialized history whose
+    # iter_train_metrics is SHORTER than iterations merges an empty telemetry dict for the
+    # unguarded tail rather than raising IndexError. record() keeps them in lockstep, so this
+    # branch is only reachable by direct construction — pin it so a refactor can't drop it.
+    h = CurriculumHistory()
+    h.iterations.append(("s0", 0, ()))
+    h.iterations.append(("s0", 1, ()))
+    h.iter_train_metrics = [{"epochs_run": 2.0}]  # one short of iterations
+    recs = history_metric_records(h)
+    assert len(recs) == 2
+    assert recs[0]["epochs_run"] == 2.0
+    assert "epochs_run" not in recs[1]  # index-guarded tail -> empty, no IndexError
+
+
 def test_curriculum_schedule_default_is_the_committed_ladder():
     sched = CurriculumSchedule.default()
     assert sched.stages == DEFAULT_LADDER

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -153,6 +153,35 @@ def test_curriculum_history_records_and_notes():
     assert h.promotions == [("s0", 3, "competency")]
 
 
+def test_history_records_train_metrics_surfaced_in_jsonl():
+    # #816: per-iteration training telemetry (epochs_run + applied entropy_coef) is stored in
+    # the parallel iter_train_metrics list (the 3-tuple iterations shape is UNCHANGED) and
+    # merged into the --metrics-out JSONL record.
+    h = CurriculumHistory()
+    h.record(
+        "s0",
+        0,
+        [EpisodeStat(0.5, True, 1.0)],
+        train_metrics={"epochs_run": 3.0, "entropy_coef": 0.02},
+    )
+    assert h.iterations == [("s0", 0, (EpisodeStat(0.5, True, 1.0),))]  # shape unchanged
+    assert h.iter_train_metrics == [{"epochs_run": 3.0, "entropy_coef": 0.02}]
+    rec = history_metric_records(h)[0]
+    assert rec["epochs_run"] == 3.0
+    assert rec["entropy_coef"] == 0.02
+    assert rec["stage"] == "s0" and rec["iter"] == 0
+
+
+def test_history_metric_records_default_neutral_without_train_metrics():
+    # A record with no train_metrics (every pre-#816 call site) adds NO new JSONL keys —
+    # the parallel list gets an empty dict so it stays in lockstep with iterations.
+    h = CurriculumHistory()
+    h.record("s0", 0, [EpisodeStat(0.5, True, 1.0)])
+    assert h.iter_train_metrics == [{}]
+    rec = history_metric_records(h)[0]
+    assert "epochs_run" not in rec and "entropy_coef" not in rec
+
+
 def test_curriculum_schedule_default_is_the_committed_ladder():
     sched = CurriculumSchedule.default()
     assert sched.stages == DEFAULT_LADDER

--- a/tests/ml/test_pipeline_update.py
+++ b/tests/ml/test_pipeline_update.py
@@ -146,3 +146,12 @@ def test_pipeline_preserves_sequential_run_structure():
     assert [(s, by) for s, _it, by in pipe.promotions] == [(s, by) for s, _it, by in seq.promotions]
     assert pipe.promotions[-1][2] == "cap"
     assert len(pipe.iterations) == len(seq.iterations) == 3
+    # #816: the pipeline path records AFTER ppo_update (moved from before), so its
+    # per-iteration telemetry lands in the metrics JSONL like the serial/vec paths.
+    from ml.curriculum import history_metric_records
+
+    pipe_recs = history_metric_records(pipe)
+    assert len(pipe_recs) == 3
+    for r in pipe_recs:
+        assert isinstance(r["epochs_run"], float) and r["epochs_run"] >= 1.0
+        assert "entropy_coef" in r

--- a/tests/ml/test_pipeline_update.py
+++ b/tests/ml/test_pipeline_update.py
@@ -146,8 +146,9 @@ def test_pipeline_preserves_sequential_run_structure():
     assert [(s, by) for s, _it, by in pipe.promotions] == [(s, by) for s, _it, by in seq.promotions]
     assert pipe.promotions[-1][2] == "cap"
     assert len(pipe.iterations) == len(seq.iterations) == 3
-    # #816: the pipeline path records AFTER ppo_update (moved from before), so its
-    # per-iteration telemetry lands in the metrics JSONL like the serial/vec paths.
+    # #816: the pipeline path records AFTER ppo_update (moved from before) — structure /
+    # promotion-equivalence is covered by the asserts above; here we assert the per-iteration
+    # telemetry now lands in the metrics JSONL like the serial/vec paths.
     from ml.curriculum import history_metric_records
 
     pipe_recs = history_metric_records(pipe)

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -93,6 +93,9 @@ def test_train_curriculum_is_deterministic():
     h2 = train_curriculum(seed=0, schedule=sched, rollout_len=16)
     assert h1.promotions == h2.promotions
     assert h1.iterations == h2.iterations
+    # #816: the parallel telemetry is also deterministic (epochs_run is target_kl-driven but
+    # reproducible on the fixed-seed serial path; entropy_coef is a pure computed value).
+    assert h1.iter_train_metrics == h2.iter_train_metrics
 
 
 def test_train_curriculum_promotes_by_competency_then_advances():
@@ -1689,3 +1692,44 @@ def test_curriculum_jsonl_carries_epochs_run_and_entropy_coef(n_envs):
     for r in recs:
         assert isinstance(r["epochs_run"], float) and r["epochs_run"] >= 1.0
         assert r["entropy_coef"] == pytest.approx(0.01)  # PPOConfig default, no anneal
+
+
+def test_jsonl_entropy_coef_is_the_applied_floored_value_not_the_base(monkeypatch):
+    # The decisive #816 x #815 test: the JSONL must carry the APPLIED per-iteration coef
+    # (it_cfg.entropy_coef, post-anneal + post-floor) — not the base cfg.entropy_coef. Stubs
+    # ppo_update (returning epochs_run) + empty rollouts so the loop caps; then reads the
+    # entropy_coef straight out of history_metric_records. t1 is the frontier rung: its tail
+    # anneal (0.005) must show FLOORED to 0.02 in the JSONL, while t0 shows the bare anneal.
+    import ml.train as train_mod
+    from ml.curriculum import history_metric_records
+    from ml.ppo import PPOConfig, RolloutBuffer
+
+    def stub_update(policy, optimizer, buf, config, *, normalizer=None):
+        return {
+            "policy_loss": 0.0,
+            "value_loss": 0.0,
+            "entropy": 0.0,
+            "loss": 0.0,
+            "epochs_run": 1.0,
+        }
+
+    def empty_rollout(env, policy, enc, rollout_len, *, sample_request=None):
+        return RolloutBuffer(), []
+
+    monkeypatch.setattr(train_mod, "ppo_update", stub_update)
+    monkeypatch.setattr(train_mod, "collect_rollout", empty_rollout)
+
+    sched = _tiny_schedule(threshold=2.0)
+    sched = CurriculumSchedule(stages=sched.stages, policy=replace(sched.policy, max_iters=3))
+    cfg = PPOConfig(
+        entropy_coef_start=0.05,
+        entropy_coef_end=0.005,
+        entropy_anneal_iters=2,
+        entropy_floor=0.02,
+        entropy_floor_rungs=("t1",),
+    )
+    recs = history_metric_records(train_curriculum(seed=0, schedule=sched, rollout_len=8, ppo=cfg))
+    t0 = [r["entropy_coef"] for r in recs if r["stage"] == "t0"]
+    t1 = [r["entropy_coef"] for r in recs if r["stage"] == "t1"]
+    assert t0 == pytest.approx([0.05, 0.0275, 0.005])  # non-frontier: bare anneal in the JSONL
+    assert t1 == pytest.approx([0.05, 0.0275, 0.02])  # frontier: FLOORED applied value, not 0.005

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -126,7 +126,13 @@ def test_train_curriculum_competency_reads_honest_per_iteration_mean_not_episode
     monkeypatch.setattr(
         train_mod,
         "ppo_update",
-        lambda *a, **k: {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0, "loss": 0.0},
+        lambda *a, **k: {
+            "policy_loss": 0.0,
+            "value_loss": 0.0,
+            "entropy": 0.0,
+            "loss": 0.0,
+            "epochs_run": 1.0,
+        },
     )
 
     sched = CurriculumSchedule.default()
@@ -164,7 +170,13 @@ def test_auto_budget_floor_guard_blocks_premature_stop_in_loop(monkeypatch, min_
     monkeypatch.setattr(
         train_mod,
         "ppo_update",
-        lambda *a, **k: {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0, "loss": 0.0},
+        lambda *a, **k: {
+            "policy_loss": 0.0,
+            "value_loss": 0.0,
+            "entropy": 0.0,
+            "loss": 0.0,
+            "epochs_run": 1.0,
+        },
     )
 
     sched = CurriculumSchedule.default()
@@ -331,7 +343,13 @@ def test_entropy_schedule_rewarms_per_stage_in_train_curriculum(monkeypatch):
 
     def recorder(policy, optimizer, buf, config, *, normalizer=None):
         recorded.append(config.entropy_coef)
-        return {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0, "loss": 0.0}
+        return {
+            "policy_loss": 0.0,
+            "value_loss": 0.0,
+            "entropy": 0.0,
+            "loss": 0.0,
+            "epochs_run": 1.0,
+        }
 
     def empty_rollout(env, policy, enc, rollout_len, *, sample_request=None):
         return RolloutBuffer(), []  # no completed episodes -> never promotes by competency
@@ -1566,7 +1584,13 @@ def test_entropy_floor_applies_only_on_frontier_rung_in_train_curriculum(monkeyp
 
     def recorder(policy, optimizer, buf, config, *, normalizer=None):
         recorded.append(config.entropy_coef)
-        return {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0, "loss": 0.0}
+        return {
+            "policy_loss": 0.0,
+            "value_loss": 0.0,
+            "entropy": 0.0,
+            "loss": 0.0,
+            "epochs_run": 1.0,
+        }
 
     def empty_rollout(env, policy, enc, rollout_len, *, sample_request=None):
         return RolloutBuffer(), []  # no completed episodes -> never promotes by competency
@@ -1642,3 +1666,26 @@ def test_comma_split_rungs_edge_cases(raw, expected):
     from ml.train import _comma_split_rungs
 
     assert _comma_split_rungs(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# #816 frontier-gate instrumentation — epochs_run + applied entropy_coef land
+# in the --metrics-out JSONL (the #815 gate's target_kl confound watch needs them).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_envs", [1, 2])
+def test_curriculum_jsonl_carries_epochs_run_and_entropy_coef(n_envs):
+    # Real (tiny) curriculum run over BOTH the serial (n_envs==1) and vectorized
+    # (n_envs>1) call-sites: every per-iteration metrics record must carry epochs_run
+    # (>=1, the target_kl epoch count) and the applied entropy_coef (default 0.01).
+    from ml.curriculum import history_metric_records
+
+    sched = _tiny_schedule(threshold=2.0)  # caps at max_iters
+    sched = CurriculumSchedule(stages=sched.stages, policy=replace(sched.policy, max_iters=2))
+    h = train_curriculum(seed=0, schedule=sched, rollout_len=16, n_envs=n_envs, vec_backend="sync")
+    recs = history_metric_records(h)
+    assert recs  # non-vacuous
+    for r in recs:
+        assert isinstance(r["epochs_run"], float) and r["epochs_run"] >= 1.0
+        assert r["entropy_coef"] == pytest.approx(0.01)  # PPOConfig default, no anneal


### PR DESCRIPTION
## Persist `epochs_run` + `entropy_coef` to the metrics JSONL — frontier-gate instrumentation (#816)

Closes #816. Part of the #736 backlog (epic #607).

**Stacked on #817 (#815 entropy-floor lever).** Branch cut off `feature/815-entropy-floor-frontier-rungs`, **base = develop** (per the repo's stacking rule — CI + `Closes #N` only fire for develop-based PRs), so this PR shows the **cumulative** diff until #817 merges. **Merge order: #817 first, then #816.**

### Why
The #815 entropy-floor gate is pre-registered with a **`target_kl` confound watch**: a higher floor raises approx-KL and can early-stop the epoch loop (`epochs_run`→1), starving the consolidation the floor is meant to buy — so a KILL with collapsed `epochs_run` is ambiguous. But `history_metric_records` built each `--metrics-out` JSONL row purely from `(stage, it, ep_stats)`; the `ppo_update` return dict (which carries `epochs_run`) was **discarded** at every curriculum call-site. This PR persists `epochs_run` + the applied `entropy_coef` per iteration so the gate can be graded as pre-registered (and confirm the floor actually bit).

### Design (additive, determinism-safe)
- `ml/curriculum.py`: `CurriculumHistory` gains a **parallel** `iter_train_metrics: list[dict[str,float]]` appended in lockstep by `record(..., *, train_metrics=None)`. The `iterations` **3-tuple shape is unchanged** — so every existing unpacker (~12 sites) and the determinism canary (`h1.iterations == h2.iterations`) are untouched. `history_metric_records` merges the parallel telemetry (index-guarded → additive: no new keys when no `train_metrics` were recorded).
- `ml/train.py`: a small `_iter_train_metrics(metrics, it_cfg)` helper; all **three** curriculum call-sites (serial `n_envs==1`, vectorized non-pipeline, and pipeline) capture the `ppo_update` return and record `{epochs_run, entropy_coef}`. The pipeline path's `record` moved to **after** `ppo_update` (verified behavior-neutral: `record` does not feed `_rung_stop_reason`, which already ran off `ep_stats`).
- Checkpoint resume is unaffected (it never serialized the history).

### Tests (TDD)
- `tests/ml/test_curriculum.py`: telemetry stored in the parallel list + surfaced in the JSONL; **default-neutral** (a record with no `train_metrics` adds no JSONL keys); the exact-equality `iterations` test still passes (shape unchanged).
- `tests/ml/test_train_curriculum.py`: a real tiny-run integration test parametrized over `n_envs {1,2}` (serial + vec sites) asserting every JSONL row carries `epochs_run ≥ 1` and `entropy_coef`. Existing `ppo_update` stubs updated to honor the contract (the real `ppo_update` always returns `epochs_run`; `_iter_train_metrics` reads it loudly, no silent `.get` default).
- `tests/ml/test_pipeline_update.py`: the pipeline path's records carry the telemetry too (the third call-site).

Full `tests/ml/` green; `ruff`/`mypy ml/` clean. Dev/CI-only `ml/` — no CHANGELOG entry. `ml-rl-guard` applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
