### PR TITLE
Completion paired-witness diagnostic probe — code (ADR-0028 trigger-#3)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-completion-paired-witness-probe.md
+++ b/docs/superpowers/plans/2026-06-25-completion-paired-witness-probe.md
@@ -1,0 +1,559 @@
+# Completion Paired-Witness Diagnostic Probe — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decide one bit — is the learned-backend cold-start completion wall the door→interior *drive* (learning capacity) or the *slot sparsity* (geometry)? — via one paired door-spawn training run that holds the drive fixed and toggles only the manifold width.
+
+**Architecture:** Add two opt-in single-rung "completion" curriculum stages (pre-park k=N−1=2 of a valid 3-object witness, drive the last object in from the door at φ=1, no backplay knob): one on the tight Herrenteich notch (`witness_notch.yaml`, conditional last-slot ~0.064), one on a new roomy witness (`witness_roomy.yaml` on the 25×30 m `test_hangar_large.yaml`, ~0.278). A `--completion-probe {notch,roomy}` flag trains exactly one stage from a fresh policy. The decision metric is **marginal completion** read from the existing `--metrics-out` JSONL via the floor-aware transform `max(0, 3·valid_placed − 2)`. No `ml/env.py` / `ml/reward.py` / `ml/action_space.py` / `ml/encoding.py` changes.
+
+**Tech Stack:** Python 3.12, PyTorch (the `[train]` extra), the `ml/` dev/CI-only RL workspace, `hangarfit` CLI (`solve`/`check`), pytest.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-25-learned-backend-completion-paired-witness-probe-design.md` — every requirement there is in force.
+- **Determinism / default-neutrality (ml-rl-guard):** the new flag MUST default off; absent `--completion-probe`, every existing ladder is **byte-identical** to before. No change to the action table, `SCHEMA_VERSION`, env reset distribution, or reward emission.
+- **Feasibility-first (the #832/#835 lesson):** the roomy arm is invalid as evidence unless `witness_roomy.yaml` is `hangarfit check`-VERIFIED valid and a k-prefix of a valid layout (any prefix of a valid layout is valid by construction).
+- **Metric is MARGINAL, never aggregate:** read `valid_placed` only through the floor-aware transform against the pre-registered (N−1)/N = 2/3 null. A place-nothing completion reads 2/3, not 0.
+- **No env/reward/encoding code:** witness fixture + curriculum stages + CLI flag + an analysis helper only.
+- **`ml/` is a top-level package outside `src/`:** run from repo root (`cwd=root` or `PYTHONPATH=$PWD`). In a worktree, use `PYTHONPATH=$PWD/src python -m …` (the editable `.pth` points at the main checkout).
+- **GitFlow:** issue-driven; PR-1 (code) lands and merges before the run; PR-2 records the verdict. Never commit to `develop` directly; never `--no-verify`/force.
+- **Roomy arm fixtures use** `tests/fixtures/test_hangar_large.yaml` (25 w × 30 l, clearance 0.3) + `data/fleet.yaml`. Tight arm reuses `examples/herrenteich/hangar.yaml` + `examples/herrenteich/fleet.yaml` at clearance 0.05 (the existing notch manifold — the measured 0.000 wall). The clearance differs by arm *on purpose*: the controlled variable is the resulting conditional last-slot probability (the manifold), confirmed in Task 1.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `tests/fixtures/ml/witness_roomy.yaml` | **Create.** Bare `placements:` (3 objects) — a valid k=3 layout on `test_hangar_large.yaml`. | T1 |
+| `tests/fixtures/ml/scenario_roomy.yaml` | **Create.** Solve scenario used to author the roomy witness (reproducible/auditable). | T1 |
+| `tests/ml/test_stage_builder.py` | **Modify.** Add `test_witness_roomy_*` validity-pin tests mirroring the notch ones. | T1 |
+| `ml/curriculum.py` | **Modify.** Add roomy path constants + `_completion_stage(witness)` builder. | T2 |
+| `tests/ml/test_curriculum.py` (or the curriculum test module) | **Modify.** Stage-config + default-neutrality tests. | T2, T3 |
+| `ml/train.py` | **Modify.** Add `--completion-probe {notch,roomy}` → single-rung schedule. | T3 |
+| `ml/probe_metric.py` | **Create.** `marginal_completion()` floor-aware transform. | T4 |
+| `tests/ml/test_probe_metric.py` | **Create.** Unit test for the transform. | T4 |
+| `ml/README.md` | **Modify.** Lever-ledger placeholder row for the pending probe (PR-1); verdict (PR-2). | T5, T7 |
+| `docs/adr/0028-...md` | **Modify (PR-2).** Re-open-trigger ledger: record the bit. | T7 |
+
+---
+
+## Task 1: Author + validity-pin the roomy witness
+
+**Files:**
+- Create: `tests/fixtures/ml/scenario_roomy.yaml`, `tests/fixtures/ml/witness_roomy.yaml`
+- Modify: `tests/ml/test_stage_builder.py`
+- Test: `tests/ml/test_stage_builder.py::test_witness_roomy_*`
+
+**Interfaces:**
+- Produces: `tests/fixtures/ml/witness_roomy.yaml` — a bare `placements:` list of 3 objects, valid on `test_hangar_large.yaml` + `data/fleet.yaml` at clearance 0.3, every prefix valid. Consumed by T2's `_completion_stage("roomy")` via `anchor_layout_path`.
+
+- [ ] **Step 1: Write the failing validity-pin tests.** In `tests/ml/test_stage_builder.py`, mirror the existing `test_witness_notch_*` block (read it first, lines ~156–202). Add:
+
+```python
+def _load_witness_roomy(clearance_m: float = 0.3):
+    """Load the committed roomy witness against the roomy completion rung's hangar
+    (test_hangar_large, clearance override) + the synthetic box fleet — the same hangar/fleet
+    the completion-roomy probe trains on (ADR-0028 trigger-#3 paired probe)."""
+    hangar = dataclasses.replace(
+        load_hangar("tests/fixtures/test_hangar_large.yaml"),
+        clearance_m=clearance_m,
+        apron_depth_m=8.0,
+    )
+    fleet = load_fleet("data/fleet.yaml")
+    return load_layout("tests/fixtures/ml/witness_roomy.yaml", fleet=fleet, hangar=hangar)
+
+
+def test_witness_roomy_is_a_valid_three_object_layout():
+    lay = _load_witness_roomy()
+    assert len(lay.placements) == 3
+    assert go.layout_valid(lay)
+
+
+def test_witness_roomy_every_prefix_is_valid():
+    lay = _load_witness_roomy()
+    for k in range(len(lay.placements) + 1):
+        prefix = dataclasses.replace(lay, placements=lay.placements[:k])
+        assert go.layout_valid(prefix), f"roomy witness prefix k={k} is invalid"
+
+
+def test_witness_roomy_every_single_anchor_is_valid():
+    lay = _load_witness_roomy()
+    for i in range(len(lay.placements)):
+        single = dataclasses.replace(lay, placements=(lay.placements[i],))
+        assert go.layout_valid(single), f"single anchor #{i} ({lay.placements[i].plane_id}) invalid"
+
+
+def test_witness_roomy_has_margin_at_stricter_clearance():
+    # Roomy slack: still valid at a stricter 0.5 m clearance, so the trio has real geometric
+    # margin at the rung's 0.3 m (the fat-slot manifold is not a borderline graze).
+    assert go.layout_valid(_load_witness_roomy(clearance_m=0.5))
+```
+
+- [ ] **Step 2: Run the tests; verify they fail (fixture absent).**
+
+Run: `pytest tests/ml/test_stage_builder.py -k witness_roomy -v`
+Expected: FAIL — `LoaderError`/file-not-found on `witness_roomy.yaml`.
+
+- [ ] **Step 3: Author the solve scenario.** Read `tests/fixtures/scenario_minimal.yaml` to confirm the scenario schema, then create `tests/fixtures/ml/scenario_roomy.yaml` selecting **three small `data/fleet.yaml` aircraft** (e.g. `fuji`, `cessna_150`, `aviat_husky` — pick three that the fleet defines and that fit comfortably) on the large test hangar:
+
+```yaml
+# Solve scenario used to AUTHOR tests/fixtures/ml/witness_roomy.yaml (ADR-0028 trigger-#3).
+# A roomy 3-object fill on the 25x30 test hangar: produces the fat-conditional-last-slot
+# witness (the paired probe's roomy arm). Reproducible/auditable per the spec's default.
+fleet: ../../../data/fleet.yaml
+hangar: ../test_hangar_large.yaml
+planes: [fuji, cessna_150, aviat_husky]
+```
+
+(Adjust the `planes:` ids to three the fleet actually defines; confirm with `python -c "from hangarfit.loader import load_fleet; print(list(load_fleet('data/fleet.yaml').planes))"`. Match the scenario key names to `scenario_minimal.yaml` exactly.)
+
+- [ ] **Step 4: Solve → write layout → check VALID.**
+
+```bash
+hangarfit solve tests/fixtures/ml/scenario_roomy.yaml --write-yaml /tmp/claude-1000/-home-pkuhn-hangarfit/bc5a17c0-b276-47e0-8338-44c16929904d/scratchpad/roomy.yaml
+hangarfit check /tmp/claude-1000/-home-pkuhn-hangarfit/bc5a17c0-b276-47e0-8338-44c16929904d/scratchpad/roomy.yaml --render /tmp/claude-1000/-home-pkuhn-hangarfit/bc5a17c0-b276-47e0-8338-44c16929904d/scratchpad/roomy.png; echo "check exit=$?"
+```
+Expected: `hangarfit check` prints `VALID` and `check exit=0`. If solve reports trivial-infeasible or check exits 1, widen the plane choice / re-run; the 25×30 hangar fits 3 small aircraft comfortably.
+
+- [ ] **Step 5: Strip fleet/hangar keys → bare witness.** `solve --write-yaml` emits `fleet:`/`hangar:`/`placements:`; the witness loader **rejects** a file that sets `fleet:`/`hangar:` AND takes overrides. Create `tests/fixtures/ml/witness_roomy.yaml` with ONLY the `placements:` block (drop `on_carts` if all `false`, matching `witness_notch.yaml`), plus a header comment mirroring `witness_notch.yaml`'s provenance note:
+
+```yaml
+# Committed seed-anchor witness for the ADR-0028 trigger-#3 completion-roomy probe rung.
+#
+# A VALID 3-object layout on the roomy 25x30 test hangar (tests/fixtures/test_hangar_large.yaml),
+# produced by `hangarfit solve tests/fixtures/ml/scenario_roomy.yaml` and verified by
+# `hangarfit check` (exit 0). The paired completion probe pre-parks a k=2 prefix and drives the
+# last object in from the door (phi=1); the fat conditional last-slot (~0.278, vs the notch's
+# ~0.064) is the manifold-width arm. A k-prefix of a valid layout is itself valid, so the
+# pre-parked 2-prefix is feasibility-clean with NO runtime solver call. Validity pinned by
+# tests/ml/test_stage_builder.py::test_witness_roomy_*. Do not hand-edit poses without re-running.
+#
+# No `fleet:`/`hangar:` fields on purpose: the env + stage_builder load this with fleet=/hangar=
+# OVERRIDES (test_hangar_large at clearance 0.3 + data/fleet.yaml), and the loader rejects a file
+# that sets those AND takes overrides.
+placements:
+  - {plane: <id1>, x_m: <x>, y_m: <y>, heading_deg: <h>}
+  - {plane: <id2>, x_m: <x>, y_m: <y>, heading_deg: <h>}
+  - {plane: <id3>, x_m: <x>, y_m: <y>, heading_deg: <h>}
+```
+(Fill `<...>` from the solved `/tmp/.../roomy.yaml`.)
+
+- [ ] **Step 6: Run the validity-pin tests; verify they pass.**
+
+Run: `pytest tests/ml/test_stage_builder.py -k witness_roomy -v`
+Expected: 4 PASS.
+
+- [ ] **Step 7: Manifold-contrast sanity check (record, don't commit a flaky test).** Write a throwaway script in the scratchpad that MC-samples the 3rd object's pose (uniform over in-bounds x,y and 8 headings) given the committed 2-prefix, for BOTH witnesses, and prints the valid fraction (conditional last-slot P). Confirm roomy ≫ notch (target ≥ 3×). Record both numbers in the PR-1 body. This proves the controlled variable (manifold width) is real on the *actual* committed prefixes, not just the session estimate.
+
+```bash
+PYTHONPATH=$PWD python /tmp/claude-1000/-home-pkuhn-hangarfit/bc5a17c0-b276-47e0-8338-44c16929904d/scratchpad/manifold_contrast.py
+# Expected stdout, e.g.:  notch cond-last-slot ~0.06 (N=20000) | roomy ~0.28 | ratio ~4.4x
+```
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add tests/fixtures/ml/witness_roomy.yaml tests/fixtures/ml/scenario_roomy.yaml tests/ml/test_stage_builder.py
+git commit -m "test(607): roomy completion witness + validity pins (ADR-0028 trigger-#3 probe)"
+```
+
+---
+
+## Task 2: Two completion stages + curriculum config tests
+
+**Files:**
+- Modify: `ml/curriculum.py`
+- Test: the curriculum test module (find it: `tests/ml/test_curriculum.py` or wherever `Stage`/ladder builders are tested)
+
+**Interfaces:**
+- Consumes: `_NOTCH_HANGAR`, `_NOTCH_FLEET`, `_WITNESS_NOTCH`, `_LENIENT_CLEARANCE` (existing in `ml/curriculum.py`).
+- Produces: `_completion_stage(witness: str) -> Stage` — `witness ∈ {"notch","roomy"}`; both `max_objects=3, seed_anchor_k=2, per_object_step_budget=80, total_step_budget=80`, **no** `backplay_phi_cap` (door spawn, φ=1). Stage names `"completion-notch"` / `"completion-roomy"`. Consumed by T3's CLI wiring.
+
+- [ ] **Step 1: Write the failing stage-config test.** In the curriculum test module, add:
+
+```python
+def test_completion_stage_notch_is_door_spawn_drive_one():
+    from ml.curriculum import _completion_stage
+    s = _completion_stage("notch")
+    assert s.name == "completion-notch"
+    assert s.difficulty.max_objects == 3
+    assert s.difficulty.seed_anchor_k == 2            # pre-park 2, drive 1
+    assert s.difficulty.backplay_phi_cap is None      # door spawn (phi=1), no backplay mixture
+    assert s.difficulty.anchor_prob is None           # fixed-k, not mixed-start
+    assert s.anchor_layout_path == "tests/fixtures/ml/witness_notch.yaml"
+    assert s.hangar_path == "examples/herrenteich/hangar.yaml"
+    assert s.clearance_m == 0.05
+
+
+def test_completion_stage_roomy_uses_large_hangar_and_roomy_witness():
+    from ml.curriculum import _completion_stage
+    s = _completion_stage("roomy")
+    assert s.name == "completion-roomy"
+    assert s.difficulty.max_objects == 3
+    assert s.difficulty.seed_anchor_k == 2
+    assert s.difficulty.backplay_phi_cap is None
+    assert s.anchor_layout_path == "tests/fixtures/ml/witness_roomy.yaml"
+    assert s.hangar_path == "tests/fixtures/test_hangar_large.yaml"
+    assert s.fleet_path == "data/fleet.yaml"
+    assert s.clearance_m == 0.3
+
+
+def test_completion_stage_rejects_unknown_witness():
+    import pytest
+    from ml.curriculum import _completion_stage
+    with pytest.raises(ValueError):
+        _completion_stage("bogus")
+```
+
+- [ ] **Step 2: Run; verify fail.**
+
+Run: `pytest <curriculum_test_module> -k completion_stage -v`
+Expected: FAIL — `cannot import name '_completion_stage'`.
+
+- [ ] **Step 3: Implement the stage builder + constants.** In `ml/curriculum.py`, near the existing notch constants (after `_LENIENT_CLEARANCE`), add:
+
+```python
+# ADR-0028 trigger-#3 completion paired-witness probe (opt-in via --completion-probe; NOT in any
+# default ladder, so absent the flag the env is byte-identical). The ROOMY arm's hangar/fleet:
+_ROOMY_HANGAR = "tests/fixtures/test_hangar_large.yaml"
+_ROOMY_FLEET = "data/fleet.yaml"
+# Committed roomy completion witness (a valid 3-object fill on the 25x30 test hangar). Validity
+# pinned by tests/ml/test_stage_builder.py::test_witness_roomy_*.
+_WITNESS_ROOMY = "tests/fixtures/ml/witness_roomy.yaml"
+_ROOMY_CLEARANCE = 0.3  # the test_hangar_large file value; the roomy slot is the controlled var
+
+
+def _completion_stage(witness: str) -> Stage:
+    """A single door-spawn COMPLETION rung for the ADR-0028 trigger-#3 paired probe: pre-park
+    k=N-1=2 of a valid 3-object witness and drive the LAST object in from the door (phi=1, NO
+    backplay knob). ``witness`` selects the manifold arm — 'notch' (tight Herrenteich notch,
+    conditional last-slot ~0.064, the measured 0.000 wall) or 'roomy' (the fat 25x30 hangar,
+    ~0.278). The arms differ ONLY in hangar/fleet/witness/clearance; manifold width is the
+    controlled variable. Opt-in (built only by --completion-probe); no default ladder includes
+    it, so the env stays byte-identical when the flag is absent."""
+    if witness == "notch":
+        return Stage(
+            name="completion-notch",
+            difficulty=DifficultyConfig(
+                max_objects=3, seed_anchor_k=2, per_object_step_budget=80, total_step_budget=80
+            ),
+            hangar_path=_NOTCH_HANGAR,
+            fleet_path=_NOTCH_FLEET,
+            anchor_layout_path=_WITNESS_NOTCH,
+            clearance_m=_LENIENT_CLEARANCE,
+        )
+    if witness == "roomy":
+        return Stage(
+            name="completion-roomy",
+            difficulty=DifficultyConfig(
+                max_objects=3, seed_anchor_k=2, per_object_step_budget=80, total_step_budget=80
+            ),
+            hangar_path=_ROOMY_HANGAR,
+            fleet_path=_ROOMY_FLEET,
+            anchor_layout_path=_WITNESS_ROOMY,
+            clearance_m=_ROOMY_CLEARANCE,
+        )
+    raise ValueError(f"_completion_stage: unknown witness {witness!r} (expected 'notch'|'roomy')")
+```
+
+- [ ] **Step 4: Run; verify pass.**
+
+Run: `pytest <curriculum_test_module> -k completion_stage -v`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add ml/curriculum.py <curriculum_test_module>
+git commit -m "feat(607): completion-probe curriculum stages (door-spawn, drive-one)"
+```
+
+---
+
+## Task 3: `--completion-probe` CLI flag (single-rung schedule)
+
+**Files:**
+- Modify: `ml/train.py`
+- Test: the train/curriculum test module
+
+**Interfaces:**
+- Consumes: `_completion_stage` (T2).
+- Produces: `--completion-probe {notch,roomy}` (default `None`). When set, the trained schedule is exactly `[_completion_stage(value)]` (a fresh policy, one rung). When `None`, schedule building is byte-identical to before.
+
+- [ ] **Step 1: Write the failing test.** First read `ml/train.py` to find the function that maps parsed args → the `list[Stage]`/ladder (where `--anchor-trio-notch` and `--schedule` are consumed; likely `build_schedule(args)` or inline in `main`). Then add a test asserting the flag yields the single completion rung and that absence is unchanged:
+
+```python
+def test_completion_probe_flag_builds_single_completion_rung():
+    from ml.train import build_argparser, build_schedule  # adjust to the real builder name
+    args = build_argparser().parse_args(["--completion-probe", "roomy"])
+    stages = build_schedule(args)
+    assert [s.name for s in stages] == ["completion-roomy"]
+
+
+def test_no_completion_probe_is_default_neutral():
+    from ml.train import build_argparser, build_schedule
+    base = build_argparser().parse_args(["--schedule", "curriculum"])
+    with_flag_default = build_argparser().parse_args(["--schedule", "curriculum"])
+    # default None => identical schedule to the pre-change curriculum
+    assert [s.name for s in build_schedule(base)] == [s.name for s in build_schedule(with_flag_default)]
+    assert all(s.name not in ("completion-notch", "completion-roomy") for s in build_schedule(base))
+```
+
+(If schedule construction is inlined in `main`, refactor the minimal mapping into a `build_schedule(args)` helper as part of this step so it is unit-testable; keep behavior byte-identical for existing flags.)
+
+- [ ] **Step 2: Run; verify fail.**
+
+Run: `pytest <train_test_module> -k completion_probe -v`
+Expected: FAIL — unrecognized argument `--completion-probe` (or import error on `build_schedule`).
+
+- [ ] **Step 3: Add the argparse flag.** In `ml/train.py`'s `build_argparser()`, near `--anchor-trio-notch`:
+
+```python
+p.add_argument(
+    "--completion-probe",
+    choices=["notch", "roomy"],
+    default=None,
+    help="ADR-0028 trigger-#3 diagnostic: train ONLY a single door-spawn completion rung "
+    "(pre-park 2 of a 3-object witness, drive the last in from the door at phi=1) on the chosen "
+    "manifold arm — 'notch' (tight, the measured 0.000 wall) or 'roomy' (fat slot). Overrides "
+    "the ladder with one rung from a fresh policy; default None = unchanged (byte-identical).",
+)
+```
+
+- [ ] **Step 4: Wire the single-rung schedule.** In the schedule builder, BEFORE the normal ladder construction, short-circuit on the flag:
+
+```python
+if args.completion_probe is not None:
+    return [_completion_stage(args.completion_probe)]
+```
+
+(Place this so it takes precedence over `--schedule`/`--anchor-trio-notch`. Import `_completion_stage` from `ml.curriculum` if not already in scope.)
+
+- [ ] **Step 5: Run; verify pass + full curriculum suite green (no neutrality regression).**
+
+Run: `pytest <train_test_module> -k completion_probe -v && pytest tests/ml/test_curriculum.py -q`
+Expected: new tests PASS; existing curriculum tests unchanged/green.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add ml/train.py <train_test_module>
+git commit -m "feat(607): --completion-probe single-rung schedule (default-neutral)"
+```
+
+---
+
+## Task 4: Marginal-completion metric helper
+
+**Files:**
+- Create: `ml/probe_metric.py`
+- Test: `tests/ml/test_probe_metric.py`
+
+**Interfaces:**
+- Produces: `marginal_completion(valid_placed: float, *, n: int = 3, k: int = 2) -> float` — for a drive-one (k = n−1) completion rung, returns the floor-aware marginal completion `max(0.0, n*valid_placed - k)`. Consumed by the grading step (T7).
+
+- [ ] **Step 1: Write the failing unit test.** Create `tests/ml/test_probe_metric.py`:
+
+```python
+import math
+import pytest
+from ml.probe_metric import marginal_completion
+
+
+def test_place_nothing_floor_reads_zero_marginal():
+    # k=2 of n=3 pre-parked => a place-nothing/abstain policy reads valid_placed = 2/3 exactly,
+    # which is the pre-registered null: MARGINAL completion = 0 (it never parked the last object).
+    assert marginal_completion(2.0 / 3.0, n=3, k=2) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_full_completion_reads_one():
+    assert marginal_completion(1.0, n=3, k=2) == pytest.approx(1.0)
+
+
+def test_partial_completion_is_linear_above_floor():
+    # valid_placed = 0.7667 => marginal = 3*0.7667 - 2 = 0.30 (the GO threshold).
+    assert marginal_completion(0.76667, n=3, k=2) == pytest.approx(0.30, abs=1e-3)
+
+
+def test_invalid_piling_below_floor_clamps_to_zero():
+    # An invalid-pile policy reads valid_placed BELOW the 2/3 floor; marginal clamps to 0
+    # (no spurious negative, no false GO).
+    assert marginal_completion(0.5, n=3, k=2) == 0.0
+
+
+def test_rejects_non_drive_one():
+    with pytest.raises(ValueError):
+        marginal_completion(0.8, n=3, k=1)  # drive=2: the affine transform does not apply
+```
+
+- [ ] **Step 2: Run; verify fail.**
+
+Run: `pytest tests/ml/test_probe_metric.py -v`
+Expected: FAIL — `No module named 'ml.probe_metric'`.
+
+- [ ] **Step 3: Implement.** Create `ml/probe_metric.py`:
+
+```python
+"""Marginal last-object completion metric for the ADR-0028 trigger-#3 completion probe.
+
+With ``seed_anchor_k = N-1`` pre-parked of a valid witness, a place-nothing / abstain policy
+already reads ``valid_placed = (N-1)/N`` (the pre-parked prefix is valid and counts in both the
+numerator ``len(_parked)`` and the denominator ``len(requested_ids)`` — env.py:112,355). So the
+training-time aggregate ``valid_placed`` is FLOORED and must be read MARGINALLY, never as a raw
+success rate (the #821 0.63 masquerade). For a DRIVE-ONE rung (k = N-1, no backplay mixture) the
+relation is exact and conservative:
+
+    valid_placed = (N-1)/N + p/N - (2/N)*q     where p = P(last object validly parked),
+                                                     q = P(last object INVALIDLY piled)
+    => p = N*valid_placed - (N-1)   when q ≈ 0 (abstain, not pile);
+       q>0 only makes N*valid_placed-(N-1) an UNDER-estimate, so clamping at 0 never yields a
+       false positive. Hence marginal_completion = max(0, N*valid_placed - (N-1)).
+
+Analysis-only: no env/reward/encoding change. Read the door-spawn rung's windowed-final
+``valid_placed`` (both seeds) through this transform; threshold the result, never the raw value.
+"""
+
+from __future__ import annotations
+
+
+def marginal_completion(valid_placed: float, *, n: int = 3, k: int = 2) -> float:
+    """Floor-aware marginal last-object completion from a drive-one completion rung's aggregate
+    ``valid_placed``. Returns ``max(0, n*valid_placed - k)``. Requires k == n-1 (drive exactly
+    one object); the affine transform is undefined for drive>1."""
+    if k != n - 1:
+        raise ValueError(
+            f"marginal_completion is defined only for a drive-one rung (k == n-1); got n={n}, k={k}"
+        )
+    return max(0.0, n * valid_placed - k)
+```
+
+- [ ] **Step 4: Run; verify pass.**
+
+Run: `pytest tests/ml/test_probe_metric.py -v`
+Expected: 5 PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add ml/probe_metric.py tests/ml/test_probe_metric.py
+git commit -m "feat(607): floor-aware marginal-completion metric for the probe"
+```
+
+---
+
+## Task 5: README ledger placeholder + assemble PR-1
+
+**Files:**
+- Modify: `ml/README.md`
+
+- [ ] **Step 1: Add a pending-probe row to the lever ledger.** In `ml/README.md`'s lever-ledger section (read it first), add one row marking the probe as RUNNABLE-NOT-YET-RUN, with the pre-registered metric, floor, and GO/NO-GO rule. No verdict yet (filled in T7). Example row text:
+
+```markdown
+| completion paired-witness probe (ADR-0028 trigger-#3) | door-spawn φ=1, k=2/3, paired notch (~0.064) vs roomy (~0.278) | **runnable — not yet run** | metric = marginal completion `max(0, 3·valid_placed − 2)` vs the pre-registered 2/3 floor; GO = roomy ≥ 0.30 & notch ≈ 0 (slot-geometry) → scoped roomy charter; NO-GO = both ≈ 0 (drive binding) → resolved-negative generalizes |
+```
+
+- [ ] **Step 2: No CHANGELOG entry.** `ml/` is dev/CI-only (never shipped in the wheel), so this is not a user-facing change — confirm no `CHANGELOG.md` `[Unreleased]` entry is needed (the PR-create hook warning is advisory here; note the dev/CI-only rationale in the PR body).
+
+- [ ] **Step 3: Commit + run the ml/ gates locally.**
+
+```bash
+git add ml/README.md
+git commit -m "docs(607): ledger row for the pending completion paired-witness probe"
+ruff check ml/ && ruff format --check ml/ && mypy ml/ && pytest tests/ml/ -q
+```
+Expected: all green.
+
+- [ ] **Step 4: Open PR-1 (draft) and run the review arc.**
+
+```bash
+git push -u origin feature/<issue>-completion-paired-witness-probe
+gh pr create --draft --base develop --title "Completion paired-witness diagnostic probe (ADR-0028 trigger-#3)" \
+  --body "Closes #<issue>. Code-only for the paired probe: roomy witness + validity pins, two door-spawn completion stages, --completion-probe single-rung schedule, floor-aware marginal-completion metric. ml/ is dev/CI-only (no CHANGELOG). Manifold-contrast: notch ~0.06 vs roomy ~0.28 (recorded in Task 1). The RUN + verdict land in PR-2."
+```
+Then run `/pr-review` incl. **ml-rl-guard** (mandatory — this touches `ml/`), convert findings to threads, fix + resolve, flip out of draft when clean. **User merges.**
+
+---
+
+## Task 6: Run the paired probe (post-merge)
+
+**Files:** none (operational). Run from a **worktree pinned to the merged branch** (fixtures are read lazily from the working tree — a mid-run branch switch breaks the run, the #736 gotcha).
+
+- [ ] **Step 1: Pin a worktree to the merged code.**
+
+```bash
+git fetch origin develop
+git worktree add /home/pkuhn/completion-probe-runs/wt origin/develop
+```
+
+- [ ] **Step 2: Run the 4 cells (2 arms × 2 seeds), identical config except the witness.** From inside the worktree (so `ml` resolves there and lazy fixture reads point at it):
+
+```bash
+cd /home/pkuhn/completion-probe-runs/wt
+for arm in notch roomy; do for seed in 0 1; do
+  PYTHONPATH=$PWD/src python -m ml.train --completion-probe $arm --seed $seed \
+    --max-iters-per-stage 200 \
+    --metrics-out /home/pkuhn/completion-probe-runs/metrics-$arm-s$seed.jsonl \
+    --save /home/pkuhn/completion-probe-runs/policy-$arm-s$seed.pt
+done; done
+```
+(Run in the background; this is the only expensive step. `--max-iters-per-stage 200` gives both arms an identical fixed budget. Confirm `--anchor-trio-notch` is NOT passed — the `--completion-probe` short-circuit owns the schedule.)
+
+- [ ] **Step 3: Confirm engagement.** For each run, confirm the trained rung was `completion-<arm>` (grep the metrics JSONL `stage` field) and that `seed_anchor_k=2` / door spawn engaged (the metrics carry no `phi_cap` key — backplay was off). Record `n_eps`>0 per iter.
+
+---
+
+## Task 7: Grade + record the verdict (PR-2)
+
+**Files:**
+- Modify: `ml/README.md`, `docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md`
+
+- [ ] **Step 1: Compute marginal completion per cell.** For each of the 4 JSONL files, take the windowed-final `valid_placed` (mean of the last ~10 iterations of the `completion-<arm>` stage, per the gate convention) and apply the helper:
+
+```bash
+PYTHONPATH=$PWD python -c "
+import json, statistics as st
+from ml.probe_metric import marginal_completion
+for arm in ('notch','roomy'):
+  for seed in (0,1):
+    rows=[json.loads(l) for l in open(f'/home/pkuhn/completion-probe-runs/metrics-{arm}-s{seed}.jsonl')]
+    vp=[r['valid_placed'] for r in rows if r['stage']==f'completion-{arm}' and r['valid_placed'] is not None]
+    final=st.mean(vp[-10:])
+    print(f'{arm} s{seed}: valid_placed_final={final:.3f}  marginal={marginal_completion(final):.3f}')
+"
+```
+
+- [ ] **Step 2: Apply the pre-registered decision rule.**
+  - **GO (slot-geometry):** roomy marginal ≥ ~0.30 (both seeds) AND notch marginal ≈ 0.000 → the wall is slot sparsity. Open a *scoped* roomy/medium completion charter as a separate issue; tight-dense KILL stays intact.
+  - **NO-GO (drive binding):** roomy marginal ≈ 0.000 too → resolved-negative generalizes; geometry confound closed; bank fortified.
+  - **Ambiguous** (roomy lifts but < 0.30, or notch non-zero): report the numbers, do not over-claim; treat as NO-GO for charter purposes, note the residual.
+
+- [ ] **Step 3: Record the verdict (both directions).** Update the `ml/README.md` ledger row from "runnable — not yet run" to the measured marginal numbers + the bit; add an ADR-0028 re-open-trigger ledger entry recording trigger-#3 as EXERCISED with the outcome (drive-binding-generalizes vs slot-geometry-reopen). Keep the gate code/logic untouched (docs-only).
+
+- [ ] **Step 4: Commit + open PR-2 (draft), review arc, user merges.**
+
+```bash
+git switch -c feature/<issue2>-completion-probe-verdict develop  # off fresh develop
+git add ml/README.md docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md
+git commit -m "docs(607): record completion paired-witness probe verdict (ADR-0028 trigger-#3)"
+git push -u origin feature/<issue2>-completion-probe-verdict
+gh pr create --draft --base develop --title "Record completion paired-witness probe verdict" --body "Closes #<issue2>. ..."
+```
+Run `/pr-review` (comment-analyzer + ml-rl-guard for the ledger/ADR wording), resolve, flip ready. **User merges.**
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3 paired door-spawn, 2 arms, controlled variable → T1 (roomy witness) + T2 (both stages) + T6 (paired run). ✓
+- §4 marginal metric + pre-registered floor → T4 (helper + null encoded in tests) + T7 (windowed-final read). ✓
+- §5 decision rule (GO/NO-GO/ambiguous) → T7 Step 2. ✓
+- §6 feasibility witness (roomy authored + check-verified + validity-pinned) → T1. ✓
+- §7 kill conditions: (1) aggregate-vs-marginal → T4 transform + the no-backplay-mixture design; (2) check-verified → T1 Step 4; (3) diagnostic-only → recorded in T7 / PR bodies; (4) arms differ only in witness → T2 (identical DifficultyConfig) + T6 (identical flags). ✓
+- §8 success criteria → T1 (committed pinned witness), T2–T5 (no env/reward/action change, ml-rl-guard), T6 (4 cells × marginal), T7 (bit recorded). ✓
+- §11 delivery: PR-1 (T1–T5) → run (T6) → PR-2 (T7). ✓
+
+**Placeholder scan:** `<id1>/<x>/<y>` in T1 Step 5 and `<issue>`/`<curriculum_test_module>`/`<train_test_module>` are deliberate fill-ins resolved by their own steps (solved poses; the issue number; the test-module path located in the step) — not hidden work. The `build_schedule` name in T3 is flagged "adjust to the real builder name" with a refactor fallback. All code steps show real code.
+
+**Type consistency:** `_completion_stage(witness: str) -> Stage` (T2) is called as `_completion_stage(args.completion_probe)` (T3) and `_completion_stage("notch"/"roomy")` (T2 tests) — consistent. `marginal_completion(valid_placed, *, n=3, k=2)` (T4) called the same in T7. DifficultyConfig fields (`max_objects`, `seed_anchor_k`, `per_object_step_budget`, `total_step_budget`, `backplay_phi_cap`) match the verbatim dataclass. Stage fields (`name`, `difficulty`, `hangar_path`, `fleet_path`, `anchor_layout_path`, `clearance_m`) match. ✓

--- a/docs/superpowers/specs/2026-06-25-learned-backend-completion-paired-witness-probe-design.md
+++ b/docs/superpowers/specs/2026-06-25-learned-backend-completion-paired-witness-probe-design.md
@@ -1,0 +1,173 @@
+# Design — Completion paired-witness diagnostic probe (ADR-0028 trigger-#3 geometry confound)
+
+**Date:** 2026-06-25
+**Status:** Draft for review
+**Relates to:** epic #607 (learned backend), [ADR-0028](../../adr/0028-learned-backend-train-to-mastery-resolved-negative.md) (train-to-mastery resolved-negative), the #821 backplay lever, the #832/#835 feasibility-first lesson.
+
+---
+
+## 1. Context
+
+The learned RL backend's **dense empty-start train-to-mastery** charter is *resolved-negative* (ADR-0028):
+six orthogonal levers each KILLed at the same `valid_placed ≈ 0.333` "place-one-validly-then-abstain"
+fixed point. The measure-first probe named the binding wall as **cold-start drive-and-pack of the
+marginal object into a sparse, clearance-invariant valid slot**, evidenced by a `valid_placed = 0.000`
+at φ=1 (the last object spawned at the door and towed all the way in) — confirmed on *non-backplay
+control* checkpoints, i.e. a policy-family property, not training damage.
+
+The natural next direction is the **real deployment shape**: complete a mostly-parked hangar (place the
+last 1–2 planes after a late return / surprise maintenance), ADR-0028 re-open trigger #3. A design-panel
+evaluation (4 lenses + 3 adversarial verifiers) surfaced one decisive observation that reopens the
+question as *testable* rather than settled:
+
+> ADR-0028's load-bearing "2e-3 needle" is the **unconditional** joint-triple probability. Completion
+> never samples three random planes — it **conditions on a valid (N−1)-prefix already parked**. The
+> decision-relevant quantity is the **conditional last-slot probability**, measured this session at
+> **0.064 (tight notch) vs 0.278 (roomy)** — a 4.4× gap. So completion structurally escapes the 2e-3
+> needle, and manifold width becomes a controllable experimental variable.
+
+ADR-0028's diagnosis has **two ingredients**: the door→interior **drive** and the sparse **slot**. No
+single naive framing separates them. This probe does.
+
+## 2. Problem statement
+
+Decide one bit, cheaply and feasibly-grounded: **is the binding wall the door→interior drive (learning
+capacity) or the slot sparsity (geometry)?**
+
+- If it is **slot geometry**, a fatter conditional last-slot should lift door-start completion → a
+  *scoped* completion charter on roomy/medium hangars becomes defensible.
+- If it is the **drive**, more valid termini will not help → the resolved-negative *generalizes* beyond
+  the notch and the bank is fortified.
+
+The honest prior (stated by the synthesis lead) is **NO-GO**: a fatter slot multiplies valid *termini*
+but does not teach the multi-segment reverse-capable tow from the door into any of them; the φ=1=0.000
+floor is a strong policy-family prior. The probe's value is that a NO-GO **at 4.4× more slack** closes
+the last geometry confound and makes the bank bulletproof; a GO reopens a *scoped* direction. **Either
+outcome is decision-grade.**
+
+## 3. The probe — paired door-spawn, manifold-width as the only controlled variable
+
+One paired experiment. Hold the **drive fixed** (door spawn, φ=1) and toggle **only** slot-width:
+
+| Arm | Hangar / witness | N | seed_anchor_k | Driven | Conditional last-slot |
+|---|---|---|---|---|---|
+| **Tight** | `tests/fixtures/ml/witness_notch.yaml` (existing, validity-pinned) on the Herrenteich notch | 3 | 2 | 1 | ~0.064 (the measured 0.000 wall) |
+| **Roomy** | **`tests/fixtures/ml/witness_roomy.yaml` (new)** on `tests/fixtures/test_hangar_large.yaml` (25×30 m, clearance 0.3) | 3 | 2 | 1 | ~0.278 |
+
+- **Start state = door, φ=1.** This is the env default `_spawn` at the door pose: a completion rung with
+  `seed_anchor_k = N−1` and **no** backplay-φ knob. No env / reward / action-space code changes
+  (the substrate map confirms F_door is zero-new-code).
+- **Controlled variable = the witness/hangar fixture only.** Identical training config, hyperparameters,
+  and seeds across both arms.
+- **Replication:** 2 seeds per arm (mirrors the #815/#821/#827 two-seed gate convention), 4 cells total.
+- **Reward unchanged:** the product checker (`collisions.check` + Caddy egress); `validity_conditional_terminal`
+  gate intact.
+
+## 4. Metric and pre-registered null — the masquerade guard
+
+With `seed_anchor_k = 2` of `N = 3`, a **place-nothing** policy already reads
+`terminal_fraction = len(_parked)/len(requested_ids) = 2/3 ≈ 0.667` (`ml/env.py:112` pre-parks into
+`_parked`; `ml/env.py:355` divides by the full `requested_ids`). Aggregate `valid_placed` is therefore
+**floored at ~2/3 and uninformative** — this is exactly the artifact that made #821's "0.63" look like
+competence.
+
+**The probe metric is MARGINAL last-object completion, never aggregate `valid_placed`:**
+
+> **marginal completion** = P( all N validly parked | valid (N−1)-prefix pre-parked )
+> operationally: the fraction of deterministic eval episodes whose `terminal_fraction == 1.0`
+> (the single driven object validly parked), read at fixed φ=1.
+
+**Pre-register the null BEFORE the run:** marginal completion of a place-nothing / abstain policy = **0**
+(it never lifts `terminal_fraction` above the 2/3 floor). Record the floor and the null in the metrics
+notes at run start.
+
+**The first implementation step must confirm the exact extraction** of marginal completion from the
+`--metrics-out` JSONL (the precise field/derivation that isolates "driven object validly parked" from the
+floor), and add a tiny unit asserting a place-nothing rollout reads marginal = 0 while a witness-prefix +
+valid-last-park reads 1.0. This nails the metric to code, not prose.
+
+## 5. Decision rule (go/no-go)
+
+Read marginal completion at fixed φ=1 per arm (windowed over the rung's iterations, both seeds):
+
+- **GO (slot-geometry binding):** roomy marginal ≥ **~0.30** (clearly learning the fat slot) **AND**
+  notch marginal ≈ **0.000**. → Open a *scoped* completion charter on roomy/medium hangars; the
+  tight-dense KILL stays explicitly intact (not a blanket re-open).
+- **NO-GO (drive binding):** roomy marginal ≈ **0.000** too. → Resolved-negative generalizes; record
+  that the geometry confound is closed and the bank stands harder.
+- **Ambiguous** (roomy lifts but < ~0.30, or notch non-zero): inconclusive — report the curve, do not
+  over-claim; treat as NO-GO for charter purposes and note the residual.
+
+The verdict is recorded in `ml/README.md` (lever ledger) **and** ADR-0028's re-open-trigger ledger
+**regardless of direction**.
+
+## 6. Feasibility-witness requirement (the #832/#835 guard)
+
+The probe is only valid if **both** arms rest on a layout *proven valid by construction*:
+
+- **Tight arm:** `witness_notch.yaml` is already a proven k-prefix of the valid all-8
+  `examples/herrenteich/layout.yaml`, validity-pinned by `tests/ml/test_stage_builder.py`.
+- **Roomy arm:** author `tests/fixtures/ml/witness_roomy.yaml` — a valid k=3 layout on
+  `tests/fixtures/test_hangar_large.yaml` produced by a **big-budget `hangarfit solve`**
+  (reproducible/auditable; roomy fills are trivial for RR-MC), then **verified with
+  `hangarfit check witness_roomy.yaml --render out.png` (must report VALID)**, then committed with a
+  `test_stage_builder` validity pin mirroring the notch witness. *Any k-prefix of a valid layout is
+  valid*, so the pre-parked 2-prefix is feasibility-clean by construction.
+
+**Without the verified roomy witness, a roomy 0.000 would be infeasibility, not learning failure — the
+#832/#835 trap re-applied to start-states.** The verified fixture is a hard precondition for the run.
+
+## 7. Kill conditions (what would invalidate the probe)
+
+1. Marginal completion read off **aggregate `valid_placed`** or a **φ-mixture windowed mean** instead of
+   fixed-φ=1 marginal — re-creates the 2/3-floor masquerade.
+2. The **roomy witness is not `hangarfit check`-verified** → a roomy 0.000 is infeasibility, not a result.
+3. Treating a roomy **GO as a deploy/dominance claim** — RR-MC saturates roomy fills, so even a roomy
+   learning success is **diagnostic-only** and beats RR-MC nowhere it is chartered (ADR-0028 rejected
+   re-scope-to-easier for exactly this).
+4. The arms differ in **anything but the witness/hangar** (config, seeds, k, budget) → slot-width is no
+   longer the controlled variable.
+
+## 8. Success criteria (probe is "done")
+
+1. A committed, `hangarfit check`-verified `witness_roomy.yaml` with a `test_stage_builder` validity pin
+   exists before any training run.
+2. Two completion door-spawn Stages (notch, roomy; `seed_anchor_k=2`, `max_objects=3`, no backplay knob)
+   plus the marginal-metric unit test — **no env / reward / action-space code changed**, ml-rl-guard
+   invariants intact, determinism contract honored.
+3. The paired run produces a fixed-φ=1 **marginal** completion number for both arms × 2 seeds, read
+   against the pre-registered 2/3-floor null, from the existing `--metrics-out` JSONL.
+4. The one bit (drive-binding vs slot-geometry-binding) is decided and recorded in `ml/README.md` +
+   ADR-0028 — either direction.
+5. If GO: a scoped roomy/medium completion charter is opened as a *separate* follow-up with the
+   tight-dense KILL left intact.
+
+## 9. Out of scope
+
+- No changes to `ml/env.py`, `ml/reward.py`, `ml/action_space.py`, or `ml/encoding.py`.
+- No beat-RR-MC / deploy claim from this probe (diagnostic only).
+- F_reposition (warm-start in-hangar nudge) — off-charter, needs an arc42 §3 / ADR-0028 amendment + a
+  new perturbed-start witness family + new code; explicitly deferred. May be escalated as a *separate*
+  charter-amendment decision only if this probe is NO-GO and the user wants one more lever.
+- The φ-anneal sweep (F_staged): demoted — it adds drive-length as an uncontrolled confound on top of
+  slot-width; the paired door-spawn probe is strictly cleaner for the same cost.
+
+## 10. Open decisions for spec review
+
+1. **Roomy-witness authoring** — defaulted to big-budget `hangarfit solve` (reproducible/auditable). The
+   alternative is hand-author + `hangarfit check` (faster, but the check gate is then the only proof).
+   Confirm the default.
+2. **Iteration budget & seeds per arm** — defaulted to the two-seed gate convention and a budget matching
+   the prior trio-notch-anchored rungs. Confirm or set explicitly.
+3. **Marginal-metric extraction** — the exact JSONL field/derivation is to be pinned in the first
+   implementation step (with the unit test in §4); flag if you want a specific definition.
+
+## 11. Delivery shape (for the implementation plan)
+
+Issue-driven GitFlow, two stages so the verified code lands before the run:
+
+- **PR-1 (code):** `witness_roomy.yaml` + validity-pin test + two completion Stages + the marginal-metric
+  unit test + an ml/README placeholder row. Full `/pr-review` arc incl. **ml-rl-guard**. User merges.
+- **Run:** execute the paired probe on merged code from a **worktree pinned to the branch** (fixtures are
+  read lazily from the working tree — a mid-run branch switch breaks it; the #736 gotcha).
+- **PR-2 (docs):** record the verdict in `ml/README.md` lever ledger + ADR-0028 re-open-trigger ledger.

--- a/ml/README.md
+++ b/ml/README.md
@@ -20,10 +20,19 @@ Six gate-run levers, spanning every lever class (the representation axis was pro
 | #817 `--entropy-floor` | exploration | inert, vp 0.333 = control |
 | #823 `--backplay-trio-notch` | start-state distribution (ρ₀) | transfer 0.000; scaffold-only 0.63–0.69 |
 | #827 `--relative-encoder` | representation (coordinate frame) | vp 0.353/0.332 PILING ≈ control 0.317/0.316 |
+| **ADR-0028 trigger-#3** | **completion paired-witness probe** | **runnable — not yet run** |
 
 (The empty-start `trio-notch` *baseline* sat slightly lower at `valid_placed ≈ 0.25` — the
 coverage-minimum number quoted in the lever recipes below; the *levered* runs converge to the
 1-of-3 = `0.333` place-one fixed point. Same failure mode, two measurement contexts.)
+
+**Pending probe: ADR-0028 trigger-#3 (completion paired-witness).** The third re-open diagnostic
+(runnable but not yet run) is a **paired-witness A/B** on the completion skill backplay proved
+viable: door-spawn φ=1, pre-park k=2 of 3, tight notch vs roomy (`witness_roomy.yaml`). Both arms
+measure marginal completion `max(0, 3·valid_placed − 2)` against a pre-registered 2/3 floor. GO =
+roomy vp ≥ 0.30 & notch ≈ 0 → slot geometry drives the wall → reframe to roomy scoped charter
+(the on-demand-exception real use case). NO-GO = both ≈ 0 → drive binding without witness spawn
+→ resolved-negative generalizes to completion. See [ADR-0028](../docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md) for the charter details and re-open gate.
 
 A **pre-registered measure-first probe** (`basin_mc.py` + `phi_eval.py` + `phi_eval_control.py`
 + `probe-verdict.md`, gitignored gate-run scratch; torch-light, through the product checker;

--- a/ml/README.md
+++ b/ml/README.md
@@ -27,8 +27,9 @@ coverage-minimum number quoted in the lever recipes below; the *levered* runs co
 1-of-3 = `0.333` place-one fixed point. Same failure mode, two measurement contexts.)
 
 **Pending probe: ADR-0028 trigger-#3 (completion paired-witness).** The third re-open diagnostic
-(runnable but not yet run) is a **paired-witness A/B** on the completion skill backplay proved
-viable: door-spawn φ=1, pre-park k=2 of 3, tight notch vs roomy (`witness_roomy.yaml`). Both arms
+(runnable but not yet run) is a **paired-witness A/B** on the completion skill — door-spawn φ=1,
+pre-park k=2 of 3, NO backplay knob, testing whether manifold width is the barrier: tight notch vs
+roomy (`witness_roomy.yaml`). Both arms
 measure marginal completion `max(0, 3·valid_placed − 2)` against a pre-registered 2/3 floor. GO =
 roomy vp ≥ 0.30 & notch ≈ 0 → slot geometry drives the wall → reframe to roomy scoped charter
 (the on-demand-exception real use case). NO-GO = both ≈ 0 → drive binding without witness spawn

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -506,7 +506,8 @@ _ROOMY_FLEET = "data/fleet.yaml"
 # Committed roomy completion witness (a valid 3-object fill on the 25x30 test hangar). Validity
 # pinned by tests/ml/test_stage_builder.py::test_witness_roomy_*.
 _WITNESS_ROOMY = "tests/fixtures/ml/witness_roomy.yaml"
-_ROOMY_CLEARANCE = 0.3  # the test_hangar_large file value; the roomy slot is the controlled var
+_ROOMY_CLEARANCE = 0.3  # explicit clearance for the roomy arm (matches test_hangar_large.yaml;
+# keep in sync if that file changes)
 
 
 def _completion_stage(witness: str) -> Stage:

--- a/ml/curriculum.py
+++ b/ml/curriculum.py
@@ -499,6 +499,49 @@ _LENIENT_CLEARANCE = (
     0.05  # below the herrenteich file value (0.10) so the clearance ramp truly tightens
 )
 
+# ADR-0028 trigger-#3 completion paired-witness probe (opt-in via --completion-probe; NOT in any
+# default ladder, so absent the flag the env is byte-identical). The ROOMY arm's hangar/fleet:
+_ROOMY_HANGAR = "tests/fixtures/test_hangar_large.yaml"
+_ROOMY_FLEET = "data/fleet.yaml"
+# Committed roomy completion witness (a valid 3-object fill on the 25x30 test hangar). Validity
+# pinned by tests/ml/test_stage_builder.py::test_witness_roomy_*.
+_WITNESS_ROOMY = "tests/fixtures/ml/witness_roomy.yaml"
+_ROOMY_CLEARANCE = 0.3  # the test_hangar_large file value; the roomy slot is the controlled var
+
+
+def _completion_stage(witness: str) -> Stage:
+    """A single door-spawn COMPLETION rung for the ADR-0028 trigger-#3 paired probe: pre-park
+    k=N-1=2 of a valid 3-object witness and drive the LAST object in from the door (phi=1, NO
+    backplay knob). ``witness`` selects the manifold arm — 'notch' (tight Herrenteich notch,
+    conditional last-slot ~0.064, the measured 0.000 wall) or 'roomy' (the fat 25x30 hangar,
+    ~0.278). The arms differ ONLY in hangar/fleet/witness/clearance; manifold width is the
+    controlled variable. Opt-in (built only by --completion-probe); no default ladder includes
+    it, so the env stays byte-identical when the flag is absent."""
+    if witness == "notch":
+        return Stage(
+            name="completion-notch",
+            difficulty=DifficultyConfig(
+                max_objects=3, seed_anchor_k=2, per_object_step_budget=80, total_step_budget=80
+            ),
+            hangar_path=_NOTCH_HANGAR,
+            fleet_path=_NOTCH_FLEET,
+            anchor_layout_path=_WITNESS_NOTCH,
+            clearance_m=_LENIENT_CLEARANCE,
+        )
+    if witness == "roomy":
+        return Stage(
+            name="completion-roomy",
+            difficulty=DifficultyConfig(
+                max_objects=3, seed_anchor_k=2, per_object_step_budget=80, total_step_budget=80
+            ),
+            hangar_path=_ROOMY_HANGAR,
+            fleet_path=_ROOMY_FLEET,
+            anchor_layout_path=_WITNESS_ROOMY,
+            clearance_m=_ROOMY_CLEARANCE,
+        )
+    raise ValueError(f"_completion_stage: unknown witness {witness!r} (expected 'notch'|'roomy')")
+
+
 # Opt-in #714 rung (wired via with_solo_box_rung / --solo-box-rung), NOT part of DEFAULT_LADDER.
 # max_objects=1 like trivial, but the WHOLE-fleet pool (fleet_ids omitted) instead of trivial's
 # single ("fuji",) — decouples the count jump (1->2) from the sampling-pool jump at the

--- a/ml/probe_metric.py
+++ b/ml/probe_metric.py
@@ -7,23 +7,24 @@ training-time aggregate ``valid_placed`` is FLOORED and must be read MARGINALLY,
 success rate (the #821 0.63 masquerade). For a DRIVE-ONE rung (k = N-1, no backplay mixture) the
 relation is exact and conservative:
 
-    valid_placed = (N-1)/N + p/N - (2/N)*q     where p = P(last object validly parked),
-                                                     q = P(last object INVALIDLY piled)
+    valid_placed = (N-1)/N + p/N - ((N-1)/N)*q     where p = P(last object validly parked),
+                                                         q = P(last object INVALIDLY piled)
     => p = N*valid_placed - (N-1)   when q ≈ 0 (abstain, not pile);
        q>0 only makes N*valid_placed-(N-1) an UNDER-estimate, so clamping at 0 never yields a
        false positive. Hence marginal_completion = max(0, N*valid_placed - (N-1)).
+
+Note: ABANDON episodes contribute (N-1)/N (not 0) to ``valid_placed`` because the pre-parked
+prefix is valid and included in the count — this is exactly what establishes the floor.
 
 Analysis-only: no env/reward/encoding change. Read the door-spawn rung's windowed-final
 ``valid_placed`` (both seeds) through this transform; threshold the result, never the raw value.
 """
 
-from __future__ import annotations
-
 
 def marginal_completion(valid_placed: float, *, n: int = 3, k: int = 2) -> float:
     """Floor-aware marginal last-object completion from a drive-one completion rung's aggregate
     ``valid_placed``. Returns ``max(0, n*valid_placed - k)``. Requires k == n-1 (drive exactly
-    one object); the affine transform is undefined for drive>1."""
+    one object); the affine transform is not derived for drive>1."""
     if k != n - 1:
         raise ValueError(
             f"marginal_completion is defined only for a drive-one rung (k == n-1); got n={n}, k={k}"

--- a/ml/probe_metric.py
+++ b/ml/probe_metric.py
@@ -1,0 +1,31 @@
+"""Marginal last-object completion metric for the ADR-0028 trigger-#3 completion probe.
+
+With ``seed_anchor_k = N-1`` pre-parked of a valid witness, a place-nothing / abstain policy
+already reads ``valid_placed = (N-1)/N`` (the pre-parked prefix is valid and counts in both the
+numerator ``len(_parked)`` and the denominator ``len(requested_ids)`` — env.py:112,355). So the
+training-time aggregate ``valid_placed`` is FLOORED and must be read MARGINALLY, never as a raw
+success rate (the #821 0.63 masquerade). For a DRIVE-ONE rung (k = N-1, no backplay mixture) the
+relation is exact and conservative:
+
+    valid_placed = (N-1)/N + p/N - (2/N)*q     where p = P(last object validly parked),
+                                                     q = P(last object INVALIDLY piled)
+    => p = N*valid_placed - (N-1)   when q ≈ 0 (abstain, not pile);
+       q>0 only makes N*valid_placed-(N-1) an UNDER-estimate, so clamping at 0 never yields a
+       false positive. Hence marginal_completion = max(0, N*valid_placed - (N-1)).
+
+Analysis-only: no env/reward/encoding change. Read the door-spawn rung's windowed-final
+``valid_placed`` (both seeds) through this transform; threshold the result, never the raw value.
+"""
+
+from __future__ import annotations
+
+
+def marginal_completion(valid_placed: float, *, n: int = 3, k: int = 2) -> float:
+    """Floor-aware marginal last-object completion from a drive-one completion rung's aggregate
+    ``valid_placed``. Returns ``max(0, n*valid_placed - k)``. Requires k == n-1 (drive exactly
+    one object); the affine transform is undefined for drive>1."""
+    if k != n - 1:
+        raise ValueError(
+            f"marginal_completion is defined only for a drive-one rung (k == n-1); got n={n}, k={k}"
+        )
+    return max(0.0, n * valid_placed - k)

--- a/ml/train.py
+++ b/ml/train.py
@@ -1197,26 +1197,38 @@ def build_argparser() -> argparse.ArgumentParser:
 def build_schedule(args: argparse.Namespace) -> list[Stage]:
     """Map parsed CLI args → the ordered list of curriculum Stages to train.
 
-    Short-circuits to a single completion rung when ``--completion-probe`` is set
-    (ADR-0028 trigger-#3 diagnostic), taking precedence over all other ladder flags and
-    returning a one-element list from a fresh policy. Default ``None`` → identical Stage
-    list to before (byte-identical for every existing flag combination). Extracted from
-    ``main()`` so it is unit-testable.
-
-    Note: promotion-policy overrides (``--promotion-metric`` etc.) are embedded in the
-    ``CurriculumSchedule`` built by ``_build_curriculum_schedule``; ``main()`` uses that
-    helper to get the full schedule object for ``train_curriculum``. This function exposes
-    only the Stage list for testing the ladder shape."""
-    # ADR-0028 trigger-#3: one rung, fresh policy, overrides everything else.
-    if args.completion_probe is not None:
-        return [_completion_stage(args.completion_probe)]
+    Delegates to ``_build_curriculum_schedule`` so the ladder logic — including the
+    ``--completion-probe`` short-circuit — lives in exactly one place and the runtime
+    path cannot diverge from tests."""
     return list(_build_curriculum_schedule(args).stages)
 
 
 def _build_curriculum_schedule(args: argparse.Namespace) -> CurriculumSchedule:
     """Build the full ``CurriculumSchedule`` (stages + promotion policy) from parsed args.
-    Used by ``main()`` for ``train_curriculum``; ``build_schedule`` delegates here for the
-    non-probe path so the ladder logic lives in one place."""
+    Used by ``main()`` for ``train_curriculum``; ``build_schedule`` delegates here so the
+    two cannot diverge.
+
+    ADR-0028 trigger-#3: when ``--completion-probe`` is set, short-circuits to a single
+    completion rung (taking precedence over all other ladder flags). Promotion-policy
+    overrides (``--max-iters-per-stage`` etc.) are applied to the single-stage schedule so
+    the probe respects iteration controls. Default ``None`` → behaviour byte-identical to
+    before (the short-circuit is an added early-return branch only)."""
+    # ADR-0028 trigger-#3: one rung, fresh policy, overrides everything else.
+    if args.completion_probe is not None:
+        single = CurriculumSchedule(
+            stages=(_completion_stage(args.completion_probe),), policy=PromotionPolicy()
+        )
+        single = replace(
+            single,
+            policy=with_promotion_overrides(
+                single.policy,
+                metric=args.promotion_metric,
+                threshold=args.promotion_threshold,
+                max_iters=args.max_iters_per_stage,
+                window=args.promotion_window,
+            ),
+        )
+        return single
     sched = CurriculumSchedule.default()
     sched = replace(
         sched,
@@ -1316,6 +1328,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         if args.entropy_floor is not None or args.frontier_rungs:
             # The entropy floor is rung-scoped; the trivial path has no rungs.
             parser.error("--entropy-floor/--frontier-rungs require --schedule curriculum")
+        if args.completion_probe is not None:
+            parser.error("--completion-probe requires --schedule curriculum")
         if args.auto_budget or args.auto_budget_max_iters is not None:
             parser.error("--auto-budget/--auto-budget-max-iters require --schedule curriculum")
         if args.n_envs > 1:  # resolve_n_envs floors at 1, so >1 is the only over-floor case

--- a/ml/train.py
+++ b/ml/train.py
@@ -37,6 +37,7 @@ from ml.curriculum import (
     EpisodeStat,
     PromotionPolicy,
     Stage,
+    _completion_stage,
     format_iter_log,
     history_metric_records,
     make_episode_sampler,
@@ -1002,6 +1003,16 @@ def build_argparser() -> argparse.ArgumentParser:
         "--mixed-anchor grafts, so a name they introduce (pair-mixed) is valid.",
     )
     p.add_argument(
+        "--completion-probe",
+        choices=["notch", "roomy"],
+        default=None,
+        help="ADR-0028 trigger-#3 diagnostic: train ONLY a single door-spawn completion rung "
+        "(pre-park 2 of a 3-object witness, drive the last in from the door at phi=1) on the "
+        "chosen manifold arm — 'notch' (tight, the measured 0.000 wall) or 'roomy' (fat slot). "
+        "Overrides the ladder with one rung from a fresh policy; default None = unchanged "
+        "(byte-identical).",
+    )
+    p.add_argument(
         "--r-valid-park",
         type=float,
         default=0.0,
@@ -1183,6 +1194,56 @@ def build_argparser() -> argparse.ArgumentParser:
     return p
 
 
+def build_schedule(args: argparse.Namespace) -> list[Stage]:
+    """Map parsed CLI args → the ordered list of curriculum Stages to train.
+
+    Short-circuits to a single completion rung when ``--completion-probe`` is set
+    (ADR-0028 trigger-#3 diagnostic), taking precedence over all other ladder flags and
+    returning a one-element list from a fresh policy. Default ``None`` → identical Stage
+    list to before (byte-identical for every existing flag combination). Extracted from
+    ``main()`` so it is unit-testable.
+
+    Note: promotion-policy overrides (``--promotion-metric`` etc.) are embedded in the
+    ``CurriculumSchedule`` built by ``_build_curriculum_schedule``; ``main()`` uses that
+    helper to get the full schedule object for ``train_curriculum``. This function exposes
+    only the Stage list for testing the ladder shape."""
+    # ADR-0028 trigger-#3: one rung, fresh policy, overrides everything else.
+    if args.completion_probe is not None:
+        return [_completion_stage(args.completion_probe)]
+    return list(_build_curriculum_schedule(args).stages)
+
+
+def _build_curriculum_schedule(args: argparse.Namespace) -> CurriculumSchedule:
+    """Build the full ``CurriculumSchedule`` (stages + promotion policy) from parsed args.
+    Used by ``main()`` for ``train_curriculum``; ``build_schedule`` delegates here for the
+    non-probe path so the ladder logic lives in one place."""
+    sched = CurriculumSchedule.default()
+    sched = replace(
+        sched,
+        policy=with_promotion_overrides(
+            sched.policy,
+            metric=args.promotion_metric,
+            threshold=args.promotion_threshold,
+            max_iters=args.max_iters_per_stage,
+            window=args.promotion_window,
+        ),
+    )
+    if args.solo_box_rung:
+        sched = with_solo_box_rung(sched)
+    if args.seed_anchor:
+        sched = with_pair_anchored_rung(sched)
+    if args.mixed_anchor:
+        sched = with_mixed_anchor_rung(sched)
+    if args.anchor_trio_notch:
+        sched = with_trio_notch_anchored_rung(sched)
+    if args.backplay_trio_notch:
+        sched = with_trio_notch_backplay_rung(sched)
+    # Truncate LAST, after the grafts, so a name they introduce (pair-mixed) is in scope.
+    if args.stop_after_rung is not None:
+        sched = truncate_after_rung(sched, args.stop_after_rung)
+    return sched
+
+
 def main(argv: Sequence[str] | None = None) -> None:
     parser = build_argparser()
     args = parser.parse_args(argv)
@@ -1283,30 +1344,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         # absent flag, not 0/negative).
         if args.entropy_floor is not None and args.entropy_floor <= 0:
             parser.error("--entropy-floor must be > 0")
-        sched = CurriculumSchedule.default()
-        sched = replace(
-            sched,
-            policy=with_promotion_overrides(
-                sched.policy,
-                metric=args.promotion_metric,
-                threshold=args.promotion_threshold,
-                max_iters=args.max_iters_per_stage,
-                window=args.promotion_window,
-            ),
-        )
-        if args.solo_box_rung:
-            sched = with_solo_box_rung(sched)
-        if args.seed_anchor:
-            sched = with_pair_anchored_rung(sched)
-        if args.mixed_anchor:
-            sched = with_mixed_anchor_rung(sched)
-        if args.anchor_trio_notch:
-            sched = with_trio_notch_anchored_rung(sched)
-        if args.backplay_trio_notch:
-            sched = with_trio_notch_backplay_rung(sched)
-        # Truncate LAST, after the grafts, so a name they introduce (pair-mixed) is in scope.
-        if args.stop_after_rung is not None:
-            sched = truncate_after_rung(sched, args.stop_after_rung)
+        sched = _build_curriculum_schedule(args)
         # #734/#743: build the slope-aware controller only when --auto-budget is set; None keeps
         # the fixed per-rung cap (byte-identical default). Each per-knob override (max-iters /
         # min-iters / min-level) is inert without the switch, so fail LOUD rather than silently

--- a/tests/fixtures/ml/scenario_roomy.yaml
+++ b/tests/fixtures/ml/scenario_roomy.yaml
@@ -1,0 +1,6 @@
+# Solve scenario used to AUTHOR tests/fixtures/ml/witness_roomy.yaml (ADR-0028 trigger-#3).
+# A roomy 3-object fill on the 25x30 test hangar: produces the fat-conditional-last-slot
+# witness (the paired probe's roomy arm). Reproducible/auditable per the spec's default.
+fleet: ../../../data/fleet.yaml
+hangar: ../test_hangar_large.yaml
+fleet_in: [fuji, cessna_150, aviat_husky]

--- a/tests/fixtures/ml/witness_roomy.yaml
+++ b/tests/fixtures/ml/witness_roomy.yaml
@@ -1,0 +1,17 @@
+# Committed seed-anchor witness for the ADR-0028 trigger-#3 completion-roomy probe rung.
+#
+# A VALID 3-object layout on the roomy 25x30 test hangar (tests/fixtures/test_hangar_large.yaml),
+# produced by `hangarfit solve tests/fixtures/ml/scenario_roomy.yaml` and verified by
+# `hangarfit check` (exit 0). The paired completion probe pre-parks a k=2 prefix and drives the
+# last object in from the door (phi=1); the fat conditional last-slot (~0.278, vs the notch's
+# ~0.064) is the manifold-width arm. A k-prefix of a valid layout is itself valid, so the
+# pre-parked 2-prefix is feasibility-clean with NO runtime solver call. Validity pinned by
+# tests/ml/test_stage_builder.py::test_witness_roomy_*. Do not hand-edit poses without re-running.
+#
+# No `fleet:`/`hangar:` fields on purpose: the env + stage_builder load this with fleet=/hangar=
+# OVERRIDES (test_hangar_large at clearance 0.3 + data/fleet.yaml), and the loader rejects a file
+# that sets those AND takes overrides.
+placements:
+  - {plane: fuji, x_m: 4.71, y_m: 25.29, heading_deg: 130.40165377698696, on_carts: false}
+  - {plane: cessna_150, x_m: 5.085, y_m: 8.461677752183649, heading_deg: 13.664575523528717, on_carts: true}
+  - {plane: aviat_husky, x_m: 19.59, y_m: 24.438637914466803, heading_deg: 262.7182656910553, on_carts: false}

--- a/tests/ml/test_curriculum.py
+++ b/tests/ml/test_curriculum.py
@@ -992,3 +992,45 @@ def test_validate_ladder_rejects_backplay_rung_with_wrong_prefix_k():
     )
     with pytest.raises(ValueError, match="k=N-1"):
         validate_ladder([bad], encoder_max_objects=8)
+
+
+# ---------------------------------------------------------------------------
+# ADR-0028 trigger-#3 — _completion_stage builder (paired-witness probe)
+# ---------------------------------------------------------------------------
+
+
+def test_completion_stage_notch_is_door_spawn_drive_one():
+    from ml.curriculum import _completion_stage
+
+    s = _completion_stage("notch")
+    assert s.name == "completion-notch"
+    assert s.difficulty.max_objects == 3
+    assert s.difficulty.seed_anchor_k == 2  # pre-park 2, drive 1
+    assert s.difficulty.backplay_phi_cap is None  # door spawn (phi=1), no backplay mixture
+    assert s.difficulty.anchor_prob is None  # fixed-k, not mixed-start
+    assert s.anchor_layout_path == "tests/fixtures/ml/witness_notch.yaml"
+    assert s.hangar_path == "examples/herrenteich/hangar.yaml"
+    assert s.clearance_m == 0.05
+
+
+def test_completion_stage_roomy_uses_large_hangar_and_roomy_witness():
+    from ml.curriculum import _completion_stage
+
+    s = _completion_stage("roomy")
+    assert s.name == "completion-roomy"
+    assert s.difficulty.max_objects == 3
+    assert s.difficulty.seed_anchor_k == 2
+    assert s.difficulty.backplay_phi_cap is None
+    assert s.anchor_layout_path == "tests/fixtures/ml/witness_roomy.yaml"
+    assert s.hangar_path == "tests/fixtures/test_hangar_large.yaml"
+    assert s.fleet_path == "data/fleet.yaml"
+    assert s.clearance_m == 0.3
+
+
+def test_completion_stage_rejects_unknown_witness():
+    import pytest
+
+    from ml.curriculum import _completion_stage
+
+    with pytest.raises(ValueError):
+        _completion_stage("bogus")

--- a/tests/ml/test_probe_metric.py
+++ b/tests/ml/test_probe_metric.py
@@ -1,0 +1,29 @@
+import pytest
+
+from ml.probe_metric import marginal_completion
+
+
+def test_place_nothing_floor_reads_zero_marginal():
+    # k=2 of n=3 pre-parked => a place-nothing/abstain policy reads valid_placed = 2/3 exactly,
+    # which is the pre-registered null: MARGINAL completion = 0 (it never parked the last object).
+    assert marginal_completion(2.0 / 3.0, n=3, k=2) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_full_completion_reads_one():
+    assert marginal_completion(1.0, n=3, k=2) == pytest.approx(1.0)
+
+
+def test_partial_completion_is_linear_above_floor():
+    # valid_placed = 0.7667 => marginal = 3*0.7667 - 2 = 0.30 (the GO threshold).
+    assert marginal_completion(0.76667, n=3, k=2) == pytest.approx(0.30, abs=1e-3)
+
+
+def test_invalid_piling_below_floor_clamps_to_zero():
+    # An invalid-pile policy reads valid_placed BELOW the 2/3 floor; marginal clamps to 0
+    # (no spurious negative, no false GO).
+    assert marginal_completion(0.5, n=3, k=2) == 0.0
+
+
+def test_rejects_non_drive_one():
+    with pytest.raises(ValueError):
+        marginal_completion(0.8, n=3, k=1)  # drive=2: the affine transform does not apply

--- a/tests/ml/test_stage_builder.py
+++ b/tests/ml/test_stage_builder.py
@@ -279,6 +279,52 @@ def test_witness_notch_b_is_a_genuine_held_out_of_witness_notch():
 
 
 # ---------------------------------------------------------------------------
+# ADR-0028 trigger-#3 — the roomy completion witness (paired probe, roomy arm)
+# ---------------------------------------------------------------------------
+
+_WITNESS_ROOMY = "tests/fixtures/ml/witness_roomy.yaml"
+
+
+def _load_witness_roomy(clearance_m: float = 0.3):
+    """Load the committed roomy witness against the roomy completion rung's hangar
+    (test_hangar_large, clearance override) + the synthetic box fleet — the same hangar/fleet
+    the completion-roomy probe trains on (ADR-0028 trigger-#3 paired probe)."""
+    hangar = dataclasses.replace(
+        load_hangar("tests/fixtures/test_hangar_large.yaml"),
+        clearance_m=clearance_m,
+        apron_depth_m=8.0,
+    )
+    fleet = load_fleet("data/fleet.yaml")
+    return load_layout(_WITNESS_ROOMY, fleet=fleet, hangar=hangar)
+
+
+def test_witness_roomy_is_a_valid_three_object_layout():
+    lay = _load_witness_roomy()
+    assert len(lay.placements) == 3
+    assert go.layout_valid(lay)
+
+
+def test_witness_roomy_every_prefix_is_valid():
+    lay = _load_witness_roomy()
+    for k in range(len(lay.placements) + 1):
+        prefix = dataclasses.replace(lay, placements=lay.placements[:k])
+        assert go.layout_valid(prefix), f"roomy witness prefix k={k} is invalid"
+
+
+def test_witness_roomy_every_single_anchor_is_valid():
+    lay = _load_witness_roomy()
+    for i in range(len(lay.placements)):
+        single = dataclasses.replace(lay, placements=(lay.placements[i],))
+        assert go.layout_valid(single), f"single anchor #{i} ({lay.placements[i].plane_id}) invalid"
+
+
+def test_witness_roomy_has_margin_at_stricter_clearance():
+    # Roomy slack: still valid at a stricter 0.5 m clearance, so the trio has real geometric
+    # margin at the rung's 0.3 m (the fat-slot manifold is not a borderline graze).
+    assert go.layout_valid(_load_witness_roomy(clearance_m=0.5))
+
+
+# ---------------------------------------------------------------------------
 # #712 — stage_builder threads the witness into an anchored rung's env
 # ---------------------------------------------------------------------------
 

--- a/tests/ml/test_stage_builder.py
+++ b/tests/ml/test_stage_builder.py
@@ -287,8 +287,8 @@ _WITNESS_ROOMY = "tests/fixtures/ml/witness_roomy.yaml"
 
 def _load_witness_roomy(clearance_m: float = 0.3):
     """Load the committed roomy witness against the roomy completion rung's hangar
-    (test_hangar_large, clearance override) + the synthetic box fleet — the same hangar/fleet
-    the completion-roomy probe trains on (ADR-0028 trigger-#3 paired probe)."""
+    (test_hangar_large, clearance override) + the shared central ``data/fleet.yaml`` fleet — the
+    same hangar/fleet the completion-roomy probe trains on (ADR-0028 trigger-#3 paired probe)."""
     hangar = dataclasses.replace(
         load_hangar("tests/fixtures/test_hangar_large.yaml"),
         clearance_m=clearance_m,

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -1827,4 +1827,35 @@ def test_iter_train_metrics_logs_phi_cap_only_for_backplay_rungs():
     assert "phi_cap" not in plain
     bp = _iter_train_metrics(metrics, cfg, backplay_phi_cap=0.75)
     assert bp["phi_cap"] == pytest.approx(0.75)
-    assert bp["epochs_run"] == 3.0  # the existing telemetry is preserved
+
+
+def test_completion_probe_flag_builds_single_completion_rung():
+    # ADR-0028 trigger-#3: --completion-probe produces EXACTLY one stage, the completion rung.
+    from ml.train import build_argparser, build_schedule
+
+    args = build_argparser().parse_args(["--completion-probe", "roomy"])
+    stages = build_schedule(args)
+    assert [s.name for s in stages] == ["completion-roomy"]
+
+
+def test_completion_probe_notch_builds_notch_rung():
+    # --completion-probe notch → the tight-arm stage.
+    from ml.train import build_argparser, build_schedule
+
+    args = build_argparser().parse_args(["--completion-probe", "notch"])
+    stages = build_schedule(args)
+    assert [s.name for s in stages] == ["completion-notch"]
+
+
+def test_no_completion_probe_is_default_neutral():
+    # ADR-0028 / 4c-ii default-neutrality: absent --completion-probe, the schedule is the
+    # concrete DEFAULT_LADDER — no completion rung injected, byte-identical to pre-flag.
+    from ml.train import build_argparser, build_schedule
+
+    args = build_argparser().parse_args(["--schedule", "curriculum"])
+    stages = build_schedule(args)
+    rung_names = [s.name for s in stages]
+    # Must match the actual DEFAULT_LADDER exactly (no injection).
+    assert rung_names == ["trivial", "pair-box", "trio-box", "trio-notch", "trio-notch-strict"]
+    # Must contain no completion rung regardless of value.
+    assert all(s.name not in ("completion-notch", "completion-roomy") for s in stages)

--- a/tests/ml/test_train_curriculum.py
+++ b/tests/ml/test_train_curriculum.py
@@ -1830,32 +1830,60 @@ def test_iter_train_metrics_logs_phi_cap_only_for_backplay_rungs():
 
 
 def test_completion_probe_flag_builds_single_completion_rung():
-    # ADR-0028 trigger-#3: --completion-probe produces EXACTLY one stage, the completion rung.
-    from ml.train import build_argparser, build_schedule
+    # ADR-0028 trigger-#3: --completion-probe produces EXACTLY one stage on the RUNTIME path
+    # (_build_curriculum_schedule, which main() calls) — not just on the helper used by tests.
+    from ml.train import _build_curriculum_schedule, build_argparser, build_schedule
 
     args = build_argparser().parse_args(["--completion-probe", "roomy"])
-    stages = build_schedule(args)
+    # Pin on the runtime path so a future divergence between the helper and main() fails here.
+    stages = _build_curriculum_schedule(args).stages
     assert [s.name for s in stages] == ["completion-roomy"]
+    # build_schedule must agree (it delegates to _build_curriculum_schedule).
+    assert [s.name for s in build_schedule(args)] == ["completion-roomy"]
 
 
 def test_completion_probe_notch_builds_notch_rung():
-    # --completion-probe notch → the tight-arm stage.
-    from ml.train import build_argparser, build_schedule
+    # --completion-probe notch → the tight-arm stage, both on the runtime path and via the helper.
+    from ml.train import _build_curriculum_schedule, build_argparser, build_schedule
 
     args = build_argparser().parse_args(["--completion-probe", "notch"])
-    stages = build_schedule(args)
+    stages = _build_curriculum_schedule(args).stages
     assert [s.name for s in stages] == ["completion-notch"]
+    assert [s.name for s in build_schedule(args)] == ["completion-notch"]
+
+
+def test_completion_probe_honors_max_iters_per_stage():
+    # --max-iters-per-stage must be applied to the single completion-probe schedule so that
+    # e.g. `--completion-probe roomy --max-iters-per-stage 200` caps the probe run.
+    from ml.train import _build_curriculum_schedule, build_argparser
+
+    args = build_argparser().parse_args(
+        ["--completion-probe", "roomy", "--max-iters-per-stage", "200"]
+    )
+    sched = _build_curriculum_schedule(args)
+    assert sched.policy.max_iters == 200
 
 
 def test_no_completion_probe_is_default_neutral():
     # ADR-0028 / 4c-ii default-neutrality: absent --completion-probe, the schedule is the
     # concrete DEFAULT_LADDER — no completion rung injected, byte-identical to pre-flag.
-    from ml.train import build_argparser, build_schedule
+    from ml.train import _build_curriculum_schedule, build_argparser, build_schedule
 
     args = build_argparser().parse_args(["--schedule", "curriculum"])
-    stages = build_schedule(args)
+    # Pin on the runtime path.
+    stages = _build_curriculum_schedule(args).stages
     rung_names = [s.name for s in stages]
     # Must match the actual DEFAULT_LADDER exactly (no injection).
     assert rung_names == ["trivial", "pair-box", "trio-box", "trio-notch", "trio-notch-strict"]
     # Must contain no completion rung regardless of value.
     assert all(s.name not in ("completion-notch", "completion-roomy") for s in stages)
+    # build_schedule must agree.
+    assert [s.name for s in build_schedule(args)] == rung_names
+
+
+def test_completion_probe_trivial_schedule_errors():
+    # --completion-probe + --schedule trivial must error LOUD, not silently train the full ladder.
+    from ml.train import main
+
+    with pytest.raises(SystemExit):
+        main(["--schedule", "trivial", "--completion-probe", "roomy"])


### PR DESCRIPTION
Part of #837 (epic #607). **PR-1 of 2** — the code surface for the ADR-0028 trigger-#3 completion paired-witness probe. The RUN + verdict land in PR-2 after this merges.

## What this decides
One bit: is the learned-backend cold-start completion wall the door→interior **drive** (learning capacity) or the **slot sparsity** (geometry)? A paired door-spawn (φ=1) run holds the drive fixed and toggles only the manifold width (tight notch vs roomy).

## Changes (zero env/reward/action/encoding code)
- **`tests/fixtures/ml/witness_roomy.yaml`** — a valid 3-object layout on the 25×30 `test_hangar_large.yaml` (solver-authored, `hangarfit check`-VERIFIED), bare `placements:`, every prefix valid. Validity-pinned by `test_witness_roomy_*`.
- **Two opt-in completion stages** (`_completion_stage(notch|roomy)`): pre-park k=2 of 3, drive the last in from the door (φ=1, no backplay knob). Identical `DifficultyConfig` across arms — manifold width is the only controlled variable.
- **`--completion-probe {notch,roomy}`** — single-rung schedule (fresh policy). Default `None` → schedule byte-identical (the `build_schedule` extraction was verified behavior-preserving line-by-line).
- **`ml/probe_metric.py`** — `marginal_completion()` = `max(0, 3·valid_placed − 2)`: the floor-aware transform that reads the door-spawn rung's aggregate `valid_placed` MARGINALLY against the pre-registered 2/3 floor (a place-nothing completion reads 2/3, NOT success — the #821 masquerade guard).
- **`ml/README.md`** — ledger entry for the pending probe (runnable, not yet run).

## Feasibility-first
Both arms rest on a proven-valid witness (any prefix of a valid layout is valid). Manifold-contrast measured on the **actual committed 2-prefixes**: notch conditional last-slot **~0.076** vs roomy **~0.280** (3.7×) — the controlled variable is real.

## Scope notes
- `ml/` is dev/CI-only (never in the wheel) → **no CHANGELOG** entry (the PR-create CHANGELOG warning is expected here).
- Default-neutral: absent `--completion-probe`, every existing ladder is byte-identical (ml-rl-guard invariant).
- Spec: `docs/superpowers/specs/2026-06-25-learned-backend-completion-paired-witness-probe-design.md` · Plan: `docs/superpowers/plans/2026-06-25-completion-paired-witness-probe.md`

Tests: 691 ml tests pass; ruff + `mypy ml/` clean.