### PR TITLE
feat(667): Rung B — Herrenteich routing-ceiling bench baseline

### DIFF
--- a/bench/harness.py
+++ b/bench/harness.py
@@ -205,13 +205,21 @@ def _path_failures(plan: MovesPlan, target: Layout) -> list[str]:
     placed: list[Placement] = []
     failures: list[str] = []
     for move in plan.moves:
+        if move.plane_id not in by_id:
+            # A placed_routed_mover ground-object move (towplanner.py): its id is
+            # not an aircraft placement. Movers route LAST against the fully-placed
+            # aircraft set and are not aircraft keep-outs (they live in
+            # `ground_object_placements`), so they are out of scope for this
+            # aircraft-arc re-validation — re-validating mover arcs is Rung E / #602
+            # work. Skipping avoids both a KeyError here and corrupting `placed`
+            # (an aircraft-only list) with a ground object.
+            continue
         original = by_id[move.plane_id]
         if move.path is None:
-            # A path-less at-rest move (a #667 hand-placed body, or a #601
-            # deferred mover): no arc to re-validate. It is still a keep-out for
-            # later routed bodies — `plan_fill` seeds `placed` with the
-            # hand-placed slots — so keep the obstacle context faithful by
-            # committing it before the next move.
+            # A path-less at-rest move (a #667 hand-placed aircraft body): no arc
+            # to re-validate. It is still a keep-out for later routed bodies —
+            # `plan_fill` seeds `placed` with the hand-placed slots — so keep the
+            # obstacle context faithful by committing it before the next move.
             placed.append(original)
             continue
         placed_layout = Layout(

--- a/bench/harness.py
+++ b/bench/harness.py
@@ -205,13 +205,21 @@ def _path_failures(plan: MovesPlan, target: Layout) -> list[str]:
     placed: list[Placement] = []
     failures: list[str] = []
     for move in plan.moves:
+        original = by_id[move.plane_id]
+        if move.path is None:
+            # A path-less at-rest move (a #667 hand-placed body, or a #601
+            # deferred mover): no arc to re-validate. It is still a keep-out for
+            # later routed bodies — `plan_fill` seeds `placed` with the
+            # hand-placed slots — so keep the obstacle context faithful by
+            # committing it before the next move.
+            placed.append(original)
+            continue
         placed_layout = Layout(
             fleet=target.fleet,
             hangar=target.hangar,
             placements=tuple(placed),
             maintenance_plane=target.maintenance_plane,
         )
-        original = by_id[move.plane_id]
         conflict = path_first_conflict(
             move.path,
             target.fleet[move.plane_id],
@@ -248,6 +256,12 @@ def _plan_digest(plan: MovesPlan | None) -> str:
     parts: list[str] = []
     for move in plan.moves:
         slot: Pose = move.target_slot
+        if move.path is None:
+            # Path-less at-rest move (#667 hand-placed / #601 deferred): no arc to
+            # digest. Still digest the at-rest slot so a change in the hand-placed
+            # pose is caught as a difference.
+            parts.append(f"{move.plane_id}@{slot.x_m!r},{slot.y_m!r},{slot.heading_deg!r}<at-rest>")
+            continue
         segs = ",".join(f"{s.kind}{s.gear:+d}:{s.length_m!r}" for s in move.path.segments)
         parts.append(
             f"{move.plane_id}@{slot.x_m!r},{slot.y_m!r},{slot.heading_deg!r}"

--- a/bench/harness.py
+++ b/bench/harness.py
@@ -38,7 +38,7 @@ import time
 from dataclasses import dataclass, field
 
 from hangarfit.collisions import check as check_layout
-from hangarfit.loader import load_scenario
+from hangarfit.loader import load_layout, load_scenario
 from hangarfit.models import Layout, Placement, Scenario, SolveResult
 from hangarfit.solver import SearchConfig, solve
 from hangarfit.towplanner import (
@@ -127,8 +127,21 @@ def load_regime_scenario(regime: Regime) -> Scenario:
     ``0`` passes ``apron_depth=None`` so the no-apron regimes keep the original
     load path (and their numbers) byte-identical.
     """
+    assert regime.scenario is not None, f"{regime.key}: not a solve regime (no scenario)"
     apron = regime.apron_depth if regime.apron_depth else None
     return load_scenario(regime.scenario, apron_depth=apron)
+
+
+def load_regime_layout(regime: Regime) -> Layout:
+    """Load a WITNESS regime's pre-built layout (#667 Rung B).
+
+    Relative ``fleet:`` / ``hangar:`` refs resolve against the layout file's own
+    directory; a non-zero ``apron_depth`` is applied identically to the solve
+    path. The layout is routed as-is — no solve runs.
+    """
+    assert regime.layout is not None, f"{regime.key}: not a witness regime (no layout)"
+    apron = regime.apron_depth if regime.apron_depth else None
+    return load_layout(regime.layout, apron_depth=apron)
 
 
 def _search_config(regime: Regime) -> SearchConfig:
@@ -158,11 +171,15 @@ def _route_layout(regime: Regime, layout: Layout) -> RouteOutcome:
             max_total_expansions=regime.tow_max_total_expansions,
         )
     except NoFeasiblePlanError as exc:
+        # Name the deepest unplaceable body AND the conflict detail — the detail
+        # distinguishes a genuine geometric wall from a global-budget-exhaustion
+        # bail (both report kind ``no_feasible_path``), which the #667 routing
+        # ceiling baseline needs to interpret the wall honestly.
         return RouteOutcome(
             routed=False,
             routing_s=time.perf_counter() - start,
             plan=None,
-            note=f"un-routable ({exc.conflict.kind})",
+            note=f"un-routable: {exc.plane_id} ({exc.conflict.kind}: {exc.conflict.detail})",
         )
     return RouteOutcome(routed=True, routing_s=time.perf_counter() - start, plan=plan)
 
@@ -248,8 +265,60 @@ def _result_digest(result: SolveResult, plans: list[MovesPlan | None]) -> str:
 # ── top-level run ───────────────────────────────────────────────────────────
 
 
+def _route_digest(outcome: RouteOutcome) -> str:
+    """Determinism key for a single witness route (#667 Rung B).
+
+    Excludes the wall-clock ``routing_s`` (which varies run-to-run); includes the
+    bail note so a *different* deepest-unplaceable body across two routes — which
+    would leave both plans ``None`` and so escape ``_plan_digest`` alone — is
+    still caught as non-deterministic.
+    """
+    return f"{outcome.routed}|{outcome.note}|{_plan_digest(outcome.plan)}"
+
+
+def _run_witness_regime(regime: Regime) -> RegimeResult:
+    """Route a pre-built WITNESS layout directly — no solve (#667 Rung B).
+
+    The real Herrenteich all-8 is statically valid but ``solve`` cannot reproduce
+    it, so its *routing* ceiling is measured by routing the known-valid witness
+    layout via ``plan_fill``. Placement is skipped entirely (``placement_s == 0.0``,
+    ``restarts_done == 0``); validity / path-validity / determinism are computed on
+    the single witness layout exactly as the solve path computes them.
+    """
+    layout = load_regime_layout(regime)
+
+    outcome = _route_layout(regime, layout)
+    notes: list[str] = [outcome.note] if outcome.note else []
+
+    layouts_valid = _layout_score(layout) == (0, 0.0)
+    path_fails = _path_failures(outcome.plan, layout) if outcome.plan is not None else []
+    if path_fails:
+        notes.append("path failures: " + ", ".join(path_fails))
+
+    # Determinism: a second identical route must produce the same digest (ADR-0003).
+    deterministic = _route_digest(_route_layout(regime, layout)) == _route_digest(outcome)
+
+    return RegimeResult(
+        key=regime.key,
+        n_planes=regime.n_planes,
+        spread=regime.spread,
+        restarts_done=0,
+        placement_s=0.0,
+        routing_s=outcome.routing_s,
+        n_layouts=1,
+        n_routed=1 if outcome.routed else 0,
+        layouts_valid=layouts_valid,
+        paths_valid=not path_fails,
+        deterministic=deterministic,
+        status="witness",
+        notes=notes,
+    )
+
+
 def run_regime(regime: Regime) -> RegimeResult:
     """Measure one regime end-to-end: timing + the three correctness verdicts."""
+    if regime.layout is not None:
+        return _run_witness_regime(regime)
     scenario = load_regime_scenario(regime)
 
     start = time.perf_counter()
@@ -326,11 +395,15 @@ def profile_routing(regime: Regime) -> tuple[float, list[tuple[str, float, int]]
 
     Returns (total_routing_seconds, stage_buckets, pstats_top_text).
     """
-    scenario = load_regime_scenario(regime)
-    result = _solve_placement(regime, scenario)
-    if not result.layouts:
-        return (0.0, [], "(no layout to route)")
-    layout = result.layouts[0]
+    if regime.layout is not None:
+        # #667 Rung B: witness regimes route a pre-built layout directly (no solve).
+        layout = load_regime_layout(regime)
+    else:
+        scenario = load_regime_scenario(regime)
+        result = _solve_placement(regime, scenario)
+        if not result.layouts:
+            return (0.0, [], "(no layout to route)")
+        layout = result.layouts[0]
 
     profiler = cProfile.Profile()
     start = time.perf_counter()
@@ -357,6 +430,9 @@ def profile_routing(regime: Regime) -> tuple[float, list[tuple[str, float, int]]
 
 def profile_placement(regime: Regime) -> tuple[float, list[tuple[str, float, int]], str]:
     """cProfile the placement solve (no tow planning)."""
+    if regime.layout is not None:
+        # #667 Rung B: a witness regime has no placement phase.
+        return (0.0, [], "(witness regime: placement skipped — no solve)")
     scenario = load_regime_scenario(regime)
     profiler = cProfile.Profile()
     start = time.perf_counter()

--- a/bench/profile_pipeline.py
+++ b/bench/profile_pipeline.py
@@ -110,7 +110,7 @@ _SPEED_CEILING_S: dict[str, float] = {
     # multi-minute all-8 route never runs in CI; the entry documents the bounded
     # wall and arms a manual `--heavy --gate`. The witness layout is routed
     # directly (no solve), so `total_s == routing_s` (placement is 0). Measured
-    # local dev ~66 s (all-8) / ~68 s (today) at the 8000 global cap — both
+    # local dev ~64.6 s (all-8) / ~65.4 s (today) at the 8000 global cap — both
     # EXHAUST the budget and bail (the dense fill does not route; that wall IS the
     # baseline). 150/160 s ≈ 2.3x local (the CI-runner factor seen on other
     # regimes), generous since these never gate in CI.

--- a/bench/profile_pipeline.py
+++ b/bench/profile_pipeline.py
@@ -104,6 +104,18 @@ _SPEED_CEILING_S: dict[str, float] = {
     # or a #453 memoization revert (both multi-x placement growth). Tripwire, not a
     # microbenchmark.
     "full_nine_placement": 190.0,
+    # #667 Rung B (2026-06-27): the real-Herrenteich routing-ceiling WITNESS
+    # regimes. DOCUMENTARY ceilings: both are heavy ⇒ excluded from the default
+    # fast `--gate` (the CI bench-gates job runs the fast set only), so the
+    # multi-minute all-8 route never runs in CI; the entry documents the bounded
+    # wall and arms a manual `--heavy --gate`. The witness layout is routed
+    # directly (no solve), so `total_s == routing_s` (placement is 0). Measured
+    # local dev ~66 s (all-8) / ~68 s (today) at the 8000 global cap — both
+    # EXHAUST the budget and bail (the dense fill does not route; that wall IS the
+    # baseline). 150/160 s ≈ 2.3x local (the CI-runner factor seen on other
+    # regimes), generous since these never gate in CI.
+    "herrenteich_all_eight": 150.0,
+    "herrenteich_today": 160.0,
 }
 
 

--- a/bench/regimes.py
+++ b/bench/regimes.py
@@ -26,6 +26,7 @@ from typing import Literal
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURES = REPO_ROOT / "tests" / "fixtures"
+HERRENTEICH = REPO_ROOT / "examples" / "herrenteich"
 
 
 @dataclass(frozen=True)
@@ -43,21 +44,44 @@ class Regime:
     ``"auto"`` ⇒ fleet-derived). It enlarges the per-plane tow start set (forward
     + reverse cones × the apron y-samples) and lengthens each path, so it is the
     knob that characterises the apron's routing-cost effect (#499).
+
+    A regime drives **exactly one** of two modes (enforced in ``__post_init__``):
+
+    * ``scenario`` — *solve-then-route*: ``solve()`` finds the layout(s), which are
+      then tow-routed. The original mode (the solve-feasible regimes).
+    * ``layout`` — *route a pre-built WITNESS layout directly*, skipping the solve
+      (#667 Rung B). This is for a statically-valid layout that ``solve`` **cannot
+      reproduce** — the real Herrenteich all-8 (``examples/herrenteich/scenario.yaml``
+      header): RR-MC won't find the dense nest, so a solve-then-route regime would
+      measure placement-failure, not the *routing ceiling*. The witness layout is
+      loaded and routed as-is, so ``placement`` is skipped (``placement_s == 0.0``,
+      ``restarts_done == 0``) and ``seed``/``max_restarts``/``spread`` are unused.
     """
 
     key: str
     description: str
-    scenario: Path
-    seed: int
-    max_restarts: int
-    spread: bool
-    n_planes: int
+    scenario: Path | None = None
+    layout: Path | None = None
+    seed: int = 1
+    max_restarts: int = 0
+    spread: bool = True
+    n_planes: int = 0
     alternatives: int = 1
     tow_heuristic: Literal["euclidean", "grid"] = "grid"
     tow_max_expansions: int | None = None
     tow_max_total_expansions: int | None = None
     heavy: bool = False
     apron_depth: float | Literal["auto"] = 0.0
+
+    def __post_init__(self) -> None:
+        # Exactly one routing source: a typo'd / half-specified regime must fail
+        # loudly here, never silently route nothing (silent-failure guard).
+        if (self.scenario is None) == (self.layout is None):
+            raise ValueError(
+                f"regime {self.key!r}: exactly one of `scenario` or `layout` must "
+                "be set (`scenario` ⇒ solve-then-route; `layout` ⇒ route a "
+                "pre-built witness layout directly)"
+            )
 
 
 REGIMES: tuple[Regime, ...] = (
@@ -161,6 +185,36 @@ REGIMES: tuple[Regime, ...] = (
         n_planes=6,
         tow_max_total_expansions=4000,
         apron_depth=10.0,
+        heavy=True,
+    ),
+    # ── #667 Rung B: real-Herrenteich routing-ceiling WITNESS regimes ─────────
+    # The objective baseline every later #667 rung (C/D/E) is graded against.
+    # These route the KNOWN-VALID hand-authored witness layouts directly (no
+    # solve — `solve` provably cannot reproduce the dense all-8 nest), so they
+    # measure the *routing* ceiling, not placement. `plan_fill` is all-or-nothing
+    # (a full plan or a `NoFeasiblePlanError` naming the deepest unplaceable
+    # body), so the baseline is binary: does the dense fill route? Measured
+    # 2026-06-27: it does NOT — at the 8000 global cap (and at 16000, the solve
+    # default) both witnesses EXHAUST the budget grinding the nest and bail
+    # (deepest-unplaced `zlin_savage`). The cap bounds the un-routable disprove;
+    # 8000 matches `full_nine_spread_on` (~66–68 s local). A partial routed-body
+    # COUNT is Rung C's reverse-teardown probe, not this binary baseline. heavy ⇒
+    # excluded from the default fast `--gate` (the multi-minute route never runs
+    # in CI). Move-aside (Rung E) must flip the verdict to routed.
+    Regime(
+        key="herrenteich_all_eight",
+        description="Real Herrenteich all-8 WITNESS layout — #667 routing-ceiling baseline",
+        layout=HERRENTEICH / "layout.yaml",
+        n_planes=8,
+        tow_max_total_expansions=8000,
+        heavy=True,
+    ),
+    Regime(
+        key="herrenteich_today",
+        description="Real Herrenteich today (all-8 + Fuji = 9) WITNESS — #667 routing baseline",
+        layout=HERRENTEICH / "layout_today.yaml",
+        n_planes=9,
+        tow_max_total_expansions=8000,
         heavy=True,
     ),
 )

--- a/bench/regimes.py
+++ b/bench/regimes.py
@@ -50,12 +50,13 @@ class Regime:
     * ``scenario`` — *solve-then-route*: ``solve()`` finds the layout(s), which are
       then tow-routed. The original mode (the solve-feasible regimes).
     * ``layout`` — *route a pre-built WITNESS layout directly*, skipping the solve
-      (#667 Rung B). This is for a statically-valid layout that ``solve`` **cannot
+      (#667 Rung B). This is for a statically-valid layout that ``solve`` **does not
       reproduce** — the real Herrenteich all-8 (``examples/herrenteich/scenario.yaml``
       header): RR-MC won't find the dense nest, so a solve-then-route regime would
       measure placement-failure, not the *routing ceiling*. The witness layout is
       loaded and routed as-is, so ``placement`` is skipped (``placement_s == 0.0``,
-      ``restarts_done == 0``) and ``seed``/``max_restarts``/``spread`` are unused.
+      ``restarts_done == 0``); ``seed``/``max_restarts`` are inert and ``spread``
+      only labels the output row (no spread post-pass runs).
     """
 
     key: str
@@ -190,17 +191,19 @@ REGIMES: tuple[Regime, ...] = (
     # ── #667 Rung B: real-Herrenteich routing-ceiling WITNESS regimes ─────────
     # The objective baseline every later #667 rung (C/D/E) is graded against.
     # These route the KNOWN-VALID hand-authored witness layouts directly (no
-    # solve — `solve` provably cannot reproduce the dense all-8 nest), so they
-    # measure the *routing* ceiling, not placement. `plan_fill` is all-or-nothing
-    # (a full plan or a `NoFeasiblePlanError` naming the deepest unplaceable
-    # body), so the baseline is binary: does the dense fill route? Measured
-    # 2026-06-27: it does NOT — at the 8000 global cap (and at 16000, the solve
-    # default) both witnesses EXHAUST the budget grinding the nest and bail
-    # (deepest-unplaced `zlin_savage`). The cap bounds the un-routable disprove;
-    # 8000 matches `full_nine_spread_on` (~66–68 s local). A partial routed-body
-    # COUNT is Rung C's reverse-teardown probe, not this binary baseline. heavy ⇒
-    # excluded from the default fast `--gate` (the multi-minute route never runs
-    # in CI). Move-aside (Rung E) must flip the verdict to routed.
+    # solve — `solve` does not reproduce the dense all-8 nest within budget), so
+    # they measure the *routing* ceiling, not placement. `plan_fill` is
+    # all-or-nothing (a full plan or a `NoFeasiblePlanError` naming the deepest
+    # unplaceable body), so the baseline is binary: does the dense fill route?
+    # Measured 2026-06-27: it does NOT — at the 8000 global cap both bail
+    # (deepest-unplaced `zlin_savage`); doubling the all-8 to 16000 (the solve
+    # default) doubles its wall and bails on the same body, so the wall is
+    # budget-exhaustion, not an early geometric dead-end. The cap bounds the
+    # un-routable disprove; 8000 matches `full_nine_spread_on`'s global cap (the
+    # witness routes take ~65 s local). A partial routed-body COUNT is Rung C's
+    # reverse-teardown probe, not this binary baseline. heavy ⇒ excluded from the
+    # default fast `--gate` (the multi-minute route never runs in CI). Move-aside
+    # (Rung E) must flip the verdict to routed.
     Regime(
         key="herrenteich_all_eight",
         description="Real Herrenteich all-8 WITNESS layout — #667 routing-ceiling baseline",

--- a/docs/spikes/herrenteich-routing-ceiling-baseline.md
+++ b/docs/spikes/herrenteich-routing-ceiling-baseline.md
@@ -15,10 +15,12 @@ The real Herrenteich dense fleet is **statically valid parked** (`hangarfit chec
 but does **not** tow-route within a bounded expansion budget. Routing the known-valid
 witness layouts directly (no solve) via `plan_fill`:
 
-| witness regime | bodies | hand-placed | global cap | routes? | bail | wall (local) |
+| witness regime | aircraft | hand-placed | global cap | routes? | bail | wall (local) |
 |---|---|---|---|---|---|---|
 | `herrenteich_all_eight` | 8 | 2 (Scheibe + Stemme) | 8 000 | **NO** | budget-exhausted, deepest-unplaced `zlin_savage` | ~64.6 s |
 | `herrenteich_today` | 9 (+ Fuji) | 2 | 8 000 | **NO** | budget-exhausted, deepest-unplaced `zlin_savage` | ~65.4 s |
+
+(`n_planes` counts aircraft; `layout_today.yaml` also carries ground objects — Caddy, fuel + glider trailers.)
 
 Measured via `python -m bench.profile_pipeline --regime herrenteich_all_eight --regime herrenteich_today`
 (2026-06-27, local): both report `place_s 0.000`, `routed 0/1`, `valid ok`, `paths ok`, `det ok`, and the
@@ -29,7 +31,7 @@ deterministic (ADR-0003), so it is a stable regression anchor.
 
 ## Why route the witness, not solve
 
-`solve` (RR-MC) provably **cannot reproduce** the dense all-8 nest — `examples/herrenteich/scenario.yaml`'s
+`solve` (RR-MC) **does not reproduce** the dense all-8 nest within budget — `examples/herrenteich/scenario.yaml`'s
 own header records it, and it is the founding observation of the 2026-06 spike series. So a
 *solve-then-route* bench regime would measure **placement-failure**, not the **routing** ceiling
 that move-aside is built to raise — vacuous by the feasibility-witness principle (the #832 lesson:
@@ -48,8 +50,8 @@ husky-gate's "6 routed vs 4") needs the reverse-teardown traversal of **Rung C**
 
 ## The bail is budget-exhaustion, not an early geometric wall
 
-A control: doubling the global cap (8 000 → 16 000, the `solve` default) **doubled the wall-clock**
-(~66 s → ~132 s for the all-8) and bailed on the **same** body (`zlin_savage`). An early *geometric* dead-end
+A control: doubling the global cap (8 000 → 16 000, the `solve` default) **roughly doubled the wall-clock**
+for the all-8 (~65 s → ~130 s; an earlier scout run) and bailed on the **same** body (`zlin_savage`). An early *geometric* dead-end
 would bail in roughly constant time regardless of cap; instead the planner grinds the full budget
 threading the dense nest and then names the deepest body it never reached. So the operative ceiling
 is **expansion budget**: the all-8 fill does not route within any *affordable* budget. (This is

--- a/docs/spikes/herrenteich-routing-ceiling-baseline.md
+++ b/docs/spikes/herrenteich-routing-ceiling-baseline.md
@@ -1,0 +1,84 @@
+# Herrenteich routing-ceiling baseline (#667 Rung B)
+
+**Status:** baseline measured — **complete**. **Date:** 2026-06-27.
+**Issue:** [#861](https://github.com/DocGerd/hangarfit/issues/861) (Rung B of the
+[#667](https://github.com/DocGerd/hangarfit/issues/667) shuffle-aware tow-routing program).
+
+> The objective routing-ceiling baseline every later #667 rung (C/D/E) is graded against.
+> Spec: [`docs/superpowers/specs/2026-06-27-667-shuffle-aware-tow-routing-design.md`](../superpowers/specs/2026-06-27-667-shuffle-aware-tow-routing-design.md) §4 Rung B.
+
+---
+
+## TL;DR
+
+The real Herrenteich dense fleet is **statically valid parked** (`hangarfit check` exits 0)
+but does **not** tow-route within a bounded expansion budget. Routing the known-valid
+witness layouts directly (no solve) via `plan_fill`:
+
+| witness regime | bodies | hand-placed | global cap | routes? | bail | wall (local) |
+|---|---|---|---|---|---|---|
+| `herrenteich_all_eight` | 8 | 2 (Scheibe + Stemme) | 8 000 | **NO** | budget-exhausted, deepest-unplaced `zlin_savage` | ~64.6 s |
+| `herrenteich_today` | 9 (+ Fuji) | 2 | 8 000 | **NO** | budget-exhausted, deepest-unplaced `zlin_savage` | ~65.4 s |
+
+Measured via `python -m bench.profile_pipeline --regime herrenteich_all_eight --regime herrenteich_today`
+(2026-06-27, local): both report `place_s 0.000`, `routed 0/1`, `valid ok`, `paths ok`, `det ok`, and the
+bail note `un-routable: zlin_savage (no_feasible_path: global fill expansion budget (8000) exhausted)`.
+
+Move-aside (Rung E) must flip the `routes?` verdict. This baseline is RNG-free and
+deterministic (ADR-0003), so it is a stable regression anchor.
+
+## Why route the witness, not solve
+
+`solve` (RR-MC) provably **cannot reproduce** the dense all-8 nest — `examples/herrenteich/scenario.yaml`'s
+own header records it, and it is the founding observation of the 2026-06 spike series. So a
+*solve-then-route* bench regime would measure **placement-failure**, not the **routing** ceiling
+that move-aside is built to raise — vacuous by the feasibility-witness principle (the #832 lesson:
+a "method reaches what the baseline misses" claim is only meaningful against a layout *proven* to
+exist). The hand-authored `layout.yaml` / `layout_today.yaml` **are** that proof (a valid all-8 the
+solver can't find), so Rung B routes them directly: `placement_s == 0.0`, the route is the whole
+measurement.
+
+## Why the verdict is binary (not a routed-body count)
+
+`plan_fill` is **all-or-nothing**: it returns a complete `MovesPlan` or raises
+`NoFeasiblePlanError` naming the *deepest unplaceable* body. There is no partial "routed N of 8"
+return. So Rung B reports the honest binary baseline — *routes-fully? · bail-body · conflict-kind ·
+conflict-detail · bounded wall-clock · determinism*. A partial routed-body **count** (e.g. the
+husky-gate's "6 routed vs 4") needs the reverse-teardown traversal of **Rung C**, not this baseline.
+
+## The bail is budget-exhaustion, not an early geometric wall
+
+A control: doubling the global cap (8 000 → 16 000, the `solve` default) **doubled the wall-clock**
+(~66 s → ~132 s for the all-8) and bailed on the **same** body (`zlin_savage`). An early *geometric* dead-end
+would bail in roughly constant time regardless of cap; instead the planner grinds the full budget
+threading the dense nest and then names the deepest body it never reached. So the operative ceiling
+is **expansion budget**: the all-8 fill does not route within any *affordable* budget. (This is
+consistent with the known `fk9↔cessna` corridor needing ~97 k expansions for that pair alone — the
+whole fill is far beyond a shippable cap; see
+[`herrenteich-fk9-cessna-lateral-shuffle.md`](herrenteich-fk9-cessna-lateral-shuffle.md).) The
+`conflict.detail` string (`global fill expansion budget (8000) exhausted`) makes this explicit in
+the bench note; `8000` is the affordable cap (matches `full_nine_spread_on`) and bounds the
+un-routable disprove.
+
+## How to reproduce
+
+```bash
+# the two witness regimes (heavy — excluded from the default fast set)
+python -m bench.profile_pipeline --regime herrenteich_all_eight --regime herrenteich_today
+
+# the regression guard (slow — excluded from the default pytest run + CI)
+pytest -m slow tests/bench/test_profile_pipeline_witness.py
+```
+
+The witness regimes are `heavy=True`, so the default fast `--gate` (the CI bench-gates job, fast
+set only) never grinds the multi-minute route. Their `_SPEED_CEILING_S` entries are **documentary**
+(they arm a manual `--heavy --gate`).
+
+## What this buys / what it does not
+
+- **Buys:** a deterministic, feasibility-grounded number that says *the dense Herrenteich fill does
+  not tow-route* — the wall Rungs C–E are measured against, and the anchor the slow regression test
+  guards.
+- **Does not:** touch the wall. Rung B is pure measurement (bench-only; no `src/hangarfit/` change).
+  Raising the ceiling is Rung E (move-aside), and even then the `fk9↔cessna` cm-scale parallel-park
+  may remain a documented manual-insertion case (spec §2 honest caveat).

--- a/tests/bench/test_profile_pipeline_witness.py
+++ b/tests/bench/test_profile_pipeline_witness.py
@@ -1,0 +1,141 @@
+"""Rung B (#667): the bench harness's witness-layout routing mode + the
+Herrenteich routing-ceiling regimes.
+
+The Herrenteich all-eight is **statically valid** (``hangarfit check`` exits 0)
+but ``solve`` provably cannot reproduce it (``examples/herrenteich/scenario.yaml``
+header), and the dense nest does not fully tow-route (the ``fk9↔cessna`` wall,
+spikes 2026-06). So the routing-ceiling baseline that Rungs C–E are graded
+against must route the *known-valid witness layout* directly — not a solve
+output. This module covers that bench-only ``Regime.layout`` mode and the two
+witness regimes.
+
+The witness mechanism is exercised against a small, fast, fully-routable layout
+(``valid_left_side_nesting.yaml``, 2 bodies, ~0.5 s) so the contract is verified
+without the slow all-eight grind; the slow all-eight determinism guard is marked
+``@pytest.mark.slow``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bench.harness import run_regime
+from bench.profile_pipeline import _SPEED_CEILING_S
+from bench.regimes import FIXTURES, REGIMES, Regime, regime_by_key
+
+_FAST_WITNESS = FIXTURES / "valid_left_side_nesting.yaml"
+
+
+def _fast_witness_regime() -> Regime:
+    return Regime(
+        key="_test_fast_witness",
+        description="fast fully-routable witness (mechanism test)",
+        layout=_FAST_WITNESS,
+        n_planes=2,
+        heavy=True,
+    )
+
+
+# ── Regime contract: exactly one of scenario / layout ────────────────────────
+
+
+def test_regime_requires_exactly_one_source() -> None:
+    """A regime drives EITHER a solve (``scenario``) OR a direct witness route
+    (``layout``) — never both, never neither. The mis-specified cases raise
+    loudly so a typo'd regime cannot silently route nothing (silent-failure)."""
+    with pytest.raises(ValueError, match="exactly one"):
+        Regime(key="neither", description="no source", n_planes=1)
+    with pytest.raises(ValueError, match="exactly one"):
+        Regime(
+            key="both",
+            description="two sources",
+            scenario=FIXTURES / "solve_trivial_single_plane.yaml",
+            layout=_FAST_WITNESS,
+            n_planes=1,
+        )
+
+
+# ── Witness routing mode in run_regime ───────────────────────────────────────
+
+
+def test_witness_regime_skips_solve_and_routes_layout() -> None:
+    """A witness regime loads the layout directly and routes it — no solve.
+
+    Placement is skipped entirely (``placement_s == 0.0``, ``restarts_done == 0``)
+    and exactly one layout (the witness) is routed. The fast witness fully routes,
+    so it scores valid + path-valid.
+    """
+    result = run_regime(_fast_witness_regime())
+    assert result.restarts_done == 0
+    assert result.placement_s == 0.0
+    assert result.n_layouts == 1
+    assert result.n_routed == 1
+    assert result.layouts_valid is True
+    assert result.paths_valid is True
+
+
+def test_witness_regime_is_deterministic() -> None:
+    """Routing the witness twice yields a byte-identical digest (ADR-0003)."""
+    assert run_regime(_fast_witness_regime()).deterministic is True
+
+
+# ── Herrenteich witness regimes are registered + gated ───────────────────────
+
+
+@pytest.mark.parametrize(
+    ("key", "layout_name", "n_planes"),
+    [
+        ("herrenteich_all_eight", "layout.yaml", 8),
+        ("herrenteich_today", "layout_today.yaml", 9),
+    ],
+)
+def test_herrenteich_witness_regime_registered(key: str, layout_name: str, n_planes: int) -> None:
+    """Both Herrenteich witness regimes exist, are witness-mode (``layout`` set,
+    ``scenario`` unset), heavy (excluded from the default fast gate), and carry a
+    documentary speed ceiling."""
+    regime = regime_by_key(key)
+    assert regime.scenario is None
+    assert regime.layout is not None
+    assert regime.layout.name == layout_name
+    assert regime.n_planes == n_planes
+    assert regime.heavy is True
+    assert key in _SPEED_CEILING_S
+
+
+def test_herrenteich_regimes_are_excluded_from_fast_gate() -> None:
+    """The witness regimes are heavy, so the default fast `--gate` (fast set
+    only) never grinds the multi-minute all-eight route in CI."""
+    from bench.regimes import FAST_REGIMES
+
+    fast_keys = {r.key for r in FAST_REGIMES}
+    assert "herrenteich_all_eight" not in fast_keys
+    assert "herrenteich_today" not in fast_keys
+    # but they are part of the full set (run under --heavy)
+    all_keys = {r.key for r in REGIMES}
+    assert {"herrenteich_all_eight", "herrenteich_today"} <= all_keys
+
+
+@pytest.mark.slow
+def test_herrenteich_all_eight_routing_ceiling_baseline() -> None:
+    """The #667 routing-ceiling BASELINE, as a regression guard (~130 s — slow).
+
+    The hand-authored all-eight witness is statically valid, but the dense fill
+    does **not** tow-route within the bounded budget — it exhausts the cap and
+    bails (measured 2026-06-27). The route is RNG-free, so the verdict is
+    deterministic. This anchors the wall move-aside (Rung E) must raise: when
+    Rung E lands, ``n_routed`` is expected to flip to 1 and this assertion is
+    updated as the deliberate grading signal (spec §4 Rung E acceptance 3).
+
+    @pytest.mark.slow is INTENTIONAL: ``run_regime`` routes the all-8 twice (the
+    determinism check), ~130 s total, so it is excluded from the default `pytest`
+    run and from CI (``addopts = -m 'not slow'``).
+    """
+    result = run_regime(regime_by_key("herrenteich_all_eight"))
+    assert result.layouts_valid is True, "witness layout must be statically valid"
+    assert result.placement_s == 0.0, "witness routes directly — no placement"
+    assert result.deterministic is True, "RNG-free routing must be deterministic"
+    assert result.n_routed == 0, (
+        "BASELINE: the dense all-8 does not route within budget (the #667 wall). "
+        "When move-aside (Rung E) raises the ceiling, flip this to 1."
+    )
+    assert result.notes and result.notes[0].startswith("un-routable:")

--- a/tests/bench/test_profile_pipeline_witness.py
+++ b/tests/bench/test_profile_pipeline_witness.py
@@ -2,12 +2,12 @@
 Herrenteich routing-ceiling regimes.
 
 The Herrenteich all-eight is **statically valid** (``hangarfit check`` exits 0)
-but ``solve`` provably cannot reproduce it (``examples/herrenteich/scenario.yaml``
-header), and the dense nest does not fully tow-route (the ``fk9↔cessna`` wall,
-spikes 2026-06). So the routing-ceiling baseline that Rungs C–E are graded
-against must route the *known-valid witness layout* directly — not a solve
-output. This module covers that bench-only ``Regime.layout`` mode and the two
-witness regimes.
+but ``solve`` does not reproduce it within budget (``examples/herrenteich/scenario.yaml``
+header), and the dense nest exhausts the expansion budget without routing
+(consistent with the known ``fk9↔cessna`` corridor cost, spikes 2026-06). So the
+routing-ceiling baseline that Rungs C–E are graded against must route the
+*known-valid witness layout* directly — not a solve output. This module covers
+that bench-only ``Regime.layout`` mode and the two witness regimes.
 
 The witness mechanism is exercised against a small, fast, fully-routable layout
 (``valid_left_side_nesting.yaml``, 2 bodies, ~0.5 s) so the contract is verified
@@ -77,6 +77,31 @@ def test_witness_regime_skips_solve_and_routes_layout() -> None:
 def test_witness_regime_is_deterministic() -> None:
     """Routing the witness twice yields a byte-identical digest (ADR-0003)."""
     assert run_regime(_fast_witness_regime()).deterministic is True
+
+
+def test_witness_with_hand_placed_body_routes_and_scores() -> None:
+    """A fully-routable witness whose plan contains a path-less hand-placed move
+    must still score validity / path-validity / determinism — not crash.
+
+    ``plan_fill`` emits ``Move(plane_id, pose, None)`` for a hand-placed body, so
+    the harness's path-validity (`_path_failures`) and determinism (`_plan_digest`)
+    must skip the ``path is None`` move rather than deref it. The all-bailing
+    Herrenteich baseline never reaches this today, but Rung E (a routed witness)
+    will — both witnesses carry two hand-placed gliders.
+    """
+    result = run_regime(
+        Regime(
+            key="_test_witness_hand_placed",
+            description="fully-routable witness with a hand-placed body",
+            layout=FIXTURES / "valid_left_side_nesting_hand_placed.yaml",
+            n_planes=2,
+            heavy=True,
+        )
+    )
+    assert result.n_routed == 1
+    assert result.layouts_valid is True
+    assert result.paths_valid is True
+    assert result.deterministic is True
 
 
 # ── Herrenteich witness regimes are registered + gated ───────────────────────

--- a/tests/bench/test_profile_pipeline_witness.py
+++ b/tests/bench/test_profile_pipeline_witness.py
@@ -104,6 +104,35 @@ def test_witness_with_hand_placed_body_routes_and_scores() -> None:
     assert result.deterministic is True
 
 
+def test_path_failures_skips_ground_object_mover_moves() -> None:
+    """`_path_failures` must skip a placed-routed-mover's Move, not KeyError.
+
+    `plan_fill` emits a Move for every placed_routed_mover ground object, whose
+    `plane_id` is NOT in the aircraft-only `by_id` map. Movers route last and are
+    not aircraft keep-outs (they live in `ground_object_placements`), so this
+    aircraft-arc re-validation must skip them — re-validating mover arcs is Rung E
+    / #602 work. `herrenteich_today` carries such movers (vw_caddy, glider
+    trailers), so this fires the moment that witness routes (Rung E).
+    """
+    from bench.harness import _path_failures
+    from hangarfit.loader import load_layout
+    from hangarfit.towplanner import Move, MovesPlan, Pose
+
+    layout = load_layout("examples/herrenteich/layout_today.yaml")
+    mover_gp = next(
+        gp
+        for gp in layout.ground_object_placements
+        if layout.ground_objects[gp.plane_id].object_class == "placed_routed_mover"
+    )
+    # A path-less mover Move (the best-effort un-routed mover case) — and the
+    # routed-arc case takes the same by_id lookup, so both are covered by the guard.
+    plan = MovesPlan(
+        target_layout=layout,
+        moves=(Move(mover_gp.plane_id, Pose.from_placement(mover_gp), None),),
+    )
+    assert _path_failures(plan, layout) == []
+
+
 # ── Herrenteich witness regimes are registered + gated ───────────────────────
 
 

--- a/tests/fixtures/valid_left_side_nesting_hand_placed.yaml
+++ b/tests/fixtures/valid_left_side_nesting_hand_placed.yaml
@@ -1,0 +1,29 @@
+# Rung B (#667) regression fixture: a fully-routable layout that ALSO contains a
+# `hand_placed` body — so `plan_fill` emits a path-less at-rest Move for it
+# (Move(plane_id, pose, None)) alongside the routed body's arc.
+#
+# This is a copy of `valid_left_side_nesting.yaml` with the DEEP body `fuji`
+# marked hand-placed (it seeds the fill as a fixed keep-out), so the shallow,
+# near-door `cessna_150` still tow-routes — giving a plan with BOTH a path-less
+# at-rest move (the hand-placed Fuji) and a routed arc. It exists to exercise the
+# bench harness's witness path-validity + determinism digest on a plan that
+# carries a `path is None` move — the case the real Herrenteich witnesses will
+# produce once they route (Rung E), which the all-bailing baseline never reaches
+# today. `hand_placed` is orthogonal to `on_carts` (how it got there vs its
+# physical state), so on_carts stays false.
+
+fleet: ../../data/fleet.yaml
+hangar: ../../data/hangar.yaml
+
+placements:
+  - plane: cessna_150
+    x_m: 9.0
+    y_m: 5.0
+    heading_deg: 0.0
+    on_carts: false
+  - plane: fuji
+    x_m: 5.0
+    y_m: 10.0
+    heading_deg: 90.0
+    on_carts: false
+    hand_placed: true


### PR DESCRIPTION
**Rung B of the #667 shuffle-aware tow-routing program** (spec: `docs/superpowers/specs/2026-06-27-667-shuffle-aware-tow-routing-design.md`, §4 Rung B). Establishes the **objective routing-ceiling baseline** every later rung (C/D/E) is graded against. **Pure measurement — bench-only (dev/CI), no `src/hangarfit/` change.**

## Why route the witness, not solve (corrects the spec's literal wording)

Two facts scoped this:

1. **`solve` cannot reproduce the all-8.** `examples/herrenteich/scenario.yaml`'s own header documents that RR-MC won't find the dense nest within budget. So a *solve-then-route* regime measures **placement-failure**, not the **routing ceiling** — vacuous per the #832 feasibility-witness lesson.
2. **`plan_fill` is all-or-nothing.** It returns a full plan or raises `NoFeasiblePlanError` naming the deepest unplaceable body — no partial "routed N of 8". A partial *count* is **Rung C**'s reverse-teardown probe, not Rung B.

So Rung B routes the **known-valid witness layouts directly** via `plan_fill` (skipping solve, `placement_s == 0.0`) and reports the honest binary baseline.

## What's here

- **`bench/regimes.py`** — `Regime` gains an optional `layout` (witness) source alongside `scenario`; `__post_init__` enforces **exactly one** (a typo'd/half-specified regime fails loudly, never silently routes nothing). Adds witness regimes `herrenteich_all_eight` (8) and `herrenteich_today` (9), `heavy=True`, global cap `8000`.
- **`bench/harness.py`** — `_run_witness_regime` loads + routes the witness directly (placement skipped); validity / path-validity / determinism computed exactly as the solve path. The bail note now names the deepest unplaceable body **and** the conflict `detail` (distinguishes budget-exhaustion from a geometric wall). `--profile` paths guarded for witness regimes.
- **`bench/profile_pipeline.py`** — documentary `_SPEED_CEILING_S` entries (heavy ⇒ excluded from the default fast `--gate`; arms `--heavy --gate`).
- **`tests/bench/test_profile_pipeline_witness.py`** — TDD (RED→GREEN): the exactly-one-source contract, the witness routing mechanism, regime registration, determinism, + a `@pytest.mark.slow` all-8 baseline guard.
- **`docs/spikes/herrenteich-routing-ceiling-baseline.md`** — the measured baseline.

## Measured baseline (2026-06-27, `python -m bench.profile_pipeline --regime herrenteich_all_eight --regime herrenteich_today`)

| regime | bodies | place_s | route_s | routed | valid | paths | det | bail |
|---|---|---|---|---|---|---|---|---|
| `herrenteich_all_eight` | 8 | 0.000 | 64.6 | **0/1** | ok | ok | ok | `zlin_savage` (global fill expansion budget (8000) exhausted) |
| `herrenteich_today` | 9 | 0.000 | 65.4 | **0/1** | ok | ok | ok | `zlin_savage` (same) |

**The wall is budget-exhaustion, not an early geometric dead-end:** doubling the cap (8k→16k, the solve default) doubled the wall (~66 s→~132 s) and bailed on the same body. The dense fill does not route within any affordable budget. Move-aside (Rung E) must flip the verdict; `fk9↔cessna` may persist as a manual-insertion case.

## Verification

- `pytest tests/bench/` → 8 passed, 3 slow deselected; bench-importing siblings green.
- Existing solve regimes byte-identical in behaviour (new field defaults `None` → unchanged path); `trivial_single` still valid/det/routed.
- `ruff check` / `ruff format --check` clean.

## Notes

- **No CHANGELOG entry:** bench/ is dev/CI-only (never shipped in the wheel), so this is not a user-facing change. (The advisory `gh pr create` CHANGELOG hook warning is expected and non-blocking here.)
- `#860` (CLAUDE.md sync) is still open and independent of this branch.

Closes #861
Refs #667
