### PR TITLE
feat(550): fuselage outline polygon — loader clips it into front/aft sub-polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- A `kind: fuselage` part may now carry a `vertices:` outline polygon, which the
+  loader clips into area-conserving `fuselage_front`/`fuselage_aft` sub-polygons
+  at the wing trailing edge (#550). Capability-only — no fleet behaviour change.
+
 ### Changed
 
 - **Learned backend (epic #607, #736): dense train-to-mastery is RESOLVED-NEGATIVE — the lever

--- a/docs/adr/0012-fuselage-front-aft-split.md
+++ b/docs/adr/0012-fuselage-front-aft-split.md
@@ -208,3 +208,23 @@ at zero (only a header comment) and the break a single derived value.
   — the operational statement of this decision.
 - Related spec: [`docs/superpowers/specs/2026-05-27-fuselage-parts-split-design.md`](../superpowers/specs/2026-05-27-fuselage-parts-split-design.md).
 - Related issue: [#50](https://github.com/DocGerd/hangarfit/issues/50).
+
+## Amendment (#550, 2026-06-27): polygon fuselage outline → Shapely clip
+
+D2's auto-split now has a second path. When the source `kind: fuselage` part
+carries an outline polygon (the raw `vertices:` YAML key, part-own centred
+frame), the front/aft split is a **Shapely half-plane clip** at the same
+wing-trailing-edge `x_break`, producing two area-conserving **sub-polygons**
+(`fuselage_front` / `fuselage_aft`) instead of two boxes. The scalar
+box-interval split is unchanged and stays the path for every current aircraft
+(byte-identical — no catalog fuselage carries `vertices:`). D1 (the
+`wing × fuselage_front` hard-conflict rule), the conflict-kind taxonomy, and the
+"break derived from the wing chord, not a YAML station" decision are all
+unchanged. The clip is interpolation-only (deterministic, cross-machine-robust),
+re-canonicalized by `Part.__post_init__`, and requires an axis-aligned fuselage
+(`angle_deg = 0`). It enforces "exactly one non-degenerate Polygon per side" —
+the formal guarantee that the front sub-outline is genuinely the cockpit; a
+non-x-monotone outline that would clip into disconnected nose-side pieces is a
+`LoaderError`. This re-opens D2 additively (a capability; no fleet behaviour
+change). See
+[`docs/superpowers/specs/2026-06-27-fuselage-outline-polygon-design.md`](../superpowers/specs/2026-06-27-fuselage-outline-polygon-design.md).

--- a/docs/adr/0012-fuselage-front-aft-split.md
+++ b/docs/adr/0012-fuselage-front-aft-split.md
@@ -220,9 +220,11 @@ box-interval split is unchanged and stays the path for every current aircraft
 (byte-identical — no catalog fuselage carries `vertices:`). D1 (the
 `wing × fuselage_front` hard-conflict rule), the conflict-kind taxonomy, and the
 "break derived from the wing chord, not a YAML station" decision are all
-unchanged. The clip is interpolation-only (deterministic, cross-machine-robust),
-re-canonicalized by `Part.__post_init__`, and requires an axis-aligned fuselage
-(`angle_deg = 0`). It enforces "exactly one non-degenerate Polygon per side" —
+unchanged. The clip is interpolation-only (no trig) and re-canonicalized by
+`Part.__post_init__`, so it is deterministic same-machine; cross-machine
+byte-identity stays asserted-not-tested (ADR-0003), and unlike the transform the
+clip adds no libm-transcendental surface (GEOS aside). It requires an
+axis-aligned fuselage (`angle_deg = 0`). It enforces "exactly one non-degenerate Polygon per side" —
 the formal guarantee that the front sub-outline is genuinely the cockpit; a
 non-x-monotone outline that would clip into disconnected nose-side pieces is a
 `LoaderError`. This re-opens D2 additively (a capability; no fleet behaviour

--- a/docs/superpowers/plans/2026-06-27-fuselage-outline-polygon.md
+++ b/docs/superpowers/plans/2026-06-27-fuselage-outline-polygon.md
@@ -1,0 +1,619 @@
+# Fuselage outline polygon (#550) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a `kind: fuselage` part carry a tapered `vertices:` outline that the loader Shapely-clips into area-conserving `fuselage_front`/`fuselage_aft` sub-polygons at the wing trailing edge (capability-only; real fleet byte-identical).
+
+**Architecture:** All work is in `src/hangarfit/loader.py` plus tests + docs. The collision predicate, the det(−1) transform (`aircraft_parts_world`), and the scene/v2 viewer seam are already polygon-generic (spike #541), so they are untouched. `_split_fuselage` gains a polygon branch; a new `vertices:` YAML key sets `Part.local_vertices` directly.
+
+**Tech Stack:** Python 3.12, Shapely (core dep), pytest, ruff, mypy. Design spec: `docs/superpowers/specs/2026-06-27-fuselage-outline-polygon-design.md`.
+
+## Global Constraints
+
+- **Byte-identical real fleet.** The scalar (`local_vertices is None`) `_split_fuselage` path must stay literally unchanged; no catalog/example aircraft gains `vertices:`. A guard test enforces this.
+- **Determinism (ADR-0003).** The clip is interpolation-only (no trig); all constructed sub-Parts pass through `Part.__post_init__` canonicalization, so same YAML → byte-identical sub-polygons.
+- **Placeholder-rename gotcha.** A `kind: fuselage` YAML entry is built by `_build_part` under the renamed kind `"fuselage_aft"` (loader.py:1322); `"fuselage"` is **not** a valid `PartKind`. So the `vertices:` kind-scope gate must allow the fuselage family `{"fuselage_front", "fuselage_aft"}`, never literally `"fuselage"`.
+- **`vertices:` rules.** Mutually exclusive with `planform:`; allowed only on the fuselage family; value is a list of `[x, y]` pairs in the part's **own centred frame** (each within `±length_m/2 × ±width_m/2`).
+- **Polygon fuselage must be axis-aligned** (`angle_deg == 0`, tolerance `1e-9`).
+- **No silent fallbacks.** An outline that cannot cleanly split is a `LoaderError`, never a silent revert to a box.
+- Lint/type clean: `ruff check src/ tests/`, `ruff format --check`, `mypy src/hangarfit/` all pass. Delivered via a GitFlow PR (`feature/550-fuselage-outline-polygon` → `develop`, body `Closes #550`) with a `CHANGELOG.md [Unreleased]` entry.
+
+Reference helpers already in the test suite: `tests/test_collisions.py` uses `check(_load("fixture"))`, `result.valid`, `result.conflicts`, and a local `_conflict_kinds(result)` helper. `models.Part` is a frozen dataclass; `Vertex = tuple[float, float]`; degeneracy floor `_RING_MIN_ABS_SIGNED_AREA = 1e-9`.
+
+---
+
+### Task 1: `vertices:` authoring key in the loader
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (`_ALLOWED_PART_KEYS` ~line 1494; `_build_part` ~line 1558)
+- Test: `tests/test_loader_fuselage_outline.py` (create)
+
+**Interfaces:**
+- Consumes: `models.Part(local_vertices=...)`, `LoaderError`, `_build_part(data, index)`.
+- Produces: `_build_part` accepts a `"vertices"` key → a `Part` with `local_vertices` set; raises `LoaderError` on `vertices`+`planform` together or `vertices` on a non-fuselage-family kind.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_loader_fuselage_outline.py
+import pytest
+from hangarfit.loader import _build_part, LoaderError
+
+
+def _fuselage_outline_dict(**over):
+    # A simple symmetric tapered outline in the part's own centred frame,
+    # within +/- length/2 (=2.0) x +/- width/2 (=0.5). Pointed nose at +x.
+    d = {
+        "kind": "fuselage_aft",  # the loader's placeholder rename for `kind: fuselage`
+        "length_m": 4.0,
+        "width_m": 1.0,
+        "z_bottom_m": 0.3,
+        "z_top_m": 1.4,
+        "vertices": [[2.0, 0.0], [0.5, 0.5], [-2.0, 0.5], [-2.0, -0.5], [0.5, -0.5]],
+    }
+    d.update(over)
+    return d
+
+
+def test_vertices_key_sets_local_vertices():
+    part = _build_part(_fuselage_outline_dict(), 0)
+    assert part.local_vertices is not None
+    assert len(part.local_vertices) == 5
+
+
+def test_vertices_and_planform_mutually_exclusive():
+    d = _fuselage_outline_dict(kind="wing", planform={"root_chord_m": 1.0, "tip_chord_m": 0.5})
+    with pytest.raises(LoaderError, match="mutually exclusive|both"):
+        _build_part(d, 0)
+
+
+def test_vertices_rejected_on_non_fuselage_kind():
+    d = _fuselage_outline_dict(kind="wing")
+    with pytest.raises(LoaderError, match="vertices"):
+        _build_part(d, 0)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_loader_fuselage_outline.py -v`
+Expected: FAIL — `_build_part` rejects the unknown key `vertices` (`has unknown key(s) ['vertices']`).
+
+- [ ] **Step 3: Implement the `vertices:` key**
+
+In `src/hangarfit/loader.py`, add `"vertices"` to `_ALLOWED_PART_KEYS`:
+
+```python
+_ALLOWED_PART_KEYS = frozenset(
+    {
+        "kind",
+        "length_m",
+        "width_m",
+        "offset_x_m",
+        "offset_y_m",
+        "angle_deg",
+        "z_bottom_m",
+        "z_top_m",
+        "planform",
+        "vertices",
+    }
+)
+```
+
+Add a module constant near the other part constants:
+
+```python
+# vertices: is valid only on the fuselage family. `kind: fuselage` is built under
+# the placeholder kind "fuselage_aft" (see _build_aircraft), so "fuselage" itself
+# is never a Part kind here.
+_VERTICES_ALLOWED_KINDS = frozenset({"fuselage_front", "fuselage_aft"})
+```
+
+In `_build_part`, after the existing `planform`-is-wing-only check (line ~1571-1575) and before computing `width_m`/`length_m`, add:
+
+```python
+    if "vertices" in data and "planform" in data:
+        raise LoaderError(
+            f"parts[{index}]: 'vertices:' and 'planform:' are mutually exclusive "
+            f"(both author a polygon footprint)"
+        )
+    if "vertices" in data and data["kind"] not in _VERTICES_ALLOWED_KINDS:
+        raise LoaderError(
+            f"parts[{index}]: 'vertices:' is only valid on a fuselage part "
+            f"(authored as kind 'fuselage'), got kind {data['kind']!r}"
+        )
+```
+
+Then, where `local_vertices` is computed (line ~1578-1580), add the `vertices` branch:
+
+```python
+    local_vertices = None
+    if "planform" in data:
+        local_vertices = _build_planform(data["planform"], width_m, length_m, index)
+    elif "vertices" in data:
+        local_vertices = _build_vertices(data["vertices"], index)
+```
+
+Add the `_build_vertices` helper near `_build_planform`:
+
+```python
+def _build_vertices(data: Any, index: int) -> tuple[tuple[float, float], ...]:
+    """Parse a raw `vertices:` ring (part-own centred frame) into Part vertices.
+
+    Each entry is an ``[x, y]`` pair. Part.__post_init__ canonicalizes the ring
+    (ADR-0003) and enforces the bbox subset; this helper only does shape/type
+    validation so a malformed entry is a clear LoaderError, not a deep TypeError.
+    """
+    if not isinstance(data, list):
+        raise LoaderError(f"parts[{index}].vertices must be a list of [x, y] pairs")
+    ring: list[tuple[float, float]] = []
+    for j, pair in enumerate(data):
+        if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+            raise LoaderError(
+                f"parts[{index}].vertices[{j}] must be an [x, y] pair, got {pair!r}"
+            )
+        x = _to_float(pair[0], f"parts[{index}].vertices[{j}][0]")
+        y = _to_float(pair[1], f"parts[{index}].vertices[{j}][1]")
+        ring.append((x, y))
+    return tuple(ring)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_loader_fuselage_outline.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader_fuselage_outline.py
+git commit -m "feat(550): accept a raw vertices: outline on fuselage parts"
+```
+
+---
+
+### Task 2: `_split_fuselage` polygon clip (the core algorithm)
+
+**Files:**
+- Modify: `src/hangarfit/loader.py` (`_split_fuselage` ~line 1721; add `_clip_fuselage_outline` + `_subpart_from_clip`; add a Shapely import)
+- Test: `tests/test_loader_fuselage_outline.py` (extend)
+
+**Interfaces:**
+- Consumes: `_wing_trailing_edge_x(wing)`, `models.Part`, `_RING_MIN_ABS_SIGNED_AREA` (import from `hangarfit.models`), Shapely `Polygon`/`box`.
+- Produces: `_split_fuselage(fuselage, wing)` returns `[fuselage_front, fuselage_aft]` polygon Parts when `fuselage.local_vertices is not None`; scalar path unchanged. Raises `LoaderError` on `angle_deg != 0`, break outside span, or a non-single-Polygon clip.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/test_loader_fuselage_outline.py
+import math
+from hangarfit.loader import _split_fuselage
+from hangarfit.models import Part
+from shapely.geometry import Polygon
+
+
+def _outline_fuselage(angle_deg=0.0):
+    # Tapered tube: pointed nose at +x=2, full-width cabin to tail at x=-2.
+    return Part(
+        kind="fuselage_aft",
+        length_m=4.0,
+        width_m=1.0,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=angle_deg,
+        z_bottom_m=0.3,
+        z_top_m=1.4,
+        local_vertices=((2.0, 0.0), (0.5, 0.5), (-2.0, 0.5), (-2.0, -0.5), (0.5, -0.5)),
+    )
+
+
+def _wing_at(te_x):
+    # wing trailing edge = offset_x - length/2; pick offset/length to land TE at te_x
+    return Part(kind="wing", length_m=1.0, width_m=8.0, offset_x_m=te_x + 0.5,
+               offset_y_m=0.0, angle_deg=0.0, z_bottom_m=1.4, z_top_m=1.7)
+
+
+def _ring_world(part):
+    # part-own centred ring shifted to plane-local (angle 0): (offset+vx, offset+vy)
+    return Polygon([(part.offset_x_m + x, part.offset_y_m + y) for x, y in part.local_vertices])
+
+
+def test_clip_produces_front_and_aft_polygons():
+    fus = _outline_fuselage()
+    parts = _split_fuselage(fus, _wing_at(0.0))  # break at plane-local x=0
+    kinds = {p.kind for p in parts}
+    assert kinds == {"fuselage_front", "fuselage_aft"}
+    for p in parts:
+        assert p.local_vertices is not None
+
+
+def test_clip_is_area_conserving_and_abutting():
+    fus = _outline_fuselage()
+    front, aft = sorted(_split_fuselage(fus, _wing_at(0.0)),
+                        key=lambda p: p.offset_x_m, reverse=True)
+    orig = _ring_world(fus).area
+    assert math.isclose(_ring_world(front).area + _ring_world(aft).area, orig, rel_tol=1e-9)
+    # front is the nose side (greater plane-local x), aft the tail side
+    assert front.offset_x_m > aft.offset_x_m
+
+
+def test_clip_rejects_break_outside_span():
+    with pytest.raises(LoaderError, match="strictly inside|span"):
+        _split_fuselage(_outline_fuselage(), _wing_at(5.0))  # TE beyond the nose
+
+
+def test_clip_rejects_rotated_polygon_fuselage():
+    with pytest.raises(LoaderError, match="axis-aligned|angle_deg"):
+        _split_fuselage(_outline_fuselage(angle_deg=10.0), _wing_at(0.0))
+
+
+def test_clip_rejects_non_x_monotone_outline():
+    # A concave "C" opening toward +x: a vertical cut at x=0 leaves two
+    # disconnected nose-side arms -> MultiPolygon -> rejected (the "front is
+    # genuinely the cockpit" guard). Simple, non-self-intersecting, fits +/-2 x +/-0.5.
+    cshape = Part(
+        kind="fuselage_aft", length_m=4.0, width_m=1.0, offset_x_m=0.0, offset_y_m=0.0,
+        angle_deg=0.0, z_bottom_m=0.3, z_top_m=1.4,
+        local_vertices=((2.0, 0.5), (-2.0, 0.5), (-2.0, -0.5), (2.0, -0.5),
+                        (2.0, -0.3), (-1.5, -0.3), (-1.5, 0.3), (2.0, 0.3)),
+    )
+    with pytest.raises(LoaderError, match="single|x-monotone|piece"):
+        _split_fuselage(cshape, _wing_at(0.0))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_loader_fuselage_outline.py -k clip -v`
+Expected: FAIL — `_split_fuselage` currently raises `LoaderError("a fuselage part may not carry a polygon footprint")`.
+
+- [ ] **Step 3: Implement the clip**
+
+At the top of `src/hangarfit/loader.py` (with the other imports), add:
+
+```python
+from shapely.geometry import Polygon, box
+
+from hangarfit.models import _RING_MIN_ABS_SIGNED_AREA
+```
+
+(If `models` is already imported, add `_RING_MIN_ABS_SIGNED_AREA` to that import instead.)
+
+Add a tolerance constant near the other loader constants:
+
+```python
+_FUSELAGE_OUTLINE_ANGLE_TOL_DEG = 1e-9
+```
+
+In `_split_fuselage`, replace the polygon **rejection** (lines ~1749-1753) with a dispatch to the clip, keeping the scalar path below unchanged:
+
+```python
+    x_break = _wing_trailing_edge_x(wing)
+    if fuselage.local_vertices is not None:
+        return _clip_fuselage_outline(fuselage, x_break)
+    # --- scalar box-interval path below is UNCHANGED (byte-identical) ---
+    c = fuselage.offset_x_m
+    half_len = fuselage.length_m / 2.0
+    ...
+```
+
+Add the two helpers after `_split_fuselage`:
+
+```python
+def _clip_fuselage_outline(fuselage: Part, x_break: float) -> list[Part]:
+    """Clip a polygon fuselage outline into front/aft sub-polygons at x_break.
+
+    ``x_break`` is the wing trailing edge in plane-local coords (ADR-0012). The
+    outline lives in the part's own centred frame; for an axis-aligned fuselage
+    that frame is plane-local shifted by offset_x_m, so the part-own clip station
+    is ``xs = x_break - offset_x_m``. The half-plane intersection is
+    interpolation-only (deterministic) and area-conserving; each side is
+    re-canonicalized by Part.__post_init__.
+    """
+    if abs(fuselage.angle_deg) > _FUSELAGE_OUTLINE_ANGLE_TOL_DEG:
+        raise LoaderError(
+            f"a polygon fuselage (vertices:) must be axis-aligned (angle_deg = 0); "
+            f"got angle_deg={fuselage.angle_deg:g}"
+        )
+    c = fuselage.offset_x_m
+    xs = x_break - c
+    outline = Polygon(fuselage.local_vertices)
+    minx, miny, maxx, maxy = outline.bounds
+    if not (minx < xs < maxx):
+        raise LoaderError(
+            f"kind 'fuselage': derived front/aft section break x={x_break:g} "
+            f"(wing trailing edge) must lie strictly inside the fuselage outline "
+            f"x-span; the break must be strictly inside the span. Check the wing "
+            f"offset_x_m / length_m or the fuselage outline."
+        )
+    pad = (maxx - minx) + (maxy - miny) + 1.0  # any margin past the bbox
+    front_geom = outline.intersection(box(xs, miny - pad, maxx + pad, maxy + pad))
+    aft_geom = outline.intersection(box(minx - pad, miny - pad, xs, maxy + pad))
+    return [
+        _subpart_from_clip(fuselage, "fuselage_front", front_geom, "front"),
+        _subpart_from_clip(fuselage, "fuselage_aft", aft_geom, "aft"),
+    ]
+
+
+def _subpart_from_clip(fuselage: Part, kind: str, geom: Any, side_label: str) -> Part:
+    """Build one fuselage_front/aft Part from a clipped sub-polygon.
+
+    Enforces "exactly one non-degenerate Polygon" — the formal guarantee that the
+    front piece is genuinely the cockpit. The sub-polygon comes back in the source
+    part's own centred frame; re-express it about its own sub-bbox centre.
+    """
+    if geom.is_empty or geom.geom_type != "Polygon" or geom.area < _RING_MIN_ABS_SIGNED_AREA:
+        raise LoaderError(
+            f"kind 'fuselage': the outline does not clip into a single non-degenerate "
+            f"{side_label} piece at the wing trailing edge; the outline must be a simple, "
+            f"x-monotone polygon spanning the break (got {geom.geom_type}, area={geom.area:g})."
+        )
+    coords = list(geom.exterior.coords)[:-1]  # drop Shapely's closing duplicate
+    xs_ = [x for x, _ in coords]
+    ys_ = [y for _, y in coords]
+    sub_cx = (min(xs_) + max(xs_)) / 2.0
+    sub_cy = (min(ys_) + max(ys_)) / 2.0
+    return Part(
+        kind=kind,  # type: ignore[arg-type]  # kind is a valid PartKind literal
+        length_m=max(xs_) - min(xs_),
+        width_m=max(ys_) - min(ys_),
+        offset_x_m=fuselage.offset_x_m + sub_cx,
+        offset_y_m=fuselage.offset_y_m + sub_cy,
+        angle_deg=fuselage.angle_deg,
+        z_bottom_m=fuselage.z_bottom_m,
+        z_top_m=fuselage.z_top_m,
+        local_vertices=tuple((x - sub_cx, y - sub_cy) for x, y in coords),
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_loader_fuselage_outline.py -v`
+Expected: PASS (all). If `mypy` flags the `kind` literal, keep the `# type: ignore[arg-type]`; verify with `mypy src/hangarfit/loader.py`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/loader.py tests/test_loader_fuselage_outline.py
+git commit -m "feat(550): clip a fuselage outline into front/aft sub-polygons"
+```
+
+---
+
+### Task 3: integration build, determinism, byte-identical-fleet guard
+
+**Files:**
+- Test: `tests/test_loader_fuselage_outline.py` (extend)
+
+**Interfaces:**
+- Consumes: `_build_aircraft(entry: dict) -> Aircraft` (internal; the function that runs the fuselage split — importable from `hangarfit.loader`, already referenced by `tests/test_loader_catalog.py` + the fuzz suite). `load_fleet(path) -> dict[str, Aircraft]` for the fleet guard. **There is no `load_aircraft`** — a single aircraft is built from an entry dict via `_build_aircraft` (the catalog `type:` discriminator is stripped before it). Produces: nothing new; these are built on Tasks 1-2, so they pass on first run (no red phase).
+
+- [ ] **Step 1: Write the tests**
+
+```python
+# append to tests/test_loader_fuselage_outline.py
+from pathlib import Path
+from hangarfit.loader import _build_aircraft, load_fleet
+
+
+def _outline_entry():
+    # Minimal aircraft entry with a tapered fuselage outline + a wing whose
+    # trailing edge (offset_x - length/2 = 0.6 - 0.7 = -0.1) lands inside the
+    # fuselage x-span [-3, 3]. Required entry keys: id, name, wing_position,
+    # gear, movement_mode, parts (add more only if _build_aircraft demands them).
+    return {
+        "id": "outline_test",
+        "name": "Outline Test Plane",
+        "wing_position": "high",
+        "gear": "nosewheel",
+        "movement_mode": "tow_pivotable",
+        "parts": [
+            {"kind": "wing", "length_m": 1.4, "width_m": 9.0, "offset_x_m": 0.6,
+             "z_bottom_m": 1.7, "z_top_m": 2.0},
+            {"kind": "fuselage", "length_m": 6.0, "width_m": 1.2, "offset_x_m": 0.0,
+             "z_bottom_m": 0.3, "z_top_m": 1.6,
+             "vertices": [[3.0, 0.0], [1.0, 0.6], [-3.0, 0.6], [-3.0, -0.6], [1.0, -0.6]]},
+        ],
+    }
+
+
+def test_outline_aircraft_builds_polygon_front_aft():
+    ac = _build_aircraft(_outline_entry())
+    by_kind = {p.kind: p for p in ac.parts}
+    assert by_kind["fuselage_front"].local_vertices is not None
+    assert by_kind["fuselage_aft"].local_vertices is not None
+
+
+def test_outline_build_is_deterministic():
+    a = _build_aircraft(_outline_entry())
+    b = _build_aircraft(_outline_entry())
+    fa = next(p for p in a.parts if p.kind == "fuselage_front")
+    fb = next(p for p in b.parts if p.kind == "fuselage_front")
+    assert fa.local_vertices == fb.local_vertices
+
+
+def test_no_shipped_fuselage_part_is_a_polygon():
+    # byte-identical-fleet guard: every real fleet fuselage stays a scalar box
+    # (the scalar split produces fuselage_front/aft with local_vertices is None).
+    fleet = load_fleet(Path("data/fleet.yaml"))
+    for ac in fleet.values():
+        for p in ac.parts:
+            if p.kind in ("fuselage_front", "fuselage_aft"):
+                assert p.local_vertices is None, f"{ac.id} {p.kind} became a polygon"
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pytest tests/test_loader_fuselage_outline.py -k "outline_aircraft or deterministic or shipped" -v`
+Expected: PASS. If `_build_aircraft` rejects the entry for a missing key (e.g. wheels), mirror the minimal non-geometry fields from `data/catalog/cessna_140.yaml` until it builds. The fleet guard passes immediately (no catalog fuselage uses `vertices:`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_loader_fuselage_outline.py
+git commit -m "test(550): integration build + determinism + byte-identical fleet guard"
+```
+
+---
+
+### Task 4: downstream behavior (det(−1) transform + collision semantics)
+
+**Files:**
+- Create: `tests/fixtures/outline_wing_over_cockpit.yaml` (a layout: `hangar:` ref + placements, **no** `fleet:` — the fleet is supplied as an override)
+- Test: `tests/test_loader_fuselage_outline.py` (extend) — proves the already-generic transform + collision pipeline behaves on the clip output. No src change.
+
+**Interfaces:**
+- Consumes: `hangarfit.geometry.aircraft_parts_world(aircraft, x_m, y_m, heading_deg)` (cross-check the exact signature in `tests/test_geometry.py`; returns world parts each with `.kind` and `.polygon`). `hangarfit.loader.load_layout(path, *, fleet=<dict>)` (override path — fixture omits `fleet:`). `hangarfit.collisions.check(layout)` → result with `.valid` / `.conflicts` (each conflict has `.kind`). Produces: nothing.
+
+Note: aft-tail nesting and scene `vertices` emission are already covered generically for polygon parts by spike #541's suite (`tests/test_scene.py`, `tests/test_collisions.py`) and behave identically here (same kind-keyed predicate), so they are not re-tested.
+
+- [ ] **Step 1: transform test (no fixture needed)**
+
+```python
+# append to tests/test_loader_fuselage_outline.py
+from hangarfit.geometry import aircraft_parts_world
+
+
+def test_clipped_front_flows_through_det_minus_one_transform():
+    ac = _build_aircraft(_outline_entry())
+    world = aircraft_parts_world(ac, 10.0, 5.0, 37.0)  # non-axis heading
+    fronts = [w for w in world if w.kind == "fuselage_front"]
+    assert len(fronts) == 1
+    assert fronts[0].polygon.is_valid and not fronts[0].polygon.is_empty
+```
+
+Run: `pytest tests/test_loader_fuselage_outline.py -k det_minus_one -v` → PASS. (If `aircraft_parts_world` takes keyword args, match `tests/test_geometry.py`.)
+
+- [ ] **Step 2: collision value test — wing over the polygon cockpit**
+
+Create the layout fixture (hangar ref, no `fleet:`):
+
+```yaml
+# tests/fixtures/outline_wing_over_cockpit.yaml
+hangar: ../../data/hangar.yaml
+placements:
+  - plane: outline_test
+    x_m: 11.0
+    y_m: 7.0
+    heading_deg: 0.0
+    on_carts: false
+  - plane: overflyer
+    x_m: 11.0
+    y_m: 7.0
+    heading_deg: 0.0
+    on_carts: false
+```
+
+Add the test (builds the fleet override via `_build_aircraft` → no catalog/manifest plumbing):
+
+```python
+from hangarfit.loader import load_layout
+from hangarfit.collisions import check
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _overflyer_entry():
+    # A high-winger whose broad wing (z [1.7,2.0], above the fuselage z [0.3,1.6])
+    # sits over the outline plane's cockpit (fuselage_front, plane-local x ~[-0.1, 3]).
+    return {
+        "id": "overflyer", "name": "Overflyer", "wing_position": "high",
+        "gear": "nosewheel", "movement_mode": "tow_pivotable",
+        "parts": [
+            {"kind": "wing", "length_m": 6.0, "width_m": 9.0, "offset_x_m": 1.5,
+             "z_bottom_m": 1.7, "z_top_m": 2.0},
+            {"kind": "fuselage", "length_m": 6.0, "width_m": 1.2, "offset_x_m": 0.0,
+             "z_bottom_m": 0.3, "z_top_m": 1.6},
+        ],
+    }
+
+
+def _conflict_kinds(result):
+    return {c.kind for c in result.conflicts}
+
+
+def test_wing_over_polygon_cockpit_conflicts():
+    fleet = {"outline_test": _build_aircraft(_outline_entry()),
+             "overflyer": _build_aircraft(_overflyer_entry())}
+    layout = load_layout(FIXTURES / "outline_wing_over_cockpit.yaml", fleet=fleet)
+    result = check(layout)
+    assert "fuselage_front_wing_overlap" in _conflict_kinds(result), (
+        f"expected a cockpit conflict, got {result.conflicts!r}"
+    )
+```
+
+Run: `pytest tests/test_loader_fuselage_outline.py -k cockpit -v`
+Expected: PASS — the overflyer's wing covers the outline plane's polygon cockpit in plan view at a separated height, which D1 makes a hard `fuselage_front_wing_overlap` regardless of z. The assertion checks *membership* (extra conflicts from the co-located fuselages are fine). If it does not fire, nudge `overflyer.offset_x_m`/the placement so the wing footprint clearly overlaps the front sub-polygon (use the Step-1 transform output to read the front span); keep the wing z above the fuselage z so it is a genuine overhang.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/fixtures/outline_wing_over_cockpit.yaml tests/test_loader_fuselage_outline.py
+git commit -m "test(550): det(-1) transform + cockpit-conflict semantics on clipped outline"
+```
+
+---
+
+### Task 5: ADR-0012 amendment, CHANGELOG, docstrings
+
+**Files:**
+- Modify: `docs/adr/0012-fuselage-front-aft-split.md` (add a dated Amendment)
+- Modify: `CHANGELOG.md` (`[Unreleased] / ### Added`)
+- Modify: `src/hangarfit/loader.py` `_split_fuselage` docstring (note the dual path)
+- Check: `docs/architecture/08-crosscutting-concepts.md` "the parts model" — add a one-line pointer only if it materially helps; otherwise leave (capability is opt-in, fleet unchanged).
+
+**Interfaces:** docs only.
+
+- [ ] **Step 1: Amend ADR-0012**
+
+Append to `docs/adr/0012-fuselage-front-aft-split.md`:
+
+```markdown
+## Amendment (#550, 2026-06-27): polygon fuselage outline → Shapely clip
+
+D2's auto-split now has a second path. When the source `kind: fuselage` part
+carries an outline polygon (the raw `vertices:` YAML key, part-own centred
+frame), the front/aft split is a **Shapely half-plane clip** at the same
+wing-trailing-edge `x_break`, producing two area-conserving **sub-polygons**
+(`fuselage_front`/`fuselage_aft`). The scalar box-interval split is unchanged and
+remains the path for every current aircraft (byte-identical). D1 (the
+`wing × fuselage_front` hard-conflict rule), the conflict-kind taxonomy, and the
+"break derived from the wing, not a YAML station" decision are all unchanged. The
+clip enforces "exactly one non-degenerate Polygon per side", which is the formal
+guarantee that the front sub-outline is genuinely the cockpit. See
+`docs/superpowers/specs/2026-06-27-fuselage-outline-polygon-design.md`.
+```
+
+- [ ] **Step 2: CHANGELOG entry**
+
+Under `## [Unreleased]` → `### Added` in `CHANGELOG.md`:
+
+```markdown
+- A `kind: fuselage` part may now carry a `vertices:` outline polygon, which the
+  loader clips into area-conserving `fuselage_front`/`fuselage_aft` sub-polygons
+  at the wing trailing edge (#550). Capability-only — no fleet behaviour change.
+```
+
+- [ ] **Step 3: Update the `_split_fuselage` docstring**
+
+Note the dual path in the `_split_fuselage` docstring (scalar box-interval vs polygon clip) so the next reader sees both branches.
+
+- [ ] **Step 4: Verify docs + full suite**
+
+Run: `ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/ && pytest tests/test_loader_fuselage_outline.py tests/test_collisions.py tests/test_loader.py -v`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/ CHANGELOG.md src/hangarfit/loader.py
+git commit -m "docs(550): ADR-0012 amendment + CHANGELOG for fuselage outline clip"
+```
+
+---
+
+## Final integration
+
+- [ ] Run the safe full local suite: `make test` (two-pass split; never bare `pytest -n auto`).
+- [ ] `ruff check src/ tests/`, `ruff format --check src/ tests/`, `mypy src/hangarfit/` — all clean.
+- [ ] Push `feature/550-fuselage-outline-polygon`; open a **draft** PR, base `develop`, body `Closes #550`.
+- [ ] Review arc: `pr-review-toolkit:code-reviewer` (main) + `geometry-invariant-guard` (collision/transform interaction) + `silent-failure-hunter` (loader) + `comment-analyzer` (ADR/docstrings). Thread-per-finding, fix + resolve.
+- [ ] Flip out of draft when the review arc is clean; the user merges.

--- a/docs/superpowers/specs/2026-06-27-fuselage-outline-polygon-design.md
+++ b/docs/superpowers/specs/2026-06-27-fuselage-outline-polygon-design.md
@@ -1,0 +1,209 @@
+# Design: Fuselage outline polygon (#550) — capability-only
+
+- **Status:** Approved design (brainstorming complete); ready for an implementation plan.
+- **Date:** 2026-06-27
+- **Issue:** [#550](https://github.com/DocGerd/hangarfit/issues/550) — *Fuselage outline polygon (approach b) — single-outline replacing front/aft boxes*
+- **Refs:** spike #541 (`docs/spikes/polygon-part-geometry-feasibility.md`, PR #543), ADR-0012 (fuselage front/aft split), ADR-0023 (empennage surfaces), ADR-0001 (parts model), ADR-0002 (det(−1) transform), ADR-0003 (determinism contract).
+
+---
+
+## Goal & scope
+
+Make a `kind: fuselage` part able to carry a tapered **outline polygon** that the loader **clips** into
+`fuselage_front` / `fuselage_aft` sub-polygons at the wing trailing edge — the one genuinely-new
+algorithm called out by #550. This is the deferred (b) piece of spike #541; ~85 % of the polygon-part
+pipeline already shipped with that spike's (c)+(d-param) phase.
+
+**This is a capability-only build.** No catalog aircraft adopts a fuselage outline, so the **entire real
+fleet stays byte-identical**. A dedicated test-fixture aircraft exercises the new clip. A parametrized
+fuselage-outline authoring DSL and any real fleet data are explicitly future work.
+
+### Already shipped (do NOT rebuild)
+
+| Component | Where | State |
+|---|---|---|
+| `Part.local_vertices` field + `_canonicalize_ring` (CCW, lexicographic-min rotation, degeneracy/self-intersection rejection) + `__post_init__` bbox-containment | `src/hangarfit/models.py` | ✓ shipped |
+| Per-vertex det(−1) transform of polygon parts (`part_local_ring` + `aircraft_parts_world`) | `src/hangarfit/geometry.py` | ✓ shipped |
+| scene/v2 `vertices` emission + viewer `ExtrudeGeometry` rendering | `src/hangarfit/scene.py`, `viewer/src/planes.ts`, `scene-contract.ts` | ✓ shipped |
+| Polygon-part tests (canonicalization, transform equivalence, scene emission) | `tests/test_part_polygon.py`, `tests/test_geometry.py`, `tests/test_scene.py` | ✓ shipped |
+| Wing taper authoring (`planform:` → 6-vertex hexagon) | `loader._build_planform` | ✓ shipped (wing-only) |
+
+The only catalog polygon part today is `scheibe_falke`'s **wing** via `planform:`.
+
+---
+
+## Approach for the clip (the one real design choice)
+
+**Chosen: Shapely `intersection` of the outline with each half-plane** (`x ≥ x_break` and `x ≤ x_break`).
+Shapely is a core dependency; intersecting a simple polygon with a convex half-plane is robust and yields
+exactly one `Polygon` per side for an x-monotone (tapered-tube) fuselage. Requiring "exactly one non-empty,
+non-degenerate `Polygon` per side" *is* the formal "the front sub-outline is genuinely the cockpit"
+guarantee #550 asks for.
+
+Rejected alternatives:
+- **`shapely.ops.split` with a vertical line** — returns a `GeometryCollection` needing side-assignment by
+  centroid-x and multi-piece handling; no advantage over half-plane intersection.
+- **Hand-rolled Sutherland–Hodgman half-plane clip** — reinvents Shapely and adds determinism surface for
+  no benefit.
+
+---
+
+## Components & changes
+
+### 1. `loader._split_fuselage` — dual path (the core change)
+
+`src/hangarfit/loader.py`. Today the function **rejects** a polygon fuselage
+(`if fuselage.local_vertices is not None: raise`) and box-interval-splits a scalar fuselage.
+
+New behaviour:
+
+- **Scalar fuselage (`local_vertices is None`):** the existing box-interval split is **unchanged**, line
+  for line. This is what guarantees byte-identical output for every current aircraft.
+- **Polygon fuselage (`local_vertices is not None`):** remove the rejection; clip instead.
+
+The clip, given the fuselage `Part` (part-own `local_vertices` `V`, centre `(c, oy)`, `length L`,
+`width W`, `angle_deg θ`) and the wing-derived break station `x_break = _wing_trailing_edge_x(wing)`
+(plane-local):
+
+1. **Axis-aligned guard.** Require `θ == 0` for a polygon fuselage (raise `LoaderError` otherwise). The
+   clip works in part-local x, which equals plane-local x only when the part is unrotated; fuselages are
+   angle-0 by construction, so rotation support is YAGNI.
+2. Map the break to part-local x: `xs = x_break − c`.
+3. Build the part-local outline `Polygon(V)` (a closed ring from the canonical open `local_vertices`).
+4. **Break-inside guard.** Require `min_x(V) < xs < max_x(V)` strictly (mirrors today's
+   `tail_x < x_break < nose_x`). Else `LoaderError` (degenerate split).
+5. `front = outline ∩ {x ≥ xs}`, `aft = outline ∩ {x ≤ xs}` via intersection with a bbox-covering
+   half-plane rectangle.
+6. **Single-piece guard.** Each side must be exactly one non-empty, non-degenerate `Polygon` (no
+   `MultiPolygon`, no empty, area above the canonicalizer's degeneracy floor). Else `LoaderError`
+   ("the fuselage outline does not clip into a single front/aft piece at the wing trailing edge — the
+   outline must be a simple, x-monotone polygon across the break").
+7. For each side polygon `S` (in the source fuselage's own centred frame): compute its bbox → new
+   `length_m` (x-extent), `width_m` (y-extent), `offset_x_m` (plane-local = `c + bbox_x_mid(S)`),
+   `offset_y_m` (`oy + bbox_y_mid(S)`); re-express `S`'s exterior ring relative to its own sub-centre
+   (subtract the sub-bbox centre) → new `local_vertices`. Construct
+   `Part(kind="fuselage_front"|"fuselage_aft", …)`; `__post_init__`
+   re-canonicalizes the ring and re-validates bbox containment. Inherit `z_bottom_m`, `z_top_m`,
+   `angle_deg` (= 0) from the source.
+
+**Area-conservation** holds by construction: the half-plane cut introduces matching vertices at `x = xs`
+on both sides, so `front ∪ aft = outline` exactly and `front.area + aft.area == outline.area` (up to FP).
+
+### 2. `loader._build_part` + `_ALLOWED_PART_KEYS` — accept raw `vertices:`
+
+`src/hangarfit/loader.py`. Add `"vertices"` to `_ALLOWED_PART_KEYS`. A `vertices:` value is a list of
+`[x, y]` pairs in the part's **own (centred) frame** — the same frame `planform:` emits and
+`local_vertices` stores (each vertex within `±L/2 × ±W/2`) — set directly as `local_vertices`
+(canonicalized + bbox-validated by `Part.__post_init__`).
+
+Validation:
+- `vertices:` and `planform:` are **mutually exclusive** (`LoaderError` if both present).
+- For this issue, `vertices:` is valid only on `kind: fuselage` (parallel to the existing
+  `planform:`-is-wing-only rule). Broadening to other kinds is a future decision.
+
+The `kind: fuselage` placeholder Part (built in `_build_aircraft`) thus carries the whole authored
+outline, which `_split_fuselage` then clips — preserving ADR-0012 D2's "author one fuselage, the loader
+expands it into canonical Parts" model.
+
+### 3. ADR-0012 amendment
+
+`docs/adr/0012-fuselage-front-aft-split.md`. Add a dated **Amendment (#550)** to D2: when the source
+fuselage carries an outline polygon (`vertices:`), the front/aft split is a Shapely **clip** at the same
+wing-trailing-edge `x_break`, producing area-conserving front/aft **sub-polygons**; the scalar
+box-interval path is unchanged. D1 (the `wing × fuselage_front` hard-conflict rule) and the PartKind
+taxonomy are untouched. Matches the in-place dated-amendment convention used by ADR-0003.
+
+### 4. Test-fixture aircraft
+
+A small catalog-shaped fixture YAML under `tests/fixtures/` with a `kind: fuselage` + tapered `vertices:`
+outline, plus a `wing` so the break derives. Used by the loader/collision tests.
+
+---
+
+## Data flow
+
+```
+YAML (kind: fuselage + vertices:)
+  → _build_part            (canonical polygon Part, bbox-validated)
+  → _build_aircraft        (placeholder fuselage held aside)
+  → _split_fuselage CLIP   (half-plane intersection at wing TE → 2 polygon sub-Parts)
+  → aircraft_parts_world   (UNCHANGED: per-vertex det(−1) local_to_world)
+  → collisions.check       (UNCHANGED: wing×fuselage_front hard-conflict; wing×fuselage_aft z-gap)
+  → scene.build_scene      (UNCHANGED: emits `vertices` for fuselage_front/aft)
+  → viewer                 (UNCHANGED: ExtrudeGeometry)
+```
+
+Only the first three boxes change; everything downstream is already polygon-generic.
+
+---
+
+## Error handling (all deterministic `LoaderError`)
+
+| Condition | Behaviour |
+|---|---|
+| `x_break` not strictly inside the outline x-span | existing degenerate-split error (retained, wording generalized) |
+| Either clipped side empty / `MultiPolygon` / sub-degenerate | "outline does not clip into a single front/aft piece … must be simple & x-monotone across the break" |
+| `angle_deg ≠ 0` on a polygon fuselage | "a polygon fuselage must be axis-aligned (angle_deg = 0)" |
+| `vertices:` and `planform:` both present | mutual-exclusion error |
+| `vertices:` on a kind other than `fuselage` | kind-scope error (parallel to planform-is-wing-only) |
+
+No silent fallbacks: an outline that cannot be cleanly split is a load error, never a silent revert to a
+box.
+
+---
+
+## Determinism & back-compat
+
+- The clip is **interpolation-only** (linear half-plane intersection — no `sin/cos/atan2`), so it is far
+  more cross-machine-robust than the trig in the transform; results are re-canonicalized by
+  `Part.__post_init__`. Same YAML → byte-identical sub-polygons (ADR-0003).
+- The scalar path is literally unchanged → **every current catalog/example aircraft is byte-identical**.
+  A guard test asserts no shipped fuselage carries `vertices:` (so the fleet cannot silently change).
+
+---
+
+## Explicitly out of scope
+
+- No catalog fuselage outline data (real fleet unchanged).
+- No parametrized fuselage-outline DSL (future data-authoring issue).
+- Empennage (`tail` / `vertical_stabilizer`, ADR-0023) stays as separate rectangles — the fuselage
+  outline is the cockpit + cabin tube only.
+- No change to the collision predicate, the det(−1) transform, or the scene/v2 schema.
+- No rotation support for polygon fuselages (`angle_deg` must be 0).
+- No change to the solver trivial-infeasibility area-gate (`_check_sum_areas`): it already sums polygon
+  footprints (polygon area ≤ bbox area → still a sound lower bound, #425/#541); it only ever gets
+  *tighter* for an outline plane, never unsound.
+
+---
+
+## Testing
+
+- **Clip unit** (`_split_fuselage` polygon path): a tapered fuselage fixture → assert two sub-polygons;
+  `front.area + aft.area == outline.area`; the two share the cut edge at `x_break` (abut, no gap/overlap);
+  `offset_x_m`/`length_m`/`width_m` match the sub-bbox; `kind` correct.
+- **Determinism:** double-load the fixture → byte-identical `local_vertices` on both sub-Parts.
+- **Byte-identical guard:** scalar-fuselage fleet aircraft produce identical `fuselage_front`/`fuselage_aft`
+  Parts as before (regression), and an assert that no shipped fuselage uses `vertices:`.
+- **Error paths:** break outside span; non-x-monotone outline that clips to `MultiPolygon`; `angle_deg ≠ 0`;
+  `vertices:`+`planform:`; `vertices:` on a wing.
+- **Transform:** a heading ≠ 0 placement of the outline plane through `aircraft_parts_world` (per-vertex
+  det(−1) correctness for the clipped sub-polygons).
+- **Collision semantics (value preservation):** a wing overlapping the **polygon cockpit** conflicts
+  (`fuselage_front_wing_overlap`) while a wing overlapping the **polygon aft tail** at a z-gap nests —
+  the exact ADR-0012 D1 behaviour, now exercised on polygon front/aft.
+- **Scene/viewer:** a fuselage-outline plane emits `vertices` for `fuselage_front`/`fuselage_aft` in
+  `build_scene`.
+
+### Review guards expected to apply
+
+`geometry-invariant-guard` (collision/transform interaction), `silent-failure-hunter` (loader changes),
+`comment-analyzer` (ADR amendment + docstrings), and a loader-determinism check on the clip. The standard
+`pr-review-toolkit:code-reviewer` pass runs regardless.
+
+---
+
+## CHANGELOG
+
+A user-facing `[Unreleased]` entry under `### Added`: authors can now give a `kind: fuselage` part a
+`vertices:` outline polygon, which the loader clips into area-conserving front/aft sub-polygons at the
+wing trailing edge (capability; no fleet behaviour change).

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -1572,10 +1572,11 @@ def _build_planform(
 def _build_vertices(data: Any, index: int) -> tuple[tuple[float, float], ...]:
     """Parse a raw ``vertices:`` ring (part-own centred frame) into Part vertices.
 
-    Each entry is an ``[x, y]`` pair. ``Part.__post_init__`` canonicalizes the
-    ring (ADR-0003) and enforces the bbox subset; this helper only does
-    shape/type validation so a malformed entry is a clear LoaderError rather
-    than a deep TypeError.
+    Each entry is an ``[x, y]`` pair. This helper does **shape/type** validation
+    only (a list of numeric pairs → a clear LoaderError, not a deep TypeError);
+    **ring validity** — vertex count, degeneracy, self-intersection, and the bbox
+    subset — is enforced by ``Part.__post_init__`` / ``_canonicalize_ring``
+    (ADR-0003) and surfaces as a LoaderError at the load boundary.
     """
     if not isinstance(data, list):
         raise LoaderError(f"parts[{index}].vertices must be a list of [x, y] pairs")
@@ -1782,7 +1783,7 @@ def _split_fuselage(fuselage: Part, wing: Part) -> list[Part]:
     Shapely-clips the outline into front/aft **sub-polygons** at the same
     ``x_break``.
 
-    The split is **area-conserving**: both segments inherit the source
+    The **scalar** split is **area-conserving**: both boxes inherit the source
     fuselage's ``width_m``, ``z_bottom_m``, ``z_top_m``, ``angle_deg`` and
     ``offset_y_m``; they abut at ``x_break`` and their union reconstitutes the
     original footprint exactly (no gap, no overlap). Let the source fuselage
@@ -1792,12 +1793,16 @@ def _split_fuselage(fuselage: Part, wing: Part) -> list[Part]:
     - ``fuselage_aft`` spans ``[c − L/2, x_break]`` (tail side),
 
     each with ``offset_x_m`` at the midpoint of its span and ``length_m`` its
-    span width.
+    span width. (The polygon path is also area-conserving, but each sub-polygon
+    gets its own ``width_m``/``offset_y_m`` from its sub-bbox — see
+    :func:`_subpart_from_clip`.)
 
     Raises :class:`LoaderError` if the derived break does not lie strictly
     inside the fuselage span (the wing trailing edge is forward of the nose or
     aft of the tail) — a degenerate split that would produce a zero- or
-    negative-length segment.
+    negative-length segment. (The polygon path raises additionally — angle ≠ 0,
+    break outside the outline x-span, or a non-single-Polygon clip; see
+    :func:`_clip_fuselage_outline`.)
     """
     x_break = _wing_trailing_edge_x(wing)
     if fuselage.local_vertices is not None:
@@ -1851,8 +1856,11 @@ def _clip_fuselage_outline(fuselage: Part, x_break: float) -> list[Part]:
     outline lives in the part's own centred frame; for an axis-aligned fuselage
     that frame is plane-local shifted by ``offset_x_m``, so the part-own clip
     station is ``xs = x_break - offset_x_m``. The half-plane intersection is
-    interpolation-only (deterministic, cross-machine-robust) and area-conserving;
-    each side is re-canonicalized by ``Part.__post_init__``.
+    interpolation-only (no trig) and area-conserving, and each side is
+    re-canonicalized by ``Part.__post_init__``, so the result is deterministic
+    same-machine (the canary regime). Cross-machine byte-identity stays
+    asserted-not-tested like the rest of the pipeline (ADR-0003); unlike the
+    transform the clip adds no libm-transcendental surface (GEOS aside).
     """
     if abs(fuselage.angle_deg) > _FUSELAGE_OUTLINE_ANGLE_TOL_DEG:
         raise LoaderError(
@@ -1882,10 +1890,19 @@ def _clip_fuselage_outline(fuselage: Part, x_break: float) -> list[Part]:
 def _subpart_from_clip(fuselage: Part, kind: PartKind, geom: Any, side_label: str) -> Part:
     """Build one fuselage_front/aft Part from a clipped sub-polygon (#550).
 
-    Enforces "exactly one non-degenerate Polygon" — the formal guarantee that the
-    front sub-outline is genuinely the cockpit. The sub-polygon comes back in the
-    source part's own centred frame; re-express it about its own sub-bbox centre.
+    Requires exactly one connected, non-degenerate ``Polygon`` per side (a
+    ``MultiPolygon`` — e.g. from a non-x-monotone outline — is rejected). A single
+    connected piece per side is what makes the front sub-outline the nose-side
+    cockpit; x-monotonicity of the authored outline is the authoring contract, not
+    a checked invariant. The sub-polygon comes back in the source part's own
+    centred frame; re-express it about its own sub-bbox centre.
+    ``Part.__post_init__`` is the authoritative ring-validity gate (degeneracy,
+    self-intersection, bbox subset); any rejection there is re-raised as an
+    attributed ``LoaderError`` so the clip's error contract is total.
     """
+    # `_RING_MIN_ABS_SIGNED_AREA` is reused here only as a conservative fast-reject
+    # area floor for the obvious empty/sliver case; the precise degeneracy gate is
+    # the Part constructor below (its threshold is on |2·signed-area|, not area).
     if geom.is_empty or geom.geom_type != "Polygon" or geom.area < _RING_MIN_ABS_SIGNED_AREA:
         raise LoaderError(
             f"kind 'fuselage': the outline does not clip into a single non-degenerate "
@@ -1897,17 +1914,23 @@ def _subpart_from_clip(fuselage: Part, kind: PartKind, geom: Any, side_label: st
     ys_ = [y for _, y in coords]
     sub_cx = (min(xs_) + max(xs_)) / 2.0
     sub_cy = (min(ys_) + max(ys_)) / 2.0
-    return Part(
-        kind=kind,
-        length_m=max(xs_) - min(xs_),
-        width_m=max(ys_) - min(ys_),
-        offset_x_m=fuselage.offset_x_m + sub_cx,
-        offset_y_m=fuselage.offset_y_m + sub_cy,
-        angle_deg=fuselage.angle_deg,
-        z_bottom_m=fuselage.z_bottom_m,
-        z_top_m=fuselage.z_top_m,
-        local_vertices=tuple((x - sub_cx, y - sub_cy) for x, y in coords),
-    )
+    try:
+        return Part(
+            kind=kind,
+            length_m=max(xs_) - min(xs_),
+            width_m=max(ys_) - min(ys_),
+            offset_x_m=fuselage.offset_x_m + sub_cx,
+            offset_y_m=fuselage.offset_y_m + sub_cy,
+            angle_deg=fuselage.angle_deg,
+            z_bottom_m=fuselage.z_bottom_m,
+            z_top_m=fuselage.z_top_m,
+            local_vertices=tuple((x - sub_cx, y - sub_cy) for x, y in coords),
+        )
+    except ValueError as e:
+        raise LoaderError(
+            f"kind 'fuselage': the clipped {side_label} sub-polygon at the wing "
+            f"trailing edge is not a valid part ring ({e})"
+        ) from e
 
 
 def _build_placement(data: Any) -> Placement:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -1502,8 +1502,14 @@ _ALLOWED_PART_KEYS = frozenset(
         "z_bottom_m",
         "z_top_m",
         "planform",
+        "vertices",
     }
 )
+
+# vertices: is valid only on the fuselage family. A `kind: fuselage` entry is
+# built under the placeholder kind "fuselage_aft" (see _build_aircraft), so
+# "fuselage" itself is never a Part kind reaching _build_part.
+_VERTICES_ALLOWED_KINDS = frozenset({"fuselage_front", "fuselage_aft"})
 
 
 def _build_planform(
@@ -1555,6 +1561,26 @@ def _build_planform(
     )
 
 
+def _build_vertices(data: Any, index: int) -> tuple[tuple[float, float], ...]:
+    """Parse a raw ``vertices:`` ring (part-own centred frame) into Part vertices.
+
+    Each entry is an ``[x, y]`` pair. ``Part.__post_init__`` canonicalizes the
+    ring (ADR-0003) and enforces the bbox subset; this helper only does
+    shape/type validation so a malformed entry is a clear LoaderError rather
+    than a deep TypeError.
+    """
+    if not isinstance(data, list):
+        raise LoaderError(f"parts[{index}].vertices must be a list of [x, y] pairs")
+    ring: list[tuple[float, float]] = []
+    for j, pair in enumerate(data):
+        if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+            raise LoaderError(f"parts[{index}].vertices[{j}] must be an [x, y] pair, got {pair!r}")
+        x = _to_float(pair[0], f"parts[{index}].vertices[{j}][0]")
+        y = _to_float(pair[1], f"parts[{index}].vertices[{j}][1]")
+        ring.append((x, y))
+    return tuple(ring)
+
+
 def _build_part(data: Any, index: int) -> Part:
     if not isinstance(data, dict):
         raise LoaderError(f"parts[{index}] must be a mapping")
@@ -1573,11 +1599,23 @@ def _build_part(data: Any, index: int) -> Part:
             f"parts[{index}]: planform: is only valid on a kind 'wing' part, "
             f"got kind {data['kind']!r}"
         )
+    if "vertices" in data and "planform" in data:
+        raise LoaderError(
+            f"parts[{index}]: 'vertices:' and 'planform:' are mutually exclusive "
+            f"(both author a polygon footprint)"
+        )
+    if "vertices" in data and data["kind"] not in _VERTICES_ALLOWED_KINDS:
+        raise LoaderError(
+            f"parts[{index}]: 'vertices:' is only valid on a fuselage part "
+            f"(authored as kind 'fuselage'), got kind {data['kind']!r}"
+        )
     width_m = _to_float(data["width_m"], f"parts[{index}].width_m")
     length_m = _to_float(data["length_m"], f"parts[{index}].length_m")
     local_vertices = None
     if "planform" in data:
         local_vertices = _build_planform(data["planform"], width_m, length_m, index)
+    elif "vertices" in data:
+        local_vertices = _build_vertices(data["vertices"], index)
     return Part(
         kind=data["kind"],
         length_m=length_m,

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -41,8 +41,10 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 import yaml
+from shapely.geometry import Polygon, box
 
 from .models import (
+    _RING_MIN_ABS_SIGNED_AREA,
     Aircraft,
     Door,
     GroundObject,
@@ -51,6 +53,7 @@ from .models import (
     MaintenanceBay,
     MoverMotionMode,
     Part,
+    PartKind,
     Placement,
     PlaneConstraint,
     RegionPreference,
@@ -1511,6 +1514,11 @@ _ALLOWED_PART_KEYS = frozenset(
 # "fuselage" itself is never a Part kind reaching _build_part.
 _VERTICES_ALLOWED_KINDS = frozenset({"fuselage_front", "fuselage_aft"})
 
+# A polygon fuselage must be axis-aligned: the clip works in part-own x, which
+# equals plane-local x only when unrotated (#550). Fuselages are angle-0 by
+# construction, so rotation support is YAGNI.
+_FUSELAGE_OUTLINE_ANGLE_TOL_DEG = 1e-9
+
 
 def _build_planform(
     data: Any, span_m: float, length_m: float, index: int
@@ -1784,16 +1792,14 @@ def _split_fuselage(fuselage: Part, wing: Part) -> list[Part]:
     aft of the tail) — a degenerate split that would produce a zero- or
     negative-length segment.
     """
+    x_break = _wing_trailing_edge_x(wing)
     if fuselage.local_vertices is not None:
-        raise LoaderError(
-            "a fuselage part may not carry a polygon footprint (local_vertices); "
-            "polygon footprints are wing-only"
-        )
+        return _clip_fuselage_outline(fuselage, x_break)
+    # --- scalar box-interval path below is UNCHANGED (byte-identical, #550) ---
     c = fuselage.offset_x_m
     half_len = fuselage.length_m / 2.0
     nose_x = c + half_len  # forward tip (+x)
     tail_x = c - half_len  # aft tip (−x)
-    x_break = _wing_trailing_edge_x(wing)
 
     if not (tail_x < x_break < nose_x):
         raise LoaderError(
@@ -1829,6 +1835,72 @@ def _split_fuselage(fuselage: Part, wing: Part) -> list[Part]:
             z_top_m=fuselage.z_top_m,
         ),
     ]
+
+
+def _clip_fuselage_outline(fuselage: Part, x_break: float) -> list[Part]:
+    """Clip a polygon fuselage outline into front/aft sub-polygons at x_break (#550).
+
+    ``x_break`` is the wing trailing edge in plane-local coords (ADR-0012). The
+    outline lives in the part's own centred frame; for an axis-aligned fuselage
+    that frame is plane-local shifted by ``offset_x_m``, so the part-own clip
+    station is ``xs = x_break - offset_x_m``. The half-plane intersection is
+    interpolation-only (deterministic, cross-machine-robust) and area-conserving;
+    each side is re-canonicalized by ``Part.__post_init__``.
+    """
+    if abs(fuselage.angle_deg) > _FUSELAGE_OUTLINE_ANGLE_TOL_DEG:
+        raise LoaderError(
+            f"a polygon fuselage (vertices:) must be axis-aligned (angle_deg = 0); "
+            f"got angle_deg={fuselage.angle_deg:g}"
+        )
+    assert fuselage.local_vertices is not None  # caller guarantees; narrows for mypy
+    xs = x_break - fuselage.offset_x_m
+    outline = Polygon(fuselage.local_vertices)
+    minx, miny, maxx, maxy = outline.bounds
+    if not (minx < xs < maxx):
+        raise LoaderError(
+            f"kind 'fuselage': derived front/aft section break x={x_break:g} "
+            f"(wing trailing edge) must lie strictly inside the fuselage outline "
+            f"x-span; the break must be strictly inside the span. Check the wing "
+            f"offset_x_m / length_m or the fuselage outline."
+        )
+    pad = (maxx - minx) + (maxy - miny) + 1.0  # any margin past the bbox
+    front_geom = outline.intersection(box(xs, miny - pad, maxx + pad, maxy + pad))
+    aft_geom = outline.intersection(box(minx - pad, miny - pad, xs, maxy + pad))
+    return [
+        _subpart_from_clip(fuselage, "fuselage_front", front_geom, "front"),
+        _subpart_from_clip(fuselage, "fuselage_aft", aft_geom, "aft"),
+    ]
+
+
+def _subpart_from_clip(fuselage: Part, kind: PartKind, geom: Any, side_label: str) -> Part:
+    """Build one fuselage_front/aft Part from a clipped sub-polygon (#550).
+
+    Enforces "exactly one non-degenerate Polygon" — the formal guarantee that the
+    front sub-outline is genuinely the cockpit. The sub-polygon comes back in the
+    source part's own centred frame; re-express it about its own sub-bbox centre.
+    """
+    if geom.is_empty or geom.geom_type != "Polygon" or geom.area < _RING_MIN_ABS_SIGNED_AREA:
+        raise LoaderError(
+            f"kind 'fuselage': the outline does not clip into a single non-degenerate "
+            f"{side_label} piece at the wing trailing edge; the outline must be a simple, "
+            f"x-monotone polygon spanning the break (got {geom.geom_type}, area={geom.area:g})."
+        )
+    coords = list(geom.exterior.coords)[:-1]  # drop Shapely's closing duplicate
+    xs_ = [x for x, _ in coords]
+    ys_ = [y for _, y in coords]
+    sub_cx = (min(xs_) + max(xs_)) / 2.0
+    sub_cy = (min(ys_) + max(ys_)) / 2.0
+    return Part(
+        kind=kind,
+        length_m=max(xs_) - min(xs_),
+        width_m=max(ys_) - min(ys_),
+        offset_x_m=fuselage.offset_x_m + sub_cx,
+        offset_y_m=fuselage.offset_y_m + sub_cy,
+        angle_deg=fuselage.angle_deg,
+        z_bottom_m=fuselage.z_bottom_m,
+        z_top_m=fuselage.z_top_m,
+        local_vertices=tuple((x - sub_cx, y - sub_cy) for x, y in coords),
+    )
 
 
 def _build_placement(data: Any) -> Placement:

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -1767,13 +1767,20 @@ def _wing_trailing_edge_x(wing: Part) -> float:
 def _split_fuselage(fuselage: Part, wing: Part) -> list[Part]:
     """Split one full fuselage :class:`Part` into a front/aft pair.
 
-    ``fuselage`` is the already-field-validated full-fuselage box (built from
-    a ``kind: fuselage`` YAML entry under a placeholder kind in
+    ``fuselage`` is the already-field-validated full fuselage (built from a
+    ``kind: fuselage`` YAML entry under a placeholder kind in
     :func:`_build_aircraft`). The break station is derived from the aircraft's
     own ``wing`` part — the wing trailing edge
     ``x_break = wing.offset_x_m − wing.length_m/2`` (:func:`_wing_trailing_edge_x`,
     ADR-0012). There is no ``wing_root_x_m`` YAML field; the break is always
     derived.
+
+    **Two paths (ADR-0012 amendment, #550):** a scalar fuselage (no
+    ``local_vertices``) takes the box-interval split documented below
+    (byte-identical for every catalog aircraft). A polygon fuselage (a raw
+    ``vertices:`` outline) is delegated to :func:`_clip_fuselage_outline`, which
+    Shapely-clips the outline into front/aft **sub-polygons** at the same
+    ``x_break``.
 
     The split is **area-conserving**: both segments inherit the source
     fuselage's ``width_m``, ``z_bottom_m``, ``z_top_m``, ``angle_deg`` and

--- a/tests/fixtures/outline_wing_over_cockpit.yaml
+++ b/tests/fixtures/outline_wing_over_cockpit.yaml
@@ -1,0 +1,18 @@
+# #550 value test: a high-winger's broad wing sits over the polygon-cockpit
+# (fuselage_front) of an aircraft authored with a `vertices:` outline. Both planes
+# share (x, y) at heading 0; the overflyer wing (z [1.7, 2.0]) is above the
+# fuselage (z [0.3, 1.6]), so D1 makes it a hard `fuselage_front_wing_overlap`.
+# The fleet is supplied as a load_layout(..., fleet=override) so no catalog is needed.
+hangar: ../../data/hangar.yaml
+
+placements:
+  - plane: outline_test
+    x_m: 11.0
+    y_m: 7.0
+    heading_deg: 0.0
+    on_carts: false
+  - plane: overflyer
+    x_m: 11.0
+    y_m: 7.0
+    heading_deg: 0.0
+    on_carts: false

--- a/tests/test_loader_fuselage_outline.py
+++ b/tests/test_loader_fuselage_outline.py
@@ -10,7 +10,7 @@ import math
 from pathlib import Path
 
 import pytest
-from shapely.geometry import Polygon
+from shapely.geometry import LineString, Polygon
 
 from hangarfit.collisions import check
 from hangarfit.geometry import aircraft_parts_world
@@ -19,6 +19,7 @@ from hangarfit.loader import (
     _build_aircraft,
     _build_part,
     _split_fuselage,
+    _subpart_from_clip,
     load_fleet,
     load_layout,
 )
@@ -152,6 +153,14 @@ def test_clip_rejects_non_x_monotone_outline():
     )
     with pytest.raises(LoaderError, match="single|x-monotone|piece"):
         _split_fuselage(cshape, _wing_at(0.0))
+
+
+def test_subpart_rejects_non_polygon_geometry():
+    # Directly exercise the _subpart_from_clip type guard: a non-Polygon clip
+    # result (empty / LineString / MultiPolygon) is a LoaderError, never a crash.
+    fus = _outline_fuselage()
+    with pytest.raises(LoaderError, match="single non-degenerate|piece"):
+        _subpart_from_clip(fus, "fuselage_front", LineString([(0.0, 0.0), (1.0, 1.0)]), "front")
 
 
 # --- Task 3: integration build, determinism, byte-identical-fleet guard ---

--- a/tests/test_loader_fuselage_outline.py
+++ b/tests/test_loader_fuselage_outline.py
@@ -12,14 +12,19 @@ from pathlib import Path
 import pytest
 from shapely.geometry import Polygon
 
+from hangarfit.collisions import check
+from hangarfit.geometry import aircraft_parts_world
 from hangarfit.loader import (
     LoaderError,
     _build_aircraft,
     _build_part,
     _split_fuselage,
     load_fleet,
+    load_layout,
 )
-from hangarfit.models import Part
+from hangarfit.models import Part, Placement
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 
 def _fuselage_outline_dict(**over):
@@ -210,3 +215,60 @@ def test_no_shipped_fuselage_part_is_a_polygon():
         for p in ac.parts:
             if p.kind in ("fuselage_front", "fuselage_aft"):
                 assert p.local_vertices is None, f"{ac.id} {p.kind} became a polygon"
+
+
+# --- Task 4: downstream behavior (det(-1) transform + collision semantics) ---
+
+
+def _overflyer_entry():
+    # A high-winger whose broad wing (z [1.7, 2.0], above the fuselage z [0.3, 1.6])
+    # sits over the outline plane's cockpit (fuselage_front).
+    return {
+        "id": "overflyer",
+        "name": "Overflyer",
+        "wing_position": "high",
+        "gear": "nosewheel",
+        "movement_mode": "cart_eligible",
+        "turn_radius_m": 8.0,
+        "wheels": {"main_offset_x_m": -0.5, "track_m": 2.0, "third_wheel_offset_x_m": 1.5},
+        "parts": [
+            {
+                "kind": "wing",
+                "length_m": 6.0,
+                "width_m": 9.0,
+                "offset_x_m": 1.5,
+                "z_bottom_m": 1.7,
+                "z_top_m": 2.0,
+            },
+            {
+                "kind": "fuselage",
+                "length_m": 6.0,
+                "width_m": 1.2,
+                "offset_x_m": 0.0,
+                "z_bottom_m": 0.3,
+                "z_top_m": 1.6,
+            },
+        ],
+    }
+
+
+def test_clipped_front_flows_through_det_minus_one_transform():
+    ac = _build_aircraft(_outline_entry())
+    pl = Placement(plane_id="outline_test", x_m=10.0, y_m=5.0, heading_deg=37.0, on_carts=False)
+    world = aircraft_parts_world(ac, pl)
+    fronts = [w for w in world if w.kind == "fuselage_front"]
+    assert len(fronts) == 1
+    assert fronts[0].polygon.is_valid and not fronts[0].polygon.is_empty
+
+
+def test_wing_over_polygon_cockpit_conflicts():
+    fleet = {
+        "outline_test": _build_aircraft(_outline_entry()),
+        "overflyer": _build_aircraft(_overflyer_entry()),
+    }
+    layout = load_layout(_FIXTURES / "outline_wing_over_cockpit.yaml", fleet=fleet)
+    result = check(layout)
+    kinds = {c.kind for c in result.conflicts}
+    assert "fuselage_front_wing_overlap" in kinds, (
+        f"expected a cockpit conflict, got {result.conflicts!r}"
+    )

--- a/tests/test_loader_fuselage_outline.py
+++ b/tests/test_loader_fuselage_outline.py
@@ -7,11 +7,18 @@ wing trailing edge (capability-only; the real fleet stays byte-identical). See
 """
 
 import math
+from pathlib import Path
 
 import pytest
 from shapely.geometry import Polygon
 
-from hangarfit.loader import LoaderError, _build_part, _split_fuselage
+from hangarfit.loader import (
+    LoaderError,
+    _build_aircraft,
+    _build_part,
+    _split_fuselage,
+    load_fleet,
+)
 from hangarfit.models import Part
 
 
@@ -140,3 +147,66 @@ def test_clip_rejects_non_x_monotone_outline():
     )
     with pytest.raises(LoaderError, match="single|x-monotone|piece"):
         _split_fuselage(cshape, _wing_at(0.0))
+
+
+# --- Task 3: integration build, determinism, byte-identical-fleet guard ---
+
+
+def _outline_entry():
+    # Minimal aircraft entry with a tapered fuselage outline + a wing whose
+    # trailing edge (offset_x - length/2 = 0.6 - 0.7 = -0.1) lands inside the
+    # fuselage x-span [-3, 3]. Required entry keys: id, name, wing_position,
+    # gear, movement_mode, parts.
+    return {
+        "id": "outline_test",
+        "name": "Outline Test Plane",
+        "wing_position": "high",
+        "gear": "nosewheel",
+        "movement_mode": "cart_eligible",
+        "turn_radius_m": 8.0,
+        "wheels": {"main_offset_x_m": -0.5, "track_m": 2.0, "third_wheel_offset_x_m": 1.5},
+        "parts": [
+            {
+                "kind": "wing",
+                "length_m": 1.4,
+                "width_m": 9.0,
+                "offset_x_m": 0.6,
+                "z_bottom_m": 1.7,
+                "z_top_m": 2.0,
+            },
+            {
+                "kind": "fuselage",
+                "length_m": 6.0,
+                "width_m": 1.2,
+                "offset_x_m": 0.0,
+                "z_bottom_m": 0.3,
+                "z_top_m": 1.6,
+                "vertices": [[3.0, 0.0], [1.0, 0.6], [-3.0, 0.6], [-3.0, -0.6], [1.0, -0.6]],
+            },
+        ],
+    }
+
+
+def test_outline_aircraft_builds_polygon_front_aft():
+    ac = _build_aircraft(_outline_entry())
+    by_kind = {p.kind: p for p in ac.parts}
+    assert by_kind["fuselage_front"].local_vertices is not None
+    assert by_kind["fuselage_aft"].local_vertices is not None
+
+
+def test_outline_build_is_deterministic():
+    a = _build_aircraft(_outline_entry())
+    b = _build_aircraft(_outline_entry())
+    fa = next(p for p in a.parts if p.kind == "fuselage_front")
+    fb = next(p for p in b.parts if p.kind == "fuselage_front")
+    assert fa.local_vertices == fb.local_vertices
+
+
+def test_no_shipped_fuselage_part_is_a_polygon():
+    # byte-identical-fleet guard: every real fleet fuselage stays a scalar box
+    # (the scalar split produces fuselage_front/aft with local_vertices is None).
+    fleet = load_fleet(Path(__file__).resolve().parents[1] / "data" / "fleet.yaml")
+    for ac in fleet.values():
+        for p in ac.parts:
+            if p.kind in ("fuselage_front", "fuselage_aft"):
+                assert p.local_vertices is None, f"{ac.id} {p.kind} became a polygon"

--- a/tests/test_loader_fuselage_outline.py
+++ b/tests/test_loader_fuselage_outline.py
@@ -6,9 +6,13 @@ wing trailing edge (capability-only; the real fleet stays byte-identical). See
 `docs/superpowers/specs/2026-06-27-fuselage-outline-polygon-design.md`.
 """
 
-import pytest
+import math
 
-from hangarfit.loader import LoaderError, _build_part
+import pytest
+from shapely.geometry import Polygon
+
+from hangarfit.loader import LoaderError, _build_part, _split_fuselage
+from hangarfit.models import Part
 
 
 def _fuselage_outline_dict(**over):
@@ -42,3 +46,97 @@ def test_vertices_rejected_on_non_fuselage_kind():
     d = _fuselage_outline_dict(kind="wing")
     with pytest.raises(LoaderError, match="vertices"):
         _build_part(d, 0)
+
+
+# --- Task 2: the _split_fuselage polygon clip ---
+
+
+def _outline_fuselage(angle_deg=0.0):
+    # Tapered tube: pointed nose at +x=2, full-width cabin to tail at x=-2.
+    return Part(
+        kind="fuselage_aft",
+        length_m=4.0,
+        width_m=1.0,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=angle_deg,
+        z_bottom_m=0.3,
+        z_top_m=1.4,
+        local_vertices=((2.0, 0.0), (0.5, 0.5), (-2.0, 0.5), (-2.0, -0.5), (0.5, -0.5)),
+    )
+
+
+def _wing_at(te_x):
+    # wing trailing edge = offset_x - length/2; pick offset/length to land TE at te_x
+    return Part(
+        kind="wing",
+        length_m=1.0,
+        width_m=8.0,
+        offset_x_m=te_x + 0.5,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=1.4,
+        z_top_m=1.7,
+    )
+
+
+def _ring_world(part):
+    # part-own centred ring shifted to plane-local (angle 0): (offset+vx, offset+vy)
+    return Polygon([(part.offset_x_m + x, part.offset_y_m + y) for x, y in part.local_vertices])
+
+
+def test_clip_produces_front_and_aft_polygons():
+    fus = _outline_fuselage()
+    parts = _split_fuselage(fus, _wing_at(0.0))  # break at plane-local x=0
+    assert {p.kind for p in parts} == {"fuselage_front", "fuselage_aft"}
+    for p in parts:
+        assert p.local_vertices is not None
+
+
+def test_clip_is_area_conserving_and_abutting():
+    fus = _outline_fuselage()
+    front, aft = sorted(
+        _split_fuselage(fus, _wing_at(0.0)), key=lambda p: p.offset_x_m, reverse=True
+    )
+    orig = _ring_world(fus).area
+    assert math.isclose(_ring_world(front).area + _ring_world(aft).area, orig, rel_tol=1e-9)
+    # front is the nose side (greater plane-local x), aft the tail side
+    assert front.offset_x_m > aft.offset_x_m
+
+
+def test_clip_rejects_break_outside_span():
+    with pytest.raises(LoaderError, match="strictly inside|span"):
+        _split_fuselage(_outline_fuselage(), _wing_at(5.0))  # TE beyond the nose
+
+
+def test_clip_rejects_rotated_polygon_fuselage():
+    with pytest.raises(LoaderError, match="axis-aligned|angle_deg"):
+        _split_fuselage(_outline_fuselage(angle_deg=10.0), _wing_at(0.0))
+
+
+def test_clip_rejects_non_x_monotone_outline():
+    # A concave "C" opening toward +x: a vertical cut at x=0 leaves two
+    # disconnected nose-side arms -> MultiPolygon -> rejected (the "front is
+    # genuinely the cockpit" guard). Simple, non-self-intersecting, fits +/-2 x +/-0.5.
+    cshape = Part(
+        kind="fuselage_aft",
+        length_m=4.0,
+        width_m=1.0,
+        offset_x_m=0.0,
+        offset_y_m=0.0,
+        angle_deg=0.0,
+        z_bottom_m=0.3,
+        z_top_m=1.4,
+        local_vertices=(
+            (2.0, 0.5),
+            (-2.0, 0.5),
+            (-2.0, -0.5),
+            (2.0, -0.5),
+            (2.0, -0.3),
+            (-1.5, -0.3),
+            (-1.5, 0.3),
+            (2.0, 0.3),
+        ),
+    )
+    with pytest.raises(LoaderError, match="single|x-monotone|piece"):
+        _split_fuselage(cshape, _wing_at(0.0))

--- a/tests/test_loader_fuselage_outline.py
+++ b/tests/test_loader_fuselage_outline.py
@@ -1,0 +1,44 @@
+"""Tests for the #550 fuselage outline polygon capability.
+
+A `kind: fuselage` part may carry a raw `vertices:` outline that the loader
+clips into area-conserving `fuselage_front`/`fuselage_aft` sub-polygons at the
+wing trailing edge (capability-only; the real fleet stays byte-identical). See
+`docs/superpowers/specs/2026-06-27-fuselage-outline-polygon-design.md`.
+"""
+
+import pytest
+
+from hangarfit.loader import LoaderError, _build_part
+
+
+def _fuselage_outline_dict(**over):
+    # A simple symmetric tapered outline in the part's own centred frame,
+    # within +/- length/2 (=2.0) x +/- width/2 (=0.5). Pointed nose at +x.
+    d = {
+        "kind": "fuselage_aft",  # the loader's placeholder rename for `kind: fuselage`
+        "length_m": 4.0,
+        "width_m": 1.0,
+        "z_bottom_m": 0.3,
+        "z_top_m": 1.4,
+        "vertices": [[2.0, 0.0], [0.5, 0.5], [-2.0, 0.5], [-2.0, -0.5], [0.5, -0.5]],
+    }
+    d.update(over)
+    return d
+
+
+def test_vertices_key_sets_local_vertices():
+    part = _build_part(_fuselage_outline_dict(), 0)
+    assert part.local_vertices is not None
+    assert len(part.local_vertices) == 5
+
+
+def test_vertices_and_planform_mutually_exclusive():
+    d = _fuselage_outline_dict(kind="wing", planform={"root_chord_m": 1.0, "tip_chord_m": 0.5})
+    with pytest.raises(LoaderError, match="mutually exclusive|both"):
+        _build_part(d, 0)
+
+
+def test_vertices_rejected_on_non_fuselage_kind():
+    d = _fuselage_outline_dict(kind="wing")
+    with pytest.raises(LoaderError, match="vertices"):
+        _build_part(d, 0)


### PR DESCRIPTION
## What & why

Closes #550 — the deferred **(b)** fuselage-outline piece of spike #541. A `kind: fuselage` part may now carry a raw `vertices:` outline polygon, which the loader **Shapely-clips** into area-conserving `fuselage_front`/`fuselage_aft` sub-polygons at the wing trailing edge (the one genuinely-new algorithm #550 called out).

**Capability-only:** no catalog aircraft adopts a fuselage outline, so the **entire real fleet stays byte-identical** (a guard test enforces it). A test-fixture aircraft exercises the clip. ~85% of the polygon-part pipeline already shipped with spike #541's (c)+(d-param) phase (the `Part.local_vertices` field + canonicalization, the per-vertex det(−1) transform, the scene/v2 viewer seam), so this is almost entirely a loader change.

Design spec: `docs/superpowers/specs/2026-06-27-fuselage-outline-polygon-design.md`. Plan: `docs/superpowers/plans/2026-06-27-fuselage-outline-polygon.md`.

## How it works

- **Authoring** — a new `vertices:` key on a `kind: fuselage` part (mutually exclusive with `planform:`, fuselage-family only; the placeholder rename to `fuselage_aft` is handled). Vertices are part-own centred coords, canonicalized + bbox-validated by `Part.__post_init__`.
- **The clip** (`_split_fuselage` dual path) — scalar fuselage keeps the **exact** box-interval split (byte-identical); a polygon fuselage is clipped by half-plane `intersection` at the same `x_break`. Each side must be **exactly one non-degenerate Polygon** — that guard *is* the formal "the front sub-outline is genuinely the cockpit" guarantee.
- **Determinism** — the clip is interpolation-only (no trig → cross-machine-robust) and re-canonicalized; same YAML → byte-identical sub-polygons (ADR-0003).

## ADR

Additive **Amendment (#550)** to ADR-0012 D2: the front/aft split is a Shapely clip when the fuselage carries an outline; D1 (the `wing × fuselage_front` hard-conflict rule), the conflict-kind taxonomy, and the wing-derived break are all unchanged.

## Error handling (all deterministic `LoaderError`)

`vertices:`+`planform:` together · `vertices:` on a non-fuselage kind · `angle_deg ≠ 0` on a polygon fuselage · break outside the outline x-span · a non-x-monotone outline that clips to a `MultiPolygon`.

## Tests (13 new, all green; full suite 2508 + 7 serial canaries pass)

authoring key + validation · clip area-conservation/abutting/front-aft · the five error paths · integration build via `_build_aircraft` · determinism double-build · **byte-identical-fleet guard** (no fleet fuselage is a polygon) · det(−1) transform at heading ≠ 0 · **value preservation**: a wing over the polygon cockpit fires `fuselage_front_wing_overlap` (ADR-0012 D1).

## Out of scope (by design)

No catalog fuselage data · no parametrized fuselage DSL (future data issue) · empennage stays separate rectangles · no change to the collision predicate, the transform, or the scene/v2 schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5sDVS1j2mhJQj5J2GwxTM
