### PR TITLE
feat(607): ego-centric relative coordinate encoder lever (#827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Learned backend (#827, epic #607): opt-in `--relative-encoder` ego-centric observation encoder
+  (ADR-0028 re-open trigger #2).** Augments object pose tokens with four SE(2) ego-relative
+  coordinates (`fwd, right, sinΔθ, cosΔθ` in the active object's body frame); `TOKEN_DIM` 24→28 and
+  `SCHEMA_VERSION` 1→2 when on, default off = byte-identical. The encoder's frame is derived from the
+  policy architecture so the token width and `token_proj` can never disagree. Dev/CI-only (`ml/`),
+  not shipped in the wheel. The `trio-notch` ladder gate result is recorded separately once run.
 - **Learned backend (#821, epic #607): backplay reverse-curriculum lever (`--backplay-trio-notch`)
   for the dense `trio-notch` plateau (#736), plus a held-out `witness_notch_B` generalization probe.**
   The fifth #736 lever after four refutations (#736 anchor, #809 representation, #812 economics,

--- a/docs/architecture/ml-observation-schema.md
+++ b/docs/architecture/ml-observation-schema.md
@@ -51,6 +51,24 @@ Keys: `cell_m`, `origin_x_m`, `origin_y_m`, `grid_h`, `grid_w`, `steps_this_obje
 `steps_total` (integers stored as floats). For debugging / un-normalization. Returned as
 an immutable `MappingProxyType`; writing to any key raises `TypeError`.
 
+## Schema 2 — ego-centric augment (`--relative-encoder`, opt-in; #827)
+With `EncoderConfig.ego_centric` (CLI `--relative-encoder`), each token is **augmented** to
+width **28** and `schema_version` is stamped **2**. Cols 0–23 are written identically to schema 1
+(the absolute pose stays in 18–21); four columns are appended:
+
+| cols | feature |
+|---|---|
+| 24–25 | active-frame position `[fwd, right]` of this object relative to the active object, ÷ `pos_ref_m` |
+| 26–27 | active-frame relative heading `[sinΔθ, cosΔθ]` |
+
+The frame is the active object's SE(2) body frame — basis `forward=(sinθ_a, cosθ_a)`,
+`right=(cosθ_a, −sinθ_a)`, the compass-convention (det −1) frame that matches the kinematic
+integrator. The active object's own ego cols are `(0, 0, 0, 1)`; unplaced objects' ego cols are
+zero. The encoding is invariant under proper rigid scene motions (SE(2)). Default off =
+byte-identical to schema 1. See [ADR-0028](../adr/0028-learned-backend-train-to-mastery-resolved-negative.md)
+(re-open trigger #2) and `docs/superpowers/specs/2026-06-24-relative-encoder-ego-centric-design.md`.
+
 ## Versioning
 Adding/reordering channels or token columns, or wiring the reserved slots, bumps
-`SCHEMA_VERSION`. Validity-only across machines; bit-identical within a build.
+`SCHEMA_VERSION`. Validity-only across machines; bit-identical within a build. The opt-in
+ego-centric augment stamps `SCHEMA_VERSION_EGO = 2` (default off stays `1`, byte-identical).

--- a/docs/superpowers/plans/2026-06-24-relative-encoder-ego-centric.md
+++ b/docs/superpowers/plans/2026-06-24-relative-encoder-ego-centric.md
@@ -1,0 +1,715 @@
+# Ego-centric (relative) coordinate encoder — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in ego-centric (relative) coordinate encoder for the learned backend — each object's pose expressed in the active object's SE(2) body frame — behind a default-neutral `--relative-encoder` flag, then gate it on the `trio-notch` ladder.
+
+**Architecture:** *Augment* the 24-dim object-pose token with four new ego-relative columns (`fwd, right, sinΔθ, cosΔθ`) while keeping the existing absolute columns. `TOKEN_DIM` 24 (OFF) / 28 (ON); `SCHEMA_VERSION` 1 (OFF) / 2 (ON). The new columns are written by `ml/encoding.py`; the policy's `token_proj` is resized to consume them; the single CLI flag threads through `policy_kwargs`, and the encoder's `ego_centric` is *derived from the resolved policy_kwargs inside the trainer* so the token width and `token_proj` can never disagree.
+
+**Tech Stack:** Python 3.12, numpy (encoder, no torch), PyTorch (policy/train), pytest. The `ml/` package is dev/CI-only (top-level, never shipped in the wheel).
+
+## Global Constraints
+
+- **OFF byte-identical (4c-ii default-neutrality).** With the flag absent, every output — tokens, schema, policy `state_dict` — is bit-identical to today. Keep the module constants `TOKEN_DIM=24` and `SCHEMA_VERSION=1` as the OFF values; add *new* `EGO_TOKEN_DIM=28` / `SCHEMA_VERSION_EGO=2`. Existing canary tests run on the default (OFF) config and MUST stay green **unchanged** — they are the byte-identity proof.
+- **Single source of truth for the flag.** One CLI flag (`--relative-encoder`) → one `policy_kwargs` key (`relative_encoder`). The encoder's `EncoderConfig.ego_centric` is *derived* from that key inside `train()`/`train_curriculum()`, never set independently.
+- **Heading convention (ADR-0002 compass).** `heading_deg` from world +y, CW-positive. The token stores `(sin(radians(heading_deg)), cos(radians(heading_deg)))`. The ego basis is `forward=(sinθ_a, cosθ_a)`, `right=(cosθ_a, −sinθ_a)` — determinant −1 by the compass convention; this is *not* the ADR-0002 part-polygon trap (the kinematic frame is self-consistent). The encoding is invariant under proper rigid scene motions (SE(2)).
+- **Normalization.** Ego deltas are normalized by `config.pos_ref_m` (=20.0), **not** the 24×48 m raster window (absolute cols keep the window).
+- **Guards (run before PR-ready):** `ml-rl-guard` (knob default-neutrality, training reproducibility) + `determinism-guard`. CI's `mypy` covers `src/hangarfit/` only; run `mypy ml/` over the **whole package** locally.
+- **`ml/` import:** run from repo root (`cwd=/home/pkuhn/hangarfit` or `PYTHONPATH=$PWD`); torch is the user's `~/.local` GPU build — do **not** `pip install .[train]` (clobbers it). Tests: `pytest tests/ml/`.
+- **Spec:** `docs/superpowers/specs/2026-06-24-relative-encoder-ego-centric-design.md`. **Issue:** #827 (epic #607). **Branch:** `feature/827-relative-encoder` (already cut, spec committed).
+
+---
+
+### Task 1: Encoder constants, `EncoderConfig.ego_centric`, dim/schema helpers
+
+**Files:**
+- Modify: `ml/encoding.py:22` (SCHEMA_VERSION area), `:38` (TOKEN_DIM), `:50-57` (EncoderConfig)
+- Test: `tests/ml/test_encoding.py` (new test function)
+
+**Interfaces:**
+- Produces: `EGO_EXTRA_COLS=4`, `EGO_TOKEN_DIM=28`, `SCHEMA_VERSION_EGO=2`; `EncoderConfig.ego_centric: bool` (default `False`); `token_dim(config: EncoderConfig) -> int`; `schema_version_for(config: EncoderConfig) -> int`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/ml/test_encoding.py`, add (near `test_schema_version_and_dims_constants`, ~line 47):
+
+```python
+def test_ego_constants_and_helpers():
+    # OFF constants are unchanged (byte-identity anchor)
+    assert encoding.TOKEN_DIM == 24 and encoding.SCHEMA_VERSION == 1
+    # New ego constants
+    assert encoding.EGO_EXTRA_COLS == 4
+    assert encoding.EGO_TOKEN_DIM == 28
+    assert encoding.SCHEMA_VERSION_EGO == 2
+    off = EncoderConfig()
+    on = EncoderConfig(ego_centric=True)
+    assert off.ego_centric is False and on.ego_centric is True
+    assert encoding.token_dim(off) == 24 and encoding.token_dim(on) == 28
+    assert encoding.schema_version_for(off) == 1
+    assert encoding.schema_version_for(on) == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/ml/test_encoding.py::test_ego_constants_and_helpers -v`
+Expected: FAIL — `AttributeError: module 'ml.encoding' has no attribute 'EGO_EXTRA_COLS'` (and `ego_centric` not a field).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ml/encoding.py`, after `SCHEMA_VERSION = 1` (line 22) add:
+
+```python
+SCHEMA_VERSION_EGO = 2  # stamped when EncoderConfig.ego_centric (the augment ego frame, #827)
+```
+
+After `TOKEN_DIM = 24` (line 38) add:
+
+```python
+EGO_EXTRA_COLS = 4  # ego-relative pose cols (fwd, right, sinΔθ, cosΔθ) appended when ego_centric
+EGO_TOKEN_DIM = TOKEN_DIM + EGO_EXTRA_COLS  # 28
+```
+
+In `EncoderConfig` (after `pos_ref_m: float = 20.0`, line 57) add the field:
+
+```python
+    ego_centric: bool = False  # #827: augment tokens with SE(2) ego-relative pose cols (24..27)
+```
+
+After the `EncoderConfig` dataclass (before `ObservationTensors`, ~line 59) add the helpers:
+
+```python
+def token_dim(config: EncoderConfig) -> int:
+    """Per-token feature width for ``config``: EGO_TOKEN_DIM (28) when ego-centric, else 24."""
+    return EGO_TOKEN_DIM if config.ego_centric else TOKEN_DIM
+
+
+def schema_version_for(config: EncoderConfig) -> int:
+    """Observation schema version for ``config``: SCHEMA_VERSION_EGO (2) when ego-centric, else 1."""
+    return SCHEMA_VERSION_EGO if config.ego_centric else SCHEMA_VERSION
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/ml/test_encoding.py::test_ego_constants_and_helpers tests/ml/test_encoding.py::test_config_defaults -v`
+Expected: PASS (both — `test_config_defaults` still green; the new field has a default so its tuple assertions are untouched).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/encoding.py tests/ml/test_encoding.py
+git commit -m "feat(827): ego-centric encoder constants + EncoderConfig.ego_centric + dim/schema helpers
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0158YRoWo9BXVv6kAuJ9kC2U"
+```
+
+---
+
+### Task 2: `_token_row` + `_tokens` write the ego-relative columns
+
+**Files:**
+- Modify: `ml/encoding.py:229-264` (`_token_row`), `:267-310` (`_tokens`)
+- Test: `tests/ml/test_encoding.py`
+
+**Interfaces:**
+- Consumes: `token_dim()`, `EncoderConfig.ego_centric` (Task 1).
+- Produces: `_token_row(..., active_pose: tuple[float,float,float] | None = None)` writes cols `24..27` when `config.ego_centric`; `_tokens` sizes the table by `token_dim(config)` and passes the active object's pose as `active_pose`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/ml/test_encoding.py`, add (after `test_tokens_status_type_pose_and_padding`, ~line 203). The fixture mirrors the existing one (active `aviat_husky` at `(11, -4, 90°)`, parked `fuji` at `(11, 12, 0°)`):
+
+```python
+def test_tokens_ego_relative_cols_worked_example():
+    c = EncoderConfig(ego_centric=True)
+    fleet = _fuji()
+    pl = Placement(plane_id="fuji", x_m=11.0, y_m=12.0, heading_deg=0.0, on_carts=False)
+    active = ActiveObject(
+        object_id="aviat_husky",
+        body=fleet["aviat_husky"],
+        pose=Pose(x_m=11.0, y_m=-4.0, heading_deg=90.0),
+        on_carts=False,
+    )
+    obs = _obs(
+        parked=(ParkedObject(object_id="fuji", placement=pl),),
+        active=active,
+        unplaced=("cessna_150",),
+    )
+    tokens, _mask, active_index = _tokens(obs, fleet, c)
+    # width grew to 28
+    assert tokens.shape == (16, encoding.EGO_TOKEN_DIM)
+    # absolute cols 18..21 are STILL written (augment, not replace): active heading 90 -> sin1 cos0
+    assert abs(tokens[1, 20] - 1.0) < 1e-6 and abs(tokens[1, 21]) < 1e-6
+    # active object's own ego cols are the origin (0,0,0,1)
+    assert active_index == 1
+    assert list(tokens[1, 24:28]) == [0.0, 0.0, 0.0, 1.0]
+    # parked fuji is 16 m due-north of an east-facing active -> fwd 0, right -16 (to its left),
+    # normalized by pos_ref_m=20 -> (0, -0.8); relative heading 0-90=-90 -> sin -1, cos 0
+    assert abs(tokens[0, 24] - 0.0) < 1e-6
+    assert abs(tokens[0, 25] - (-0.8)) < 1e-6
+    assert abs(tokens[0, 26] - (-1.0)) < 1e-6
+    assert abs(tokens[0, 27] - 0.0) < 1e-6
+    # unplaced row has zero ego cols (no pose)
+    assert list(tokens[2, 24:28]) == [0.0, 0.0, 0.0, 0.0]
+
+
+def test_tokens_off_path_is_24_wide_and_unchanged():
+    # OFF config: width stays 24, no ego cols exist (byte-identity anchor)
+    c = EncoderConfig()
+    fleet = _fuji()
+    pl = Placement(plane_id="fuji", x_m=11.0, y_m=12.0, heading_deg=0.0, on_carts=False)
+    obs = _obs(parked=(ParkedObject(object_id="fuji", placement=pl),), active=None, unplaced=())
+    tokens, _mask, _ai = _tokens(obs, fleet, c)
+    assert tokens.shape == (16, encoding.TOKEN_DIM) == (16, 24)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/ml/test_encoding.py::test_tokens_ego_relative_cols_worked_example -v`
+Expected: FAIL — `IndexError` (row is 24-wide, col 27 out of range) or shape `(16, 24)` ≠ `(16, 28)`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ml/encoding.py`, change `_token_row`'s signature (line 229-236) to add `active_pose`:
+
+```python
+def _token_row(
+    body: Aircraft | GroundObject,
+    *,
+    status: str,
+    on_carts: bool,
+    pose: tuple[float, float, float] | None,
+    config: EncoderConfig,
+    active_pose: tuple[float, float, float] | None = None,
+) -> np.ndarray:
+    row = np.zeros(token_dim(config), dtype=np.float32)
+```
+
+Then at the END of `_token_row`, replace the `# reserved 22..23 stay 0` comment/return (line 263-264) with:
+
+```python
+    # reserved 22..23 stay 0 (region_side, seq_order)
+    if config.ego_centric and pose is not None and active_pose is not None:
+        ax, ay, ah = active_pose
+        th_a = np.radians(ah)
+        s_a, c_a = float(np.sin(th_a)), float(np.cos(th_a))
+        dx, dy = pose[0] - ax, pose[1] - ay
+        fwd = dx * s_a + dy * c_a  # forward axis (sinθ_a, cosθ_a)
+        right = dx * c_a - dy * s_a  # right axis (cosθ_a, -sinθ_a); det-1 compass frame
+        dth = np.radians(pose[2] - ah)
+        row[TOKEN_DIM + 0] = fwd / config.pos_ref_m
+        row[TOKEN_DIM + 1] = right / config.pos_ref_m
+        row[TOKEN_DIM + 2] = float(np.sin(dth))
+        row[TOKEN_DIM + 3] = float(np.cos(dth))
+    return row
+```
+
+In `_tokens` (line 276), size the table by config and compute the anchor. Change line 276:
+
+```python
+    tokens = np.zeros((config.max_objects, token_dim(config)), dtype=np.float32)
+```
+
+After the active block (after line 293, where `active_index`/`a` are set) compute the anchor pose, and pass it to `_token_row` in the build loop (line 308). Insert before the `for oid in obs.unplaced_ids` loop (line 294):
+
+```python
+    active_pose = (
+        (obs.active.pose.x_m, obs.active.pose.y_m, obs.active.pose.heading_deg)
+        if obs.active is not None
+        else None
+    )
+```
+
+And change the build-loop call (line 308) to thread `active_pose`:
+
+```python
+        tokens[i] = _token_row(
+            body, status=status, on_carts=on_carts, pose=pose, config=config, active_pose=active_pose
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/ml/test_encoding.py -k "ego_relative or off_path_is_24 or status_type_pose or wing_and_movement" -v`
+Expected: PASS — the two new tests pass AND the existing `test_tokens_status_type_pose_and_padding` / `test_tokens_wing_and_movement_one_hots` stay green (OFF byte-identity).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/encoding.py tests/ml/test_encoding.py
+git commit -m "feat(827): _token_row/_tokens write SE(2) ego-relative pose cols 24..27
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0158YRoWo9BXVv6kAuJ9kC2U"
+```
+
+---
+
+### Task 3: `encode`/`encode_dynamic` schema stamp + the SE(2) invariance property test
+
+**Files:**
+- Modify: `ml/encoding.py:436` (`encode` stamp), `:463` (`encode_dynamic` stamp)
+- Test: `tests/ml/test_encoding.py`
+
+**Interfaces:**
+- Consumes: `schema_version_for()` (Task 1), the ego token columns (Task 2).
+- Produces: `encode()`/`encode_dynamic()` stamp `schema_version=schema_version_for(config)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/ml/test_encoding.py`, add. The invariance test applies a rigid SE(2) transform (rotate by α about the origin, then translate) to **every** pose including the active object, and asserts the ego cols are invariant while the absolute cols move:
+
+```python
+def test_encode_ego_schema_is_2():
+    fleet = _fuji()
+    pl = Placement(plane_id="fuji", x_m=11.0, y_m=12.0, heading_deg=0.0, on_carts=False)
+    active = ActiveObject(
+        object_id="aviat_husky", body=fleet["aviat_husky"],
+        pose=Pose(x_m=11.0, y_m=-4.0, heading_deg=90.0), on_carts=False,
+    )
+    obs = _obs(parked=(ParkedObject(object_id="fuji", placement=pl),), active=active, unplaced=())
+    out = encode(obs, _hangar(), fleet, EncoderConfig(ego_centric=True))
+    assert out.schema_version == 2
+    assert out.tokens.shape == (16, 28)
+
+
+def test_ego_cols_are_se2_invariant():
+    import math
+
+    fleet = _fuji()
+
+    def build(rot_deg: float, tx: float, ty: float):
+        # rotate (x,y) by rot_deg in the compass sense and shift headings by the same amount,
+        # so the WHOLE scene undergoes one rigid SE(2) motion.
+        a = math.radians(rot_deg)
+        ca, sa = math.cos(a), math.sin(a)
+
+        def xf(x, y):
+            return (ca * x - sa * y + tx, sa * x + ca * y + ty)
+
+        px, py = xf(11.0, 12.0)
+        axp, ayp = xf(11.0, -4.0)
+        pl = Placement(plane_id="fuji", x_m=px, y_m=py, heading_deg=0.0 + rot_deg, on_carts=False)
+        active = ActiveObject(
+            object_id="aviat_husky", body=fleet["aviat_husky"],
+            pose=Pose(x_m=axp, y_m=ayp, heading_deg=90.0 + rot_deg), on_carts=False,
+        )
+        obs = _obs(parked=(ParkedObject(object_id="fuji", placement=pl),), active=active, unplaced=())
+        return _tokens(obs, fleet, EncoderConfig(ego_centric=True))[0]
+
+    base = build(0.0, 0.0, 0.0)
+    moved = build(37.0, 5.0, -8.0)
+    # ego cols (24..27) of the parked object are unchanged under the rigid motion
+    assert np.allclose(base[0, 24:28], moved[0, 24:28], atol=1e-5)
+    # absolute cols (18..21) DO change (different world pose)
+    assert not np.allclose(base[0, 18:22], moved[0, 18:22], atol=1e-3)
+```
+
+> Note: reuse the module's existing `_hangar()` / `_fuji()` / `_obs()` test helpers. If `_hangar()` is not already a helper in this file, use the same hangar fixture `test_encode_full_shapes_and_meta` (line 273) uses.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/ml/test_encoding.py::test_encode_ego_schema_is_2 -v`
+Expected: FAIL — `assert out.schema_version == 2` fails (encode still stamps `SCHEMA_VERSION`=1).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ml/encoding.py`, change the `encode()` return (line 436) from `schema_version=SCHEMA_VERSION,` to:
+
+```python
+        schema_version=schema_version_for(config),
+```
+
+and the identical line in `encode_dynamic()` (line 463) the same way.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/ml/test_encoding.py -v`
+Expected: PASS — all of `test_encoding.py`, including the unchanged `test_encode_full_shapes_and_meta` (`out.schema_version == 1` on the default config) and `test_encode_dynamic_nonraster_fields_match_full_encode` (schema parity holds: both stamp via the same `config`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/encoding.py tests/ml/test_encoding.py
+git commit -m "feat(827): stamp SCHEMA_VERSION_EGO + prove SE(2) ego-col invariance
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0158YRoWo9BXVv6kAuJ9kC2U"
+```
+
+---
+
+### Task 4: Policy `relative_encoder` kwarg resizes `token_proj`
+
+**Files:**
+- Modify: `ml/policy.py:18` (import), `:119-143` (`__init__` signature + `token_proj`)
+- Test: `tests/ml/test_policy.py`
+
+**Interfaces:**
+- Consumes: `EGO_TOKEN_DIM` (Task 1).
+- Produces: `HangarFitPolicy(..., relative_encoder: bool = False)`; `token_proj.in_features` = 28 when on, 24 when off; `self.relative_encoder` attribute.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/ml/test_policy.py`, add:
+
+```python
+def test_policy_off_is_byte_identical():
+    import torch
+    torch.manual_seed(0)
+    a = HangarFitPolicy()
+    torch.manual_seed(0)
+    b = HangarFitPolicy(relative_encoder=False)
+    sa, sb = a.state_dict(), b.state_dict()
+    assert sa.keys() == sb.keys()
+    assert all(torch.equal(sa[k], sb[k]) for k in sa)
+    assert a.token_proj.in_features == 24
+
+
+def test_policy_relative_encoder_sizes_token_proj():
+    p = HangarFitPolicy(relative_encoder=True)
+    assert p.relative_encoder is True
+    assert p.token_proj.in_features == 28
+
+
+def test_policy_relative_forward_consumes_28_wide_tokens():
+    import numpy as np
+    import torch
+    from ml.encoding import EncoderConfig, encode
+    from ml.policy import to_batch
+    # build one ego observation (reuse a minimal env/obs fixture available in tests/ml)
+    obs_t = _one_ego_observation()  # helper: encode(..., EncoderConfig(ego_centric=True))
+    assert obs_t.tokens.shape[-1] == 28
+    batch = to_batch([obs_t])
+    out = HangarFitPolicy(relative_encoder=True)(batch)
+    assert out.kind_logits.shape == (1, 9) and out.magnitude_bin_logits.shape == (1, 5)
+```
+
+> `_one_ego_observation()`: if `tests/ml/test_policy.py` already has an observation fixture/helper, wrap it to pass `EncoderConfig(ego_centric=True)`. Otherwise build the same `_fuji()`/`_obs()` fixture as `test_encoding.py` and call `encode(obs, hangar, fleet, EncoderConfig(ego_centric=True))`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/ml/test_policy.py::test_policy_relative_encoder_sizes_token_proj -v`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'relative_encoder'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ml/policy.py`, extend the import (line 18, `from ml.encoding import (`) to include `EGO_TOKEN_DIM` alongside `TOKEN_DIM`, `RASTER_CHANNELS`.
+
+In `HangarFitPolicy.__init__`, add the kwarg (after `spatial_tokens: bool = False,`, line 126):
+
+```python
+        relative_encoder: bool = False,
+```
+
+After `self.spatial_tokens = spatial_tokens` (line 129) add:
+
+```python
+        self.relative_encoder = relative_encoder
+```
+
+Change `token_proj` (line 143) from `nn.Linear(TOKEN_DIM, d_model)` to:
+
+```python
+        token_in = EGO_TOKEN_DIM if relative_encoder else TOKEN_DIM
+        self.token_proj = nn.Linear(token_in, d_model)  # tokens 24 (or 28 ego) -> D
+```
+
+> Byte-identity: when `relative_encoder=False`, `token_in == TOKEN_DIM == 24`, so `token_proj` and every later module's init RNG draw are identical to today. `relative_encoder` is a plain bool attribute (no RNG). The `spatial_tokens` ON-only block stays last (unchanged).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/ml/test_policy.py -v`
+Expected: PASS — the three new tests pass and all existing policy tests stay green (OFF byte-identity).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/policy.py tests/ml/test_policy.py
+git commit -m "feat(827): HangarFitPolicy --relative-encoder sizes token_proj 24->28
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0158YRoWo9BXVv6kAuJ9kC2U"
+```
+
+---
+
+### Task 5: CLI flag + `policy_kwargs` + encoder derivation (end-to-end)
+
+**Files:**
+- Modify: `ml/train.py:55` (import `replace`), `:288-308` (`train()`), `:451-504` (`train_curriculum()`), `:895-902` (argparse), `:1187-1196` (policy_kwargs)
+- Test: `tests/ml/test_train.py` (or the existing train smoke test file)
+
+**Interfaces:**
+- Consumes: `EncoderConfig.ego_centric` (Task 1), `relative_encoder` policy kwarg (Task 4).
+- Produces: `--relative-encoder` CLI flag; `policy_kwargs["relative_encoder"]=True` when set; `enc.ego_centric` derived from `policy_kwargs["relative_encoder"]` in both trainers.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/ml/test_train.py` add a flag-threading unit and an end-to-end smoke (the smoke is the key integration proof — encoder 28-wide tokens consumed by a `relative_encoder=True` policy without a shape crash):
+
+```python
+def test_relative_encoder_flag_threads_to_policy_kwargs():
+    import ml.train as t
+    parser = t.build_parser()
+    args = parser.parse_args(
+        ["solve_stub", "--schedule", "trivial", "--relative-encoder", "--iterations", "1"]
+    )
+    assert args.relative_encoder is True
+
+
+def test_train_trivial_relative_encoder_smoke(tmp_path):
+    # 1-iteration trivial run with the flag on: proves encoder(28) <-> policy(token_proj 28) agree
+    import ml.train as t
+    save = tmp_path / "p.pt"
+    t.train(
+        seed=0, iterations=1, rollout_len=4,
+        policy_kwargs={"relative_encoder": True}, log=False, save=str(save),
+    )
+    assert save.exists()
+```
+
+> Adapt the argparse positional/flags to the real `build_parser()` signature (check how an existing `test_train.py` smoke constructs `parser.parse_args([...])`). If `build_parser` is named differently, use the actual entry (`grep -n "def build_parser\|add_argument(\"--schedule\"" ml/train.py`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/ml/test_train.py::test_relative_encoder_flag_threads_to_policy_kwargs -v`
+Expected: FAIL — `AttributeError: 'Namespace' object has no attribute 'relative_encoder'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ml/train.py`:
+
+(a) Import `replace` — change the top-of-file import. Add near the stdlib imports:
+
+```python
+from dataclasses import replace
+```
+
+(b) Argparse — after the `--spatial-tokens` block (line 902) add:
+
+```python
+    p.add_argument(
+        "--relative-encoder",
+        action="store_true",
+        help="opt-in ego-centric augment encoder (#827, ADR-0028 re-open trigger #2): each "
+        "object's pose is ALSO written in the active object's SE(2) body frame (4 extra token "
+        "cols). Default off = byte-identical (TOKEN_DIM 24, schema 1); a deliberate representation "
+        "re-baseline when on (TOKEN_DIM 28, schema 2); the flag is persisted in the checkpoint's "
+        "policy_kwargs",
+    )
+```
+
+(c) policy_kwargs — in the dict comprehension (line 1187-1196) add the key after `spatial_tokens`:
+
+```python
+            ("relative_encoder", True if args.relative_encoder else None),
+```
+
+(d) `train()` derivation — after `policy = HangarFitPolicy(**(policy_kwargs or {})).to(...)` (line 308) add:
+
+```python
+    enc = replace(enc, ego_centric=bool((policy_kwargs or {}).get("relative_encoder", False)))
+```
+
+(e) `train_curriculum()` derivation — after the load/else block resolves `saved_policy_kwargs` and `policy` (after line 503, before `completed_set = ...` line 504) add:
+
+```python
+    # Encoder ego-frame is DERIVED from the (post-load authoritative) architecture, so the token
+    # width and the policy's token_proj can never disagree, and a loaded ego checkpoint auto-uses
+    # an ego encoder regardless of whether --relative-encoder was re-passed (#827).
+    enc = replace(enc, ego_centric=bool(saved_policy_kwargs.get("relative_encoder", False)))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/ml/test_train.py -k "relative_encoder" -v`
+Expected: PASS — both tests; the smoke completes a 1-iteration trivial run, proving encoder/policy agreement end-to-end.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ml/train.py tests/ml/test_train.py
+git commit -m "feat(827): --relative-encoder CLI flag; derive encoder ego-frame from policy_kwargs
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0158YRoWo9BXVv6kAuJ9kC2U"
+```
+
+---
+
+### Task 6: Audit eval / benchmark / gate consumers for encoder derivation
+
+**Files:**
+- Inspect/Modify (as the audit finds): `ml/eval.py`, `ml/benchmark.py`, `ml/gate.py` (if present), any standalone consumer that builds its own `EncoderConfig` to evaluate a **loaded** checkpoint.
+- Test: `tests/ml/test_eval.py` (or wherever standalone eval is tested)
+
+**Interfaces:**
+- Produces: any standalone consumer that loads a checkpoint and builds an encoder derives `ego_centric` from the checkpoint's `policy_kwargs.get("relative_encoder", False)`, mirroring Task 5's trainer derivation.
+
+- [ ] **Step 1: Audit**
+
+Run:
+```bash
+grep -rnE "EncoderConfig\(|load_checkpoint|policy_kwargs|encode\(|encode_dynamic\(" ml/eval.py ml/benchmark.py ml/gate.py 2>/dev/null
+```
+For each site that (a) loads a checkpoint AND (b) constructs an `EncoderConfig()` to encode observations for that loaded policy: it must derive `ego_centric` from the loaded `policy_kwargs`. If a consumer receives its `EncoderConfig` from the caller (e.g. the curriculum passes `enc` already derived in Task 5), **no change** is needed there — record that in the commit message.
+
+- [ ] **Step 2: Write the failing test (only if a site needs changing)**
+
+If e.g. `ml/eval.py` builds its own default encoder, add to `tests/ml/test_eval.py`:
+
+```python
+def test_eval_of_ego_checkpoint_uses_ego_encoder(tmp_path):
+    # train+save a 1-iteration ego checkpoint, then standalone-eval it without re-passing the flag
+    import ml.train as t
+    save = tmp_path / "ego.pt"
+    t.train(seed=0, iterations=1, rollout_len=4,
+            policy_kwargs={"relative_encoder": True}, log=False, save=str(save))
+    from ml.eval import evaluate_checkpoint  # adapt to the real entry point
+    result = evaluate_checkpoint(str(save), episodes=1)  # must NOT raise a 24-vs-28 shape error
+    assert result is not None
+```
+
+- [ ] **Step 3: Implement the derivation at each site found**
+
+At each loading site, after the checkpoint's `policy_kwargs` are known:
+
+```python
+enc = replace(enc, ego_centric=bool(ckpt.policy_kwargs.get("relative_encoder", False)))
+```
+
+- [ ] **Step 4: Run the relevant tests**
+
+Run: `pytest tests/ml/test_eval.py tests/ml/test_benchmark.py -v`
+Expected: PASS (or, if no site needed changing, the existing suites stay green and this task is a verified no-op).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A ml/ tests/ml/
+git commit -m "feat(827): derive ego encoder from checkpoint policy_kwargs in standalone eval/benchmark
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0158YRoWo9BXVv6kAuJ9kC2U"
+```
+
+> ONNX export (`--save-onnx`) of an ego policy needs a 28-wide dummy input; that path is **out of scope for the trio-notch gate** (the gate trains + evals in-process, no ONNX). Track it as a follow-up under #827 only if ego weights are later shipped through the #706 inference seam.
+
+---
+
+### Task 7: Docs, CHANGELOG, ml/README knob table
+
+**Files:**
+- Modify: `docs/architecture/ml-observation-schema.md`, `CHANGELOG.md`, `ml/README.md`
+
+**Interfaces:** none (documentation).
+
+- [ ] **Step 1: Observation-schema doc**
+
+In `docs/architecture/ml-observation-schema.md`, add a "Schema 2 — ego-centric augment (#827, opt-in)" subsection documenting: cols `24..27` = `(fwd, right, sinΔθ, cosΔθ)` in the active object's SE(2) body frame, normalized by `pos_ref_m`; `SCHEMA_VERSION_EGO=2`; OFF (schema 1) byte-identical; the det-−1 compass-basis note.
+
+- [ ] **Step 2: CHANGELOG**
+
+In `CHANGELOG.md` under `[Unreleased] → ### Added`, add:
+
+```markdown
+- Learned backend: opt-in `--relative-encoder` ego-centric observation encoder (#827, ADR-0028
+  re-open trigger #2) — augments object pose tokens with SE(2) ego-relative coordinates (default
+  off = byte-identical; schema 2 when on). Dev/CI-only (`ml/`), not shipped in the wheel.
+```
+
+- [ ] **Step 3: ml/README knob table**
+
+In `ml/README.md`, add a row for `--relative-encoder` to the 4c-ii training-knob table (default-neutral; OFF byte-identical) with a one-line description and a pointer to the spec.
+
+- [ ] **Step 4: Verify docs render / no broken refs**
+
+Run: `grep -n "relative-encoder\|SCHEMA_VERSION_EGO\|#827" docs/architecture/ml-observation-schema.md CHANGELOG.md ml/README.md`
+Expected: each file shows the new content.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/architecture/ml-observation-schema.md CHANGELOG.md ml/README.md
+git commit -m "docs(827): document ego-centric encoder schema 2 + --relative-encoder knob
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0158YRoWo9BXVv6kAuJ9kC2U"
+```
+
+---
+
+### Task 8: Full local verification + guards + PR
+
+**Files:** none (verification + workflow)
+
+- [ ] **Step 1: Full ml test suite + lint + types**
+
+```bash
+pytest tests/ml/ -v
+ruff check ml/ tests/ml/ && ruff format --check ml/ tests/ml/
+mypy ml/        # whole package (follow_imports=skip needs the full run)
+```
+Expected: all green. (Existing OFF canaries green unchanged = byte-identity proof.)
+
+- [ ] **Step 2: Determinism + default-neutrality spot check**
+
+```bash
+# OFF byte-identity: ego_centric off encodes exactly as TOKEN_DIM=24 / schema 1
+pytest tests/ml/test_encoding.py -k "off_path or schema or status_type_pose or deterministic" -v
+```
+Expected: PASS.
+
+- [ ] **Step 3: Dispatch the guards (read-only, on origin refs)**
+
+Dispatch `ml-rl-guard` and `determinism-guard` on the branch diff (`git diff origin/develop...HEAD`). Address any finding as its own commit.
+
+- [ ] **Step 4: Push, open draft PR**
+
+```bash
+git push -u origin feature/827-relative-encoder
+gh pr create --draft --base develop \
+  --title "feat(607): ego-centric relative coordinate encoder lever (#827)" \
+  --body "Closes #827 ..."   # body: spec link, ADR-0028 trigger #2, OFF byte-identical, gate plan
+```
+Set assignee/labels/milestone via `gh api -X PATCH` (per project convention). Run the `/pr-review` arc (code-reviewer + ml-rl-guard + determinism-guard + comment-analyzer for the docs), one inline thread per finding, fix + resolve, then `gh pr ready`.
+
+---
+
+### Task 9 (post-merge, SUPERVISED): the trio-notch gate
+
+**This is the experiment, not code — run after the PR merges, supervised, from a worktree pinned to the branch (the lazy-fixture branch-switch gotcha).**
+
+- [ ] **Pre-register** (write to the gate result doc BEFORE running): rung = `trio-notch` ladder; arms = OFF (control) vs `--relative-encoder` (treatment); 2 seeds; metric = windowed-final valid-placed `vp` (+ first-park `fp`); **WIN** = `vp` materially breaks the `≈0.333` fixed point; **KILL** = `vp` stays `≈0.333`.
+
+- [ ] **Run** (GPU, 2 seeds, both arms; the `ml.gate` harness as in prior levers):
+
+```bash
+# from a worktree pinned to feature/827-relative-encoder (cwd inside it so `ml` resolves there)
+python -m ml.train --schedule curriculum --anchor-trio-notch --relative-encoder \
+  --n-envs auto --seed <S> --checkpoint-out ck-ego-s<S>.pt --metrics-out metrics-ego-s<S>.jsonl ...
+# control arm: identical command WITHOUT --relative-encoder
+```
+
+- [ ] **Confound watch:** `epochs_run` parity between arms (#816 lesson); OFF arm reproduces the established control baseline before trusting the contrast.
+
+- [ ] **On KILL:** record as the **6th refuted lever** in `ml/README.md` + auto-memory; encoder stays opt-in infra (do not re-run on notch). **On WIN:** proceed to the ADR-0028 trigger-#1 follow-up (reach-rate vs RR-MC on witness-absent, extend #711) — necessary for the real re-open.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §2 scope (encoder + flag + gate) → Tasks 1–8 (code) + Task 9 (gate). ✓
+- §3 decisions (ego/augment/full-SE(2)/TOKEN_DIM 24→28/schema 1→2/locus EncoderConfig+policy_kwargs) → Tasks 1,2,4,5. ✓
+- §4 encoding (cols 24..27, basis, pos_ref_m norm, active=(0,0,0,1), unplaced=0) → Task 2 + its tests. ✓
+- §5 flag/schema/checkpoint → Tasks 3,4,5 (+ load-mismatch reuse of existing `policy.py:466`). ✓
+- §6 canary re-baseline → realized as "keep OFF constants, add EGO_* constants; existing OFF tests stay green + new ON tests" (Tasks 1–4). Documented refinement: NO re-baseline of existing assertions is needed (cleaner than the spec assumed). ✓
+- §6 guards (ml-rl-guard, determinism-guard) → Task 8. ✓
+- §7 files touched → Tasks 1–7 cover all listed except ONNX export (explicitly deferred in Task 6, out of gate scope). ✓
+- §8 gate methodology → Task 9. ✓
+
+**2. Placeholder scan:** No "TBD/TODO/handle edge cases". The two `_one_ego_observation()` / `evaluate_checkpoint` references include explicit adaptation instructions to the real fixtures/entry points (the test files' exact helper names are discovered at implementation time, not invented here). ✓
+
+**3. Type consistency:** `token_dim`/`schema_version_for`/`EGO_TOKEN_DIM`/`ego_centric`/`relative_encoder` are used with identical names and signatures across Tasks 1→6. `replace` (dataclasses) used identically in Tasks 5–6. ✓

--- a/docs/superpowers/specs/2026-06-24-relative-encoder-ego-centric-design.md
+++ b/docs/superpowers/specs/2026-06-24-relative-encoder-ego-centric-design.md
@@ -1,0 +1,190 @@
+# Ego-centric (relative) coordinate encoder — design
+
+**Status:** Brainstorming output (design approved; pending spec review → implementation plan).
+
+**Issue:** [#827](https://github.com/DocGerd/hangarfit/issues/827) — "ego-centric relative coordinate
+encoder lever — ADR-0028 re-open trigger #2", under epic #607.
+
+**Decision context:** [ADR-0028](../../adr/0028-learned-backend-train-to-mastery-resolved-negative.md)
+banked the dense train-to-mastery program (epic #607) *resolved-negative* (PR #826, closing #736) and
+named two falsifiable re-open triggers. This spec implements the structural change behind **trigger #2**.
+
+---
+
+## 1. Motivation
+
+The five gate-run levers (#794 scaffold, #810 representation, #813 reward, #817 exploration,
+#823 backplay) all KILLed at the same `vp≈0.333` *place-one-then-abstain* fixed point on the dense
+`trio-notch` rung. The measure-first probe localized the wall to **cold-start drive-and-pack of the
+marginal object into a sparse, clearance-invariant slot** (φ=1 cold-start completion `vp=0.000`,
+P(triple)≈2e-3 flat-in-clearance).
+
+Every object pose token currently carries an **absolute world pose** (`ml/encoding.py:213-262`):
+`_norm_pos` maps each object's world `(x, y)` into `[-1, 1]` over the 24×48 m raster window and
+`_token_row` writes `row[18..21] = (nx, ny, sinθ, cosθ)` — never re-centered on anything. The policy
+must therefore re-learn "slot the marginal object into the gap" separately at every absolute
+`(x, y, θ)` it can occupy. An **ego-centric (relative) frame** — expressing other objects' poses
+relative to the active object being placed — makes that skill **position- and heading-invariant**,
+the single structurally-untested representation axis ADR-0028 names.
+
+**Why this is consistent with the action space (verified).** All eight movement primitives
+(`S/L/R/T × fwd/rev`, `ml/encoding.py:26-35`) are **body-frame**: straight drives along the current
+heading (`x += step·cosθ; y += step·sinθ`, `towplanner.py:159-160`), strafe is perpendicular, arcs
+turn about a laterally-offset centre. PARK freezes the driven pose. No action names a world axis → a
+**full SE(2) ego rotation** of the observation is consistent with how the policy acts (observation
+frame ≡ action frame). The det-−1 convention (ADR-0002) governs part-polygon geometry, **not** the
+kinematic integrator, so the ego rotation is a plain 2D rotation with no sign-flip trap.
+
+**Distinct from the refuted #810 lever.** #810 (`--spatial-tokens`) changed how the **raster
+occupancy map** (`RASTER_CHANNELS=7`, a separate tensor) is pooled/attended. This lever changes the
+**coordinate frame of the per-object pose tokens** — a different axis. The raster is untouched.
+
+---
+
+## 2. Scope (Option A — encoder + cheap gate first)
+
+**In scope:**
+- The ego-centric **augment** encoder change behind a default-neutral flag (`--relative-encoder`).
+- `SCHEMA_VERSION` bump + canary re-baseline.
+- Gate: `trio-notch` ladder, OFF (control) vs ON (treatment), 2 seeds, GPU — the same protocol as the
+  five prior levers (apples-to-apples).
+
+**Out of scope (YAGNI / deferred):**
+- **Approach C** (pairwise SE(2) attention-bias in `policy.py`) — escalation only, if this lever shows
+  partial-but-insufficient signal.
+- **Reach-rate-vs-RR-MC harness** (extend #711) — the real ADR-0028 trigger-#1 criterion; runs as a
+  follow-up **only if** the trio-notch gate shows promise. Trio-notch is the fail-fast proxy.
+- **Action-space changes** — unnecessary; body-frame actions are already ego-compatible.
+- **Replace / pure-ego frames** — rejected in favour of augment (see §3).
+
+---
+
+## 3. Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Relative frame | **Ego-centric, active-object-anchored, full SE(2)** | Body-frame actions make rotation free and strictly better; invariance to active `(x,y,θ)` is exactly the cold-start wall. |
+| Token treatment | **Augment** — keep absolute `row[18..21]`, **add** relative cols | Information-preserving, lowest-variance probe; network learns which frame to use. (Replace/pure-ego risk losing absolute notch-alignment signal.) |
+| Locus | `EncoderConfig` (writes cols) **+** `policy_kwargs` (sizes `token_proj`) | Augment grows `TOKEN_DIM`, so `token_proj`'s input dim grows → a network-shape change (the #810 template), not purely encoder-only. |
+| `TOKEN_DIM` | 24 (OFF) / **28** (ON) | Four new columns; cols 22,23 stay reserved (region_side / seq_order). |
+| Schema | `SCHEMA_VERSION` = **2** (ON) / 1 (OFF) | OFF byte-identical (stamps 1, same as today); a checkpoint's frame is unambiguous. |
+
+**Accepted caveats (documented, not blockers):**
+- **C1 — network-shape change.** Unlike the clean encoder-only path, augment touches
+  `policy.token_proj` input dim → a `state_dict`-shape change, flag persisted in `policy_kwargs`,
+  mismatched `--load` raises (the `policy.py:466-471` pattern). OFF remains byte-identical.
+- **C2 — no masquerade defeat.** Absolute coords remain, so a BC/DAgger policy could still memorize
+  witness world-coords. Acceptable here (the trio-notch gate is RL-from-scratch, no imitation), but a
+  caveat for any future trigger-#1 use that pairs this encoder with imitation.
+
+---
+
+## 4. Detailed encoding (the ON path)
+
+Four new per-token columns `row[24..27]`, expressing object `i`'s pose **in the active object's body
+frame** (`θ_a = radians(heading_deg_active)`):
+
+```
+Δx = x_i − x_active ;  Δy = y_i − y_active        # world-frame delta
+fwd_i   =  Δx·sinθ_a + Δy·cosθ_a                   # forward axis  = (sinθ_a, cosθ_a)
+right_i =  Δx·cosθ_a − Δy·sinθ_a                   # right axis    = (cosθ_a, −sinθ_a)
+Δθ      = θ_i − θ_active
+row[24], row[25] = fwd_i / pos_ref_m, right_i / pos_ref_m     # NOT window-normalized
+row[26], row[27] = sin(Δθ), cos(Δθ)
+```
+
+- **Basis** `forward=(sinθ_a, cosθ_a)`, `right=(cosθ_a, −sinθ_a)` (world x,y) is the integrator's own
+  forward axis for the `S` primitive — keeps observation and dynamics in one frame.
+- **Normalization** uses `pos_ref_m` (=20.0, already the dimension/turn-radius scale), **not** the
+  48 m window — intra-hangar deltas are small and window-normalizing would crush their range.
+- **Active object self-relative** = `(0, 0, sin0, cos0) = (0, 0, 0, 1)`.
+- **Unplaced objects** (`pose=None`) → `row[24..27] = 0` (as for the absolute cols).
+- **Absolute cols `row[18..21]`** are written **identically** in both modes (augment, not replace).
+
+> **Basis handedness (preempting an invariant-guard false-positive).** The `(forward, right)` basis has
+> **determinant −1** — it is the project's compass-convention frame (heading from +y, CW-positive; "right
+> of north" = east = +x), the same convention the kinematic integrator uses. This is *not* the ADR-0002
+> det-−1 part-polygon trap and is *not* a bug: the relative encoding is invariant under proper rigid scene
+> motions (**SE(2)**) because the basis and the deltas **co-rotate with the active object** —
+> `(fwd_i, right_i)` depends only on `|Δ|` and the angle of `Δ` relative to the active heading, both
+> preserved by any rigid motion regardless of basis handedness. The det-−1 is a fixed coordinate choice,
+> not a scene reflection (the encoding is intentionally *not* invariant under scene reflections — a
+> mirrored hangar is a different problem). The §6 invariance test must apply the *same* rotation
+> convention to headings and positions.
+
+---
+
+## 5. Flag-gating, schema & checkpoint compat
+
+- **Flag:** `--relative-encoder` (`ml/train.py`), `action="store_true"`, default off. Help text mirrors
+  `--spatial-tokens`: "opt-in ego-centric augment encoder (trigger #2); default off = byte-identical;
+  a deliberate representation re-baseline when on; persisted in the checkpoint."
+- **Threading:** sets `EncoderConfig.ego_centric=True` (encoder writes the cols + stamps schema 2)
+  **and** passes `relative_encoder=True` into `policy_kwargs` (so `token_proj=Linear(28, d_model)`).
+  Only `True` is ever threaded → absent key ⇒ default `False` ⇒ byte-identical OFF (the #810 pattern,
+  `train.py:1187-1196`).
+- **Checkpoint:** `policy_kwargs` is persisted (`train.py:499-501`); a conflicting `--load` raises
+  (`policy.py:466-471`). The encoder flag must also be reconstructed for inference/eval consumers
+  (`ml/eval.py`, ONNX export) — the loaded `policy_kwargs` is the source of truth.
+- **Schema stamp:** `encode()`/`encode_dynamic()` stamp `2 if config.ego_centric else 1`;
+  `vector_env.py:238` forwards `obs.schema_version` verbatim (already correct).
+
+---
+
+## 6. Determinism / canary re-baseline (TDD)
+
+**Re-baseline (OFF path must stay byte-identical; ON path is the new contract):**
+- `tests/ml/test_encoding.py::test_schema_version_and_dims_constants` — `TOKEN_DIM`/`SCHEMA_VERSION`
+  now config-dependent; assert OFF=(24,1), ON=(28,2).
+- `::test_tokens_status_type_pose_and_padding` — value + shape re-baseline for the ON path.
+- `::test_encode_full_shapes_and_meta` — schema/shape under the flag.
+
+**New tests (write first, RED → GREEN):**
+1. **Transform correctness** — a hand-built 2-object layout with known poses → hand-computed
+   `(fwd, right, sinΔθ, cosΔθ)` for the parked object in the active frame.
+2. **SE(2) invariance property** — apply a random rigid transform (translate + rotate) to the *whole*
+   layout including the active object → `row[24..27]` for every token is **unchanged** (within tol),
+   while `row[18..21]` (absolute) **change**. This is the lever's defining property.
+3. **OFF byte-identity** — `encode(ego_off)` bit-identical to the pre-change golden; `TOKEN_DIM==24`,
+   `schema==1`.
+4. **Active self-relative** = `(0,0,0,1)`; **unplaced** relative cols = 0.
+5. **Policy round-trip** — `to_batch` + `forward` accept `TOKEN_DIM=28` when the policy is built with
+   `relative_encoder=True`; shape mismatch raises a clear error on `--load` against an OFF checkpoint.
+
+**Guards:** `ml-rl-guard` (4c-ii default-neutrality: OFF byte-identical; the new knob is neutral by
+default) + `determinism-guard` (training reproducibility under the flag).
+
+---
+
+## 7. Files touched
+
+| File | Change |
+|---|---|
+| `ml/encoding.py` | `EncoderConfig.ego_centric` field; `_token_row` writes `row[24..27]`; `TOKEN_DIM`/`SCHEMA` config-dependent; a `_norm_delta` helper. |
+| `ml/policy.py` | `token_proj` input dim from a `relative_encoder` kwarg; persisted in `policy_kwargs`. |
+| `ml/train.py` | `--relative-encoder` argparse; thread to `EncoderConfig` + `policy_kwargs`. |
+| `ml/vector_env.py` | ensure `EncoderConfig.ego_centric` reaches workers (schema forward already correct). |
+| `ml/eval.py`, ONNX export | reconstruct the encoder flag from loaded `policy_kwargs`. |
+| `tests/ml/test_encoding.py`, `test_policy.py` | re-baseline + new tests (§6). |
+| `docs/architecture/ml-observation-schema.md` | document schema 2 / the four ego columns. |
+| `CHANGELOG.md` | `[Unreleased]` entry. |
+| `ml/README.md` | note the opt-in flag under the 4c-ii knob table. |
+
+---
+
+## 8. Gate methodology (pre-registered)
+
+- **Rung:** `trio-notch` ladder (the dense rung where all five levers KILLed).
+- **Arms:** OFF (control) vs `--relative-encoder` (treatment), **2 seeds**, GPU.
+- **Metric:** windowed-final valid-placed `vp` (the honest per-iteration `valid_placed`, the #742/#743
+  gate metric), plus first-park `fp`.
+- **WIN:** breaks the `vp≈0.333` place-one-then-abstain fixed point / reaches competency
+  (`vp` materially > 0.333, ideally → mastery tier).
+- **KILL:** `vp` stays ≈0.333 → the coordinate frame is *not* the wall; record as the 6th refuted lever
+  in `ml/README.md` + auto-memory, and the encoder stays opt-in infra (do not re-run on notch).
+- **Confound watch:** check `epochs_run` parity between arms (the #816 lesson) and that the OFF arm
+  reproduces the established control baseline before trusting the contrast.
+
+**Re-open linkage.** A trio-notch WIN is necessary but not sufficient: the real ADR-0028 trigger-#1
+criterion is **reach-rate beating RR-MC on witness-absent scenarios**. That measurement (extend #711)
+is the follow-up gated on a promising trio-notch result.

--- a/ml/README.md
+++ b/ml/README.md
@@ -50,6 +50,15 @@ for these figures and this section is the operational mirror. The lever recipes 
 retained for reproducibility and any future re-open; do **not** re-run a refuted axis on the
 notch.
 
+**In flight — re-open trigger #2 (#827).** The opt-in `--relative-encoder` lever implements
+ADR-0028's one structurally-untested axis: an **ego-centric augment** encoder that *also* writes
+each object's pose in the active object's SE(2) body frame (all five KILLed levers ran on the
+**absolute** world-coordinate encoder — `ml/encoding.py`). `TOKEN_DIM` 24→28 and `SCHEMA_VERSION`
+1→2 when on; default off = byte-identical. Implemented + tested; the `trio-notch` ladder gate
+(2 seeds, GPU) is pending — a KILL adds it to the ledger as the 6th refuted lever, a WIN advances
+to the trigger-#1 reach-rate-vs-RR-MC follow-up. Design spec:
+`docs/superpowers/specs/2026-06-24-relative-encoder-ego-centric-design.md`.
+
 ## Run the tests
     pytest tests/ml/
 

--- a/ml/encoding.py
+++ b/ml/encoding.py
@@ -474,7 +474,7 @@ def encode(
         active_index=active_index,
         legal_action_mask=legal,
         meta=meta,
-        schema_version=SCHEMA_VERSION,
+        schema_version=schema_version_for(config),
     )
 
 
@@ -501,5 +501,5 @@ def encode_dynamic(
         active_index=active_index,
         legal_action_mask=legal,
         meta=meta,
-        schema_version=SCHEMA_VERSION,
+        schema_version=schema_version_for(config),
     )

--- a/ml/encoding.py
+++ b/ml/encoding.py
@@ -20,6 +20,7 @@ from ml import geometry_oracle as go
 from ml.types import Observation
 
 SCHEMA_VERSION = 1
+SCHEMA_VERSION_EGO = 2  # stamped when EncoderConfig.ego_centric (the augment ego frame, #827)
 
 # Canonical discrete action order for the legal-action mask. Magnitude is a
 # sub-project #3 concern; this covers only (kind, gear) legality + PARK.
@@ -36,6 +37,8 @@ _CANONICAL_ACTIONS: tuple[tuple[SegmentKind, Literal[1, -1]], ...] = (
 ACTION_DIM = len(_CANONICAL_ACTIONS) + 1  # + PARK
 PARK_INDEX = ACTION_DIM - 1
 TOKEN_DIM = 24
+EGO_EXTRA_COLS = 4  # ego-relative pose cols (fwd, right, sinΔθ, cosΔθ) appended when ego_centric
+EGO_TOKEN_DIM = TOKEN_DIM + EGO_EXTRA_COLS  # 28
 RASTER_CHANNELS = 7
 # #752: the 7 raster channels split into a STATIC block (depends only on hangar+config)
 # and a DYNAMIC block (depends on the observation). The vectorized rollout ships only the
@@ -55,6 +58,17 @@ class EncoderConfig:
     max_objects: int = 16  # token padding cap (Herrenteich set is 12)
     z_split_m: float = 1.6  # low-band / wing-band boundary (ADR-0023)
     pos_ref_m: float = 20.0  # normalization reference for dims / radii
+    ego_centric: bool = False  # #827: augment tokens with SE(2) ego-relative pose cols (24..27)
+
+
+def token_dim(config: EncoderConfig) -> int:
+    """Per-token feature width for ``config``: EGO_TOKEN_DIM (28) when ego-centric, else 24."""
+    return EGO_TOKEN_DIM if config.ego_centric else TOKEN_DIM
+
+
+def schema_version_for(config: EncoderConfig) -> int:
+    """Schema version for ``config``: SCHEMA_VERSION_EGO (2) when ego-centric, else 1."""
+    return SCHEMA_VERSION_EGO if config.ego_centric else SCHEMA_VERSION
 
 
 @dataclass(frozen=True, slots=True)

--- a/ml/encoding.py
+++ b/ml/encoding.py
@@ -247,8 +247,9 @@ def _token_row(
     on_carts: bool,
     pose: tuple[float, float, float] | None,
     config: EncoderConfig,
+    active_pose: tuple[float, float, float] | None = None,
 ) -> np.ndarray:
-    row = np.zeros(TOKEN_DIM, dtype=np.float32)
+    row = np.zeros(token_dim(config), dtype=np.float32)
     row[_STATUS_COL[status]] = 1.0  # status one-hot 0..2
     if isinstance(body, Aircraft):
         row[3] = 1.0  # aircraft type bit
@@ -275,6 +276,20 @@ def _token_row(
         th = np.radians(pose[2])
         row[18], row[19], row[20], row[21] = nx, ny, float(np.sin(th)), float(np.cos(th))
     # reserved 22..23 stay 0 (region_side, seq_order)
+    if config.ego_centric and pose is not None and active_pose is not None:
+        # #827: object pose in the active object's SE(2) body frame. Basis (compass, det-1):
+        # forward=(sinθ_a, cosθ_a), right=(cosθ_a, -sinθ_a). Invariant under rigid scene motion.
+        ax, ay, ah = active_pose
+        th_a = np.radians(ah)
+        s_a, c_a = float(np.sin(th_a)), float(np.cos(th_a))
+        dx, dy = pose[0] - ax, pose[1] - ay
+        fwd = dx * s_a + dy * c_a
+        right = dx * c_a - dy * s_a
+        dth = np.radians(pose[2] - ah)
+        row[TOKEN_DIM + 0] = fwd / config.pos_ref_m
+        row[TOKEN_DIM + 1] = right / config.pos_ref_m
+        row[TOKEN_DIM + 2] = float(np.sin(dth))
+        row[TOKEN_DIM + 3] = float(np.cos(dth))
     return row
 
 
@@ -287,7 +302,7 @@ def _tokens(
 
     Row order: parked (placement order) → active → unplaced (queue order), padded.
     ``active_index`` is the row of the active object, or -1 at a terminal state."""
-    tokens = np.zeros((config.max_objects, TOKEN_DIM), dtype=np.float32)
+    tokens = np.zeros((config.max_objects, token_dim(config)), dtype=np.float32)
     mask = np.zeros(config.max_objects, dtype=bool)
     entries: list[tuple[Aircraft | GroundObject, str, bool, tuple[float, float, float] | None]] = []
     for po in obs.parked:
@@ -318,8 +333,20 @@ def _tokens(
             f"unplaced={len(obs.unplaced_ids)}); the curriculum must guarantee "
             f"parked + active <= max_objects"
         )
+    active_pose = (
+        (obs.active.pose.x_m, obs.active.pose.y_m, obs.active.pose.heading_deg)
+        if obs.active is not None
+        else None
+    )
     for i, (body, status, on_carts, pose) in enumerate(entries[: config.max_objects]):
-        tokens[i] = _token_row(body, status=status, on_carts=on_carts, pose=pose, config=config)
+        tokens[i] = _token_row(
+            body,
+            status=status,
+            on_carts=on_carts,
+            pose=pose,
+            config=config,
+            active_pose=active_pose,
+        )
         mask[i] = True
     return tokens, mask, active_index
 

--- a/ml/eval.py
+++ b/ml/eval.py
@@ -45,7 +45,9 @@ def policy_reach(
     predicate (spec §4): valid (product checker `_layout_valid` on the terminal layout) +
     routable-by-construction (no swept intrusion on any leg). Raises NotImplementedError for
     fixed-obstacle scenarios (deferred to 4c-ii)."""
-    enc = encoder or EncoderConfig()
+    # #827: the encoder's ego-frame follows the policy's own architecture (single source of
+    # truth), so an ego policy gets 28-wide ego tokens instead of a 24-vs-28 shape crash.
+    enc = encoder or EncoderConfig(ego_centric=getattr(policy, "relative_encoder", False))
     env = build_scenario_env(scenario)  # raises on fixed-obstacle scenarios
     bodies = {**env.fleet, **env.ground_objects}
     policy.eval()

--- a/ml/export.py
+++ b/ml/export.py
@@ -70,6 +70,12 @@ def export_onnx(
     """Trace ``policy``'s forward to an ONNX file at ``path``. Pass ``example`` (an
     ``ObservationTensors``) to trace real shapes, else a default-config dummy is used.
     Batch ``B`` and token count ``N`` are dynamic axes."""
+    if example is None and getattr(policy, "relative_encoder", False):
+        raise ValueError(
+            "export_onnx: a relative_encoder (ego-centric, 28-wide) policy needs a real ego "
+            "`example`; the default 24-wide dummy would mis-trace into a shape crash. Torch-free "
+            "ONNX inference for --relative-encoder is a deferred #827 follow-up."
+        )
     # The legacy TorchScript ONNX exporter leaves the module in train() mode on return,
     # which would silently re-activate the encoder dropout for any later forward the caller
     # makes on this policy. Capture and restore the original mode so export has no side

--- a/ml/policy.py
+++ b/ml/policy.py
@@ -17,6 +17,7 @@ from ml import action_space
 from ml.action_space import MAGNITUDE_DIM
 from ml.encoding import (
     ACTION_DIM,
+    EGO_TOKEN_DIM,
     RASTER_CHANNELS,
     TOKEN_DIM,
     ObservationTensors,
@@ -124,9 +125,11 @@ class HangarFitPolicy(nn.Module):
         n_heads: int = 4,
         cnn_channels: tuple[int, ...] = (16, 32, 64),
         spatial_tokens: bool = False,
+        relative_encoder: bool = False,
     ) -> None:
         super().__init__()
         self.spatial_tokens = spatial_tokens
+        self.relative_encoder = relative_encoder
         convs: list[nn.Module] = []
         in_ch = RASTER_CHANNELS
         for ch in cnn_channels:
@@ -140,7 +143,8 @@ class HangarFitPolicy(nn.Module):
                 *convs, nn.AdaptiveAvgPool2d(1), nn.Flatten()
             )  # (B, cnn_channels[-1])
         self.cnn_proj = nn.Linear(cnn_channels[-1], d_model)  # g: -> D
-        self.token_proj = nn.Linear(TOKEN_DIM, d_model)  # tokens 24 -> D
+        token_in = EGO_TOKEN_DIM if relative_encoder else TOKEN_DIM
+        self.token_proj = nn.Linear(token_in, d_model)  # tokens 24 (or 28 ego) -> D
         self.fuse = nn.Linear(2 * d_model, d_model)  # concat(token, g) 2D -> D
         layer = nn.TransformerEncoderLayer(
             d_model, n_heads, dim_feedforward=4 * d_model, batch_first=True

--- a/ml/reach_rate.py
+++ b/ml/reach_rate.py
@@ -217,7 +217,9 @@ def policy_reach_count(scenario: Scenario, policy, *, samples: int, seed: int = 
     from ml.benchmark import _verdict_from  # single-source the spec §4 reach predicate
     from ml.encoding import EncoderConfig, encode
 
-    enc = EncoderConfig()
+    # #827: the encoder's ego-frame follows the policy's own architecture (single source of
+    # truth), so an ego policy gets 28-wide ego tokens instead of a 24-vs-28 shape crash.
+    enc = EncoderConfig(ego_centric=getattr(policy, "relative_encoder", False))
     env = _build_env(scenario)
     bodies = {**env.fleet, **env.ground_objects}
     deterministic = samples == 1

--- a/ml/train.py
+++ b/ml/train.py
@@ -306,6 +306,9 @@ def train(
     enc = encoder or EncoderConfig()
     env = build_trivial_env(seed, weights=weights)
     policy = HangarFitPolicy(**(policy_kwargs or {})).to(torch.device(device))
+    # #827: the encoder's ego-frame is DERIVED from the policy architecture so the token width
+    # and the policy's token_proj input can never disagree.
+    enc = replace(enc, ego_centric=bool((policy_kwargs or {}).get("relative_encoder", False)))
     optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.lr)
     normalizer = ReturnNormalizer(eps=cfg.return_norm_eps) if cfg.normalize_returns else None
     history: list[float] = []
@@ -501,6 +504,10 @@ def train_curriculum(
         policy = HangarFitPolicy(**saved_policy_kwargs).to(dev)
         optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.lr)
         normalizer = ReturnNormalizer(eps=cfg.return_norm_eps) if cfg.normalize_returns else None
+    # #827: derive the encoder's ego-frame from the (post-load authoritative) architecture, so the
+    # token width and the policy's token_proj can never disagree, and a loaded ego checkpoint
+    # auto-uses an ego encoder regardless of whether --relative-encoder was re-passed.
+    enc = replace(enc, ego_centric=bool(saved_policy_kwargs.get("relative_encoder", False)))
     completed_set = set(completed_stages)
     history = CurriculumHistory()
     for stage_index, stage in enumerate(sched.stages):
@@ -901,6 +908,15 @@ def build_argparser() -> argparse.ArgumentParser:
         "checkpoint's policy_kwargs)",
     )
     p.add_argument(
+        "--relative-encoder",
+        action="store_true",
+        help="opt-in ego-centric augment encoder (#827, ADR-0028 re-open trigger #2): each "
+        "object's pose is ALSO written in the active object's SE(2) body frame (4 extra token "
+        "cols). Default off = byte-identical (TOKEN_DIM 24, schema 1); a deliberate "
+        "representation re-baseline when on (TOKEN_DIM 28, schema 2); persisted in the "
+        "checkpoint's policy_kwargs",
+    )
+    p.add_argument(
         "--epochs",
         type=int,
         default=PPOConfig().epochs,
@@ -1191,6 +1207,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             ("n_layers", args.n_layers),
             ("n_heads", args.n_heads),
             ("spatial_tokens", True if args.spatial_tokens else None),
+            ("relative_encoder", True if args.relative_encoder else None),
         )
         if v is not None
     } or None

--- a/ml/train.py
+++ b/ml/train.py
@@ -1188,6 +1188,11 @@ def main(argv: Sequence[str] | None = None) -> None:
     args = parser.parse_args(argv)
     if args.device == "cuda" and not torch.cuda.is_available():
         parser.error("--device cuda requested but torch.cuda.is_available() is False")
+    if args.relative_encoder and args.save_onnx:
+        parser.error(
+            "--save-onnx is not yet supported with --relative-encoder; torch-free ONNX "
+            "inference for the ego-centric encoder is a deferred #827 follow-up"
+        )
     weights = RewardWeights(
         w_col=args.w_col,
         r_valid_park=args.r_valid_park,

--- a/tests/ml/test_encoding.py
+++ b/tests/ml/test_encoding.py
@@ -351,6 +351,48 @@ def test_encode_full_shapes_and_meta():
     assert all(isinstance(v, float) for v in out.meta.values())
 
 
+def test_encode_ego_schema_is_2():
+    fleet = _fuji()
+    out = encode(_two_body_obs(fleet), empty_hangar(), fleet, EncoderConfig(ego_centric=True))
+    assert out.schema_version == 2
+    assert out.tokens.shape == (16, 28)
+
+
+def test_ego_cols_are_se2_invariant():
+    import math
+
+    fleet = _fuji()
+
+    def build(rot_deg: float, tx: float, ty: float):
+        # One rigid SE(2) scene motion: rotate (x,y) CCW by rot_deg, then translate. Compass
+        # headings are CW-positive, so a CCW position rotation pairs with heading - rot_deg
+        # (the position and facing must rotate in the same physical sense).
+        a = math.radians(rot_deg)
+        ca, sa = math.cos(a), math.sin(a)
+
+        def xf(x, y):
+            return (ca * x - sa * y + tx, sa * x + ca * y + ty)
+
+        px, py = xf(11.0, 12.0)
+        axp, ayp = xf(11.0, -4.0)
+        pl = Placement(plane_id="fuji", x_m=px, y_m=py, heading_deg=0.0 - rot_deg, on_carts=False)
+        active = ActiveObject(
+            object_id="aviat_husky",
+            body=fleet["aviat_husky"],
+            pose=Pose(x_m=axp, y_m=ayp, heading_deg=90.0 - rot_deg),
+            on_carts=False,
+        )
+        obs = _obs(parked=(ParkedObject(object_id="fuji", placement=pl),), active=active)
+        return _tokens(obs, fleet, EncoderConfig(ego_centric=True))[0]
+
+    base = build(0.0, 0.0, 0.0)
+    moved = build(37.0, 5.0, -8.0)
+    # ego cols (24..27) of the parked object are unchanged under the rigid motion
+    assert np.allclose(base[0, 24:28], moved[0, 24:28], atol=1e-5)
+    # absolute cols (18..21) DO change (different world pose)
+    assert not np.allclose(base[0, 18:22], moved[0, 18:22], atol=1e-3)
+
+
 def test_encode_meta_is_immutable():
     c = EncoderConfig()
     fleet = _fuji()

--- a/tests/ml/test_encoding.py
+++ b/tests/ml/test_encoding.py
@@ -46,6 +46,21 @@ def test_schema_version_and_dims_constants():
     assert encoding.PARK_INDEX == 8
 
 
+def test_ego_constants_and_helpers():
+    # OFF constants are unchanged (byte-identity anchor)
+    assert encoding.TOKEN_DIM == 24 and encoding.SCHEMA_VERSION == 1
+    # New ego constants
+    assert encoding.EGO_EXTRA_COLS == 4
+    assert encoding.EGO_TOKEN_DIM == 28
+    assert encoding.SCHEMA_VERSION_EGO == 2
+    off = EncoderConfig()
+    on = EncoderConfig(ego_centric=True)
+    assert off.ego_centric is False and on.ego_centric is True
+    assert encoding.token_dim(off) == 24 and encoding.token_dim(on) == 28
+    assert encoding.schema_version_for(off) == 1
+    assert encoding.schema_version_for(on) == 2
+
+
 def test_config_defaults():
     c = EncoderConfig()
     assert (c.cell_m, c.grid_w, c.grid_h, c.max_objects) == (0.25, 96, 192, 16)

--- a/tests/ml/test_encoding.py
+++ b/tests/ml/test_encoding.py
@@ -217,6 +217,49 @@ def test_tokens_status_type_pose_and_padding():
     assert tokens[5].sum() == 0.0
 
 
+def test_tokens_ego_relative_cols_worked_example():
+    c = EncoderConfig(ego_centric=True)
+    fleet = _fuji()
+    pl = Placement(plane_id="fuji", x_m=11.0, y_m=12.0, heading_deg=0.0, on_carts=False)
+    active = ActiveObject(
+        object_id="aviat_husky",
+        body=fleet["aviat_husky"],
+        pose=Pose(x_m=11.0, y_m=-4.0, heading_deg=90.0),
+        on_carts=False,
+    )
+    obs = _obs(
+        parked=(ParkedObject(object_id="fuji", placement=pl),),
+        active=active,
+        unplaced=("cessna_150",),
+    )
+    tokens, _mask, active_index = _tokens(obs, fleet, c)
+    # width grew to 28
+    assert tokens.shape == (16, encoding.EGO_TOKEN_DIM)
+    # absolute cols 18..21 are STILL written (augment, not replace): active heading 90 -> sin1 cos0
+    assert abs(tokens[1, 20] - 1.0) < 1e-6 and abs(tokens[1, 21]) < 1e-6
+    # active object's own ego cols are the origin (0,0,0,1)
+    assert active_index == 1
+    assert list(tokens[1, 24:28]) == [0.0, 0.0, 0.0, 1.0]
+    # parked fuji is 16 m due-north of an east-facing active -> fwd 0, right -16 (to its left),
+    # normalized by pos_ref_m=20 -> (0, -0.8); relative heading 0-90=-90 -> sin -1, cos 0
+    assert abs(tokens[0, 24] - 0.0) < 1e-6
+    assert abs(tokens[0, 25] - (-0.8)) < 1e-6
+    assert abs(tokens[0, 26] - (-1.0)) < 1e-6
+    assert abs(tokens[0, 27] - 0.0) < 1e-6
+    # unplaced row has zero ego cols (no pose)
+    assert list(tokens[2, 24:28]) == [0.0, 0.0, 0.0, 0.0]
+
+
+def test_tokens_off_path_is_24_wide_and_unchanged():
+    # OFF config: width stays 24, no ego cols exist (byte-identity anchor)
+    c = EncoderConfig()
+    fleet = _fuji()
+    pl = Placement(plane_id="fuji", x_m=11.0, y_m=12.0, heading_deg=0.0, on_carts=False)
+    obs = _obs(parked=(ParkedObject(object_id="fuji", placement=pl),), active=None, unplaced=())
+    tokens, _mask, _ai = _tokens(obs, fleet, c)
+    assert tokens.shape == (16, encoding.TOKEN_DIM) == (16, 24)
+
+
 def test_tokens_wing_and_movement_one_hots():
     c = EncoderConfig()
     fleet = _fuji()

--- a/tests/ml/test_eval.py
+++ b/tests/ml/test_eval.py
@@ -21,6 +21,15 @@ def test_policy_reach_runs_on_go_free_control():
     # An untrained policy will not reach; we only assert it runs end-to-end and verdicts.
 
 
+def test_policy_reach_runs_on_ego_policy_without_shape_crash():
+    # #827: policy_reach must derive a 28-wide ego encoder from policy.relative_encoder rather
+    # than shape-crash a 24-wide default encoder against an ego policy's token_proj.
+    policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2, relative_encoder=True)
+    v = policy_reach(_DEMO, policy)
+    assert isinstance(v, ReachVerdict)
+    assert v.total == 3
+
+
 def test_checkpoint_save_load_roundtrip(tmp_path):
     policy = HangarFitPolicy(d_model=32, n_layers=1, n_heads=2)
     ckpt = tmp_path / "p.pt"

--- a/tests/ml/test_export.py
+++ b/tests/ml/test_export.py
@@ -82,3 +82,21 @@ def test_train_save_onnx_writes_file(tmp_path):
     onnx_path = tmp_path / "trivial.onnx"
     train(iterations=1, rollout_len=16, save_onnx=str(onnx_path))
     assert onnx_path.exists() and onnx_path.stat().st_size > 0
+
+
+def test_export_onnx_ego_policy_without_example_fails_clearly(tmp_path):
+    # #827: a relative_encoder (28-wide) policy with the default 24-wide dummy must fail with a
+    # clear message naming the deferred follow-up, NOT an obscure matmul RuntimeError.
+    policy = HangarFitPolicy(relative_encoder=True)
+    with pytest.raises(ValueError, match="relative_encoder"):
+        export_onnx(policy, tmp_path / "ego.onnx")
+
+
+def test_main_rejects_relative_encoder_with_save_onnx(tmp_path):
+    # #827: --save-onnx + --relative-encoder must fail FAST (before any training run), not crash
+    # at export after the whole run completes.
+    from ml.train import main
+
+    argv = ["--schedule", "trivial", "--relative-encoder", "--save-onnx", str(tmp_path / "x.onnx")]
+    with pytest.raises(SystemExit):
+        main(argv)

--- a/tests/ml/test_policy.py
+++ b/tests/ml/test_policy.py
@@ -32,6 +32,49 @@ def _obs():
     return encode(obs, empty_hangar(), fleet, EncoderConfig())
 
 
+def _ego_obs():
+    fleet = _fuji()
+    pl = Placement(plane_id="fuji", x_m=11.0, y_m=12.0, heading_deg=0.0, on_carts=False)
+    active = ActiveObject(
+        object_id="aviat_husky",
+        body=fleet["aviat_husky"],
+        pose=Pose(x_m=11.0, y_m=-4.0, heading_deg=90.0),
+        on_carts=False,
+    )
+    obs = Observation(
+        active=active,
+        parked=(ParkedObject(object_id="fuji", placement=pl),),
+        unplaced_ids=("cessna_150",),
+        steps_this_object=0,
+        steps_total=0,
+    )
+    return encode(obs, empty_hangar(), fleet, EncoderConfig(ego_centric=True))
+
+
+def test_policy_off_is_byte_identical():
+    torch.manual_seed(0)
+    a = HangarFitPolicy()
+    torch.manual_seed(0)
+    b = HangarFitPolicy(relative_encoder=False)
+    sa, sb = a.state_dict(), b.state_dict()
+    assert sa.keys() == sb.keys()
+    assert all(torch.equal(sa[k], sb[k]) for k in sa)
+    assert a.token_proj.in_features == 24
+
+
+def test_policy_relative_encoder_sizes_token_proj():
+    p = HangarFitPolicy(relative_encoder=True)
+    assert p.relative_encoder is True
+    assert p.token_proj.in_features == 28
+
+
+def test_policy_relative_forward_consumes_28_wide_tokens():
+    obs_t = _ego_obs()
+    assert obs_t.tokens.shape[-1] == 28
+    out = HangarFitPolicy(relative_encoder=True).eval()(to_batch([obs_t]))
+    assert out.kind_gear_logits.shape == (1, 9) and out.magnitude_bin_logits.shape == (1, 5)
+
+
 def test_to_batch_shapes_and_dtypes():
     batch = to_batch([_obs(), _obs()])
     assert batch["raster"].shape == (2, 7, 192, 96) and batch["raster"].dtype == torch.float32

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -59,6 +59,22 @@ def test_spatial_tokens_ppo_smoke_trains_without_nan():
     assert all(isinstance(r, float) and r == r and abs(r) < 1e9 for r in history)
 
 
+def test_relative_encoder_ppo_smoke_trains_without_nan():
+    # A handful of PPO iterations on the trivial rung with the ego encoder (#827) must run and
+    # return finite rewards — proves the train()-derived 28-wide ego tokens are consumed by the
+    # relative_encoder policy end-to-end (rollout + GAE + update), no NaN, no shape crash. The
+    # encoder's ego_centric is DERIVED from policy_kwargs, so passing only the policy kwarg here
+    # exercises the derivation in train().
+    history = train(
+        seed=0,
+        iterations=2,
+        rollout_len=32,
+        policy_kwargs={"relative_encoder": True, "d_model": 32, "n_layers": 1, "n_heads": 2},
+    )
+    assert len(history) == 2
+    assert all(isinstance(r, float) and r == r and abs(r) < 1e9 for r in history)
+
+
 from ml.curriculum import (  # noqa: E402
     CurriculumSchedule,
     DifficultyConfig,
@@ -286,6 +302,11 @@ def test_argparser_vec_start_method_defaults_to_spawn():
     assert parser.parse_args(["--vec-start-method", "fork"]).vec_start_method == "fork"
     with pytest.raises(SystemExit):
         parser.parse_args(["--vec-start-method", "bogus"])
+
+
+def test_argparser_relative_encoder_flag():
+    assert build_argparser().parse_args([]).relative_encoder is False
+    assert build_argparser().parse_args(["--relative-encoder"]).relative_encoder is True
 
 
 def test_argparser_n_envs_auto_resolves_to_positive_int(monkeypatch):


### PR DESCRIPTION
Closes #827.

## What

Opt-in **ego-centric (relative) coordinate encoder** for the learned backend — ADR-0028
**re-open trigger #2**. Each object pose token is *augmented* with four SE(2) ego-relative
columns (`fwd, right, sinΔθ, cosΔθ`) expressed in the **active object's body frame**, on top of
the existing absolute pose columns. `TOKEN_DIM` 24→28 and `SCHEMA_VERSION` 1→2 when on;
**default off = byte-identical**. Dev/CI-only (`ml/`), not shipped in the wheel.

## Why

The five gate-run levers (#794/#810/#813/#817/#823) all KILLed at the same `vp≈0.333`
place-one-then-abstain fixed point on the dense `trio-notch` rung — all on the **absolute**
world-coordinate encoder. An ego-centric frame makes "slot the marginal object into the gap
**relative to its neighbours**" position- and heading-invariant: the one structurally-untested
representation axis ADR-0028 names. Distinct from the refuted #810 (which changed the raster
occupancy-map pooling, not the pose-token coordinate frame). Verified: actions are body-frame,
so a full SE(2) ego frame matches the action space (observation frame ≡ action frame).

## Design

- **Augment** (keep absolute + add ego cols): information-preserving, lowest-variance probe.
- Encoder/policy agreement is **structural** — `enc.ego_centric` is *derived* from
  `policy_kwargs["relative_encoder"]` / `policy.relative_encoder`, so the token width and
  `token_proj` input can never disagree (fresh-train, `--load` resume, and the trivial path all
  covered).
- Spec: `docs/superpowers/specs/2026-06-24-relative-encoder-ego-centric-design.md`;
  plan: `docs/superpowers/plans/2026-06-24-relative-encoder-ego-centric.md`.

## Tests

Full `tests/ml/` **657 passed**; `ruff` / `ruff format` / `mypy ml/` clean. New tests pin the
worked-example ego cols, the **SE(2)-invariance property**, OFF 24-wide byte-identity, policy
OFF state_dict bit-identity, an end-to-end PPO smoke through the derivation, an eval
no-shape-crash, and the `--save-onnx + --relative-encoder` fail-fast guards.

## Review arc (pre-PR)

- **`ml-rl-guard`: PASS** — four RL invariants intact; `--relative-encoder` default-neutral
  (absent ⇒ key dropped ⇒ OFF byte-identical); seeded RNG order undisturbed; validity oracle +
  GAE untouched.
- **`code-reviewer`: 1 Important finding** — ONNX export of an ego policy crashed obscurely after
  a full training run. **Fixed**: fail-fast guards at the export boundary (`export_onnx`) and the
  CLI boundary (`main()` rejects `--save-onnx + --relative-encoder` before training). Torch-free
  ONNX inference for the ego encoder is a deferred #827 follow-up.
- `determinism-guard`: **N/A** (no `solver.py`/`towplanner.py` change).

## Caveats (in the spec)

- Augment grows `TOKEN_DIM` → a `token_proj` shape change via `policy_kwargs` (the #810 template),
  not purely encoder-only.
- Augment keeps absolute coords → does **not** defeat the BC/DAgger masquerade (acceptable for
  this RL-from-scratch gate).

## Gate (post-merge, supervised)

`trio-notch` ladder, OFF vs `--relative-encoder`, 2 seeds, GPU. WIN = breaks the `vp≈0.333` fixed
point (→ trigger-#1 reach-rate follow-up). KILL → recorded as the 6th refuted lever in
`ml/README.md` + the ledger. The encoder stays opt-in infra either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158YRoWo9BXVv6kAuJ9kC2U
