### PR TITLE
feat(667): Rung E — move-aside repair core (relocate a parked aircraft to route a stuck one)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ All notable changes to this project are documented here. Format follows [Keep a 
   (timeline + floor polylines) animates each leg, resting a body at its staging
   pose between legs; the 2D PNG renderer already draws each leg unchanged.
   `SCHEMA` stays `hangarfit.scene/v2` (additive only).
+- The tow-path fill planner can now resolve a tow-order deadlock by temporarily
+  relocating an already-parked aircraft to an apron-out staging pose, routing the
+  stuck aircraft past it, and returning it — **"move-aside"** (#667, Rung E),
+  emitting a valid multi-leg plan (and a faithfully interleaved `view` animation)
+  where no monotone fill order exists. It engages automatically whenever a staging
+  apron is set (`--apron-depth` / hangar `apron_depth_m > 0`) and only after the
+  non-displacing search deadlocks within budget, so a layout that doesn't need a
+  shuffle is byte-identical to before (ADR-0003). The relocation is bounded
+  depth-1 and globally capped, and it adds reachability only for in-budget cyclic
+  blocks — it does not, on its own, crack the budget-bound dense Herrenteich all-8
+  (the corridor there exhausts the affordable expansion budget before any shuffle;
+  see the routing-ceiling spike).
 - A `kind: fuselage` part may now carry a `vertices:` outline polygon, which the
   loader clips into area-conserving `fuselage_front`/`fuselage_aft` sub-polygons
   at the wing trailing edge (#550). Capability-only — no fleet behaviour change.

--- a/docs/spikes/herrenteich-routing-ceiling-baseline.md
+++ b/docs/spikes/herrenteich-routing-ceiling-baseline.md
@@ -84,3 +84,50 @@ set only) never grinds the multi-minute route. Their `_SPEED_CEILING_S` entries 
 - **Does not:** touch the wall. Rung B is pure measurement (bench-only; no `src/hangarfit/` change).
   Raising the ceiling is Rung E (move-aside), and even then the `fk9↔cessna` cm-scale parallel-park
   may remain a documented manual-insertion case (spec §2 honest caveat).
+
+## Rung E (move-aside): re-baseline — the wall is unmoved on the budget-bound all-8
+
+Rung E adds **move-aside**: when the non-displacing fill search deadlocks *within budget*, a
+second phase temporarily relocates a parked aircraft to an apron-out staging pose, routes the stuck
+aircraft past it, and returns it — a depth-1, apron-gated relocation emitting a valid multi-leg plan
+(byte-identical when no shuffle is needed; ADR-0003). Re-running the all-8 witness route (the same
+direct `plan_fill`, budget 8000) **with** `apron_depth=auto` (which is what *enables* move-aside)
+vs **without**:
+
+| run | result | bail body | reason | wall-clock |
+|---|---|---|---|---|
+| no apron (Rung B) | **BAILS** | `zlin_savage` | global fill budget (8000) exhausted | ~70 s |
+| `apron=auto` (Rung E) | **BAILS** | `zlin_savage` | global fill budget (8000) exhausted | ~114 s |
+
+**The ceiling is unmoved: same body, same budget-exhaustion reason.** The bail message is the
+budget *raise* (`...budget (8000) exhausted`), not the in-budget `no feasible tow order`
+deadlock — so **phase 1 raises before phase 2 ever runs**, and move-aside never engages on the
+dense all-8. This is the predicted behaviour: the all-8 corridor is *budget-bound* (it grinds the
+full cap threading the nest, see "the bail is budget-exhaustion" above), and move-aside only adds
+reachability for an **in-budget** deadlock (a cyclic block the search *disproves* cheaply). The
+`zlin_savage`/`fk9↔cessna` parallel-park stays a documented manual-insertion case.
+
+The ~70 s → ~114 s rise (≈1.6×) is **the apron's own routing cost** (#499: the apron-out forward
++ reverse cones × the y-samples enlarge each route's start set), **not** Rung E's two-phase change:
+because phase 1 raises, the two-phase driver's `if result is None` block is never reached, so the
+move-aside path is provably inert on this regime. Without an apron, Rung E is byte-identical and
+same-speed (move-aside is gated off when `apron_depth_m <= 0`).
+
+**Perf gate (no regression).** The fast `--gate` set is unchanged (correctness + determinism `ok`
+on every fast regime; `roomy_three_apron` ≈ 27 s, on par with its non-apron sibling
+`roomy_three_spread_on`). The phase-2-sensitive heavy disprove `tight_six_apron` likewise bails at
+phase-1 budget exhaustion (`budget (4000) exhausted`, ~80 s, `det ok`) — phase 2 never runs, so the
+two-phase change adds no cost there either. (Reproduce the all-8 re-baseline by routing
+`examples/herrenteich/layout.yaml` via `plan_fill(..., max_total_expansions=8000)` with
+`load_layout(..., apron_depth="auto")` vs `None`.)
+
+**Why no small fixture proves the *capability*.** A targeted search of ~480 synthetic 2–3 plane
+configs found **zero** move-aside resolutions. In a monotone fill any plane can be placed first into
+an empty hangar, so a *small* deadlock is necessarily a symmetric mutual block — and the displaced
+body's return leg is then blocked for the very same reason the stuck body was, so depth-1 move-aside
+cannot resolve it. Move-aside adds reachability only for **larger cyclic cores** (the ≥5-body core
+the Rung C reverse-teardown probe found), which a unit fixture can't capture. Rung E's capability is
+therefore exercised by the real phase-2 *execution* on real geometry (the `@slow`
+`test_move_aside_real_geometry_unresolvable_block_runs_phase2_and_bails`: the real `_staging_poses`
++ `plan_path` return legs run and bail cleanly) plus the control-flow unit tests
+(`tests/test_towplanner_fill.py`); it is **not** a guaranteed all-8 route.

--- a/docs/superpowers/plans/2026-06-29-667-rung-e-move-aside.md
+++ b/docs/superpowers/plans/2026-06-29-667-rung-e-move-aside.md
@@ -1,0 +1,718 @@
+# Rung E — Move-aside repair core (#667) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the empty-hangar fill planner resolve a mutual block by temporarily relocating an already-parked aircraft to an apron-out staging pose, routing the stuck aircraft, then returning the displaced one — producing a valid **multi-leg** `MovesPlan` (and a faithfully-animated `view`) — while keeping every non-shuffle layout's plan **byte-identical** (ADR-0003).
+
+**Architecture:** A **two-phase** order search in `_plan_fill` (`towplanner.py`). *Phase 1* is today's non-displacing backtracking DFS, run to completion, **byte-identical**. *Phase 2* runs **only if phase 1 fully deadlocks** (returns `None`, not a budget/backtrack-cap raise), with a fresh expansion budget: it re-runs the DFS with `allow_displace=True`, so at a dead-end level it picks a displaceable body **D** (deepest-first), enumerates **apron-out lateral** staging poses, routes three legs (D→staging, S→final, staging→D-final) via the existing `plan_path` single-start mode, then recurses. Move-aside is **gated on `hangar.apron_depth_m > 0`** (it relocates a body *outside* the door; the scenario hangar must model that apron — `--apron-depth auto|N` or `hangar.yaml`). A scene `_timeline` change lays legs in **global execution order when a multi-leg body is present** so the shuffle animates faithfully (single-leg plans keep the existing per-body path → byte-identical). The only other consumer fixes are two dev/CI `ml/` routed-leg counters.
+
+**Tech Stack:** Python 3.12, frozen-slots dataclasses, pytest, esbuild (viewer — *not rebuilt*; no `.ts` change). No new deps. The tow module stays RNG-free.
+
+## Global Constraints
+
+- **ADR-0003 byte-identity:** same scenario + seed → bit-identical `MovesPlan` and scene bytes. Any layout that does **not** trigger a shuffle must produce exactly what it produces today. **Two hinges:** (1) move-aside lives in *phase 2*, reached only when the *whole-fill* phase-1 DFS deadlocks (verify-before-displace at the fill level, not the per-DFS-level tail); (2) the scene global-order pass is gated on a multi-leg body actually being present.
+- **Move-aside requires `hangar.apron_depth_m > 0`.** No apron ⇒ `_try_move_aside` returns `None` (today's bail). This keeps every leg's geometry self-consistent with `target.hangar`: `plan_path`'s exact oracle `path_first_conflict` derives its motion-bounds hangar from `placed.hangar`, so the `placed` Layout for **every** leg must be built with the scenario `hangar` — and that hangar must already carry the apron, never a fabricated one.
+- **No RNG / no wall-clock** in `towplanner.py`. Determinism is structural.
+- **Tie-break keys:** which body to displace = `back_first_order` total order `(-y_m, +x_m, +plane_id)`; staging-pose enumeration = fixed grid, **y-outer (deepest first), x-outer (lateral, off-to-side), heading-inner**, exact-float `seen` set used **only to dedup, never to order**; route choice = first-feasible-in-enumeration-order wins; never iterate a `set` of plane-ids for emit order (membership only).
+- **Hand-placed bodies are never displaceable** (`Placement.hand_placed`).
+- **#668 Conflict-naming:** any bail names the **stuck body S**, never the displaced D — `raise NoFeasiblePlanError(bail.planes[0], bail)` with `bail` = the stuck body's conflict.
+- **#844 cross-machine:** move-aside is **same-machine-byte-bound** only (documented). The deepest-apron-pose lever hardens D's open-apron legs, but the tight leg (S threading the near-door corridor past D@staging) routes against the scenario hangar and remains libm-sensitive; keep move-aside **out of any cross-machine determinism canary**.
+- **Staging `target_slot` is transient** (apron-out, `y < 0`) and is **never** added to `target_layout.placements`. It lives only inside a `Move(leg_index=...)`.
+- **Budget accounting:** every `plan_path` call (aside, S-entry, return, and every failed attempt) folds `stats["expansions"]` into `total_used`. Phase 2 gets a **fresh** budget (reset `total_used`); phase 2 runs only after a *cheap* phase-1 deadlock, so worst-case disprove cost stays bounded (verify in Task 8's bench gate).
+- **Files Rung E may touch:** `src/hangarfit/towplanner.py`, `src/hangarfit/scene.py`, `ml/benchmark.py`, `ml/reach_rate.py`, `tests/test_towplanner.py`, `tests/test_towplanner_fill.py`, `tests/test_scene.py`, `tests/ml/test_*`, `bench/`, `CHANGELOG.md`, `docs/spikes/`. **Do not** edit `visualize.py`, `viewer/` (the Rung-D seam already handles multi-leg; no `.ts`/`viewer.js` change), `geometry.py`, `collisions.py`, `models.py`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/hangarfit/towplanner.py` | `MovesPlan.__post_init__` (F1); `_staging_poses` helper; `_FillStep` internal type; two-phase order search + `_try_move_aside` (+ `allow_displace` on `_place_rest`); new constant `_MAX_FILL_DISPLACEMENTS` + `plan_fill` `max_displacements` kwarg. |
+| `src/hangarfit/scene.py` | `_timeline` lays legs in global execution order **iff** a multi-leg body is present (else unchanged). |
+| `ml/benchmark.py`, `ml/reach_rate.py` | Count distinct routed `plane_id`s, not routed legs. |
+| `tests/test_towplanner.py` | F1 invariant accept/reject units. |
+| `tests/test_towplanner_fill.py` | `_staging_poses` unit; `_FillStep` regression; move-aside force-displacement unit (monkeypatch); geometry integration fixture + multi-leg validity validator; `max_displacements=0` inert byte-identity; two-phase byte-identity; double-solve. |
+| `tests/test_scene.py` | interleaved multi-leg timeline test; single-leg byte-identity stays green. |
+| `tests/ml/test_benchmark.py`, `tests/ml/test_reach_rate.py` | multi-leg routed-count regression. |
+| `bench/`, `CHANGELOG.md`, `docs/spikes/` | re-baseline + user entry + measured before/after + same-machine note. |
+
+**Mutual recursion:** `_try_move_aside` and `_place_rest` are both nested in `_plan_fill` and call each other; define `_place_rest` first, then `_try_move_aside`, then run the two phases. Name resolution at call time makes the forward reference safe.
+
+---
+
+### Task 1: F1 — `MovesPlan` aggregate leg-index invariant
+
+**Files:** Modify `src/hangarfit/towplanner.py:270-278`; Test `tests/test_towplanner.py`.
+
+**Interfaces:** Produces `MovesPlan.__post_init__` — *for each `plane_id`, the `leg_index` values of its **routed** (`path is not None`) moves are distinct.* Deferred `path=None` legs exempt; no `target_slot ∈ placements` check.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_towplanner.py  (reuse this file's _layout()/_arc helpers; add minimal ones if absent)
+import pytest
+from hangarfit.towplanner import Move, MovesPlan, Pose
+
+def test_movesplan_rejects_duplicate_routed_leg_index_for_a_plane(_layout, _arc):
+    with pytest.raises(ValueError, match="leg_index"):
+        MovesPlan(target_layout=_layout, moves=(
+            Move("fk9", Pose(0.0, 5.0, 0.0), _arc, leg_index=0),
+            Move("fk9", Pose(1.0, 6.0, 0.0), _arc, leg_index=0),
+        ))
+
+def test_movesplan_allows_routed_plus_deferred_same_leg_index(_layout, _arc):
+    MovesPlan(target_layout=_layout, moves=(
+        Move("fuji", Pose(0.0, 5.0, 0.0), _arc, leg_index=0),
+        Move("fuji", Pose(0.0, 5.0, 0.0), None, leg_index=0),
+    ))
+
+def test_movesplan_allows_distinct_routed_legs_same_plane(_layout, _arc):
+    MovesPlan(target_layout=_layout, moves=(
+        Move("ctsl", Pose(0.0, -3.0, 180.0), _arc, leg_index=0),
+        Move("ctsl", Pose(0.0, 5.0, 0.0), _arc, leg_index=1),
+    ))
+```
+
+- [ ] **Step 2: Run to verify the reject test fails**
+Run: `pytest tests/test_towplanner.py -k movesplan -v` → reject test FAILS; allow tests already PASS.
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/hangarfit/towplanner.py — inside class MovesPlan, after the fields
+    def __post_init__(self) -> None:
+        # #667 Rung E (type-design F1): a plane's ROUTED legs must carry distinct
+        # leg_index so scene._timeline's sorted(..., key=leg_index) is well-defined.
+        # Deferred (path=None) legs are exempt — build_moves_plan (ml/infer.py) and
+        # placed-routed movers legitimately emit a routed + a deferred leg both at
+        # leg_index=0; mover/deferred target_slots also need not be in placements,
+        # so NO target_slot membership check is added.
+        seen_routed: dict[str, set[int]] = {}
+        for m in self.moves:
+            if m.path is None:
+                continue
+            legs = seen_routed.setdefault(m.plane_id, set())
+            if m.leg_index in legs:
+                raise ValueError(
+                    f"MovesPlan: plane {m.plane_id!r} has duplicate routed "
+                    f"leg_index {m.leg_index}"
+                )
+            legs.add(m.leg_index)
+```
+
+- [ ] **Step 4: Run** `pytest tests/test_towplanner.py tests/test_scene.py tests/ml/test_infer.py -q` → PASS.
+- [ ] **Step 5: Commit** `git commit -m "feat(667): Rung E — MovesPlan routed-leg-index uniqueness invariant (F1)"`
+
+---
+
+### Task 2: Fix `ml/` routed-leg counters (count planes, not legs)
+
+**Files:** Modify `ml/benchmark.py:299`, `ml/reach_rate.py:312`; Test `tests/ml/test_benchmark.py`, `tests/ml/test_reach_rate.py`.
+
+> A multi-leg plan has routed *legs* > planes, so `sum(...) == n_total` silently flips to a false negative. Must land in this PR (dev/CI-only, but `plan_fill` is the exact Rung-E producer these call).
+
+- [ ] **Step 1: Write the failing test** (analogous in both modules)
+
+```python
+# tests/ml/test_benchmark.py
+def test_rrmc_verdict_counts_planes_not_legs(monkeypatch):
+    import ml.benchmark as bm
+    from hangarfit.towplanner import Move, MovesPlan, Pose
+    plan = MovesPlan(target_layout=_FAKE_LAYOUT, moves=(
+        Move("a", Pose(0, -3, 180), _ARC, leg_index=0),   # staging
+        Move("a", Pose(0, 5, 0), _ARC, leg_index=1),       # final
+        Move("b", Pose(1, 4, 0), _ARC, leg_index=0),
+    ))
+    monkeypatch.setattr(bm, "plan_fill", lambda *a, **k: plan)
+    verdict = bm._rrmc_verdict(_SCENARIO_WITH_2_PLACEABLE, _RESULT_VALID_LAYOUT)
+    assert verdict.n_routed == 2 and verdict.reached is True
+```
+
+- [ ] **Step 2: Run** `pytest tests/ml/test_benchmark.py -k counts_planes -v` → FAIL (`n_routed == 3`).
+- [ ] **Step 3: Implement**
+
+```python
+# ml/benchmark.py:299
+    n_routed = len({m.plane_id for m in plan.moves if m.path is not None})
+```
+```python
+# ml/reach_rate.py:312
+        if len({m.plane_id for m in plan.moves if m.path is not None}) == n_total:
+```
+
+- [ ] **Step 4: Run** `pytest tests/ml/test_benchmark.py tests/ml/test_reach_rate.py -q` → PASS.
+- [ ] **Step 5: Commit** `git commit -m "fix(667): Rung E — ml/ reach counters count distinct planes not routed legs"`
+
+---
+
+### Task 3: `_staging_poses` helper (apron-out, lateral, deepest-first)
+
+**Files:** Modify `src/hangarfit/towplanner.py` (add a module-level helper after `entry_pose`, ~line 1194); Test `tests/test_towplanner_fill.py`.
+
+**Interfaces:** Produces `_staging_poses(target: Placement, hangar: Hangar) -> tuple[Pose, ...]` — apron-out (`y<0`) nose-out **lateral** staging candidates for a displaced body, ordered **y-outer (deepest first), x-outer (off-to-side first), heading-inner**, exact-float `seen` dedup. Empty if `apron_depth_m <= 0`.
+
+> **Lateral, not in front of the door.** Door-clamped staging parks D *in the corridor S must enter through* — the viability paradox pushed deeper. D must roll *off to the side* on the apron. x-samples span the apron width (left-of-door, right-of-door, door-centre fallback), clamped to `[0, width]`; infeasible/out-of-bounds candidates are rejected by the routing legs, so no static pre-filter is needed here.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_towplanner_fill.py
+from hangarfit.towplanner import _staging_poses
+
+def test_staging_poses_are_apron_out_lateral_deepest_first_nose_out():
+    h = _hangar(apron_depth_m=6.0)              # this file's _hangar() helper; door narrower than width
+    slot = _slot("d", x=4.0, y=8.0, heading=0.0)
+    poses = _staging_poses(slot, h)
+    assert poses
+    assert all(p.y_m < 0.0 for p in poses)                       # outside the door
+    assert poses[0].y_m == -6.0                                  # deepest first (#844 margin)
+    assert any(p.x_m < h.door.center_x_m - h.door.width_m / 2 or  # lateral, off the door
+               p.x_m > h.door.center_x_m + h.door.width_m / 2 for p in poses)
+    assert all(135.0 <= p.heading_deg <= 225.0 for p in poses)   # nose-out cone
+    assert _staging_poses(slot, h) == poses                      # deterministic
+    assert len({(p.x_m, p.y_m, p.heading_deg) for p in poses}) == len(poses)
+
+def test_staging_poses_empty_without_apron():
+    assert _staging_poses(_slot("d", 4.0, 8.0, 0.0), _hangar(apron_depth_m=0.0)) == ()
+```
+
+- [ ] **Step 2: Run** `pytest tests/test_towplanner_fill.py -k staging_poses -v` → FAIL (`ImportError`).
+- [ ] **Step 3: Implement**
+
+```python
+# src/hangarfit/towplanner.py — after entry_pose() (~line 1194)
+def _staging_poses(target: Placement, hangar: Hangar) -> tuple[Pose, ...]:
+    """Apron-out (y<0) nose-out LATERAL staging candidates for a displaced body
+    (#667 Rung E).
+
+    Reuses entry_poses' apron y-samples but parks the body OFF TO THE SIDE of the
+    door (x spans the apron width, not just the door opening) so it does not jam the
+    corridor the stuck body must enter through — the real club shuffle rolls a plane
+    laterally aside, not straight out the door. Headings are nose-out
+    (_REVERSE_CONE_HEADINGS, ~180°) so the body parks fully outside. Ordered
+    y-OUTER (deepest apron first → #844 cost margin), x-OUTER (off-to-side first),
+    heading-inner; the `seen` set dedups only, never orders (ADR-0003 tie-break 2).
+    Empty if no apron. Infeasible/out-of-bounds candidates are dropped later by the
+    routing legs (path_first_conflict), so no static pre-filter here.
+    """
+    depth = hangar.apron_depth_m
+    if depth <= 0.0:
+        return ()
+    door = hangar.door
+    half = door.width_m / 2.0
+    lo = door.center_x_m - half
+    hi = door.center_x_m + half
+    width = hangar.width_m
+
+    def _clamp(x: float) -> float:
+        return min(max(x, 0.0), width)
+
+    # Lateral x: midpoint of the left apron strip, midpoint of the right strip, then
+    # the door centre as a fallback. Off-to-side first (x-outer), so D clears S's
+    # door swath before a centre pose is tried.
+    x_left = _clamp(lo / 2.0)
+    x_right = _clamp((hi + width) / 2.0)
+    x_centre = _clamp(door.center_x_m)
+    x_samples = (x_left, x_right, x_centre)
+    y_samples = (-depth, -depth / 2.0)  # deepest first (#844 margin)
+
+    seen: set[tuple[float, float, float]] = set()
+    poses: list[Pose] = []
+    for y in y_samples:  # outer: deepest apron first
+        for x in x_samples:  # middle: off-to-side first, door-centre last
+            for h in _REVERSE_CONE_HEADINGS:  # inner: nose-out cone
+                key = (x, y, h)
+                if key in seen:
+                    continue
+                seen.add(key)
+                poses.append(Pose(x_m=x, y_m=y, heading_deg=h))
+    return tuple(poses)
+```
+
+- [ ] **Step 4: Run** `pytest tests/test_towplanner_fill.py -k staging_poses -v` → PASS.
+- [ ] **Step 5: Commit** `git commit -m "feat(667): Rung E — apron-out lateral staging-pose enumeration"`
+
+---
+
+### Task 4: `_FillStep` result-type refactor (byte-identical, no behavior change)
+
+**Files:** Modify `src/hangarfit/towplanner.py` — add `_FillStep` near `MovesPlan` (~line 279); change `_place_rest` success path (1948-1950) + materialization loop (1984-1998). Existing fill tests are the regression net.
+
+**Interfaces:** Produces `_FillStep(moves: tuple[Move, ...], committed: tuple[Placement, ...], apron_fallback_planes: tuple[str, ...])`. A normal step: `moves=(Move(slot.plane_id, Pose.from_placement(slot), arc),)` (default `leg_index=0`), `committed=(slot,)`, `apron_fallback_planes=(slot.plane_id,) if apron_fb else ()`.
+
+> Pure refactor; the materialized `MovesPlan`/`placed`/`apron_dropped_out` must be **identical** to today.
+
+- [ ] **Step 1: Add the type**
+
+```python
+# src/hangarfit/towplanner.py — after MovesPlan (~line 279)
+@dataclass(frozen=True, slots=True)
+class _FillStep:
+    """One committed unit of an order-search result (#667 Rung E). A normal
+    placement emits one Move + commits one Placement. A move-aside emits THREE moves
+    (displaced-aside, stuck-final, displaced-return) and commits ONE placement (the
+    stuck body; the displaced body is already in `placed`). `apron_fallback_planes`
+    names committed bodies that towed via the y=0 door-line fallback despite an apron
+    (#503 diagnostic). Internal to _plan_fill; never exposed."""
+    moves: tuple[Move, ...]
+    committed: tuple[Placement, ...]
+    apron_fallback_planes: tuple[str, ...]
+```
+
+- [ ] **Step 2: Change `_place_rest`'s return annotation + success path**
+
+```python
+    def _place_rest(
+        placed_list: list[Placement], rest: list[Placement]
+    ) -> list[_FillStep] | None:
+        ...
+            sub = _place_rest(placed_list + [slot], rest[:idx] + rest[idx + 1 :])
+            if sub is not None:
+                step = _FillStep(
+                    moves=(Move(slot.plane_id, Pose.from_placement(slot), arc),),
+                    committed=(slot,),
+                    apron_fallback_planes=(slot.plane_id,) if apron_fb else (),
+                )
+                return [step, *sub]
+            backtracks_used += 1
+            ...
+```
+
+- [ ] **Step 3: Change materialization** (replace 1984-1998)
+
+```python
+    for step in result:
+        moves.extend(step.moves)
+        placed.extend(step.committed)
+        if apron_dropped_out is not None:
+            for pid in step.apron_fallback_planes:
+                apron_dropped_out.append(
+                    ApronShallowDrop(
+                        plane_id=pid,
+                        min_depth_m=_plane_fore_aft_length_m(fleet[pid]),
+                    )
+                )
+```
+
+- [ ] **Step 4: Run the byte-identity net** `pytest tests/test_towplanner_fill.py tests/test_solver_towplanner.py -q` → PASS (esp. `test_plan_fill_is_deterministic`, `..._inert_with_no_hand_placed_body`, `..._backtracks_order_...`, `..._backtrack_cap_...`).
+- [ ] **Step 5: Commit** `git commit -m "refactor(667): Rung E — _place_rest returns _FillStep units (byte-identical)"`
+
+---
+
+### Task 5: Two-phase order search + move-aside core
+
+**Files:** Modify `src/hangarfit/towplanner.py` — `_MAX_FILL_DISPLACEMENTS` constant; `plan_fill`/`_plan_fill` `max_displacements` kwarg; nonlocals; `allow_displace` on `_place_rest`; `_try_move_aside`; the two-phase driver replacing the single `result = _place_rest(...)` call (1969). Test `tests/test_towplanner_fill.py`.
+
+**Interfaces:** Consumes `_FillStep` (T4), `_staging_poses` (T3). Produces `_MAX_FILL_DISPLACEMENTS = 16`; `plan_fill(..., max_displacements: int | None = None)` (`None` ⇒ constant; `0` ⇒ disabled). Move-aside emits a `_FillStep` with `moves=(Move(D, staging, aside, leg_index=1), Move(S, S_final, s_arc, leg_index=0), Move(D, D_final, ret, leg_index=2))`, `committed=(S_slot,)`.
+
+- [ ] **Step 1: Write the failing tests (monkeypatched `plan_path`)**
+
+```python
+def test_plan_fill_resolves_mutual_block_via_move_aside(monkeypatch):
+    target = _two_plane_mutual_block_layout()    # apron_depth_m>0; S deep, D in the only corridor
+    s_id, d_id = "stuck", "blocker"
+
+    def fake_plan_path(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):
+        stats = kw.get("stats")
+        if stats is not None:
+            stats["expansions"] = 1
+        present = {p.plane_id for p in placed.placements}
+        moving = getattr(mover, "id", None)
+        if goal.y_m < 0.0 or entry.y_m < 0.0:        # D's aside/return legs (apron) succeed
+            return _fake_arc(entry, goal)
+        if moving == s_id and d_id in present:        # S blocked while D present
+            raise _forced_infeasible(s_id)
+        return _fake_arc(entry, goal)                 # D's original placement + S-when-D-absent
+
+    monkeypatch.setattr(tp, "plan_path", fake_plan_path)
+    plan = tp.plan_fill(target)
+    legs = {(m.plane_id, m.leg_index) for m in plan.moves if m.path is not None}
+    assert {(s_id, 0), (d_id, 0), (d_id, 1), (d_id, 2)} <= legs
+    order = [(m.plane_id, m.leg_index) for m in plan.moves if m.path is not None]
+    assert order.index((d_id, 1)) < order.index((s_id, 0)) < order.index((d_id, 2))
+
+def test_plan_fill_max_displacements_zero_is_inert(monkeypatch):
+    target = _two_plane_mutual_block_layout()
+    monkeypatch.setattr(tp, "plan_path", _fake_that_needs_displacement())
+    with pytest.raises(tp.NoFeasiblePlanError) as exc:
+        tp.plan_fill(target, max_displacements=0)
+    assert exc.value.plane_id == "stuck"             # #668: names the STUCK body
+
+def test_plan_fill_move_aside_skipped_without_apron(monkeypatch):
+    target = _two_plane_mutual_block_layout(apron_depth_m=0.0)
+    monkeypatch.setattr(tp, "plan_path", _fake_that_needs_displacement())
+    with pytest.raises(tp.NoFeasiblePlanError):     # no apron ⇒ move-aside cannot fire
+        tp.plan_fill(target)
+```
+
+- [ ] **Step 2: Run** `pytest tests/test_towplanner_fill.py -k "move_aside or max_displacements_zero" -v` → FAIL.
+
+- [ ] **Step 3: Constant + kwarg + nonlocals**
+
+```python
+# near _MAX_FILL_BACKTRACKS (~line 2116)
+_MAX_FILL_DISPLACEMENTS = 16  # GLOBAL cap on committed move-aside recursions (#667).
+# Each (S,D,staging) combo whose three legs all route and which RECURSES counts once
+# (whether or not it ultimately succeeds): a monotonic, non-decremented global ceiling
+# that terminates the move-aside search independent of the per-plane expansion budget.
+# Per-path cycle-safety + clean leg_index come from `displaced_planes` (a body is
+# displaced at most once per DFS path); depth is structurally 1 (a shuffle's legs are
+# direct plan_path calls, never a nested order search). 0 ⇒ move-aside disabled
+# (byte-identical to pre-Rung-E).
+```
+
+Thread `max_displacements` through `plan_fill` (signature + the `_plan_fill(..., max_displacements=max_displacements)` call) and `_plan_fill` (signature). Near the other budgets (~1848):
+
+```python
+    disp_cap = _MAX_FILL_DISPLACEMENTS if max_displacements is None else max_displacements
+    displacements_used = 0          # monotonic global counter (never decremented)
+    displaced_planes: set[str] = set()  # per-path membership — add before recurse, discard on fail
+```
+
+Add `displacements_used` to `_place_rest`'s and `_try_move_aside`'s `nonlocal` (sets are mutated in place, so `displaced_planes` needs no `nonlocal`).
+
+- [ ] **Step 4: Add `allow_displace` to `_place_rest` + the tail hook**
+
+Change the signature to `def _place_rest(placed_list, rest, allow_displace: bool = False)`, propagate it on the recursive call (`_place_rest(placed_list + [slot], rest[:idx] + rest[idx + 1 :], allow_displace=allow_displace)`), and replace the final `return None` (1967) with:
+
+```python
+        if allow_displace:
+            ms = _try_move_aside(placed_list, rest)
+            if ms is not None:
+                return ms
+        return None
+```
+
+- [ ] **Step 5: Add `_try_move_aside`** (immediately after `_place_rest`)
+
+```python
+    def _try_move_aside(
+        placed_list: list[Placement], rest: list[Placement]
+    ) -> list[_FillStep] | None:
+        """Depth-1 move-aside (#667 Rung E), phase 2 only. For the deepest stuck body
+        S, displace a committed body D (deepest-first, never hand-placed, never twice
+        per DFS path) to an apron-out lateral staging pose, route S past D@staging,
+        return D to its slot, then recurse. First feasible (S, D, staging) in
+        deterministic order wins. Requires hangar.apron_depth_m > 0. Returns the step
+        list or None."""
+        nonlocal total_used, displacements_used
+        if displacements_used >= disp_cap or hangar.apron_depth_m <= 0.0:
+            return None
+
+        def _layout_of(placements: list[Placement]) -> Layout:
+            # All legs use the SCENARIO `hangar` (which carries the apron): plan_path's
+            # path_first_conflict derives motion bounds from placed.hangar, so a y<0
+            # staging sweep is only exempt when placed.hangar.apron_depth_m > 0.
+            return Layout(
+                fleet=fleet, hangar=hangar, placements=tuple(placements),
+                maintenance_plane=target.maintenance_plane,
+                ground_objects=target.ground_objects,
+                ground_object_placements=fixed_obstacle_placements,
+            )
+
+        def _route(
+            mover: Aircraft, start: Pose, goal: Pose, *,
+            placed_obs: Layout, on_carts: bool,
+        ) -> DubinsArc | None:
+            # Single-start plan_path wrapper; charges expansions to total_used on
+            # success OR failure; never touches deepest_conflict (the phase-2 main
+            # loop's capture is the #668 actionable reason).
+            nonlocal total_used
+            remaining = total_budget - total_used
+            if remaining <= 0:
+                return None
+            stats: dict[str, object] = {}
+            try:
+                arc = plan_path(
+                    mover, start, goal, hangar=hangar, placed=placed_obs,
+                    mover_on_carts=on_carts, heuristic=heuristic,
+                    max_expansions=min(budget, remaining), stats=stats,
+                )
+            except NoFeasiblePlanError:
+                exp = stats.get("expansions", 0)
+                total_used += exp if isinstance(exp, int) else 0
+                return None
+            exp = stats.get("expansions", 0)
+            total_used += exp if isinstance(exp, int) else 0
+            return arc
+
+        for s_slot in rest:  # rest is back_first_order: deepest stuck body first
+            displaceable = back_first_order(
+                tuple(p for p in placed_list
+                      if not p.hand_placed and p.plane_id not in displaced_planes)
+            )
+            for d_slot in displaceable:
+                without_d = [p for p in placed_list if p.plane_id != d_slot.plane_id]
+                d_aircraft = fleet[d_slot.plane_id]
+                for staging in _staging_poses(d_slot, hangar):
+                    aside = _route(  # leg 1 — D: final -> staging (S not yet in)
+                        d_aircraft, Pose.from_placement(d_slot), staging,
+                        placed_obs=_layout_of(without_d), on_carts=d_slot.on_carts,
+                    )
+                    if aside is None:
+                        continue
+                    d_at_staging = Placement(
+                        d_slot.plane_id, staging.x_m, staging.y_m,
+                        staging.heading_deg, d_slot.on_carts, d_slot.hand_placed,
+                    )
+                    # S: door -> final, against others + D@staging.
+                    remaining = total_budget - total_used
+                    if remaining <= 0:
+                        return None
+                    s_cone = entry_poses(s_slot, hangar)
+                    s_stats: dict[str, object] = {}
+                    try:
+                        s_arc = plan_path(
+                            fleet[s_slot.plane_id], s_cone[0],
+                            Pose.from_placement(s_slot), hangar=hangar,
+                            placed=_layout_of([*without_d, d_at_staging]),
+                            mover_on_carts=s_slot.on_carts, entries=s_cone,
+                            heuristic=heuristic,
+                            max_expansions=min(budget, remaining), stats=s_stats,
+                        )
+                    except NoFeasiblePlanError:
+                        exp = s_stats.get("expansions", 0)
+                        total_used += exp if isinstance(exp, int) else 0
+                        continue
+                    exp = s_stats.get("expansions", 0)
+                    total_used += exp if isinstance(exp, int) else 0
+                    s_apron_fb = s_stats.get("apron_fallback") is True
+                    ret = _route(  # leg 2 — D: staging -> final, against others + S@final
+                        d_aircraft, staging, Pose.from_placement(d_slot),
+                        placed_obs=_layout_of([*without_d, s_slot]),
+                        on_carts=d_slot.on_carts,
+                    )
+                    if ret is None:
+                        continue
+                    # All three legs feasible — commit and recurse for the rest.
+                    if displacements_used >= disp_cap:
+                        return None
+                    displacements_used += 1
+                    displaced_planes.add(d_slot.plane_id)
+                    new_rest = [p for p in rest if p.plane_id != s_slot.plane_id]
+                    sub = _place_rest(placed_list + [s_slot], new_rest, allow_displace=True)
+                    if sub is not None:
+                        step = _FillStep(
+                            moves=(
+                                Move(d_slot.plane_id, staging, aside, leg_index=1),
+                                Move(s_slot.plane_id, Pose.from_placement(s_slot),
+                                     s_arc, leg_index=0),
+                                Move(d_slot.plane_id, Pose.from_placement(d_slot),
+                                     ret, leg_index=2),
+                            ),
+                            committed=(s_slot,),
+                            apron_fallback_planes=(s_slot.plane_id,) if s_apron_fb else (),
+                        )
+                        return [step, *sub]
+                    displaced_planes.discard(d_slot.plane_id)  # per-path undo; counter stays
+        return None
+```
+
+- [ ] **Step 6: Replace the single search call with the two-phase driver** (at ~1969)
+
+```python
+    # Phase 1: today's non-displacing DFS, byte-identical. May RAISE on budget /
+    # backtrack-cap exhaustion (propagates → no phase 2, so an un-routable fill's
+    # disprove cost stays 1×). Returns None only on an IN-BUDGET deadlock.
+    result = _place_rest(placed, ordered, allow_displace=False)
+    if result is None:
+        # Phase 2 (#667 Rung E): the whole-fill order search deadlocked within budget
+        # — enable move-aside with a FRESH expansion budget. Reached only here, so any
+        # layout phase 1 solves is byte-identical (ADR-0003). Phase 2 runs only after a
+        # cheap phase-1 deadlock, bounding worst-case disprove cost.
+        total_used = 0
+        backtracks_used = 0
+        deepest_conflict = None
+        result = _place_rest(placed, ordered, allow_displace=True)
+    if result is None:
+        bail = deepest_conflict or Conflict.single(
+            kind="no_feasible_path",
+            plane=ordered[0].plane_id,
+            detail="no feasible tow order (every placement order deadlocks)",
+        )
+        raise NoFeasiblePlanError(bail.planes[0], bail)
+```
+
+(Delete the old `result = _place_rest(placed, ordered)` + its `if result is None:` raise — folded above.)
+
+- [ ] **Step 7: Run** `pytest tests/test_towplanner_fill.py tests/test_towplanner.py tests/test_solver_towplanner.py -q` → PASS (move-aside resolves the block; `max_displacements=0` and no-apron both bail naming the stuck body; all inert/determinism/backtracking tests green).
+- [ ] **Step 8: Commit** `git commit -m "feat(667): Rung E — two-phase order search + depth-1 move-aside repair"`
+
+---
+
+### Task 6: Scene `_timeline` — global execution order when multi-leg
+
+**Files:** Modify `src/hangarfit/scene.py` `_timeline` (~249-331); Test `tests/test_scene.py`.
+
+> **Why required:** today `_timeline` lays a body's legs contiguously then the next body, so a move-aside `view` plays D-in→aside→**return**, then S — and `affineAt` parks D at its final slot during S's entry, rendering **S driving through D's parked slot**. Faithful animation needs legs in global execution order. **Gated on a multi-leg body being present** so every single-leg plan (inert + backtracked) keeps today's per-body path → byte-identical (ADR-0003). Viewer needs **no** change (`affineAt` already rests a body at its staging pose between non-contiguous legs; recon-confirmed). `SCHEMA` stays `hangarfit.scene/v2` (no new keys).
+
+- [ ] **Step 1: Write the failing + regression tests**
+
+```python
+# tests/test_scene.py
+def test_timeline_interleaves_legs_in_global_execution_order():
+    # plan tuple order: D-aside(leg1), S(leg0), D-return(leg2)  → segments must follow it
+    plan = _moveaside_plan()   # build a MovesPlan whose .moves is [D@stg, S@final, D@final]
+    tl, finals = _timeline(plan.target_layout, plan, tow_speed_mps=1.0)
+    segs = tl["segments"]
+    seq = [(s["plane_id"], s.get("leg_index")) for s in segs]
+    assert seq == [("D", 1), ("S", 0), ("D", 2)]                 # interleaved, tuple order
+    assert segs[0]["end_s"] == segs[1]["start_s"]                # contiguous global clock
+    assert finals["D"] == segs[2]["samples"][-1]                 # D ends at its slot, not staging
+
+def test_timeline_single_leg_unchanged_byte_identical():
+    # the existing single-leg fixtures must produce byte-identical segments (no regression)
+    ...  # keep/extend the existing test_scene single-leg assertions
+```
+
+The existing `test_timeline_multi_leg_emits_one_segment_per_leg_in_leg_order` (one body, 2 consecutive legs) stays green: with one multi-leg body and no other body between its legs in the tuple, the global-order path emits them contiguously — same result.
+
+- [ ] **Step 2: Run** `pytest tests/test_scene.py -k "interleave or multi_leg or single_leg" -v` → interleave test FAILS (legs grouped per body today).
+
+- [ ] **Step 3: Implement** — in `_timeline`, after building `moves_by_id`, detect multi-leg and branch:
+
+```python
+    multi_leg_present = any(
+        sum(1 for m in legs if m.path is not None) > 1 for legs in moves_by_id.values()
+    )
+    if multi_leg_present:
+        # #667 Rung E: lay routed legs in GLOBAL execution order (moves tuple order)
+        # so a move-aside shuffle animates faithfully (D-aside → S enters → D returns).
+        # Gated on a multi-leg body being present, so single-leg plans keep the
+        # back_first_order path below → byte-identical (ADR-0003). finals still take
+        # each routed leg's samples[-1] in tuple order, so a body's last leg (its
+        # return-to-slot) sets its final pose.
+        for m in moves_plan.moves:
+            if m.path is None:
+                continue
+            _append_one_leg(m)   # emit one segment for this leg, advancing the shared t
+    else:
+        for placement in back_first_order(layout.placements):
+            _append_segment(placement.plane_id, record_final=True)
+        for gp in sorted(layout.ground_object_placements, key=lambda p: p.plane_id):
+            _append_segment(gp.plane_id, record_final=False)
+```
+
+Factor the per-leg segment body out of `_append_segment` into a small `_append_one_leg(move)` helper (duration clamp, `seg` dict with `leg_index` key only when `multi_leg_present`, `t += dur`, `finals[move.plane_id] = samples[-1]`), and have the existing `_append_segment` call it per leg so the single-leg path is unchanged. Keep `samples`/`start_s`/`end_s`/`leg_index` shapes identical to today.
+
+- [ ] **Step 4: Run** `pytest tests/test_scene.py tests/test_viewer.py -q` → PASS (interleave test green; single-leg + existing multi-leg byte-identity green).
+- [ ] **Step 5: Headless viewer sanity** (optional but recommended): render the Task-7 fixture with `view`, screenshot headless (the CLAUDE.md swiftshader recipe), confirm S enters while D sits on the apron and no transform banner.
+- [ ] **Step 6: Commit** `git commit -m "feat(667): Rung E — scene timeline lays legs in global execution order for shuffles"`
+
+---
+
+### Task 7: Geometry integration fixture + multi-leg validity validator + double-solve byte-identity
+
+**Files:** Test `tests/test_towplanner_fill.py`.
+
+**Interfaces:** Real `plan_fill`/`plan_path`/`path_first_conflict`; an apron>0 fixture that **forces** a real shuffle; `_assert_plan_legs_valid(plan, target)` replaying legs in tuple order with a live pose map.
+
+- [ ] **Step 1: Write the validator + fixture test**
+
+```python
+def _assert_plan_legs_valid(plan, target):
+    """Every routed leg is collision-free against the world state at execution time.
+    Fixture-scoped: aircraft-only, apron>0 (target.hangar carries the apron the
+    planner used). Replays plan.moves in tuple order with a live {plane_id: Pose}; a
+    staging leg's target_slot (y<0) is transient → only the motion oracle applies."""
+    from hangarfit.towplanner import path_first_conflict
+    fleet = target.fleet
+    current: dict[str, object] = {}
+    on_carts = {p.plane_id: p.on_carts for p in target.placements}
+    for m in plan.moves:
+        if m.path is None:
+            continue
+        others = [
+            Placement(pid, pose.x_m, pose.y_m, pose.heading_deg, on_carts.get(pid, False))
+            for pid, pose in current.items() if pid != m.plane_id
+        ]
+        obstacles = Layout(
+            fleet=fleet, hangar=target.hangar, placements=tuple(others),
+            maintenance_plane=target.maintenance_plane,
+            ground_objects=target.ground_objects,
+            ground_object_placements=tuple(
+                gp for gp in target.ground_object_placements
+                if target.ground_objects[gp.plane_id].object_class == "fixed_obstacle"
+            ),
+        )
+        assert path_first_conflict(
+            m.path, fleet[m.plane_id],
+            mover_on_carts=on_carts.get(m.plane_id, False), placed=obstacles,
+        ) is None, f"leg {m.plane_id} #{m.leg_index} collides at execution time"
+        current[m.plane_id] = m.target_slot
+
+def test_move_aside_geometry_fixture_routes_and_is_valid():
+    target = _corridor_block_fixture()   # apron_depth_m>0; D between door and S's deep slot
+    plan = plan_fill(target)
+    assert {m.plane_id for m in plan.moves if m.path is not None} == {p.plane_id for p in target.placements}
+    assert any(m.leg_index > 0 for m in plan.moves), "fixture must force a shuffle"
+    _assert_plan_legs_valid(plan, target)
+
+def test_move_aside_plan_is_byte_identical_double_solve():
+    target = _corridor_block_fixture()
+    assert plan_fill(target) == plan_fill(target)
+```
+
+`_corridor_block_fixture()`: a hangar with `apron_depth_m > 0` and a **door narrower than the hangar width** (so lateral apron room exists beside the door), two box planes where D sits squarely in the only door→deep-slot corridor; with D rolled to a side-apron pose the corridor opens for S. Build with this file's `_box_plane`/`_hangar`/`_slot` helpers. **Verify by hand** the static all-bodies layout is valid (`hangarfit check`), and that a lateral deepest staging pose provably clears S's door swath (the medium-finding caveat — tune door width / D depth until it does).
+
+- [ ] **Step 2: Run** `pytest tests/test_towplanner_fill.py -k move_aside_geometry -v`. If the plan is single-leg, tighten the corridor until move-aside is the only resolution; if S can't thread past D@staging, widen the door / shallow D so a lateral pose clears it.
+- [ ] **Step 3:** If the validator surfaces a real bug, fix it under systematic-debugging, re-run.
+- [ ] **Step 4: Run** `pytest tests/test_towplanner_fill.py -q && pytest tests/test_solver_canaries.py -q -m ""` → PASS.
+- [ ] **Step 5: Commit** `git commit -m "test(667): Rung E — move-aside geometry fixture + multi-leg validity + byte-identity"`
+
+---
+
+### Task 8: Re-baseline the bench ceiling + CHANGELOG + spike
+
+**Files:** `bench/regimes.py`, `bench/profile_pipeline.py`, `CHANGELOG.md`, `docs/spikes/herrenteich-routing-ceiling-baseline.md`.
+
+- [ ] **Step 1: Re-run the Rung B witness baseline with `--apron-depth auto`** (move-aside needs an apron). Run `python -m bench.profile_pipeline --heavy` and record routed-body counts / timing vs Rung B. **Confirm the disprove wall-clock stays under the perf gate** (the two-phase fresh budget can add cost only for in-budget deadlocks; Herrenteich is budget-bound → phase-1 raise → no phase 2 → 1× cost). If a regime regresses past the gate, cap phase-2's budget (a separate constant) and re-measure.
+- [ ] **Step 2:** Append a "Rung E (move-aside)" section to the routing-ceiling spike (measured before/after; the same-machine-byte-bound #844 note). CHANGELOG `[Unreleased] ### Added`:
+
+```markdown
+- Tow-path fill planner can resolve a mutual block by temporarily relocating a
+  parked aircraft to an apron-out staging pose and returning it ("move-aside"),
+  producing a valid multi-leg plan (and a faithfully animated `view`) where a
+  monotone fill has none — requires a staging apron (`--apron-depth`/hangar apron)
+  and is bounded depth-1 (#667 Rung E). Layouts that don't need a shuffle are
+  byte-identical (ADR-0003).
+```
+
+(Write **milestone N** bare in CHANGELOG prose; `#667` issue refs are correct.)
+
+- [ ] **Step 3: Verification gate** `make test && ruff check src/ tests/ && ruff format --check src/ tests/ && mypy src/hangarfit/ && mypy ml/` → all green.
+- [ ] **Step 4: Commit** `git commit -m "docs(667): Rung E — re-baseline routing ceiling + CHANGELOG"`
+
+---
+
+## Review & Guard Plan (after the branch is green)
+
+Open a **draft** PR (`Closes #<rung-E-issue>`, base `develop`), run the review arc — one inline thread per finding, fix, resolve, re-review if non-trivial:
+
+- **`determinism-guard`** — MANDATORY (`towplanner.py`). Double-solve diff; confirm two-phase inert byte-identity + `max_displacements`-scoped determinism. **State move-aside is same-machine-byte-bound only** (keep it out of cross-machine canaries).
+- **`scene-schema-guard`** — MANDATORY now (`scene.py` touched). Confirm `build_scene` byte-identical for single-leg plans; `SCHEMA` unchanged; the global-order path additive.
+- **`pr-review-toolkit:code-reviewer`** — main pass.
+- **`pr-review-toolkit:silent-failure-hunter`** — the `try/except NoFeasiblePlanError` swallow points in `_try_move_aside`/`_route` (each must charge budget, not hide a real error).
+- **`pr-review-toolkit:type-design-analyzer`** — `MovesPlan.__post_init__` + `_FillStep`.
+- **`ml-rl-guard`** — the `ml/benchmark.py`/`ml/reach_rate.py` counters.
+- `geometry-invariant-guard` is **not** triggered (no `geometry.py`/`collisions.py` change) — note explicitly.
+
+---
+
+## Self-Review
+
+**Adversarial-review findings (all incorporated):**
+- F1 inert-byte-identity hole (deep move-aside preempting shallow backtrack) → **two-phase** (Task 5 Step 6). ✓
+- F2 `plan_path` `placed.hangar` mismatch → **require apron>0 + scenario hangar throughout** (Task 5 `_layout_of`; Task 3 gate). ✓
+- F3 wrong `view` animation → **scene global-execution-order pass** (Task 6). ✓
+- Staging in front of the door → **lateral x-samples** (Task 3). ✓
+- Cap mislabel → **monotonic global, documented**; `displaced_planes` per-path (Task 5 Step 3). ✓
+- #844 tight S-leg → **same-machine-byte-bound note** (Global Constraints + Task 8). ✓
+- Unannotated nested defs → **annotated** `_route`/`_layout_of` (Task 5). ✓
+- Unused `field` import → **not added** (no `replace` needed once the local-apron fabrication is dropped). ✓
+- Validator scope → **documented fixture-scoped** (Task 7). ✓
+- In-budget deadlock 2× cost → phase 2 only after a *cheap* phase-1 deadlock; **bench-verified** (Task 8). ✓
+
+**Spec coverage (§4 Rung E):** move-aside in `_place_rest` ✓; depth-1 (structural + `displaced_planes`) ✓; apron-out staging ✓; separate cap (`_MAX_FILL_DISPLACEMENTS`/`max_displacements`) ✓; #668 stuck-body naming ✓; spread excludes staging legs (solver spread runs on `placements`, never `MovesPlan.moves` — recon-confirmed, no code change) ✓; multi-leg model reused (leg_index 0/1/2) ✓; acceptance (valid multi-leg fixture + every leg collision-free/in-bounds; byte-identity; bench ceiling; bounded cost) ✓.
+
+**Honest ceiling caveat (carry into the PR body):** move-aside may still not seat the real `fk9↔cessna` cm-scale parallel-park (intrinsic ~97k-expansion plateau; Herrenteich is budget-bound so phase 1 raises and phase 2 never runs there). The bar is the **capability** (synthetic + small-geometry fixtures) + byte-identity + a re-baselined ceiling, **not** a guaranteed all-8 route.

--- a/ml/benchmark.py
+++ b/ml/benchmark.py
@@ -18,7 +18,7 @@ from typing import Literal
 from hangarfit.loader import load_layout, load_scenario
 from hangarfit.models import Layout, SearchConfig, SolveStatus
 from hangarfit.solver import solve
-from hangarfit.towplanner import NoFeasiblePlanError, plan_fill
+from hangarfit.towplanner import MovesPlan, NoFeasiblePlanError, plan_fill
 from ml import geometry_oracle as go
 from ml.env import HangarFitEnv
 from ml.types import Action, DifficultyConfig, StepInfo
@@ -265,6 +265,16 @@ def score_episode(env: HangarFitEnv, actions: Sequence[Action]) -> ReachVerdict:
 _BASELINE_PATH = _ROOT / "tests/fixtures/ml/bench_baseline.json"
 
 
+def _routed_plane_count(plan: MovesPlan) -> int:
+    """Number of DISTINCT aircraft with at least one routed leg (#667 Rung E).
+
+    Counts planes, not legs: a move-aside plan emits multiple routed legs for one
+    plane (a staging leg + the final leg), so summing routed Moves would over-count
+    and falsely fail the ``== n_total`` reach check. Deferred (``path is None``)
+    legs are excluded, matching the prior semantics."""
+    return len({m.plane_id for m in plan.moves if m.path is not None})
+
+
 def rrmc_reach(scenario: BenchScenario) -> RrmcVerdict:
     """Run the RR-MC -> tow pipeline on `scenario` at its pinned budget and apply the SAME
     valid+routable predicate as the policy side (_layout_valid, the product checker). OFFLINE/
@@ -296,7 +306,7 @@ def rrmc_reach(scenario: BenchScenario) -> RrmcVerdict:
         plan = plan_fill(layout, heuristic="grid", max_total_expansions=scenario.tow_max_expansions)
     except NoFeasiblePlanError:
         return RrmcVerdict(reached=False, n_routed=0, n_total=n_total, status="unroutable")
-    n_routed = sum(1 for m in plan.moves if m.path is not None)
+    n_routed = _routed_plane_count(plan)
     return RrmcVerdict(
         reached=(n_routed == n_total), n_routed=n_routed, n_total=n_total, status=result.status
     )

--- a/ml/reach_rate.py
+++ b/ml/reach_rate.py
@@ -40,7 +40,7 @@ from pathlib import Path
 from hangarfit.loader import load_fleet, load_hangar
 from hangarfit.models import Scenario, SearchConfig
 from hangarfit.solver import solve
-from hangarfit.towplanner import NoFeasiblePlanError, plan_fill
+from hangarfit.towplanner import MovesPlan, NoFeasiblePlanError, plan_fill
 from ml import geometry_oracle as go
 
 _ROOT = Path(__file__).resolve().parent.parent  # repo root (ml/ sits at the root)
@@ -280,6 +280,16 @@ def sample_population(
 # ── reach predicates (the #695 product-checker predicate, both arms) ─────────
 
 
+def _routed_plane_count(plan: MovesPlan) -> int:
+    """Number of DISTINCT aircraft with at least one routed leg (#667 Rung E).
+
+    Counts planes, not legs: a move-aside plan emits multiple routed legs for one
+    plane (a staging leg + the final leg), so summing routed Moves would over-count
+    and falsely fail the ``== n_total`` reach check. Deferred (``path is None``)
+    legs are excluded, matching the prior semantics."""
+    return len({m.plane_id for m in plan.moves if m.path is not None})
+
+
 def rrmc_reach_multi(
     scenario: Scenario,
     *,
@@ -309,7 +319,7 @@ def rrmc_reach_multi(
             plan = plan_fill(layout, heuristic="grid", max_total_expansions=tow_max_expansions)
         except NoFeasiblePlanError:
             continue
-        if sum(1 for m in plan.moves if m.path is not None) == n_total:
+        if _routed_plane_count(plan) == n_total:
             return True
     return False
 

--- a/src/hangarfit/scene.py
+++ b/src/hangarfit/scene.py
@@ -297,46 +297,13 @@ def _timeline(
     multi_leg_present = any(c > 1 for c in routed_count.values())
     aircraft_ids = {p.plane_id for p in layout.placements}
 
-    def _append_segment(body_id: str, *, record_final: bool) -> None:
-        nonlocal t
-        legs = moves_by_id.get(body_id)
-        if not legs:
-            return
-        # One sequential segment per ROUTED leg, in leg_index order. A deferred
-        # (path=None) leg emits no segment — an un-routable placed-routed mover
-        # (#197/#602), or for an aircraft a defensive guard (every aircraft is
-        # routed). The `leg_index` key is emitted ONLY for a multi-leg body (>1
-        # routed leg) — a single-leg body stays byte-identical to before (#865).
-        #
-        # Rung D scope (#667): a body's legs are laid end-to-end HERE (each leg's
-        # `start_s == prev.end_s`), then the next body — so a body is never paused
-        # mid-fill while another routes past. The viewer + scene-v2 state machine
-        # already model that inter-leg "wait at staging" gap (`affineAt`), but no
-        # producer emits it yet; Rung E (move-aside) will lay legs in global
-        # execution order across bodies. Edge (deferred only, no producer today):
-        # a multi-leg body whose non-final leg is `path=None` drops to one routed
-        # leg and serializes as single-leg (no `leg_index`) — revisit in Rung E.
-        routed = sorted((m for m in legs if m.path is not None), key=lambda m: m.leg_index)
-        multi_leg = len(routed) > 1
-        for leg in routed:
-            assert leg.path is not None  # narrowed by the filter above
-            samples = _sample_affines(leg.path, max_samples_per_path)
-            dur = min(max(leg.path.length_m / tow_speed_mps, min_seg_s), max_seg_s)
-            seg: dict = {"plane_id": body_id, "start_s": t, "end_s": t + dur, "samples": samples}
-            if multi_leg:
-                seg["leg_index"] = leg.leg_index
-            segments.append(seg)
-            if record_final:
-                finals[body_id] = samples[-1]
-            t += dur
-
-    def _emit_leg(leg: Move) -> None:
-        # #667 Rung E global-order emitter: one segment for a single routed leg, in the
-        # caller's (moves-tuple = execution) order. Mirrors _append_segment's per-leg
-        # body but does NOT group by plane: a move-aside body's legs interleave with the
-        # bodies routed between them. `leg_index` is emitted only for a multi-leg body
-        # (>1 routed leg); finals records the last leg of each AIRCRAFT (a mover's
-        # resting pose lives in its ground-object block, like record_final=False above).
+    def _emit_segment(leg: Move, *, record_final: bool) -> None:
+        # Single source of truth for one timeline segment of a single ROUTED leg
+        # (shared by the per-body and the global-execution-order paths so the segment
+        # shape can never desync). The `leg_index` key is emitted ONLY for a multi-leg
+        # body (routed_count > 1) — a single-leg body stays byte-identical to before
+        # (#865). `record_final` records the body's last-sample pose in `finals`
+        # (aircraft only; a mover's resting pose lives in its ground-object block).
         nonlocal t
         assert leg.path is not None  # caller filters path-None legs
         samples = _sample_affines(leg.path, max_samples_per_path)
@@ -345,18 +312,32 @@ def _timeline(
         if routed_count.get(leg.plane_id, 0) > 1:
             seg["leg_index"] = leg.leg_index
         segments.append(seg)
-        if leg.plane_id in aircraft_ids:
+        if record_final:
             finals[leg.plane_id] = samples[-1]
         t += dur
 
+    def _append_segment(body_id: str, *, record_final: bool) -> None:
+        # Per-body path: emit one sequential segment per ROUTED leg of `body_id`, laid
+        # end-to-end in leg_index order (a deferred path=None leg emits nothing — an
+        # un-routable mover #197/#602, or a defensive guard for an aircraft). A body's
+        # legs are laid end-to-end here, then the next body. Used only when NO multi-leg
+        # body is present, so this reproduces the pre-Rung-E byte-identical timeline.
+        legs = moves_by_id.get(body_id)
+        if not legs:
+            return
+        for leg in sorted((m for m in legs if m.path is not None), key=lambda m: m.leg_index):
+            _emit_segment(leg, record_final=record_final)
+
     if multi_leg_present:
         # A shuffle is present: lay legs in GLOBAL execution order (the producer builds
-        # moves_plan.moves in commitment order: aircraft, then id-sorted movers). The
+        # moves_plan.moves in commitment order: aircraft, then id-sorted movers), so a
+        # move-aside body's legs interleave with the bodies routed between them. The
         # viewer's affineAt rests a displaced body at its staging pose between its
-        # non-contiguous legs while the stuck body routes past (#667 Rung E).
+        # non-contiguous legs while the stuck body routes past (#667 Rung E). finals
+        # records aircraft only (a mover's resting pose lives in its ground-object block).
         for m in moves_plan.moves:
             if m.path is not None:
-                _emit_leg(m)
+                _emit_segment(m, record_final=m.plane_id in aircraft_ids)
     else:
         # No shuffle: aircraft drive in deepest-first, then placed-routed movers
         # (id-sorted) after every aircraft is parked (#651). Byte-identical to before.

--- a/src/hangarfit/scene.py
+++ b/src/hangarfit/scene.py
@@ -285,6 +285,18 @@ def _timeline(
     segments: list[dict] = []
     t = 0.0
 
+    # #667 Rung E: count routed legs per body. A body with >1 routed leg is a
+    # move-aside shuffle — its legs must animate in GLOBAL execution order
+    # (interleaved with the bodies that route between them), not grouped per body.
+    # Gating the global-order path on a multi-leg body being present keeps every
+    # single-leg plan on the back_first_order path below → byte-identical (ADR-0003).
+    routed_count: dict[str, int] = {}
+    for m in moves_plan.moves:
+        if m.path is not None:
+            routed_count[m.plane_id] = routed_count.get(m.plane_id, 0) + 1
+    multi_leg_present = any(c > 1 for c in routed_count.values())
+    aircraft_ids = {p.plane_id for p in layout.placements}
+
     def _append_segment(body_id: str, *, record_final: bool) -> None:
         nonlocal t
         legs = moves_by_id.get(body_id)
@@ -318,15 +330,40 @@ def _timeline(
                 finals[body_id] = samples[-1]
             t += dur
 
-    # Aircraft drive in first (deepest slot first); then placed-routed movers
-    # (id-sorted, matching _ground_object_blocks) animate after every aircraft is
-    # parked (#651) — the real fill order (plan_fill routes aircraft, then movers).
-    # A mover's resting pose lives in its ground-object block's final_pose /
-    # go_anchors, not in `finals` (aircraft-only), so record_final=False for them.
-    for placement in back_first_order(layout.placements):
-        _append_segment(placement.plane_id, record_final=True)
-    for gp in sorted(layout.ground_object_placements, key=lambda p: p.plane_id):
-        _append_segment(gp.plane_id, record_final=False)
+    def _emit_leg(leg: Move) -> None:
+        # #667 Rung E global-order emitter: one segment for a single routed leg, in the
+        # caller's (moves-tuple = execution) order. Mirrors _append_segment's per-leg
+        # body but does NOT group by plane: a move-aside body's legs interleave with the
+        # bodies routed between them. `leg_index` is emitted only for a multi-leg body
+        # (>1 routed leg); finals records the last leg of each AIRCRAFT (a mover's
+        # resting pose lives in its ground-object block, like record_final=False above).
+        nonlocal t
+        assert leg.path is not None  # caller filters path-None legs
+        samples = _sample_affines(leg.path, max_samples_per_path)
+        dur = min(max(leg.path.length_m / tow_speed_mps, min_seg_s), max_seg_s)
+        seg: dict = {"plane_id": leg.plane_id, "start_s": t, "end_s": t + dur, "samples": samples}
+        if routed_count.get(leg.plane_id, 0) > 1:
+            seg["leg_index"] = leg.leg_index
+        segments.append(seg)
+        if leg.plane_id in aircraft_ids:
+            finals[leg.plane_id] = samples[-1]
+        t += dur
+
+    if multi_leg_present:
+        # A shuffle is present: lay legs in GLOBAL execution order (the producer builds
+        # moves_plan.moves in commitment order: aircraft, then id-sorted movers). The
+        # viewer's affineAt rests a displaced body at its staging pose between its
+        # non-contiguous legs while the stuck body routes past (#667 Rung E).
+        for m in moves_plan.moves:
+            if m.path is not None:
+                _emit_leg(m)
+    else:
+        # No shuffle: aircraft drive in deepest-first, then placed-routed movers
+        # (id-sorted) after every aircraft is parked (#651). Byte-identical to before.
+        for placement in back_first_order(layout.placements):
+            _append_segment(placement.plane_id, record_final=True)
+        for gp in sorted(layout.ground_object_placements, key=lambda p: p.plane_id):
+            _append_segment(gp.plane_id, record_final=False)
 
     return {"total_s": t, "segments": segments}, finals
 

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -296,6 +296,22 @@ class MovesPlan:
             legs.add(m.leg_index)
 
 
+@dataclass(frozen=True, slots=True)
+class _FillStep:
+    """One committed unit of an order-search result (#667 Rung E).
+
+    A normal placement emits a single ``Move`` and commits one ``Placement``. A
+    move-aside emits THREE moves (displaced-aside, stuck-final, displaced-return) and
+    commits ONE placement (the stuck body; the displaced body is already in ``placed``
+    at its final pose). ``apron_fallback_planes`` names committed bodies that towed via
+    the ``y = 0`` door-line fallback despite an apron (the #503 diagnostic). Internal to
+    ``_plan_fill``; never exposed."""
+
+    moves: tuple[Move, ...]
+    committed: tuple[Placement, ...]
+    apron_fallback_planes: tuple[str, ...]
+
+
 # ---------------------------------------------------------------------------
 # Heading-convention adapter (ADR-0002)
 #
@@ -1947,12 +1963,10 @@ def _plan_fill(
     # the first (deepest plane's) routing conflict for that bail message.
     deepest_conflict: Conflict | None = None
 
-    def _place_rest(
-        placed_list: list[Placement], rest: list[Placement]
-    ) -> list[tuple[Placement, DubinsArc, bool]] | None:
-        """Return the chosen (slot, arc, apron_fallback) sequence that places every
-        body in ``rest`` against ``placed_list``, greedy-first with backtracking, or
-        ``None`` if no order does. Raises on global-budget or backtrack-cap exhaustion."""
+    def _place_rest(placed_list: list[Placement], rest: list[Placement]) -> list[_FillStep] | None:
+        """Return the chosen :class:`_FillStep` sequence that places every body in
+        ``rest`` against ``placed_list``, greedy-first with backtracking, or ``None`` if
+        no order does. Raises on global-budget or backtrack-cap exhaustion."""
         nonlocal total_used, deepest_conflict, backtracks_used
         if not rest:
             return []
@@ -2014,7 +2028,12 @@ def _plan_fill(
             apron_fb = stats.get("apron_fallback") is True
             sub = _place_rest(placed_list + [slot], rest[:idx] + rest[idx + 1 :])
             if sub is not None:
-                return [(slot, arc, apron_fb), *sub]
+                step = _FillStep(
+                    moves=(Move(slot.plane_id, Pose.from_placement(slot), arc),),
+                    committed=(slot,),
+                    apron_fallback_planes=(slot.plane_id,) if apron_fb else (),
+                )
+                return [step, *sub]
             # Routed here, but the rest dead-ends downstream → backtrack to the next
             # candidate (the old monotonic loop could not). Bound the total dead-end
             # backtracks so a generous per-plane budget can't fund a runaway order
@@ -2048,21 +2067,22 @@ def _plan_fill(
         # body; on a pure ordering lock it's the deepest (the synthesized fallback).
         raise NoFeasiblePlanError(bail.planes[0], bail)
 
-    for slot, arc, apron_fb in result:
-        moves.append(Move(slot.plane_id, Pose.from_placement(slot), arc))
-        placed.append(slot)
+    for step in result:
+        moves.extend(step.moves)
+        placed.extend(step.committed)
         # #503: record (plan-inert) the planes that towed via the y=0 door-line
         # fallback DESPITE an apron being set — their footprint is too deep for the
         # apron. Committed-move order (deterministic, ADR-0003), only when the
         # caller passed `apron_dropped_out`; the depth is the per-plane FOOTPRINT
         # extent, not the fleet-wide `auto` over-margin. Never read back.
-        if apron_fb and apron_dropped_out is not None:
-            apron_dropped_out.append(
-                ApronShallowDrop(
-                    plane_id=slot.plane_id,
-                    min_depth_m=_plane_fore_aft_length_m(fleet[slot.plane_id]),
+        if apron_dropped_out is not None:
+            for pid in step.apron_fallback_planes:
+                apron_dropped_out.append(
+                    ApronShallowDrop(
+                        plane_id=pid,
+                        min_depth_m=_plane_fore_aft_length_m(fleet[pid]),
+                    )
                 )
-            )
 
     # Ground-object movers (#602): route each placed-routed mover with its own
     # path. id-sorted + appended after the aircraft loop => aircraft moves stay

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -277,6 +277,24 @@ class MovesPlan:
     target_layout: Layout
     moves: tuple[Move, ...]
 
+    def __post_init__(self) -> None:
+        # #667 Rung E (type-design F1): a plane's ROUTED legs must carry distinct
+        # leg_index values so scene._timeline's `sorted(..., key=leg_index)` order is
+        # well-defined. Deferred (path=None) legs are exempt — build_moves_plan
+        # (ml/infer.py) and placed-routed movers legitimately emit a routed leg and a
+        # deferred leg both at leg_index=0; mover/deferred target_slots also need not
+        # be in `placements`, so NO target_slot membership check is added.
+        seen_routed: dict[str, set[int]] = {}
+        for m in self.moves:
+            if m.path is None:
+                continue
+            legs = seen_routed.setdefault(m.plane_id, set())
+            if m.leg_index in legs:
+                raise ValueError(
+                    f"MovesPlan: plane {m.plane_id!r} has duplicate routed leg_index {m.leg_index}"
+                )
+            legs.add(m.leg_index)
+
 
 # ---------------------------------------------------------------------------
 # Heading-convention adapter (ADR-0002)

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1824,6 +1824,7 @@ def plan_fill(
     max_expansions: int | None = None,
     max_total_expansions: int | None = None,
     max_backtracks: int | None = None,
+    max_displacements: int | None = None,
     apron_dropped_out: list[ApronShallowDrop] | None = None,
     unroutable_movers: list[str] | None = None,
 ) -> MovesPlan:
@@ -1893,8 +1894,18 @@ def plan_fill(
     budget can't fund a runaway order search on an un-routable fill. Deterministic
     (ADR-0003): the order, the Hybrid-A* primitive fan, the cone grid, and the
     candidate scan are all RNG-free, so a given ``target`` always yields the same
-    :class:`MovesPlan`. (A truly cyclic lock — no order routes — still bails; the
-    move-aside that resolves those is tracked on #667.)
+    :class:`MovesPlan`.
+
+    Since #667 Rung E, a mutual block that **no** placement order resolves triggers a
+    second phase: if the byte-identical phase-1 DFS deadlocks within budget, the search
+    re-runs with **move-aside** enabled — it temporarily relocates a parked body to an
+    apron-out staging pose so the stuck body can route, then returns it, emitting a
+    multi-leg plan (``Move.leg_index``). ``max_displacements`` (``None`` ⇒ the module
+    ``_MAX_FILL_DISPLACEMENTS``) caps committed displacements; ``0`` disables move-aside
+    (byte-identical to pre-Rung-E). Move-aside requires a staging apron
+    (``hangar.apron_depth_m > 0``); without one it is skipped. Phase 2 runs only after a
+    phase-1 deadlock and gets a fresh expansion budget, so a layout solvable without a
+    shuffle is byte-identical and never pays for move-aside.
     """
     # #626: memoize body world-parts for the WHOLE fill. The static obstacle field
     # is rebuilt by every plan_path's _build_obstacles, and the greedy scan re-routes
@@ -1910,6 +1921,7 @@ def plan_fill(
             max_expansions=max_expansions,
             max_total_expansions=max_total_expansions,
             max_backtracks=max_backtracks,
+            max_displacements=max_displacements,
             apron_dropped_out=apron_dropped_out,
             unroutable_movers=unroutable_movers,
         )
@@ -1922,6 +1934,7 @@ def _plan_fill(
     max_expansions: int | None = None,
     max_total_expansions: int | None = None,
     max_backtracks: int | None = None,
+    max_displacements: int | None = None,
     apron_dropped_out: list[ApronShallowDrop] | None = None,
     unroutable_movers: list[str] | None = None,
 ) -> MovesPlan:
@@ -1929,8 +1942,11 @@ def _plan_fill(
     budget = _MAX_EXPANSIONS if max_expansions is None else max_expansions
     total_budget = _MAX_FILL_EXPANSIONS if max_total_expansions is None else max_total_expansions
     bt_cap = _MAX_FILL_BACKTRACKS if max_backtracks is None else max_backtracks
+    disp_cap = _MAX_FILL_DISPLACEMENTS if max_displacements is None else max_displacements
     total_used = 0
     backtracks_used = 0
+    displacements_used = 0  # #667 Rung E: monotonic global counter (never decremented)
+    displaced_planes: set[str] = set()  # per-path membership — never iterated for order
     fleet = target.fleet
     hangar = target.hangar
     # #667 Stage 0: HAND-POSITIONED bodies (dolly-borne gliders) are parked by
@@ -1963,10 +1979,14 @@ def _plan_fill(
     # the first (deepest plane's) routing conflict for that bail message.
     deepest_conflict: Conflict | None = None
 
-    def _place_rest(placed_list: list[Placement], rest: list[Placement]) -> list[_FillStep] | None:
+    def _place_rest(
+        placed_list: list[Placement], rest: list[Placement], allow_displace: bool = False
+    ) -> list[_FillStep] | None:
         """Return the chosen :class:`_FillStep` sequence that places every body in
         ``rest`` against ``placed_list``, greedy-first with backtracking, or ``None`` if
-        no order does. Raises on global-budget or backtrack-cap exhaustion."""
+        no order does. Raises on global-budget or backtrack-cap exhaustion. When
+        ``allow_displace`` (phase 2, #667 Rung E), a level that exhausts its
+        non-displacing candidates tries a move-aside before returning ``None``."""
         nonlocal total_used, deepest_conflict, backtracks_used
         if not rest:
             return []
@@ -2026,7 +2046,9 @@ def _plan_fill(
             exp = stats.get("expansions", 0)
             total_used += exp if isinstance(exp, int) else 0
             apron_fb = stats.get("apron_fallback") is True
-            sub = _place_rest(placed_list + [slot], rest[:idx] + rest[idx + 1 :])
+            sub = _place_rest(
+                placed_list + [slot], rest[:idx] + rest[idx + 1 :], allow_displace=allow_displace
+            )
             if sub is not None:
                 step = _FillStep(
                     moves=(Move(slot.plane_id, Pose.from_placement(slot), arc),),
@@ -2050,13 +2072,184 @@ def _plan_fill(
                     detail=f"order-search backtracking cap ({bt_cap}) exceeded",
                 )
                 raise NoFeasiblePlanError(bail.planes[0], bail)
+        if allow_displace:
+            ms = _try_move_aside(placed_list, rest)
+            if ms is not None:
+                return ms
         return None
 
-    result = _place_rest(placed, ordered)
+    def _try_move_aside(
+        placed_list: list[Placement], rest: list[Placement]
+    ) -> list[_FillStep] | None:
+        """Depth-1 move-aside (#667 Rung E), phase 2 only. For the deepest stuck body
+        S, displace a committed body D (deepest-first, never hand-placed, never twice
+        per DFS path) to an apron-out lateral staging pose, route S past D@staging,
+        return D to its slot, then recurse. First feasible (S, D, staging) in
+        deterministic order wins. Requires ``hangar.apron_depth_m > 0`` (it relocates a
+        body OUTSIDE the door). Depth is structurally 1: a shuffle's legs are direct
+        ``plan_path`` calls, never a nested order search."""
+        nonlocal total_used, displacements_used
+        if displacements_used >= disp_cap or hangar.apron_depth_m <= 0.0:
+            return None
+
+        def _layout_of(placements: list[Placement]) -> Layout:
+            # All legs use the SCENARIO `hangar` (which carries the apron): plan_path's
+            # path_first_conflict derives motion bounds from placed.hangar, so a y<0
+            # staging sweep is only apron-exempt when placed.hangar.apron_depth_m > 0.
+            return Layout(
+                fleet=fleet,
+                hangar=hangar,
+                placements=tuple(placements),
+                maintenance_plane=target.maintenance_plane,
+                ground_objects=target.ground_objects,
+                ground_object_placements=fixed_obstacle_placements,
+            )
+
+        def _route(
+            mover: Aircraft, start: Pose, goal: Pose, *, placed_obs: Layout, on_carts: bool
+        ) -> DubinsArc | None:
+            # Single-start plan_path wrapper (entries omitted ⇒ None): charges
+            # expansions to total_used on success OR failure; returns the arc or None.
+            # Never touches deepest_conflict (the main loop's capture is the #668
+            # actionable reason).
+            nonlocal total_used
+            remaining = total_budget - total_used
+            if remaining <= 0:
+                return None
+            stats: dict[str, object] = {}
+            try:
+                arc = plan_path(
+                    mover,
+                    start,
+                    goal,
+                    hangar=hangar,
+                    placed=placed_obs,
+                    mover_on_carts=on_carts,
+                    heuristic=heuristic,
+                    max_expansions=min(budget, remaining),
+                    stats=stats,
+                )
+            except NoFeasiblePlanError:
+                exp = stats.get("expansions", 0)
+                total_used += exp if isinstance(exp, int) else 0
+                return None
+            exp = stats.get("expansions", 0)
+            total_used += exp if isinstance(exp, int) else 0
+            return arc
+
+        for s_slot in rest:  # back_first_order: deepest stuck body first
+            displaceable = back_first_order(
+                tuple(
+                    p
+                    for p in placed_list
+                    if not p.hand_placed and p.plane_id not in displaced_planes
+                )
+            )
+            for d_slot in displaceable:
+                without_d = [p for p in placed_list if p.plane_id != d_slot.plane_id]
+                d_aircraft = fleet[d_slot.plane_id]
+                for staging in _staging_poses(d_slot, hangar):
+                    # Leg 1 — D: final -> staging (others parked, S not yet in).
+                    aside = _route(
+                        d_aircraft,
+                        Pose.from_placement(d_slot),
+                        staging,
+                        placed_obs=_layout_of(without_d),
+                        on_carts=d_slot.on_carts,
+                    )
+                    if aside is None:
+                        continue
+                    remaining = total_budget - total_used
+                    if remaining <= 0:
+                        return None
+                    d_at_staging = Placement(
+                        d_slot.plane_id,
+                        staging.x_m,
+                        staging.y_m,
+                        staging.heading_deg,
+                        d_slot.on_carts,
+                        d_slot.hand_placed,
+                    )
+                    # S: door -> final, against others + D@staging (multi-start cone).
+                    s_cone = entry_poses(s_slot, hangar)
+                    s_stats: dict[str, object] = {}
+                    try:
+                        s_arc = plan_path(
+                            fleet[s_slot.plane_id],
+                            s_cone[0],
+                            Pose.from_placement(s_slot),
+                            hangar=hangar,
+                            placed=_layout_of([*without_d, d_at_staging]),
+                            mover_on_carts=s_slot.on_carts,
+                            entries=s_cone,
+                            heuristic=heuristic,
+                            max_expansions=min(budget, remaining),
+                            stats=s_stats,
+                        )
+                    except NoFeasiblePlanError:
+                        exp = s_stats.get("expansions", 0)
+                        total_used += exp if isinstance(exp, int) else 0
+                        continue
+                    exp = s_stats.get("expansions", 0)
+                    total_used += exp if isinstance(exp, int) else 0
+                    s_apron_fb = s_stats.get("apron_fallback") is True
+                    # Leg 2 — D: staging -> final, against others + S@final.
+                    ret = _route(
+                        d_aircraft,
+                        staging,
+                        Pose.from_placement(d_slot),
+                        placed_obs=_layout_of([*without_d, s_slot]),
+                        on_carts=d_slot.on_carts,
+                    )
+                    if ret is None:
+                        continue
+                    # All three legs feasible — commit and recurse for the rest.
+                    if displacements_used >= disp_cap:
+                        return None
+                    displacements_used += 1
+                    displaced_planes.add(d_slot.plane_id)
+                    new_rest = [p for p in rest if p.plane_id != s_slot.plane_id]
+                    sub = _place_rest(placed_list + [s_slot], new_rest, allow_displace=True)
+                    if sub is not None:
+                        step = _FillStep(
+                            moves=(
+                                Move(d_slot.plane_id, staging, aside, leg_index=1),
+                                Move(
+                                    s_slot.plane_id,
+                                    Pose.from_placement(s_slot),
+                                    s_arc,
+                                    leg_index=0,
+                                ),
+                                Move(
+                                    d_slot.plane_id,
+                                    Pose.from_placement(d_slot),
+                                    ret,
+                                    leg_index=2,
+                                ),
+                            ),
+                            committed=(s_slot,),
+                            apron_fallback_planes=(s_slot.plane_id,) if s_apron_fb else (),
+                        )
+                        return [step, *sub]
+                    displaced_planes.discard(d_slot.plane_id)  # per-path undo; counter stays
+        return None
+
+    # Phase 1: today's non-displacing DFS, byte-identical. May RAISE on budget /
+    # backtrack-cap exhaustion (propagates → no phase 2, so an un-routable fill's
+    # disprove cost stays 1×). Returns None only on an IN-BUDGET deadlock.
+    result = _place_rest(placed, ordered, allow_displace=False)
     if result is None:
-        # No placement order seats every body (a true lock — needs the Stage 1
-        # move-aside, still to come) or every candidate conflicts. Name the
-        # deepest body and carry its conflict (matches the old monotonic bail).
+        # Phase 2 (#667 Rung E): the whole-fill order search deadlocked within budget
+        # — enable move-aside with a FRESH expansion budget. Reached only here, so any
+        # layout phase 1 solves is byte-identical (ADR-0003). Phase 2 runs only after a
+        # cheap phase-1 deadlock, bounding worst-case disprove cost.
+        total_used = 0
+        backtracks_used = 0
+        deepest_conflict = None
+        result = _place_rest(placed, ordered, allow_displace=True)
+    if result is None:
+        # No order seats every body, with or without move-aside. Name the deepest
+        # body and carry its conflict (matches the old monotonic bail).
         bail = deepest_conflict or Conflict.single(
             kind="no_feasible_path",
             plane=ordered[0].plane_id,
@@ -2209,6 +2402,17 @@ _MAX_FILL_BACKTRACKS = 2000  # GLOBAL cap on order-search dead-end backtracks (#
 # of the per-plane budget. Inert for the greedy-success path (0 backtracks ⇒
 # byte-identical, ADR-0003) and far above any legitimate small reorder; it only
 # bounds a pathological/un-routable order search. Overridable via ``max_backtracks``.
+
+_MAX_FILL_DISPLACEMENTS = 16  # GLOBAL cap on committed move-aside recursions (#667 Rung E).
+# Move-aside relocates a parked body so a stuck body can route, then restores it. Each
+# (S, D, staging) combo whose three legs all route and which RECURSES counts once
+# (whether or not it ultimately succeeds): a MONOTONIC, non-decremented global ceiling
+# that terminates the phase-2 search independent of the per-plane expansion budget.
+# Per-path cycle-safety + clean leg_index come from the `displaced_planes` membership set
+# (a body is displaced at most once per DFS path); depth is structurally 1 (a shuffle's
+# legs are direct plan_path calls, never a nested order search). 0 ⇒ move-aside disabled
+# (byte-identical to pre-Rung-E). Overridable via the ``max_displacements`` param.
+
 # Sampling resolution for the FAST in-search `_motion_clear` validity checks
 # (edges + the analytic-shot screen). Coarser than the exact oracle's default
 # (0.05 m / 1°) to keep the search tractable: the worst case is a plane that can

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1272,7 +1272,11 @@ def _staging_poses(target: Placement, hangar: Hangar) -> tuple[Pose, ...]:
         for x in x_samples:  # middle: off-to-side first, door-centre last
             for h in _REVERSE_CONE_HEADINGS:  # inner: nose-out cone
                 key = (x, y, h)
-                if key in seen:
+                # Defensive dedup: the three x-samples coincide only for a degenerate door
+                # centred on/past a wall (where _clamp coalesces them) — never for a valid
+                # door, so this skip is unreachable in practice. The no-duplicate
+                # post-condition is asserted by test_staging_poses_are_apron_out_*.
+                if key in seen:  # pragma: no cover - x-samples never collide for a valid door
                     continue
                 seen.add(key)
                 poses.append(Pose(x_m=x, y_m=y, heading_deg=h))

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -1211,6 +1211,55 @@ def entry_pose(target: Placement, hangar: Hangar) -> Pose:
     return Pose(x_m=x, y_m=0.0, heading_deg=0.0)
 
 
+def _staging_poses(target: Placement, hangar: Hangar) -> tuple[Pose, ...]:
+    """Apron-out (y<0) nose-out LATERAL staging candidates for a displaced body
+    (#667 Rung E move-aside).
+
+    Reuses ``entry_poses``' apron y-samples but parks the body OFF TO THE SIDE of the
+    door (x spans the apron width, not just the door opening) so it does not jam the
+    corridor the stuck body must enter through — the real club shuffle rolls a plane
+    laterally aside, not straight out the door. Headings are nose-out
+    (``_REVERSE_CONE_HEADINGS``, ~180°) so the body parks fully outside regardless of
+    its parked heading. Ordered **y-outer (deepest apron first → the #844 cost-margin
+    lever), x-outer (off-to-side first), heading-inner**; the ``seen`` set dedups only,
+    never orders (ADR-0003 tie-break 2). Empty if no apron. Infeasible / out-of-bounds
+    candidates are dropped later by the routing legs (``path_first_conflict``), so no
+    static pre-filter is applied here.
+    """
+    depth = hangar.apron_depth_m
+    if depth <= 0.0:
+        return ()
+    door = hangar.door
+    half = door.width_m / 2.0
+    lo = door.center_x_m - half
+    hi = door.center_x_m + half
+    width = hangar.width_m
+
+    def _clamp(x: float) -> float:
+        return min(max(x, 0.0), width)
+
+    # Lateral x: midpoint of the left apron strip, midpoint of the right strip, then
+    # the door centre as a fallback. Off-to-side first (x-outer) so the body clears the
+    # stuck plane's door swath before a centre pose is tried.
+    x_left = _clamp(lo / 2.0)
+    x_right = _clamp((hi + width) / 2.0)
+    x_centre = _clamp(door.center_x_m)
+    x_samples = (x_left, x_right, x_centre)
+    y_samples = (-depth, -depth / 2.0)  # deepest apron first (#844 margin)
+
+    seen: set[tuple[float, float, float]] = set()
+    poses: list[Pose] = []
+    for y in y_samples:  # outer: deepest apron first
+        for x in x_samples:  # middle: off-to-side first, door-centre last
+            for h in _REVERSE_CONE_HEADINGS:  # inner: nose-out cone
+                key = (x, y, h)
+                if key in seen:
+                    continue
+                seen.add(key)
+                poses.append(Pose(x_m=x, y_m=y, heading_deg=h))
+    return tuple(poses)
+
+
 # ---------------------------------------------------------------------------
 # Sampled collision-during-motion (spike Q4)
 # ---------------------------------------------------------------------------

--- a/src/hangarfit/towplanner.py
+++ b/src/hangarfit/towplanner.py
@@ -279,8 +279,11 @@ class MovesPlan:
 
     def __post_init__(self) -> None:
         # #667 Rung E (type-design F1): a plane's ROUTED legs must carry distinct
-        # leg_index values so scene._timeline's `sorted(..., key=leg_index)` order is
-        # well-defined. Deferred (path=None) legs are exempt — build_moves_plan
+        # leg_index values so each leg is unambiguously identifiable per body — the
+        # scene/v2 `timeline.segments[].leg_index` and the viewer's per-body
+        # `segByPlane[pid]` leg array key on it, and it backstops the move-aside
+        # producer's hardcoded leg_index 0/1/2 (a body is displaced at most once per
+        # DFS path). Deferred (path=None) legs are exempt — build_moves_plan
         # (ml/infer.py) and placed-routed movers legitimately emit a routed leg and a
         # deferred leg both at leg_index=0; mover/deferred target_slots also need not
         # be in `placements`, so NO target_slot membership check is added.
@@ -2238,11 +2241,15 @@ def _plan_fill(
     # backtrack-cap exhaustion (propagates → no phase 2, so an un-routable fill's
     # disprove cost stays 1×). Returns None only on an IN-BUDGET deadlock.
     result = _place_rest(placed, ordered, allow_displace=False)
-    if result is None:
+    if result is None and disp_cap > 0 and hangar.apron_depth_m > 0.0:
         # Phase 2 (#667 Rung E): the whole-fill order search deadlocked within budget
         # — enable move-aside with a FRESH expansion budget. Reached only here, so any
         # layout phase 1 solves is byte-identical (ADR-0003). Phase 2 runs only after a
-        # cheap phase-1 deadlock, bounding worst-case disprove cost.
+        # cheap phase-1 deadlock, bounding worst-case disprove cost. Skip it entirely
+        # when move-aside CANNOT engage (no apron, or displacement cap 0): _try_move_aside
+        # would be a guaranteed no-op, so re-running the order search is pure waste — and
+        # this keeps the no-apron / disp-0 disprove genuinely same-speed as pre-Rung-E
+        # (it bails on phase 1's deepest_conflict, identical to the re-captured one).
         total_used = 0
         backtracks_used = 0
         deepest_conflict = None

--- a/tests/ml/test_benchmark.py
+++ b/tests/ml/test_benchmark.py
@@ -120,6 +120,34 @@ def test_rrmcverdict_is_constructible():
     assert v.reached and v.n_routed == 8
 
 
+def test_routed_plane_count_counts_planes_not_legs():
+    # #667 Rung E: a move-aside plan emits MULTIPLE routed legs for one plane
+    # (staging + final), so summing routed Moves over-counts and would falsely fail
+    # the reach check. Count DISTINCT planes with a routed leg; deferred (path=None)
+    # legs are excluded.
+    from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+    from ml.benchmark import _routed_plane_count
+
+    def _arc(x: float, y: float) -> DubinsArc:
+        return DubinsArc(
+            start=Pose(0.0, 0.0, 0.0),
+            end=Pose(x, y, 0.0),
+            turn_radius_m=8.0,
+            segments=(Segment("S", (x * x + y * y) ** 0.5),),
+        )
+
+    plan = MovesPlan(
+        target_layout=object(),  # MovesPlan does not validate the layout
+        moves=(
+            Move("a", Pose(0.0, -3.0, 180.0), _arc(0.0, -3.0), leg_index=0),  # staging
+            Move("a", Pose(0.0, 5.0, 0.0), _arc(0.0, 5.0), leg_index=1),  # final
+            Move("b", Pose(1.0, 4.0, 0.0), _arc(1.0, 4.0), leg_index=0),
+            Move("c", Pose(2.0, 4.0, 0.0), None, leg_index=0),  # deferred — excluded
+        ),
+    )
+    assert _routed_plane_count(plan) == 2  # planes a, b — not 3 routed legs, not c
+
+
 _TODAY = BenchScenario(
     name="today",
     scenario_path="examples/herrenteich/scenario_today.yaml",

--- a/tests/ml/test_reach_rate.py
+++ b/tests/ml/test_reach_rate.py
@@ -170,6 +170,34 @@ def test_rrmc_reach_multi_is_deterministic():
     assert rrmc_reach_multi(ss.scenario, **kw) == rrmc_reach_multi(ss.scenario, **kw)
 
 
+def test_routed_plane_count_counts_planes_not_legs():
+    # #667 Rung E: a move-aside plan emits MULTIPLE routed legs for one plane
+    # (staging + final), so summing routed Moves over-counts and would falsely fail
+    # the reach check. Count DISTINCT planes with a routed leg; deferred (path=None)
+    # legs are excluded.
+    from hangarfit.towplanner import DubinsArc, Move, MovesPlan, Pose, Segment
+    from ml.reach_rate import _routed_plane_count
+
+    def _arc(x: float, y: float) -> DubinsArc:
+        return DubinsArc(
+            start=Pose(0.0, 0.0, 0.0),
+            end=Pose(x, y, 0.0),
+            turn_radius_m=8.0,
+            segments=(Segment("S", (x * x + y * y) ** 0.5),),
+        )
+
+    plan = MovesPlan(
+        target_layout=object(),  # MovesPlan does not validate the layout
+        moves=(
+            Move("a", Pose(0.0, -3.0, 180.0), _arc(0.0, -3.0), leg_index=0),  # staging
+            Move("a", Pose(0.0, 5.0, 0.0), _arc(0.0, 5.0), leg_index=1),  # final
+            Move("b", Pose(1.0, 4.0, 0.0), _arc(1.0, 4.0), leg_index=0),
+            Move("c", Pose(2.0, 4.0, 0.0), None, leg_index=0),  # deferred — excluded
+        ),
+    )
+    assert _routed_plane_count(plan) == 2  # planes a, b — not 3 routed legs, not c
+
+
 # ── policy arm (torch-gated) ─────────────────────────────────────────────────
 
 

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -237,11 +237,11 @@ def test_timeline_single_leg_segment_omits_leg_index_key():
     assert all("leg_index" not in s for s in tl["segments"])
 
 
-def test_timeline_multi_leg_emits_one_segment_per_leg_in_leg_order():
-    # #865 Rung D: a body that relocates carries MULTIPLE Move legs (staging, then
-    # final). `_timeline` emits one sequential segment per ROUTED leg, in leg_index
-    # order regardless of tuple order, each tagged with `leg_index`; the body's
-    # final pose is the LAST leg's end (not the staging leg's).
+def test_timeline_multi_leg_emits_one_segment_per_leg_in_execution_order():
+    # #865 Rung D + #667 Rung E: a body that relocates carries MULTIPLE Move legs
+    # (staging, then final). `_timeline` emits one segment per ROUTED leg in EXECUTION
+    # (moves-tuple) order — the order the producer commits them — each tagged with
+    # `leg_index`; the body's final pose is the LAST leg's end (not the staging leg's).
     from hangarfit.towplanner import Move, MovesPlan
 
     lay = load_layout(LAYOUT)
@@ -251,8 +251,8 @@ def test_timeline_multi_leg_emits_one_segment_per_leg_in_leg_order():
     pid = a.plane_id
     staging = Move(plane_id=pid, target_slot=b.target_slot, path=b.path, leg_index=0)
     final = Move(plane_id=pid, target_slot=a.target_slot, path=a.path, leg_index=1)
-    # Tuple order REVERSED on purpose — output must still be leg-index ordered.
-    plan = MovesPlan(target_layout=base.target_layout, moves=(final, staging))
+    # Producer emits legs in execution order (staging, then final).
+    plan = MovesPlan(target_layout=base.target_layout, moves=(staging, final))
     tl, finals = scene._timeline(lay, plan)
 
     segs = [s for s in tl["segments"] if s["plane_id"] == pid]
@@ -260,8 +260,40 @@ def test_timeline_multi_leg_emits_one_segment_per_leg_in_leg_order():
     assert [s["leg_index"] for s in segs] == [0, 1]
     assert math.isclose(segs[0]["start_s"], 0.0)
     assert math.isclose(segs[1]["start_s"], segs[0]["end_s"])  # sequential, end-to-end
-    assert finals[pid] == segs[1]["samples"][-1]  # final pose = LAST leg's end
-    assert finals[pid] != segs[0]["samples"][-1]  # not the staging leg's end
+    assert finals[pid] == segs[1]["samples"][-1]  # final pose = last (final) leg, not staging
+
+
+def test_timeline_interleaves_multi_leg_in_global_execution_order():
+    # #667 Rung E: a move-aside is INTERLEAVED — D drives in (leg0), drives aside
+    # (leg1), S enters (leg0), D returns (leg2). The timeline must follow the
+    # moves-tuple execution order, NOT group D's three legs then S. Single-leg S
+    # carries no leg_index key; D (multi-leg) does. D's final pose is its last (return)
+    # leg, so it parks at its slot — not the apron — in the static scene.
+    from hangarfit.towplanner import Move, MovesPlan
+
+    lay = load_layout(LAYOUT)
+    base = plan_fill(lay)
+    routed = [m for m in base.moves if m.path is not None]
+    d_id, s_id = routed[0].plane_id, routed[1].plane_id
+    assert d_id != s_id
+    d_final, d_aside, s_route = routed[0], routed[1], routed[1]
+    plan = MovesPlan(
+        target_layout=base.target_layout,
+        moves=(
+            Move(plane_id=d_id, target_slot=d_final.target_slot, path=d_final.path, leg_index=0),
+            Move(plane_id=d_id, target_slot=d_aside.target_slot, path=d_aside.path, leg_index=1),
+            Move(plane_id=s_id, target_slot=s_route.target_slot, path=s_route.path, leg_index=0),
+            Move(plane_id=d_id, target_slot=d_final.target_slot, path=d_final.path, leg_index=2),
+        ),
+    )
+    tl, finals = scene._timeline(lay, plan)
+    segs = tl["segments"]
+    assert [s["plane_id"] for s in segs] == [d_id, d_id, s_id, d_id]  # interleaved, not grouped
+    assert [s["leg_index"] for s in segs if s["plane_id"] == d_id] == [0, 1, 2]  # D multi-leg
+    assert all("leg_index" not in s for s in segs if s["plane_id"] == s_id)  # S single-leg
+    for prev, nxt in zip(segs, segs[1:], strict=False):
+        assert math.isclose(nxt["start_s"], prev["end_s"])  # contiguous global clock
+    assert finals[d_id] == segs[3]["samples"][-1]  # D parks at its return-leg end (its slot)
 
 
 def test_sample_affines_hard_clamp_is_exact_and_keeps_endpoints():

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -296,6 +296,34 @@ def test_timeline_interleaves_multi_leg_in_global_execution_order():
     assert finals[d_id] == segs[3]["samples"][-1]  # D parks at its return-leg end (its slot)
 
 
+def test_timeline_multi_leg_skips_deferred_path_none_move():
+    # #667 Rung E: a multi-leg plan that ALSO carries a deferred (path=None) move — e.g. a
+    # hand-placed glider parked alongside a move-aside shuffle — emits NO segment for the
+    # deferred body (its `path is None` short-circuits the global-order emit loop), while
+    # the shuffle still interleaves. Covers the path=None branch of the multi-leg timeline.
+    from hangarfit.towplanner import Move, MovesPlan
+
+    lay = load_layout(LAYOUT)
+    base = plan_fill(lay)
+    routed = [m for m in base.moves if m.path is not None]
+    d_id, s_id = routed[0].plane_id, routed[1].plane_id
+    d_final, d_aside, s_route = routed[0], routed[1], routed[1]
+    plan = MovesPlan(
+        target_layout=base.target_layout,
+        moves=(
+            Move(plane_id=d_id, target_slot=d_final.target_slot, path=d_final.path, leg_index=0),
+            Move(plane_id=d_id, target_slot=d_aside.target_slot, path=d_aside.path, leg_index=1),
+            Move(plane_id=s_id, target_slot=s_route.target_slot, path=s_route.path, leg_index=0),
+            Move(plane_id=d_id, target_slot=d_final.target_slot, path=d_final.path, leg_index=2),
+            # deferred body: present at rest, never routed (mirrors a hand-placed glider)
+            Move(plane_id="deferred", target_slot=d_final.target_slot, path=None, leg_index=0),
+        ),
+    )
+    tl, _ = scene._timeline(lay, plan)
+    assert all(s["plane_id"] != "deferred" for s in tl["segments"])  # path=None emits nothing
+    assert [s["plane_id"] for s in tl["segments"]] == [d_id, d_id, s_id, d_id]  # shuffle intact
+
+
 def test_sample_affines_hard_clamp_is_exact_and_keeps_endpoints():
     # Directly exercise the overshoot branch: max_samples=2 forces the densely
     # sampled path to overshoot, so the clamp must fire — bounding the count

--- a/tests/test_towplanner.py
+++ b/tests/test_towplanner.py
@@ -149,6 +149,26 @@ def test_movesplan_allows_multiple_legs_per_plane():
     assert [m.leg_index for m in same_plane] == [0, 1]
 
 
+def test_movesplan_rejects_duplicate_routed_leg_index_for_a_plane():
+    # #667 Rung E (type-design F1): two ROUTED legs of one plane sharing a leg_index
+    # make scene._timeline's `sorted(..., key=leg_index)` order ill-defined, so it is
+    # rejected at construction.
+    a = Move("fk9", Pose(0.0, 5.0, 0.0), _straight_arc(0.0, 5.0), leg_index=0)
+    b = Move("fk9", Pose(1.0, 6.0, 0.0), _straight_arc(1.0, 6.0), leg_index=0)
+    with pytest.raises(ValueError, match="leg_index"):
+        MovesPlan(target_layout=object(), moves=(a, b))
+
+
+def test_movesplan_allows_routed_plus_deferred_same_leg_index():
+    # #667 Rung E (F1): a routed leg + a DEFERRED (path=None) leg of one plane may
+    # share leg_index=0 — build_moves_plan (ml/infer.py) and placed-routed movers do
+    # exactly this. Only routed legs are checked for uniqueness.
+    routed = Move("fuji", Pose(0.0, 5.0, 0.0), _straight_arc(0.0, 5.0), leg_index=0)
+    deferred = Move("fuji", Pose(0.0, 5.0, 0.0), None, leg_index=0)
+    plan = MovesPlan(target_layout=object(), moves=(routed, deferred))
+    assert len(plan.moves) == 2
+
+
 def test_movesplan_construction_roundtrip():
     layout = object()  # placeholder; Move/MovesPlan do not validate layout in Wave 1
     move = Move(

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -380,6 +380,150 @@ def test_plan_fill_move_aside_skipped_without_apron(monkeypatch: pytest.MonkeyPa
     assert exc.value.plane_id == "stuck"
 
 
+def _assert_plan_legs_valid(plan: MovesPlan, target: Layout) -> None:
+    """Every routed leg is collision-free against the world state at its execution time.
+
+    Replays ``plan.moves`` in tuple (= execution) order against a live ``{plane_id:
+    Pose}`` map seeded empty; each routed leg is checked with the exact ``path_first_
+    conflict`` oracle against the bodies parked *before* it (plus any fixed obstacles).
+    A staging leg's ``target_slot`` (y<0, apron) is transient — only the motion oracle
+    applies to it, and it updates the live map so a later leg sees the body at staging.
+    Aircraft-only fixture scope; the apron the planner used rides on ``target.hangar``.
+    """
+    from hangarfit.towplanner import path_first_conflict
+
+    fleet = target.fleet
+    on_carts = {p.plane_id: p.on_carts for p in target.placements}
+    fixed = tuple(
+        gp
+        for gp in target.ground_object_placements
+        if target.ground_objects[gp.plane_id].object_class == "fixed_obstacle"
+    )
+    current: dict[str, Pose] = {}
+    for m in plan.moves:
+        if m.path is None:  # hand-placed / deferred: a parked obstacle, no motion
+            current[m.plane_id] = m.target_slot
+            continue
+        others = tuple(
+            Placement(pid, pose.x_m, pose.y_m, pose.heading_deg, on_carts.get(pid, False))
+            for pid, pose in current.items()
+            if pid != m.plane_id
+        )
+        obstacles = Layout(
+            fleet=fleet,
+            hangar=target.hangar,
+            placements=others,
+            maintenance_plane=target.maintenance_plane,
+            ground_objects=target.ground_objects,
+            ground_object_placements=fixed,
+        )
+        assert (
+            path_first_conflict(
+                m.path,
+                fleet[m.plane_id],
+                mover_on_carts=on_carts.get(m.plane_id, False),
+                placed=obstacles,
+            )
+            is None
+        ), f"leg {m.plane_id} #{m.leg_index} collides at execution time"
+        current[m.plane_id] = m.target_slot
+
+
+def test_assert_plan_legs_valid_accepts_a_clean_real_plan() -> None:
+    # The multi-leg validity validator: replay every routed leg against the world state
+    # at its execution time. A clean, real (single-leg) plan must pass.
+    h = _hangar(width_m=20.0, length_m=30.0)
+    fleet = {"A": _box_plane("A"), "B": _box_plane("B")}
+    target = _layout(fleet, h, _slot("A", 6.0, 8.0), _slot("B", 14.0, 22.0))
+    _assert_plan_legs_valid(plan_fill(target), target)  # must not raise
+
+
+def test_assert_plan_legs_valid_rejects_a_leg_that_collides_at_execution_time() -> None:
+    # Forge a leg that drives the shallow plane onto the deep plane's parked pose
+    # (reusing the deep plane's own valid path): validating it against the deep plane
+    # already in the live pose map must raise — proving the validator actually checks.
+    h = _hangar(width_m=20.0, length_m=30.0)
+    fleet = {"A": _box_plane("A"), "B": _box_plane("B")}
+    target = _layout(fleet, h, _slot("A", 6.0, 8.0), _slot("B", 14.0, 22.0))
+    plan = plan_fill(target)  # back_first_order → [B (deep), A (shallow)]
+    deep = next(m for m in plan.moves if m.plane_id == "B")
+    forged = tp.Move("A", deep.target_slot, deep.path, leg_index=0)  # A drives to B's pose
+    bad = MovesPlan(target_layout=target, moves=(deep, forged))
+    with pytest.raises(AssertionError, match="collides at execution time"):
+        _assert_plan_legs_valid(bad, target)
+
+
+def _wide_plane(plane_id: str, *, span_m: float = 4.5, turn_radius_m: float = 5.0) -> Aircraft:
+    """A wide-wing own-gear plane: wide enough to mutually block in a tight hangar,
+    narrow enough to clear a ~6 m door. Used by the real-geometry move-aside tests."""
+    return Aircraft(
+        id=plane_id,
+        name=f"Wide {plane_id}",
+        wing_position="high",
+        gear="tailwheel",
+        movement_mode="always_own_gear",
+        turn_radius_m=turn_radius_m,
+        measured=False,
+        parts=(
+            Part(
+                "wing",
+                length_m=1.2,
+                width_m=span_m,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=1.8,
+                z_top_m=2.1,
+            ),
+            Part(
+                "fuselage_aft",
+                length_m=3.0,
+                width_m=1.0,
+                offset_x_m=0.0,
+                offset_y_m=0.0,
+                angle_deg=0.0,
+                z_bottom_m=0.0,
+                z_top_m=2.1,
+            ),
+        ),
+        wheels=_TAIL_WHEELS,
+    )
+
+
+def test_move_aside_inert_on_routable_real_fill_and_byte_identical() -> None:
+    # On a REAL fill the non-displacing search already routes, move-aside never fires:
+    # every leg is single (leg_index 0), the plan is leg-valid by the exact oracle, and
+    # a second solve is byte-identical. The apron is set so the two-phase path is
+    # REACHABLE but goes unused — i.e. phase 1 alone seats everyone (ADR-0003).
+    h = _hangar(width_m=20.0, length_m=30.0, apron_depth_m=8.0)
+    fleet = {"A": _box_plane("A"), "B": _box_plane("B")}
+    target = _layout(fleet, h, _slot("A", 6.0, 8.0), _slot("B", 14.0, 22.0))
+    plan = plan_fill(target)
+    assert all(m.leg_index == 0 for m in plan.moves)  # no shuffle: phase 1 sufficed
+    _assert_plan_legs_valid(plan, target)
+    assert plan_fill(target) == plan  # byte-identical double-solve
+
+
+@pytest.mark.slow
+def test_move_aside_real_geometry_unresolvable_block_runs_phase2_and_bails() -> None:
+    # The ONLY coverage that runs the phase-2 move-aside on REAL geometry (real
+    # _staging_poses + real plan_path return legs, not monkeypatched). A tight two-wide
+    # block plus a third body deadlocks phase 1 within budget, so phase 2 runs the real
+    # shuffle search; depth-1 move-aside cannot resolve this symmetric block (see the
+    # spike), so it bails with a structured NoFeasiblePlanError rather than crashing.
+    h = _hangar(width_m=12.0, length_m=16.0, door_center=6.0, door_width=6.0, apron_depth_m=8.0)
+    fleet = {k: _wide_plane(k) for k in ("A", "B", "C")}
+    target = _layout(
+        fleet,
+        h,
+        _slot("A", 3.5, 10.0),
+        _slot("B", 8.5, 10.0),
+        _slot("C", 6.0, 5.0),
+    )
+    with pytest.raises(NoFeasiblePlanError):
+        plan_fill(target, max_total_expansions=5000)
+
+
 def test_plan_fill_bails_with_structured_error_when_unplannable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -318,6 +318,68 @@ def test_plan_fill_backtrack_cap_bounds_the_order_search(
     assert ei.value.conflict is not None and ei.value.conflict.planes[0] == "B"
 
 
+# ── #667 Rung E: move-aside (two-phase order search) ─────────────────────────
+
+
+def _two_plane_mutual_block_layout(apron_depth_m: float = 6.0) -> Layout:
+    """Two planes that MUTUALLY block: neither tow order works (so the non-displacing
+    DFS deadlocks), but a depth-1 move-aside resolves it — exactly the case Rung E
+    targets. ``blocker`` (D) is deep, ``stuck`` (S) shallow."""
+    h = _hangar(width_m=20.0, length_m=30.0, apron_depth_m=apron_depth_m)
+    fleet = {"blocker": _box_plane("blocker"), "stuck": _box_plane("stuck")}
+    return _layout(fleet, h, _slot("blocker", 10.0, 22.0), _slot("stuck", 10.0, 8.0))
+
+
+def _mutual_block_fake_plan_path(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
+    """plan_path stand-in for a mutual block. Single-start calls (``entries`` is None)
+    are the displaced body's move-aside legs (to/from the apron) — always feasible.
+    Multi-start (cone) calls apply the block: S (``stuck``) can't route while D
+    (``blocker``) sits at its FINAL slot (y>=0), but CAN once D is on the apron (y<0);
+    D can't route while S is parked. So [D,S] and [S,D] both deadlock, and only moving
+    D aside lets S in."""
+    if kw.get("entries") is None:  # a single-start move-aside leg (D aside / return)
+        return _fake_arc(mover, entry, goal)
+    by_id = {p.plane_id: p for p in placed.placements}
+    if mover.id == "stuck":
+        d = by_id.get("blocker")
+        if d is not None and d.y_m >= 0.0:  # D at its final slot blocks S; D@staging (y<0) doesn't
+            raise _forced_infeasible("stuck")
+    if mover.id == "blocker" and "stuck" in by_id:  # S parked blocks D
+        raise _forced_infeasible("blocker")
+    return _fake_arc(mover, entry, goal)
+
+
+def test_plan_fill_resolves_mutual_block_via_move_aside(monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _two_plane_mutual_block_layout()
+    monkeypatch.setattr(tp, "plan_path", _mutual_block_fake_plan_path)
+    plan = plan_fill(target)
+    legs = {(m.plane_id, m.leg_index) for m in plan.moves if m.path is not None}
+    # D gets its original placement leg (0) + the aside (1) and return (2) legs; S routes (0).
+    assert {("stuck", 0), ("blocker", 0), ("blocker", 1), ("blocker", 2)} <= legs
+    # The shuffle bundle is in execution order: D drives aside, S enters, D returns.
+    order = [(m.plane_id, m.leg_index) for m in plan.moves if m.path is not None]
+    assert order.index(("blocker", 1)) < order.index(("stuck", 0)) < order.index(("blocker", 2))
+
+
+def test_plan_fill_max_displacements_zero_is_inert(monkeypatch: pytest.MonkeyPatch) -> None:
+    # max_displacements=0 disables move-aside → the mutual block bails, naming the stuck body.
+    target = _two_plane_mutual_block_layout()
+    monkeypatch.setattr(tp, "plan_path", _mutual_block_fake_plan_path)
+    with pytest.raises(NoFeasiblePlanError) as exc:
+        plan_fill(target, max_displacements=0)
+    assert exc.value.plane_id == "stuck"  # #668: names the STUCK body, not the displaced one
+
+
+def test_plan_fill_move_aside_skipped_without_apron(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Move-aside relocates a body OUTSIDE the door, so it requires a staging apron.
+    # With apron_depth_m=0 the mutual block cannot be resolved and bails.
+    target = _two_plane_mutual_block_layout(apron_depth_m=0.0)
+    monkeypatch.setattr(tp, "plan_path", _mutual_block_fake_plan_path)
+    with pytest.raises(NoFeasiblePlanError) as exc:
+        plan_fill(target)
+    assert exc.value.plane_id == "stuck"
+
+
 def test_plan_fill_bails_with_structured_error_when_unplannable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -505,12 +505,21 @@ def test_move_aside_inert_on_routable_real_fill_and_byte_identical() -> None:
 
 
 @pytest.mark.slow
-def test_move_aside_real_geometry_unresolvable_block_runs_phase2_and_bails() -> None:
+def test_move_aside_real_geometry_unresolvable_block_runs_phase2_and_bails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # The ONLY coverage that runs the phase-2 move-aside on REAL geometry (real
     # _staging_poses + real plan_path return legs, not monkeypatched). A tight two-wide
     # block plus a third body deadlocks phase 1 within budget, so phase 2 runs the real
     # shuffle search; depth-1 move-aside cannot resolve this symmetric block (see the
     # spike), so it bails with a structured NoFeasiblePlanError rather than crashing.
+    #
+    # The per-plane cap (max_expansions) is kept low so failed routes fail fast and
+    # phase 1 *completes* the order search (returns None) rather than raising on the
+    # global budget — only then does phase 2 run. We SPY on _staging_poses (delegating
+    # to the real impl) and assert it was invoked, so the test fails loudly if a future
+    # change ever lets phase 1 budget-raise and skip phase 2 (PR #869 review) instead of
+    # passing vacuously on a phase-1 bail (which would also satisfy `pytest.raises`).
     h = _hangar(width_m=12.0, length_m=16.0, door_center=6.0, door_width=6.0, apron_depth_m=8.0)
     fleet = {k: _wide_plane(k) for k in ("A", "B", "C")}
     target = _layout(
@@ -520,8 +529,19 @@ def test_move_aside_real_geometry_unresolvable_block_runs_phase2_and_bails() -> 
         _slot("B", 8.5, 10.0),
         _slot("C", 6.0, 5.0),
     )
+    staging_calls = {"n": 0}
+    real_staging = tp._staging_poses
+
+    def _spy_staging(*args: object, **kwargs: object) -> object:
+        staging_calls["n"] += 1
+        return real_staging(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(tp, "_staging_poses", _spy_staging)
     with pytest.raises(NoFeasiblePlanError):
-        plan_fill(target, max_total_expansions=5000)
+        plan_fill(target, max_expansions=300, max_total_expansions=3000)
+    assert staging_calls["n"] > 0, (
+        "phase 2 move-aside must execute (not be skipped by a phase-1 raise)"
+    )
 
 
 def test_plan_fill_bails_with_structured_error_when_unplannable(

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -78,6 +78,7 @@ def _hangar(
     length_m: float = 30.0,
     door_center: float = 10.0,
     door_width: float = 6.0,
+    apron_depth_m: float = 0.0,
 ) -> Hangar:
     return Hangar(
         length_m=length_m,
@@ -86,11 +87,36 @@ def _hangar(
         maintenance_bay=MaintenanceBay(center_x_m=width_m / 2, width_m=2.0, depth_m=2.0),
         clearance_m=0.5,
         wing_layer_clearance_m=0.3,
+        apron_depth_m=apron_depth_m,
     )
 
 
 def _slot(pid: str, x: float, y: float, h: float = 0.0, on_carts: bool = False) -> Placement:
     return Placement(plane_id=pid, x_m=x, y_m=y, heading_deg=h, on_carts=on_carts)
+
+
+def test_staging_poses_are_apron_out_lateral_deepest_first_nose_out() -> None:
+    # #667 Rung E: where a displaced body parks. Apron-out (y<0), off-to-the-side of
+    # the door (so it doesn't jam the corridor the stuck body enters through), nose-out,
+    # deepest apron pose first (the #844 cross-machine cost-margin lever).
+    h = _hangar(apron_depth_m=6.0)  # door [7, 13] in a width-20 hangar
+    slot = _slot("d", 4.0, 8.0)
+    poses = tp._staging_poses(slot, h)
+    assert poses
+    assert all(p.y_m < 0.0 for p in poses)  # outside the door
+    assert poses[0].y_m == -6.0  # deepest apron first
+    door_lo, door_hi = (
+        h.door.center_x_m - h.door.width_m / 2,
+        h.door.center_x_m + h.door.width_m / 2,
+    )
+    assert any(p.x_m < door_lo or p.x_m > door_hi for p in poses)  # lateral, off the door
+    assert all(135.0 <= p.heading_deg <= 225.0 for p in poses)  # nose-out cone
+    assert tp._staging_poses(slot, h) == poses  # deterministic
+    assert len({(p.x_m, p.y_m, p.heading_deg) for p in poses}) == len(poses)  # dedup
+
+
+def test_staging_poses_empty_without_apron() -> None:
+    assert tp._staging_poses(_slot("d", 4.0, 8.0), _hangar(apron_depth_m=0.0)) == ()
 
 
 def test_entry_pose_is_at_front_pointing_in() -> None:

--- a/tests/test_towplanner_fill.py
+++ b/tests/test_towplanner_fill.py
@@ -330,22 +330,25 @@ def _two_plane_mutual_block_layout(apron_depth_m: float = 6.0) -> Layout:
     return _layout(fleet, h, _slot("blocker", 10.0, 22.0), _slot("stuck", 10.0, 8.0))
 
 
+def _mutual_block_cone(mover, placed) -> None:  # noqa: ANN001
+    """The phase-1 cone block shared by the move-aside fakes: D (``blocker``) at its
+    FINAL slot (y>=0) blocks S (``stuck``) — but D@staging (y<0) does not; S parked
+    blocks D. So [D,S] and [S,D] both deadlock and only moving D aside lets S in."""
+    by_id = {p.plane_id: p for p in placed.placements}
+    d = by_id.get("blocker")
+    if mover.id == "stuck" and d is not None and d.y_m >= 0.0:
+        raise _forced_infeasible("stuck")
+    if mover.id == "blocker" and "stuck" in by_id:
+        raise _forced_infeasible("blocker")
+
+
 def _mutual_block_fake_plan_path(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
     """plan_path stand-in for a mutual block. Single-start calls (``entries`` is None)
     are the displaced body's move-aside legs (to/from the apron) — always feasible.
-    Multi-start (cone) calls apply the block: S (``stuck``) can't route while D
-    (``blocker``) sits at its FINAL slot (y>=0), but CAN once D is on the apron (y<0);
-    D can't route while S is parked. So [D,S] and [S,D] both deadlock, and only moving
-    D aside lets S in."""
+    Multi-start (cone) calls apply :func:`_mutual_block_cone`."""
     if kw.get("entries") is None:  # a single-start move-aside leg (D aside / return)
         return _fake_arc(mover, entry, goal)
-    by_id = {p.plane_id: p for p in placed.placements}
-    if mover.id == "stuck":
-        d = by_id.get("blocker")
-        if d is not None and d.y_m >= 0.0:  # D at its final slot blocks S; D@staging (y<0) doesn't
-            raise _forced_infeasible("stuck")
-    if mover.id == "blocker" and "stuck" in by_id:  # S parked blocks D
-        raise _forced_infeasible("blocker")
+    _mutual_block_cone(mover, placed)
     return _fake_arc(mover, entry, goal)
 
 
@@ -378,6 +381,186 @@ def test_plan_fill_move_aside_skipped_without_apron(monkeypatch: pytest.MonkeyPa
     with pytest.raises(NoFeasiblePlanError) as exc:
         plan_fill(target)
     assert exc.value.plane_id == "stuck"
+
+
+# The move-aside happy path (a shuffle that commits) is covered above; the rest of
+# the two-phase core is its failure/edge branches. These exercise them FAST with a
+# monkeypatched plan_path (no real geometry search), so the move-aside logic is fully
+# covered without leaning on the one @slow real-geometry integration test.
+
+
+def test_move_aside_skips_to_next_staging_when_aside_leg_infeasible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Aside leg (D -> deepest-apron staging) infeasible: _route swallows it and the
+    # loop tries the next staging pose, which routes -> the shuffle still resolves.
+    target = _two_plane_mutual_block_layout()
+
+    def fake(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
+        if kw.get("entries") is None:  # move-aside leg
+            if goal.y_m == -hangar.apron_depth_m:  # aside to the DEEPEST apron pose fails
+                raise _forced_infeasible(mover.id)
+            return _fake_arc(mover, entry, goal)
+        _mutual_block_cone(mover, placed)
+        return _fake_arc(mover, entry, goal)
+
+    monkeypatch.setattr(tp, "plan_path", fake)
+    legs = {(m.plane_id, m.leg_index) for m in plan_fill(target).moves if m.path is not None}
+    assert {("stuck", 0), ("blocker", 1), ("blocker", 2)} <= legs  # resolved via a shallower pose
+
+
+def test_move_aside_bails_when_every_aside_leg_infeasible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No staging pose admits the aside leg: every attempt is skipped and the order
+    # search exhausts move-aside, so the whole fill bails with a structured error.
+    target = _two_plane_mutual_block_layout()
+
+    def fake(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
+        if kw.get("entries") is None:  # every move-aside leg infeasible
+            raise _forced_infeasible(mover.id)
+        _mutual_block_cone(mover, placed)
+        return _fake_arc(mover, entry, goal)
+
+    monkeypatch.setattr(tp, "plan_path", fake)
+    with pytest.raises(NoFeasiblePlanError):
+        plan_fill(target)
+
+
+def test_move_aside_continues_when_stuck_body_still_blocked_at_staging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # S can't route even with D on the apron: the S-leg failure is charged and the
+    # loop moves on; with no staging that admits S, the fill bails.
+    target = _two_plane_mutual_block_layout()
+
+    def fake(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
+        if kw.get("entries") is None:  # D's aside/return legs feasible
+            return _fake_arc(mover, entry, goal)
+        if mover.id == "stuck":  # S never routes via the cone, even with D aside
+            raise _forced_infeasible("stuck")
+        _mutual_block_cone(mover, placed)
+        return _fake_arc(mover, entry, goal)
+
+    monkeypatch.setattr(tp, "plan_path", fake)
+    with pytest.raises(NoFeasiblePlanError):
+        plan_fill(target)
+
+
+def test_move_aside_skips_to_next_staging_when_return_leg_infeasible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Return leg (deepest staging -> D's slot, against S@final) infeasible: skip to the
+    # next staging pose, whose return routes -> the shuffle resolves.
+    target = _two_plane_mutual_block_layout()
+
+    def fake(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
+        if kw.get("entries") is None:  # move-aside leg
+            if goal.y_m >= 0.0 and entry.y_m == -hangar.apron_depth_m:  # return from DEEPEST fails
+                raise _forced_infeasible(mover.id)
+            return _fake_arc(mover, entry, goal)
+        _mutual_block_cone(mover, placed)
+        return _fake_arc(mover, entry, goal)
+
+    monkeypatch.setattr(tp, "plan_path", fake)
+    legs = {(m.plane_id, m.leg_index) for m in plan_fill(target).moves if m.path is not None}
+    assert {("stuck", 0), ("blocker", 1), ("blocker", 2)} <= legs
+
+
+def test_move_aside_bails_when_aside_leg_exhausts_global_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The aside leg alone drains the global expansion budget: the post-aside budget
+    # check trips and move-aside abandons the shuffle (it never wastes the S leg).
+    target = _two_plane_mutual_block_layout()
+
+    def fake(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
+        if kw.get("entries") is None:  # move-aside legs are charged a huge cost
+            kw["stats"]["expansions"] = 10_000
+            return _fake_arc(mover, entry, goal)
+        _mutual_block_cone(mover, placed)  # phase-1 cone calls charge nothing
+        return _fake_arc(mover, entry, goal)
+
+    monkeypatch.setattr(tp, "plan_path", fake)
+    with pytest.raises(NoFeasiblePlanError):
+        plan_fill(target, max_total_expansions=100)
+
+
+def test_move_aside_bails_when_budget_drains_before_return_leg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Aside is cheap (passes the post-aside check) but S drains the budget, so the
+    # return leg's _route sees no budget at entry and returns None -> the loop skips on,
+    # and every later _route also short-circuits on the drained budget -> the fill bails.
+    target = _two_plane_mutual_block_layout()
+
+    def fake(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
+        if kw.get("entries") is None:  # aside/return: free
+            kw["stats"]["expansions"] = 0
+            return _fake_arc(mover, entry, goal)
+        if any(p.y_m < 0.0 for p in placed.placements):  # phase-2 S leg (D parked on the apron)
+            kw["stats"]["expansions"] = 10_000  # S succeeds but drains the global budget
+            return _fake_arc(mover, entry, goal)
+        _mutual_block_cone(mover, placed)  # phase-1 cone calls charge nothing
+        return _fake_arc(mover, entry, goal)
+
+    monkeypatch.setattr(tp, "plan_path", fake)
+    with pytest.raises(NoFeasiblePlanError):
+        plan_fill(target, max_total_expansions=100)
+
+
+def test_move_aside_records_apron_fallback_for_committed_stuck_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # When S commits via the y=0 door-line fallback (apron_fallback set on its leg) the
+    # diagnostics out-param records it — in committed-move order, plan-inert.
+    target = _two_plane_mutual_block_layout()
+
+    def fake(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
+        if kw.get("entries") is None:
+            return _fake_arc(mover, entry, goal)
+        if any(p.y_m < 0.0 for p in placed.placements):  # phase-2 S leg
+            kw["stats"]["apron_fallback"] = True
+            return _fake_arc(mover, entry, goal)
+        _mutual_block_cone(mover, placed)
+        return _fake_arc(mover, entry, goal)
+
+    monkeypatch.setattr(tp, "plan_path", fake)
+    drops: list[tp.ApronShallowDrop] = []
+    plan = plan_fill(target, apron_dropped_out=drops)
+    assert {(m.plane_id, m.leg_index) for m in plan.moves if m.path is not None} >= {("stuck", 0)}
+    assert [d.plane_id for d in drops] == ["stuck"]  # the committed stuck body, recorded
+
+
+def _three_plane_all_block_layout(apron_depth_m: float = 6.0) -> Layout:
+    """Three planes that each block every other at its FINAL slot, so only one places
+    before the fill deadlocks. Used to exercise the displacement cap + per-path undo."""
+    h = _hangar(width_m=20.0, length_m=30.0, apron_depth_m=apron_depth_m)
+    fleet = {k: _box_plane(k) for k in ("p1", "p2", "p3")}
+    return _layout(
+        fleet, h, _slot("p1", 10.0, 24.0), _slot("p2", 10.0, 16.0), _slot("p3", 10.0, 8.0)
+    )
+
+
+def test_move_aside_respects_displacement_cap_and_undoes_failed_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # max_displacements=1: the first shuffle commits, but the remaining body needs a
+    # SECOND displacement which the cap forbids -> the recursion fails, the committed
+    # body is undone (counter stays), the next staging hits the cap guard, and the fill
+    # bails. Drives the cap entry-guard, the commit-time cap check, and the undo path.
+    target = _three_plane_all_block_layout()
+
+    def fake(mover, entry, goal, *, hangar, placed, mover_on_carts, **kw):  # noqa: ANN001, ANN202
+        if kw.get("entries") is None:  # move-aside legs feasible
+            return _fake_arc(mover, entry, goal)
+        if any(p.plane_id != mover.id and p.y_m >= 0.0 for p in placed.placements):
+            raise _forced_infeasible(mover.id)  # any plane parked at a final slot blocks the rest
+        return _fake_arc(mover, entry, goal)
+
+    monkeypatch.setattr(tp, "plan_path", fake)
+    with pytest.raises(NoFeasiblePlanError):
+        plan_fill(target, max_displacements=1, max_backtracks=2000)
 
 
 def _assert_plan_legs_valid(plan: MovesPlan, target: Layout) -> None:

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -598,15 +598,18 @@ class TestDrawTowPaths:
     """
 
     @staticmethod
-    def _vertical_move(plane_id: str, x0: float, y0: float, length: float):
+    def _vertical_move(plane_id: str, x0: float, y0: float, length: float, leg_index: int = 0):
         """A trivial straight (S-leg) move from (x0,y0) heading +y, so the
-        sampled polyline is the vertical segment (x0, y0)→(x0, y0+length)."""
+        sampled polyline is the vertical segment (x0, y0)→(x0, y0+length).
+
+        ``leg_index`` (default 0) lets a test give one plane several distinct legs
+        (the multi-leg model), which the routed-leg-uniqueness invariant requires."""
         from hangarfit.towplanner import DubinsArc, Move, Pose, Segment
 
         start = Pose(x_m=x0, y_m=y0, heading_deg=0.0)
         end = Pose(x_m=x0, y_m=y0 + length, heading_deg=0.0)
         arc = DubinsArc(start=start, end=end, turn_radius_m=1.0, segments=(Segment("S", length),))
-        return Move(plane_id=plane_id, target_slot=end, path=arc)
+        return Move(plane_id=plane_id, target_slot=end, path=arc, leg_index=leg_index)
 
     def _plan(self, *moves):
         from hangarfit.towplanner import MovesPlan
@@ -637,12 +640,13 @@ class TestDrawTowPaths:
         assert len(set(colours)) == 2, f"distinct planes must get distinct colours, got {colours}"
 
     def test_same_plane_keeps_one_colour(self) -> None:
-        # "one colour per plane": two moves for the same plane id share a colour.
+        # "one colour per plane": two routed LEGS of the same plane id (a move-aside
+        # body carries multiple legs, distinct leg_index) share a colour.
         from hangarfit.visualize import _draw_tow_paths
 
         plan = self._plan(
-            self._vertical_move("a", 0.0, 0.0, 5.0),
-            self._vertical_move("a", 1.0, 0.0, 3.0),
+            self._vertical_move("a", 0.0, 0.0, 5.0, leg_index=0),
+            self._vertical_move("a", 1.0, 0.0, 3.0, leg_index=1),
         )
         ax = MagicMock()
         _draw_tow_paths(ax, plan)


### PR DESCRIPTION
Closes #868. Rung E of the #667 shuffle-aware tow-routing program (A–D merged).

## What this adds

**Move-aside**: when the empty-hangar fill's non-displacing order search deadlocks
*within budget*, a second phase temporarily relocates an already-parked aircraft (D)
to an apron-out staging pose, routes the stuck aircraft (S) past it, and returns D to
its slot — emitting a valid **multi-leg** plan (D legs 0/1/2, S leg 0) where no monotone
fill order exists.

## Architecture

- **Two-phase order search** (`_plan_fill`): phase 1 is today's non-displacing
  backtracking DFS, unchanged (`allow_displace=False`). Phase 2 runs **only** if phase 1
  returns `None` (an *in-budget* deadlock — not a budget/backtrack raise, which
  propagates straight out), with a fresh expansion budget and move-aside enabled. This is
  the byte-identity hinge: any layout phase 1 solves never reaches phase 2 (ADR-0003), and
  a budget-bound fill raises in phase 1 so phase 2 never runs (→ no added cost).
- **`_try_move_aside`** (depth-1): for the deepest stuck S, displace a placed body D
  (deepest-first via `back_first_order`, never hand-placed, never twice per DFS path via a
  `displaced_planes` set), route the 3 legs with real `plan_path` against the **scenario
  hangar** (so `path_first_conflict`'s apron exemption is self-consistent), first feasible
  wins. Requires a staging apron (`hangar.apron_depth_m > 0`); globally capped by
  `_MAX_FILL_DISPLACEMENTS=16` / the `max_displacements` kwarg (`0` disables → pre-Rung-E).
- **Scene timeline** (`scene._timeline`): with a multi-leg body present, segments are laid
  in global execution (moves-tuple) order so D's legs interleave with S routing between
  them; single-leg plans keep the `back_first_order` path → byte-identical. `SCHEMA`
  unchanged (additive).
- **`MovesPlan.__post_init__`** invariant (F1): routed legs are distinct per plane.
- **`_FillStep`** result unit: `_place_rest` returns step bundles (byte-identical refactor).
- **ml/ reach counters** now count distinct *planes*, not routed *legs* (a multi-leg plan
  has >1 routed Move per plane).

## Honest ceiling caveat

Move-aside adds reachability only for **in-budget cyclic cores**. Re-baselining the real
Herrenteich all-8 witness with `--apron-depth auto` (which enables move-aside) shows it
**still bails on the same body** (`zlin_savage`, budget 8000 exhausted) — the corridor is
budget-bound, so phase 1 raises before phase 2 ever runs. A targeted search of ~480
synthetic 2–3 plane configs found **zero** move-aside resolutions: in a monotone fill any
plane places first into an empty hangar, so a *small* deadlock is a symmetric mutual block
whose displaced-body return leg is blocked for the same reason — depth-1 move-aside helps
only larger cyclic cores (the ≥5-body core the Rung C probe found), which a unit fixture
can't capture. The bar here is the **capability** + byte-identity + a re-baselined ceiling,
**not** a guaranteed all-8 route. Full numbers in
`docs/spikes/herrenteich-routing-ceiling-baseline.md` (new "Rung E" section).

## Perf / determinism

No regression: fast bench correctness + `det=ok` on every regime; `roomy_three_apron`
≈ 27 s (on par with its non-apron sibling); the phase-2-sensitive heavy disprove
`tight_six_apron` bails at phase-1 budget exhaustion (~80 s, `det ok`) so the two-phase
change is inert there. Move-aside is **same-machine-byte-bound** (kept out of cross-machine
canaries; the #844 libm note).

## Tests

- Control flow (fast, monkeypatched `plan_path`): mutual-block resolves, `max_displacements=0`
  inert, no-apron skip, #668 stuck-body naming.
- Real geometry: move-aside inert + byte-identical double-solve on a routable fill; `@slow`
  test runs the **real** phase-2 (real `_staging_poses` + `plan_path` return legs) on a tight
  block and bails cleanly.
- `_assert_plan_legs_valid` multi-leg validator (accepts a clean plan, rejects a forged
  colliding leg).
- Scene: interleaved global-execution-order timeline; single-leg byte-identity preserved.
- `make test` green (two-pass full suite incl. serial determinism canaries).

`geometry-invariant-guard` is **not** triggered (no `geometry.py` / `collisions.py` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
