### PR TITLE
feat(viewer,#442): Chunk 1 — pure interaction core (intent-contract/selection/export + node tests)

### DIFF
--- a/viewer/src/interaction/export.ts
+++ b/viewer/src/interaction/export.ts
@@ -1,0 +1,39 @@
+// viewer/src/interaction/export.ts
+import type { Intent, EditorContext } from './intent-contract.ts';
+
+/** Deterministic float rendering: round to 4 dp, always show ≥1 decimal. */
+function num(n: number): string {
+  const r = Math.round(n * 1e4) / 1e4;
+  return Number.isInteger(r) ? `${r}.0` : `${r}`;
+}
+
+export function intentToScenarioYaml(intent: Intent, ctx: EditorContext): string {
+  const selected = [...intent.selectedPlaneIds].sort();
+  // The maintenance occupant is never rendered/selected/constrained, but the Scenario
+  // invariant requires maintenance ∈ fleet_in (models.py Scenario.__post_init__) — union it in.
+  const fleetIn = [...new Set(ctx.maintenance ? [...selected, ctx.maintenance.plane] : selected)].sort();
+  const lines: string[] = [];
+  lines.push(`fleet: ${ctx.fleet}`);
+  lines.push(`hangar: ${ctx.hangar}`);
+  lines.push(`fleet_in: [${fleetIn.join(', ')}]`);
+  if (ctx.maintenance) { lines.push('maintenance:'); lines.push(`  plane: ${ctx.maintenance.plane}`); }
+
+  // Only selected planes may carry constraints (never the maintenance plane).
+  const constrained = selected.filter((id) => intent.mustPositions[id] || intent.priorities[id] !== undefined);
+  if (constrained.length) {
+    lines.push('constraints:');
+    for (const id of constrained) {
+      lines.push(`  ${id}:`);
+      const mp = intent.mustPositions[id];
+      if (mp) {
+        lines.push(
+          `    pin: { x_m: ${num(mp.x)}, y_m: ${num(mp.y)}, ` +
+          `heading_deg: ${num(mp.heading)}, on_carts: ${mp.onCarts} }`,
+        );
+      }
+      const p = intent.priorities[id];
+      if (p !== undefined) lines.push(`    priority: ${num(p)}`);
+    }
+  }
+  return lines.join('\n') + '\n';
+}

--- a/viewer/src/interaction/intent-contract.ts
+++ b/viewer/src/interaction/intent-contract.ts
@@ -1,0 +1,15 @@
+// viewer/src/interaction/intent-contract.ts
+export interface MustPosition { x: number; y: number; heading: number; onCarts: boolean; }
+export interface Intent {
+  selectedPlaneIds: string[];
+  priorities: Record<string, number>;
+  mustPositions: Record<string, MustPosition>;
+}
+export interface CurrentPose { x_m: number; y_m: number; heading_deg: number; on_carts: boolean; }
+export interface EditorContext {
+  fleet: string;
+  hangar: string;
+  maintenance: { plane: string } | null;
+  currentPoses: Record<string, CurrentPose>;
+  cartEligible: Record<string, boolean>;
+}

--- a/viewer/src/interaction/selection.ts
+++ b/viewer/src/interaction/selection.ts
@@ -1,0 +1,52 @@
+// viewer/src/interaction/selection.ts
+import type { Intent, MustPosition, EditorContext } from './intent-contract.ts';
+
+export function initialIntent(ctx: EditorContext): Intent {
+  return { selectedPlaneIds: Object.keys(ctx.currentPoses).sort(), priorities: {}, mustPositions: {} };
+}
+
+export function isSelected(intent: Intent, id: string): boolean {
+  return intent.selectedPlaneIds.includes(id);
+}
+
+export function toggleSelection(intent: Intent, id: string): Intent {
+  const selected = isSelected(intent, id);
+  const selectedPlaneIds = selected
+    ? intent.selectedPlaneIds.filter((x) => x !== id)
+    : [...intent.selectedPlaneIds, id].sort();
+  const priorities = { ...intent.priorities };
+  const mustPositions = { ...intent.mustPositions };
+  if (selected) { delete priorities[id]; delete mustPositions[id]; } // can't constrain an absent plane
+  return { selectedPlaneIds, priorities, mustPositions };
+}
+
+export function setPriority(intent: Intent, id: string, priority: number | null): Intent {
+  const priorities = { ...intent.priorities };
+  if (priority === null) delete priorities[id]; else priorities[id] = priority;
+  return { ...intent, priorities };
+}
+
+export function pinAtCurrent(intent: Intent, id: string, ctx: EditorContext): Intent {
+  const c = ctx.currentPoses[id];
+  if (!c) return intent;
+  const mp: MustPosition = { x: c.x_m, y: c.y_m, heading: c.heading_deg, onCarts: c.on_carts };
+  return { ...intent, mustPositions: { ...intent.mustPositions, [id]: mp } };
+}
+
+export function unpin(intent: Intent, id: string): Intent {
+  const mustPositions = { ...intent.mustPositions };
+  delete mustPositions[id];
+  return { ...intent, mustPositions };
+}
+
+export function setPinField(intent: Intent, id: string, field: 'x' | 'y' | 'heading', value: number): Intent {
+  const cur = intent.mustPositions[id];
+  if (!cur) return intent;
+  return { ...intent, mustPositions: { ...intent.mustPositions, [id]: { ...cur, [field]: value } } };
+}
+
+export function setOnCarts(intent: Intent, id: string, onCarts: boolean): Intent {
+  const cur = intent.mustPositions[id];
+  if (!cur) return intent;
+  return { ...intent, mustPositions: { ...intent.mustPositions, [id]: { ...cur, onCarts } } };
+}

--- a/viewer/test/export.test.ts
+++ b/viewer/test/export.test.ts
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { intentToScenarioYaml } from '../src/interaction/export.ts';
+import { initialIntent, setPriority, pinAtCurrent, toggleSelection } from '../src/interaction/selection.ts';
+import type { EditorContext } from '../src/interaction/intent-contract.ts';
+
+const CTX: EditorContext = {
+  fleet: 'data/fleet.yaml', hangar: 'data/hangar.yaml',
+  maintenance: { plane: 'fuji' },
+  currentPoses: {
+    husky: { x_m: 2.1, y_m: 14.3, heading_deg: 0, on_carts: false },
+    ctsl: { x_m: 5.0, y_m: 3.0, heading_deg: 90, on_carts: false },
+  },
+  cartEligible: { husky: false, ctsl: false },
+};
+
+test('export has the scenario_with_pin shape (pin + priority)', () => {
+  let i = initialIntent(CTX);
+  i = pinAtCurrent(i, 'husky', CTX);
+  i = setPriority(i, 'ctsl', 3);
+  const y = intentToScenarioYaml(i, CTX);
+  assert.match(y, /^fleet: data\/fleet\.yaml$/m);
+  assert.match(y, /^hangar: data\/hangar\.yaml$/m);
+  assert.match(y, /^fleet_in: \[ctsl, fuji, husky\]$/m); // maintenance plane fuji unioned in
+  assert.match(y, /^maintenance:\n {2}plane: fuji$/m);
+  assert.match(y, /^ {2}husky:\n {4}pin: \{ x_m: 2.1, y_m: 14.3, heading_deg: 0.0, on_carts: false \}$/m);
+  assert.match(y, /^ {2}ctsl:\n {4}priority: 3.0$/m);
+});
+
+test('a selected plane with neither pin nor priority emits no constraints entry', () => {
+  const y = intentToScenarioYaml(initialIntent(CTX), CTX);
+  assert.doesNotMatch(y, /constraints:/); // nobody constrained
+});
+
+test('deselected planes never appear', () => {
+  let i = toggleSelection(initialIntent(CTX), 'ctsl'); // drop ctsl
+  i = pinAtCurrent(i, 'husky', CTX);
+  const y = intentToScenarioYaml(i, CTX);
+  assert.match(y, /^fleet_in: \[fuji, husky\]$/m); // fuji (maintenance) always present; ctsl dropped
+  assert.doesNotMatch(y, /ctsl/);
+});
+
+test('no maintenance block when ctx.maintenance is null', () => {
+  const y = intentToScenarioYaml(initialIntent(CTX), { ...CTX, maintenance: null });
+  assert.doesNotMatch(y, /maintenance:/);
+});

--- a/viewer/test/export.test.ts
+++ b/viewer/test/export.test.ts
@@ -44,3 +44,15 @@ test('no maintenance block when ctx.maintenance is null', () => {
   const y = intentToScenarioYaml(initialIntent(CTX), { ...CTX, maintenance: null });
   assert.doesNotMatch(y, /maintenance:/);
 });
+
+test('a plane can carry both a pin and a priority', () => {
+  let i = initialIntent(CTX);
+  i = pinAtCurrent(i, 'husky', CTX);
+  i = setPriority(i, 'husky', 2);
+  const y = intentToScenarioYaml(i, CTX);
+  // both sub-keys appear under the same constraint entry, pin before priority
+  assert.match(
+    y,
+    /^ {2}husky:\n {4}pin: \{ x_m: 2.1, y_m: 14.3, heading_deg: 0.0, on_carts: false \}\n {4}priority: 2.0$/m,
+  );
+});

--- a/viewer/test/selection.test.ts
+++ b/viewer/test/selection.test.ts
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  initialIntent, isSelected, toggleSelection, setPriority,
+  pinAtCurrent, unpin, setPinField, setOnCarts,
+} from '../src/interaction/selection.ts';
+import type { EditorContext } from '../src/interaction/intent-contract.ts';
+
+const CTX: EditorContext = {
+  fleet: 'data/fleet.yaml', hangar: 'data/hangar.yaml',
+  maintenance: { plane: 'fuji' },
+  currentPoses: {
+    husky: { x_m: 2.1, y_m: 14.3, heading_deg: 0, on_carts: false },
+    ctsl: { x_m: 5.0, y_m: 3.0, heading_deg: 90, on_carts: false },
+  },
+  cartEligible: { husky: false, ctsl: false },
+};
+
+test('initialIntent selects all rendered planes, no constraints', () => {
+  const i = initialIntent(CTX);
+  assert.deepEqual(i.selectedPlaneIds, ['ctsl', 'husky']); // sorted
+  assert.deepEqual(i.priorities, {});
+  assert.deepEqual(i.mustPositions, {});
+});
+
+test('deselect drops the plane and its constraints', () => {
+  let i = initialIntent(CTX);
+  i = setPriority(i, 'husky', 2);
+  i = pinAtCurrent(i, 'husky', CTX);
+  i = toggleSelection(i, 'husky');
+  assert.ok(!isSelected(i, 'husky'));
+  assert.equal(i.priorities.husky, undefined);
+  assert.equal(i.mustPositions.husky, undefined);
+});
+
+test('reselect adds back with no constraints', () => {
+  let i = toggleSelection(initialIntent(CTX), 'husky'); // drop
+  i = toggleSelection(i, 'husky');                      // add back
+  assert.ok(isSelected(i, 'husky'));
+  assert.equal(i.priorities.husky, undefined);
+});
+
+test('pinAtCurrent copies the Python-emitted scalar pose', () => {
+  const i = pinAtCurrent(initialIntent(CTX), 'husky', CTX);
+  assert.deepEqual(i.mustPositions.husky, { x: 2.1, y: 14.3, heading: 0, onCarts: false });
+});
+
+test('unpin removes a pin', () => {
+  let i = pinAtCurrent(initialIntent(CTX), 'husky', CTX);
+  i = unpin(i, 'husky');
+  assert.equal(i.mustPositions.husky, undefined);
+});
+
+test('setPinField edits only a pinned plane', () => {
+  let i = pinAtCurrent(initialIntent(CTX), 'ctsl', CTX);
+  i = setPinField(i, 'ctsl', 'x', 6.5);
+  assert.equal(i.mustPositions.ctsl.x, 6.5);
+  const j = setPinField(initialIntent(CTX), 'ctsl', 'x', 6.5); // not pinned → no-op
+  assert.equal(j.mustPositions.ctsl, undefined);
+});
+
+test('setOnCarts edits only a pinned plane', () => {
+  let i = pinAtCurrent(initialIntent(CTX), 'husky', CTX);
+  i = setOnCarts(i, 'husky', true);
+  assert.equal(i.mustPositions.husky.onCarts, true);
+  const j = setOnCarts(initialIntent(CTX), 'husky', true); // not pinned → no-op
+  assert.equal(j.mustPositions.husky, undefined);
+});
+
+test('setPriority(null) clears', () => {
+  let i = setPriority(initialIntent(CTX), 'husky', 4);
+  i = setPriority(i, 'husky', null);
+  assert.equal(i.priorities.husky, undefined);
+});
+
+test('functions are pure (no input mutation)', () => {
+  const i0 = initialIntent(CTX);
+  const snapshot = JSON.stringify(i0);
+  toggleSelection(i0, 'husky');
+  setPriority(i0, 'husky', 9);
+  pinAtCurrent(i0, 'husky', CTX);
+  assert.equal(JSON.stringify(i0), snapshot);
+});

