### PR TITLE
feat(667): Rung D — multi-leg tow-plan data model + consumer seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ All notable changes to this project are documented here. Format follows [Keep a 
   silently dropping them (#667), mirroring the ground-object entry allowlist — so
   a misspelled flag (e.g. `hand_palced`) fails loudly rather than silently
   inverting intent (a hand-positioned glider getting tow-routed).
+- The tow-plan data model now supports **multi-leg** moves (#667, Rung D): a body
+  may carry more than one `Move` (one per leg) under the same `plane_id`, tagged
+  with an additive `leg_index` (default `0`), and the scene/v2
+  `timeline.segments[]` gains an optional `leg_index` emitted **only** for a
+  multi-leg body. This is the byte-identical seam for the move-aside relocation
+  (Rung E): no producer emits more than one leg yet, so every existing plan,
+  scene, render, and viewer animation is unchanged (ADR-0003). The viewer (2D
+  paths, 3D timeline + floor polylines) draws and animates each leg, resting a
+  body at its staging pose between legs. `SCHEMA` stays `hangarfit.scene/v2`
+  (additive only).
 - A `kind: fuselage` part may now carry a `vertices:` outline polygon, which the
   loader clips into area-conserving `fuselage_front`/`fuselage_aft` sub-polygons
   at the wing trailing edge (#550). Capability-only — no fleet behaviour change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,16 +18,16 @@ All notable changes to this project are documented here. Format follows [Keep a 
   silently dropping them (#667), mirroring the ground-object entry allowlist — so
   a misspelled flag (e.g. `hand_palced`) fails loudly rather than silently
   inverting intent (a hand-positioned glider getting tow-routed).
-- The tow-plan data model now supports **multi-leg** moves (#667, Rung D): a body
-  may carry more than one `Move` (one per leg) under the same `plane_id`, tagged
-  with an additive `leg_index` (default `0`), and the scene/v2
+- The tow-plan data model now supports **multi-leg** moves (#667 / #865, Rung D):
+  a body may carry more than one `Move` (one per leg) under the same `plane_id`,
+  tagged with an additive `leg_index` (default `0`), and the scene/v2
   `timeline.segments[]` gains an optional `leg_index` emitted **only** for a
   multi-leg body. This is the byte-identical seam for the move-aside relocation
   (Rung E): no producer emits more than one leg yet, so every existing plan,
-  scene, render, and viewer animation is unchanged (ADR-0003). The viewer (2D
-  paths, 3D timeline + floor polylines) draws and animates each leg, resting a
-  body at its staging pose between legs. `SCHEMA` stays `hangarfit.scene/v2`
-  (additive only).
+  scene, render, and viewer animation is unchanged (ADR-0003). The 3D viewer
+  (timeline + floor polylines) animates each leg, resting a body at its staging
+  pose between legs; the 2D PNG renderer already draws each leg unchanged.
+  `SCHEMA` stays `hangarfit.scene/v2` (additive only).
 - A `kind: fuselage` part may now carry a `vertices:` outline polygon, which the
   loader clips into area-conserving `fuselage_front`/`fuselage_aft` sub-polygons
   at the wing trailing edge (#550). Capability-only — no fleet behaviour change.

--- a/docs/architecture/scene-v2-schema.md
+++ b/docs/architecture/scene-v2-schema.md
@@ -193,7 +193,7 @@ self-check as `anchors`; the egress lane is draw-only and not anchored.
 ```jsonc
 {
   "total_s": 24.0,
-  "segments": [                // one per plane, in back_first_order (deepest first)
+  "segments": [                // one per LEG, in back_first_order (deepest first)
     {
       "plane_id": "fk9_mkii",
       "start_s": 0.0,
@@ -202,6 +202,7 @@ self-check as `anchors`; the egress lane is draw-only and not anchored.
         [0.0, 1.0, 9.0, 1.0, 0.0, 0.0],
         // …
       ]
+      // "leg_index": 0        // OPTIONAL (#865) — present ONLY for a multi-leg body
     }
   ]
 }
@@ -212,15 +213,35 @@ Per-plane duration is proportional to path length (`DubinsArc.length_m`) via a t
 speed, clamped to `[min_seg_s, max_seg_s]`. Sample count per path is capped (the
 sampling step is coarsened) to keep the HTML small.
 
-**Viewer state machine** — for a plane with segment `s` at time `t`:
+### Multi-leg bodies (`leg_index`, #865 Rung D)
+
+A body normally has **one** segment (one leg, door → slot). A *move-aside* body
+([#667](https://github.com/DocGerd/hangarfit/issues/667) Rung E) instead drives to a
+transient **staging pose** (leg 0), waits while another body routes past, then drives
+to its final slot (leg 1) — so `segments` may carry **more than one entry per
+`plane_id`**, laid end-to-end in leg order. Each such segment then carries an
+**optional** `leg_index: int` (`0`-based, execution order).
+
+`leg_index` is emitted **only for a multi-leg body** — a single-leg body (every body
+today) omits the key entirely, so an existing scene is **byte-identical** to the
+pre-Rung-D form. The `SCHEMA` stays `hangarfit.scene/v2` (additive only). A consumer
+that ignores `leg_index` still animates correctly (segments are already sequential);
+the field is an explicit, robust ordering label. The body's **final** pose is the
+*last* leg's end; a staging pose is **not** in `final_poses` / `placements`.
+
+**Viewer state machine** — for a plane with leg list `S` (sorted by `leg_index`) at
+time `t`:
 
 | Condition | State | Affine |
 |---|---|---|
-| `t < s.start_s` | hidden (still outside) | — |
-| `s.start_s ≤ t < s.end_s` | animating | `s.samples[round(frac·(n−1))]` |
-| `t ≥ s.end_s` | parked | `final_poses[plane_id]` |
+| `t < S[0].start_s` | hidden (still outside) | — |
+| `S[k].start_s ≤ t < S[k].end_s` | animating leg `k` | `S[k].samples[round(frac·(n−1))]` |
+| `S[k].end_s ≤ t < S[k+1].start_s` | waiting at staging | `S[k].samples[−1]` |
+| `t ≥ S[−1].end_s` | parked | `final_poses[plane_id]` |
 
-A plane with **no** segment (static scene) is always shown at `final_poses`.
+For a single-leg body these collapse to the original hidden → animating → parked
+transitions. A plane with **no** segment (static scene) is always shown at
+`final_poses`.
 
 ### Static / un-routable layouts
 

--- a/docs/architecture/scene-v2-schema.md
+++ b/docs/architecture/scene-v2-schema.md
@@ -229,6 +229,12 @@ that ignores `leg_index` still animates correctly (segments are already sequenti
 the field is an explicit, robust ordering label. The body's **final** pose is the
 *last* leg's end; a staging pose is **not** in `final_poses` / `placements`.
 
+> **Producer status (Rung D, #667).** The data model + viewer are the *seam* for
+> move-aside: the state machine below (incl. the "waiting at staging" gap row) is
+> fully consumer-ready, but **no producer emits a multi-leg plan yet** — the scene
+> builder lays a body's legs end-to-end with no gap, so the wait row is not reached
+> by any shipped layout. Rung E (move-aside) supplies the first multi-leg producer.
+
 **Viewer state machine** — for a plane with leg list `S` (sorted by `leg_index`) at
 time `t`:
 

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -432,22 +432,24 @@ function pathPoints(seg) {
 }
 function addTowPaths(scene, SCENE, BRAND2) {
   const Z_OFFSET = 0.02;
-  const segByPlane = {};
-  for (const s of SCENE.timeline.segments) segByPlane[s.plane_id] = s;
+  const segsByPlane = {};
+  for (const s of SCENE.timeline.segments) (segsByPlane[s.plane_id] ??= []).push(s);
   const lines = [];
   for (const p of SCENE.planes) {
-    const seg = segByPlane[p.id];
-    if (!seg) continue;
-    const pts = pathPoints(seg);
-    if (pts.length < 2) continue;
+    const segs = segsByPlane[p.id];
+    if (!segs) continue;
     const conflicted = SCENE.conflicts.includes(p.id);
     const colour = new THREE8.Color(conflicted ? BRAND2.conflict : p.color);
-    const geom = new THREE8.BufferGeometry().setFromPoints(
-      pts.map(([x, y]) => new THREE8.Vector3(x, y, Z_OFFSET))
-    );
-    const line = new THREE8.Line(geom, new THREE8.LineBasicMaterial({ color: colour }));
-    scene.add(line);
-    lines.push(line);
+    for (const seg of segs) {
+      const pts = pathPoints(seg);
+      if (pts.length < 2) continue;
+      const geom = new THREE8.BufferGeometry().setFromPoints(
+        pts.map(([x, y]) => new THREE8.Vector3(x, y, Z_OFFSET))
+      );
+      const line = new THREE8.Line(geom, new THREE8.LineBasicMaterial({ color: colour }));
+      scene.add(line);
+      lines.push(line);
+    }
   }
   const setVisible = (on) => {
     for (const l of lines) l.visible = on;
@@ -543,16 +545,25 @@ function checkAnchors(scene) {
 
 // src/timeline.ts
 function affineAt(segByPlane, finals, pid, t) {
-  const seg = segByPlane[pid];
-  if (!seg) {
+  const segs = segByPlane[pid];
+  if (!segs || segs.length === 0) {
     const aff = finals[pid];
     return aff ? { vis: true, aff } : { vis: false, aff: null };
   }
-  if (t < seg.start_s) return { vis: false, aff: null };
-  if (t >= seg.end_s) return { vis: true, aff: finals[pid] };
-  const frac = (t - seg.start_s) / (seg.end_s - seg.start_s);
-  const i = Math.round(frac * (seg.samples.length - 1));
-  return { vis: true, aff: seg.samples[i] };
+  if (t < segs[0].start_s) return { vis: false, aff: null };
+  const last = segs[segs.length - 1];
+  if (t >= last.end_s) return { vis: true, aff: finals[pid] };
+  let rest = null;
+  for (const seg of segs) {
+    if (t < seg.start_s) break;
+    if (t < seg.end_s) {
+      const frac = (t - seg.start_s) / (seg.end_s - seg.start_s);
+      const i = Math.round(frac * (seg.samples.length - 1));
+      return { vis: true, aff: seg.samples[i] };
+    }
+    rest = seg.samples[seg.samples.length - 1];
+  }
+  return { vis: true, aff: rest };
 }
 function framePoses(scene, segByPlane, t) {
   const out = {};
@@ -570,7 +581,7 @@ function createTimeline(scene, groups, goGroups = {}) {
   const TOTAL = TL.total_s;
   const hasAnim = TOTAL > 0 && SEGS.length > 0;
   const segByPlane = {};
-  for (const s of SEGS) segByPlane[s.plane_id] = s;
+  for (const s of SEGS) (segByPlane[s.plane_id] ??= []).push(s);
   const active = byId("active");
   const clock = byId("clock");
   const applyTime = (t) => {

--- a/src/hangarfit/scene.py
+++ b/src/hangarfit/scene.py
@@ -24,7 +24,7 @@ from hangarfit.models import CheckResult, Layout, Part, Placement
 from hangarfit.towplanner import back_first_order
 
 if TYPE_CHECKING:
-    from hangarfit.towplanner import DubinsArc, MovesPlan
+    from hangarfit.towplanner import DubinsArc, Move, MovesPlan
 
 SCHEMA = "hangarfit.scene/v2"
 
@@ -271,24 +271,40 @@ def _timeline(
     if moves_plan is None:
         return {"total_s": 0.0, "segments": []}, finals
 
-    move_by_id = {m.plane_id: m for m in moves_plan.moves}
+    # #865 Rung D: GROUP (don't overwrite) — a body may carry multiple legs
+    # (move-aside staging + final, #667 Rung E). dict insertion order preserves the
+    # plan's execution order; legs are emitted in leg_index order below. Today every
+    # body has exactly one leg, so each list is single-element and the output is
+    # byte-identical to the prior `{m.plane_id: m}` form.
+    moves_by_id: dict[str, list[Move]] = {}
+    for m in moves_plan.moves:
+        moves_by_id.setdefault(m.plane_id, []).append(m)
     segments: list[dict] = []
     t = 0.0
 
     def _append_segment(body_id: str, *, record_final: bool) -> None:
         nonlocal t
-        move = move_by_id.get(body_id)
-        if move is None or move.path is None:
-            # No move, or a deferred (path=None) move — the body stays at its final
-            # pose. A deferred path is an un-routable placed-routed mover (#197/#602);
-            # for an aircraft this guard is defensive (every aircraft is routed).
+        legs = moves_by_id.get(body_id)
+        if not legs:
             return
-        samples = _sample_affines(move.path, max_samples_per_path)
-        dur = min(max(move.path.length_m / tow_speed_mps, min_seg_s), max_seg_s)
-        segments.append({"plane_id": body_id, "start_s": t, "end_s": t + dur, "samples": samples})
-        if record_final:
-            finals[body_id] = samples[-1]
-        t += dur
+        # One sequential segment per ROUTED leg, in leg_index order. A deferred
+        # (path=None) leg emits no segment — an un-routable placed-routed mover
+        # (#197/#602), or for an aircraft a defensive guard (every aircraft is
+        # routed). The `leg_index` key is emitted ONLY for a multi-leg body (>1
+        # routed leg) — a single-leg body stays byte-identical to before (#865).
+        routed = sorted((m for m in legs if m.path is not None), key=lambda m: m.leg_index)
+        multi_leg = len(routed) > 1
+        for leg in routed:
+            assert leg.path is not None  # narrowed by the filter above
+            samples = _sample_affines(leg.path, max_samples_per_path)
+            dur = min(max(leg.path.length_m / tow_speed_mps, min_seg_s), max_seg_s)
+            seg: dict = {"plane_id": body_id, "start_s": t, "end_s": t + dur, "samples": samples}
+            if multi_leg:
+                seg["leg_index"] = leg.leg_index
+            segments.append(seg)
+            if record_final:
+                finals[body_id] = samples[-1]
+            t += dur
 
     # Aircraft drive in first (deepest slot first); then placed-routed movers
     # (id-sorted, matching _ground_object_blocks) animate after every aircraft is

--- a/src/hangarfit/scene.py
+++ b/src/hangarfit/scene.py
@@ -272,10 +272,13 @@ def _timeline(
         return {"total_s": 0.0, "segments": []}, finals
 
     # #865 Rung D: GROUP (don't overwrite) — a body may carry multiple legs
-    # (move-aside staging + final, #667 Rung E). dict insertion order preserves the
-    # plan's execution order; legs are emitted in leg_index order below. Today every
-    # body has exactly one leg, so each list is single-element and the output is
-    # byte-identical to the prior `{m.plane_id: m}` form.
+    # (move-aside staging + final, #667 Rung E). `moves_by_id` is a
+    # plane_id -> legs LOOKUP only; its iteration order is never consumed. Body
+    # emission order is driven by `back_first_order` + id-sorted movers (below);
+    # within a body, legs are re-sorted by `leg_index` in `_append_segment`, so the
+    # plan tuple order is NOT relied on. Today every body has exactly one leg, so
+    # each list is single-element and the output is byte-identical to the prior
+    # `{m.plane_id: m}` form.
     moves_by_id: dict[str, list[Move]] = {}
     for m in moves_plan.moves:
         moves_by_id.setdefault(m.plane_id, []).append(m)
@@ -292,6 +295,15 @@ def _timeline(
         # (#197/#602), or for an aircraft a defensive guard (every aircraft is
         # routed). The `leg_index` key is emitted ONLY for a multi-leg body (>1
         # routed leg) — a single-leg body stays byte-identical to before (#865).
+        #
+        # Rung D scope (#667): a body's legs are laid end-to-end HERE (each leg's
+        # `start_s == prev.end_s`), then the next body — so a body is never paused
+        # mid-fill while another routes past. The viewer + scene-v2 state machine
+        # already model that inter-leg "wait at staging" gap (`affineAt`), but no
+        # producer emits it yet; Rung E (move-aside) will lay legs in global
+        # execution order across bodies. Edge (deferred only, no producer today):
+        # a multi-leg body whose non-final leg is `path=None` drops to one routed
+        # leg and serializes as single-leg (no `leg_index`) — revisit in Rung E.
         routed = sorted((m for m in legs if m.path is not None), key=lambda m: m.leg_index)
         multi_leg = len(routed) > 1
         for leg in routed:

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -252,10 +252,19 @@ class Move:
     # #602 routes). A routed aircraft (or, post-#602, a routed mover) always has a
     # DubinsArc here. See the class docstring for the full contract.
     path: DubinsArc | None
+    # #865 Rung D: the execution-order index of this leg within its body's tow.
+    # A single-leg move (every body today) keeps the default ``0``; a future
+    # move-aside relocation (#667 Rung E) emits a staging leg (``leg_index=0``)
+    # then the final leg (``leg_index=1``) for the SAME ``plane_id``. The field is
+    # ADDITIVE and trailing-defaulted, so every existing positional/keyword
+    # ``Move(...)`` constructor and serialization is byte-identical to before.
+    leg_index: int = 0
 
     def __post_init__(self) -> None:
         if not self.plane_id:
             raise ValueError("Move.plane_id must be non-empty")
+        if self.leg_index < 0:
+            raise ValueError(f"Move.leg_index must be >= 0, got {self.leg_index}")
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -226,6 +226,44 @@ def test_timeline_sample_count_capped():
         assert len(s["samples"]) <= 20  # hard-clamped to the exact bound
 
 
+def test_timeline_single_leg_segment_omits_leg_index_key():
+    # #865 Rung D byte-identity hinge: a single-leg body (every body today) emits
+    # NO `leg_index` key, so an existing scene serializes byte-identically. The key
+    # appears ONLY to disambiguate a multi-leg body (next test).
+    lay = load_layout(LAYOUT)
+    plan = plan_fill(lay)
+    tl, _ = scene._timeline(lay, plan)
+    assert tl["segments"], "fixture must produce segments"
+    assert all("leg_index" not in s for s in tl["segments"])
+
+
+def test_timeline_multi_leg_emits_one_segment_per_leg_in_leg_order():
+    # #865 Rung D: a body that relocates carries MULTIPLE Move legs (staging, then
+    # final). `_timeline` emits one sequential segment per ROUTED leg, in leg_index
+    # order regardless of tuple order, each tagged with `leg_index`; the body's
+    # final pose is the LAST leg's end (not the staging leg's).
+    from hangarfit.towplanner import Move, MovesPlan
+
+    lay = load_layout(LAYOUT)
+    base = plan_fill(lay)
+    routed = [m for m in base.moves if m.path is not None]
+    a, b = routed[0], routed[1]
+    pid = a.plane_id
+    staging = Move(plane_id=pid, target_slot=b.target_slot, path=b.path, leg_index=0)
+    final = Move(plane_id=pid, target_slot=a.target_slot, path=a.path, leg_index=1)
+    # Tuple order REVERSED on purpose — output must still be leg-index ordered.
+    plan = MovesPlan(target_layout=base.target_layout, moves=(final, staging))
+    tl, finals = scene._timeline(lay, plan)
+
+    segs = [s for s in tl["segments"] if s["plane_id"] == pid]
+    assert len(segs) == 2
+    assert [s["leg_index"] for s in segs] == [0, 1]
+    assert math.isclose(segs[0]["start_s"], 0.0)
+    assert math.isclose(segs[1]["start_s"], segs[0]["end_s"])  # sequential, end-to-end
+    assert finals[pid] == segs[1]["samples"][-1]  # final pose = LAST leg's end
+    assert finals[pid] != segs[0]["samples"][-1]  # not the staging leg's end
+
+
 def test_sample_affines_hard_clamp_is_exact_and_keeps_endpoints():
     # Directly exercise the overshoot branch: max_samples=2 forces the densely
     # sampled path to overshoot, so the clamp must fire — bounding the count
@@ -397,6 +435,28 @@ def _animated_scene() -> dict:
     return scene.build_scene(lay, moves_plan=plan_fill(lay))
 
 
+def _multi_leg_segment() -> dict:
+    """A serialized timeline segment from a MULTI-leg body, which carries the
+    optional ``leg_index`` key (#865 Rung D). The single-leg animated scene omits
+    that key (byte-identity), so it cannot pin the full SegmentData key set."""
+    from hangarfit.towplanner import Move, MovesPlan
+
+    lay = load_layout(LAYOUT)
+    base = plan_fill(lay)
+    routed = [m for m in base.moves if m.path is not None]
+    a, b = routed[0], routed[1]
+    pid = a.plane_id
+    plan = MovesPlan(
+        target_layout=base.target_layout,
+        moves=(
+            Move(plane_id=pid, target_slot=b.target_slot, path=b.path, leg_index=0),
+            Move(plane_id=pid, target_slot=a.target_slot, path=a.path, leg_index=1),
+        ),
+    )
+    sc = scene.build_scene(lay, moves_plan=plan)
+    return next(s for s in sc["timeline"]["segments"] if "leg_index" in s)
+
+
 def test_brand_contract_ts_keys_match_brand_py():
     from hangarfit import brand
 
@@ -418,11 +478,19 @@ def test_scene_contract_ts_nested_keys_match_scene_py():
         "PlaneData": sc["planes"][0],
         "BoxData": sc["planes"][0]["boxes"][0],
         "TimelineData": sc["timeline"],
-        "SegmentData": sc["timeline"]["segments"][0],
+        # SegmentData is pinned separately below against a MULTI-leg segment so the
+        # optional `leg_index` key (#865) is present — the single-leg animated scene
+        # omits it (byte-identity), so segments[0] can't pin the full key set.
         "Readouts": sc["readouts"],
     }
     for interface, obj in cases.items():
         assert _ts_interface_fields("scene-contract.ts", interface) == set(obj), interface
+
+    # SegmentData (#865 Rung D): the optional `leg_index` key only appears on a
+    # multi-leg body, so pin the contract against a multi-leg segment.
+    seg = _multi_leg_segment()
+    assert "leg_index" in seg  # the fixture must actually exercise the optional key
+    assert _ts_interface_fields("scene-contract.ts", "SegmentData") == set(seg)
 
     # StructuralNotchData: the animated scene uses a rectangular hangar, so its
     # structural_notches list is empty — sample a notched hangar block to pin the

--- a/tests/test_towplanner.py
+++ b/tests/test_towplanner.py
@@ -92,6 +92,63 @@ def test_move_rejects_empty_plane_id():
         )
 
 
+def _straight_arc(x: float, y: float) -> DubinsArc:
+    return DubinsArc(
+        start=Pose(0.0, 0.0, 0.0),
+        end=Pose(x, y, 0.0),
+        turn_radius_m=8.0,
+        segments=(Segment("S", math.hypot(x, y)),),
+    )
+
+
+def test_move_defaults_leg_index_zero():
+    # #865 Rung D: leg_index is an ADDITIVE trailing field — every existing
+    # positional/keyword constructor keeps working and defaults to leg 0, so a
+    # single-leg plan is byte-identical to before.
+    move = Move(plane_id="DG-ABC", target_slot=Pose(1.0, 2.0, 0.0), path=_straight_arc(1.0, 2.0))
+    assert move.leg_index == 0
+
+
+def test_move_accepts_explicit_leg_index():
+    move = Move(
+        plane_id="DG-ABC",
+        target_slot=Pose(1.0, 2.0, 0.0),
+        path=_straight_arc(1.0, 2.0),
+        leg_index=1,
+    )
+    assert move.leg_index == 1
+
+
+def test_move_rejects_negative_leg_index():
+    with pytest.raises(ValueError):
+        Move(
+            plane_id="DG-ABC",
+            target_slot=Pose(1.0, 2.0, 0.0),
+            path=_straight_arc(1.0, 2.0),
+            leg_index=-1,
+        )
+
+
+def test_movesplan_allows_multiple_legs_per_plane():
+    # #865 Rung D: a single plane_id may carry MULTIPLE Move entries (one per leg,
+    # in execution order) — the move-aside staging leg followed by the final leg.
+    staging = Move(
+        plane_id="DG-ABC",
+        target_slot=Pose(5.0, 1.0, 0.0),
+        path=_straight_arc(5.0, 1.0),
+        leg_index=0,
+    )
+    final = Move(
+        plane_id="DG-ABC",
+        target_slot=Pose(1.0, 2.0, 0.0),
+        path=_straight_arc(1.0, 2.0),
+        leg_index=1,
+    )
+    plan = MovesPlan(target_layout=object(), moves=(staging, final))
+    same_plane = [m for m in plan.moves if m.plane_id == "DG-ABC"]
+    assert [m.leg_index for m in same_plane] == [0, 1]
+
+
 def test_movesplan_construction_roundtrip():
     layout = object()  # placeholder; Move/MovesPlan do not validate layout in Wave 1
     move = Move(

--- a/viewer/src/paths.ts
+++ b/viewer/src/paths.ts
@@ -41,23 +41,28 @@ export interface TowPaths {
  * the parked planes' bellies. Returns the lines + a visibility toggle. */
 export function addTowPaths(scene: THREE.Object3D, SCENE: SceneV2, BRAND: BrandTokens): TowPaths {
   const Z_OFFSET = 0.02; // just above the floor (grid sits at 0.003); under any belly
-  const segByPlane: Record<string, SegmentData> = {};
-  for (const s of SCENE.timeline.segments) segByPlane[s.plane_id] = s;
+  // #865 Rung D: group legs per plane (don't overwrite) so a move-aside body
+  // (#667 Rung E) draws BOTH its staging and final legs. Single-leg bodies (every
+  // body today) yield single-element lists → one line, byte-identical to before.
+  const segsByPlane: Record<string, SegmentData[]> = {};
+  for (const s of SCENE.timeline.segments) (segsByPlane[s.plane_id] ??= []).push(s);
 
   const lines: THREE.Line[] = [];
   for (const p of SCENE.planes) {
-    const seg = segByPlane[p.id];
-    if (!seg) continue; // static plane: no tow route to draw
-    const pts = pathPoints(seg);
-    if (pts.length < 2) continue; // a single point is not a line
+    const segs = segsByPlane[p.id];
+    if (!segs) continue; // static plane: no tow route to draw
     const conflicted = SCENE.conflicts.includes(p.id);
     const colour = new THREE.Color(conflicted ? BRAND.conflict : p.color);
-    const geom = new THREE.BufferGeometry().setFromPoints(
-      pts.map(([x, y]) => new THREE.Vector3(x, y, Z_OFFSET)),
-    );
-    const line = new THREE.Line(geom, new THREE.LineBasicMaterial({ color: colour }));
-    scene.add(line);
-    lines.push(line);
+    for (const seg of segs) {
+      const pts = pathPoints(seg);
+      if (pts.length < 2) continue; // a single point is not a line
+      const geom = new THREE.BufferGeometry().setFromPoints(
+        pts.map(([x, y]) => new THREE.Vector3(x, y, Z_OFFSET)),
+      );
+      const line = new THREE.Line(geom, new THREE.LineBasicMaterial({ color: colour }));
+      scene.add(line);
+      lines.push(line);
+    }
   }
 
   const setVisible = (on: boolean): void => {

--- a/viewer/src/scene-contract.ts
+++ b/viewer/src/scene-contract.ts
@@ -89,6 +89,11 @@ export interface SegmentData {
   start_s: number;
   end_s: number;
   samples: Affine[];
+  // #865 Rung D: execution-order index of this leg within its body's tow. Present
+  // ONLY for a multi-leg body (move-aside staging + final, #667 Rung E); a
+  // single-leg body omits it (byte-identical to the pre-Rung-D scene). Absent ⇒
+  // treat as leg 0. Field name matches the Python `leg_index` key (#440 parity).
+  leg_index?: number;
 }
 
 export interface TimelineData {

--- a/viewer/src/timeline.ts
+++ b/viewer/src/timeline.ts
@@ -5,25 +5,41 @@ import { byId } from './dom.ts';
 import type { Affine, SceneV2, SegmentData } from './scene-contract.ts';
 
 /** Pose + visibility of a plane at time `t`. PURE given `(segByPlane, finals, pid, t)`
- * — no THREE, no DOM (node-tested in #440). A static plane (no segment) renders at
- * its parked pose, or hides if a malformed scene is missing its final pose (the
- * anchor self-check already banners that). */
+ * — no THREE, no DOM (node-tested in #440). A static plane (no leg) renders at its
+ * parked pose, or hides if a malformed scene is missing its final pose (the anchor
+ * self-check already banners that).
+ *
+ * #865 Rung D: `segByPlane` maps a plane to its LIST of legs (one entry today). A
+ * move-aside body (#667 Rung E) has a staging leg then a final leg: it animates each
+ * leg, and in a GAP between legs it rests at the staging pose (the just-completed
+ * leg's last sample), NOT hidden. Single-leg input is byte-identical to before. */
 export function affineAt(
-  segByPlane: Record<string, SegmentData>,
+  segByPlane: Record<string, SegmentData[]>,
   finals: Record<string, Affine>,
   pid: string,
   t: number,
 ): { vis: boolean; aff: Affine | null } {
-  const seg = segByPlane[pid];
-  if (!seg) {
+  const segs = segByPlane[pid];
+  if (!segs || segs.length === 0) {
     const aff = finals[pid];
     return aff ? { vis: true, aff } : { vis: false, aff: null };
   }
-  if (t < seg.start_s) return { vis: false, aff: null };        // not entered yet
-  if (t >= seg.end_s) return { vis: true, aff: finals[pid] };
-  const frac = (t - seg.start_s) / (seg.end_s - seg.start_s);
-  const i = Math.round(frac * (seg.samples.length - 1));
-  return { vis: true, aff: seg.samples[i] };
+  if (t < segs[0].start_s) return { vis: false, aff: null };          // not entered yet
+  const last = segs[segs.length - 1];
+  if (t >= last.end_s) return { vis: true, aff: finals[pid] };        // parked at final pose
+  // Legs are in execution order. Find the one covering t; if t falls in a gap
+  // BETWEEN legs, the body waits at the most-recently-completed leg's last sample.
+  let rest: Affine | null = null;
+  for (const seg of segs) {
+    if (t < seg.start_s) break;                                       // gap before this leg → use `rest`
+    if (t < seg.end_s) {
+      const frac = (t - seg.start_s) / (seg.end_s - seg.start_s);
+      const i = Math.round(frac * (seg.samples.length - 1));
+      return { vis: true, aff: seg.samples[i] };
+    }
+    rest = seg.samples[seg.samples.length - 1];                       // past this leg → staging pose candidate
+  }
+  return { vis: true, aff: rest };
 }
 
 /** Pure: pose + visibility of EVERY animated body — planes ∪ placed-routed
@@ -35,7 +51,7 @@ export function affineAt(
  * path=None mover) shows at its own final pose. No THREE, no DOM — node-tested. */
 export function framePoses(
   scene: SceneV2,
-  segByPlane: Record<string, SegmentData>,
+  segByPlane: Record<string, SegmentData[]>,
   t: number,
 ): Record<string, { vis: boolean; aff: Affine | null }> {
   const out: Record<string, { vis: boolean; aff: Affine | null }> = {};
@@ -68,8 +84,10 @@ export function createTimeline(
   const SEGS = TL.segments;
   const TOTAL = TL.total_s;
   const hasAnim = TOTAL > 0 && SEGS.length > 0;
-  const segByPlane: Record<string, SegmentData> = {};
-  for (const s of SEGS) segByPlane[s.plane_id] = s;
+  // #865 Rung D: group legs per plane (don't overwrite) — a move-aside body has
+  // more than one. Single-leg bodies (every body today) yield single-element lists.
+  const segByPlane: Record<string, SegmentData[]> = {};
+  for (const s of SEGS) (segByPlane[s.plane_id] ??= []).push(s);
 
   const active = byId('active');
   const clock = byId('clock');

--- a/viewer/test/paths.test.ts
+++ b/viewer/test/paths.test.ts
@@ -155,3 +155,21 @@ test('addTowPaths: one line per routable plane; conflicted line uses BRAND.confl
   setVisible(true);
   assert.ok(lines.every((l) => l.visible === true), 'setVisible(true) shows every line again');
 });
+
+test('addTowPaths: a multi-leg plane (#865) draws one line PER leg, all in the plane colour', () => {
+  // A move-aside body (#667 Rung E) has a staging leg AND a final leg for the
+  // SAME plane_id. Both legs are drawn (so the whole shuffle route is visible),
+  // each in the plane's own hue — the leg list must not be collapsed to one line.
+  const mover = plane({ id: 'mover', color: '#1f77b4' });
+  const staging: SegmentData = { plane_id: 'mover', start_s: 0, end_s: 2, samples: [[1, 0, 5, 0, 1, 0], [1, 0, 7, 0, 1, 3]], leg_index: 0 };
+  const final: SegmentData = { plane_id: 'mover', start_s: 4, end_s: 6, samples: [[1, 0, 7, 0, 1, 3], [1, 0, 9, 0, 1, 6]], leg_index: 1 };
+  const SCENE = makeScene([mover], [], [staging, final]);
+
+  const scene = new THREE.Scene();
+  const { lines } = addTowPaths(scene, SCENE, BRAND);
+
+  assert.equal(lines.length, 2, 'both legs of the multi-leg plane get a line');
+  const colourOf = (l: THREE.Line): string =>
+    '#' + (l.material as THREE.LineBasicMaterial).color.getHexString();
+  assert.ok(lines.every((l) => colourOf(l) === mover.color.toLowerCase()), 'every leg uses the plane colour');
+});

--- a/viewer/test/timeline.test.ts
+++ b/viewer/test/timeline.test.ts
@@ -11,7 +11,8 @@ const A0: Affine = [1, 0, 0, 0, 1, 0];
 const A1: Affine = [1, 0, 5, 0, 1, 0];
 const A2: Affine = [1, 0, 9, 0, 1, 0];
 const seg: SegmentData = { plane_id: 'p', start_s: 2, end_s: 6, samples: [A0, A1, A2] };
-const segByPlane: Record<string, SegmentData> = { p: seg };
+// #865 Rung D: segByPlane maps a plane to its LIST of legs (one entry today).
+const segByPlane: Record<string, SegmentData[]> = { p: [seg] };
 const finals: Record<string, Affine> = { p: FINAL, q: FINAL };
 
 test('static plane (no segment) → shown at its final pose', () => {
@@ -38,6 +39,27 @@ test('mid-animation → sample chosen by the rounded fraction', () => {
   assert.deepEqual(affineAt(segByPlane, finals, 'p', 5.9), { vis: true, aff: A2 }); // frac .975 → round 2
 });
 
+// ── multi-leg body (#865 Rung D): staging leg, wait, then final leg ───────────
+// A move-aside body (#667 Rung E) drives to a staging pose (leg 0), waits there
+// while another body routes past, then drives to its final slot (leg 1). Between
+// the legs the body rests at the staging pose (leg 0's last sample), NOT hidden.
+const L0a: Affine = [1, 0, 2, 0, 1, 0]; // staging leg, first sample
+const L0b: Affine = [1, 0, 3, 0, 1, 0]; // staging leg, last sample (the staging pose)
+const L1a: Affine = [1, 0, 8, 0, 1, 0]; // final leg, first sample
+const L1b: Affine = [1, 0, 9, 0, 1, 0]; // final leg, last sample
+const leg0: SegmentData = { plane_id: 'm', start_s: 0, end_s: 4, samples: [L0a, L0b], leg_index: 0 };
+const leg1: SegmentData = { plane_id: 'm', start_s: 6, end_s: 10, samples: [L1a, L1b], leg_index: 1 };
+const multiLeg: Record<string, SegmentData[]> = { m: [leg0, leg1] };
+const mFinals: Record<string, Affine> = { m: FINAL };
+
+test('multi-leg: hidden → leg0 → waits at staging between legs → leg1 → parked', () => {
+  assert.deepEqual(affineAt(multiLeg, mFinals, 'm', -1), { vis: false, aff: null }); // before leg0
+  assert.deepEqual(affineAt(multiLeg, mFinals, 'm', 0), { vis: true, aff: L0a }); // leg0 start
+  assert.deepEqual(affineAt(multiLeg, mFinals, 'm', 5), { vis: true, aff: L0b }); // gap → staging pose
+  assert.deepEqual(affineAt(multiLeg, mFinals, 'm', 6), { vis: true, aff: L1a }); // leg1 start
+  assert.deepEqual(affineAt(multiLeg, mFinals, 'm', 99), { vis: true, aff: FINAL }); // after leg1 → parked
+});
+
 // ── framePoses: planes ∪ ground-object movers, one state machine (#651) ───────
 // A mover reuses the SAME hidden→sample→parked transitions as a plane, but its
 // resting pose lives on its own block (final_pose), not in scene.final_poses.
@@ -61,7 +83,7 @@ function sceneWithMover(): SceneV2 {
 
 test('framePoses animates a routed mover (hidden → sample → parked); plane unaffected', () => {
   const moverSeg: SegmentData = { plane_id: 'caddy', start_s: 4, end_s: 8, samples: [A0, A1, A2] };
-  const seg2: Record<string, SegmentData> = { caddy: moverSeg };
+  const seg2: Record<string, SegmentData[]> = { caddy: [moverSeg] };
   const sc = sceneWithMover();
   assert.deepEqual(framePoses(sc, seg2, 0).caddy, { vis: false, aff: null }); // not entered
   assert.deepEqual(framePoses(sc, seg2, 6).caddy, { vis: true, aff: A1 }); // mid-animation


### PR DESCRIPTION
## What & why

**Rung D of the #667 shuffle-aware tow-routing program** — the multi-leg tow-plan
data model + its full consumer seam, landed **byte-identically** (no behavior
change). This is the seam that move-aside relocation (Rung E) needs: a body that
is rolled aside and later restored has **two tow legs** for one `plane_id`, but
today every consumer assumes exactly one. Landing the seam now — with zero
producer emitting >1 leg — keeps Rung E a *localized* planner change instead of
planner + schema + viewer all at once, and lets `determinism-guard` prove the
seam itself changed nothing.

Closes #865.

## Changes (all additive)

- **`Move.leg_index: int = 0`** (towplanner.py) — additive trailing field; rejects
  `< 0`. A body may now carry multiple `Move`s (one per leg) under one `plane_id`.
- **`scene._timeline`** groups legs per body (was an overwriting dict), emits one
  sequential segment per routed leg in `leg_index` order, and tags each segment
  with `leg_index` **only for a multi-leg body** — the byte-identity hinge (a
  single-leg body gains no key).
- **scene/v2**: `timeline.segments[]` gains optional `leg_index`; `SCHEMA` stays
  `hangarfit.scene/v2` (additive). Documented in `scene-v2-schema.md`.
- **Viewer**: `SegmentData.leg_index?` (TS), `affineAt`/`framePoses`/`createTimeline`
  (`timeline.ts`) and `addTowPaths` (`paths.ts`) reshaped to `segByPlane:
  Record<string, SegmentData[]>`; `affineAt` iterates legs and rests a body at its
  **staging pose** between legs. Rebuilt + committed `viewer.js`.
- `visualize.py` needs **no change** — `_draw_tow_paths` already iterates every
  `Move` (pinned by the pre-existing `test_same_plane_keeps_one_colour`).

## Two spec corrections found during scoping
1. **`viewer/src/paths.ts`** also built an overwriting `segByPlane` (3D floor
   polylines) — the spec only named `timeline.ts`. Fixed here too.
2. The #440 parity test asserts **name-equal** key sets (it strips the `?`), so the
   TS field had to be `leg_index` (not the spec's `leg`), and the `SegmentData`
   parity case had to switch to a **multi-leg** segment (the single-leg fixture
   omits the optional key by design).

## Byte-identity proof
Every pre-existing scene/viewer/plan test stays green **unmodified** (single-leg
output is unchanged); the determinism canaries pass. New synthetic multi-leg unit
tests exercise the new path: `_timeline` (2 segments, leg-ordered, final = last
leg), `affineAt` (hidden → leg0 → wait-at-staging → leg1 → parked), and
`addTowPaths` (one line per leg).

## Guards
`scene-schema-guard` · #440 key-parity · #438 viewer-build-drift · `determinism-guard`
(towplanner.py touched, additive/byte-identical) · full `make test` · viewer
typecheck/lint/node-test.

## Non-goals
No move-aside *behavior* (that's Rung E). No producer emits a second leg yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELeppKxGc7KbckFEzEEyYt
