### PR TITLE
reach_rate: opt-in --distinct population to avoid RR-MC pseudo-replication at high k

### DIFF
--- a/ml/README.md
+++ b/ml/README.md
@@ -159,6 +159,12 @@ the env oracle's parked-score validity.
 - **Population (v1):** `sample_population` draws fill scenarios that vary the **fleet subset**
   (`k ∈ [k_min, k_max]` aircraft from a pool) on a fixed roomy hangar, deterministic in `seed`.
   Varying hangar geometry / GO placements (the issue's other axes) is a documented extension.
+- **`--distinct` (avoid pseudo-replication):** by default the sampler draws each subset
+  independently, so it can repeat one. RR-MC reach is **deterministic** per subset, so a repeated
+  subset is **not** an independent trial — counting it inflates `n` and tightens the Wilson CI for
+  free. `--distinct` draws guaranteed-distinct subsets and **caps** the population at the available
+  distinct count (printing `[distinct: capped from N to M …]`). It matters at high `k` / over-
+  capacity, where the distinct space is tiny (e.g. `C(9, 8) = 9`). Default off → byte-identical.
 - **Multi-alternative RR-MC:** `rrmc_reach_multi` solves for `--alternatives N` and counts
   RR-MC-reached if **any** candidate is valid + fully routable — strictly stronger than
   `benchmark.rrmc_reach` (`alternatives=1`, best-spread only). Load-bearing the moment the

--- a/ml/README.md
+++ b/ml/README.md
@@ -163,8 +163,9 @@ the env oracle's parked-score validity.
   independently, so it can repeat one. RR-MC reach is **deterministic** per subset, so a repeated
   subset is **not** an independent trial — counting it inflates `n` and tightens the Wilson CI for
   free. `--distinct` draws guaranteed-distinct subsets and **caps** the population at the available
-  distinct count (printing `[distinct: capped from N to M …]`). It matters at high `k` / over-
-  capacity, where the distinct space is tiny (e.g. `C(9, 8) = 9`). Default off → byte-identical.
+  distinct count (printing `[distinct: capped from N to M …]`). Capping triggers whenever the
+  request exceeds the available distinct count — most acute at high `k` relative to the pool, where
+  the distinct space is tiny (e.g. `C(9, 8) = 9`). Default off → byte-identical.
 - **Multi-alternative RR-MC:** `rrmc_reach_multi` solves for `--alternatives N` and counts
   RR-MC-reached if **any** candidate is valid + fully routable — strictly stronger than
   `benchmark.rrmc_reach` (`alternatives=1`, best-spread only). Load-bearing the moment the

--- a/ml/reach_rate.py
+++ b/ml/reach_rate.py
@@ -34,6 +34,7 @@ import math
 import random
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
+from itertools import combinations
 from pathlib import Path
 
 from hangarfit.loader import load_fleet, load_hangar
@@ -120,11 +121,20 @@ def sample_population(
     seed: int,
     fleet_path: str = "data/fleet.yaml",
     hangar_path: str = "tests/fixtures/test_hangar_large.yaml",
+    distinct: bool = False,
 ) -> list[SampledScenario]:
     """Sample ``n`` aircraft-subset fill scenarios on a fixed hangar — the reach-rate
     population. Each draws ``k ∈ [k_min, k_max]`` aircraft from the fleet pool (no ground
     objects, no maintenance, no pins). Deterministic in ``seed`` (its sole RNG), so the
-    population — and thus the baseline — is reproducible."""
+    population — and thus the baseline — is reproducible.
+
+    When ``distinct`` is True, the members are guaranteed-distinct ``(k, subset)`` pairs and the
+    population is **capped** at the number of available distinct subsets across ``[k_min, k_max]``
+    (a request for more returns *fewer*, never duplicates). This matters at high ``k`` / over-
+    capacity, where the distinct-subset space is small (e.g. ``C(9, 8) = 9``): RR-MC reach is
+    deterministic per subset, so a duplicate subset is **not** an independent trial, and counting
+    it would inflate ``n`` and tighten the Wilson CI without new information (pseudo-replication).
+    Default ``False`` preserves the independent-draw behaviour byte-for-byte."""
     if not 1 <= k_min <= k_max:
         raise ValueError(f"sample_population: need 1 <= k_min <= k_max, got {k_min}, {k_max}")
     fleet = load_fleet(str(_ROOT / fleet_path))
@@ -133,11 +143,9 @@ def sample_population(
     if k_max > len(pool):
         raise ValueError(f"sample_population: k_max {k_max} exceeds fleet pool size {len(pool)}")
     rng = random.Random(seed)
-    out: list[SampledScenario] = []
-    for i in range(n):
-        k = rng.randint(k_min, k_max)
-        subset = tuple(sorted(rng.sample(pool, k)))
-        sc = Scenario(
+
+    def _scenario(subset: tuple[str, ...]) -> Scenario:
+        return Scenario(
             fleet=fleet,
             hangar=hangar,
             fleet_in=subset,
@@ -145,7 +153,27 @@ def sample_population(
             ground_object_defs={},
             region_preferences={},
         )
-        out.append(SampledScenario(name=f"sample{i:03d}_k{k}", kind=f"k{k}", scenario=sc))
+
+    if distinct:
+        # Enumerate the distinct-subset universe, deterministically shuffle, take min(n, available).
+        universe = [
+            tuple(subset) for k in range(k_min, k_max + 1) for subset in combinations(pool, k)
+        ]
+        rng.shuffle(universe)
+        return [
+            SampledScenario(
+                name=f"sample{i:03d}_k{len(s)}", kind=f"k{len(s)}", scenario=_scenario(s)
+            )
+            for i, s in enumerate(universe[:n])
+        ]
+
+    out: list[SampledScenario] = []
+    for i in range(n):
+        k = rng.randint(k_min, k_max)
+        subset = tuple(sorted(rng.sample(pool, k)))
+        out.append(
+            SampledScenario(name=f"sample{i:03d}_k{k}", kind=f"k{k}", scenario=_scenario(subset))
+        )
     return out
 
 
@@ -320,6 +348,12 @@ def main(argv: Sequence[str] | None = None) -> None:
     p.add_argument("--scenarios", type=int, default=8, help="population size N (default: 8)")
     p.add_argument("--k-min", type=int, default=2, help="min aircraft per scenario (default: 2)")
     p.add_argument("--k-max", type=int, default=4, help="max aircraft per scenario (default: 4)")
+    p.add_argument(
+        "--distinct",
+        action="store_true",
+        help="draw DISTINCT fleet subsets and cap N at the available distinct count — avoids "
+        "RR-MC pseudo-replication at high k / few distinct subsets (e.g. C(9,8)=9)",
+    )
     p.add_argument("--seed", type=int, default=0, help="population + RR-MC seed (default: 0)")
     p.add_argument("--alternatives", type=int, default=4, help="RR-MC alternatives (default: 4)")
     p.add_argument("--max-restarts", type=int, default=16, help="RR-MC restarts (default: 16)")
@@ -350,10 +384,17 @@ def main(argv: Sequence[str] | None = None) -> None:
         seed=args.seed,
         fleet_path=args.fleet,
         hangar_path=args.hangar,
+        distinct=args.distinct,
     )
+    capped = args.distinct and len(population) < args.scenarios
     print(
         f"population: {len(population)} fill scenarios (k {args.k_min}..{args.k_max}) on "
         f"{args.hangar}, seed {args.seed}"
+        + (
+            f" [distinct: capped from {args.scenarios} to the {len(population)} available subsets]"
+            if capped
+            else (" [distinct]" if args.distinct else "")
+        )
     )
     rrmc = rrmc_population_rates(
         population,

--- a/ml/reach_rate.py
+++ b/ml/reach_rate.py
@@ -130,10 +130,11 @@ def sample_population(
 
     When ``distinct`` is True, the members are guaranteed-distinct ``(k, subset)`` pairs and the
     population is **capped** at the number of available distinct subsets across ``[k_min, k_max]``
-    (a request for more returns *fewer*, never duplicates). This matters at high ``k`` / over-
-    capacity, where the distinct-subset space is small (e.g. ``C(9, 8) = 9``): RR-MC reach is
-    deterministic per subset, so a duplicate subset is **not** an independent trial, and counting
-    it would inflate ``n`` and tighten the Wilson CI without new information (pseudo-replication).
+    (a request for more returns *fewer*, never duplicates). Capping triggers whenever ``n`` exceeds
+    the available distinct count — most acute at high ``k`` relative to the pool, where the
+    distinct-subset space is small (e.g. ``C(9, 8) = 9``): RR-MC reach is deterministic per subset,
+    so a duplicate subset is **not** an independent trial, and counting it would inflate ``n`` and
+    tighten the Wilson CI without new information (pseudo-replication).
     Default ``False`` preserves the independent-draw behaviour byte-for-byte."""
     if not 1 <= k_min <= k_max:
         raise ValueError(f"sample_population: need 1 <= k_min <= k_max, got {k_min}, {k_max}")

--- a/tests/ml/test_reach_rate.py
+++ b/tests/ml/test_reach_rate.py
@@ -105,6 +105,46 @@ def test_sample_population_rejects_k_over_pool():
         sample_population(n=1, k_min=2, k_max=999, seed=0)
 
 
+def _subset_keys(pop):
+    return [(s.kind, tuple(s.scenario.fleet_in)) for s in pop]
+
+
+def test_sample_population_distinct_has_no_duplicate_subsets():
+    # distinct=True guarantees each (kind, subset) appears at most once — RR-MC is deterministic,
+    # so duplicate subsets are not independent trials (pseudo-replication).
+    pop = sample_population(n=30, k_min=2, k_max=4, seed=0, distinct=True)
+    keys = _subset_keys(pop)
+    assert len(keys) == len(set(keys))
+
+
+def test_sample_population_distinct_caps_at_available():
+    # Only C(9,8)=9 distinct k8 subsets exist; a request for more is capped, not padded with dups.
+    pop = sample_population(n=50, k_min=8, k_max=8, seed=0, distinct=True)
+    keys = _subset_keys(pop)
+    assert len(pop) == 9
+    assert len(keys) == len(set(keys))
+
+
+def test_sample_population_distinct_is_deterministic_in_seed():
+    a = sample_population(n=12, k_min=2, k_max=4, seed=5, distinct=True)
+    b = sample_population(n=12, k_min=2, k_max=4, seed=5, distinct=True)
+    assert [s.name for s in a] == [s.name for s in b]
+    assert _subset_keys(a) == _subset_keys(b)
+
+
+def test_sample_population_distinct_varies_with_seed():
+    a = _subset_keys(sample_population(n=10, k_min=2, k_max=4, seed=1, distinct=True))
+    b = _subset_keys(sample_population(n=10, k_min=2, k_max=4, seed=2, distinct=True))
+    assert a != b  # n < available ⇒ a different seeded draw selects different subsets
+
+
+def test_sample_population_default_is_unchanged_and_can_repeat():
+    # Default (distinct=False) is byte-identical to today: returns exactly n even where the
+    # distinct space is smaller (here 9 distinct k8 subsets, but n=20 is honored).
+    pop = sample_population(n=20, k_min=8, k_max=8, seed=0)
+    assert len(pop) == 20
+
+
 # ── multi-alternative RR-MC ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

`ml/reach_rate.sample_population` draws each scenario's fleet subset independently
(`rng.sample(pool, k)`), so it can return **duplicate subsets**. RR-MC reach is **deterministic**
given a subset, so two identical subsets are **not independent trials** — counting both inflates
`n` and tightens the Wilson CI without new information (**pseudo-replication**), *silently*.

This bites exactly the regime the trigger-#1 dominance gate (#831 / PR #832) needs: a
**witness-absent** population is high-`k` / over-capacity, where the distinct-subset space is tiny
(e.g. `C(9, 8) = 9`). Until now the only statistically-honest way to run it was to enumerate
distinct subsets by hand.

## Change (opt-in, default byte-identical)

- `sample_population(..., distinct: bool = False)` — when True, enumerate the distinct-subset
  universe across `[k_min, k_max]`, deterministically shuffle (seeded), take `min(n, available)`:
  guaranteed-distinct members, population **capped** at the available distinct count (a request for
  more returns *fewer*, never duplicates).
- CLI `--distinct`, with an honest `population: … [distinct: capped from N to M available subsets]`
  print.
- Default `False` preserves the independent-draw behaviour **byte-for-byte** (existing determinism
  tests untouched).

```
$ python -m ml.reach_rate --k-min 8 --k-max 8 --scenarios 50 --distinct --hangar <tight>
population: 9 fill scenarios (k 8..8) on … [distinct: capped from 50 to the 9 available subsets]
  k8    0.000   [0.00, 0.30]   9     # n=9, not a pseudo-replicated 50
```

## Verification

- 6 new unit tests (no duplicate subsets; caps at available; deterministic in seed; varies with
  seed; default unchanged + can repeat). `tests/ml/test_reach_rate.py` 21 passed.
- `ruff` + `ruff format` + `mypy ml/` clean.
- No `CHANGELOG` entry — `ml/` is dev/CI-only.

Closes #833. Refs #831 (the trigger-#1 gate this de-foot-guns), #711, epic #607.
