### PR TITLE
docs(#442): Chunk 0 — ADR-0029 intent-artifact contract + flip ADR-0020 to Accepted

### DIFF
--- a/docs/adr/0020-viewer-typescript-architecture.md
+++ b/docs/adr/0020-viewer-typescript-architecture.md
@@ -1,8 +1,15 @@
 # ADR-0020: The viewer is a typed, modular TypeScript application built by a dev-only toolchain; the Python-owned transform is retained
 
-- **Status:** Proposed
-  <!-- Proposed at PR-open; Accepted at PR-merge. Supersedes ADR-0017's
-       "No build toolchain" / thin-renderer sub-decision (see below). -->
+- **Status:** Accepted
+  <!-- Accepted at merge of the #439 port. Supersedes ADR-0017's
+       "No build toolchain" / thin-renderer sub-decision (see below). The
+       reserved `interaction/` editor seam is now ACTIVE — its contract is
+       recorded in [ADR-0029](0029-editor-intent-artifact-contract.md) and
+       implemented across #442 (Stage 2 interactive placement editor). -->
+
+  <!-- Housekeeping (2026-07-02, #442 Chunk 0): flipped Proposed → Accepted;
+       the toolchain and viewer port shipped (#437–#441), so the Proposed
+       status was stale. -->
 
 - **Date:** 2026-06-04
 - **Deciders:** Patrick Kuhn (DocGerd)
@@ -221,12 +228,15 @@ language pytest cannot exercise — the precise hazard ADR-0002/0017 guard again
   build-toolchain sub-decision this supersedes), [ADR-0002](0002-determinant-minus-one-transform.md)
   (the transform retained in Python), [ADR-0019](0019-brand-tokens-single-source.md) (the
   BRAND blob the typed `brand-contract.ts` mirrors), [ADR-0003](0003-rr-mc-solver-algorithm.md)
-  (the determinism spirit the build-drift guard extends).
+  (the determinism spirit the build-drift guard extends),
+  [ADR-0029](0029-editor-intent-artifact-contract.md) (the intent-artifact contract that
+  activates the `interaction/` seam reserved here).
 - Related specs: [`docs/superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md`](../superpowers/specs/2026-06-04-viewer-typescript-architecture-design.md);
   schema reference [`docs/architecture/scene-v2-schema.md`](../architecture/scene-v2-schema.md).
 - Related issues / PRs: #436 (epic), #437 (toolchain), #438 (CI), #439 (port), #440
   (typed contract + interaction seam), #441 (Python `priority` groundwork), #442
-  (deferred interactive editor — Stage 2 round-trip), #444 (deferred JSON-Schema
+  (interactive editor — Stage 2 round-trip, now ACTIVE; contract in
+  [ADR-0029](0029-editor-intent-artifact-contract.md)), #444 (deferred JSON-Schema
   single-source spike), #445 (deferred Stage 3: viewer-as-full-frontend via `hangarfit
   serve` — own ADR); follows #423, subsumes #433.
 - External references: [esbuild](https://esbuild.github.io/) (reproducible builds,

--- a/docs/adr/0020-viewer-typescript-architecture.md
+++ b/docs/adr/0020-viewer-typescript-architecture.md
@@ -1,15 +1,13 @@
 # ADR-0020: The viewer is a typed, modular TypeScript application built by a dev-only toolchain; the Python-owned transform is retained
 
 - **Status:** Accepted
-  <!-- Accepted at merge of the #439 port. Supersedes ADR-0017's
-       "No build toolchain" / thin-renderer sub-decision (see below). The
-       reserved `interaction/` editor seam is now ACTIVE — its contract is
-       recorded in [ADR-0029](0029-editor-intent-artifact-contract.md) and
-       implemented across #442 (Stage 2 interactive placement editor). -->
-
-  <!-- Housekeeping (2026-07-02, #442 Chunk 0): flipped Proposed → Accepted;
-       the toolchain and viewer port shipped (#437–#441), so the Proposed
-       status was stale. -->
+  <!-- Decision effective when the toolchain + viewer port shipped (#437–#441);
+       the status FIELD was flipped Proposed → Accepted on 2026-07-02 in #442
+       Chunk 0 (it had been left stale at Proposed after the port merged).
+       Supersedes ADR-0017's "No build toolchain" / thin-renderer sub-decision
+       (see below). The reserved `interaction/` editor seam is now ACTIVE — its
+       contract is recorded in [ADR-0029](0029-editor-intent-artifact-contract.md)
+       and implemented across #442 (Stage 2 interactive placement editor). -->
 
 - **Date:** 2026-06-04
 - **Deciders:** Patrick Kuhn (DocGerd)

--- a/docs/adr/0029-editor-intent-artifact-contract.md
+++ b/docs/adr/0029-editor-intent-artifact-contract.md
@@ -178,6 +178,10 @@ recover from `scene/v2` is supplied by Python via `EditorContext`.
 
 ## Compliance
 
+The mechanisms below land with **Chunks 1–3** of #442 (this ADR ships in Chunk 0,
+ahead of the code it governs); `render_viewer` and the `scene/v2` byte-identity
+guards it anchors on already exist today.
+
 - **Grep-able hard rule**: no file under `viewer/src/interaction/` imports
   `affine.ts` or `anchors.ts` (also stated in `interaction/README.md` and the
   ADR-0020 seam rule).

--- a/docs/adr/0029-editor-intent-artifact-contract.md
+++ b/docs/adr/0029-editor-intent-artifact-contract.md
@@ -1,0 +1,216 @@
+# ADR-0029: The interactive editor captures a pinned pose by copying Python-emitted scalars and exports a full `Scenario` YAML — the browser never composes a transform
+
+- **Status:** Proposed
+  <!-- Proposed at PR-open; Accepted at PR-merge. Records the intent-artifact
+       contract + the ADR-0002 carve-out that Chunks 1–3 of #442 build on. -->
+
+- **Date:** 2026-07-02
+- **Deciders:** Patrick Kuhn (DocGerd)
+
+> **Scope of this ADR.** It records the contract for the Stage-2 interactive
+> placement editor (`hangarfit view --edit`, epic [#442](https://github.com/DocGerd/hangarfit/issues/442)):
+> **how** the browser turns a user's intent — which planes go in, which matter
+> more, which must sit in a specific spot — into a loader-valid `Scenario` YAML
+> the Python solver re-runs, and **why** that is safe under
+> [ADR-0002](0002-determinant-minus-one-transform.md). It activates the
+> `interaction/` seam that [ADR-0020](0020-viewer-typescript-architecture.md)
+> reserved. It does **not** change `scene/v2`, the solver, the loader, or the
+> Python model — those authorities are reaffirmed unchanged.
+
+## Context & Problem Statement
+
+`hangarfit view` renders a solved layout into a read-only offline 3D HTML page.
+The next step ([ADR-0020](0020-viewer-typescript-architecture.md) Stage 2) turns
+that page into the tool's **front door**: a human captures *intent* and hands it
+back to the Python solver. Intent has three parts — **select** which planes go in
+(→ `fleet_in`), assign a soft **priority** (→ `PlaneConstraint.priority`, #441),
+and mark a hard **must-position** (→ `PlaneConstraint.pin`).
+
+The third part is the dangerous one. A "must-position" is a *pose* — an
+`(x, y, heading)` in hangar coordinates — and [ADR-0002](0002-determinant-minus-one-transform.md)
+establishes that the plane-local → world transform has **determinant −1** (a
+reflection, not a rotation), so it is owned by tested Python and **never
+re-derived in JavaScript**. The question this ADR answers: **how does the editor
+let a user express and refine a hard pose, and export a complete, loader-valid
+`Scenario`, without the browser ever composing or inverting that transform?**
+
+## Decision Drivers
+
+- **ADR-0002 is inviolate.** No `interaction/` module may compose, invert, or
+  re-derive the determinant-−1 transform — that is the one hazard the whole
+  viewer architecture (ADR-0002/0017/0020) is built to prevent.
+- **Python stays the sole authority** for solving, geometry, and validity. The
+  browser is an intent-capture surface with no oracle.
+- **The exported artifact must round-trip unchanged** — `hangarfit solve
+  EXPORTED.yaml` must consume it with no hand-editing.
+- **Ship a correct MVP fast** with a boundary that is crisp and testable in the
+  one language pytest cannot exercise.
+- **Determinism / diffability** of the artifact — a stable YAML shape so two
+  exports of the same intent are byte-identical.
+
+## Considered Options
+
+The crux is **how a hard must-position is captured and edited**:
+
+1. **Pin-at-current-pose + numeric edit** (chosen). Toggling "pin here" copies
+   the plane's *current* pose — already computed by Python and emitted as plain
+   scalars in `editor-context.currentPoses[id]` — into the `Intent`; the user
+   refines it with `x` / `y` / `heading` **number fields**. Pure data entry; the
+   browser performs no geometry math.
+2. **Live translation drag.** Drag the plane in the floor plane; the browser
+   derives `x`/`y` from pointer deltas (heading stays a number field).
+3. **Drag + rotate as a non-authoritative preview.** A full move+rotate gizmo;
+   the browser composes a *preview* affine (clearly marked "not validated"),
+   with authoritative geometry only after the Python re-solve.
+
+A supporting sub-decision is **what the editor exports**:
+
+- **A complete `Scenario` YAML** (chosen) — `fleet` / `hangar` / `fleet_in` /
+  `maintenance` / `constraints`, self-contained.
+- **A `constraints`-only fragment** the user hand-merges into their scenario.
+
+## Decision Outcome
+
+**Chosen option: Option 1 (pin-at-current-pose + numeric edit), exporting a
+complete `Scenario` YAML**, because it is the only option in which the browser
+performs **zero** geometry math — every pose value it emits *originated in
+Python* — so ADR-0002 holds **by construction** rather than by discipline, and it
+is the fastest path to a correct, testable MVP.
+
+### The recorded contract — `Intent` → `Scenario`
+
+The browser builds an `Intent` and serializes it deterministically. The
+non-constraint scaffold it cannot recover from `scene/v2` alone (fleet/hangar
+paths, the maintenance passthrough, and each plane's current pose as scalars) is
+injected by `viewer.py` as an `EditorContext` blob.
+
+| `Intent` / `EditorContext` field | `Scenario` YAML target |
+|---|---|
+| `EditorContext.fleet` / `.hangar` (path strings) | top-level `fleet:` / `hangar:` (echoed verbatim) |
+| `Intent.selectedPlaneIds` ∪ `{maintenance.plane}` | top-level `fleet_in: [...]` |
+| `EditorContext.maintenance.plane` | `maintenance:\n  plane: <id>` (passthrough; **also** in `fleet_in`) |
+| `Intent.priorities[id]` (soft, ≥0) | `constraints[id].priority` |
+| `Intent.mustPositions[id]` `{x,y,heading,onCarts}` | `constraints[id].pin` `{x_m, y_m, heading_deg, on_carts}` |
+
+**Serializer invariants** (enforced in `export.ts`, checked by node + Python
+tests):
+
+- `fleet_in` = `selectedPlaneIds` ∪ `{maintenance.plane}` when present. The
+  maintenance occupant **must** appear in `fleet_in` — `models.py`
+  `Scenario.__post_init__` rejects otherwise, even though it is never
+  rendered/selectable.
+- `constraints` keys ⊆ `selectedPlaneIds` ⊆ `fleet_in`; the maintenance plane is
+  **never** emitted under `constraints` (pinning it is forbidden).
+- `priority` is **omitted when unset** (round-trips "user never set a priority"
+  as absent, per the #441 `float | None` design).
+- A `pin` block carries **all** of `x_m` / `y_m` / `heading_deg` / `on_carts`
+  (loader `pin` validation); `on_carts` defaults from `currentPoses[id].on_carts`
+  and is only user-toggleable for cart-eligible planes (`Scenario.__post_init__`
+  cross-checks it against `movement_mode`).
+- Numbers are formatted deterministically (fixed decimals) so the artifact is
+  stable and diffable.
+
+### The ADR-0002 carve-out (why this is safe)
+
+"Pin here" is a **scalar copy**, not a geometry operation:
+`mustPositions[id] = {x: currentPoses[id].x_m, y: …, heading: …, onCarts: …}`.
+Every value already exists because Python computed the solved pose. Editing a pin
+is typing into number fields. The browser **never** composes an affine, never
+maps screen coordinates to floor coordinates, and never touches the `final_poses`
+affines for pose purposes. The 3D scene shows the *last solved* geometry; the
+authoritative re-render happens in Python after the re-solve. This keeps the
+editor strictly on the data-entry side of the ADR-0002 boundary.
+
+### Why not Option 2 (live translation drag)?
+
+Reading `x`/`y` from pointer deltas requires mapping screen coordinates onto the
+hangar floor plane — i.e. **inverting** the Python-owned world transform in
+JavaScript, or re-deriving an independent ground-plane mapping that can silently
+diverge from the `checkAnchors()` oracle. That is exactly the determinant-−1
+math ADR-0002 forbids in JS. Recorded as future work behind a design that keeps
+the derivation on the Python side.
+
+### Why not Option 3 (drag + rotate preview)?
+
+Composing even a "preview-only" affine reintroduces the determinant-−1
+sign-flip trap in the one language pytest cannot exercise, and a
+non-authoritative preview that later disagrees with the post-solve render is a
+UX foot-gun (the user "placed" a plane the solver then moves). Deferred behind a
+clearly-marked, explicitly-non-authoritative preview design; not part of the MVP.
+
+### Why not a `constraints`-only fragment?
+
+`hangarfit solve` consumes a whole `Scenario` (fleet / hangar / fleet_in /
+maintenance / constraints). A fragment would force the user to hand-merge it into
+their source scenario — a manual, error-prone step at odds with the "re-run
+`solve EXPORTED.yaml`" round-trip. Emitting a complete, self-contained
+`Scenario` makes the round-trip a single command; the scaffold the browser can't
+recover from `scene/v2` is supplied by Python via `EditorContext`.
+
+## Consequences
+
+### Positive
+
+- **ADR-0002 holds by construction**: the browser emits only Python-origin
+  scalars, so no `interaction/` module needs — or is permitted — to do transform
+  math.
+- The exported artifact is a **self-contained, diffable, loader-valid
+  `Scenario`** the user re-runs with one command.
+- The capture/serialize logic (`selection.ts`, `export.ts`) is **pure** and
+  node-unit-testable — coverage the single-file viewer could not have had.
+
+### Negative
+
+- **No live drag/rotate in the MVP.** A user repositioning "by feel" must read
+  the current coordinates and type new ones; the 3D scene is the last-solved
+  geometry, not a live manipulation preview. (Options 2/3 are the recorded
+  upgrade path.)
+
+### Neutral
+
+- The `editor-context` blob is a **viewer-HTML-level artifact** (schema
+  `hangarfit.editor-context/v1`), layered over an **untouched** `scene/v2`
+  document — the same pattern as the `viewer-compare/v1` wrapper
+  ([ADR-0017](0017-3d-viewer-architecture.md), #666). It is **not** a `scene/v2`
+  schema change, so `scene.build_scene()` and its key-parity guard are untouched.
+- Prior intent is **not echoed** on re-open (the editor starts blank); the user's
+  intent persists in the exported YAML. Echoing it is deferred future work.
+
+## Compliance
+
+- **Grep-able hard rule**: no file under `viewer/src/interaction/` imports
+  `affine.ts` or `anchors.ts` (also stated in `interaction/README.md` and the
+  ADR-0020 seam rule).
+- **`viewer/test/selection.test.ts`** pins that `pinAtCurrent` is a pure scalar
+  copy of `currentPoses[id]` (no math) and that the state functions are pure.
+- **`viewer/test/export.test.ts`** golden-tests the `Scenario`-YAML shape and the
+  reject/omit paths (maintenance ∈ `fleet_in`; deselected planes absent;
+  `priority` omitted when unset).
+- **`tests/test_viewer.py`** Python round-trip: a representative exported YAML
+  **loads via `load_scenario`** and yields the expected `PlaneConstraint`s — the
+  authoritative loader-validity guard.
+- **`scene/v2` untouched**: `tests/test_scene.py` byte-identity + the
+  `scene-schema-guard` subagent; the `editor-context` blob is asserted additive
+  (the `render_edit_viewer` render-path invariants in `tests/test_viewer.py`: the
+  `#scene` bytes are identical to `render_viewer`'s, and the non-edit path emits
+  no `#editor-context`).
+- The runtime **`checkAnchors()`** self-check remains the fail-loud cross-language
+  transform-**value** backstop.
+
+## More Information
+
+- Related ADRs: [ADR-0002](0002-determinant-minus-one-transform.md) (the transform
+  retained in Python — the constraint this ADR is designed around),
+  [ADR-0017](0017-3d-viewer-architecture.md) (the viewer architecture + the
+  viewer-HTML-level blob precedent), [ADR-0020](0020-viewer-typescript-architecture.md)
+  (the typed modular viewer whose `interaction/` seam this activates),
+  [ADR-0019](0019-brand-tokens-single-source.md) (a prior viewer-injected blob),
+  [ADR-0003](0003-rr-mc-solver-algorithm.md) (the determinism spirit the artifact
+  formatting extends).
+- Related specs: [`docs/superpowers/specs/2026-07-02-v0.18.0-interactive-placement-editor-design.md`](../superpowers/specs/2026-07-02-v0.18.0-interactive-placement-editor-design.md)
+  (design) and [`docs/superpowers/plans/2026-07-02-v0.18.0-interactive-placement-editor.md`](../superpowers/plans/2026-07-02-v0.18.0-interactive-placement-editor.md)
+  (implementation plan).
+- Related issues / PRs: #442 (epic / MVP), #896 (Chunk 0 — this ADR), #440 (typed
+  `scene-contract.ts` + inert `interaction/` seam), #441 (Python soft `priority`
+  groundwork), #444 (deferred JSON-Schema single-source spike), #445 (deferred
+  Stage 3 — `hangarfit serve` full frontend).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -97,7 +97,7 @@ manual workflow above is canonical.
 | 0017 | [3D viewer — `scene/v1` JSON seam → self-contained offline Three.js HTML, transform owned by Python](0017-3d-viewer-architecture.md) | Accepted (build-toolchain / thin-renderer decision superseded by [ADR-0020](0020-viewer-typescript-architecture.md)) |
 | 0018 | [Model the non-rectangular hangar footprint — list of keep-out rects + derived Shapely floor polygon for containment](0018-non-rectangular-hangar-footprint.md) | Accepted |
 | 0019 | [Brand tokens live in one Python module (`brand.py`), injected into the viewer as a canonical BRAND blob](0019-brand-tokens-single-source.md) | Proposed |
