### PR TITLE
learned-backend: make ADR-0028 re-open trigger #1 (reach-not-beat) executable + record the verdict (NOT MET)

### DIFF
--- a/docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md
+++ b/docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md
@@ -106,7 +106,13 @@ success criterion is the shipped, verifier-gated inference seam (#706).
 **Re-open this decision if (any one):**
 
 1. a future policy's dense-notch **reach-rate** (Wilson CI) **exceeds RR-MC's** on a
-   **witness-absent** scenario-kind (the true charter target — masquerade-proof), **or**
+   **witness-absent** scenario-kind (the true charter target — masquerade-proof). *This gate is
+   now **runnable** (`ml.reach_rate.dominance_verdict` / `--witness-absent-tau`, #831) and was
+   executed once: on the witness-absent `k8` over-capacity stratum (a fair-budget RR-MC reaches
+   **0/9** distinct subsets, Wilson `ci_hi` 0.30) all six trained gate-run checkpoints
+   (control / ego / backplay × 2 seeds) reach **0/108** → verdict **NOT MET**. The trigger stays
+   open for a future policy; no current one trips it, because the policies' competence regime
+   (≤3-aircraft rungs) and RR-MC's miss regime (over-capacity dense) are disjoint.* **or**
 2. ~~a **relative / object-centric coordinate encoder lands**~~ — **RESOLVED-NEGATIVE
    (#827 / #829, 2026-06-25).** *Rationale at the time: that encoder was the one
    structurally-untested confound.* The opt-in `--relative-encoder` ego-centric augment encoder

--- a/ml/README.md
+++ b/ml/README.md
@@ -225,7 +225,12 @@ sweep (distinct over-capacity subsets, same fair budget) maps the boundary direc
 frontier (`k ≥ 6`) sits well above the policies' `≤3`-aircraft competence, making the disjointness
 quantitative. (The band closest to plausible near-term help is the `k = 4…5` transition — RR-MC is
 already half-missing there, just past where *today's* `≤3`-aircraft policies operate; the `k ≥ 6`
-frontier stays out of reach for any backend trained on the current rungs, not intrinsically.)
+frontier stays out of reach for any backend trained on the current rungs, not intrinsically.) The
+verdict survives the **fairest** framing too: re-run on the *specific* `k = 4` subsets RR-MC misses
+(the witness-absent boundary nearest competence — not the far-OOD `k = 8`; RR-MC drops ≈41 % of `k4`
+here), all six checkpoints still reach **0/216** → NOT MET. So "no current policy beats RR-MC where
+it misses" holds from the boundary nearest competence (`k = 4`) to far OOD (`k = 8`) — not an
+artifact of out-of-distribution testing.
 
 ## Training knobs (4c-ii)
 

--- a/ml/README.md
+++ b/ml/README.md
@@ -207,6 +207,8 @@ python -m ml.reach_rate --hangar tests/fixtures/canary_hangar_tight_18m.yaml \
   --policy model.pt --samples 12 --witness-absent-tau 0.35
 # NB: there are only C(9,8)=9 DISTINCT k8 subsets; RR-MC is deterministic, so beyond 9 the
 # sampler repeats scenarios (pseudo-replication). Enumerate the distinct subsets for a clean CI.
+# tau 0.35 > the measured RR-MC ci_hi 0.30, so k8 registers as witness-absent; the 0.15 default
+# would NOT (0.30 > 0.15) — at n=9 the Wilson width forces tau above the small-sample ci_hi.
 ```
 
 **Current reading (2026-06-25, NOT MET).** Executed on the witness-absent `k8` stratum (9 distinct

--- a/ml/README.md
+++ b/ml/README.md
@@ -223,8 +223,9 @@ trigger #1 is not met, now as a runnable verdict rather than a prediction. A per
 sweep (distinct over-capacity subsets, same fair budget) maps the boundary directly: reach falls
 **1.00 → 0.83 → 0.50 → 0.42** across `k = 2…5`, then **0.00 at `k ≥ 6`** — so the witness-absent
 frontier (`k ≥ 6`) sits well above the policies' `≤3`-aircraft competence, making the disjointness
-quantitative. (The only band where a *future* learned backend could plausibly help is the `k = 4…5`
-transition, where RR-MC is already half-missing just past where the policies operate.)
+quantitative. (The band closest to plausible near-term help is the `k = 4…5` transition — RR-MC is
+already half-missing there, just past where *today's* `≤3`-aircraft policies operate; the `k ≥ 6`
+frontier stays out of reach for any backend trained on the current rungs, not intrinsically.)
 
 ## Training knobs (4c-ii)
 

--- a/ml/README.md
+++ b/ml/README.md
@@ -183,6 +183,42 @@ large-population RR-MC baseline is meant to be recorded once and **frozen** (mir
 measuring so the policy-vs-RR-MC comparison can't go circular. The policy arm is cheap (rollouts,
 no solver), so it affords a larger population × more samples.
 
+### The trigger-#1 dominance gate (#831 — the re-open test, now runnable)
+
+[ADR-0028](../docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md)'s **re-open
+trigger #1** is the masquerade-proof charter test: *a future policy's dense-notch reach-rate
+(Wilson CI) **exceeds RR-MC's** on a **witness-absent** scenario-kind*. The harness above measures
+both arms; `#831` encodes the **decision** so it's a runnable verdict, not a human eyeballing two
+tables:
+
+- `witness_absent_kinds(rrmc, tau)` — the kinds RR-MC genuinely **misses** (Wilson `ci_hi <= tau`).
+  Only these are chartered ground; a policy "win" anywhere RR-MC already reaches is not a win.
+- `dominance_verdict(rrmc, policy, tau)` — the trigger-#1 predicate as one boolean. It requires
+  Wilson-CI **non-overlap** (`policy.ci_lo > rrmc.ci_hi`), so a policy that merely *matches* RR-MC
+  by sampling luck cannot trip it; it reports `exercised` (was there a witness-absent kind at all?)
+  separately from `reopen`, so a **vacuous** "no witness-absent kind" negative never masquerades as
+  a clean "tested and did not beat RR-MC".
+
+```bash
+# A witness-absent population needs a regime a FAIR-budget RR-MC misses (not a starved one).
+# Over-capacity fleet subsets on the tight 18 m hangar work; the witness-absent kind is k8.
+python -m ml.reach_rate --hangar tests/fixtures/canary_hangar_tight_18m.yaml \
+  --k-min 8 --k-max 8 --scenarios 9 --alternatives 4 --max-restarts 16 \
+  --policy model.pt --samples 12 --witness-absent-tau 0.35
+# NB: there are only C(9,8)=9 DISTINCT k8 subsets; RR-MC is deterministic, so beyond 9 the
+# sampler repeats scenarios (pseudo-replication). Enumerate the distinct subsets for a clean CI.
+```
+
+**Current reading (2026-06-25, NOT MET).** Executed on the witness-absent `k8` stratum (9 distinct
+over-capacity subsets): a fair-budget RR-MC reaches **0/9** (Wilson `ci_hi` 0.30), and **all six**
+trained gate-run checkpoints (control / ego / backplay × 2 seeds) reach **0/108** → `policy.ci_lo`
+0.000 cannot clear `rrmc.ci_hi` 0.30, so **trigger #1 is NOT MET** on every checkpoint. The
+structural reason is the charter gap [ADR-0028](../docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md)
+measured: where RR-MC misses (over-capacity dense) the policies (trained on ≤3-aircraft rungs) reach
+**0**, and where the policies are competent (trio-box / trio-notch) RR-MC reaches everything, so
+there is no witness-absent kind there to contest. The two regimes are **disjoint** — which is *why*
+trigger #1 is not met, now as a runnable verdict rather than a prediction.
+
 ## Training knobs (4c-ii)
 
 Four optional basin-escape knobs were added in sub-project #4c-ii (#693). All

--- a/ml/README.md
+++ b/ml/README.md
@@ -219,7 +219,12 @@ structural reason is the charter gap [ADR-0028](../docs/adr/0028-learned-backend
 measured: where RR-MC misses (over-capacity dense) the policies (trained on ≤3-aircraft rungs) reach
 **0**, and where the policies are competent (trio-box / trio-notch) RR-MC reaches everything, so
 there is no witness-absent kind there to contest. The two regimes are **disjoint** — which is *why*
-trigger #1 is not met, now as a runnable verdict rather than a prediction.
+trigger #1 is not met, now as a runnable verdict rather than a prediction. A per-`k` RR-MC reach
+sweep (distinct over-capacity subsets, same fair budget) maps the boundary directly: reach falls
+**1.00 → 0.83 → 0.50 → 0.42** across `k = 2…5`, then **0.00 at `k ≥ 6`** — so the witness-absent
+frontier (`k ≥ 6`) sits well above the policies' `≤3`-aircraft competence, making the disjointness
+quantitative. (The only band where a *future* learned backend could plausibly help is the `k = 4…5`
+transition, where RR-MC is already half-missing just past where the policies operate.)
 
 ## Training knobs (4c-ii)
 

--- a/ml/README.md
+++ b/ml/README.md
@@ -229,8 +229,8 @@ frontier stays out of reach for any backend trained on the current rungs, not in
 verdict survives the **fairest** framing too: re-run on the *specific* `k = 4` subsets RR-MC misses
 (the witness-absent boundary nearest competence — not the far-OOD `k = 8`; RR-MC drops ≈41 % of `k4`
 here), all six checkpoints still reach **0/216** → NOT MET. So "no current policy beats RR-MC where
-it misses" holds from the boundary nearest competence (`k = 4`) to far OOD (`k = 8`) — not an
-artifact of out-of-distribution testing.
+it misses" holds at **both** measured ends — the boundary nearest competence (`k = 4`) *and* far
+OOD (`k = 8`) — so the verdict is not an artifact of out-of-distribution testing.
 
 ## Training knobs (4c-ii)
 

--- a/ml/reach_rate.py
+++ b/ml/reach_rate.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import argparse
 import math
 import random
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -97,6 +97,90 @@ def aggregate(pairs: Iterable[tuple[str, bool]]) -> dict[str, ReachRate]:
     if all_trials:
         out["overall"] = reach_rate("overall", sum(all_trials), len(all_trials))
     return out
+
+
+# ── trigger-#1 dominance gate (ADR-0028 re-open condition #1) ─────────────────
+
+
+def _check_tau(tau: float) -> None:
+    if not 0.0 <= tau <= 1.0:
+        raise ValueError(f"tau must be in [0, 1], got {tau}")
+
+
+def witness_absent_kinds(rrmc: Mapping[str, ReachRate], *, tau: float) -> list[str]:
+    """The scenario-kinds RR-MC genuinely *misses* — its reach-rate upper Wilson bound sits at
+    or below ``tau``. Only on these can a learned policy "reach what the deterministic solver
+    misses" (the #607 charter); a policy win anywhere RR-MC already reaches is not chartered.
+    Excludes the synthetic ``"overall"`` pooled row. Sorted for a deterministic verdict."""
+    _check_tau(tau)
+    return sorted(k for k, r in rrmc.items() if k != "overall" and r.ci_hi <= tau)
+
+
+@dataclass(frozen=True, slots=True)
+class KindDominance:
+    """Per-kind dominance fact on one witness-absent kind: does the policy's reach-rate Wilson
+    lower bound clear RR-MC's upper bound? ``policy_covered`` is False when the policy arm never
+    sampled this kind (no evidence ⇒ cannot beat)."""
+
+    kind: str
+    rrmc_ci_hi: float
+    policy_covered: bool
+    policy_ci_lo: float
+    policy_beats: bool
+
+
+@dataclass(frozen=True, slots=True)
+class DominanceVerdict:
+    """ADR-0028 re-open **trigger #1**: does a policy's dense-notch reach-rate Wilson CI *exceed*
+    RR-MC's on a **witness-absent** kind? Masquerade-proof by construction — it requires Wilson-CI
+    **non-overlap** (policy lower bound strictly above RR-MC upper bound), so a policy that merely
+    matches RR-MC by sampling luck cannot trip it.
+
+    ``exercised`` (the population actually contained a witness-absent kind) is reported separately
+    from ``reopen`` so a *vacuous* negative — "no witness-absent kind in this population" — is never
+    mistaken for a clean "policy tested and did not beat RR-MC"."""
+
+    tau: float
+    witness_absent: tuple[str, ...]
+    per_kind: tuple[KindDominance, ...]
+    reopen: bool
+
+    @property
+    def exercised(self) -> bool:
+        """True iff the population contained at least one witness-absent kind to test on."""
+        return bool(self.witness_absent)
+
+
+def dominance_verdict(
+    rrmc: Mapping[str, ReachRate], policy: Mapping[str, ReachRate], *, tau: float
+) -> DominanceVerdict:
+    """The trigger-#1 verdict from the two arms' per-kind reach-rates (the ``aggregate`` outputs).
+    See :class:`DominanceVerdict`."""
+    wa = witness_absent_kinds(rrmc, tau=tau)
+    per_kind: list[KindDominance] = []
+    for k in wa:
+        rr_hi = rrmc[k].ci_hi
+        p = policy.get(k)
+        if p is None:
+            per_kind.append(
+                KindDominance(k, rr_hi, policy_covered=False, policy_ci_lo=0.0, policy_beats=False)
+            )
+        else:
+            per_kind.append(
+                KindDominance(
+                    k,
+                    rr_hi,
+                    policy_covered=True,
+                    policy_ci_lo=p.ci_lo,
+                    policy_beats=p.ci_lo > rr_hi,
+                )
+            )
+    return DominanceVerdict(
+        tau=tau,
+        witness_absent=tuple(wa),
+        per_kind=tuple(per_kind),
+        reopen=any(kd.policy_beats for kd in per_kind),
+    )
 
 
 # ── sampled population ───────────────────────────────────────────────────────
@@ -312,6 +396,26 @@ def _print_rates(title: str, rates: dict[str, ReachRate]) -> None:
         print(f"  {kind:10}  {r.rate:>10.3f}  {ci:>16}  {r.n:>5}")
 
 
+def _print_dominance(v: DominanceVerdict) -> None:
+    """Print the ADR-0028 trigger-#1 verdict — the masquerade-proof reach-not-beat decision."""
+    print(f"\nADR-0028 trigger #1 — reach-not-beat (witness-absent tau={v.tau})")
+    if not v.exercised:
+        print(
+            "  ⚠ NOT EXERCISED — no witness-absent kind in this population (every kind's RR-MC\n"
+            "    reach-rate CI upper bound exceeds tau). Use a denser/tighter population\n"
+            "    (--hangar <tight fixture> and/or a higher --k-max) to create one."
+        )
+        return
+    print(f"  witness-absent kinds: {', '.join(v.witness_absent)}")
+    print(f"  {'kind':10}  {'RR-MC ci_hi':>12}  {'policy ci_lo':>13}  {'beats?':>7}")
+    for kd in v.per_kind:
+        pol = f"{kd.policy_ci_lo:.3f}" if kd.policy_covered else "(n/a)"
+        beats = "YES" if kd.policy_beats else "no"
+        print(f"  {kd.kind:10}  {kd.rrmc_ci_hi:>12.3f}  {pol:>13}  {beats:>7}")
+    decision = "MET — RE-OPEN ADR-0028 (trigger #1)" if v.reopen else "NOT MET (decision stands)"
+    print(f"  ==> TRIGGER #1: {decision}")
+
+
 def main(argv: Sequence[str] | None = None) -> None:
     p = argparse.ArgumentParser(
         description="Statistical reach-rate harness (#711): reach-rate ± CI over a sampled "
@@ -341,6 +445,18 @@ def main(argv: Sequence[str] | None = None) -> None:
     p.add_argument("--d-model", type=int, default=128)
     p.add_argument("--n-layers", type=int, default=2)
     p.add_argument("--n-heads", type=int, default=4)
+    p.add_argument(
+        "--relative-encoder",
+        action="store_true",
+        help="load the policy with the #827 ego-centric encoder (must match the checkpoint)",
+    )
+    p.add_argument(
+        "--witness-absent-tau",
+        type=float,
+        default=0.15,
+        help="a kind is witness-absent when its RR-MC reach-rate Wilson ci_hi <= tau "
+        "(default: 0.15) — the only kinds on which trigger #1 can be met",
+    )
     args = p.parse_args(argv)
 
     population = sample_population(
@@ -365,6 +481,8 @@ def main(argv: Sequence[str] | None = None) -> None:
     _print_rates(
         f"RR-MC reach-rate (alternatives={args.alternatives}, restarts={args.max_restarts})", rrmc
     )
+    wa = witness_absent_kinds(rrmc, tau=args.witness_absent_tau)
+    print(f"\nwitness-absent kinds (RR-MC ci_hi <= {args.witness_absent_tau}): {wa or '(none)'}")
     if args.policy is not None:
         from ml.eval import load_policy
 
@@ -374,10 +492,12 @@ def main(argv: Sequence[str] | None = None) -> None:
                 "d_model": args.d_model,
                 "n_layers": args.n_layers,
                 "n_heads": args.n_heads,
+                "relative_encoder": args.relative_encoder,
             },
         )
         pol = policy_population_rates(population, policy, samples=args.samples, seed=args.seed)
         _print_rates(f"policy reach-rate ({args.samples} samples/scenario)", pol)
+        _print_dominance(dominance_verdict(rrmc, pol, tau=args.witness_absent_tau))
 
 
 if __name__ == "__main__":

--- a/tests/ml/test_reach_rate.py
+++ b/tests/ml/test_reach_rate.py
@@ -6,13 +6,17 @@ from __future__ import annotations
 import pytest
 
 from ml.reach_rate import (
+    DominanceVerdict,
+    KindDominance,
     ReachRate,
     SampledScenario,
     aggregate,
+    dominance_verdict,
     reach_rate,
     rrmc_reach_multi,
     sample_population,
     wilson_ci,
+    witness_absent_kinds,
 )
 
 # ── pure statistics ──────────────────────────────────────────────────────────
@@ -153,3 +157,107 @@ def test_policy_population_rates_shape():
     assert "overall" in rates
     assert rates["overall"].n == 4  # 2 scenarios × 2 samples
     assert 0.0 <= rates["overall"].rate <= 1.0
+
+
+# ── trigger-#1 dominance gate (ADR-0028 re-open condition #1) ─────────────────
+# Pure decision logic over Wilson CIs — torch-free, no solver. The Wilson math itself is
+# covered by the wilson_ci tests above, so these construct synthetic ReachRates with chosen
+# bounds and assert the *gate* logic: which kinds are witness-absent, and the masquerade-proof
+# CI-non-overlap dominance verdict.
+
+
+def _rr(kind: str, *, ci_lo: float = 0.0, ci_hi: float = 1.0) -> ReachRate:
+    """A synthetic ReachRate whose only meaningful fields are the Wilson bounds the dominance
+    logic keys on; n/reached/rate are filler."""
+    return ReachRate(kind=kind, n=0, reached=0, rate=0.0, ci_lo=ci_lo, ci_hi=ci_hi)
+
+
+def test_witness_absent_kinds_selects_low_rrmc_and_excludes_high():
+    rrmc = {
+        "k2": _rr("k2", ci_hi=0.95),  # RR-MC reaches ⇒ NOT witness-absent
+        "k7": _rr("k7", ci_hi=0.08),  # RR-MC misses ⇒ witness-absent
+    }
+    assert witness_absent_kinds(rrmc, tau=0.1) == ["k7"]
+
+
+def test_witness_absent_kinds_excludes_overall_pool_row():
+    rrmc = {"overall": _rr("overall", ci_hi=0.05), "k7": _rr("k7", ci_hi=0.05)}
+    assert witness_absent_kinds(rrmc, tau=0.1) == ["k7"]  # the pooled row is never a kind
+
+
+def test_witness_absent_kinds_is_sorted():
+    rrmc = {k: _rr(k, ci_hi=0.05) for k in ("k9", "k3", "k7")}
+    assert witness_absent_kinds(rrmc, tau=0.1) == ["k3", "k7", "k9"]
+
+
+def test_witness_absent_kinds_boundary_is_inclusive():
+    rrmc = {"k7": _rr("k7", ci_hi=0.10)}
+    assert witness_absent_kinds(rrmc, tau=0.10) == ["k7"]  # ci_hi == tau ⇒ included
+
+
+def test_witness_absent_kinds_rejects_bad_tau():
+    with pytest.raises(ValueError, match="tau"):
+        witness_absent_kinds({}, tau=1.5)
+
+
+def test_dominance_verdict_reopens_when_policy_ci_clears_rrmc():
+    rrmc = {"k7": _rr("k7", ci_hi=0.08)}
+    policy = {"k7": _rr("k7", ci_lo=0.20)}  # 0.20 > 0.08 ⇒ CI non-overlap ⇒ beats
+    v = dominance_verdict(rrmc, policy, tau=0.1)
+    assert v.reopen is True
+    assert v.exercised is True
+    assert v.witness_absent == ("k7",)
+    (kd,) = v.per_kind
+    assert kd.policy_beats is True
+
+
+def test_dominance_verdict_no_reopen_on_ci_overlap():
+    # Masquerade-proof: the policy POINT estimate could be higher, but overlapping CIs don't trip.
+    rrmc = {"k7": _rr("k7", ci_hi=0.30)}
+    policy = {"k7": _rr("k7", ci_lo=0.25)}  # 0.25 is NOT > 0.30
+    v = dominance_verdict(rrmc, policy, tau=0.35)
+    assert v.reopen is False
+    assert v.exercised is True
+    assert v.per_kind[0].policy_beats is False
+
+
+def test_dominance_verdict_ignores_kinds_rrmc_already_reaches():
+    # A kind RR-MC reaches (not witness-absent) is excluded even if the policy "beats" there:
+    # reaching what the solver already reaches is not the charter.
+    rrmc = {"k2": _rr("k2", ci_hi=0.90)}
+    policy = {"k2": _rr("k2", ci_lo=0.99)}
+    v = dominance_verdict(rrmc, policy, tau=0.1)
+    assert v.exercised is False  # no witness-absent kind ⇒ gate not exercised
+    assert v.reopen is False
+    assert v.witness_absent == ()
+
+
+def test_dominance_verdict_missing_policy_kind_counts_as_no_evidence():
+    rrmc = {"k7": _rr("k7", ci_hi=0.05)}
+    policy: dict[str, ReachRate] = {}  # policy arm never covered k7
+    v = dominance_verdict(rrmc, policy, tau=0.1)
+    assert v.exercised is True
+    assert v.reopen is False
+    kd = v.per_kind[0]
+    assert kd.policy_covered is False
+    assert kd.policy_beats is False
+
+
+def test_dominance_verdict_not_exercised_distinct_from_not_met():
+    # Empty population ⇒ NOT exercised (vacuous), which must not masquerade as a clean negative.
+    v = dominance_verdict({}, {}, tau=0.1)
+    assert v.exercised is False
+    assert v.reopen is False
+
+
+def test_dominance_verdict_rejects_bad_tau():
+    with pytest.raises(ValueError, match="tau"):
+        dominance_verdict({}, {}, tau=-0.1)
+
+
+def test_dominance_verdict_types():
+    rrmc = {"k7": _rr("k7", ci_hi=0.05)}
+    policy = {"k7": _rr("k7", ci_lo=0.5)}
+    v = dominance_verdict(rrmc, policy, tau=0.1)
+    assert isinstance(v, DominanceVerdict)
+    assert all(isinstance(kd, KindDominance) for kd in v.per_kind)


### PR DESCRIPTION
## What & why

[ADR-0028](docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md) banked the dense
train-to-mastery chase but kept a **falsifiable re-open gate**. Its **trigger #1** — *a future
policy's dense-notch reach-rate (Wilson CI) exceeds RR-MC's on a **witness-absent** scenario-kind*
— is the masquerade-proof charter test, but the harness meant to run it (`ml/reach_rate.py`, #711)
only sampled a roomy population where RR-MC reaches everything and left the decision to a human
eyeballing two tables. **This makes the re-open test runnable** (open #690 scope-item-1).

## Change (pure decision logic — no training, no solver/determinism code)

`ml/reach_rate.py`:
- `witness_absent_kinds(rrmc, *, tau)` — kinds RR-MC genuinely misses (Wilson `ci_hi <= tau`).
- `dominance_verdict(rrmc, policy, *, tau)` — the trigger-#1 predicate as one boolean, requiring
  Wilson-CI **non-overlap** (`policy.ci_lo > rrmc.ci_hi`) so a policy matching RR-MC by sampling
  luck can't trip it; reports `exercised` separately from `reopen` so a vacuous "no witness-absent
  kind" negative never masquerades as a clean one.
- CLI `--witness-absent-tau` / `--relative-encoder` + a `_print_dominance` PASS/NOT-MET/NOT-EXERCISED
  printer.
- 12 new torch-free unit tests (CI-overlap, boundary `ci_hi == tau`, missing-policy-kind,
  not-exercised-vs-not-met, NaN-tau).

## Result — the gate, executed for the first time (NOT MET)

On the witness-absent **k8** over-capacity stratum (9 distinct subsets on the tight 18 m hangar):

| arm | reach | Wilson |
|---|---|---|
| RR-MC (fair budget: alt=4, restarts=16) | **0 / 9** | ci_hi **0.30** |
| policy — all 6 trained checkpoints (control / ego / backplay × 2 seeds) | **0 / 108** | ci_lo **0.000** |

`policy.ci_lo 0.000` cannot clear `rrmc.ci_hi 0.30` → **TRIGGER #1: NOT MET** on every checkpoint.
The trigger stays **open** for a future policy; no current one trips it because the policies'
competence regime (≤3-aircraft rungs) and RR-MC's miss regime (over-capacity dense) are **disjoint**.
Recorded in `ml/README.md` and a note under ADR-0028 trigger #1.

## Verification

- 28 `tests/ml/test_reach_rate.py` green (12 new); `ruff` + `ruff format` clean; `mypy ml/` clean (21 files).
- Review arc clean — **code-reviewer** (no findings ≥80), **ml-rl-guard** (PASS all 5 RL invariants:
  product-checker validity intact, both new flags default-neutral, no nondeterminism, loud `_check_tau`),
  **silent-failure-hunter** (no silent failures — vacuous/no-evidence/untested negatives each distinctly
  observable, NaN-tau caught). Comment-analyzer on the docs to follow.
- No `CHANGELOG` entry: `ml/` is dev/CI-only (never shipped in the wheel), consistent with #711.

Closes #831. Refs #690 (sub-project #4c, scope-item-1), epic #607, ADR-0028 (re-open trigger #1).
