### PR TITLE
docs(#442): v0.18.0 interactive-placement-editor design spec + impl plan

### DIFF
--- a/docs/superpowers/plans/2026-07-02-v0.18.0-interactive-placement-editor.md
+++ b/docs/superpowers/plans/2026-07-02-v0.18.0-interactive-placement-editor.md
@@ -15,7 +15,7 @@
 - **Determinism of the artifact:** the exported YAML is formatted deterministically (fixed decimals, sorted keys) so it is stable/diffable.
 - **`viewer-build-drift` guard:** any `interaction/*.ts` imported by `main.ts` changes the inlined bundle → run `npm --prefix viewer/ run build` and commit `src/hangarfit/_viewer_assets/viewer.js` in the SAME commit.
 - **`viewer.js` is inlined** (`viewer.py:106`): there is NO "byte-identical HTML" invariant. What holds: `#scene` bytes unchanged; non-edit path emits no `editor-context` blob and uses the normal `_HUD`; edit mode is additive HTML.
-- **Export target shape** = `tests/fixtures/scenario_with_pin.yaml` (proven loader-valid). Loader allowlist: `{pin, force_on_carts, priority, nose_out}`. A `pin` requires ALL of `x_m/y_m/heading_deg/on_carts`; plane_id is the constraint KEY (never inside the block).
+- **Export target shape** = based on `tests/fixtures/scenario_with_pin.yaml` (proven loader-valid) plus the #441 `priority` sub-key (also in the allowlist). A maintenance plane MUST appear in `fleet_in` (Scenario invariant). Loader allowlist: `{pin, force_on_carts, priority, nose_out}`. A `pin` requires ALL of `x_m/y_m/heading_deg/on_carts`; plane_id is the constraint KEY (never inside the block).
 - **Node dev toolchain:** run viewer commands via `npm --prefix viewer/ …`; verify a build without clobbering the committed bundle with `VIEWER_OUTFILE=/tmp/viewer-scratch.js npm --prefix viewer/ run build`.
 - **Python invocation:** bare `pytest` / `hangarfit` (editable install `.pth` points at the main checkout — do not use a worktree for these runs without `PYTHONPATH=$PWD/src`).
 - **GitFlow:** branch `feature/442-interactive-placement-editor` off `develop`; one PR per chunk, base `develop`, `Closes #<chunk-issue>` in the body; never push to `develop`.
@@ -62,7 +62,7 @@ Expected: highest existing is `0028-*`; use `0029` (adjust if not).
 
 - [ ] **Step 2: Write the ADR** (`docs/adr/0029-editor-intent-artifact-contract.md`)
 
-Content: Context (the editor needs to hand intent back to Python); Decision — the `Intent` object (`selectedPlaneIds`/`priorities`/`mustPositions`) maps 1:1 to `Scenario.constraints` (`fleet_in`/`priority`/`pin`); the round-trip is a file (Stage 2); **the ADR-0002 carve-out** — pin captures the Python-emitted current pose as scalars and edits them as number fields; no in-browser drag/rotation composes an affine; Consequences — `interaction/*` never imports `affine.ts`/`anchors.ts`; the `editor-context` blob is a viewer-HTML-level artifact (like `viewer-compare/v1`), NOT a scene/v2 change; Alternatives considered (live translation drag; non-authoritative drag+rotate preview) — deferred.
+Content: Context (the editor needs to hand intent back to Python); Decision — the `Intent` object maps to the `Scenario`: `selectedPlaneIds` (+ the maintenance plane) → the **top-level** `fleet_in`; `priorities`/`mustPositions` → `constraints[id].priority`/`.pin`; the round-trip is a file (Stage 2); **the ADR-0002 carve-out** — pin captures the Python-emitted current pose as scalars and edits them as number fields; no in-browser drag/rotation composes an affine; Consequences — `interaction/*` never imports `affine.ts`/`anchors.ts`; the `editor-context` blob is a viewer-HTML-level artifact (like `viewer-compare/v1`), NOT a scene/v2 change; Alternatives considered (live translation drag; non-authoritative drag+rotate preview) — deferred.
 
 - [ ] **Step 3: Flip ADR-0020 status**
 
@@ -308,7 +308,7 @@ test('export has the scenario_with_pin shape (pin + priority)', () => {
   const y = intentToScenarioYaml(i, CTX);
   assert.match(y, /^fleet: data\/fleet\.yaml$/m);
   assert.match(y, /^hangar: data\/hangar\.yaml$/m);
-  assert.match(y, /^fleet_in: \[ctsl, husky\]$/m);
+  assert.match(y, /^fleet_in: \[ctsl, fuji, husky\]$/m); // maintenance plane fuji unioned in
   assert.match(y, /^maintenance:\n  plane: fuji$/m);
   assert.match(y, /^  husky:\n    pin: \{ x_m: 2.1, y_m: 14.3, heading_deg: 0.0, on_carts: false \}$/m);
   assert.match(y, /^  ctsl:\n    priority: 3.0$/m);
@@ -323,7 +323,7 @@ test('deselected planes never appear', () => {
   let i = toggleSelection(initialIntent(CTX), 'ctsl'); // drop ctsl
   i = pinAtCurrent(i, 'husky', CTX);
   const y = intentToScenarioYaml(i, CTX);
-  assert.match(y, /^fleet_in: \[husky\]$/m);
+  assert.match(y, /^fleet_in: \[fuji, husky\]$/m); // fuji (maintenance) always present; ctsl dropped
   assert.doesNotMatch(y, /ctsl/);
 });
 
@@ -351,14 +351,18 @@ function num(n: number): string {
 }
 
 export function intentToScenarioYaml(intent: Intent, ctx: EditorContext): string {
-  const ids = [...intent.selectedPlaneIds].sort();
+  const selected = [...intent.selectedPlaneIds].sort();
+  // The maintenance occupant is never rendered/selected/constrained, but the Scenario
+  // invariant requires maintenance ∈ fleet_in (models.py Scenario.__post_init__) — union it in.
+  const fleetIn = [...new Set(ctx.maintenance ? [...selected, ctx.maintenance.plane] : selected)].sort();
   const lines: string[] = [];
   lines.push(`fleet: ${ctx.fleet}`);
   lines.push(`hangar: ${ctx.hangar}`);
-  lines.push(`fleet_in: [${ids.join(', ')}]`);
+  lines.push(`fleet_in: [${fleetIn.join(', ')}]`);
   if (ctx.maintenance) { lines.push('maintenance:'); lines.push(`  plane: ${ctx.maintenance.plane}`); }
 
-  const constrained = ids.filter((id) => intent.mustPositions[id] || intent.priorities[id] !== undefined);
+  // Only selected planes may carry constraints (never the maintenance plane).
+  const constrained = selected.filter((id) => intent.mustPositions[id] || intent.priorities[id] !== undefined);
   if (constrained.length) {
     lines.push('constraints:');
     for (const id of constrained) {
@@ -723,25 +727,32 @@ Proves the serializer's output shape is loader-valid (the authoritative guard):
 
 ```python
 def test_editor_export_shape_loads_via_load_scenario(tmp_path):
+    from pathlib import Path
     from hangarfit.loader import load_scenario
-    # Mirror export.ts output exactly for a husky pin + ctsl priority.
+    # Real catalog ids (aviat_husky/ctsl/fuji — see tests/fixtures/scenario_with_pin.yaml).
+    # load_scenario resolves fleet:/hangar: relative to the scenario file's parent
+    # (loader.py:523,536), so use ABSOLUTE repo-data paths from a tmp scenario file.
+    repo = Path(__file__).resolve().parents[1]              # tests/ -> repo root
+    fleet, hangar = repo / "data" / "fleet.yaml", repo / "data" / "hangar.yaml"
     yaml = (
-        "fleet: data/fleet.yaml\n"
-        "hangar: data/hangar.yaml\n"
-        "fleet_in: [ctsl, husky]\n"
+        f"fleet: {fleet}\n"
+        f"hangar: {hangar}\n"
+        "fleet_in: [aviat_husky, ctsl, fuji]\n"            # maintenance plane fuji IS in fleet_in
+        "maintenance:\n  plane: fuji\n"
         "constraints:\n"
-        "  husky:\n"
+        "  aviat_husky:\n"
         "    pin: { x_m: 2.1, y_m: 14.3, heading_deg: 0.0, on_carts: false }\n"
         "  ctsl:\n"
         "    priority: 3.0\n"
     )
     p = tmp_path / "edited.yaml"; p.write_text(yaml)
-    sc = load_scenario(p)   # confirm signature; use repo-relative fleet/hangar or a fixture pair
-    assert sc.constraints["husky"].pin is not None
+    sc = load_scenario(p)                                   # confirm signature vs loader
+    assert "fuji" in sc.fleet_in                            # Finding-1 guard: maintenance ∈ fleet_in
+    assert sc.constraints["aviat_husky"].pin is not None
     assert sc.constraints["ctsl"].priority == 3.0
 ```
 
-(If `load_scenario` resolves `fleet:`/`hangar:` relative to the scenario file, point them at the real `data/` files or a fixture pair so the load succeeds.)
+(This mirrors the `scenario_with_pin.yaml` fixture's proven-valid shape — real ids + maintenance ∈ fleet_in — extended with the `priority` sub-key.)
 
 - [ ] **Step 3: Run to verify fail→pass**
 

--- a/docs/superpowers/plans/2026-07-02-v0.18.0-interactive-placement-editor.md
+++ b/docs/superpowers/plans/2026-07-02-v0.18.0-interactive-placement-editor.md
@@ -1,0 +1,792 @@
+# Interactive Placement Editor (#442) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn `hangarfit view` into an intent-capture front door — select planes, set soft priorities and hard must-positions in the 3D viewer, and export a loader-valid `Scenario` YAML that `hangarfit solve` re-runs.
+
+**Architecture:** The browser is a pure intent-capture surface (ADR-0002/0017/0020): it reads Python-emitted scalars, never re-derives geometry, and serializes an `Intent` to a `Scenario` YAML. Python stays the sole solver/geometry/validity authority — **no changes to `scene.py`, `solver.py`, `models.py`, `loader.py`, `geometry.py`.** The only Python touch is a viewer-HTML-level `editor-context` blob + a `--edit` CLI flag. Ships behind opt-in `view --edit`; editor code is bundled-but-dormant unless the `editor-context` blob is present.
+
+**Tech Stack:** TypeScript (esbuild, `node --test`), THREE.js r160 (external), Python 3.12, pytest, YAML (loader-side).
+
+## Global Constraints
+
+- **ADR-0002:** `interaction/*.ts` must NEVER import `affine.ts` or `anchors.ts`, and never touch `final_poses` affines for pose purposes. Poses come as scalars from the Python-emitted `editor-context.currentPoses`.
+- **ADR-0003:** `scene.build_scene()` output stays byte-identical. Do not edit `scene.py`.
+- **Determinism of the artifact:** the exported YAML is formatted deterministically (fixed decimals, sorted keys) so it is stable/diffable.
+- **`viewer-build-drift` guard:** any `interaction/*.ts` imported by `main.ts` changes the inlined bundle → run `npm --prefix viewer/ run build` and commit `src/hangarfit/_viewer_assets/viewer.js` in the SAME commit.
+- **`viewer.js` is inlined** (`viewer.py:106`): there is NO "byte-identical HTML" invariant. What holds: `#scene` bytes unchanged; non-edit path emits no `editor-context` blob and uses the normal `_HUD`; edit mode is additive HTML.
+- **Export target shape** = `tests/fixtures/scenario_with_pin.yaml` (proven loader-valid). Loader allowlist: `{pin, force_on_carts, priority, nose_out}`. A `pin` requires ALL of `x_m/y_m/heading_deg/on_carts`; plane_id is the constraint KEY (never inside the block).
+- **Node dev toolchain:** run viewer commands via `npm --prefix viewer/ …`; verify a build without clobbering the committed bundle with `VIEWER_OUTFILE=/tmp/viewer-scratch.js npm --prefix viewer/ run build`.
+- **Python invocation:** bare `pytest` / `hangarfit` (editable install `.pth` points at the main checkout — do not use a worktree for these runs without `PYTHONPATH=$PWD/src`).
+- **GitFlow:** branch `feature/442-interactive-placement-editor` off `develop`; one PR per chunk, base `develop`, `Closes #<chunk-issue>` in the body; never push to `develop`.
+
+---
+
+## File Structure
+
+| Path | New/Mod | Responsibility |
+|---|---|---|
+| `docs/adr/0029-editor-intent-artifact-contract.md` | new | Records the `Intent → Scenario YAML` mapping + the ADR-0002 "pin-at-current-pose, no in-browser rotation" carve-out. (Number = next free ADR; confirm.) |
+| `docs/adr/0020-viewer-typescript-architecture.md` | mod | Flip status Proposed → Accepted; mark `interaction/` seam active. |
+| `viewer/src/interaction/README.md` | mod | "inert" → shipped module map. |
+| `viewer/src/interaction/intent-contract.ts` | new | Types: `Intent`, `MustPosition`, `CurrentPose`, `EditorContext`. |
+| `viewer/src/interaction/selection.ts` | new | PURE selection-state machine + pin-at-current (scalar copy). No THREE/DOM. |
+| `viewer/src/interaction/export.ts` | new | PURE `(Intent, EditorContext) → Scenario-YAML string`. No THREE/DOM. |
+| `viewer/src/interaction/editor.ts` | new | IMPURE edge: raycaster over `planes` groups, highlight, controls gating, HUD wiring, Blob download. |
+| `viewer/src/main.ts` | mod | Mount editor iff the `#editor-context` blob is present. Non-edit boot unchanged. |
+| `viewer/test/selection.test.ts` | new | `node --test` units for `selection.ts`. |
+| `viewer/test/export.test.ts` | new | `node --test` units for `export.ts` (golden YAML + reject paths). |
+| `src/hangarfit/_viewer_assets/viewer.js` | mod (built) | Rebuilt bundle; committed with the `main.ts` wiring (Task 6). |
+| `src/hangarfit/viewer.py` | mod | `_HUD_EDIT`, `_EDITOR_CONTEXT_SCHEMA`, `build_editor_context()`, `render_edit_viewer()`. |
+| `src/hangarfit/cli.py` | mod | `--edit` flag on `view` (+ guards); dispatch to `render_edit_viewer`. |
+| `tests/test_viewer.py` | mod | Render-path invariants (§3.5) + editor-context blob content + round-trip. |
+| `tests/test_cli.py` (or the CLI test module) | mod | `--edit`-without-`--solve` → exit 2; `--edit` + `--alternatives` → exit 2. |
+| `CHANGELOG.md` | mod | One `### Added` `[Unreleased]` entry (see workflow note on parallel PRs). |
+| `CLAUDE.md`, `docs/architecture/05-building-block-view.md` | mod | `view --edit` command + `interaction/` module. |
+
+---
+
+## Task 1: Docs & decision (Chunk 0)
+
+**Files:**
+- Create: `docs/adr/0029-editor-intent-artifact-contract.md`
+- Modify: `docs/adr/0020-viewer-typescript-architecture.md` (status line), `viewer/src/interaction/README.md`
+
+**Interfaces:**
+- Produces: the recorded `Intent` shape + the ADR-0002 carve-out that every later task relies on for rationale.
+
+- [ ] **Step 1: Confirm the next free ADR number**
+
+Run: `ls docs/adr/ | tail`
+Expected: highest existing is `0028-*`; use `0029` (adjust if not).
+
+- [ ] **Step 2: Write the ADR** (`docs/adr/0029-editor-intent-artifact-contract.md`)
+
+Content: Context (the editor needs to hand intent back to Python); Decision — the `Intent` object (`selectedPlaneIds`/`priorities`/`mustPositions`) maps 1:1 to `Scenario.constraints` (`fleet_in`/`priority`/`pin`); the round-trip is a file (Stage 2); **the ADR-0002 carve-out** — pin captures the Python-emitted current pose as scalars and edits them as number fields; no in-browser drag/rotation composes an affine; Consequences — `interaction/*` never imports `affine.ts`/`anchors.ts`; the `editor-context` blob is a viewer-HTML-level artifact (like `viewer-compare/v1`), NOT a scene/v2 change; Alternatives considered (live translation drag; non-authoritative drag+rotate preview) — deferred.
+
+- [ ] **Step 3: Flip ADR-0020 status**
+
+In `docs/adr/0020-viewer-typescript-architecture.md`, change the status field from `Proposed` to `Accepted` and note the `interaction/` seam is now active (#442).
+
+- [ ] **Step 4: Update the seam README**
+
+In `viewer/src/interaction/README.md`, replace the "intentionally inert" framing with the shipped module map (`intent-contract.ts`, `selection.ts`, `export.ts`, `editor.ts`) and keep the "never import affine.ts/anchors.ts" hard rule.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/adr/0029-editor-intent-artifact-contract.md docs/adr/0020-viewer-typescript-architecture.md viewer/src/interaction/README.md
+git commit -m "docs(#442): ADR for editor intent-artifact contract; ADR-0020 Accepted"
+```
+
+---
+
+## Task 2: Pure selection core (Chunk 1)
+
+**Files:**
+- Create: `viewer/src/interaction/intent-contract.ts`, `viewer/src/interaction/selection.ts`
+- Test: `viewer/test/selection.test.ts`
+
+**Interfaces:**
+- Produces (consumed by Tasks 3 & 6):
+  - `interface Intent { selectedPlaneIds: string[]; priorities: Record<string, number>; mustPositions: Record<string, MustPosition>; }`
+  - `interface MustPosition { x: number; y: number; heading: number; onCarts: boolean; }`
+  - `interface CurrentPose { x_m: number; y_m: number; heading_deg: number; on_carts: boolean; }`
+  - `interface EditorContext { fleet: string; hangar: string; maintenance: {plane: string} | null; currentPoses: Record<string, CurrentPose>; cartEligible: Record<string, boolean>; }`
+  - `initialIntent(ctx: EditorContext): Intent`
+  - `isSelected(intent: Intent, id: string): boolean`
+  - `toggleSelection(intent: Intent, id: string): Intent`
+  - `setPriority(intent: Intent, id: string, priority: number | null): Intent`
+  - `pinAtCurrent(intent: Intent, id: string, ctx: EditorContext): Intent`
+  - `unpin(intent: Intent, id: string): Intent`
+  - `setPinField(intent: Intent, id: string, field: 'x'|'y'|'heading', value: number): Intent`
+  - `setOnCarts(intent: Intent, id: string, onCarts: boolean): Intent`
+
+- [ ] **Step 1: Write `intent-contract.ts`**
+
+```ts
+// viewer/src/interaction/intent-contract.ts
+export interface MustPosition { x: number; y: number; heading: number; onCarts: boolean; }
+export interface Intent {
+  selectedPlaneIds: string[];
+  priorities: Record<string, number>;
+  mustPositions: Record<string, MustPosition>;
+}
+export interface CurrentPose { x_m: number; y_m: number; heading_deg: number; on_carts: boolean; }
+export interface EditorContext {
+  fleet: string;
+  hangar: string;
+  maintenance: { plane: string } | null;
+  currentPoses: Record<string, CurrentPose>;
+  cartEligible: Record<string, boolean>;
+}
+```
+
+- [ ] **Step 2: Write the failing test** (`viewer/test/selection.test.ts`)
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  initialIntent, isSelected, toggleSelection, setPriority,
+  pinAtCurrent, unpin, setPinField, setOnCarts,
+} from '../src/interaction/selection.ts';
+import type { EditorContext } from '../src/interaction/intent-contract.ts';
+
+const CTX: EditorContext = {
+  fleet: 'data/fleet.yaml', hangar: 'data/hangar.yaml',
+  maintenance: { plane: 'fuji' },
+  currentPoses: {
+    husky: { x_m: 2.1, y_m: 14.3, heading_deg: 0, on_carts: false },
+    ctsl: { x_m: 5.0, y_m: 3.0, heading_deg: 90, on_carts: false },
+  },
+  cartEligible: { husky: false, ctsl: false },
+};
+
+test('initialIntent selects all rendered planes, no constraints', () => {
+  const i = initialIntent(CTX);
+  assert.deepEqual(i.selectedPlaneIds, ['ctsl', 'husky']); // sorted
+  assert.deepEqual(i.priorities, {});
+  assert.deepEqual(i.mustPositions, {});
+});
+
+test('deselect drops the plane and its constraints', () => {
+  let i = initialIntent(CTX);
+  i = setPriority(i, 'husky', 2);
+  i = pinAtCurrent(i, 'husky', CTX);
+  i = toggleSelection(i, 'husky');
+  assert.ok(!isSelected(i, 'husky'));
+  assert.equal(i.priorities.husky, undefined);
+  assert.equal(i.mustPositions.husky, undefined);
+});
+
+test('reselect adds back with no constraints', () => {
+  let i = toggleSelection(initialIntent(CTX), 'husky'); // drop
+  i = toggleSelection(i, 'husky');                      // add back
+  assert.ok(isSelected(i, 'husky'));
+  assert.equal(i.priorities.husky, undefined);
+});
+
+test('pinAtCurrent copies the Python-emitted scalar pose', () => {
+  const i = pinAtCurrent(initialIntent(CTX), 'husky', CTX);
+  assert.deepEqual(i.mustPositions.husky, { x: 2.1, y: 14.3, heading: 0, onCarts: false });
+});
+
+test('setPinField edits only a pinned plane', () => {
+  let i = pinAtCurrent(initialIntent(CTX), 'ctsl', CTX);
+  i = setPinField(i, 'ctsl', 'x', 6.5);
+  assert.equal(i.mustPositions.ctsl.x, 6.5);
+  const j = setPinField(initialIntent(CTX), 'ctsl', 'x', 6.5); // not pinned → no-op
+  assert.equal(j.mustPositions.ctsl, undefined);
+});
+
+test('setPriority(null) clears', () => {
+  let i = setPriority(initialIntent(CTX), 'husky', 4);
+  i = setPriority(i, 'husky', null);
+  assert.equal(i.priorities.husky, undefined);
+});
+
+test('functions are pure (no input mutation)', () => {
+  const i0 = initialIntent(CTX);
+  const snapshot = JSON.stringify(i0);
+  toggleSelection(i0, 'husky');
+  setPriority(i0, 'husky', 9);
+  pinAtCurrent(i0, 'husky', CTX);
+  assert.equal(JSON.stringify(i0), snapshot);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm --prefix viewer/ run test`
+Expected: FAIL — `Cannot find module '../src/interaction/selection.ts'`.
+
+- [ ] **Step 4: Write `selection.ts`**
+
+```ts
+// viewer/src/interaction/selection.ts
+import type { Intent, MustPosition, EditorContext } from './intent-contract.ts';
+
+export function initialIntent(ctx: EditorContext): Intent {
+  return { selectedPlaneIds: Object.keys(ctx.currentPoses).sort(), priorities: {}, mustPositions: {} };
+}
+
+export function isSelected(intent: Intent, id: string): boolean {
+  return intent.selectedPlaneIds.includes(id);
+}
+
+export function toggleSelection(intent: Intent, id: string): Intent {
+  const selected = isSelected(intent, id);
+  const selectedPlaneIds = selected
+    ? intent.selectedPlaneIds.filter((x) => x !== id)
+    : [...intent.selectedPlaneIds, id].sort();
+  const priorities = { ...intent.priorities };
+  const mustPositions = { ...intent.mustPositions };
+  if (selected) { delete priorities[id]; delete mustPositions[id]; } // can't constrain an absent plane
+  return { selectedPlaneIds, priorities, mustPositions };
+}
+
+export function setPriority(intent: Intent, id: string, priority: number | null): Intent {
+  const priorities = { ...intent.priorities };
+  if (priority === null) delete priorities[id]; else priorities[id] = priority;
+  return { ...intent, priorities };
+}
+
+export function pinAtCurrent(intent: Intent, id: string, ctx: EditorContext): Intent {
+  const c = ctx.currentPoses[id];
+  if (!c) return intent;
+  const mp: MustPosition = { x: c.x_m, y: c.y_m, heading: c.heading_deg, onCarts: c.on_carts };
+  return { ...intent, mustPositions: { ...intent.mustPositions, [id]: mp } };
+}
+
+export function unpin(intent: Intent, id: string): Intent {
+  const mustPositions = { ...intent.mustPositions };
+  delete mustPositions[id];
+  return { ...intent, mustPositions };
+}
+
+export function setPinField(intent: Intent, id: string, field: 'x' | 'y' | 'heading', value: number): Intent {
+  const cur = intent.mustPositions[id];
+  if (!cur) return intent;
+  return { ...intent, mustPositions: { ...intent.mustPositions, [id]: { ...cur, [field]: value } } };
+}
+
+export function setOnCarts(intent: Intent, id: string, onCarts: boolean): Intent {
+  const cur = intent.mustPositions[id];
+  if (!cur) return intent;
+  return { ...intent, mustPositions: { ...intent.mustPositions, [id]: { ...cur, onCarts } } };
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm --prefix viewer/ run test`
+Expected: PASS. Also run `npm --prefix viewer/ run typecheck` (clean) and confirm the bundle is untouched: `VIEWER_OUTFILE=/tmp/v.js npm --prefix viewer/ run build && git diff --exit-code -- src/hangarfit/_viewer_assets/viewer.js` (no diff — `main.ts` does not import these yet).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add viewer/src/interaction/intent-contract.ts viewer/src/interaction/selection.ts viewer/test/selection.test.ts
+git commit -m "feat(viewer,#442): pure selection-state core + node tests (bundle unchanged)"
+```
+
+---
+
+## Task 3: Pure Scenario-YAML export (Chunk 1)
+
+**Files:**
+- Create: `viewer/src/interaction/export.ts`
+- Test: `viewer/test/export.test.ts`
+
+**Interfaces:**
+- Consumes: `Intent`, `EditorContext` (Task 2).
+- Produces (consumed by Task 6/7): `intentToScenarioYaml(intent: Intent, ctx: EditorContext): string`.
+
+- [ ] **Step 1: Write the failing test** (`viewer/test/export.test.ts`)
+
+```ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { intentToScenarioYaml } from '../src/interaction/export.ts';
+import { initialIntent, setPriority, pinAtCurrent, toggleSelection } from '../src/interaction/selection.ts';
+import type { EditorContext } from '../src/interaction/intent-contract.ts';
+
+const CTX: EditorContext = {
+  fleet: 'data/fleet.yaml', hangar: 'data/hangar.yaml',
+  maintenance: { plane: 'fuji' },
+  currentPoses: {
+    husky: { x_m: 2.1, y_m: 14.3, heading_deg: 0, on_carts: false },
+    ctsl: { x_m: 5.0, y_m: 3.0, heading_deg: 90, on_carts: false },
+  },
+  cartEligible: { husky: false, ctsl: false },
+};
+
+test('export has the scenario_with_pin shape (pin + priority)', () => {
+  let i = initialIntent(CTX);
+  i = pinAtCurrent(i, 'husky', CTX);
+  i = setPriority(i, 'ctsl', 3);
+  const y = intentToScenarioYaml(i, CTX);
+  assert.match(y, /^fleet: data\/fleet\.yaml$/m);
+  assert.match(y, /^hangar: data\/hangar\.yaml$/m);
+  assert.match(y, /^fleet_in: \[ctsl, husky\]$/m);
+  assert.match(y, /^maintenance:\n  plane: fuji$/m);
+  assert.match(y, /^  husky:\n    pin: \{ x_m: 2.1, y_m: 14.3, heading_deg: 0.0, on_carts: false \}$/m);
+  assert.match(y, /^  ctsl:\n    priority: 3.0$/m);
+});
+
+test('a selected plane with neither pin nor priority emits no constraints entry', () => {
+  const y = intentToScenarioYaml(initialIntent(CTX), CTX);
+  assert.doesNotMatch(y, /constraints:/); // nobody constrained
+});
+
+test('deselected planes never appear', () => {
+  let i = toggleSelection(initialIntent(CTX), 'ctsl'); // drop ctsl
+  i = pinAtCurrent(i, 'husky', CTX);
+  const y = intentToScenarioYaml(i, CTX);
+  assert.match(y, /^fleet_in: \[husky\]$/m);
+  assert.doesNotMatch(y, /ctsl/);
+});
+
+test('no maintenance block when ctx.maintenance is null', () => {
+  const y = intentToScenarioYaml(initialIntent(CTX), { ...CTX, maintenance: null });
+  assert.doesNotMatch(y, /maintenance:/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix viewer/ run test`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write `export.ts`**
+
+```ts
+// viewer/src/interaction/export.ts
+import type { Intent, EditorContext } from './intent-contract.ts';
+
+/** Deterministic float rendering: round to 4 dp, always show ≥1 decimal. */
+function num(n: number): string {
+  const r = Math.round(n * 1e4) / 1e4;
+  return Number.isInteger(r) ? `${r}.0` : `${r}`;
+}
+
+export function intentToScenarioYaml(intent: Intent, ctx: EditorContext): string {
+  const ids = [...intent.selectedPlaneIds].sort();
+  const lines: string[] = [];
+  lines.push(`fleet: ${ctx.fleet}`);
+  lines.push(`hangar: ${ctx.hangar}`);
+  lines.push(`fleet_in: [${ids.join(', ')}]`);
+  if (ctx.maintenance) { lines.push('maintenance:'); lines.push(`  plane: ${ctx.maintenance.plane}`); }
+
+  const constrained = ids.filter((id) => intent.mustPositions[id] || intent.priorities[id] !== undefined);
+  if (constrained.length) {
+    lines.push('constraints:');
+    for (const id of constrained) {
+      lines.push(`  ${id}:`);
+      const mp = intent.mustPositions[id];
+      if (mp) {
+        lines.push(
+          `    pin: { x_m: ${num(mp.x)}, y_m: ${num(mp.y)}, ` +
+          `heading_deg: ${num(mp.heading)}, on_carts: ${mp.onCarts} }`,
+        );
+      }
+      const p = intent.priorities[id];
+      if (p !== undefined) lines.push(`    priority: ${num(p)}`);
+    }
+  }
+  return lines.join('\n') + '\n';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix viewer/ run test` → PASS. `npm --prefix viewer/ run typecheck` → clean. Confirm bundle untouched (as Task 2 Step 5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add viewer/src/interaction/export.ts viewer/test/export.test.ts
+git commit -m "feat(viewer,#442): pure Intent→Scenario-YAML serializer + node tests"
+```
+
+> **PR checkpoint:** Tasks 2–3 = Chunk 1 PR. `viewer.js` unchanged; `Closes` the Chunk-1 issue.
+
+---
+
+## Task 4: Python `editor-context` blob + edit render path (Chunk 2)
+
+**Files:**
+- Modify: `src/hangarfit/viewer.py`
+- Test: `tests/test_viewer.py`
+
+**Interfaces:**
+- Produces (consumed by Task 5): `build_editor_context(*, fleet_ref: str, hangar_ref: str, maintenance_plane: str | None, layout, cart_eligible: dict[str, bool]) -> dict` and `render_edit_viewer(scene: dict, context: dict, output_path: Path | str) -> None`.
+- `layout` is the solved layout (an iterable of placements each exposing `plane_id`, `x_m`, `y_m`, `heading_deg`, `on_carts`). **Implementer confirm** the exact attribute names against `models.py` `Placement`/`Layout`.
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/test_viewer.py`)
+
+```python
+def test_render_edit_viewer_adds_context_blob_but_keeps_scene_bytes(tmp_path):
+    from hangarfit import viewer
+    scene = _a_scene()  # reuse the module's existing scene fixture/helper
+    ctx = {"schema": "hangarfit.editor-context/v1", "fleet": "data/fleet.yaml",
+           "hangar": "data/hangar.yaml", "maintenance": None,
+           "currentPoses": {"husky": {"x_m": 2.1, "y_m": 14.3, "heading_deg": 0.0, "on_carts": False}},
+           "cartEligible": {"husky": False}}
+    edit = tmp_path / "edit.html"; plain = tmp_path / "plain.html"
+    viewer.render_edit_viewer(scene, ctx, edit)
+    viewer.render_viewer(scene, plain)
+    e = edit.read_text(); p = plain.read_text()
+    assert 'id="editor-context"' in e
+    assert 'id="editor-context"' not in p
+    # scene blob bytes identical across modes
+    import re
+    grab = lambda s: re.search(r'id="scene">(.*?)</script>', s, re.S).group(1)
+    assert grab(e) == grab(p)
+
+
+def test_build_editor_context_shape():
+    from hangarfit import viewer
+    layout = _a_solved_layout()  # existing helper; husky placed
+    ctx = viewer.build_editor_context(
+        fleet_ref="data/fleet.yaml", hangar_ref="data/hangar.yaml",
+        maintenance_plane=None, layout=layout, cart_eligible={"husky": False})
+    assert ctx["fleet"] == "data/fleet.yaml"
+    assert set(ctx["currentPoses"]["husky"]) == {"x_m", "y_m", "heading_deg", "on_carts"}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_viewer.py -k "editor" -v`
+Expected: FAIL — `render_edit_viewer` / `build_editor_context` not defined.
+
+- [ ] **Step 3: Implement in `viewer.py`**
+
+Add near the compare constant:
+
+```python
+_EDITOR_CONTEXT_SCHEMA = "hangarfit.editor-context/v1"
+
+_HUD_EDIT = (  # additive edit HUD; mirrors _HUD structure + an editor panel
+    _HUD.replace("</div>", "", 1)  # or author explicitly; keep normal toggles + append:
+    # a <div id="editor"> with: selection readout, priority field, pin toggle,
+    # on_carts toggle, and <button id="export">Export scenario YAML</button>
+    + '<div id="editor"><div id="sel-readout"></div>'
+      '<label>priority <input id="prio" type="number" min="0" step="0.5"></label>'
+      '<label><input id="pin-toggle" type="checkbox"> pin here</label>'
+      '<label><input id="carts-toggle" type="checkbox"> on carts</label>'
+      '<button id="export">Export scenario YAML</button></div></div>'
+)
+
+
+def build_editor_context(*, fleet_ref, hangar_ref, maintenance_plane, layout, cart_eligible):
+    poses = {}
+    for pl in layout:  # confirm attribute names vs models.Placement
+        poses[pl.plane_id] = {
+            "x_m": pl.x_m, "y_m": pl.y_m,
+            "heading_deg": pl.heading_deg, "on_carts": pl.on_carts,
+        }
+    return {
+        "schema": _EDITOR_CONTEXT_SCHEMA,
+        "fleet": fleet_ref, "hangar": hangar_ref,
+        "maintenance": {"plane": maintenance_plane} if maintenance_plane else None,
+        "currentPoses": poses,
+        "cartEligible": dict(cart_eligible),
+    }
+
+
+def render_edit_viewer(scene, context, output_path):
+    """Like render_viewer, plus the edit HUD and an additive #editor-context blob.
+    The #scene bytes are identical to render_viewer (ADR-0003 / §3.5)."""
+    data = (
+        f'<script type="application/json" id="scene">{_embed_json(scene)}</script>\n'
+        f'<script type="application/json" id="editor-context">{_embed_json(context)}</script>\n'
+    )
+    html = _assemble_html(extra_head="", hud_html=_HUD_EDIT, data_scripts=data)
+    Path(output_path).write_text(html, encoding="utf-8")
+```
+
+(Author `_HUD_EDIT` cleanly rather than string-hacking `_HUD`; the snippet shows the required control IDs. `_embed_json` handles `</script>`-escaping and rejects non-finite values.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest tests/test_viewer.py -k "editor" -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/viewer.py tests/test_viewer.py
+git commit -m "feat(viewer,#442): editor-context blob + render_edit_viewer (scene bytes unchanged)"
+```
+
+---
+
+## Task 5: CLI `--edit` flag + guards (Chunk 2)
+
+**Files:**
+- Modify: `src/hangarfit/cli.py` (the `view` subparser ~L400 + `cmd_view` body)
+- Test: `tests/test_cli.py` (or the module holding CLI tests — confirm)
+
+**Interfaces:**
+- Consumes: `viewer.build_editor_context`, `viewer.render_edit_viewer` (Task 4).
+- Produces: `hangarfit view SCENARIO.yaml --solve --edit -o out.html`.
+
+- [ ] **Step 1: Write the failing tests** (CLI test module)
+
+```python
+def test_view_edit_requires_solve(run_cli, tmp_path):
+    # run_cli = the existing helper invoking cli.main; adapt to the module's pattern
+    rc = run_cli(["view", "tests/fixtures/scenario_minimal.yaml", "--edit",
+                  "-o", str(tmp_path / "o.html")])
+    assert rc == 2
+
+def test_view_edit_rejects_alternatives(run_cli, tmp_path):
+    rc = run_cli(["view", "tests/fixtures/scenario_minimal.yaml", "--solve", "--edit",
+                  "--alternatives", "3", "-o", str(tmp_path / "o.html")])
+    assert rc == 2
+
+def test_view_edit_emits_editor_html(run_cli, tmp_path):
+    out = tmp_path / "o.html"
+    rc = run_cli(["view", "tests/fixtures/scenario_minimal.yaml", "--solve", "--edit", "-o", str(out)])
+    assert rc == 0
+    assert 'id="editor-context"' in out.read_text()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/test_cli.py -k "view_edit" -v` → FAIL (`--edit` unknown / exits 0).
+
+- [ ] **Step 3: Implement**
+
+In the `view` subparser: `view.add_argument("--edit", action="store_true", help="Emit the interactive placement editor (requires --solve).")`.
+
+In `cmd_view`, before rendering:
+
+```python
+if args.edit and not args.solve:
+    print("error: --edit requires --solve (the editor exports a Scenario).", file=sys.stderr)
+    return 2
+if args.edit and getattr(args, "alternatives", 1) and args.alternatives > 1:
+    print("error: --edit cannot be combined with --alternatives.", file=sys.stderr)
+    return 2
+```
+
+Then where the single-solution solve path renders, branch:
+
+```python
+if args.edit:
+    fleet_ref, hangar_ref = _raw_scenario_refs(args.scenario)  # read raw YAML: data['fleet'], data['hangar']
+    ctx = viewer.build_editor_context(
+        fleet_ref=fleet_ref, hangar_ref=hangar_ref,
+        maintenance_plane=<scenario.maintenance.plane or None>,
+        layout=<the solved layout>,
+        cart_eligible=<{pid: plane_allows_carts(pid)}>)   # derive from movement_mode
+    viewer.render_edit_viewer(scene, ctx, args.output)
+else:
+    viewer.render_viewer(scene, args.output)
+```
+
+Implementer confirms: (a) how `cmd_view` obtains the solved layout + `scene` today (reuse it); (b) the maintenance plane accessor; (c) `plane_allows_carts` from the fleet's `movement_mode` (a plane is cart-eligible when its mode is not own-gear-only — see `models.py`). Add a tiny `_raw_scenario_refs` helper that `yaml.safe_load`s the scenario file and returns its `fleet`/`hangar` strings verbatim (so the export echoes the authored paths).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest tests/test_cli.py -k "view_edit" -v` → PASS. Then full `pytest tests/test_viewer.py tests/test_cli.py -q`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/cli.py tests/test_cli.py
+git commit -m "feat(cli,#442): view --edit flag (requires --solve; rejects --alternatives)"
+```
+
+---
+
+## Task 6: Interactive selection edge + wire into main (Chunk 2)
+
+**Files:**
+- Create: `viewer/src/interaction/editor.ts`
+- Modify: `viewer/src/main.ts`
+- Build: `src/hangarfit/_viewer_assets/viewer.js` (rebuilt + committed)
+
+**Interfaces:**
+- Consumes: `initialIntent`, `toggleSelection` (Task 2); `planes` `groups: Record<string, THREE.Group>` from `addPlanes` (planes.ts); `renderer.ts` `{renderer, scene, cam, controls}`; `dom.ts` `byId`.
+- Produces: `mountEditor(opts): EditorHandle` and, in `main.ts`, the gated call.
+
+- [ ] **Step 1: Author `editor.ts` (impure edge — selection only for this task)**
+
+```ts
+// viewer/src/interaction/editor.ts
+import * as THREE from 'three';
+import { byId } from '../dom.ts';
+import { initialIntent, toggleSelection } from './selection.ts';
+import type { Intent, EditorContext } from './intent-contract.ts';
+
+export interface EditorHandle { getIntent(): Intent; }
+
+export function mountEditor(opts: {
+  groups: Record<string, THREE.Group>;
+  renderer: THREE.WebGLRenderer;
+  cam: THREE.Camera;
+  controls: { enabled: boolean };
+  ctx: EditorContext;
+}): EditorHandle {
+  let intent = initialIntent(opts.ctx);
+  const ray = new THREE.Raycaster();
+  const ndc = new THREE.Vector2();
+  const idByObject = new Map<THREE.Object3D, string>();
+  for (const [id, g] of Object.entries(opts.groups)) g.traverse((o) => idByObject.set(o, id));
+
+  function pick(ev: PointerEvent): string | null {
+    const r = opts.renderer.domElement.getBoundingClientRect();
+    ndc.set(((ev.clientX - r.left) / r.width) * 2 - 1, -((ev.clientY - r.top) / r.height) * 2 + 1);
+    ray.setFromCamera(ndc, opts.cam);
+    const hits = ray.intersectObjects(Object.values(opts.groups) as THREE.Object3D[], true);
+    for (const h of hits) { const id = idByObject.get(h.object); if (id) return id; }
+    return null;
+  }
+
+  opts.renderer.domElement.addEventListener('pointerdown', (ev) => {
+    const id = pick(ev as PointerEvent);
+    if (!id) return;
+    intent = toggleSelection(intent, id);
+    applyHighlight();
+    renderReadout();
+  });
+
+  function applyHighlight() { /* set an emissive/opacity delta on selected groups */ }
+  function renderReadout() {
+    const el = byId('sel-readout'); if (el) el.textContent = `selected: ${intent.selectedPlaneIds.join(', ')}`;
+  }
+  applyHighlight(); renderReadout();
+  return { getIntent: () => intent };
+}
+```
+
+- [ ] **Step 2: Gate the mount in `main.ts`**
+
+At the top: `import { mountEditor } from './interaction/editor.ts';` and after `addPlanes(...)` returns `groups` in the single-scene boot:
+
+```ts
+const ctxEl = byId('editor-context');
+if (ctxEl && ctxEl.textContent) {
+  const ctx = JSON.parse(ctxEl.textContent);
+  mountEditor({ groups, renderer, cam, controls, ctx });
+}
+```
+
+Editor code is thus **dormant** unless the blob is present (non-edit boot path unchanged).
+
+- [ ] **Step 3: Typecheck, lint, rebuild, commit the bundle**
+
+Run:
+```bash
+npm --prefix viewer/ run typecheck && npm --prefix viewer/ run lint && npm --prefix viewer/ run test
+npm --prefix viewer/ run build   # writes the committed viewer.js
+```
+Expected: all green; `git status` shows `src/hangarfit/_viewer_assets/viewer.js` modified.
+
+- [ ] **Step 4: Headless smoke — banner stays hidden**
+
+Run:
+```bash
+PYTHONPATH=$PWD/src python -m hangarfit view tests/fixtures/scenario_minimal.yaml --solve --edit -o /tmp/edit.html
+google-chrome --headless=new --use-gl=angle --use-angle=swiftshader \
+  --enable-unsafe-swiftshader --virtual-time-budget=8000 \
+  --dump-dom "file:///tmp/edit.html" | grep -q 'id="banner" hidden' && echo OK
+```
+Expected: `OK` (transform self-check passed; no `#banner` breakout). Regenerate any whole-file golden in `tests/test_viewer.py` (it moves because `viewer.js` moved — expected, per §3.5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add viewer/src/interaction/editor.ts viewer/src/main.ts src/hangarfit/_viewer_assets/viewer.js tests/test_viewer.py
+git commit -m "feat(viewer,#442): raycast plane selection behind view --edit; rebuild bundle"
+```
+
+> **PR checkpoint:** Tasks 4–6 = Chunk 2 PR. Route through the **scene-schema-guard** subagent (viewer.py/viewer.js touched) — assert scene/v2 untouched.
+
+---
+
+## Task 7: Intent-capture controls + export UI + round-trip (Chunk 3)
+
+**Files:**
+- Modify: `viewer/src/interaction/editor.ts` (priority/pin/on_carts controls + Export button)
+- Test: `tests/test_viewer.py` (Python round-trip), headless select→export smoke
+- Build: rebuild + commit `viewer.js`
+
+**Interfaces:**
+- Consumes: `setPriority`, `pinAtCurrent`, `unpin`, `setPinField`, `setOnCarts` (Task 2); `intentToScenarioYaml` (Task 3).
+
+- [ ] **Step 1: Wire the controls in `editor.ts`**
+
+Extend `mountEditor`: track a `focusedId` (last selected). Wire:
+- `#prio` `input` → `intent = setPriority(intent, focusedId, value === '' ? null : Math.max(0, +value))`.
+- `#pin-toggle` `change` → checked ? `pinAtCurrent(intent, focusedId, ctx)` : `unpin(intent, focusedId)`; when pinned, reveal x/y/heading number inputs bound to `setPinField`.
+- `#carts-toggle` `change` (enabled only if `ctx.cartEligible[focusedId]`) → `setOnCarts(intent, focusedId, checked)`.
+- `#export` `click` → build YAML and download:
+
+```ts
+import { intentToScenarioYaml } from './export.ts';
+byId('export')?.addEventListener('click', () => {
+  const yaml = intentToScenarioYaml(intent, opts.ctx);
+  const blob = new Blob([yaml], { type: 'text/yaml' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob); a.download = 'scenario.edited.yaml'; a.click();
+  URL.revokeObjectURL(a.href);
+});
+```
+Disable `#export` while `intent.selectedPlaneIds.length === 0`.
+
+- [ ] **Step 2: Write the failing Python round-trip test** (`tests/test_viewer.py`)
+
+Proves the serializer's output shape is loader-valid (the authoritative guard):
+
+```python
+def test_editor_export_shape_loads_via_load_scenario(tmp_path):
+    from hangarfit.loader import load_scenario
+    # Mirror export.ts output exactly for a husky pin + ctsl priority.
+    yaml = (
+        "fleet: data/fleet.yaml\n"
+        "hangar: data/hangar.yaml\n"
+        "fleet_in: [ctsl, husky]\n"
+        "constraints:\n"
+        "  husky:\n"
+        "    pin: { x_m: 2.1, y_m: 14.3, heading_deg: 0.0, on_carts: false }\n"
+        "  ctsl:\n"
+        "    priority: 3.0\n"
+    )
+    p = tmp_path / "edited.yaml"; p.write_text(yaml)
+    sc = load_scenario(p)   # confirm signature; use repo-relative fleet/hangar or a fixture pair
+    assert sc.constraints["husky"].pin is not None
+    assert sc.constraints["ctsl"].priority == 3.0
+```
+
+(If `load_scenario` resolves `fleet:`/`hangar:` relative to the scenario file, point them at the real `data/` files or a fixture pair so the load succeeds.)
+
+- [ ] **Step 3: Run to verify fail→pass**
+
+Run: `pytest tests/test_viewer.py -k "export_shape" -v`. If it fails on path resolution, fix the fixture paths (not the serializer). Expected: PASS.
+
+- [ ] **Step 4: Typecheck/lint/test/rebuild + headless select→export smoke**
+
+```bash
+npm --prefix viewer/ run typecheck && npm --prefix viewer/ run lint && npm --prefix viewer/ run test && npm --prefix viewer/ run build
+```
+Headless: load `/tmp/edit.html`, script a `pointerdown` on the canvas + a `#export` click via `--dump-dom`/DevTools protocol, or (simpler) assert the `#export` button and controls exist in the DOM. Confirm `#banner` stays hidden.
+
+- [ ] **Step 5: Docs + CHANGELOG + commit**
+
+Update `CLAUDE.md` "Useful commands" (`hangarfit view … --solve --edit -o out.html`) and `docs/architecture/05-building-block-view.md` (`interaction/` module). Add the CHANGELOG `### Added` entry.
+
+```bash
+git add viewer/src/interaction/editor.ts src/hangarfit/_viewer_assets/viewer.js tests/test_viewer.py CLAUDE.md docs/architecture/05-building-block-view.md CHANGELOG.md
+git commit -m "feat(viewer,#442): priority/pin/on_carts controls + Scenario-YAML export; docs"
+```
+
+> **PR checkpoint:** Task 7 = Chunk 3 PR (closes the editor epic #442). Route through scene-schema-guard + comment-analyzer (docs).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1–2 goal/non-goals → Tasks 2–7 (select/priority/pin/export; no solving, no serve). ✓
+- §3 constraints → Global Constraints + §3.5 correctly restated in Task 4/6 (no false byte-identity). ✓
+- §4 Intent/EditorContext → Task 2 interfaces (verbatim). ✓
+- §5 export shape → Task 3 (matches `scenario_with_pin.yaml`). ✓
+- §6 CLI activation (`--edit` requires `--solve`; rejects `--alternatives`) → Task 5. ✓
+- §7 ADR-0002 carve-out (pin-at-current scalar copy; no rotation math) → Task 1 ADR + Task 2 `pinAtCurrent`. ✓
+- §8 prior-intent deferred → not implemented (correct). ✓
+- §9 module split → File Structure + Tasks. ✓
+- §11 testing (node units, python round-trip, render-path invariants, headless smoke, drift) → Tasks 2/3/4/6/7. ✓
+- §12 docs → Task 1 + Task 7. ✓
+
+**Placeholder scan:** The two `Implementer confirm` notes (Task 4 `Placement` attribute names; Task 5 layout/maintenance/cart-eligibility accessors) are genuine codebase lookups, not vague requirements — each names the exact file to check. No "add error handling"/"TODO" placeholders. ✓
+
+**Type consistency:** `Intent`/`MustPosition`/`CurrentPose`/`EditorContext` used identically in Tasks 2/3/6/7; `intentToScenarioYaml`, `mountEditor`, `render_edit_viewer`, `build_editor_context` names stable across their consuming tasks. ✓
+
+## Execution Handoff
+
+Two execution options once the plan is approved:
+1. **Subagent-Driven (recommended)** — a fresh subagent per task with two-stage review between tasks.
+2. **Inline Execution** — batch tasks in this session with checkpoints.

--- a/docs/superpowers/specs/2026-07-02-v0.18.0-interactive-placement-editor-design.md
+++ b/docs/superpowers/specs/2026-07-02-v0.18.0-interactive-placement-editor-design.md
@@ -78,14 +78,14 @@ Note `mustPositions[id].onCarts` is required because a `pin` block requires all 
 4. User re-runs `hangarfit solve EXPORTED.yaml` (optionally `--write-yaml`) and/or `hangarfit view EXPORTED.yaml --solve --edit -o out.html`.
 5. Fresh view.
 
-**Export shape** (exactly the `scenario_with_pin.yaml` fixture shape — proven loader-valid):
+**Export shape** (based on the `scenario_with_pin.yaml` fixture shape — proven loader-valid — plus the #441 `priority` sub-key, also in the loader allowlist):
 
 ```yaml
 fleet: <echoed from EditorContext.fleet>
 hangar: <echoed from EditorContext.hangar>
-fleet_in: [<selectedPlaneIds…>]
+fleet_in: [<selectedPlaneIds… ∪ maintenance.plane if present>]
 maintenance:                # only if EditorContext.maintenance is non-null
-  plane: <maintenance.plane>
+  plane: <maintenance.plane>   # this id is ALSO in fleet_in above (Scenario invariant)
 constraints:                # only planes with a priority and/or a must-position
   <plane_id>:
     pin: { x_m: <x>, y_m: <y>, heading_deg: <heading>, on_carts: <onCarts> }
@@ -93,7 +93,7 @@ constraints:                # only planes with a priority and/or a must-position
 ```
 
 **Serializer invariants** (enforced in `export.ts`, checked by tests):
-- `fleet_in` ⊆ `EditorContext.fleetInAll`; `constraints` keys ⊆ `fleet_in` (else `Scenario.__post_init__` rejects).
+- `fleet_in` = `selectedPlaneIds` ∪ `{maintenance.plane}` when present — the maintenance occupant **must** be in `fleet_in` (`models.py` `Scenario.__post_init__` rejects otherwise, even though it is never rendered/selectable). `constraints` keys ⊆ `selectedPlaneIds` ⊆ `fleet_in`.
 - The `maintenance.plane` is never emitted under `constraints` (pinning it is forbidden).
 - `priority` omitted when unset (round-trips "user never set a priority" as absent, per the #441 `float | None` design).
 - Numbers formatted deterministically (fixed decimals) so the artifact is stable/diffable.
@@ -181,7 +181,7 @@ The following were defaulted to the leanest option while planning (user was away
 
 - **Chunk 0 — docs/decision (no code).** New ADR (intent-artifact contract + ADR-0002 carve-out) + flip ADR-0020 to Accepted. Reviewable via `comment-analyzer`.
 - **Chunk 1 — pure TS, `viewer.js` UNCHANGED.** Add `intent-contract.ts` + `selection.ts` + `export.ts` and their node tests. As long as `main.ts` doesn't import them, esbuild leaves the bundle byte-identical (drift guard green). Low-risk landing of the typed contract + pure serializer.
-- **Chunk 2 — interactive selection, `viewer.js` REBUILT.** `editor.ts` (raycaster + highlight + controls gating), wired into `main.ts` behind the edit flag; `cli.py --edit` + `viewer.py` `_HUD_EDIT` selection-readout + `editor-context` blob; rebuild+commit `viewer.js`; assert `--edit`-off byte-identity.
+- **Chunk 2 — interactive selection, `viewer.js` REBUILT.** `editor.ts` (raycaster + highlight + controls gating), wired into `main.ts` behind the edit flag; `cli.py --edit` + `viewer.py` `_HUD_EDIT` selection-readout + `editor-context` blob; rebuild+commit `viewer.js`; assert the `--edit`-off path emits no `#editor-context` blob and its `#scene` bytes are unchanged (§11 — **not** whole-HTML byte-identity, since the inlined bundle grows).
 - **Chunk 3 — intent capture + export UI.** Priority control, per-plane pin toggle, per-plane `on_carts` toggle, Export button (Blob download); Python round-trip test that the export loads via `load_scenario`.
 - **(Follow-up, out of this milestone) Chunk 4 — prior-intent echo** (§8) and **#444 JSON-Schema single-source** (§13.1).
 

--- a/docs/superpowers/specs/2026-07-02-v0.18.0-interactive-placement-editor-design.md
+++ b/docs/superpowers/specs/2026-07-02-v0.18.0-interactive-placement-editor-design.md
@@ -1,0 +1,191 @@
+# v0.18.0 — Interactive placement editor (#442) — design
+
+**Status:** Draft for review · **Date:** 2026-07-02 · **Milestone:** #38 (v0.18.0)
+**Issue:** #442 (headline / MVP) · **Deps (both DONE):** #440 (typed `scene-contract.ts` + inert `interaction/` seam), #441 (Python soft `priority` field, CLOSED)
+**Related, deferred:** #444 (JSON-Schema single-source spike), #445 (`hangarfit serve`, Stage 3)
+
+---
+
+## 1. Context & goal
+
+`hangarfit` today renders a solved layout into a **read-only** offline 3D HTML page (`hangarfit view`). The viewer TypeScript foundation (ADR-0020, #437–#441) was built specifically to unblock the next step: turning `view` from a read-only renderer into the tool's **front door**, where a human captures *intent* — which planes go in, which matter most, which must sit in a specific spot — and hands it back to the Python solver.
+
+This is **Stage 2** of the ADR-0020 viewer roadmap (the *round-trip file* model). The browser captures intent and **exports a `Scenario` YAML**; the user re-runs `hangarfit solve` and re-opens a fresh view. Python stays the sole solver/geometry/validity authority. Stage 3 (#445, `hangarfit serve`) later swaps the file transport for a localhost API, reusing this stage's intent object verbatim — it is **out of scope here**.
+
+**Goal (MVP):** In the 3D viewer, let a user
+1. **select** which planes go into the hangar for this exercise (→ `fleet_in`),
+2. assign a soft **priority** to any plane (→ `PlaneConstraint.priority`),
+3. mark a hard **must-position** for any plane (→ `PlaneConstraint.pin`),
+
+and **export a complete, loader-valid `Scenario` YAML** that `hangarfit solve` consumes unchanged.
+
+## 2. Non-goals (explicit)
+
+- **No client-side solving or collision/feasibility check.** The browser has no oracle; validity comes only from the Python re-solve/re-check round-trip.
+- **No in-browser geometry re-derivation.** The browser never composes a determinant-−1 transform (ADR-0002). See §7.
+- **No `hangarfit serve` / HTTP** (that is #445, Stage 3, its own ADR).
+- **No changes to `scene.py` / `build_scene()` / the solver / the Python models / the loader.** The export target already exists and is honored end-to-end. (The one Python change is a viewer-HTML-level context blob + a CLI flag — see §5–§6.)
+- **No live rotation preview** (MVP decision — see §7 and §11).
+- **No prior-intent echo** on re-open (MVP decision — see §8 and §11).
+
+## 3. Architecture constraints (non-negotiable)
+
+1. **ADR-0002 — the browser never re-derives the det-−1 transform.** `interaction/` modules must never import `affine.ts` or `anchors.ts`, and never touch the `final_poses` affines for pose purposes. The browser reads each plane's **current pose as Python-emitted scalars** (`editor-context.currentPoses`, §4) and edits them as scalar `x/y/heading` fields — data entry, not geometry.
+2. **Python is the sole authority** (solver, geometry, validity). The browser is an intent-capture surface.
+3. **ADR-0003 — core stays byte-deterministic.** `scene.build_scene()` output is byte-identical (guarded by `scene-schema-guard` + `tests/test_scene.py`). This design touches **none** of it.
+4. **`viewer.js` byte-drift guard** (`.github/workflows/viewer.yml`): any `interaction/*.ts` that `main.ts` imports changes the bundle → rebuild + commit `viewer.js` in the **same** PR.
+5. **Opt-in gating (correctly stated).** The editor ships behind `hangarfit view --edit`. `viewer.js` is **inlined** into the HTML (`viewer.py:106`), so growing the bundle changes *every* render — exactly like any viewer feature, guarded by `viewer-build-drift` + a regenerated whole-file golden. There is no "byte-identical HTML." The invariants that DO hold: **(a)** `scene.build_scene()` bytes are untouched (`test_scene.py` / `scene-schema-guard`); **(b)** the **non-edit render path is structurally unchanged** — `render_viewer` still uses the normal `_HUD` and emits **no** `editor-context` blob, so the editor code ships **dormant** (present in the bundle, never invoked without the blob); **(c)** **edit mode is purely additive HTML** — the same `#scene` bytes + `_HUD_EDIT` + one extra `#editor-context` blob.
+6. **`checkAnchors()` stays the load-bearing fail-loud transform-VALUE backstop** (>1e-6 divergence → on-page `#banner`). Unchanged.
+7. **The offline single-file HTML deliverable survives** — the editor is additive to it, never a replacement.
+
+## 4. The Intent contract
+
+The typed mirror of the export artifact, per `interaction/README.md`:
+
+```ts
+// viewer/src/interaction/intent-contract.ts
+export interface Intent {
+  selectedPlaneIds: string[];                                  // → Scenario.fleet_in
+  priorities: Record<string, number>;                          // → PlaneConstraint.priority (soft, ≥0)
+  mustPositions: Record<string, {                              // → PlaneConstraint.pin (hard)
+    x: number; y: number; heading: number; onCarts: boolean;
+  }>;
+}
+
+// The non-constraint scenario scaffold the browser cannot recover from scene/v2 alone.
+// Injected by viewer.py from the SOURCE scenario + solved layout (the CLI knows both).
+export interface EditorContext {
+  fleet: string;                    // path string, echoed verbatim into the export
+  hangar: string;                   // path string, echoed verbatim
+  maintenance: { plane: string } | null;   // preserved passthrough (never pinned/selectable)
+  // Per RENDERED (placeable) plane, the CURRENT pose as SCALARS — emitted by Python
+  // (which owns the geometry). Its KEYS are the selection universe (§7). "pin at current
+  // pose" is a pure scalar copy; the browser does NO affine math (ADR-0002). See §7.
+  currentPoses: Record<string, { x_m: number; y_m: number; heading_deg: number; on_carts: boolean }>;
+  cartEligible: Record<string, boolean>;    // per-plane: is on_carts a meaningful toggle?
+}
+```
+
+Note `mustPositions[id].onCarts` is required because a `pin` block requires all of `x_m/y_m/heading_deg/on_carts` (loader `pin` validation), and `Scenario.__post_init__` cross-checks it against `movement_mode`. Default it from `currentPoses[id].on_carts`; expose a toggle only for cart-eligible planes. The **selection universe is `Object.keys(currentPoses)`** — the planes actually rendered in the scene; adding a plane that was not in the solve (no pose to show) is future work, not MVP.
+
+## 5. The round-trip and the export shape
+
+**Round-trip (Stage 2, file-mediated):**
+
+1. `hangarfit view SCENARIO.yaml --solve --edit -o out.html` — renders the solved scene **and** the editor HUD/interaction script, plus the `editor-context` blob.
+2. User selects planes / sets priorities / marks must-positions in-browser.
+3. User clicks **Export** → downloads a complete `Scenario` YAML.
+4. User re-runs `hangarfit solve EXPORTED.yaml` (optionally `--write-yaml`) and/or `hangarfit view EXPORTED.yaml --solve --edit -o out.html`.
+5. Fresh view.
+
+**Export shape** (exactly the `scenario_with_pin.yaml` fixture shape — proven loader-valid):
+
+```yaml
+fleet: <echoed from EditorContext.fleet>
+hangar: <echoed from EditorContext.hangar>
+fleet_in: [<selectedPlaneIds…>]
+maintenance:                # only if EditorContext.maintenance is non-null
+  plane: <maintenance.plane>
+constraints:                # only planes with a priority and/or a must-position
+  <plane_id>:
+    pin: { x_m: <x>, y_m: <y>, heading_deg: <heading>, on_carts: <onCarts> }
+    priority: <priority>    # omitted when unset
+```
+
+**Serializer invariants** (enforced in `export.ts`, checked by tests):
+- `fleet_in` ⊆ `EditorContext.fleetInAll`; `constraints` keys ⊆ `fleet_in` (else `Scenario.__post_init__` rejects).
+- The `maintenance.plane` is never emitted under `constraints` (pinning it is forbidden).
+- `priority` omitted when unset (round-trips "user never set a priority" as absent, per the #441 `float | None` design).
+- Numbers formatted deterministically (fixed decimals) so the artifact is stable/diffable.
+
+## 6. CLI activation
+
+- New flag `--edit` on `hangarfit view` (`cli.py` `cmd_view`).
+- **`--edit` requires `--solve`** (i.e. a Scenario input). Without `--solve`, exit **2** with a clear message — mirrors the existing `--alternatives`-without-`--solve` guard. Rationale: the editor exports a *Scenario*; a bare `Layout` has no `fleet_in`/`fleet`/`hangar` scaffold to echo. (Editing from a Layout is a possible follow-up, not MVP.)
+- **`--edit` + `--alternatives` together → exit 2** (reject) in the MVP. Editing across a multi-solution switcher is a later cut; keeping them mutually exclusive keeps the semantics crisp. MVP `--edit` always edits the single primary solution.
+
+## 7. The ADR-0002 carve-out (the key design decision)
+
+The editor exposes **three distinct capabilities** (they are not the same action):
+
+- **Selection** (which planes go in → `fleet_in`): the initial `Intent` selects **all rendered planes**; clicking a plane toggles its membership. Deselecting drops it from the export's `fleet_in`. The maintenance-bay occupant is not rendered/selectable (preserved via passthrough).
+- **Priority** (soft → `priority`): a per-selected-plane control sets a non-negative weight.
+- **Must-position / pin** (hard → `pin`): a per-selected-plane **"pin here" toggle**. Turning it on **captures the current pose** (read as scalars from `editor-context.currentPoses[id]` — Python-emitted, no browser math) as the pin; the pose is then editable via `x` / `y` / `heading` **number fields** (data entry, not geometry).
+
+Placing a plane in the browser risks re-deriving geometry; the MVP stays strictly data-entry:
+
+- **Editing** a pin = typing into number fields. The browser never composes an affine.
+- **No live drag, no live rotation preview** in the MVP. The 3D scene shows the *last solved* geometry; the authoritative re-render happens in Python after re-solve.
+
+This is the safest reading of ADR-0002 and the fastest to ship. Two richer options (live translation drag; drag+rotate as a clearly-marked non-authoritative preview) are recorded as future work in §11 — both were considered and deferred to keep the MVP on the correct side of the transform boundary.
+
+## 8. Prior intent on re-open (deferred for MVP)
+
+The scene/v2 JSON does not echo the source scenario's existing `constraints`. On re-open the editor therefore starts **blank** (no pre-filled pins/priorities); the user's intent persists in the exported YAML they carry forward. This is the simplest MVP and touches nothing in `scene.py`.
+
+Two ways to add prior-intent later (recorded, not built): (a) the editor re-reads the source Scenario YAML; (b) an additive `constraints`-echo block in scene/v2 (scene-schema-guard-gated additive-only SCHEMA bump). Deferred per §11.
+
+## 9. Module design (pure-core / impure-edge)
+
+Mirrors the existing `compare.ts` precedent (pure logic node-tested; THREE/DOM edge rides the headless swiftshader smoke).
+
+| Module | Purity | Responsibility |
+|---|---|---|
+| `viewer/src/interaction/intent-contract.ts` | types | `Intent`, `EditorContext` (the typed mirror of the artifact). |
+| `viewer/src/interaction/selection.ts` | **pure** | Selection-state machine (toggle/add/remove/clear); current-pose lookup from `editor-context.currentPoses` (scalars). No THREE/DOM, no affine math. |
+| `viewer/src/interaction/export.ts` | **pure** | `(Intent, EditorContext) → Scenario-YAML string`. Enforces §5 invariants. No THREE/DOM. |
+| `viewer/src/interaction/editor.ts` | impure edge | THREE.Raycaster over `planes.ts` `groups`, selection highlight, `controls.enabled=false` during interaction, HUD wiring, Blob + `<a download>` export. Reads `scene-contract.ts`. **Forbidden** to import `affine.ts`/`anchors.ts`. |
+| `viewer/src/main.ts` | impure edge | Mount editor in `buildWorld()`/`bootSingle` behind an edit flag read from the DOM (`editor-context` blob present ⇒ edit mode). Non-edit boot path unchanged. |
+
+**Python side:**
+| File | Change |
+|---|---|
+| `src/hangarfit/viewer.py` | `_HUD_EDIT` markup string (priority slider/field, per-plane pin toggle, per-plane `on_carts` toggle for cart-eligible planes, selection readout, Export button) + a separate `<script id="editor-context" type="application/json">` blob (like the `viewer-compare/v1` wrapper) carrying `EditorContext` incl. per-plane `currentPoses` scalars (Python owns that geometry) — emitted **only** in edit mode. Non-edit HUD skeleton stays byte-identical. `</script>`-escaping reused. |
+| `src/hangarfit/cli.py` | `--edit` flag on `view` (§6), routes render to the edit path. Default off ⇒ current output. |
+
+**No changes** to `scene.py`, `geometry.py`, `solver.py`, `models.py`, `loader.py`.
+
+## 10. Error handling & edge cases
+
+- **`--edit` without `--solve`** → exit 2, actionable message.
+- **`on_carts` for a movement-mode-fixed plane** → the toggle is disabled and defaults to the mode-consistent value; the serializer emits the consistent value so `Scenario.__post_init__` never rejects.
+- **Pinning the maintenance-bay occupant** → not selectable (excluded from the pin control set).
+- **Empty selection** → the Export button is disabled with a hint until ≥1 plane is selected (a `fleet_in: []` Scenario is meaningless), independent of whatever minimum the loader enforces.
+- **YAML safety** — the serializer emits the fixed, flat shape (plane ids are simple identifiers, values are scalars); a Python round-trip test (§11) is the authoritative validity guard, and a node golden test pins the string.
+
+## 11. Testing
+
+- **Node `--test`** (new, `viewer/test/`): `selection.test.ts` (state transitions + pose decompose against a fixture scene), `export.test.ts` (golden YAML string + §5 invariants incl. the reject paths), `intent.test.ts` if contract logic warrants.
+- **Python round-trip** (`tests/`): a representative exported YAML **loads via `load_scenario` without error** and produces the expected `PlaneConstraint`s — the authoritative "the artifact is loader-valid" guard.
+- **Render-path invariants** (`tests/test_viewer.py`, per §3.5 — *not* whole-HTML byte-identity, since the inlined bundle grows): (a) `render_viewer` (non-edit) emits **no** `id="editor-context"` and uses the normal `_HUD`; (b) `render_edit_viewer` output = the non-edit assembly with `_HUD_EDIT` + one added `#editor-context` blob, and its `#scene` blob bytes are **identical** to `render_viewer`'s; (c) the `scene.build_scene()` bytes are unchanged (covered by `test_scene.py`). Regenerate the whole-file golden (it moves because `viewer.js` moves — expected).
+- **Headless smoke**: swiftshader render of an `--edit` page; `#banner` TRANSFORM CHECK stays hidden; a scripted select→export path exercises `editor.ts` (drive via the DOM the way the compare smoke does).
+- **`viewer-build-drift`**: `viewer.js` rebuilt + committed alongside the `main.ts` wiring.
+
+## 12. Docs & decisions
+
+- **New ADR** — the intent-artifact contract: the `Intent → Scenario YAML` mapping, and the §7 ADR-0002 carve-out (pin-at-current-pose + numeric edit; no in-browser rotation math). This records why the editor is safe under ADR-0002.
+- **ADR-0020** — flip status Proposed → **Accepted**; mark the `interaction/` seam **active**.
+- **`interaction/README.md`** — update from "inert" to the shipped module map.
+- **CLAUDE.md / arc42 §5** — `view --edit` in Useful commands; the `interaction/` module in the building-block view.
+- **CHANGELOG** `[Unreleased]` — one `### Added` entry.
+
+## 13. Deferred / open (assumptions pending user confirmation)
+
+The following were defaulted to the leanest option while planning (user was away); each is reversible and re-openable:
+
+1. **Scope = #442 MVP only.** #444 (JSON-Schema single-source) deferred: its trigger *is* met, but adopting it adds two hash-pinned dev/CI deps + a codegen step and risks stalling the MVP; the new `intent-contract.ts` is **hand-written** for now (consistent with the already-hand-written `scene-contract.ts`, ADR-0020's accepted stance). Re-evaluate #444 once the contract stabilizes. **Proposed milestone change:** move #444 out of #38 to a follow-up. #445 stays deferred (no milestone).
+2. **Placement UX = numeric + pin-at-current** (§7). Alternatives (live translation drag; drag+rotate non-authoritative preview) deferred.
+3. **Prior intent = deferred** (§8). Editor starts blank on re-open.
+
+## 14. Implementation chunks (each an independently reviewable PR/issue)
+
+- **Chunk 0 — docs/decision (no code).** New ADR (intent-artifact contract + ADR-0002 carve-out) + flip ADR-0020 to Accepted. Reviewable via `comment-analyzer`.
+- **Chunk 1 — pure TS, `viewer.js` UNCHANGED.** Add `intent-contract.ts` + `selection.ts` + `export.ts` and their node tests. As long as `main.ts` doesn't import them, esbuild leaves the bundle byte-identical (drift guard green). Low-risk landing of the typed contract + pure serializer.
+- **Chunk 2 — interactive selection, `viewer.js` REBUILT.** `editor.ts` (raycaster + highlight + controls gating), wired into `main.ts` behind the edit flag; `cli.py --edit` + `viewer.py` `_HUD_EDIT` selection-readout + `editor-context` blob; rebuild+commit `viewer.js`; assert `--edit`-off byte-identity.
+- **Chunk 3 — intent capture + export UI.** Priority control, per-plane pin toggle, per-plane `on_carts` toggle, Export button (Blob download); Python round-trip test that the export loads via `load_scenario`.
+- **(Follow-up, out of this milestone) Chunk 4 — prior-intent echo** (§8) and **#444 JSON-Schema single-source** (§13.1).
+
+## 15. Housekeeping surfaced during planning (not part of #442)
+
+- **Milestone #37 (v0.17.0) is still open** though v0.17.0 shipped 2026-06-29 — should be closed.
+- **ADR-0020 status** is still "Proposed" — flipped to "Accepted" in Chunk 0.


### PR DESCRIPTION
Lands the planning artifacts for the v0.18.0 interactive placement editor so implementation can start against a reviewed design.

## What this adds (docs-only, no code)
- **Design spec** — `docs/superpowers/specs/2026-07-02-v0.18.0-interactive-placement-editor-design.md`
- **Implementation plan** — `docs/superpowers/plans/2026-07-02-v0.18.0-interactive-placement-editor.md` (7 TDD tasks, 4 chunks)

## Key content
- The editor is an **intent-capture surface** (ADR-0002/0017/0020): select planes → soft `priority` + hard `pin` → export a loader-valid `Scenario` YAML that `solve` re-runs. Python stays the geometry/solver authority.
- **#442 needs zero Python model/loader/solver/scene changes** — #441's `priority` field + the loader allowlist are already the export target (`tests/fixtures/scenario_with_pin.yaml` is the shape).
- Corrected invariant: `viewer.js` is **inlined** into the HTML, so there is no "byte-identical HTML" when `--edit` is off; the real invariants are `build_scene` bytes unchanged + dormant editor code + additive edit HTML.
- Design uses a Python-emitted `editor-context` blob (separate `<script>`, like the #666 compare wrapper) carrying per-plane **scalar** poses, so the browser does zero affine math.

## Decisions (defaulted while the user was away; recorded in the spec §13)
Scope = #442 MVP only (defer #444, #445 out) · placement UX = numeric fields + pin-at-current · prior-intent deferred. All reversible.

Docs-only; implementation of the editor stays tracked by #442.

Closes #894. Refs #442.