### PR TITLE
fix(842): model the Scheibe SF-25 low-wing below the high-wing layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,21 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Fixed
 
+- **Herrenteich fleet fidelity (#842): the Scheibe SF-25's low-wing was modelled in the high-wing
+  layer, manufacturing a phantom tow-time collision.** The SF-25 is a real LOW-wing motor glider,
+  but its 18 m wing carried `z[1.9,2.1]` — the SAME vertical layer as the genuine high-wingers'
+  wings (e.g. `aviat_husky`, `z[2.0,2.3]`). A high-winger towed past the parked Scheibe then hit a
+  wing-vs-wing collision the parts-model would never see in reality (a high wing simply overhangs a
+  low one), making the real, valid all-8 `examples/herrenteich/layout.yaml` un-tow-routable. The wing
+  is now a thin raised keep-out band `z[1.70,1.80]` — the narrow corridor that clears the fuselages it
+  overhangs (floor 0.20 m above the 1.5 m fuselage tops) yet sits below the high-wing layer (ceiling
+  0.20 m under `aviat_husky`'s 2.0 m wing) so high-wingers correctly overhang it. Both bundled layouts
+  (`layout.yaml`, the dense `layout_today.yaml`) stay statically valid; a new
+  `test_scheibe_wing_sits_below_the_high_wing_layer` pins the z-layering invariant (which is
+  static-validity-neutral, so the existing layout tests alone would not catch a regression). Render
+  colour is unchanged (`wing_position: high` still selects it; collision z-layering reads the explicit
+  part z-values, not this label).
+
 ## [0.16.0] — 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,10 +146,13 @@ All notable changes to this project are documented here. Format follows [Keep a 
   wings (e.g. `aviat_husky`, `z[2.0,2.3]`). A high-winger towed past the parked Scheibe then hit a
   wing-vs-wing collision the parts-model would never see in reality (a high wing simply overhangs a
   low one), making the real, valid all-8 `examples/herrenteich/layout.yaml` un-tow-routable. The wing
-  is now a thin raised keep-out band `z[1.70,1.80]` — the narrow corridor that clears the fuselages it
-  overhangs (floor 0.20 m above the 1.5 m fuselage tops) yet sits below the high-wing layer (ceiling
-  0.20 m under `aviat_husky`'s 2.0 m wing) so high-wingers correctly overhang it. Both bundled layouts
-  (`layout.yaml`, the dense `layout_today.yaml`) stay statically valid; a new
+  is now a thin raised keep-out band `z[1.72,1.78]` — centred at 1.75 m in the narrow corridor between
+  the fuselages it overhangs and the high-wing layer, with a 0.22 m gap on each side: the floor clears
+  the 1.5 m fuselage tops and the ceiling sits below `aviat_husky`'s 2.0 m wing so high-wingers overhang
+  it. The thin centred band clears the wing-layer clearance under BOTH hangars that share this catalog
+  entry — herrenteich's 0.15 m and the synthetic `data/hangar.yaml`'s 0.20 m (a band exactly on the
+  0.20 m boundary would false-conflict on float: `1.70 - 1.50 == 0.19999…96 < 0.20`). Both bundled
+  layouts (`layout.yaml`, the dense `layout_today.yaml`) stay statically valid; a new
   `test_scheibe_wing_sits_below_the_high_wing_layer` pins the z-layering invariant (which is
   static-validity-neutral, so the existing layout tests alone would not catch a regression). Render
   colour is unchanged (`wing_position: high` still selects it; collision z-layering reads the explicit

--- a/data/catalog/scheibe_falke.yaml
+++ b/data/catalog/scheibe_falke.yaml
@@ -2,12 +2,15 @@
 type: aircraft
 id: scheibe_falke
 name: "Scheibe SF-25E Super Falke"
-wing_position: high     # real aircraft is LOW-wing (EASA TCDS); modelled HIGH for the tilt — see header
+wing_position: high     # real aircraft is LOW-wing (EASA TCDS); the wing is modelled as a thin raised flat
+                        # keep-out band (z[1.7,1.8]) for the monowheel tilt — see the wing z-layering note (#842).
+                        # `high` here only selects the render colour (visualize.py); collision z-layering reads
+                        # the explicit part z_* values below, so this label does not put the wing in the high layer.
 gear: monowheel         # central monowheel + under-wing outriggers + tailwheel (TCDS-confirmed)
 movement_mode: always_cart
 turn_radius_m: null  # always_cart → towplanner uses 0 (pivot); see ADR-0007
 measured: false
-notes: "18 m span (EASA TCDS A.098). Cantilever wing; real aircraft is low-wing but modelled high to represent the monowheel TILT (see header). Central monowheel + outriggers + tailwheel; parks lengthwise (too wide nose-in)."
+notes: "18 m span (EASA TCDS A.098). Cantilever wing; real aircraft is low-wing, modelled as a thin raised flat keep-out band z[1.7,1.8] to represent the monowheel TILT while clearing the neighbouring fuselages it overhangs (see the wing z-layering note, #842). Central monowheel + outriggers + tailwheel; parks lengthwise (too wide nose-in)."
 parts:
   - kind: fuselage
     length_m: 7.58        # EASA TCDS A.098 (length)
@@ -16,13 +19,27 @@ parts:
     offset_y_m: 0.0
     z_bottom_m: 0.0
     z_top_m: 1.5
-  - kind: wing            # modelled HIGH (z 1.9-2.1) for the monowheel tilt — real aircraft is low-wing
+  - kind: wing            # thin flat keep-out band z[1.7,1.8] for the monowheel tilt — see the z-layering note (#842)
     length_m: 1.01        # mean chord = area 18.20 m² / span 18.00 m (EASA TCDS A.098)
     width_m: 18.0         # span (EASA TCDS A.098)
     offset_x_m: 1.5
     offset_y_m: 0.0
-    z_bottom_m: 1.9
-    z_top_m: 2.1
+    # z-LAYERING (#842): the SF-25E is a real LOW-wing motor glider on a central monowheel;
+    # parked it rests on the monowheel + a wingtip outrigger + tailwheel and sits slightly
+    # tilted. Its 18 m wing is modelled as a thin flat keep-out band — NOT at its true low-wing
+    # root height — sitting in the narrow vertical corridor between the fuselages it overhangs
+    # and the genuine high-wingers' wing layer:
+    #   * FLOOR 1.70 m: in the dense 9-aircraft layout_today.yaml the wing overhangs the zlin
+    #     and husky AFT fuselages (tops 1.5 m); 1.70 leaves a 0.20 m gap, clearing the 0.15 m
+    #     wing-layer clearance. (A true-low band z~0.4-0.6 would clip those fuselages outright.)
+    #   * CEILING 1.80 m: sits 0.20 m below the high-wingers' wing layer (e.g. aviat_husky wing
+    #     bottom 2.0 m), so their wings correctly overhang it as in reality — this is the gap
+    #     that lets aviat_husky tow PAST the parked Scheibe.
+    # The prior z[1.9,2.1] put this LOW-wing glider's wing INTO the high-wing layer, manufacturing
+    # a phantom wing-vs-wing collision during the tow that has no real-world counterpart and made
+    # the real, valid Herrenteich all-8 layout un-tow-routable (#842).
+    z_bottom_m: 1.7
+    z_top_m: 1.8
     # Symmetric double-taper (no sweep, root kink at y=0) → a 6-vertex hexagon
     # (ADR-0024). The SF-25E wing is the realistically-tapered glider whose
     # narrowed wingtip nests where its bounding rectangle falsely conflicts with

--- a/data/catalog/scheibe_falke.yaml
+++ b/data/catalog/scheibe_falke.yaml
@@ -3,14 +3,14 @@ type: aircraft
 id: scheibe_falke
 name: "Scheibe SF-25E Super Falke"
 wing_position: high     # real aircraft is LOW-wing (EASA TCDS); the wing is modelled as a thin raised flat
-                        # keep-out band (z[1.7,1.8]) for the monowheel tilt — see the wing z-layering note (#842).
+                        # keep-out band (z[1.72,1.78]) for the monowheel tilt — see the wing z-layering note (#842).
                         # `high` here only selects the render colour (visualize.py); collision z-layering reads
                         # the explicit part z_* values below, so this label does not put the wing in the high layer.
 gear: monowheel         # central monowheel + under-wing outriggers + tailwheel (TCDS-confirmed)
 movement_mode: always_cart
 turn_radius_m: null  # always_cart → towplanner uses 0 (pivot); see ADR-0007
 measured: false
-notes: "18 m span (EASA TCDS A.098). Cantilever wing; real aircraft is low-wing, modelled as a thin raised flat keep-out band z[1.7,1.8] to represent the monowheel TILT while clearing the neighbouring fuselages it overhangs (see the wing z-layering note, #842). Central monowheel + outriggers + tailwheel; parks lengthwise (too wide nose-in)."
+notes: "18 m span (EASA TCDS A.098). Cantilever wing; real aircraft is low-wing, modelled as a thin raised flat keep-out band z[1.72,1.78] to represent the monowheel TILT while clearing the neighbouring fuselages it overhangs (see the wing z-layering note, #842). Central monowheel + outriggers + tailwheel; parks lengthwise (too wide nose-in)."
 parts:
   - kind: fuselage
     length_m: 7.58        # EASA TCDS A.098 (length)
@@ -19,27 +19,38 @@ parts:
     offset_y_m: 0.0
     z_bottom_m: 0.0
     z_top_m: 1.5
-  - kind: wing            # thin flat keep-out band z[1.7,1.8] for the monowheel tilt — see the z-layering note (#842)
+  - kind: wing            # thin flat keep-out band z[1.72,1.78] for the monowheel tilt — see the z-layering note (#842)
     length_m: 1.01        # mean chord = area 18.20 m² / span 18.00 m (EASA TCDS A.098)
     width_m: 18.0         # span (EASA TCDS A.098)
     offset_x_m: 1.5
     offset_y_m: 0.0
     # z-LAYERING (#842): the SF-25E is a real LOW-wing motor glider on a central monowheel;
     # parked it rests on the monowheel + a wingtip outrigger + tailwheel and sits slightly
-    # tilted. Its 18 m wing is modelled as a thin flat keep-out band — NOT at its true low-wing
-    # root height — sitting in the narrow vertical corridor between the fuselages it overhangs
-    # and the genuine high-wingers' wing layer:
-    #   * FLOOR 1.70 m: in the dense 9-aircraft layout_today.yaml the wing overhangs the zlin
-    #     and husky AFT fuselages (tops 1.5 m); 1.70 leaves a 0.20 m gap, clearing the 0.15 m
-    #     wing-layer clearance. (A true-low band z~0.4-0.6 would clip those fuselages outright.)
-    #   * CEILING 1.80 m: sits 0.20 m below the high-wingers' wing layer (e.g. aviat_husky wing
-    #     bottom 2.0 m), so their wings correctly overhang it as in reality — this is the gap
-    #     that lets aviat_husky tow PAST the parked Scheibe.
+    # tilted. Its 18 m wing is modelled as a THIN flat keep-out band — NOT at its true low-wing
+    # root height — centred at 1.75 m in the narrow vertical corridor between the fuselages it
+    # overhangs and the genuine high-wingers' wing layer, giving a 0.22 m gap on each side:
+    #   * FLOOR 1.72 m: in the dense 9-aircraft layout_today.yaml the wing overhangs the AFT
+    #     section of the zlin and husky fuselages (single whole-body fuselage part, top 1.5 m;
+    #     the loader's ADR-0012 front/aft split preserves z_top). The 0.22 m gap clears the
+    #     wing-layer clearance under BOTH hangars that share this catalog entry — herrenteich's
+    #     0.15 m AND the synthetic data/hangar.yaml's 0.20 m (a band exactly on the 0.20 m
+    #     boundary would false-conflict: 1.70-1.50 == 0.19999…96 < 0.20 in float). A true-low
+    #     band z~0.4-0.6 would clip those fuselages outright. NB this must be the AFT fuselage:
+    #     a wing over a fuselage_front / cockpit is a HARD conflict at ANY height (ADR-0012 D1),
+    #     so no z-band would rescue an overhang nudged forward over a neighbour's cockpit.
+    #   * CEILING 1.78 m: sits 0.22 m below the high-wingers' wing layer (aviat_husky wing
+    #     bottom 2.0 m is the representative one a tow passes under), so their wings correctly
+    #     overhang it as in reality — this is the gap that lets aviat_husky tow PAST the parked
+    #     Scheibe. (The z-gap rule only bites under plan-view overlap, which the husky TOW path
+    #     creates; statically-distant high-wingers like zlin never overlap the Scheibe wing.)
     # The prior z[1.9,2.1] put this LOW-wing glider's wing INTO the high-wing layer, manufacturing
     # a phantom wing-vs-wing collision during the tow that has no real-world counterpart and made
     # the real, valid Herrenteich all-8 layout un-tow-routable (#842).
-    z_bottom_m: 1.7
-    z_top_m: 1.8
+    # These neighbour z-values (husky wing bottom, fuselage tops) are pinned dynamically by
+    # tests/test_herrenteich_dataset.py::test_scheibe_wing_sits_below_the_high_wing_layer; if you
+    # change aviat_husky's wing-z or the fuselage tops, re-read them there, not from this prose.
+    z_bottom_m: 1.72
+    z_top_m: 1.78
     # Symmetric double-taper (no sweep, root kink at y=0) → a 6-vertex hexagon
     # (ADR-0024). The SF-25E wing is the realistically-tapered glider whose
     # narrowed wingtip nests where its bounding rectangle falsely conflicts with

--- a/docs/spikes/herrenteich-all8-tow-routing-rootcause.md
+++ b/docs/spikes/herrenteich-all8-tow-routing-rootcause.md
@@ -20,7 +20,7 @@ way, and the confidence in each conclusion.
 | | Finding | Status | Confidence |
 |---|---|---|---|
 | **Factor 1** | The Scheibe SF-25 (a real **low-wing** glider) had its 18 m wing modelled in the **high-wing z-layer** (`z[1.9,2.1]`), the same layer as the genuine high-wingers' wings. Towing a high-winger (e.g. `aviat_husky`, wing `z[2.0,2.3]`) past the parked Scheibe then hit a **phantom wing-vs-wing collision** with no real-world counterpart. | **Fixed** — wing re-modelled as a thin band `z[1.72,1.78]` below the high-wing layer (#842, PR #843). | **~95 %** |
-| **Factor 2** | Even with Factor 1 fixed, the **full** all-8 does not route in `plan_fill`'s natural *deepest-first* order: a front-door cluster (`aviat_husky`, `fk9_mkii`, `cessna_140`) mutually blocks, and the planner's order-backtracking does not converge in reasonable time (>20 min). | **Characterised**, not solved — handed to a follow-up. It is an **order / planner** problem, separable from the fidelity bug. | medium |
+| **Factor 2** | Even with Factor 1 fixed, the **full** all-8 does not auto-route. Narrowed to one pair: `fk9_mkii` and `cessna_140` (both genuine high-wingers) **mutually block** near the door — each space-exhausts against the other at the 0.5 m/15° grid, so no monotone order places both. A finer-grid sweep walled inconclusively (search too slow), but the 0.05 m tow clearance + "few cm" real spacing make **search resolution** the prime suspect. | **Characterised**, not solved — handed to #844. A **search-efficiency** problem (resolution/order/budget), separable from the fidelity bug; not (so far as measured) another physics error. | medium |
 
 The headline: **at least one definite model-fidelity bug made the use case impossible**, and it
 is fixed. A second factor — finding a *feasible monotone order* under the deployed planner —
@@ -97,41 +97,53 @@ The taper planform (ADR-0024 / #541) and the render colour (`wing_position: high
 ## Factor 2 — a feasible monotone order is not found by the deployed planner (CHARACTERISED)
 
 With Factor 1 fixed, the husky↔Scheibe block is gone, but the **whole** all-8 still does not
-auto-route under `plan_fill`. The evidence:
+auto-route under `plan_fill`. A long series of targeted experiments narrowed the residue to **one
+specific pair**:
 
-- **Natural deepest-first order (`back_first_order`).** Testing each plane against its exact
-  predecessors in that order (8 parallel `plan_path` calls): **5 of 8 route** (zlin, scheibe,
-  wild_thing, stemme, ctsl — ctsl even routes against all 7 predecessors), but **`aviat_husky`,
-  `fk9_mkii`, `cessna_140` block** (space-exhausted at the default 0.5 m/15° grid). These are all
-  **front-door** planes (low *y*).
-- **It is an order interaction, not (visibly) more physics.** `aviat_husky` routes past
-  `{zlin, scheibe}` but **blocks** once `wild_thing` is added — i.e. `wild_thing` walls the husky
-  corridor in this order. A different relative order of the front cluster is needed.
-- **`plan_fill` backtracks over order (#667) but does not converge.** Given a generous budget it
-  ran **>20 min** without completing — the front-cluster planes are expensive both to route and
-  to *disprove*, so the order-backtracking burns budget on failed branches.
-- **Resolution is inconclusive for the front cluster.** A grid-resolution sweep on the confirmed
-  blocker (`cessna_140` vs its 6 predecessors) space-exhausted at 0.5 m/15° but the finer grids
-  (0.33 → 0.15 m) did not *finish* within a 500 s wall — so finer resolution is neither confirmed
-  nor refuted there; it is simply too slow to settle this way.
+- **Natural deepest-first order (`back_first_order`).** Each plane tested against its exact
+  predecessors (8 parallel `plan_path` calls): **5 of 8 route** (zlin, scheibe, wild_thing, stemme,
+  ctsl — ctsl even routes against all 7), but the **front-door** planes `aviat_husky`, `fk9_mkii`,
+  `cessna_140` block.
+- **All eight are R=0 (pivot).** husky/fk9/cessna are `tow_pivotable`, so even off-carts their
+  effective turn radius is 0 — the front-cluster block is **not** a turn-radius problem.
+- **husky is purely an ORDER issue.** It routes past `{zlin, scheibe}` (1066 expansions) but
+  exhausts once `wild_thing` is also placed; placing husky earlier fixes it.
+- **The linchpin: `fk9_mkii` and `cessna_140` MUTUALLY block.** Run to completion (no time wall):
+  `fk9` routes past `{zlin, scheibe}` instantly (0 exp) and past `{zlin, scheibe, husky}` (6720 exp,
+  ~6 min) — but **genuinely space-exhausts** (10184 exp, complete search) against any predecessor
+  set that contains `cessna`; symmetrically `cessna` exhausts (11174 exp) against any set containing
+  `fk9`. So at the 0.5 m/15° grid **no monotone order can place both** — the second one in is always
+  walled by the first.
+- **Both are genuine high-wingers** (`fk9` wing z[1.9,2.2], `cessna` z[2.0,2.3]) — a fleet audit
+  confirms neither is a Scheibe-style miscoding. Their tow-time wing interaction is **physical**:
+  two real high wings cannot overlap, and threading one tug-path past the other near the door needs
+  fine lateral precision.
+- **Resolution is the suspected lever but unconfirmed.** `fk9` *provably* has no path at 0.5 m/15°
+  (exhausted), but a sweep at 0.25 / 0.20 / 0.15 m **walled at 600 s without settling** — at a finer
+  grid A* would usually find an existing path fast, so a wall is "no path **or** search too slow",
+  not a proof either way.
+- **The deployed planner can't brute-force it.** `plan_fill` with a 7.5×-raised per-plane budget
+  (60 k) and a 250×-raised global budget (4 M) **walled at 40 min** without routing — its
+  deepest-first order is wrong for the front cluster, and the fk9↔cessna mutual block sends the
+  order-backtracking into an expensive, non-converging search.
 
-**Interpretation.** Physically a monotone order exists (the club parks all eight every day). The
-gap is the deployed planner *finding* it: `back_first_order` is the wrong order for the front
-cluster, and the order-backtracking + per-plane budget are not tuned to converge on the tight
-front corridors. This is a **planner/search** problem. It is handed to a follow-up; candidate
-directions (in rough order of expected value):
+**Interpretation.** The dominant blocker was Factor 1 (now fixed). The residual is a single tight
+maneuvering corridor between two real high-wingers at the door. Physically a monotone fill exists
+(the club parks all eight daily, "with only a few cm between planes at certain parts"), and the
+tow **motion** clearance is just 0.05 m — so the real maneuver threads with ~cm precision that a
+0.5 m / 15° grid simply **cannot represent**. The most likely truth is that finer resolution would
+route it, but the current Hybrid-A* is too slow to confirm that at a cm-scale grid within practical
+time. This is a **search-efficiency** problem, handed to #844; candidate directions:
 
-1. **A better entry order than strict deepest-first** for the front cluster (e.g. order by corridor
-   tightness, or a front-cluster-aware tiebreak), so greedy routes without deep backtracking.
-2. **Per-plane budget / wall tuning** so a tight-but-feasible front plane actually routes instead
-   of spuriously failing and triggering backtracking.
-3. **Finer grid *only* where needed** (adaptive resolution near tight corridors) — the user's
-   "a few cm / finer heading" intuition, which the per-cluster sweeps could not yet settle because
-   a uniform fine grid is too slow.
+1. **Adaptive / finer grid near tight corridors** (the user's "few cm / finer heading" intuition) —
+   the prime suspect, blocked only by search speed today.
+2. **A front-cluster-aware entry order** (husky before wild_thing; fk9/cessna ordered to avoid the
+   mutual block) rather than strict deepest-first.
+3. **Per-plane budget tuning** (the default 8000 is far below the ~7–15 k these searches need).
 
 A learned tow-motion policy (the original spike direction, #840) is the longer-term lever for
-exactly this "thread the tight corridor / pick the order" search; this investigation sharpens its
-target to the front-door cluster.
+exactly this "thread the cm-scale corridor" search; this investigation sharpens its target to the
+front-door `fk9`↔`cessna` pair.
 
 ---
 
@@ -146,7 +158,7 @@ the "comparison to other options discarded" the brief asked for.
 | **Pivot point / cart strafe / reverse** mis-modelled | Exercised cart-strafe and reverse seeds in isolation | **Discarded** — present and correct |
 | **Aircraft dimensions wrong** | Re-checked spans/lengths against EASA TCDS / published specs | **Discarded** — dimensions match sources |
 | **Clearances too strict** | Swept clearance; the all-8 is valid at the calibrated 0.10/0.15 m (and motion 0.05) | **Discarded** — not the binding constraint |
-| **Search resolution too coarse** (the user's second suspicion) | Re-ran the *husky↔scheibe* block at 0.2 m/5° | **Discarded for that pair** (still space-exhausted with the wing high → it was fidelity, not resolution). **Open for the front cluster** (finer-grid runs too slow to settle — see Factor 2). |
+| **Search resolution too coarse** (the user's second suspicion) | Re-ran the *husky↔scheibe* block at 0.2 m/5°; swept the *fk9↔cessna* block at 0.25 / 0.20 / 0.15 m | **Discarded for husky↔scheibe** (still space-exhausted with the wing high → that was fidelity, not resolution). **Still the prime suspect for fk9↔cessna** (proven no path at 0.5 m/15°; finer grids walled without settling — too slow to confirm). See Factor 2. |
 | **Single-tree RRT / RRT-Connect oracle** would route it | Prototyped both | **Discarded** — weaker than the shipped `plan_path` Hybrid-A* in this clutter (goal tree trapped; ~2 % extend success) |
 | **Multi-body "move aside" needed** | Checked whether a parked plane must move | **Discarded** — the club never moves parked planes; the fill is monotone. The block was fidelity, not a need to relocate |
 | **A second wing-z fidelity bug** in the front cluster | Fleet-wide wing-z audit | **Not found** — scheibe is the only outlier; the front-cluster block reads as order/search, not another physics error |
@@ -159,11 +171,15 @@ the "comparison to other options discarded" the brief asked for.
   are clean and reproducible, the fix is shipped with a regression test, and both real layouts stay
   valid. The 5 % is residual model risk (the synthetic hangar is still a placeholder; the wing-band
   height is a tilt *approximation*, defensible but not tape-measured).
-- **Factor 2 (front-cluster order): medium and explicitly open.** A feasible monotone order
-  provably exists (real-world daily use), but the deployed planner does not yet find it in
-  reasonable time. This is a planner/search task, handed to a follow-up — not a claim that the
-  all-8 now routes end-to-end.
+- **Factor 2 (fk9↔cessna front-door corridor): medium and explicitly open.** A feasible monotone
+  fill provably exists (real-world daily use, "a few cm" spacing, 0.05 m tow clearance), but the
+  deployed planner cannot find it: the two real high-wingers mutually block at 0.5 m/15°, and a
+  finer grid — the prime suspect — is too slow for the current Hybrid-A* to settle. This is a
+  **search-efficiency** task (resolution / order / budget), handed to #844 — **not** a claim that
+  the all-8 now routes end-to-end, and **not** evidence of another physics error (both planes are
+  correctly modelled).
 
-**Bottom line:** the use case was blocked by a real, fixable model bug, now fixed. Making the full
-all-8 route end-to-end additionally needs a planner-order improvement, which is scoped and handed
-off rather than overclaimed.
+**Bottom line:** the use case was blocked by a real, fixable model bug (Factor 1), now fixed and the
+dominant cause. The remaining gap is a single tight front-door maneuvering corridor that the
+deployed grid search can't yet thread — a planner-efficiency problem, scoped to #844 and connected
+to the #840 learned-motion direction, rather than overclaimed as solved.

--- a/docs/spikes/herrenteich-all8-tow-routing-rootcause.md
+++ b/docs/spikes/herrenteich-all8-tow-routing-rootcause.md
@@ -1,0 +1,169 @@
+# Why the Herrenteich all-8 would not auto-tow-route — root-cause investigation
+
+**Status:** root cause #1 **confirmed and fixed** (#842, PR #843); a second, separable
+factor **characterised** and handed to a follow-up. **Date:** 2026-06-26.
+
+> The real Airfield Herrenteich hangar parks all eight usual occupants every day, by a
+> *monotone fill* — planes go in one at a time and an already-parked plane is never moved.
+> The tool agreed the final layout is **statically valid** (`hangarfit check` passes), yet it
+> could **not** auto-tow-route the fill (`plan_fill` / `view --animate` failed or fell back to
+> static). Because that use case is the reason the project exists, the brief was: find out why,
+> to ≥95 % confidence, with a proposed fix and an honest comparison to the options ruled out.
+
+This writeup records the method, the two factors found, every hypothesis falsified along the
+way, and the confidence in each conclusion.
+
+---
+
+## TL;DR
+
+| | Finding | Status | Confidence |
+|---|---|---|---|
+| **Factor 1** | The Scheibe SF-25 (a real **low-wing** glider) had its 18 m wing modelled in the **high-wing z-layer** (`z[1.9,2.1]`), the same layer as the genuine high-wingers' wings. Towing a high-winger (e.g. `aviat_husky`, wing `z[2.0,2.3]`) past the parked Scheibe then hit a **phantom wing-vs-wing collision** with no real-world counterpart. | **Fixed** — wing re-modelled as a thin band `z[1.72,1.78]` below the high-wing layer (#842, PR #843). | **~95 %** |
+| **Factor 2** | Even with Factor 1 fixed, the **full** all-8 does not route in `plan_fill`'s natural *deepest-first* order: a front-door cluster (`aviat_husky`, `fk9_mkii`, `cessna_140`) mutually blocks, and the planner's order-backtracking does not converge in reasonable time (>20 min). | **Characterised**, not solved — handed to a follow-up. It is an **order / planner** problem, separable from the fidelity bug. | medium |
+
+The headline: **at least one definite model-fidelity bug made the use case impossible**, and it
+is fixed. A second factor — finding a *feasible monotone order* under the deployed planner —
+remains and is a planner/search problem, not (so far as measured) another physics error.
+
+---
+
+## Method
+
+Per the brief ("use agent teams for everything and question everything"), every hypothesis was
+treated as falsifiable and tested empirically, not argued. Concretely:
+
+- **Measure-first.** Each candidate cause got a dedicated experiment that could *kill* it. The
+  32-core machine ran experiments in parallel (forkserver workers, BLAS pinned to 1 thread per
+  worker, per-candidate wall caps).
+- **Per-pair before whole-fill.** The two-body interactions were isolated first (mover P vs a
+  fixed predecessor set) so a failure could be attributed to a specific pair, not lost in the
+  8-body fill.
+- **Feasibility-grounded.** The real `examples/herrenteich/layout.yaml` is a *proven-valid*
+  witness (it passes `collisions.check`), so "the planner can't route into it" is a genuine
+  planner gap, never a vacuous test of an impossible layout.
+
+---
+
+## Factor 1 — the Scheibe wing was in the wrong z-layer (CONFIRMED, FIXED)
+
+### The mechanism
+
+`hangarfit`'s collision model is a **parts model with z-layering**: a high wing may overhang a
+lower part if their z-ranges do not overlap (within `wing_layer_clearance_m`). The Scheibe
+SF-25E is a real **low-wing** motor glider, but its catalog entry modelled the 18 m wing at
+`z[1.9,2.1]` — explicitly as a "monowheel-tilt approximation" — which placed an 18 m wing in the
+**same vertical layer** as the genuine high-wingers' wings (`aviat_husky` `z[2.0,2.3]`).
+
+Statically this is fine: in the parked layout the Scheibe and husky wings don't overlap in plan
+view, so no conflict fires. **During the tow it is fatal:** the husky tow path crosses over the
+Scheibe's parked footprint, the two wings overlap in plan view, and — both being in the same
+z-layer — the checker reports a wing-vs-wing collision. In reality the husky's high wing simply
+**overhangs** the Scheibe's low wing; the model manufactured a block that does not physically
+exist, and it made the valid all-8 **un-tow-routable**.
+
+### Evidence (measured)
+
+| Experiment | Result |
+|---|---|
+| `aviat_husky` tow past `{zlin, scheibe@HIGH z[1.9,2.1]}` | **BLOCKED** — search space-exhausted, even at a finer **0.2 m / 5°** grid (so *not* a resolution wall) |
+| `aviat_husky` tow past `{zlin, scheibe@LOW}` | **ROUTABLE** (~1 k node expansions) |
+| Fleet-wide wing-z audit | `scheibe_falke` is the **only** wing-z outlier; every other "high" wing belongs to a genuine high-wing aircraft |
+| Static validity of both bundled layouts with the lowered wing | **valid** (`layout.yaml` and the dense `layout_today.yaml`) |
+
+### The fix (shipped, PR #843)
+
+Model the wing as a **thin keep-out band `z[1.72,1.78]`**, centred at 1.75 m in the narrow
+vertical corridor:
+
+- **Floor 1.72 m** clears the 1.5 m fuselage tops it overhangs (in the dense `layout_today.yaml`
+  the wing overhangs the *aft* section of the zlin/husky fuselages) by 0.22 m.
+- **Ceiling 1.78 m** sits 0.22 m below the high-wing layer (`aviat_husky` wing bottom 2.0 m), so
+  high-wingers correctly overhang it and tow past.
+
+The band is **thin and centred** rather than 0.20 m thick because this catalog entry is *shared*
+between the Herrenteich hangar (`wing_layer_clearance_m: 0.15`) and the synthetic `data/hangar.yaml`
+(`0.20`); a band with exactly-0.20 m gaps would false-conflict under the synthetic hangar on
+float (`1.70 - 1.50 == 0.19999…96 < 0.20`, and the checker compares `gap < clearance` with no
+tolerance). The 0.22 m gaps clear both. A new regression test
+(`test_scheibe_wing_sits_below_the_high_wing_layer`) pins the z-layering invariant, which is
+static-validity-neutral and so would not be caught by the existing layout tests.
+
+The taper planform (ADR-0024 / #541) and the render colour (`wing_position: high`) are unchanged
+— collision z-layering reads the explicit part z-values, not the `wing_position` label.
+
+---
+
+## Factor 2 — a feasible monotone order is not found by the deployed planner (CHARACTERISED)
+
+With Factor 1 fixed, the husky↔Scheibe block is gone, but the **whole** all-8 still does not
+auto-route under `plan_fill`. The evidence:
+
+- **Natural deepest-first order (`back_first_order`).** Testing each plane against its exact
+  predecessors in that order (8 parallel `plan_path` calls): **5 of 8 route** (zlin, scheibe,
+  wild_thing, stemme, ctsl — ctsl even routes against all 7 predecessors), but **`aviat_husky`,
+  `fk9_mkii`, `cessna_140` block** (space-exhausted at the default 0.5 m/15° grid). These are all
+  **front-door** planes (low *y*).
+- **It is an order interaction, not (visibly) more physics.** `aviat_husky` routes past
+  `{zlin, scheibe}` but **blocks** once `wild_thing` is added — i.e. `wild_thing` walls the husky
+  corridor in this order. A different relative order of the front cluster is needed.
+- **`plan_fill` backtracks over order (#667) but does not converge.** Given a generous budget it
+  ran **>20 min** without completing — the front-cluster planes are expensive both to route and
+  to *disprove*, so the order-backtracking burns budget on failed branches.
+- **Resolution is inconclusive for the front cluster.** A grid-resolution sweep on the confirmed
+  blocker (`cessna_140` vs its 6 predecessors) space-exhausted at 0.5 m/15° but the finer grids
+  (0.33 → 0.15 m) did not *finish* within a 500 s wall — so finer resolution is neither confirmed
+  nor refuted there; it is simply too slow to settle this way.
+
+**Interpretation.** Physically a monotone order exists (the club parks all eight every day). The
+gap is the deployed planner *finding* it: `back_first_order` is the wrong order for the front
+cluster, and the order-backtracking + per-plane budget are not tuned to converge on the tight
+front corridors. This is a **planner/search** problem. It is handed to a follow-up; candidate
+directions (in rough order of expected value):
+
+1. **A better entry order than strict deepest-first** for the front cluster (e.g. order by corridor
+   tightness, or a front-cluster-aware tiebreak), so greedy routes without deep backtracking.
+2. **Per-plane budget / wall tuning** so a tight-but-feasible front plane actually routes instead
+   of spuriously failing and triggering backtracking.
+3. **Finer grid *only* where needed** (adaptive resolution near tight corridors) — the user's
+   "a few cm / finer heading" intuition, which the per-cluster sweeps could not yet settle because
+   a uniform fine grid is too slow.
+
+A learned tow-motion policy (the original spike direction, #840) is the longer-term lever for
+exactly this "thread the tight corridor / pick the order" search; this investigation sharpens its
+target to the front-door cluster.
+
+---
+
+## Hypotheses tested and discarded
+
+Every one of these was a live suspect; each was **falsified** by a dedicated experiment. This is
+the "comparison to other options discarded" the brief asked for.
+
+| Hypothesis | How tested | Verdict |
+|---|---|---|
+| **Turn-radius model wrong** (the user's first suspicion) | All eight Herrenteich movers are `R=0` (cart/pivotable); checked the pivot primitives are faithful at `R=0` | **Discarded** — `R=0` pivot is faithful; not the block |
+| **Pivot point / cart strafe / reverse** mis-modelled | Exercised cart-strafe and reverse seeds in isolation | **Discarded** — present and correct |
+| **Aircraft dimensions wrong** | Re-checked spans/lengths against EASA TCDS / published specs | **Discarded** — dimensions match sources |
+| **Clearances too strict** | Swept clearance; the all-8 is valid at the calibrated 0.10/0.15 m (and motion 0.05) | **Discarded** — not the binding constraint |
+| **Search resolution too coarse** (the user's second suspicion) | Re-ran the *husky↔scheibe* block at 0.2 m/5° | **Discarded for that pair** (still space-exhausted with the wing high → it was fidelity, not resolution). **Open for the front cluster** (finer-grid runs too slow to settle — see Factor 2). |
+| **Single-tree RRT / RRT-Connect oracle** would route it | Prototyped both | **Discarded** — weaker than the shipped `plan_path` Hybrid-A* in this clutter (goal tree trapped; ~2 % extend success) |
+| **Multi-body "move aside" needed** | Checked whether a parked plane must move | **Discarded** — the club never moves parked planes; the fill is monotone. The block was fidelity, not a need to relocate |
+| **A second wing-z fidelity bug** in the front cluster | Fleet-wide wing-z audit | **Not found** — scheibe is the only outlier; the front-cluster block reads as order/search, not another physics error |
+
+---
+
+## Confidence
+
+- **Factor 1 (fidelity bug + fix): ~95 %.** The mechanism is understood, the per-pair experiments
+  are clean and reproducible, the fix is shipped with a regression test, and both real layouts stay
+  valid. The 5 % is residual model risk (the synthetic hangar is still a placeholder; the wing-band
+  height is a tilt *approximation*, defensible but not tape-measured).
+- **Factor 2 (front-cluster order): medium and explicitly open.** A feasible monotone order
+  provably exists (real-world daily use), but the deployed planner does not yet find it in
+  reasonable time. This is a planner/search task, handed to a follow-up — not a claim that the
+  all-8 now routes end-to-end.
+
+**Bottom line:** the use case was blocked by a real, fixable model bug, now fixed. Making the full
+all-8 route end-to-end additionally needs a planner-order improvement, which is scoped and handed
+off rather than overclaimed.

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -91,6 +91,52 @@ def test_everyone_home_layout_is_valid() -> None:
     )
 
 
+def test_scheibe_wing_sits_below_the_high_wing_layer() -> None:
+    """Regression for #842. The Scheibe SF-25 is a real LOW-wing glider whose 18 m wing is
+    modelled as a thin RAISED keep-out band — deliberately NOT in the high-wing layer. Two
+    z-layering invariants make the real all-8 layout tow-routable; a future edit must not
+    silently break either (both are static-validity-neutral, so the layout tests above would
+    NOT catch a regression on the ceiling one):
+
+      * CEILING — the wing top must sit at least ``wing_layer_clearance_m`` BELOW the genuine
+        high-wingers' wing layer (aviat_husky, wing bottom 2.0 m, is the representative one a
+        tow must pass), so those wings overhang it and can be towed PAST the parked Scheibe.
+        The prior z[1.9,2.1] put this wing INTO the high layer, manufacturing a phantom
+        wing-vs-wing block during the tow that made the (real, valid) all-8 un-tow-routable.
+      * FLOOR — the wing bottom must sit at least ``wing_layer_clearance_m`` ABOVE the fuselage
+        tops it overhangs in the dense layouts (zlin/husky aft fuselage, top 1.5 m), or it
+        clips them (statically invalid) — the constraint that sets the 1.70 m floor.
+    """
+    fleet = load_fleet(HERRENTEICH / "fleet.yaml")
+    hangar = load_hangar(HERRENTEICH / "hangar.yaml")
+    wlc = hangar.wing_layer_clearance_m
+
+    scheibe_wings = [p for p in fleet["scheibe_falke"].parts if p.kind == "wing"]
+    scheibe_bottom = min(p.z_bottom_m for p in scheibe_wings)
+    scheibe_top = max(p.z_top_m for p in scheibe_wings)
+
+    # CEILING: stay clear below the high-wing layer (aviat_husky is the representative
+    # high-winger whose tow path passes over the parked Scheibe).
+    husky_wing_bottom = min(p.z_bottom_m for p in fleet["aviat_husky"].parts if p.kind == "wing")
+    assert scheibe_top + wlc <= husky_wing_bottom + 1e-9, (
+        f"Scheibe wing top {scheibe_top} m + wing-layer clearance {wlc} m must stay below the "
+        f"high-wing layer (aviat_husky wing bottom {husky_wing_bottom} m) so high-wingers can tow "
+        f"past the parked Scheibe (#842); a wing in the high layer re-creates the phantom block."
+    )
+
+    # FLOOR: clear the fuselage tops the wing overhangs in the dense layout_today.yaml.
+    fuselage_top = max(
+        p.z_top_m
+        for pid in ("zlin_savage", "aviat_husky")
+        for p in fleet[pid].parts
+        if p.kind.startswith("fuselage")
+    )
+    assert scheibe_bottom >= fuselage_top + wlc - 1e-9, (
+        f"Scheibe wing floor {scheibe_bottom} m must clear the overhung fuselage tops "
+        f"({fuselage_top} m) by the wing-layer clearance {wlc} m (#842)."
+    )
+
+
 def test_layout_clears_office_notch() -> None:
     """No plane sits in the back-right office notch.
 

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -94,18 +94,24 @@ def test_everyone_home_layout_is_valid() -> None:
 def test_scheibe_wing_sits_below_the_high_wing_layer() -> None:
     """Regression for #842. The Scheibe SF-25 is a real LOW-wing glider whose 18 m wing is
     modelled as a thin RAISED keep-out band — deliberately NOT in the high-wing layer. Two
-    z-layering invariants make the real all-8 layout tow-routable; a future edit must not
-    silently break either (both are static-validity-neutral, so the layout tests above would
-    NOT catch a regression on the ceiling one):
+    z-layering invariants are NECESSARY for the high-winger↔Scheibe tow to clear (they are not
+    by themselves *sufficient* for the full all-8 route, which additionally depends on a separate
+    fill-order factor — see #842); a future edit must not silently break either. Both are
+    static-validity-neutral, so the layout tests above would NOT catch a regression on the
+    ceiling one:
 
-      * CEILING — the wing top must sit at least ``wing_layer_clearance_m`` BELOW the genuine
-        high-wingers' wing layer (aviat_husky, wing bottom 2.0 m, is the representative one a
-        tow must pass), so those wings overhang it and can be towed PAST the parked Scheibe.
-        The prior z[1.9,2.1] put this wing INTO the high layer, manufacturing a phantom
+      * CEILING — the wing top must sit at least ``wing_layer_clearance_m`` BELOW the high-wing
+        layer of any aircraft whose tow path passes OVER the parked Scheibe (creating the
+        plan-view overlap the z-gap rule needs). aviat_husky (wing bottom 2.0 m) is that plane:
+        it is towed past the Scheibe, so its wing must overhang the Scheibe band. We assert
+        against husky specifically, NOT the min over all high-wingers — a statically-distant
+        high-winger like zlin (wing bottom 1.9 m) never overlaps the Scheibe wing in plan view,
+        so requiring clearance below *it* would over-constrain a relationship the geometry never
+        exercises. The prior z[1.9,2.1] put this wing INTO husky's layer, manufacturing a phantom
         wing-vs-wing block during the tow that made the (real, valid) all-8 un-tow-routable.
       * FLOOR — the wing bottom must sit at least ``wing_layer_clearance_m`` ABOVE the fuselage
-        tops it overhangs in the dense layouts (zlin/husky aft fuselage, top 1.5 m), or it
-        clips them (statically invalid) — the constraint that sets the 1.70 m floor.
+        tops it overhangs in the dense layouts (the aft section of the zlin/husky fuselage, top
+        1.5 m), or it clips them (statically invalid) — the constraint that sets the 1.72 m floor.
     """
     fleet = load_fleet(HERRENTEICH / "fleet.yaml")
     hangar = load_hangar(HERRENTEICH / "hangar.yaml")
@@ -115,8 +121,8 @@ def test_scheibe_wing_sits_below_the_high_wing_layer() -> None:
     scheibe_bottom = min(p.z_bottom_m for p in scheibe_wings)
     scheibe_top = max(p.z_top_m for p in scheibe_wings)
 
-    # CEILING: stay clear below the high-wing layer (aviat_husky is the representative
-    # high-winger whose tow path passes over the parked Scheibe).
+    # CEILING: stay clear below aviat_husky's wing — the high-winger whose tow path passes over
+    # the parked Scheibe (so the two wings overlap in plan view and the z-gap rule applies).
     husky_wing_bottom = min(p.z_bottom_m for p in fleet["aviat_husky"].parts if p.kind == "wing")
     assert scheibe_top + wlc <= husky_wing_bottom + 1e-9, (
         f"Scheibe wing top {scheibe_top} m + wing-layer clearance {wlc} m must stay below the "


### PR DESCRIPTION
Closes #842

## Root cause

The real **Herrenteich all-8** parks without relocating already-parked aircraft, but the tool could not auto-tow-route it. A multi-day investigation traced one confirmed blocker to a **model-fidelity bug**, not the planner / turn-model / ML.

`scheibe_falke` is a real **low-wing** SF-25 Falke, but its 18 m wing was modelled at `z[1.9,2.1]` — the **same vertical layer** as the genuine high-wingers' wings (e.g. `aviat_husky` `z[2.0,2.3]`). When a high-winger is towed past the parked Scheibe, the parts-model then reports a wing-vs-wing collision that has **no real-world counterpart** (a high wing simply overhangs a low one, per the z-layering rule).

### Measured

| Case | Result |
|---|---|
| `aviat_husky` tow past `{zlin, scheibe@HIGH z[1.9,2.1]}` | **BLOCKED** — space-exhausted even at a finer 0.2 m / 5° grid (not a resolution wall) |
| `aviat_husky` tow past `{zlin, scheibe@LOW z[1.7,1.8]}` | **ROUTABLE** (≈1k expansions) |
| Fleet-wide wing-z audit | scheibe is the **only** wing-z outlier |

## The fix

Model the wing as a thin raised keep-out band **`z[1.70,1.80]`** — the narrow corridor between:

- **FLOOR 1.70 m** — clears the fuselages it overhangs in the dense `layout_today.yaml` (zlin/husky aft fuselage tops 1.5 m) by 0.20 m (> the 0.15 m wing-layer clearance). A true-low band `z~0.4–0.6` clips them outright (statically invalid).
- **CEILING 1.80 m** — sits 0.20 m below the high-wing layer (`aviat_husky` wing bottom 2.0 m), so high-wingers correctly overhang it and can tow past.

A sweep over **both** bundled layouts (`layout.yaml`, dense `layout_today.yaml`) confirmed the valid corridor is `[1.68, 1.85]`; `z[1.70,1.80]` is the most balanced (both clearance gaps 0.20 m), and `z_top=1.80` is the exact value at which husky tow-routing was validated.

Render colour is unchanged: `wing_position: high` still selects it — collision z-layering reads the explicit part z-values, not that label.

## Tests

- `test_scheibe_wing_sits_below_the_high_wing_layer` (new) pins both z-layering bounds. The ceiling bound is **static-validity-neutral**, so the existing `test_everyone_home_layout_is_valid` / `test_today_layout_is_valid` would NOT catch a regression that moved the wing back into the high layer.
- Both existing layout-validity tests still pass.

## Scope (honest)

This fixes the **fidelity root cause** of the husky↔scheibe phantom block — a *necessary* correction. Routing the **full** all-8 end-to-end additionally hits a separate factor (a fill-order / search-resolution interaction at other slots, e.g. `cessna_140`), which is **not** claimed solved here and is being characterised under a separate follow-up. This PR is the data-fidelity half.

---

**Investigation writeup:** [`docs/spikes/herrenteich-all8-tow-routing-rootcause.md`](docs/spikes/herrenteich-all8-tow-routing-rootcause.md) (added in this PR) records the full root-cause analysis, the measured evidence, and the comparison to every discarded hypothesis. **Factor 2** (the front-door-cluster fill-order problem that remains after this fidelity fix) is tracked in #844.