-| 0020 | [The viewer is a typed, modular TypeScript application built by a dev-only toolchain; the Python-owned transform is retained](0020-viewer-typescript-architecture.md) | Proposed |
+| 0020 | [The viewer is a typed, modular TypeScript application built by a dev-only toolchain; the Python-owned transform is retained](0020-viewer-typescript-architecture.md) | Accepted |
 | 0021 | [Tow-planner staging apron — a bounded entry-staging start-region in front of the door; rearrangement holding-area deferred](0021-tow-planner-staging-apron.md) | Proposed |
 | 0022 | [Nose-out parked heading — RNG-free 180° flip post-pass (default on), plus the `tow_pivotable` towing-motion flag](0022-nose-out-parked-heading.md) | Accepted |
 | 0023 | [Model the empennage as explicit tail surfaces so a vertical fin in the wing layer can block wing-over-tail nesting](0023-empennage-tail-surfaces.md) | Accepted |
@@ -106,3 +106,4 @@ manual workflow above is canonical.
 | 0026 | [Caddy hard-door egress — clear-egress routability gate](0026-caddy-hard-door-egress.md) | Accepted |
 | 0027 | [Learned-backend determinism scope — verifier strict, proposer weaker (amends [ADR-0003](0003-rr-mc-solver-algorithm.md))](0027-learned-backend-determinism-scope.md) | Proposed |
 | 0028 | [Learned-backend dense train-to-mastery — resolved-negative; scope to the shipped inference seam](0028-learned-backend-train-to-mastery-resolved-negative.md) | Accepted |
