### PR TITLE
feat(667): shuffle-aware tow routing — program spec + Rung A (Stage 0 gliders)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- Layout placements may now carry `hand_placed: true` (#667, Rung A): a
+  hand-positioned (dolly-borne) body is treated by the fill planner as a fixed
+  keep-out and emitted as a path-less at-rest move instead of being tow-routed.
+  Activated for the dolly gliders (Scheibe Falke + Stemme S10) in the Herrenteich
+  `layout.yaml`, `layout_today.yaml`, and `layout_full.yaml`, matching the club's
+  real practice of hand-positioning the gliders on their dollies. Optional,
+  default `false` — every existing layout stays byte-identical (ADR-0003).
 - A `kind: fuselage` part may now carry a `vertices:` outline polygon, which the
   loader clips into area-conserving `fuselage_front`/`fuselage_aft` sub-polygons
   at the wing trailing edge (#550). Capability-only — no fleet behaviour change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ All notable changes to this project are documented here. Format follows [Keep a 
   hand-positioned (dolly-borne) body is treated by the fill planner as a fixed
   keep-out and emitted as a path-less at-rest move instead of being tow-routed.
   Activated for the dolly gliders (Scheibe Falke + Stemme S10) in the Herrenteich
-  `layout.yaml`, `layout_today.yaml`, and `layout_full.yaml`, matching the club's
-  real practice of hand-positioning the gliders on their dollies. Optional,
-  default `false` — every existing layout stays byte-identical (ADR-0003).
+  `layout.yaml` and `layout_today.yaml`, and for the Stemme S10 in
+  `layout_full.yaml` (where the Scheibe parks outside) — matching the club's real
+  practice of hand-positioning the gliders on their dollies. Optional, default
+  `false` — every existing layout stays byte-identical (ADR-0003).
+- Layout placements now reject unknown keys with a clear `LoaderError` instead of
+  silently dropping them (#667), mirroring the ground-object entry allowlist — so
+  a misspelled flag (e.g. `hand_palced`) fails loudly rather than silently
+  inverting intent (a hand-positioned glider getting tow-routed).
 - A `kind: fuselage` part may now carry a `vertices:` outline polygon, which the
   loader clips into area-conserving `fuselage_front`/`fuselage_aft` sub-polygons
   at the wing trailing edge (#550). Capability-only — no fleet behaviour change.

--- a/docs/superpowers/specs/2026-06-27-667-shuffle-aware-tow-routing-design.md
+++ b/docs/superpowers/specs/2026-06-27-667-shuffle-aware-tow-routing-design.md
@@ -11,10 +11,12 @@
 `hangarfit` can confirm the full Herrenteich fleet is **statically valid parked**
 (`examples/herrenteich/layout.yaml`, `layout_today.yaml`) but cannot compute a
 door-to-slot **tow fill sequence** for it. The routing ceiling for the L-shaped
-hangar is ~4–7 bodies; the real day is 9 aircraft + ground objects. The real club
-assembles the dense nest by **shuffling** — rolling a parked plane aside to let
-another past, hand-positioning the dolly-borne gliders. The planner models none
-of that.
+hangar is ~4–7 bodies; the real day is 9 aircraft + ground objects (the
+aircraft-only `layout.yaml` parks **all 8** usual occupants; `layout_today.yaml`
+adds the Fuji → **9** aircraft + ground objects — "all-8" below means the
+aircraft-only set). The real club assembles the dense nest by **shuffling** —
+rolling a parked plane aside to let another past, hand-positioning the dolly-borne
+gliders. The planner models none of that.
 
 This was diagnosed across the 2026-06 spikes
 ([`herrenteich-all8-tow-routing-rootcause.md`](../../spikes/herrenteich-all8-tow-routing-rootcause.md),
@@ -24,12 +26,15 @@ This was diagnosed across the 2026-06 spikes
 
 Two pieces #667's body proposes have **already landed** and must not be re-built:
 
-- **Stage 0 *mechanism*.** `Placement.hand_placed: bool = False`
+- **Stage 0 *planner mechanism*.** `Placement.hand_placed: bool = False`
   (`models.py:820`) exists. `_plan_fill` (`towplanner.py:1635-1652`) already
   partitions hand-placed bodies into fixed keep-outs and emits a path-less
-  at-rest `Move(plane_id, pose, None)` for each. The loader rejects the flag on
-  ground objects. **It is not activated in the shipped Herrenteich data** — no
-  layout sets the flag.
+  at-rest `Move(plane_id, pose, None)` for each. The flag is rejected on
+  ground-object placements by the `Layout.__post_init__` invariant
+  (`models.py:1010-1015`; the loader's ground-object entry allowlist also rejects
+  the key on GO YAML entries). **Before Rung A it was not activated in the shipped
+  Herrenteich data** — and the *loader* did not parse the YAML key (see Rung A,
+  §4, which wires both).
 - **Order-search backtracking.** The fill is no longer a one-pass monotonic
   greedy loop: `_place_rest` (`towplanner.py:1665-1749`) is a deterministic
   **backtracking DFS over placement order**, greedy-first. The byte-identity
@@ -119,12 +124,15 @@ change rather than planner+schema+viewer at once.
   `layout_today.yaml` (Scheibe + Stemme), `layout_full.yaml` (Stemme only — the
   Scheibe parks outside in that over-capacity what-if).
 - **Production code.** The *planner* mechanism ships (`models.py:820`,
-  `towplanner.py:1640-1652`), but TDD surfaced that the **loader did not parse the
-  `hand_placed` YAML key** — `_build_placement` (`loader.py:1943`) read only
-  `on_carts`. So Rung A adds **one loader line** (`hand_placed=_to_bool(...)`,
-  default False → inert) plus the data + tests. (The spec's earlier "data-only"
-  claim was wrong; the test caught it.)
-- **Files.** `src/hangarfit/loader.py` (one parse line),
+  `towplanner.py:1640-1652`), but TDD + review surfaced two loader gaps:
+  `_build_placement` (`loader.py:1936`) read only `on_carts` (it never parsed
+  `hand_placed`), and there was **no per-placement key allowlist** — a typo'd
+  flag silently dropped to False, *inverting intent* (a hand-positioned glider
+  would be tow-routed). So Rung A adds (a) the `hand_placed=_to_bool(...)` parse
+  (default False → inert) and (b) `_ALLOWED_PLACEMENT_KEYS` rejecting unknown
+  keys loudly, mirroring the ground-object entry allowlist. (The spec's earlier
+  "data-only" claim was wrong; the tests caught it.)
+- **Files.** `src/hangarfit/loader.py` (parse line + allowlist),
   `examples/herrenteich/layout.yaml`, `layout_today.yaml`, `layout_full.yaml`,
   `tests/test_loader.py`, `tests/test_towplanner_fill.py`,
   `tests/test_herrenteich_dataset.py`, `CHANGELOG.md`.

--- a/docs/superpowers/specs/2026-06-27-667-shuffle-aware-tow-routing-design.md
+++ b/docs/superpowers/specs/2026-06-27-667-shuffle-aware-tow-routing-design.md
@@ -1,0 +1,273 @@
+# Design — Shuffle-aware tow routing (#667)
+
+**Status:** approved design · 2026-06-27
+**Issue:** [#667](https://github.com/DocGerd/hangarfit/issues/667) — *Shuffle-aware tow routing: lift the monotonic-placement constraint so dense fleets (full Herrenteich) get valid fill paths*
+**Supersedes the "Design options (for discussion)" section of #667** with a concrete, decomposed program.
+
+---
+
+## 1. Problem
+
+`hangarfit` can confirm the full Herrenteich fleet is **statically valid parked**
+(`examples/herrenteich/layout.yaml`, `layout_today.yaml`) but cannot compute a
+door-to-slot **tow fill sequence** for it. The routing ceiling for the L-shaped
+hangar is ~4–7 bodies; the real day is 9 aircraft + ground objects. The real club
+assembles the dense nest by **shuffling** — rolling a parked plane aside to let
+another past, hand-positioning the dolly-borne gliders. The planner models none
+of that.
+
+This was diagnosed across the 2026-06 spikes
+([`herrenteich-all8-tow-routing-rootcause.md`](../../spikes/herrenteich-all8-tow-routing-rootcause.md),
+[`herrenteich-fk9-cessna-lateral-shuffle.md`](../../spikes/herrenteich-fk9-cessna-lateral-shuffle.md)).
+
+### 1.1 What already ships (the issue body is partly stale)
+
+Two pieces #667's body proposes have **already landed** and must not be re-built:
+
+- **Stage 0 *mechanism*.** `Placement.hand_placed: bool = False`
+  (`models.py:820`) exists. `_plan_fill` (`towplanner.py:1635-1652`) already
+  partitions hand-placed bodies into fixed keep-outs and emits a path-less
+  at-rest `Move(plane_id, pose, None)` for each. The loader rejects the flag on
+  ground objects. **It is not activated in the shipped Herrenteich data** — no
+  layout sets the flag.
+- **Order-search backtracking.** The fill is no longer a one-pass monotonic
+  greedy loop: `_place_rest` (`towplanner.py:1665-1749`) is a deterministic
+  **backtracking DFS over placement order**, greedy-first. The byte-identity
+  guarantee is built in (`towplanner.py:1654-1662`): the first feasible candidate
+  at each level is recursed first, so when the greedy back-first order already
+  works the search returns the identical plan untouched.
+
+What is **genuinely open**: (a) *activating* Stage 0 in the real data;
+(b) **move-aside relocation** — temporarily displacing an already-parked body so a
+later body can route, then restoring it; (c) the **multi-leg plan data model**
+that move-aside requires; (d) an objective **bench baseline** and a **reverse
+teardown diagnostic** to characterise the wall.
+
+## 2. The architectural bet (why this is not a repeat of #840/#844)
+
+The refuted levers — heading-aware SE(2) heuristic (#840, NO-GO), analytic
+parallel-park macro (#840, refuted), chartered-pair continuous traj-opt (#844b,
+NO-GO dominated) — all tried to make a **single straight-to-final-pose A\* route**
+thread the `fk9_mkii`↔`cessna_140` corridor. That is an **intrinsic near-C\* A\***
+**plateau** (~97k expansions): completeness forces expanding every `f*≤C*` state,
+so no heuristic-class method shrinks it.
+
+**Move-aside operates on a different axis.** It does not make the search smarter;
+it changes the **obstacle field** so that a route *exists at all*. The
+`fk9↔cessna` pair has no monotone order but provably has a *shuffle* order — the
+club does it by hand daily. Move-aside is therefore the **one untested lever** and
+the only one that can beat a *mutual* block.
+
+**Honest caveat (recorded, load-bearing for acceptance):** even fully built,
+move-aside may still not seat the `fk9↔cessna` cm-scale parallel-park (it is
+unproven against that specific geometry). Achievable with confidence:
+husky-class ordering locks, dense **partial** fills, and faithful glider
+modeling. *"Route the full all-8"* is a **stretch goal, not a guarantee.** Rung B
+measures this objectively.
+
+## 3. Determinism contract (ADR-0003) — the binding constraint
+
+Every rung must keep the tow plan **byte-identical-bound**: same scenario + seed →
+bit-identical `MovesPlan`. The whole tow module imports no `random`/`secrets`;
+determinism is **structural** and must stay so.
+
+- **Inert-path guarantee.** A layout that does **not** need the new capability
+  must produce a **byte-for-byte identical** plan to today. For move-aside this is
+  realised by **verify-before-displace**: a displacement is attempted only when
+  *no* non-displacing candidate at the current DFS level can route the rest. The
+  greedy-first recursion already returns the identical plan when the back-first
+  order works (`towplanner.py:1654-1658`).
+- **Deterministic tie-break keys** (no RNG, no wall-clock):
+  1. *which body to displace* — deepest-first via `back_first_order`'s existing
+     total order `(-y, +x, +plane_id)` (`towplanner.py:978`); hand-placed bodies
+     are **never** moveable.
+  2. *staging-pose enumeration* — a fixed-emit-order grid mirroring `entry_poses`
+     (y-outer, x-middle, heading-inner) with exact-float dedup via a `seen` set
+     used **only to dedup, never to order**.
+  3. *route cost ties* — strict `<` so the earliest-enumerated wins (matches
+     `_dubins_shortest`/`_rs_solve_normalised`).
+  4. *A\* open-heap* — `(f, monotonic_counter, node)` so unorderable nodes never
+     compare.
+- **Bounding.** Move-aside expansions charge the existing global
+  `total_used`/`total_budget` (dead branches included), **plus** a new
+  deterministic **per-stuck-slot displacement cap** (count-based, not wall-clock)
+  to prevent cycles (displace A → fail B → displace B → re-displace A …).
+- **Cross-machine caveat (ADR-0003 #844 amendment).** Move-aside fires multiple
+  transcendental-heavy `plan_path` calls per stuck slot (libm `sin/cos/atan2/acos`
+  unpinned cross-host). The contract stays robustly **same-machine** and
+  presumptively cross-machine; staging poses must carry **comfortable cost margin**
+  so a sub-ULP boundary cannot flip viability across hosts.
+- **Guards.** `determinism-guard` on every `towplanner.py`/`solver.py` PR;
+  `geometry-invariant-guard` on any geometry touch; `scene-schema-guard` on the
+  scene/v2 seam.
+
+## 4. Decomposition — five rungs, lowest-risk first
+
+Each rung is its own GitHub issue (sub-issue of #667) and its own PR. Ordered so
+the lowest-risk, highest-legibility rung ships first; the risky data-model change
+(D) lands with **zero behavior change** so move-aside (E) is a *localized* planner
+change rather than planner+schema+viewer at once.
+
+### Rung A — Activate Stage 0 hand-placed gliders (data only)
+
+- **Scope.** Set `hand_placed: true` on the dolly-borne gliders **Scheibe Falke**
+  and **Stemme S10** in every Herrenteich layout where they appear; keep
+  `on_carts: true` (orthogonal — `on_carts` is the physical state shown in
+  render; `hand_placed` is *how it got there*). Add a dedicated test fixture.
+- **Decision (confirmed with user).** Both gliders are hand-placed. Layouts
+  touched (verified against the data): `layout.yaml` (Scheibe + Stemme),
+  `layout_today.yaml` (Scheibe + Stemme), `layout_full.yaml` (Stemme only — the
+  Scheibe parks outside in that over-capacity what-if).
+- **No production code change** — the mechanism ships (`models.py:820`,
+  `towplanner.py:1640-1652`).
+- **Files.** `examples/herrenteich/layout*.yaml`, a new
+  `tests/fixtures/` hand-placed fixture, `tests/test_towplanner_*.py`,
+  `CHANGELOG.md`.
+- **Acceptance.** (1) Byte-identity preserved for any layout with zero
+  hand-placed bodies (regression test, double-build + diff). (2) A hand-placed
+  body emits a path-less at-rest `Move` and is treated as a keep-out by routed
+  bodies. (3) `hangarfit check` on the edited layouts still exits 0 (static
+  validity unchanged).
+- **Risk.** Low. **Buys** faithful glider modeling and shrinks the towable set;
+  does **not** touch the `fk9↔cessna` ceiling.
+
+### Rung B — Bench ceiling regime + tripwire
+
+- **Scope.** Add a `herrenteich_all_eight` (and a today-fleet) regime to
+  `bench/regimes.py` (fixed seed, bounded `max_restarts`, `heavy=True`) and a
+  `_SPEED_CEILING_S` entry in `bench/profile_pipeline.py`. Pure measurement; no
+  production code.
+- **Files.** `bench/regimes.py`, `bench/profile_pipeline.py`, optionally a short
+  `docs/spikes/` writeup of the measured baseline.
+- **Acceptance.** A deterministic digest of the routed-body count / timing for
+  the Herrenteich-class scenarios, runnable in `bench`, documenting the residual
+  wall objectively. RNG-free routing keeps the digest deterministic.
+- **Risk.** Low. **Buys** the baseline every later rung is graded against.
+
+### Rung C — Reverse-teardown read-only feasibility probe
+
+- **Scope.** Generalise `egress_first_conflict` (`towplanner.py:1386`, which
+  already routes one body slot→door backward, with `egress_path_out` plumbing and
+  ADR-0010 entry⟺egress reversibility) into a **whole-fill teardown probe**:
+  extract each body slot→door in **reverse-placed order** against shrinking
+  partial state; emit a **diagnostic verdict only** — does a teardown/fill order
+  exist? **No plan output, no data-model change → byte-identical.**
+- **Files.** `src/hangarfit/towplanner.py` (read-only probe), a
+  `tests/test_towplanner_*.py` determinism + correctness test, a `docs/spikes/`
+  writeup.
+- **Acceptance.** The probe reports whether a reverse order exists for the
+  Herrenteich layouts, and confirms the predicted dual: `fk9↔cessna` blocks
+  *extraction* too (reverse-alone has the same ceiling — it only removes, never
+  relocates). This tells us reverse is a **diagnostic**, not the writer, *before*
+  we invest in move-aside.
+- **Risk.** Medium (new traversal) but read-only and byte-safe; `determinism-guard`
+  required.
+
+### Rung D — Multi-leg data-model + consumer seam (no planner change)
+
+- **Scope.** Make a single body able to traverse **multiple legs** (to staging,
+  then to final) without changing any plan *output* yet.
+- **Data model.** Keep `Move` single-leg
+  (`{plane_id, target_slot: Pose, path: DubinsArc | None}`, `towplanner.py:236`).
+  Allow **multiple `Move` entries per `plane_id`** in `MovesPlan.moves` (one per
+  leg, in execution order) and add an **additive discriminator** `leg_index:
+  int = 0`. Existing single-leg producers keep `leg_index=0` and serialize
+  identically → byte-safe. **Rejected:** reshaping `Move.path` into
+  `tuple[DubinsArc, ...]` (forces every `.sample()`/`.length_m` site to enumerate
+  and breaks the one-`target_slot`-per-body invariant scene/visualize rely on).
+  A staging leg's `target_slot` is a **transient** pose (not in
+  `target_layout.placements`); the body's final placement remains the single
+  entry in `Layout.placements`. `SolveResult.plans` is structurally unaffected
+  (`len(plans)==len(layouts)` holds; multi-leg lives inside one `MovesPlan`).
+- **Consumers (all changes additive).**
+  - `scene.py:274` `move_by_id = {m.plane_id: m}` → `dict[str, list[Move]]`
+    (group, don't overwrite); `_timeline`/`_append_segment` (`278-291`) emit one
+    segment **per leg** with summed sequential time; carry optional `leg_index` on
+    the segment dict. The `back_first_order` loop (`298-299`) stays.
+  - scene/v2: extend `timeline.segments[]` with optional `leg_index: int`
+    (`docs/architecture/scene-v2-schema.md`); `SCHEMA` stays
+    `hangarfit.scene/v2` (additive only; a v3 bump is disallowed by ADR-0017).
+    `build_scene` stays byte-identical because **zero current producers emit >1
+    leg.**
+  - `viewer/src/scene-contract.ts:87` `SegmentData` gains `leg?: number`
+    (key-set parity test, #440); `viewer/src/timeline.ts:71` `segByPlane` →
+    array or composite `pid:leg` key; `affineAt` iterates legs to find the one
+    containing time `t`. Rebuild + commit `viewer.js` (drift guard #438).
+  - `visualize.py` `_draw_tow_paths` (`720-768`): the per-move `.sample()` loop
+    enumerates legs, plotting each (optional distinct styling for a shuffle leg).
+- **Animation (confirmed with user).** Staging legs **animate** (the viewer's
+  purpose is to *show* the shuffle); accept slightly larger HTML.
+- **Files.** `towplanner.py` (`Move`), `scene.py`, `visualize.py`,
+  `viewer/src/timeline.ts`, `viewer/src/scene-contract.ts`,
+  `src/hangarfit/_viewer_assets/viewer.js`,
+  `docs/architecture/scene-v2-schema.md`, `tests/test_scene.py`,
+  `tests/test_viewer.py`.
+- **Acceptance.** Byte-identity provable (no multi-leg producer exists yet);
+  `scene-schema-guard` + key-parity + viewer-build-drift all green; consumers
+  handle (synthetic) multi-leg input in unit tests.
+- **Risk.** Medium (wide but additive ripple).
+
+### Rung E — Move-aside repair core (the open Stage 1)
+
+- **Scope.** Extend `_place_rest` (`towplanner.py:1730`): when the greedy
+  candidate deadlocks a later body and **no non-displacing candidate routes the
+  rest**, temporarily remove a previously-committed body from `placed`, route the
+  stuck body against the reduced set, commit a **staging `Move`** (via Rung D's
+  multi-leg shape) + recurse, then **restore** the displaced body to its final
+  pose before the next iteration.
+- **Decisions (confirmed with user / recommended).**
+  - **Depth cap = 1** displacement per stuck slot to start (depth-2 explodes the
+    deterministic search + cycle surface; revisit after depth-1 ships).
+  - **Staging-pose policy = apron-out first** (y<0, reuses ADR-0021): a body
+    parked outside the door cannot jam later bodies (avoids the *viability
+    paradox* where a center staging pose blocks the whole fill). Interior
+    off-to-side wall pockets only if apron-out proves insufficient.
+  - Separate **displacement-attempt cap** distinct from `_MAX_FILL_BACKTRACKS`
+    (`towplanner.py:1898`), count-based, to bound cycles.
+  - Preserve the **stuck-body Conflict-naming** contract (the #668 review
+    contract at `1724`/`1743-1748`/`1761-1764` must name the *stuck* body, not the
+    displaced one).
+  - **Spread post-pass (ADR-0008):** intermediate/staging legs are **excluded**
+    from the spread metric; spread operates on final placements only.
+- **Files.** `src/hangarfit/towplanner.py`, `tests/test_solver_canaries.py`,
+  `tests/test_towplanner_*.py`, `bench/` (re-baseline the ceiling),
+  `CHANGELOG.md`.
+- **Acceptance.** (1) A move-aside-exercising fixture gets a valid **multi-leg**
+  fill plan; every intermediate shuffle leg is collision-free and in-bounds.
+  (2) **Byte-identical** plans for layouts that don't need a shuffle
+  (`determinism-guard` green; a canary that exercises the move-aside branch is
+  added and double-solve-diffed). (3) The bench (Rung B) shows the routing
+  ceiling raised on Herrenteich-class scenarios. (4) Bounded cost: a documented
+  cap on shuffle depth / total moves.
+- **Risk.** **High** — cycles, staging-pose count explosion, the viability
+  paradox, inert-path byte-identity, cross-machine libm under repeated
+  `plan_path`. `determinism-guard` + `geometry-invariant-guard` mandatory.
+
+## 5. Explicit non-goals
+
+- **Not** the learned backend (#607). Move-aside is a deterministic planner
+  capability, complementary to #607 (it gives #607 a richer routability oracle).
+- **Not** full TAMP / open-ended rearrangement (the issue's Stage 2). The program
+  stops at **bounded depth-1 move-aside** and explicitly defers TAMP.
+- **Not** wing-tilt-during-motion (the Scheibe routes without it), and **no**
+  change to static validity or clearances.
+- **No** guarantee the `fk9↔cessna` pair is routed; it may remain a documented
+  manual-insertion case.
+
+## 6. Sequencing & deferral of remaining decisions
+
+- A → B → C ship first (low/low/medium risk, no data-model change). C's verdict
+  informs whether reverse framing adds anything before D/E.
+- D lands the seam byte-identically; E is the only behavior-changing rung.
+- Rung-E sub-decisions (interior-pocket fallback, depth-2, exact displacement-cap
+  value) are revisited **at rung E** with the bench baseline in hand, not now.
+
+## 7. Test & guard strategy (per rung)
+
+| Rung | Primary guards / tests |
+|---|---|
+| A | byte-identity regression; hand-placed keep-out + path-less-move unit; `check` exit-0 |
+| B | deterministic bench digest |
+| C | `determinism-guard`; reverse-probe correctness + determinism unit |
+| D | `scene-schema-guard`; #440 key-parity; #438 viewer-build-drift; synthetic multi-leg consumer units |
+| E | `determinism-guard` + `geometry-invariant-guard`; move-aside canary (double-solve diff); multi-leg plan validity (every leg collision-free, in-bounds) |

--- a/docs/superpowers/specs/2026-06-27-667-shuffle-aware-tow-routing-design.md
+++ b/docs/superpowers/specs/2026-06-27-667-shuffle-aware-tow-routing-design.md
@@ -118,11 +118,16 @@ change rather than planner+schema+viewer at once.
   touched (verified against the data): `layout.yaml` (Scheibe + Stemme),
   `layout_today.yaml` (Scheibe + Stemme), `layout_full.yaml` (Stemme only — the
   Scheibe parks outside in that over-capacity what-if).
-- **No production code change** — the mechanism ships (`models.py:820`,
-  `towplanner.py:1640-1652`).
-- **Files.** `examples/herrenteich/layout*.yaml`, a new
-  `tests/fixtures/` hand-placed fixture, `tests/test_towplanner_*.py`,
-  `CHANGELOG.md`.
+- **Production code.** The *planner* mechanism ships (`models.py:820`,
+  `towplanner.py:1640-1652`), but TDD surfaced that the **loader did not parse the
+  `hand_placed` YAML key** — `_build_placement` (`loader.py:1943`) read only
+  `on_carts`. So Rung A adds **one loader line** (`hand_placed=_to_bool(...)`,
+  default False → inert) plus the data + tests. (The spec's earlier "data-only"
+  claim was wrong; the test caught it.)
+- **Files.** `src/hangarfit/loader.py` (one parse line),
+  `examples/herrenteich/layout.yaml`, `layout_today.yaml`, `layout_full.yaml`,
+  `tests/test_loader.py`, `tests/test_towplanner_fill.py`,
+  `tests/test_herrenteich_dataset.py`, `CHANGELOG.md`.
 - **Acceptance.** (1) Byte-identity preserved for any layout with zero
   hand-placed bodies (regression test, double-build + diff). (2) A hand-placed
   body emits a path-less at-rest `Move` and is treated as a keep-out by routed

--- a/examples/herrenteich/README.md
+++ b/examples/herrenteich/README.md
@@ -36,6 +36,16 @@ hangarfit view  examples/herrenteich/scenario_demo.yaml -o demo.html --seed 3
 | `scenario.yaml` | The solver input for the all-eight "everyone home" scenario (does not fully route — see below). |
 | `scenario_demo.yaml` | A 3-aircraft subset that **solves and fully tow-routes** end-to-end in the L-shaped hangar — the working toolchain demo. |
 
+> **Dolly gliders are hand-positioned (#667 Rung A).** As of #667 Stage 0, the
+> dolly-borne gliders are marked `hand_placed: true` in these layouts — the
+> Scheibe Falke + Stemme S10 in `layout.yaml` / `layout_today.yaml`, and the
+> Stemme only in `layout_full.yaml` (the Scheibe parks outside there). The fill
+> planner then treats them as fixed keep-outs and does **not** emit a tow path for
+> them (they go in by hand), so `view` / `solve --render-paths` route only the
+> powered aircraft around them. This is inert to static validity (`hangarfit
+> check` is unaffected). The lone-Stemme own-gear straight-in noted below is still
+> true as a *capability*; the dense shipped layouts just model it on its dolly.
+
 ## Three things this dataset is honest about
 
 **1. The hangar is L-shaped, and since ADR-0018 (#527) the model knows it.**

--- a/examples/herrenteich/layout.yaml
+++ b/examples/herrenteich/layout.yaml
@@ -37,11 +37,13 @@ placements:
     y_m: 22.50
     heading_deg: 90.0
     on_carts: true          # always_cart
+    hand_placed: true        # #667 Stage 0: hand-positioned on its dolly, not tow-routed
   - plane: stemme_s10
     x_m: 3.50
     y_m: 13.65
     heading_deg: 270.0
     on_carts: true          # dolly-pivotable in the hangar (#644)
+    hand_placed: true        # #667 Stage 0: hand-positioned on its dolly, not tow-routed
   - plane: aviat_husky
     x_m: 5.60
     y_m: 16.40

--- a/examples/herrenteich/layout_full.yaml
+++ b/examples/herrenteich/layout_full.yaml
@@ -75,6 +75,7 @@ placements:
     y_m: 19.89
     heading_deg: 296.9
     on_carts: true          # always_cart (dolly-pivotable in the hangar, #644)
+    hand_placed: true        # #667 Stage 0: hand-positioned on its dolly, not tow-routed
   - plane: cessna_140
     x_m: 1.8
     y_m: 22.82

--- a/examples/herrenteich/layout_today.yaml
+++ b/examples/herrenteich/layout_today.yaml
@@ -44,11 +44,13 @@ placements:
     y_m: 13.98
     heading_deg: 115.0
     on_carts: true          # always_cart (dolly-pivotable, #644)
+    hand_placed: true        # #667 Stage 0: hand-positioned on its dolly, not tow-routed
   - plane: scheibe_falke
     x_m: 5.92
     y_m: 22.15
     heading_deg: 290.0
     on_carts: true          # always_cart
+    hand_placed: true        # #667 Stage 0: hand-positioned on its dolly, not tow-routed
   - plane: zlin_savage
     x_m: 3.13
     y_m: 27.42

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -1946,6 +1946,10 @@ def _build_placement(data: Any) -> Placement:
         y_m=_to_float(data["y_m"], "y_m"),
         heading_deg=_to_float(data["heading_deg"], "heading_deg"),
         on_carts=_to_bool(data.get("on_carts", False), "on_carts"),
+        # #667 Stage 0: a hand-positioned (dolly-borne) body is parked by hand, not
+        # tow-routed. Optional, default False — every existing layout stays
+        # byte-identical (ADR-0003 inert-path guarantee).
+        hand_placed=_to_bool(data.get("hand_placed", False), "hand_placed"),
     )
 
 

--- a/src/hangarfit/loader.py
+++ b/src/hangarfit/loader.py
@@ -1933,9 +1933,25 @@ def _subpart_from_clip(fuselage: Part, kind: PartKind, geom: Any, side_label: st
         ) from e
 
 
+# Strict per-placement key allowlist (#667 review). An unknown placement key is
+# REJECTED, not silently dropped — mirroring the ground-object entry allowlist
+# (`_allowed_go_entry`) and the #513/#516 silent-failure policy. Critical for
+# `hand_placed`: a silent drop would INVERT intent (default False → a hand-
+# positioned glider gets tow-routed) with no signal to the YAML author.
+_ALLOWED_PLACEMENT_KEYS = frozenset(
+    {"plane", "x_m", "y_m", "heading_deg", "on_carts", "hand_placed"}
+)
+
+
 def _build_placement(data: Any) -> Placement:
     if not isinstance(data, dict):
         raise LoaderError(f"placement must be a mapping, got {type(data).__name__}")
+    unknown = set(data) - _ALLOWED_PLACEMENT_KEYS
+    if unknown:
+        raise LoaderError(
+            f"unknown placement key(s) {sorted(unknown)}; "
+            f"allowed: {sorted(_ALLOWED_PLACEMENT_KEYS)}"
+        )
     required = ("plane", "x_m", "y_m", "heading_deg")
     for key in required:
         if key not in data:

--- a/tests/test_herrenteich_dataset.py
+++ b/tests/test_herrenteich_dataset.py
@@ -473,3 +473,33 @@ def test_today_caddy_egress_clear() -> None:
     layout = load_layout(HERRENTEICH / "layout_today.yaml")
     c = egress_first_conflict(layout, "vw_caddy")
     assert c is None, f"expected the Caddy to have a clear egress; got {c}"
+
+
+# The dolly-borne gliders the club hand-positions: Scheibe Falke (18 m, parks
+# lengthwise on a monowheel dolly) and the folded Stemme S10. Both go in BY HAND,
+# never tow-routed (#667 Rung A / Stage 0).
+HAND_PLACED_GLIDERS = {"scheibe_falke", "stemme_s10"}
+
+
+def test_shipped_layouts_mark_dolly_gliders_hand_placed() -> None:
+    """#667 Rung A (Stage 0): the dolly-borne gliders are marked ``hand_placed`` in
+    the shipped Herrenteich layouts, so the fill planner treats them as fixed
+    keep-outs (path-less at-rest moves) instead of tow-routing them — matching the
+    club's real practice. ``on_carts`` stays True: it is orthogonal (the physical
+    dolly state shown in render vs. *how* the body reached its slot)."""
+    # layout.yaml (all eight, aircraft-only) — both gliders inside, both by hand.
+    layout = load_layout(HERRENTEICH / "layout.yaml")
+    assert {p.plane_id for p in layout.placements if p.hand_placed} == HAND_PLACED_GLIDERS
+    # layout_today.yaml (the real 'today' set) — both gliders inside, both by hand.
+    today = load_layout(HERRENTEICH / "layout_today.yaml")
+    assert {p.plane_id for p in today.placements if p.hand_placed} == HAND_PLACED_GLIDERS
+    # layout_full.yaml — only the Stemme is inside (the Scheibe parks outside here).
+    full = load_layout(HERRENTEICH / "layout_full.yaml")
+    assert {p.plane_id for p in full.placements if p.hand_placed} == {"stemme_s10"}
+    # The dolly state is preserved for rendering on every hand-placed glider.
+    for src in (layout, today, full):
+        for p in src.placements:
+            if p.hand_placed:
+                assert p.on_carts, (
+                    f"{p.plane_id} hand-placed glider should keep on_carts for render"
+                )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1442,6 +1442,49 @@ placements:
         )
         assert load_layout(layout_path).placements[0].hand_placed is False
 
+    @pytest.mark.parametrize("typo", ["hand_palced", "on_cart", "headingdeg", "bogus"])
+    def test_unknown_placement_key_rejected(self, tmp_path: Path, typo: str) -> None:
+        """A misspelled PLACEMENT key must be REJECTED, not silently dropped
+        (#667 review / silent-failure class #513/#516). The danger is intent-
+        inverting: a typo'd ``hand_placed`` would silently default to False and
+        tow-route a hand-positioned glider. Mirrors the ground-object entry
+        allowlist (``_allowed_go_entry``)."""
+        self._minimal_fleet_and_hangar(tmp_path)
+        entry = f"plane: foo, x_m: 5.0, y_m: 5.0, heading_deg: 0, on_carts: false, {typo}: true"
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            f"fleet: fleet.yaml\nhangar: hangar.yaml\nplacements:\n  - {{{entry}}}\n",
+        )
+        with pytest.raises(LoaderError, match=r"unknown placement key\(s\)"):
+            load_layout(layout_path)
+
+    def test_all_allowed_placement_keys_load(self, tmp_path: Path) -> None:
+        """Completeness guard: a placement declaring EVERY allowed key loads, so the
+        allowlist can never be too strict. Self-enforcing against
+        ``_ALLOWED_PLACEMENT_KEYS``."""
+        from hangarfit.loader import _ALLOWED_PLACEMENT_KEYS
+
+        self._minimal_fleet_and_hangar(tmp_path)
+        entry = {
+            "plane": "foo",
+            "x_m": 5.0,
+            "y_m": 5.0,
+            "heading_deg": 0,
+            "on_carts": False,
+            "hand_placed": True,
+        }
+        assert set(entry) == _ALLOWED_PLACEMENT_KEYS, (
+            f"fixture must cover the full allowlist; "
+            f"missing={sorted(_ALLOWED_PLACEMENT_KEYS - set(entry))} "
+            f"extra={sorted(set(entry) - _ALLOWED_PLACEMENT_KEYS)}"
+        )
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            "fleet: fleet.yaml\nhangar: hangar.yaml\nplacements:\n"
+            f"  - {yaml.safe_dump(entry, default_flow_style=True).strip()}\n",
+        )
+        assert load_layout(layout_path).placements[0].hand_placed is True
+
     @pytest.mark.parametrize(
         "typo",
         ["placments", "maintenence", "hangarr", "bogus_field"],

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1409,6 +1409,39 @@ placements:
         assert len(layout.placements) == 1
         assert layout.placements[0].plane_id == "foo"
 
+    def test_hand_placed_flag_parsed(self, tmp_path: Path) -> None:
+        """#667 Rung A (Stage 0): load_layout parses the optional per-placement
+        ``hand_placed`` flag (strict-bool like ``on_carts``). A hand-placed body is
+        parked by hand, not tow-routed. (Orthogonality with ``on_carts`` is proven
+        on the real cart-borne gliders in the herrenteich dataset test.)"""
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            """
+fleet: fleet.yaml
+hangar: hangar.yaml
+placements:
+  - plane: foo
+    x_m: 5.0
+    y_m: 5.0
+    heading_deg: 0
+    on_carts: false
+    hand_placed: true
+""",
+        )
+        assert load_layout(layout_path).placements[0].hand_placed is True
+
+    def test_hand_placed_defaults_false_when_omitted(self, tmp_path: Path) -> None:
+        """Omitting ``hand_placed`` yields False, so every existing layout loads
+        byte-identically (the inert-path guarantee, ADR-0003)."""
+        self._minimal_fleet_and_hangar(tmp_path)
+        layout_path = _write(
+            tmp_path / "layout.yaml",
+            "fleet: fleet.yaml\nhangar: hangar.yaml\n"
+            "placements:\n  - {plane: foo, x_m: 5.0, y_m: 5.0, heading_deg: 0, on_carts: false}\n",
+        )
+        assert load_layout(layout_path).placements[0].hand_placed is False
+
     @pytest.mark.parametrize(
         "typo",
         ["placments", "maintenence", "hangarr", "bogus_field"],

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -177,6 +177,26 @@ def test_plan_fill_skips_hand_placed_body_and_keeps_it_as_obstacle() -> None:
     )
 
 
+def test_plan_fill_inert_with_no_hand_placed_body() -> None:
+    """#667 Rung A inert-path guarantee (ADR-0003): a layout with NO hand-placed
+    body partitions the whole fleet into the routed set — no body is carried at
+    rest — and re-planning is byte-identical. So activating Stage 0 in some
+    layouts cannot perturb a layout that does not use it."""
+    h = _hangar(width_m=20.0, length_m=30.0)
+    fleet = {"A": _box_plane("A"), "B": _box_plane("B")}
+    target = _layout(
+        fleet,
+        h,
+        _slot("A", x=8.0, y=8.0),
+        _slot("B", x=12.0, y=22.0),
+    )
+    plan = plan_fill(target)
+    # No body is carried at rest: every move is tow-routed (no hand-placed keep-out).
+    assert all(m.path is not None for m in plan.moves)
+    # Re-planning the identical target yields a byte-identical plan.
+    assert plan_fill(target) == plan
+
+
 # ── plan_fill LOOP-logic tests ──────────────────────────────────────────────
 # These pin the back-first scan / swap / bail mechanics in isolation by faking
 # ``plan_path`` — the per-candidate call ``plan_fill`` actually makes. (Earlier


### PR DESCRIPTION
First increment of the **#667 shuffle-aware tow routing** program. Carries the program design spec (the whole 5-rung decomposition) **plus Rung A** (the first, lowest-risk rung).

## Program design (spec)

`docs/superpowers/specs/2026-06-27-667-shuffle-aware-tow-routing-design.md` records the approved decomposition that lifts the monotonic-placement constraint via **bounded move-aside relocation**, lowest-risk-first:

- **A** — activate Stage 0 hand-placed gliders *(this PR)*
- **B** — bench ceiling regime + determinism tripwire
- **C** — reverse-teardown read-only feasibility probe
- **D** — multi-leg `Move`/`MovesPlan` data-model seam (byte-identical)
- **E** — move-aside repair core (the only reachability-adding rung)

The spec corrects the stale issue body (the Stage 0 *mechanism* and order-search backtracking already ship), records the architectural bet (move-aside changes **reachability**, not search guidance — the one lever #840/#844 never tested), the ADR-0003 inert-path determinism strategy, and the **honest `fk9↔cessna` ceiling caveat** (routing the full all-8 is a stretch goal, not a guarantee).

## Rung A — activate Stage 0 hand-placed gliders

The club hand-positions its dolly-borne gliders (Scheibe Falke, Stemme S10); they go in by hand, never tow-routed. This marks them `hand_placed: true` so the fill planner treats them as fixed keep-outs (path-less at-rest moves), matching reality and shrinking the towable set.

**TDD surfaced a gap the spec missed:** the planner mechanism shipped, but the **loader did not parse the `hand_placed` YAML key** (`_build_placement` read only `on_carts`). So Rung A adds **one loader line** (default `False` → inert) plus the data + tests.

- `src/hangarfit/loader.py` — parse `hand_placed` (strict-bool, default False)
- `examples/herrenteich/layout.yaml`, `layout_today.yaml` (Scheibe + Stemme); `layout_full.yaml` (Stemme only — Scheibe parks outside)
- Tests: loader parse + default-false (`test_loader.py`); shipped-data activation contract (`test_herrenteich_dataset.py`); inert-path byte-identity guard (`test_towplanner_fill.py`)

### Verification

- `hangarfit check` exits 0 on all three edited layouts (static validity unchanged — `hand_placed` is a planner concept, inert to `collisions.check`).
- 232 passed across loader + fill + herrenteich + ML witness suites; `mypy src/` clean; ruff clean.
- Byte-identity preserved for any layout without the flag (ADR-0003).

Does **not** touch the `fk9↔cessna` routing ceiling (that's Rung E) — realism + towable-set reduction only.

Closes #858
Refs #667