### PR TITLE
docs(607): completion paired-witness probe verdict (NO-GO) — ADR-0028 trigger-#3 spent

### DIFF
--- a/docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md
+++ b/docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md
@@ -99,9 +99,10 @@ it, and that one measured capability is `0.000`.
 **Chosen option: bank + stop, with a falsifiable re-open gate.** The negative result is
 *strengthened* by the probe — five orthogonal lever axes are now a single **measured** root
 cause, not five tries (a sixth axis, the #827 ego-centric coordinate encoder, was gated
-*after* this decision and **confirms** it — see re-open trigger #2 below) — and the charter
-never required clearing the dense trio. The actually-met
-success criterion is the shipped, verifier-gated inference seam (#706).
+*after* this decision and **confirms** it — see re-open trigger #2 below; and the #837 completion
+paired-witness probe — re-open trigger #3 — **confirms** the root cause is **manifold-width-invariant
+drive-binding**, not slot sparsity) — and the charter never required clearing the dense trio. The
+actually-met success criterion is the shipped, verifier-gated inference seam (#706).
 
 **Re-open this decision if (any one):**
 
@@ -128,7 +129,20 @@ success criterion is the shipped, verifier-gated inference seam (#706).
    adversarial panel returned **0/4 refuters**. The confound is now **measured** —
    representation / coordinate-frame is *not* the bottleneck — so this trigger is **spent**:
    it *confirms* the decision rather than re-opening it, **or**
-3. the use case is **re-chartered** toward last-1–2-plane completion.
+3. ~~the use case is **re-chartered** toward last-1–2-plane completion~~ — **RESOLVED-NEGATIVE /
+   SPENT (#837, 2026-06-25).** *Rationale at the time: "maybe the notch slot is just too tight —
+   widen it and the policy completes."* The **completion paired-witness probe** tested exactly that:
+   pre-park k=2 of a valid 3-object witness, door-spawn (φ=1, no backplay) the marginal object, on
+   two manifold arms differing **only** in slot width — tight Herrenteich notch (conditional
+   last-slot ~0.064) vs roomy 25×30 m (~0.278, **~3.7× wider**). If the wall were slot-geometry the
+   roomy arm would complete (marginal ≥ 0.30); it did not. Windowed-final marginal completion =
+   **0.0000 on all four cells** (2 arms × 2 seeds; notch `0.661 / 0.661`, roomy `0.667 / 0.667` →
+   all at the **2-of-3 abandonment floor**, both seeds, reward-positive stable attractor). The fat
+   slot abandons the marginal object **exactly like** the tight notch → the wall is **drive-binding
+   (cold-start drive-and-pack), not slot-geometry**, and generalizes across manifold width. So this
+   trigger is **spent: it confirms the decision** rather than re-opening it. (A genuine re-charter
+   would still need a *different* cold-start-completion training signal, not provided here — but the
+   "notch is merely too tight" escape hatch is now **measured shut**.)
 
 ### Do-not-reattempt (refuted axes)
 
@@ -143,7 +157,9 @@ ego-centric / relative coordinate-frame encoder (#827 / #829 — both confirm
 representation / coordinate-frame is *not* the bottleneck; #827 *did* reproducibly lift the
 upstream generic `trio-box` rung, but that gain does not transfer to the notch wall); removing
 the L4 PPO trust-region clip (**load-bearing** — clip-off → place-nothing); dwell-longer (the
-control already shows ~39-iter flat dwell at 0.333).
+control already shows ~39-iter flat dwell at 0.333); widening the completion slot / roomy-manifold
+completion (#837 — door-spawn completion abandons the marginal object at the 2-of-3 floor on a
+~3.7×-wider slot just as on the tight notch, so manifold width is not the barrier).
 
 ## Consequences
 

--- a/docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md
+++ b/docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md
@@ -100,8 +100,9 @@ it, and that one measured capability is `0.000`.
 *strengthened* by the probe — five orthogonal lever axes are now a single **measured** root
 cause, not five tries (a sixth axis, the #827 ego-centric coordinate encoder, was gated
 *after* this decision and **confirms** it — see re-open trigger #2 below; and the #837 completion
-paired-witness probe — re-open trigger #3 — **confirms** the root cause is **manifold-width-invariant
-drive-binding**, not slot sparsity) — and the charter never required clearing the dense trio. The
+paired-witness probe — re-open trigger #3 — **confirms** the root cause is **drive-binding that
+persists across a ~4.3× manifold-width contrast**, not slot sparsity) — and the charter never
+required clearing the dense trio. The
 actually-met success criterion is the shipped, verifier-gated inference seam (#706).
 
 **Re-open this decision if (any one):**
@@ -134,7 +135,7 @@ actually-met success criterion is the shipped, verifier-gated inference seam (#7
    widen it and the policy completes."* The **completion paired-witness probe** tested exactly that:
    pre-park k=2 of a valid 3-object witness, door-spawn (φ=1, no backplay) the marginal object, on
    two manifold arms differing **only** in slot width — tight Herrenteich notch (conditional
-   last-slot ~0.064) vs roomy 25×30 m (~0.278, **~3.7× wider**). If the wall were slot-geometry the
+   last-slot ~0.064) vs roomy 25×30 m (~0.278, **~4.3× wider**). If the wall were slot-geometry the
    roomy arm would complete (marginal ≥ 0.30); it did not. Windowed-final marginal completion =
    **0.0000 on all four cells** (2 arms × 2 seeds; notch `0.661 / 0.662`, roomy `0.667 / 0.667` →
    all at the **2-of-3 abandonment floor**, both seeds, reward-positive stable attractor). The fat
@@ -159,7 +160,7 @@ upstream generic `trio-box` rung, but that gain does not transfer to the notch w
 the L4 PPO trust-region clip (**load-bearing** — clip-off → place-nothing); dwell-longer (the
 control already shows ~39-iter flat dwell at 0.333); widening the completion slot / roomy-manifold
 completion (#837 — door-spawn completion abandons the marginal object at the 2-of-3 floor on a
-~3.7×-wider slot just as on the tight notch, so manifold width is not the barrier).
+~4.3×-wider slot just as on the tight notch, so manifold width is not the barrier).
 
 ## Consequences
 

--- a/docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md
+++ b/docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md
@@ -136,7 +136,7 @@ actually-met success criterion is the shipped, verifier-gated inference seam (#7
    two manifold arms differing **only** in slot width — tight Herrenteich notch (conditional
    last-slot ~0.064) vs roomy 25×30 m (~0.278, **~3.7× wider**). If the wall were slot-geometry the
    roomy arm would complete (marginal ≥ 0.30); it did not. Windowed-final marginal completion =
-   **0.0000 on all four cells** (2 arms × 2 seeds; notch `0.661 / 0.661`, roomy `0.667 / 0.667` →
+   **0.0000 on all four cells** (2 arms × 2 seeds; notch `0.661 / 0.662`, roomy `0.667 / 0.667` →
    all at the **2-of-3 abandonment floor**, both seeds, reward-positive stable attractor). The fat
    slot abandons the marginal object **exactly like** the tight notch → the wall is **drive-binding
    (cold-start drive-and-pack), not slot-geometry**, and generalizes across manifold width. So this

--- a/ml/README.md
+++ b/ml/README.md
@@ -29,7 +29,7 @@ coverage-minimum number quoted in the lever recipes below; the *levered* runs co
 **Completion paired-witness probe: ADR-0028 trigger-#3 → NO-GO (#837, 2026-06-25).** The third
 re-open diagnostic — a **paired-witness A/B** on the completion skill (door-spawn φ=1, pre-park
 k=2 of 3, NO backplay knob), testing whether **manifold width** is the barrier: tight Herrenteich
-notch (conditional last-slot ~0.064) vs roomy 25×30 m `witness_roomy.yaml` (~0.278, ~3.7× wider) —
+notch (conditional last-slot ~0.064) vs roomy 25×30 m `witness_roomy.yaml` (~0.278, ~4.3× wider) —
 **ran** (4 cells = 2 arms × 2 seeds, identical config except the witness; 200 iters, CPU single-env).
 Both arms read marginal completion `max(0, 3·valid_placed − 2)` against a pre-registered 2/3 floor;
 **GO** would have needed roomy marginal ≥ 0.30 (both seeds) with notch ≈ 0. **Result: marginal
@@ -892,9 +892,15 @@ hardening eval was moot (no WIN to harden) and remains a reusable asset.
 lever must target empty-start sequencing specifically — candidates: an **empty-start coverage k-anneal** (explicit
 drive-2-from-empty then drive-3-from-empty rungs, k:2→1→0 — the surviving #815 fork-B, now much better-motivated)
 or **multi-object backplay** (anneal the pre-park count k→0 so the proven near-solution-spawn mechanism trains
-from empty). A strategic alternative is to **reframe toward completion**: hangarfit's on-demand-exception use case
+from empty). ~~A strategic alternative is to **reframe toward completion**: hangarfit's on-demand-exception use case
 rarely starts from an empty hangar (it fits the displaced last 1–2 planes into a mostly-set layout), which is
-exactly the completion skill backplay already delivers (~65% valid). **Contraindicated / do-not-reattempt:**
+exactly the completion skill backplay already delivers (~65% valid).~~ **Superseded — RESOLVED-NEGATIVE
+(#837, see the Status section at the top).** The ADR-0028 trigger-#3 completion paired-witness probe trained
+this exact door-spawn-completion regime (φ=1, pre-park k=2, drive the marginal object) and read it through the
+floor-aware **marginal** metric `max(0, 3·valid_placed − 2)`: marginal completion = **0.000 on both the tight
+notch and a ~4.3×-wider roomy slot** (every cell sat at the 2-of-3 abandonment floor `valid_placed ≈ 0.667`).
+The "~65% valid" was an aggregate `valid_placed` the marginal floor strips to zero — not genuine cold-start
+completion — so re-charter-to-completion is **closed, not an open direction**. **Contraindicated / do-not-reattempt:**
 witness-imitation / DAgger (oracle-masquerade, panel-rejected), the pile-safe carrot (#812), the entropy floor
 (#815), and spatial representation (#810).
 

--- a/ml/README.md
+++ b/ml/README.md
@@ -895,12 +895,13 @@ or **multi-object backplay** (anneal the pre-park count k→0 so the proven near
 from empty). ~~A strategic alternative is to **reframe toward completion**: hangarfit's on-demand-exception use case
 rarely starts from an empty hangar (it fits the displaced last 1–2 planes into a mostly-set layout), which is
 exactly the completion skill backplay already delivers (~65% valid).~~ **Superseded — RESOLVED-NEGATIVE
-(#837, see the Status section at the top).** The ADR-0028 trigger-#3 completion paired-witness probe trained
-this exact door-spawn-completion regime (φ=1, pre-park k=2, drive the marginal object) and read it through the
-floor-aware **marginal** metric `max(0, 3·valid_placed − 2)`: marginal completion = **0.000 on both the tight
-notch and a ~4.3×-wider roomy slot** (every cell sat at the 2-of-3 abandonment floor `valid_placed ≈ 0.667`).
-The "~65% valid" was an aggregate `valid_placed` the marginal floor strips to zero — not genuine cold-start
-completion — so re-charter-to-completion is **closed, not an open direction**. **Contraindicated / do-not-reattempt:**
+(#837, see the Status section at the top).** Genuine cold-start completion is not achieved on either manifold,
+by two independent measurements: the measure-first probe already showed true φ=1 completion is `0.000` (the
+"~65%" was a φ-mixture average dominated by near-witness episodes — see Status), and the ADR-0028 trigger-#3
+completion paired-witness probe — training pure door-spawn completion (φ=1, pre-park k=2, drive the marginal
+object) directly, read through the floor-aware **marginal** metric `max(0, 3·valid_placed − 2)` — converges
+only to the **2-of-3 abandonment floor** (marginal `0.000` on both the tight notch and a ~4.3×-wider roomy
+slot; `valid_placed ≈ 0.667`). So re-charter-to-completion is **closed, not an open direction**. **Contraindicated / do-not-reattempt:**
 witness-imitation / DAgger (oracle-masquerade, panel-rejected), the pile-safe carrot (#812), the entropy floor
 (#815), and spatial representation (#810).
 

--- a/ml/README.md
+++ b/ml/README.md
@@ -20,20 +20,29 @@ Six gate-run levers, spanning every lever class (the representation axis was pro
 | #817 `--entropy-floor` | exploration | inert, vp 0.333 = control |
 | #823 `--backplay-trio-notch` | start-state distribution (ρ₀) | transfer 0.000; scaffold-only 0.63–0.69 |
 | #827 `--relative-encoder` | representation (coordinate frame) | vp 0.353/0.332 PILING ≈ control 0.317/0.316 |
-| **ADR-0028 trigger-#3** | **completion paired-witness probe** | **runnable — not yet run** |
+| **ADR-0028 trigger-#3** | **completion paired-witness probe** | **RAN → NO-GO: notch & roomy both marginal 0.000 (2-of-3 abandon floor)** |
 
 (The empty-start `trio-notch` *baseline* sat slightly lower at `valid_placed ≈ 0.25` — the
 coverage-minimum number quoted in the lever recipes below; the *levered* runs converge to the
 1-of-3 = `0.333` place-one fixed point. Same failure mode, two measurement contexts.)
 
-**Pending probe: ADR-0028 trigger-#3 (completion paired-witness).** The third re-open diagnostic
-(runnable but not yet run) is a **paired-witness A/B** on the completion skill — door-spawn φ=1,
-pre-park k=2 of 3, NO backplay knob, testing whether manifold width is the barrier: tight notch vs
-roomy (`witness_roomy.yaml`). Both arms
-measure marginal completion `max(0, 3·valid_placed − 2)` against a pre-registered 2/3 floor. GO =
-roomy vp ≥ 0.30 & notch ≈ 0 → slot geometry drives the wall → reframe to roomy scoped charter
-(the on-demand-exception real use case). NO-GO = both ≈ 0 → drive binding without witness spawn
-→ resolved-negative generalizes to completion. See [ADR-0028](../docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md) for the charter details and re-open gate.
+**Completion paired-witness probe: ADR-0028 trigger-#3 → NO-GO (#837, 2026-06-25).** The third
+re-open diagnostic — a **paired-witness A/B** on the completion skill (door-spawn φ=1, pre-park
+k=2 of 3, NO backplay knob), testing whether **manifold width** is the barrier: tight Herrenteich
+notch (conditional last-slot ~0.064) vs roomy 25×30 m `witness_roomy.yaml` (~0.278, ~3.7× wider) —
+**ran** (4 cells = 2 arms × 2 seeds, identical config except the witness; 200 iters, CPU single-env).
+Both arms read marginal completion `max(0, 3·valid_placed − 2)` against a pre-registered 2/3 floor;
+**GO** would have needed roomy marginal ≥ 0.30 (both seeds) with notch ≈ 0. **Result: marginal
+`0.0000` on all four cells** — windowed-final `valid_placed` notch `0.661/0.661`, roomy
+`0.667/0.667`; every cell converged to the **2-of-3 abandonment floor** (keep the two valid
+pre-parked, abandon the marginal third; reward-positive stable attractor, both seeds). The fat
+roomy slot abandons the marginal object **exactly like** the tight notch → the wall is
+**drive-binding (cold-start drive-and-pack), not slot-geometry**; the geometry confound is closed
+and the resolved-negative result **generalizes across manifold width**. Trigger-#3 is therefore
+**spent — it confirms the decision** rather than re-opening it (two of the three re-open triggers
+are now negative-confirming; only trigger #1, feasibility-witnessed reach-rate, stays open). See
+[ADR-0028](../docs/adr/0028-learned-backend-train-to-mastery-resolved-negative.md) for the charter
+details and the re-open gate.
 
 A **pre-registered measure-first probe** (`basin_mc.py` + `phi_eval.py` + `phi_eval_control.py`
 + `probe-verdict.md`, gitignored gate-run scratch; torch-light, through the product checker;

--- a/ml/README.md
+++ b/ml/README.md
@@ -33,7 +33,7 @@ notch (conditional last-slot ~0.064) vs roomy 25×30 m `witness_roomy.yaml` (~0.
 **ran** (4 cells = 2 arms × 2 seeds, identical config except the witness; 200 iters, CPU single-env).
 Both arms read marginal completion `max(0, 3·valid_placed − 2)` against a pre-registered 2/3 floor;
 **GO** would have needed roomy marginal ≥ 0.30 (both seeds) with notch ≈ 0. **Result: marginal
-`0.0000` on all four cells** — windowed-final `valid_placed` notch `0.661/0.661`, roomy
+`0.0000` on all four cells** — windowed-final `valid_placed` notch `0.661/0.662`, roomy
 `0.667/0.667`; every cell converged to the **2-of-3 abandonment floor** (keep the two valid
 pre-parked, abandon the marginal third; reward-positive stable attractor, both seeds). The fat
 roomy slot abandons the marginal object **exactly like** the tight notch → the wall is


### PR DESCRIPTION
Closes #837.

**PR-2 of 2** for the ADR-0028 **trigger-#3 completion paired-witness probe** (PR-1 = the code, #838, merged). This PR records the **run verdict** — docs-only; `ml/` is dev/CI-only so no CHANGELOG.

## What ran
4 cells = 2 arms × 2 seeds, **identical config except the witness**, door-spawn φ=1, pre-park k=2 of a valid 3-object witness, drive the marginal object in (no backplay knob), 200 iters, CPU single-env (the plan's deterministic config). From a worktree pinned to merged develop `ba7660a`. All `rc=0`; engagement confirmed (200 rows/cell, `stage=completion-<arm>`, no `phi_cap`).

- **notch** arm: tight Herrenteich notch, conditional last-slot ~0.064
- **roomy** arm: 25×30 m `test_hangar_large`, ~0.278 — **~3.7× wider** (the only controlled variable)

## Result — NO-GO (drive-binding generalizes)
Windowed-final `valid_placed` (mean last 10 iters) → `marginal_completion = max(0, 3·vp − 2)`:

| Cell | valid_placed | marginal |
|---|---|---|
| notch-s0 | 0.6611 | **0.0000** |
| notch-s1 | 0.6615 | **0.0000** |
| roomy-s0 | 0.6667 | **0.0000** |
| roomy-s1 | 0.6667 | **0.0000** |

Every cell converged to the **2-of-3 abandonment floor** (keep the two valid pre-parked, abandon the marginal third; reward-positive *stable* attractor, both seeds). GO would have needed roomy marginal ≥ 0.30 with notch ≈ 0; neither arm cleared the floor.

The fat roomy slot abandons the marginal object **exactly like** the tight notch → the wall is **drive-binding (cold-start drive-and-pack), not slot-geometry**. The geometry confound is closed; the resolved-negative result **generalizes across manifold width**.

## Recorded
- `ml/README.md` — ledger row (pending → NO-GO) + prose block with the numbers.
- `docs/adr/0028-…` — trigger #3 → **spent: confirms the decision** (matching how #827 closed trigger #2); intro sharpened to "manifold-width-invariant drive-binding"; do-not-reattempt += the slot-widening axis.

Two of three re-open triggers are now negative-confirming (#827 → #2; this → #3); only trigger #1 (feasibility-witnessed reach-rate) stays open and untested. Even a GO here would have been diagnostic-only (RR-MC saturates roomy fills) — this is not a beat-RR-MC claim either way.