+| 0029 | [The interactive editor pins a pose by copying Python-emitted scalars and exports a full `Scenario` YAML — the browser never composes a transform](0029-editor-intent-artifact-contract.md) | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -106,4 +106,4 @@ manual workflow above is canonical.
 | 0026 | [Caddy hard-door egress — clear-egress routability gate](0026-caddy-hard-door-egress.md) | Accepted |
 | 0027 | [Learned-backend determinism scope — verifier strict, proposer weaker (amends [ADR-0003](0003-rr-mc-solver-algorithm.md))](0027-learned-backend-determinism-scope.md) | Proposed |
 | 0028 | [Learned-backend dense train-to-mastery — resolved-negative; scope to the shipped inference seam](0028-learned-backend-train-to-mastery-resolved-negative.md) | Accepted |
-| 0029 | [The interactive editor pins a pose by copying Python-emitted scalars and exports a full `Scenario` YAML — the browser never composes a transform](0029-editor-intent-artifact-contract.md) | Proposed |
+| 0029 | [The interactive editor captures a pinned pose by copying Python-emitted scalars and exports a full `Scenario` YAML — the browser never composes a transform](0029-editor-intent-artifact-contract.md) | Proposed |

--- a/viewer/src/interaction/README.md
+++ b/viewer/src/interaction/README.md
@@ -1,4 +1,4 @@
-# `interaction/` — the editor extension seam (active, #442)
+# `interaction/` — the editor extension seam (activated by #442)
 
 This directory is the **extension seam** for the interactive plane-placement
 editor (`hangarfit view --edit`, epic [#442](https://github.com/DocGerd/hangarfit/issues/442),
@@ -6,10 +6,12 @@ Stage 2 of the roadmap in [ADR-0020](../../../docs/adr/0020-viewer-typescript-ar
 Its contract is recorded in
 [ADR-0029](../../../docs/adr/0029-editor-intent-artifact-contract.md).
 
-**The seam is now active.** [ADR-0020](../../../docs/adr/0020-viewer-typescript-architecture.md)
-reserved this directory (previously inert — README-only, so esbuild bundled
-nothing and the committed `src/hangarfit/_viewer_assets/viewer.js` was
-byte-unchanged); ADR-0029 activates it. The modules below land across #442 in
+**The seam is now activated** — its contract is recorded (ADR-0029) and its
+modules land across #442; at this exact commit the directory is still
+README-only (esbuild bundles nothing, `viewer.js` byte-unchanged).
+[ADR-0020](../../../docs/adr/0020-viewer-typescript-architecture.md) reserved this
+directory (previously inert — README-only); ADR-0029 activates it. The modules
+below land across #442 in
 small, independently reviewable chunks — the bundle stays byte-identical until a
 module is actually imported by `main.ts` (the `viewer-build-drift` guard tracks
 that hand-off), so Chunk 1's pure modules ship with an **unchanged** `viewer.js`

--- a/viewer/src/interaction/README.md
+++ b/viewer/src/interaction/README.md
@@ -1,43 +1,65 @@
-# `interaction/` — the editor extension seam (inert)
+# `interaction/` — the editor extension seam (active, #442)
 
-This directory is the **extension seam** for the future interactive plane-placement
-editor (deferred — issue #442, the Stage 2 of the roadmap in ADR-0020 / the spec).
+This directory is the **extension seam** for the interactive plane-placement
+editor (`hangarfit view --edit`, epic [#442](https://github.com/DocGerd/hangarfit/issues/442),
+Stage 2 of the roadmap in [ADR-0020](../../../docs/adr/0020-viewer-typescript-architecture.md)).
+Its contract is recorded in
+[ADR-0029](../../../docs/adr/0029-editor-intent-artifact-contract.md).
 
-**It is intentionally inert.** Right now it holds this `README.md` and **no `.ts`
-files**, so esbuild bundles nothing from here and the committed
-`src/hangarfit/_viewer_assets/viewer.js` is byte-unchanged. The `viewer-build-drift`
-CI guard stays green until a real module lands with #442.
+**The seam is now active.** [ADR-0020](../../../docs/adr/0020-viewer-typescript-architecture.md)
+reserved this directory (previously inert — README-only, so esbuild bundled
+nothing and the committed `src/hangarfit/_viewer_assets/viewer.js` was
+byte-unchanged); ADR-0029 activates it. The modules below land across #442 in
+small, independently reviewable chunks — the bundle stays byte-identical until a
+module is actually imported by `main.ts` (the `viewer-build-drift` guard tracks
+that hand-off), so Chunk 1's pure modules ship with an **unchanged** `viewer.js`
+and only Chunk 2's `main.ts` wiring rebuilds it.
 
-## The contract this seam will implement (#442)
+## What the editor does
 
-The viewer is, and stays, a **thin read-only consumer** of `scene/v2` whose geometry
-is computed in Python (ADR-0002/0017/0020). The editor does **not** change that: it
-captures user **intent** and hands it back to the Python solver. When #442 lands, an
-`interaction/` module will:
+The viewer is, and stays, a **thin read-only consumer** of `scene/v2` whose
+geometry is computed in Python (ADR-0002/0017/0020). The editor does **not**
+change that: it captures user **intent** and hands it back to the Python solver
+as a loader-valid `Scenario` YAML (the Stage-2 round-trip file). The user re-runs
+`hangarfit solve` and re-opens the viewer. Stage 3 ([#445](https://github.com/DocGerd/hangarfit/issues/445))
+later delivers the same intent object over a `hangarfit serve` localhost API
+instead of a file. **Python stays the solver authority in every stage.**
 
-1. **Read** the typed `scene-contract.ts` models to know what is on screen.
-2. **Build an intent object** mirroring `Scenario.constraints`:
+## Module map
 
-   ```ts
-   interface Intent {
-     selectedPlaneIds: string[];
-     priorities: Record<string, number>;            // soft PlaneConstraint.priority (#441)
-     mustPositions: Record<string, { x: number; y: number; heading: number }>; // hard pin
-   }
-   ```
+| Module | Purity | Responsibility | Lands |
+|---|---|---|---|
+| `intent-contract.ts` | types | `Intent`, `MustPosition`, `CurrentPose`, `EditorContext` — the typed mirror of the exported artifact. | Chunk 1 |
+| `selection.ts` | **pure** | Selection-state machine (toggle/priority/pin-at-current/edit); pose lookup reads `EditorContext.currentPoses` scalars. No THREE/DOM, no affine math. | Chunk 1 |
+| `export.ts` | **pure** | `(Intent, EditorContext) → Scenario-YAML string`; enforces the ADR-0029 serializer invariants. No THREE/DOM. | Chunk 1 |
+| `editor.ts` | impure edge | THREE.Raycaster over `planes` groups, selection highlight, `controls.enabled` gating, HUD wiring, `Blob` + `<a download>` export. Reads `scene-contract.ts`. | Chunks 2–3 |
 
-   "must positions" map to `PlaneConstraint.pin`; "priorities" to the soft
-   `PlaneConstraint.priority` groundwork (#441). `intent-contract.ts` becomes the
-   typed mirror of this artifact.
-3. **Export a `Scenario` / constraints YAML** the Python solver consumes. The user
-   re-runs `hangarfit solve` and re-opens the viewer (the Stage-2 round-trip file);
-   Stage 3 (#445) delivers the same intent object over a `hangarfit serve` localhost
-   API instead of a file. **Python stays the solver authority** in every stage.
+The `Intent` the browser builds mirrors `Scenario.constraints`:
+
+```ts
+interface Intent {
+  selectedPlaneIds: string[];                    // → Scenario.fleet_in (∪ maintenance plane)
+  priorities: Record<string, number>;            // → PlaneConstraint.priority (soft, #441)
+  mustPositions: Record<string, MustPosition>;   // → PlaneConstraint.pin (hard)
+}
+interface MustPosition { x: number; y: number; heading: number; onCarts: boolean; }
+```
+
+The non-constraint scaffold the browser cannot recover from `scene/v2` (fleet /
+hangar paths, the maintenance passthrough, and each plane's **current pose as
+scalars**) is injected by `viewer.py` as an `editor-context` blob
+(`hangarfit.editor-context/v1`) — a viewer-HTML-level artifact layered over an
+untouched `scene/v2` document, exactly like the `viewer-compare/v1` wrapper. See
+[ADR-0029](../../../docs/adr/0029-editor-intent-artifact-contract.md) for the full
+`Intent → Scenario` mapping and serializer invariants.
 
 ## The one hard rule
 
 A module in `interaction/` **must never import `affine.ts` or `anchors.ts`** to
-re-derive geometry. It captures intent and serializes it; the determinant-−1
-transform stays owned by tested Python (`geometry.local_to_world`), and the browser
-never re-derives authoritative geometry (ADR-0002/0020). The runtime `checkAnchors()`
-self-check remains the cross-language backstop.
+re-derive geometry, and must never touch the `final_poses` affines for pose
+purposes. A "must-position" pin is a **scalar copy** of the Python-emitted
+`currentPoses[id]`, edited via number fields — pure data entry, never a composed
+transform. The determinant-−1 transform stays owned by tested Python
+(`geometry.local_to_world`); the browser never re-derives authoritative geometry
+(ADR-0002/0020/0029). The runtime `checkAnchors()` self-check remains the
+cross-language backstop.


### PR DESCRIPTION
## Chunk 0 of the v0.18.0 interactive placement editor (#442) — docs/decision only

Implements **Task 1** of the merged plan (`docs/superpowers/plans/2026-07-02-v0.18.0-interactive-placement-editor.md`). No code, no `scene/v2`, no `viewer.js`.

### What changed
- **New `docs/adr/0029-editor-intent-artifact-contract.md`** — records the `Intent → Scenario` YAML mapping and, crucially, the **ADR-0002 carve-out**: a hard "must-position" pin is a *scalar copy* of the Python-emitted current pose (`editor-context.currentPoses[id]`), edited via number fields; the browser never composes or inverts the determinant-−1 transform. Considered alternatives (live translation drag; drag+rotate non-authoritative preview) are recorded as deferred. Registered in the ADR index.
- **`docs/adr/0020-viewer-typescript-architecture.md`** — status `Proposed → Accepted` (the toolchain + viewer port shipped in #437–#441, so `Proposed` was stale — see the plan's §15 housekeeping) and the reserved `interaction/` seam marked **active**, cross-linking ADR-0029. Index row updated.
- **`viewer/src/interaction/README.md`** — rewritten from "intentionally inert" to the shipped module map (`intent-contract.ts` / `selection.ts` / `export.ts` land in Chunk 1; `editor.ts` in Chunks 2–3), keeping the *never import `affine.ts`/`anchors.ts`* hard rule. Accurate at this commit: the `.ts` files land in later chunks, so `viewer.js` stays byte-identical until Chunk 2 wires `main.ts`.

### Notes for review
- **No CHANGELOG entry** here by design — Chunk 0 (ADRs) and Chunk 1 (dormant pure TS) aren't user-facing; the single `[Unreleased]` `### Added` entry lands with the user-facing `view --edit` in Chunk 3, per the plan.
- **ADR-0029 status = Proposed** per the ADR convention (Proposed at PR-open, Accepted at merge). It should flip to Accepted when this PR merges — I'll fold that into a later chunk (or do it on your go-ahead) so it doesn't repeat the stale-`Proposed` situation this PR fixes for ADR-0020.
- All relative markdown links in the changed docs were verified to resolve.

Closes #896