### PR TITLE
feat(607): backplay reverse-curriculum lever for the #736 trio-notch wall (#821)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#821, epic #607): backplay reverse-curriculum lever (`--backplay-trio-notch`)
+  for the dense `trio-notch` plateau (#736), plus a held-out `witness_notch_B` generalization probe.**
+  The fifth #736 lever after four refutations (#736 anchor, #809 representation, #812 economics,
+  #815 entropy floor) — and the only one that shifts the **start-state distribution** (ρ₀) rather
+  than reward/representation/exploration (Ng–Harada–Russell proves potential-based shaping cannot
+  move the argmax, which is why those failed). `--backplay-trio-notch` (curriculum-only) inserts an
+  opt-in ladder of `trio-notch-backplay-{50,75,100}` sub-rungs before `trio-notch`: each pre-parks
+  the **k=N−1 prefix** of a committed 3-object notch witness (`tests/fixtures/ml/witness_notch.yaml`)
+  and spawns the single driven object a fraction φ∼U(0, φ_cap) along the corridor from its witness
+  park-pose (φ=0, near-solved) **out to the door** (φ=1); the φ_cap ceiling anneals 0.5→1.0 across
+  the contiguous sub-rungs, promoted on the **same** windowed `valid_placed` gate (the reverse
+  curriculum *is* the rung sequence — no per-iteration anneal code). This collapses the diagnosed
+  cold-start coverage minimum (validly park one, abandon two) by starting near the dense solution
+  and receding. The env **never snaps or auto-parks** — it only moves *where* the episode begins;
+  the corridor spawn is taken only when collision-free (deterministic admissibility check) else it
+  falls back to the door. The held-out `witness_notch_B.yaml` (a second geometrically-distinct valid
+  notch packing, shipped via #822) is the witness-absent transfer-evaluation variant that hardens
+  the pre-registered gate against near-witness overfit. Default-neutral: `--backplay-trio-notch`
+  absent ⇒ `DEFAULT_LADDER` byte-identical (φ=None ⇒ byte-identical door spawn); the flag fails
+  loud under `--schedule trivial`, `backplay_phi_cap` and `anchor_prob` are mutually exclusive, and
+  every witness k-prefix is product-checker valid (`collisions.check` + Caddy egress). The
+  per-iteration `--metrics-out` JSONL surfaces the rung's `phi_cap` (the gate's confound watch).
+  `ml/` is dev/CI-only (never shipped in the wheel).
 - **Learned backend (#812, epic #607): per-commitment economics reward lever (`--r-valid-progress`).**
   A banked marginal valid-coverage credit that targets the dense `trio-notch` plateau (#736), where the
   policy validly parks one freebie aircraft then *abstains* on the rest because the marginal 2nd/3rd

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -264,10 +264,13 @@ def sample_request(pool: Sequence[str], n: int, rng: random.Random) -> tuple[str
 class EpisodeStart:
     """Per-episode start spec produced by the sampler, consumed by env.reset. ``seed_anchor_k``
     None => the env uses ``difficulty.seed_anchor_k`` (plain rung); an int => per-episode
-    override (the #712 mixed-start rung's seeded k draw)."""
+    override (the #712 mixed-start rung's seeded k draw). ``backplay_phi`` None => no spawn
+    override (byte-identical door spawn); a float in [0, 1] => the #821 backplay corridor
+    fraction for the driven object (0 = its witness park-pose, 1 = the door)."""
 
     requested_ids: tuple[str, ...]
     seed_anchor_k: int | None = None
+    backplay_phi: float | None = None
 
 
 def plain_start(pool: Sequence[str], n: int, rng: random.Random) -> EpisodeStart:
@@ -294,21 +297,44 @@ def sample_mixed_start(
     return EpisodeStart(ids, k)
 
 
+def sample_backplay_start(
+    pool: Sequence[str],
+    n: int,
+    rng: random.Random,
+    *,
+    phi_cap: float,
+) -> EpisodeStart:
+    """A #821 backplay reverse-curriculum episode: draw the requested ids, THEN draw the corridor
+    fraction phi ~ U(0, ``phi_cap``) from the SAME rng (FIXED draw order: ids then phi), so Sync
+    and Subproc workers sharing one stream stay byte-identical. ``seed_anchor_k`` is left None (the
+    rung's fixed N-1 prefix is the env default, not a per-episode draw); the env spawns the single
+    driven object a fraction phi along the corridor from its witness park-pose (phi=0, near-solved)
+    out to the door (phi=1)."""
+    ids = sample_request(pool, n, rng)
+    phi = rng.uniform(0.0, phi_cap)
+    return EpisodeStart(ids, None, phi)
+
+
 def make_episode_sampler(
     stage: Stage, pool: Sequence[str], n: int, rng: random.Random
 ) -> Callable[[], EpisodeStart]:
-    """Build this stage's per-episode start sampler. A mixed-start rung (anchor_prob set)
-    gets ``sample_mixed_start`` (seeded per-episode k draw); every other rung gets
-    ``plain_start`` (byte-identical id draw, k left to the env default). Both bind pool/n/rng
-    by value via partial (no late-binding closure trap)."""
-    ap = stage.difficulty.anchor_prob
+    """Build this stage's per-episode start sampler. A backplay rung (backplay_phi_cap set) gets
+    ``sample_backplay_start`` (seeded per-episode phi draw); a mixed-start rung (anchor_prob set)
+    gets ``sample_mixed_start`` (seeded per-episode k draw); every other rung gets ``plain_start``
+    (byte-identical id draw, k/phi left to the env default). The backplay and mixed knobs are
+    mutually exclusive (validate_ladder enforces it). All bind pool/n/rng by value via partial
+    (no late-binding closure trap)."""
+    diff = stage.difficulty
+    if diff.backplay_phi_cap is not None:
+        return partial(sample_backplay_start, pool, n, rng, phi_cap=diff.backplay_phi_cap)
+    ap = diff.anchor_prob
     if ap is not None:
         return partial(
             sample_mixed_start,
             pool,
             n,
             rng,
-            seed_anchor_k=stage.difficulty.seed_anchor_k,
+            seed_anchor_k=diff.seed_anchor_k,
             anchor_prob=ap,
         )
     return partial(plain_start, pool, n, rng)
@@ -384,6 +410,24 @@ def validate_ladder(ladder: Sequence[Stage], *, encoder_max_objects: int) -> Non
                 raise ValueError(
                     f"stage {s.name!r}: a mixed-start rung (anchor_prob set) needs "
                     f"max_objects >= 2 (room for both a k=1 and a k=0 draw), got {n}"
+                )
+        # #821 backplay rung: phi_cap must be a real corridor fraction in (0, 1] (0 = degenerate
+        # always-witness, no corridor; >1 extrapolates past the door), needs a witness for the
+        # corridor terminals + the pre-parked prefix, and is mutually exclusive with the mixed-start
+        # k draw (each sampler owns ONE fixed rng draw order — sharing one stage desyncs them).
+        cap = s.difficulty.backplay_phi_cap
+        if cap is not None:
+            if not (0.0 < cap <= 1.0):
+                raise ValueError(f"stage {s.name!r}: backplay_phi_cap must be in (0, 1], got {cap}")
+            if s.anchor_layout_path is None:
+                raise ValueError(
+                    f"stage {s.name!r}: a backplay rung (backplay_phi_cap set) needs an "
+                    f"anchor_layout_path (the witness the driven corridor recedes from)"
+                )
+            if ap is not None:
+                raise ValueError(
+                    f"stage {s.name!r}: backplay_phi_cap and anchor_prob are mutually exclusive "
+                    f"(each owns one fixed per-episode rng draw order)"
                 )
 
 
@@ -493,6 +537,43 @@ _TRIO_NOTCH_ANCHORED_STAGE = Stage(
     fleet_path=_NOTCH_FLEET,
     anchor_layout_path=_WITNESS_NOTCH,
     clearance_m=_LENIENT_CLEARANCE,
+)
+
+# Opt-in #821 reverse-curriculum (Backplay) sub-rungs (wired via with_trio_notch_backplay_rung /
+# --backplay-trio-notch), NOT in DEFAULT_LADDER. The three notch-witness objects with the k=N-1=2
+# prefix pre-parked and the SINGLE remaining (driven) object spawned a fraction phi ~ U(0, phi_cap)
+# along the corridor from its witness park-pose (phi=0, near-solved) out to the door (phi=1). Each
+# sub-rung is a FIXED phi_cap; the ceiling anneals 0.5 -> 1.0 across the ladder, promoted on the
+# SAME windowed valid_placed competency gate (no per-iteration anneal code — the reverse curriculum
+# IS the rung sequence). The final phi_cap=1.0 sub-rung must solve from the true door, so a WIN
+# that reaches it rules out near-witness overfit (the issue-#821 confound watch). It targets the
+# diagnosed cold-start coverage minimum on the notch by collapsing the tight-3rd-pose discovery
+# horizon to ~0 and growing it back — the only lever class that shifts rho_0 (the start-state
+# distribution) rather than reward/representation/exploration. The pool IS the witness's 3 objects
+# (anchor_layout_path set => stage_builder pins it); ONE object is driven, so the budget matches the
+# pair-anchored drive-one (per_object == total). Inserted before the empty-start trio-notch.
+_BACKPLAY_PHI_CEILINGS: tuple[float, ...] = (0.5, 0.75, 1.0)
+
+
+def _trio_notch_backplay_stage(phi_cap: float) -> Stage:
+    return Stage(
+        name=f"trio-notch-backplay-{int(round(phi_cap * 100))}",
+        difficulty=DifficultyConfig(
+            max_objects=3,
+            seed_anchor_k=2,
+            backplay_phi_cap=phi_cap,
+            per_object_step_budget=80,
+            total_step_budget=80,
+        ),
+        hangar_path=_NOTCH_HANGAR,
+        fleet_path=_NOTCH_FLEET,
+        anchor_layout_path=_WITNESS_NOTCH,
+        clearance_m=_LENIENT_CLEARANCE,
+    )
+
+
+_TRIO_NOTCH_BACKPLAY_STAGES: tuple[Stage, ...] = tuple(
+    _trio_notch_backplay_stage(cap) for cap in _BACKPLAY_PHI_CEILINGS
 )
 
 DEFAULT_LADDER: tuple[Stage, ...] = (
@@ -619,6 +700,27 @@ def with_trio_notch_anchored_rung(schedule: CurriculumSchedule) -> CurriculumSch
     return replace(
         schedule, stages=stages[:before] + (_TRIO_NOTCH_ANCHORED_STAGE,) + stages[before:]
     )
+
+
+def with_trio_notch_backplay_rung(schedule: CurriculumSchedule) -> CurriculumSchedule:
+    """Return ``schedule`` with the opt-in #821 backplay (reverse-curriculum) sub-rung ladder
+    inserted immediately BEFORE the ``trio-notch`` rung — the ``--backplay-trio-notch`` lever. It
+    pre-parks the k=N-1=2 notch-witness prefix and spawns the single driven object a fraction
+    phi ~ U(0, phi_cap) along the corridor from its witness park-pose (phi=0, near-solved) out to
+    the door (phi=1); the phi_cap ceiling anneals 0.5 -> 1.0 across the contiguous sub-rungs,
+    promoted on the SAME competency gate. This collapses the diagnosed cold-start coverage minimum
+    (place one, abandon two) by starting near the dense solution and receding to the true door —
+    the only #736 lever that shifts the start-state distribution rather than reward/representation/
+    exploration. Only the ladder changes (the promotion policy is preserved); the default ladder is
+    left untouched, so default runs stay byte-identical (this is opt-in)."""
+    stages = schedule.stages
+    try:
+        before = next(i for i, s in enumerate(stages) if s.name == "trio-notch")
+    except StopIteration:
+        raise ValueError(
+            "with_trio_notch_backplay_rung: schedule has no 'trio-notch' rung to insert before"
+        ) from None
+    return replace(schedule, stages=stages[:before] + _TRIO_NOTCH_BACKPLAY_STAGES + stages[before:])
 
 
 def with_mixed_anchor_rung(schedule: CurriculumSchedule) -> CurriculumSchedule:

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -429,6 +429,16 @@ def validate_ladder(ladder: Sequence[Stage], *, encoder_max_objects: int) -> Non
                     f"stage {s.name!r}: backplay_phi_cap and anchor_prob are mutually exclusive "
                     f"(each owns one fixed per-episode rng draw order)"
                 )
+            # Backplay pre-parks the k=N-1 prefix so EXACTLY ONE object is driven via the corridor:
+            # _backplay_phi persists across the per-object _spawn calls, so a smaller k (>1 driven)
+            # would silently backplay-spawn EVERY driven object — not the single-driven reverse
+            # curriculum the lever (and every docstring) specifies. Enforce it pre-flight.
+            if s.difficulty.seed_anchor_k != n - 1:
+                raise ValueError(
+                    f"stage {s.name!r}: a backplay rung must pre-park the k=N-1 prefix "
+                    f"(seed_anchor_k == max_objects - 1 == {n - 1}) so exactly one object is "
+                    f"driven, got seed_anchor_k={s.difficulty.seed_anchor_k}"
+                )
 
 
 @dataclass(slots=True)
@@ -550,8 +560,9 @@ _TRIO_NOTCH_ANCHORED_STAGE = Stage(
 # diagnosed cold-start coverage minimum on the notch by collapsing the tight-3rd-pose discovery
 # horizon to ~0 and growing it back — the only lever class that shifts rho_0 (the start-state
 # distribution) rather than reward/representation/exploration. The pool IS the witness's 3 objects
-# (anchor_layout_path set => stage_builder pins it); ONE object is driven, so the budget matches the
-# pair-anchored drive-one (per_object == total). Inserted before the empty-start trio-notch.
+# (anchor_layout_path set => stage_builder pins it); ONE object is driven, so per_object == total
+# (the drive-one budget structure of pair-anchored) at trio-notch's per-object magnitude (80), NOT
+# pair-anchored's 60/60. Inserted before the empty-start trio-notch.
 _BACKPLAY_PHI_CEILINGS: tuple[float, ...] = (0.5, 0.75, 1.0)
 
 

--- a/ml/env.py
+++ b/ml/env.py
@@ -34,7 +34,8 @@ def _backplay_corridor_pose(witness: Placement, door: Pose, phi: float) -> Pose:
     (phi=0, the valid dense terminal) out to the door spawn (phi=1); heading interpolates on
     the shortest arc. A degenerate but kinematically-agnostic corridor (#821 v1): it realizes
     the reverse-curriculum reachable-state shift without a Reeds-Shepp solve. phi=0 returns the
-    witness pose exactly; phi=1 returns the door pose exactly."""
+    witness pose (heading normalized to [0, 360) — exact for any witness heading already in
+    range, which the committed fixtures are); phi=1 returns the door pose exactly."""
     return Pose(
         x_m=witness.x_m + (door.x_m - witness.x_m) * phi,
         y_m=witness.y_m + (door.y_m - witness.y_m) * phi,

--- a/ml/env.py
+++ b/ml/env.py
@@ -3,6 +3,7 @@ no gymnasium/torch dependency (those arrive in the training rung #3)."""
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Mapping
 
 from hangarfit.models import Aircraft, GroundObject, Hangar, Layout, Placement
@@ -19,6 +20,26 @@ from ml.types import (
     RewardWeights,
     StepInfo,
 )
+
+
+def _lerp_heading_deg(a_deg: float, b_deg: float, t: float) -> float:
+    """Interpolate ``a_deg`` -> ``b_deg`` along the SHORTEST arc, ``t`` in [0, 1]
+    (t=0 -> a, t=1 -> b). Wraps to [0, 360)."""
+    delta = ((b_deg - a_deg + 180.0) % 360.0) - 180.0
+    return (a_deg + delta * t) % 360.0
+
+
+def _backplay_corridor_pose(witness: Placement, door: Pose, phi: float) -> Pose:
+    """Pose a fraction ``phi`` along the straight corridor from the witness park-pose
+    (phi=0, the valid dense terminal) out to the door spawn (phi=1); heading interpolates on
+    the shortest arc. A degenerate but kinematically-agnostic corridor (#821 v1): it realizes
+    the reverse-curriculum reachable-state shift without a Reeds-Shepp solve. phi=0 returns the
+    witness pose exactly; phi=1 returns the door pose exactly."""
+    return Pose(
+        x_m=witness.x_m + (door.x_m - witness.x_m) * phi,
+        y_m=witness.y_m + (door.y_m - witness.y_m) * phi,
+        heading_deg=_lerp_heading_deg(witness.heading_deg, door.heading_deg, phi),
+    )
 
 
 class HangarFitEnv:
@@ -101,6 +122,9 @@ class HangarFitEnv:
         # #720 one-shot: flipped True on the first Park that yields a valid layout, so the
         # r_first_valid bonus is paid once per episode. Cleared here every reset.
         self._first_valid_reached = False
+        # #821 backplay: the per-episode corridor fraction phi (drawn by the curriculum sampler
+        # and passed to reset()). None => no spawn override => byte-identical door spawn.
+        self._backplay_phi: float | None = None
 
     def _body(self, object_id: str) -> Aircraft | GroundObject:
         return self.fleet[object_id] if object_id in self.fleet else self.ground_objects[object_id]
@@ -121,16 +145,58 @@ class HangarFitEnv:
         return body.movement_mode == "always_cart" or getattr(body, "on_carts", False)
 
     def _spawn(self) -> None:
-        """Pop the next queued object and place it on the apron at the door centre."""
+        """Pop the next queued object and place it on the apron at the door centre.
+
+        #821 backplay: when an episode carries a corridor fraction ``self._backplay_phi`` and the
+        spawned object has a witness park-pose, start it a fraction phi along the corridor from
+        that pose (phi=0, near-solved) out to the door (phi=1) instead of at the door — but ONLY
+        if that start is collision-free; otherwise fall back to the door spawn. The env never
+        snaps or auto-parks: it only moves WHERE the episode begins.
+        """
         self._active_id = self._queue.pop(0)
         depth = self.hangar.apron_depth_m or 0.0
-        self._active_pose = Pose(
+        door_pose = Pose(
             x_m=self.hangar.door.center_x_m,
             y_m=-(depth / 2.0 if depth else 0.0),
             heading_deg=0.0,
         )
+        self._active_pose = door_pose
+        phi = self._backplay_phi
+        if phi is not None and self._active_id in self._anchor_by_id:
+            candidate = _backplay_corridor_pose(self._anchor_by_id[self._active_id], door_pose, phi)
+            if self._backplay_admissible(candidate):
+                self._active_pose = candidate
         self._prev_gear = None
         self._steps_this_object = 0
+
+    def _backplay_admissible(self, candidate: Pose) -> bool:
+        """The active object placed at ``candidate``, added to the frozen scene (parked + fixed),
+        must be product-valid (no overlap / intrusion / egress block) — else backplay declines the
+        corridor pose and the spawn stays at the door. phi=0 is the witness pose, so with the
+        k=N-1 prefix already parked the full witness is valid and phi=0 always admits."""
+        active_id = self._active_id
+        assert active_id is not None
+        pl = Placement(
+            plane_id=active_id,
+            x_m=candidate.x_m,
+            y_m=candidate.y_m,
+            heading_deg=candidate.heading_deg,
+            on_carts=self._on_carts(active_id),
+        )
+        frozen = self._layout()
+        if active_id in self.fleet:
+            combined = dataclasses.replace(
+                frozen,
+                fleet={**frozen.fleet, active_id: self.fleet[active_id]},
+                placements=frozen.placements + (pl,),
+            )
+        else:
+            combined = dataclasses.replace(
+                frozen,
+                ground_objects={**frozen.ground_objects, active_id: self.ground_objects[active_id]},
+                ground_object_placements=frozen.ground_object_placements + (pl,),
+            )
+        return go.layout_valid(combined)
 
     def _layout(self) -> Layout:
         """The scene of FROZEN objects: driven-in (parked) PLUS pre-placed fixed obstacles
@@ -227,6 +293,7 @@ class HangarFitEnv:
         requested_ids: tuple[str, ...] | None = None,
         *,
         seed_anchor_k: int | None = None,
+        backplay_phi: float | None = None,
     ) -> Observation:
         if requested_ids is not None:
             if not requested_ids:
@@ -244,6 +311,9 @@ class HangarFitEnv:
             n = self.difficulty.max_objects
             self.requested_ids = requested_ids if n is None else requested_ids[:n]
         self._reset_state(seed_anchor_k_override=seed_anchor_k)
+        # Set the per-episode backplay fraction BEFORE _spawn (which consumes it). _reset_state
+        # cleared it to None, so a plain reset (backplay_phi=None) is byte-identical.
+        self._backplay_phi = backplay_phi
         self._spawn()
         self._prev_potential = self._potential()
         return self._observe()

--- a/ml/train.py
+++ b/ml/train.py
@@ -124,8 +124,17 @@ def collect_rollout(
     """Drive the env single-stream for `rollout_len` steps; return the buffer and the
     per-completed-episode stats (competency + reward sum). On each episode boundary,
     `sample_request()` (when given) returns an EpisodeStart that picks the next episode's
-    object subset and optional seed_anchor_k; None keeps the env's fixed requested set
-    (the 4a trivial path).
+    object subset and optional seed_anchor_k / backplay_phi; None keeps the env's fixed
+    requested set (the 4a trivial path).
+
+    The FIRST episode of each rollout starts from the env's construction defaults (the bare
+    `env.reset()` below) — `sample_request()` is consulted only from the first episode boundary
+    on. So a per-episode start override (requested_ids, seed_anchor_k, AND the #821 backplay
+    phi) is applied from episode 1, not episode 0; this is a deliberate, long-standing property
+    kept for byte-identity (threading the start into the initial reset would add an rng draw and
+    shift every existing rung's stream). The vectorized path (`collect_rollout_vec` →
+    `_EnvWorker.reset`) applies the start from episode 0, so the GPU gate's vec runs exercise
+    the backplay shift on every episode.
 
     `pose_cache` (#733, default-on) opens a per-step `pose_cache_scope` spanning the
     encode + env.step so the shapely parts are built once across the encoder and the

--- a/ml/train.py
+++ b/ml/train.py
@@ -50,6 +50,7 @@ from ml.curriculum import (
     with_promotion_overrides,
     with_solo_box_rung,
     with_trio_notch_anchored_rung,
+    with_trio_notch_backplay_rung,
 )
 from ml.encoding import EncoderConfig, encode, static_block
 from ml.env import HangarFitEnv
@@ -173,6 +174,7 @@ def collect_rollout(
                 obs = env.reset(
                     requested_ids=start.requested_ids if start else None,
                     seed_anchor_k=start.seed_anchor_k if start else None,
+                    backplay_phi=start.backplay_phi if start else None,
                 )
             else:
                 obs = nxt
@@ -348,12 +350,24 @@ def _clone_policy(policy: HangarFitPolicy) -> HangarFitPolicy:
     return copy.deepcopy(policy)
 
 
-def _iter_train_metrics(metrics: dict[str, float], it_cfg: PPOConfig) -> dict[str, float]:
+def _iter_train_metrics(
+    metrics: dict[str, float],
+    it_cfg: PPOConfig,
+    *,
+    backplay_phi_cap: float | None = None,
+) -> dict[str, float]:
     """#816: the per-iteration training telemetry recorded alongside each iteration for the
     --metrics-out JSONL — ``epochs_run`` (the target_kl-bounded epoch count, which a higher
     --entropy-floor can collapse toward 1) and ``entropy_coef`` (the applied coef, confirming
-    a frontier-rung floor actually bit). Pure; consumed by ``CurriculumHistory.record``."""
-    return {"epochs_run": metrics["epochs_run"], "entropy_coef": it_cfg.entropy_coef}
+    a frontier-rung floor actually bit). #821: on a backplay rung, also surface its fixed
+    ``phi_cap`` ceiling so the gate's confound watch ("a WIN must coincide with phi_cap
+    annealed to ~1.0") reads it numerically without parsing the stage name; absent (no key) on
+    every non-backplay rung, so their telemetry stays byte-identical to the pre-#821 dict. Pure;
+    consumed by ``CurriculumHistory.record``."""
+    out = {"epochs_run": metrics["epochs_run"], "entropy_coef": it_cfg.entropy_coef}
+    if backplay_phi_cap is not None:
+        out["phi_cap"] = backplay_phi_cap
+    return out
 
 
 def _rung_stop_reason(
@@ -516,7 +530,12 @@ def train_curriculum(
                 )
                 metrics = ppo_update(policy, optimizer, buf, it_cfg, normalizer=normalizer)
                 history.record(
-                    stage.name, it, ep_stats, train_metrics=_iter_train_metrics(metrics, it_cfg)
+                    stage.name,
+                    it,
+                    ep_stats,
+                    train_metrics=_iter_train_metrics(
+                        metrics, it_cfg, backplay_phi_cap=stage.difficulty.backplay_phi_cap
+                    ),
                 )
                 if log:
                     print(format_iter_log(stage.name, it, ep_stats), flush=True)
@@ -617,7 +636,11 @@ def train_curriculum(
                                 stage.name,
                                 it,
                                 ep_stats,
-                                train_metrics=_iter_train_metrics(metrics, it_cfg),
+                                train_metrics=_iter_train_metrics(
+                                    metrics,
+                                    it_cfg,
+                                    backplay_phi_cap=stage.difficulty.backplay_phi_cap,
+                                ),
                             )
                             if log:
                                 print(format_iter_log(stage.name, it, ep_stats), flush=True)
@@ -656,7 +679,9 @@ def train_curriculum(
                             stage.name,
                             it,
                             ep_stats,
-                            train_metrics=_iter_train_metrics(metrics, it_cfg),
+                            train_metrics=_iter_train_metrics(
+                                metrics, it_cfg, backplay_phi_cap=stage.difficulty.backplay_phi_cap
+                            ),
                         )
                         if log:
                             print(format_iter_log(stage.name, it, ep_stats), flush=True)
@@ -932,6 +957,16 @@ def build_argparser() -> argparse.ArgumentParser:
         "cold-start coverage minimum (place one, abandon two) before the empty-start trio-notch",
     )
     p.add_argument(
+        "--backplay-trio-notch",
+        action="store_true",
+        help="curriculum: insert the opt-in #821 backplay (reverse-curriculum) sub-rung ladder "
+        "before trio-notch — the k=N-1 notch-witness prefix pre-parked and the single driven "
+        "object spawned a fraction phi~U(0,phi_cap) along the corridor from its witness pose "
+        "(near-solved) out to the door, with phi_cap annealing 0.5->1.0 across the sub-rungs. "
+        "Shifts the start-state distribution to break the cold-start coverage minimum before "
+        "the empty-start trio-notch (the #736 frontier lever)",
+    )
+    p.add_argument(
         "--stop-after-rung",
         type=str,
         default=None,
@@ -1182,6 +1217,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             parser.error("--mixed-anchor requires --schedule curriculum")
         if args.anchor_trio_notch:
             parser.error("--anchor-trio-notch requires --schedule curriculum")
+        if args.backplay_trio_notch:
+            parser.error("--backplay-trio-notch requires --schedule curriculum")
         if args.stop_after_rung is not None:
             parser.error("--stop-after-rung requires --schedule curriculum")
         if args.entropy_floor is not None or args.frontier_rungs:
@@ -1234,6 +1271,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             sched = with_mixed_anchor_rung(sched)
         if args.anchor_trio_notch:
             sched = with_trio_notch_anchored_rung(sched)
+        if args.backplay_trio_notch:
+            sched = with_trio_notch_backplay_rung(sched)
         # Truncate LAST, after the grafts, so a name they introduce (pair-mixed) is in scope.
         if args.stop_after_rung is not None:
             sched = truncate_after_rung(sched, args.stop_after_rung)

--- a/ml/types.py
+++ b/ml/types.py
@@ -93,6 +93,13 @@ class DifficultyConfig:
     # episodes in the training mix. None => fixed-k rung (use seed_anchor_k as-is) =>
     # byte-identical to the pre-change env. anchor_prob is P(k = seed_anchor_k) per episode.
     anchor_prob: float | None = None
+    # #821 backplay reverse-curriculum: when set (0..1), each episode draws phi ~ U(0, this)
+    # from the curriculum's seeded stream and the env spawns the DRIVEN object a fraction phi
+    # along the corridor from its witness park-pose (phi=0, near-solved) out to the door
+    # (phi=1). Combined with a seed_anchor_k = N-1 prefix this shows the valid dense terminal
+    # first and recedes. None => inert (no override) => byte-identical to the door-spawn env.
+    # This is the difficulty CEILING; the per-episode draw is made by the curriculum sampler.
+    backplay_phi_cap: float | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/ml/vector_env.py
+++ b/ml/vector_env.py
@@ -77,6 +77,7 @@ class _EnvWorker:
             obs = self._env.reset(
                 requested_ids=start.requested_ids if start else None,
                 seed_anchor_k=start.seed_anchor_k if start else None,
+                backplay_phi=start.backplay_phi if start else None,
             )
             return self._encode(obs)
 
@@ -107,6 +108,7 @@ class _EnvWorker:
                 sem = self._env.reset(
                     requested_ids=start.requested_ids if start else None,
                     seed_anchor_k=start.seed_anchor_k if start else None,
+                    backplay_phi=start.backplay_phi if start else None,
                 )
             return self._encode(sem), reward, done, info, ep
 

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -9,9 +9,12 @@ import pytest
 from ml.curriculum import (
     _BOX_FLEET,
     _BOX_HANGAR,
+    _NOTCH_FLEET,
+    _NOTCH_HANGAR,
     _PAIR_MIXED_STAGE,
     _SOLO_BOX_STAGE,
     _WITNESS_BOX,
+    _WITNESS_NOTCH,
     DEFAULT_LADDER,
     CurriculumHistory,
     CurriculumSchedule,
@@ -24,6 +27,7 @@ from ml.curriculum import (
     history_metric_records,
     make_episode_sampler,
     plain_start,
+    sample_backplay_start,
     sample_mixed_start,
     sample_request,
     should_promote,
@@ -35,6 +39,7 @@ from ml.curriculum import (
     with_promotion_overrides,
     with_solo_box_rung,
     with_trio_notch_anchored_rung,
+    with_trio_notch_backplay_rung,
 )
 from ml.encoding import EncoderConfig
 from ml.types import DifficultyConfig
@@ -816,3 +821,154 @@ def test_truncate_after_rung_at_trio_box_is_the_gate_sweep_shape():
     trio = truncated.stages[-1]
     assert trio.name == "trio-box"
     assert trio.difficulty.max_objects == 3  # the ≥2-object rung the four-lever ladder must clear
+
+
+# ---------------------------------------------------------------------------
+# #821 — backplay reverse-curriculum: EpisodeStart.backplay_phi, the
+#        sample_backplay_start sampler, and the trio-notch-backplay sub-rung ladder
+# ---------------------------------------------------------------------------
+
+
+def test_episode_start_backplay_phi_defaults_none():
+    # Byte-identity: a plain/mixed EpisodeStart carries no backplay corridor fraction.
+    assert EpisodeStart(("fuji",)).backplay_phi is None
+    assert EpisodeStart(("fuji",), 1).backplay_phi is None
+
+
+def test_sample_backplay_start_draws_phi_in_range_and_leaves_k_to_env():
+    rng = random.Random(0)
+    s = sample_backplay_start(("a", "b", "c"), 3, rng, phi_cap=0.5)
+    assert isinstance(s, EpisodeStart)
+    assert set(s.requested_ids) == {"a", "b", "c"}
+    # seed_anchor_k is left None (the rung's fixed N-1 prefix is the env default, not a draw).
+    assert s.seed_anchor_k is None
+    assert s.backplay_phi is not None and 0.0 <= s.backplay_phi <= 0.5
+
+
+def test_sample_backplay_start_is_deterministic_for_equal_rngs():
+    pool = ("a", "b", "c")
+    a = sample_backplay_start(pool, 3, random.Random(7), phi_cap=1.0)
+    b = sample_backplay_start(pool, 3, random.Random(7), phi_cap=1.0)
+    assert a == b  # same seed -> identical ids AND phi
+
+
+def test_sample_backplay_start_draw_order_is_ids_then_phi():
+    # The FIXED draw order (ids via sample_request, THEN one uniform phi draw) is what keeps
+    # Sync and Subproc workers sharing one rng stream byte-identical. Reproduce it manually.
+    pool = ("a", "b", "c")
+    got = sample_backplay_start(pool, 3, random.Random(3), phi_cap=0.8)
+    ref = random.Random(3)
+    ref_ids = sample_request(pool, 3, ref)
+    ref_phi = ref.uniform(0.0, 0.8)
+    assert got.requested_ids == ref_ids
+    assert got.backplay_phi == ref_phi
+
+
+def test_sample_backplay_start_phi_spans_the_corridor():
+    # phi is a genuine U(0, cap) draw: over many episodes it spreads across the corridor
+    # (near-witness AND near-door starts), not pinned to one end.
+    rng = random.Random(123)
+    phis = [
+        sample_backplay_start(("a", "b", "c"), 3, rng, phi_cap=1.0).backplay_phi
+        for _ in range(2000)
+    ]
+    assert min(phis) < 0.1  # near-witness (near-solved) starts present
+    assert max(phis) > 0.9  # near-door starts present
+    assert 0.45 <= sum(phis) / len(phis) <= 0.55  # mean ~0.5 of U(0,1)
+
+
+def _backplay_stage(cap=0.5, *, anchor_path=_WITNESS_NOTCH, anchor_prob=None) -> Stage:
+    return Stage(
+        name="trio-notch-backplay",
+        difficulty=DifficultyConfig(
+            max_objects=3, seed_anchor_k=2, backplay_phi_cap=cap, anchor_prob=anchor_prob
+        ),
+        hangar_path=_NOTCH_HANGAR,
+        fleet_path=_NOTCH_FLEET,
+        anchor_layout_path=anchor_path,
+    )
+
+
+def test_make_episode_sampler_backplay_for_a_backplay_stage():
+    # A stage carrying backplay_phi_cap gets the backplay sampler: every draw carries a phi.
+    sampler = make_episode_sampler(_backplay_stage(0.5), ("a", "b", "c"), 3, random.Random(5))
+    s = sampler()
+    assert s.backplay_phi is not None and 0.0 <= s.backplay_phi <= 0.5
+    assert s.seed_anchor_k is None  # k stays the env default (the rung's fixed N-1 prefix)
+
+
+def test_default_ladder_has_no_backplay_rung():
+    # Byte-identity guard: every backplay sub-rung is opt-in; the default ladder is unchanged.
+    assert all("backplay" not in s.name for s in DEFAULT_LADDER)
+
+
+def test_with_trio_notch_backplay_rung_inserts_sub_rungs_before_trio_notch():
+    sched = with_trio_notch_backplay_rung(CurriculumSchedule.default())
+    names = [s.name for s in sched.stages]
+    i = names.index("trio-notch")
+    inserted = [n for n in names if "backplay" in n]
+    assert inserted  # at least one backplay sub-rung is grafted
+    # the sub-rungs sit immediately before the empty-start trio-notch, contiguous and in order
+    assert names[i - len(inserted) : i] == inserted
+
+
+def test_backplay_sub_rungs_are_three_object_k2_with_ascending_phi_to_one():
+    sched = with_trio_notch_backplay_rung(CurriculumSchedule.default())
+    rungs = [s for s in sched.stages if "backplay" in s.name]
+    caps = [s.difficulty.backplay_phi_cap for s in rungs]
+    assert caps == sorted(caps)  # the reverse-curriculum anneal grows the hardest start
+    assert caps[-1] == 1.0  # the final sub-rung solves from the true door (confound-watch target)
+    for s in rungs:
+        assert s.difficulty.max_objects == 3
+        assert s.difficulty.seed_anchor_k == 2  # N-1 prefix pre-parked, ONE driven via backplay
+        assert s.anchor_layout_path is not None  # the committed notch witness layout
+
+
+def test_backplay_sub_rungs_scaffold_the_same_notch_as_trio_notch():
+    sched = with_trio_notch_backplay_rung(CurriculumSchedule.default())
+    trio_notch = next(s for s in sched.stages if s.name == "trio-notch")
+    for s in (st for st in sched.stages if "backplay" in st.name):
+        assert s.hangar_path == trio_notch.hangar_path
+        assert s.clearance_m == trio_notch.clearance_m  # same lenient 0.05 clearance
+
+
+def test_with_trio_notch_backplay_rung_preserves_policy_and_validates():
+    base = CurriculumSchedule.default()
+    sched = with_trio_notch_backplay_rung(base)
+    assert sched.policy == base.policy  # only the ladder changes, not the promotion gate
+    validate_ladder(sched.stages, encoder_max_objects=EncoderConfig().max_objects)  # no raise
+
+
+def test_with_trio_notch_backplay_rung_does_not_mutate_the_default_ladder():
+    with_trio_notch_backplay_rung(CurriculumSchedule.default())
+    assert all("backplay" not in s.name for s in DEFAULT_LADDER)  # default still pristine
+
+
+def test_with_trio_notch_backplay_rung_raises_without_trio_notch():
+    no_trio_notch = CurriculumSchedule(
+        stages=tuple(s for s in DEFAULT_LADDER if s.name != "trio-notch"),
+        policy=PromotionPolicy(),
+    )
+    with pytest.raises(ValueError, match="trio-notch"):
+        with_trio_notch_backplay_rung(no_trio_notch)
+
+
+def test_validate_ladder_accepts_valid_backplay_rung():
+    validate_ladder([_backplay_stage(0.5)], encoder_max_objects=8)  # no raise
+
+
+@pytest.mark.parametrize("cap", [0.0, -0.1, 1.1])
+def test_validate_ladder_rejects_backplay_phi_cap_out_of_range(cap):
+    with pytest.raises(ValueError, match="backplay_phi_cap"):
+        validate_ladder([_backplay_stage(cap)], encoder_max_objects=8)
+
+
+def test_validate_ladder_rejects_backplay_rung_without_witness():
+    with pytest.raises(ValueError, match="anchor_layout_path"):
+        validate_ladder([_backplay_stage(0.5, anchor_path=None)], encoder_max_objects=8)
+
+
+def test_validate_ladder_rejects_backplay_combined_with_anchor_prob():
+    # The two start-state samplers are mutually exclusive (each owns one fixed rng draw order).
+    with pytest.raises(ValueError, match="backplay_phi_cap"):
+        validate_ladder([_backplay_stage(0.5, anchor_prob=0.5)], encoder_max_objects=8)

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -869,15 +869,20 @@ def test_sample_backplay_start_phi_spans_the_corridor():
     # (near-witness AND near-door starts), not pinned to one end.
     rng = random.Random(123)
     phis = [
-        sample_backplay_start(("a", "b", "c"), 3, rng, phi_cap=1.0).backplay_phi
+        phi
         for _ in range(2000)
+        if (phi := sample_backplay_start(("a", "b", "c"), 3, rng, phi_cap=1.0).backplay_phi)
+        is not None
     ]
+    assert len(phis) == 2000  # every backplay draw carries a phi
     assert min(phis) < 0.1  # near-witness (near-solved) starts present
     assert max(phis) > 0.9  # near-door starts present
     assert 0.45 <= sum(phis) / len(phis) <= 0.55  # mean ~0.5 of U(0,1)
 
 
-def _backplay_stage(cap=0.5, *, anchor_path=_WITNESS_NOTCH, anchor_prob=None) -> Stage:
+def _backplay_stage(
+    cap: float = 0.5, *, anchor_path: str | None = _WITNESS_NOTCH, anchor_prob: float | None = None
+) -> Stage:
     return Stage(
         name="trio-notch-backplay",
         difficulty=DifficultyConfig(
@@ -915,7 +920,8 @@ def test_with_trio_notch_backplay_rung_inserts_sub_rungs_before_trio_notch():
 def test_backplay_sub_rungs_are_three_object_k2_with_ascending_phi_to_one():
     sched = with_trio_notch_backplay_rung(CurriculumSchedule.default())
     rungs = [s for s in sched.stages if "backplay" in s.name]
-    caps = [s.difficulty.backplay_phi_cap for s in rungs]
+    caps = [c for s in rungs if (c := s.difficulty.backplay_phi_cap) is not None]
+    assert len(caps) == len(rungs)  # every backplay sub-rung carries a phi_cap
     assert caps == sorted(caps)  # the reverse-curriculum anneal grows the hardest start
     assert caps[-1] == 1.0  # the final sub-rung solves from the true door (confound-watch target)
     for s in rungs:
@@ -972,3 +978,17 @@ def test_validate_ladder_rejects_backplay_combined_with_anchor_prob():
     # The two start-state samplers are mutually exclusive (each owns one fixed rng draw order).
     with pytest.raises(ValueError, match="backplay_phi_cap"):
         validate_ladder([_backplay_stage(0.5, anchor_prob=0.5)], encoder_max_objects=8)
+
+
+def test_validate_ladder_rejects_backplay_rung_with_wrong_prefix_k():
+    # Backplay must pre-park the k=N-1 prefix so EXACTLY ONE object is driven via the corridor —
+    # _backplay_phi persists across spawns, so k<N-1 (>1 driven) would backplay every driven object.
+    bad = Stage(
+        name="trio-notch-backplay",
+        difficulty=DifficultyConfig(max_objects=3, seed_anchor_k=1, backplay_phi_cap=0.5),
+        hangar_path=_NOTCH_HANGAR,
+        fleet_path=_NOTCH_FLEET,
+        anchor_layout_path=_WITNESS_NOTCH,
+    )
+    with pytest.raises(ValueError, match="k=N-1"):
+        validate_ladder([bad], encoder_max_objects=8)

--- a/tests/ml/test_env_backplay.py
+++ b/tests/ml/test_env_backplay.py
@@ -1,0 +1,133 @@
+"""#821 backplay reverse-curriculum — env-level spawn override. No torch (loader + oracle only)."""
+
+from __future__ import annotations
+
+import dataclasses
+
+from hangarfit.loader import load_fleet, load_hangar, load_layout
+from hangarfit.towplanner import Pose
+from ml.env import HangarFitEnv, _backplay_corridor_pose, _lerp_heading_deg
+from ml.types import DifficultyConfig, Park
+
+_WITNESS_NOTCH = "tests/fixtures/ml/witness_notch.yaml"
+
+
+def _backplay_env(seed_anchor_k: int = 2):
+    """A trio-notch env with the full witness anchored and a k=N-1 prefix pre-parked, so the
+    single driven object (requested[2]) has a witness park-pose for the backplay corridor."""
+    hangar = dataclasses.replace(
+        load_hangar("examples/herrenteich/hangar.yaml"), clearance_m=0.05, apron_depth_m=8.0
+    )
+    fleet = load_fleet("examples/herrenteich/fleet.yaml")
+    lay = load_layout(_WITNESS_NOTCH, fleet=fleet, hangar=hangar)
+    ids = tuple(p.plane_id for p in lay.placements)
+    env = HangarFitEnv(
+        hangar=hangar,
+        fleet=fleet,
+        requested_ids=ids,
+        anchor_placements=tuple(lay.placements),
+        difficulty=DifficultyConfig(
+            max_objects=3,
+            seed_anchor_k=seed_anchor_k,
+            per_object_step_budget=80,
+            total_step_budget=180,
+        ),
+    )
+    return env, ids, lay
+
+
+def _door_pose(env: HangarFitEnv) -> Pose:
+    depth = env.hangar.apron_depth_m or 0.0
+    return Pose(
+        x_m=env.hangar.door.center_x_m, y_m=-(depth / 2.0 if depth else 0.0), heading_deg=0.0
+    )
+
+
+# --- pure helpers -----------------------------------------------------------------------------
+
+
+def test_backplay_phi_cap_default_inert():
+    assert DifficultyConfig().backplay_phi_cap is None
+
+
+def test_lerp_heading_endpoints_and_shortest_arc():
+    assert _lerp_heading_deg(90.0, 0.0, 0.0) == 90.0  # t=0 -> a
+    assert _lerp_heading_deg(90.0, 0.0, 1.0) == 0.0  # t=1 -> b
+    # shortest arc 350 -> 10 crosses 360, not the long way down through 180
+    assert _lerp_heading_deg(350.0, 10.0, 0.5) == 0.0
+
+
+def test_corridor_pose_endpoints_are_exact():
+    witness = load_layout(
+        _WITNESS_NOTCH,
+        fleet=load_fleet("examples/herrenteich/fleet.yaml"),
+        hangar=dataclasses.replace(
+            load_hangar("examples/herrenteich/hangar.yaml"), apron_depth_m=8.0
+        ),
+    ).placements[2]
+    door = Pose(x_m=6.73, y_m=-4.0, heading_deg=0.0)
+    at0 = _backplay_corridor_pose(witness, door, 0.0)
+    assert (at0.x_m, at0.y_m, at0.heading_deg) == (witness.x_m, witness.y_m, witness.heading_deg)
+    at1 = _backplay_corridor_pose(witness, door, 1.0)
+    assert (at1.x_m, at1.y_m, at1.heading_deg) == (door.x_m, door.y_m, door.heading_deg)
+
+
+# --- env integration --------------------------------------------------------------------------
+
+
+def test_backplay_none_is_byte_identical_door_spawn():
+    env, ids, _ = _backplay_env()
+    env.reset(requested_ids=ids)  # backplay_phi defaults None => inert
+    assert env._active_pose == _door_pose(env)
+    assert env._backplay_phi is None
+
+
+def test_backplay_phi_one_coincides_with_door_spawn():
+    env, ids, _ = _backplay_env()
+    env.reset(requested_ids=ids, backplay_phi=1.0)
+    assert env._active_pose == _door_pose(env)
+
+
+def test_backplay_phi_zero_spawns_exactly_at_the_driven_witness_pose():
+    env, ids, lay = _backplay_env()
+    env.reset(requested_ids=ids, backplay_phi=0.0)
+    driven = {p.plane_id: p for p in lay.placements}[ids[2]]  # requested[2] is the one driven
+    assert env._active_id == ids[2]
+    assert env._active_pose is not None
+    assert (env._active_pose.x_m, env._active_pose.y_m, env._active_pose.heading_deg) == (
+        driven.x_m,
+        driven.y_m,
+        driven.heading_deg,
+    )
+
+
+def test_backplay_phi_zero_parks_into_a_valid_full_layout():
+    # At phi=0 the driven object starts AT its witness pose; a single Park freezes it there,
+    # completing the full (valid) witness — the near-solved start the curriculum shows first.
+    env, ids, _ = _backplay_env()
+    env.reset(requested_ids=ids, backplay_phi=0.0)
+    _obs, _r, done, info = env.step(Park())
+    assert done  # k=2 prefix + 1 driven => queue empty after one Park
+    assert info.placed == 3
+    assert info.valid is True
+
+
+def test_backplay_intermediate_phi_is_the_corridor_pose_or_the_door_fallback():
+    # The spawn is the corridor pose when that start is collision-free, else the door fallback —
+    # never some third location. (Robust to whichever the geometry yields at this phi.)
+    env, ids, lay = _backplay_env()
+    env.reset(requested_ids=ids, backplay_phi=0.3)
+    driven = {p.plane_id: p for p in lay.placements}[ids[2]]
+    corridor = _backplay_corridor_pose(driven, _door_pose(env), 0.3)
+    assert env._active_pose in (corridor, _door_pose(env))
+
+
+def test_backplay_admissibility_gates_on_overlap():
+    # The corridor pose is accepted only if collision-free: the witness pose admits (full witness
+    # is valid), but dropping the driven object on top of a pre-parked neighbour does not.
+    env, ids, lay = _backplay_env()
+    env.reset(requested_ids=ids, backplay_phi=0.0)  # _active_id = driven, two neighbours pre-parked
+    by_id = {p.plane_id: p for p in lay.placements}
+    driven, neighbour = by_id[ids[2]], by_id[ids[0]]
+    assert env._backplay_admissible(Pose(driven.x_m, driven.y_m, driven.heading_deg))
+    assert not env._backplay_admissible(Pose(neighbour.x_m, neighbour.y_m, neighbour.heading_deg))

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -1733,3 +1733,77 @@ def test_jsonl_entropy_coef_is_the_applied_floored_value_not_the_base(monkeypatc
     t1 = [r["entropy_coef"] for r in recs if r["stage"] == "t1"]
     assert t0 == pytest.approx([0.05, 0.0275, 0.005])  # non-frontier: bare anneal in the JSONL
     assert t1 == pytest.approx([0.05, 0.0275, 0.02])  # frontier: FLOORED applied value, not 0.005
+
+
+# ---------------------------------------------------------------------------
+# #821 — backplay reverse-curriculum: the --backplay-trio-notch CLI graft + guard,
+#        and the phi_cap surfaced into the #816 per-iteration JSONL telemetry
+# ---------------------------------------------------------------------------
+
+
+def test_main_backplay_trio_notch_requires_curriculum_schedule(monkeypatch):
+    # --backplay-trio-notch is curriculum-only (the trivial path has no rungs); with --schedule
+    # trivial it must fail LOUD and BEFORE any training, never silently drop the typed flag.
+    import ml.train as train_mod
+
+    ran = {"train": False}
+
+    def guard(**kw):
+        ran["train"] = True
+        return []
+
+    monkeypatch.setattr(train_mod, "train", guard)
+    with pytest.raises(SystemExit):
+        train_mod.main(["--schedule", "trivial", "--backplay-trio-notch"])
+    assert ran["train"] is False
+
+
+def test_main_backplay_trio_notch_grafts_sub_rungs_into_schedule(monkeypatch):
+    # The flag inserts the backplay sub-rung ladder immediately before the empty-start trio-notch.
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(*, schedule, **kw):
+        captured["schedule"] = schedule
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum", "--backplay-trio-notch"])
+    names = [s.name for s in captured["schedule"].stages]
+    assert any("backplay" in n for n in names)
+    i = names.index("trio-notch")
+    assert "backplay" in names[i - 1]  # sub-rungs land right before the empty-start rung
+
+
+def test_main_no_backplay_flag_keeps_default_ladder(monkeypatch):
+    # default-neutral: without --backplay-trio-notch the schedule carries no backplay rung.
+    import ml.train as train_mod
+    from ml.curriculum import CurriculumHistory
+
+    captured: dict = {}
+
+    def fake(*, schedule, **kw):
+        captured["schedule"] = schedule
+        return CurriculumHistory()
+
+    monkeypatch.setattr(train_mod, "train_curriculum", fake)
+    train_mod.main(["--schedule", "curriculum"])
+    assert all("backplay" not in s.name for s in captured["schedule"].stages)
+
+
+def test_iter_train_metrics_logs_phi_cap_only_for_backplay_rungs():
+    # #816/#821: a backplay rung surfaces its fixed phi_cap ceiling for the gate's confound
+    # watch ("a WIN must coincide with phi_cap annealed to ~1.0"). A non-backplay rung adds NO
+    # phi_cap key, so its per-iteration JSONL telemetry stays byte-identical to the pre-#821 dict.
+    from ml.ppo import PPOConfig
+    from ml.train import _iter_train_metrics
+
+    metrics = {"epochs_run": 3.0}
+    cfg = PPOConfig()
+    plain = _iter_train_metrics(metrics, cfg)
+    assert "phi_cap" not in plain
+    bp = _iter_train_metrics(metrics, cfg, backplay_phi_cap=0.75)
+    assert bp["phi_cap"] == pytest.approx(0.75)
+    assert bp["epochs_run"] == 3.0  # the existing telemetry is preserved

--- a/tests/ml/test_vector_env.py
+++ b/tests/ml/test_vector_env.py
@@ -37,6 +37,21 @@ def test_worker_reset_anchors_when_episode_start_k_is_one():
     assert len(worker._env._parked) == 1  # k=1 from the record -> one pre-parked
 
 
+# #821: worker threads EpisodeStart.backplay_phi into env.reset (vec reset path)
+
+
+def test_worker_reset_passes_backplay_phi_from_episode_start():
+    # The vec reset path threads start.backplay_phi to env.reset; the env records it for _spawn.
+    from ml.curriculum import _TRIO_NOTCH_BACKPLAY_STAGES
+    from ml.stage_builder import build_stage_env
+
+    env = build_stage_env(_TRIO_NOTCH_BACKPLAY_STAGES[0])
+    ids = env.requested_ids
+    worker = _EnvWorker(env, EncoderConfig(), next_request=lambda: EpisodeStart(ids, None, 0.0))
+    worker.reset()
+    assert worker._env._backplay_phi == 0.0  # backplay fraction reached the env
+
+
 def test_envworker_step_matches_manual_step_encode():
     """A worker.step reproduces a manual env.step + encode (same tensors, reward, done)."""
     enc = EncoderConfig()


### PR DESCRIPTION
Closes #821.

The **fifth #736 frontier lever** after four refutations (#736 anchor, #810/#809 representation, #812 economics, #815 entropy floor). Chosen by the imitation design panel as the only candidate that shifts the **start-state distribution (ρ₀)** rather than reward / representation / exploration — Ng–Harada–Russell proves potential-based shaping cannot move the argmax, which is why the prior four refuted — *and* the only one structurally immune to the oracle-masquerade (its scored transfer rung is witness-absent).

## What this PR adds

`--backplay-trio-notch` (curriculum-only) inserts an opt-in ladder of `trio-notch-backplay-{50,75,100}` sub-rungs immediately before the empty-start `trio-notch`. Each sub-rung:
- pre-parks the **k=N−1=2** prefix of the committed notch witness (`tests/fixtures/ml/witness_notch.yaml`), and
- spawns the **single** driven object a fraction `φ ~ U(0, φ_cap)` along the corridor from its witness park-pose (`φ=0`, near-solved) **out to the door** (`φ=1`).

`φ_cap` anneals **0.5 → 1.0** across the contiguous sub-rungs, promoted on the **same** windowed `valid_placed` gate — the reverse curriculum *is* the rung sequence, so there is **no per-iteration anneal code**. This collapses the diagnosed cold-start coverage minimum (validly park one, abandon two) by starting near the dense solution and receding to the true door.

The env **never snaps or auto-parks** — it only changes *where* the episode begins; the corridor spawn is taken only when collision-free (deterministic admissibility check), else it falls back to the door (the env-spawn half shipped in c789c82, this PR is the curriculum half).

## Surface (OFF ⇒ byte-identical)
- `EpisodeStart.backplay_phi` + `sample_backplay_start` (FIXED draw order **ids → φ** for Sync/Subproc byte-identity); `make_episode_sampler` branch.
- `validate_ladder` guards: `backplay_phi_cap ∈ (0,1]`, witness required, mutually exclusive with `anchor_prob`.
- `_TRIO_NOTCH_BACKPLAY_STAGES` + `with_trio_notch_backplay_rung` (NOT in `DEFAULT_LADDER`).
- `backplay_phi` threaded at **all 3 reset paths** (serial + 2 vec-worker paths), same value (determinism-sensitive).
- `--backplay-trio-notch` flag + curriculum-only guard + schedule graft.
- #816: per-iter `phi_cap` surfaced in `--metrics-out` JSONL **on backplay rungs only** (the gate's confound watch); non-backplay telemetry byte-identical.

## Verification
- 33 new tests (curriculum samplers/rung/validate, CLI graft+guard, vec reset threading, `_iter_train_metrics`); **645 ml tests pass**, ruff + ruff-format + `mypy ml/` clean.
- End-to-end smoke: a tiny curriculum reaches and trains `trio-notch-backplay-50` (exit 0); the JSONL carries `"phi_cap": 0.5` on the backplay rung and **no** `phi_cap` key on `trio-box`.
- Default-neutral: flag absent ⇒ `DEFAULT_LADDER` byte-identical (`φ=None` ⇒ byte-identical door spawn).

## Pre-registered gate (separate, user-triggered)
Control = #736 recipe; treatment = identical **+ `--backplay-trio-notch`** only (entropy-floor OFF), seeds 0,1. **WIN:** transfer `trio-notch` windowed-final vp ≥ 0.6 on both seeds. **KILL:** vp ≤ 0.4 either seed; or backplay rung masters but transfer collapses to ~0.333; or piling. **Confound watch:** a WIN must coincide with `phi_cap` annealed to ~1.0. The held-out `witness_notch_B` (#822, merged) hardens the transfer read against near-witness overfit.

`ml/` is dev/CI-only (never shipped in the wheel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)