--- a/viewer/test/selection.test.ts
+++ b/viewer/test/selection.test.ts
@@ -81,3 +81,12 @@ test('functions are pure (no input mutation)', () => {
   pinAtCurrent(i0, 'husky', CTX);
   assert.equal(JSON.stringify(i0), snapshot);
 });
+
+test('pin-editing functions do not mutate their input', () => {
+  const pinned = pinAtCurrent(initialIntent(CTX), 'husky', CTX);
+  const snapshot = JSON.stringify(pinned);
+  unpin(pinned, 'husky');
+  setPinField(pinned, 'husky', 'x', 99);
+  setOnCarts(pinned, 'husky', true);
+  assert.equal(JSON.stringify(pinned), snapshot);
+});


### PR DESCRIPTION
## What

Chunk 1 of the v0.18.0 interactive placement editor (#442): the **pure TypeScript interaction core** — the lowest-risk slice, with no wiring into the running viewer yet.

Adds five files, all additions:

- `viewer/src/interaction/intent-contract.ts` — types only: `Intent`, `MustPosition`, `CurrentPose`, `EditorContext`.
- `viewer/src/interaction/selection.ts` — pure selection-state machine + `pinAtCurrent` (a **scalar copy** of the Python-emitted `EditorContext.currentPoses`, per the ADR-0002 carve-out — no geometry, no affines).
- `viewer/src/interaction/export.ts` — pure `intentToScenarioYaml(intent, ctx)` → loader-valid `Scenario` YAML (unions the maintenance plane into a sorted `fleet_in` per the `Scenario` invariant; deterministic float rendering for a stable/diffable artifact).
- `viewer/test/selection.test.ts`, `viewer/test/export.test.ts` — `node --test` units (59 tests total across the viewer suite).

Because nothing in `main.ts` imports these modules yet, **the committed bundle `src/hangarfit/_viewer_assets/viewer.js` is byte-identical to `develop`** (`git diff --exit-code` = 0, verified in every commit and the working tree). Wiring into `main.ts` and the rebuilt bundle come in Chunk 2 (#898).

No Python changes; no `scene.py`/`solver.py`/`models.py`/`loader.py` touch (ADR-0002/0003).

Closes #897

### Notes
- **No `CHANGELOG.md` entry (intentional).** This chunk is internal, dormant TS with no user-facing behavior; the single `### Added` editor entry lands with the user-facing feature in Chunk 3 (#899), per the plan's File Structure. The advisory no-CHANGELOG PR warning is expected here.
- The final review round-tripped the serializer's exact bytes through `load_scenario` (parsed valid, including the `priority` sub-key). Four Minor findings: two fixed here (combined pin+priority export coverage; pin-editing purity coverage), two correctly deferred to Chunk 3's UI (empty-selection export guard; `cartEligible`/`on_carts` gating).

## Checklist

- [x] Branched from `develop`
- [x] Tests added/updated and pass locally (59/59 node --test; typecheck + lint clean)
- [x] No skipped hooks (no `--no-verify`)
- [x] CLAUDE.md updated if design assumptions changed (n/a — no design change this chunk; docs updated in Chunk 3)
- [x] pr-review-toolkit run; all threads resolved (code-reviewer opus + per-task reviews; 3 inline threads posted & resolved)
- [x] No direct push expected — waiting for review + merge by maintainer
