### PR TITLE
test(607): held-out witness_notch_B for the #821 backplay generalization probe

### DIFF
--- a/tests/fixtures/ml/witness_notch_B.yaml
+++ b/tests/fixtures/ml/witness_notch_B.yaml
@@ -1,0 +1,32 @@
+# HELD-OUT second notch witness (#821) — a SECOND, geometrically-distinct valid
+# 3-object packing of the SAME notch trio (aviat_husky, cessna_140, fk9_mkii) on the
+# REAL Airfield Herrenteich L-shaped hangar (examples/herrenteich/hangar.yaml).
+#
+# WHY a second witness. The encoder writes ABSOLUTE world coordinates into the object
+# token (ml/encoding.py), and there is only ONE committed notch geometry
+# (witness_notch.yaml). So a policy could satisfy the trio-notch transfer WIN by
+# MEMORIZING the witness coordinates rather than learning to pack — the oracle-
+# masquerade the imitation design panel flagged (#821). This file is the held-out
+# generalization probe: a backplay/transfer EVALUATION seeded from THIS geometry
+# fails for a coordinate-memorizing policy and passes only for one that generalizes.
+#
+# DISTINCTNESS (vs witness_notch.yaml). Every object is relocated by >= 10.9 m AND
+# every heading is changed (90->0, 90->270, 270->90); the trio spans the full hangar
+# depth (y 5.78 -> 25.57, into the deep notch-approach region) rather than the front
+# half. So reproducing the witness_notch coordinates cannot satisfy this layout.
+#
+# VALIDITY. Found by a deterministic search (seed 736) over the SAME notch fleet +
+# hangar and accepted by the PRODUCT checker (collisions.check + Caddy egress): the
+# full trio, every prefix, and every single anchor are valid at the rung's 0.05 m
+# clearance, with real geometric margin (still valid up to 0.50 m clearance — 5x the
+# witness_notch 0.10 m bar). Verified in tests/ml/test_stage_builder.py
+# (test_witness_notch_b_*). Do not hand-edit the poses without re-running those tests.
+#
+# No `fleet:` / `hangar:` fields on purpose (same as witness_notch.yaml): the env +
+# stage_builder load this with fleet=/hangar= OVERRIDES (the notch fleet + notch
+# hangar at clearance 0.05), and the loader rejects a file that sets those AND takes
+# overrides.
+placements:
+  - {plane: aviat_husky, x_m: 8.07, y_m: 5.78, heading_deg: 0.0}
+  - {plane: cessna_140, x_m: 4.51, y_m: 13.94, heading_deg: 270.0}
+  - {plane: fk9_mkii, x_m: 6.17, y_m: 25.57, heading_deg: 90.0}

--- a/tests/ml/test_stage_builder.py
+++ b/tests/ml/test_stage_builder.py
@@ -215,6 +215,70 @@ def test_committed_trio_notch_anchored_rung_builds_and_resets_from_a_valid_parti
 
 
 # ---------------------------------------------------------------------------
+# #821 — the held-out SECOND notch witness (backplay-seed generalization probe)
+# ---------------------------------------------------------------------------
+
+_WITNESS_NOTCH_B = "tests/fixtures/ml/witness_notch_B.yaml"
+
+
+def _load_witness_notch_b(clearance_m: float = 0.05):
+    """Load the held-out second notch witness against the SAME real notch hangar + fleet the
+    trio-notch rungs train on — so it is a drop-in alternative backplay/transfer seed geometry."""
+    hangar = dataclasses.replace(
+        load_hangar("examples/herrenteich/hangar.yaml"), clearance_m=clearance_m, apron_depth_m=8.0
+    )
+    fleet = load_fleet("examples/herrenteich/fleet.yaml")
+    return load_layout(_WITNESS_NOTCH_B, fleet=fleet, hangar=hangar)
+
+
+def test_witness_notch_b_is_a_valid_three_object_layout():
+    # The held-out witness is itself a valid 3-object layout on the real notch hangar under the
+    # rung's 0.05 m clearance — PRODUCT checker (collisions.check + Caddy egress), no solver.
+    lay = _load_witness_notch_b()
+    assert len(lay.placements) == 3
+    assert go.layout_valid(lay)
+
+
+def test_witness_notch_b_every_prefix_is_valid():
+    # Same seed-anchor correctness property as witness_notch: every k-prefix is valid, so the
+    # held-out witness is a drop-in alternative anchor/backplay seed with no per-reset search.
+    lay = _load_witness_notch_b()
+    for k in range(len(lay.placements) + 1):
+        prefix = dataclasses.replace(lay, placements=lay.placements[:k])
+        assert go.layout_valid(prefix), f"witness_B prefix k={k} is invalid"
+
+
+def test_witness_notch_b_every_single_anchor_is_valid():
+    # Any single object of the held-out trio may be the seeded anchor — each must be valid alone.
+    lay = _load_witness_notch_b()
+    for i in range(len(lay.placements)):
+        single = dataclasses.replace(lay, placements=(lay.placements[i],))
+        assert go.layout_valid(single), (
+            f"witness_B single anchor #{i} ({lay.placements[i].plane_id}) invalid"
+        )
+
+
+def test_witness_notch_b_has_robust_margin():
+    # Robustness: valid not just at the file's 0.10 m but well past it (the fixture was selected
+    # for margin up to 0.50 m), so it is a solid, non-borderline held-out geometry.
+    assert go.layout_valid(_load_witness_notch_b(clearance_m=0.10))
+    assert go.layout_valid(_load_witness_notch_b(clearance_m=0.50))
+
+
+def test_witness_notch_b_is_a_genuine_held_out_of_witness_notch():
+    # The held-out property (#821): SAME trio, GEOMETRICALLY DISTINCT arrangement — so a policy
+    # that memorized the witness_notch absolute coordinates cannot satisfy witness_B. Every object
+    # is relocated (>= 5 m planar) and every heading differs between the two witnesses.
+    a = {p.plane_id: p for p in _load_witness_notch().placements}
+    b = {p.plane_id: p for p in _load_witness_notch_b().placements}
+    assert set(a) == set(b), "held-out witness must use the SAME trio (isolates memorization)"
+    for pid in a:
+        disp = ((a[pid].x_m - b[pid].x_m) ** 2 + (a[pid].y_m - b[pid].y_m) ** 2) ** 0.5
+        assert disp >= 5.0, f"{pid} moved only {disp:.2f} m — not geometrically distinct enough"
+        assert a[pid].heading_deg != b[pid].heading_deg, f"{pid} heading unchanged — too similar"
+
+
+# ---------------------------------------------------------------------------
 # #712 — stage_builder threads the witness into an anchored rung's env
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
First increment of #821 (the backplay reverse-curriculum lever): the **held-out second notch witness** the lever's gate needs. No behavior change — a dev/CI-only fixture + its validation tests.

## Why
The encoder writes **absolute** world coordinates and there is only **one** committed notch geometry (`witness_notch.yaml`). So a policy could satisfy the trio-notch transfer WIN by **memorizing the witness coordinates** — the oracle-masquerade the imitation design panel flagged. `witness_notch_B.yaml` is the held-out generalization probe: a second geometrically-distinct valid packing of the **same** notch trio, used as a held-out backplay-seed evaluation. A memorizing policy fails it; a generalizing one passes.

## What
- `tests/fixtures/ml/witness_notch_B.yaml` — same trio (aviat_husky, cessna_140, fk9_mkii), **every object relocated ≥ 10.9 m and every heading changed**, spanning the full hangar depth (y 5.78 → 25.57).
- Found by a **deterministic** search (seed 736); accepted by the **product checker** (`go.layout_valid` = collisions.check + Caddy egress) for the full trio, every prefix, and every single anchor, with **robust margin** (valid up to 0.50 m clearance vs witness_notch's 0.10 m).
- `tests/ml/test_stage_builder.py::test_witness_notch_b_*` mirror `test_witness_notch_*` and add `test_witness_notch_b_is_a_genuine_held_out_of_witness_notch` (asserts same-trio + geometric distinctness).

## Scope / determinism
- Dev/CI-only fixture + tests. No `ml/*.py`, no behavior change, no flag.
- The held-out property is the deliverable and is test-enforced.
- No CHANGELOG entry (not user-facing).

Part of #821 (does not close it — the backplay lever lands separately and closes it).