### PR TITLE
feat(viewer,#442): Chunk 2 — view --edit interactive plane selection (editor-context blob + CLI + raycaster)

### DIFF
--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -745,7 +745,19 @@ function mountEditor(opts) {
   const ray = new THREE11.Raycaster();
   const ndc = new THREE11.Vector2();
   const idByObject = /* @__PURE__ */ new Map();
-  for (const [id, g] of Object.entries(opts.groups)) g.traverse((o) => idByObject.set(o, id));
+  const targets = [];
+  for (const [id, g] of Object.entries(opts.groups)) {
+    g.traverse((o) => {
+      idByObject.set(o, id);
+      const mesh = o;
+      const m = mesh.material;
+      if (m && !Array.isArray(m) && m.emissive) {
+        const cloned = m.clone();
+        mesh.material = cloned;
+        targets.push({ id, mat: cloned, orig: cloned.emissive.getHex() });
+      }
+    });
+  }
   const el = opts.renderer.domElement;
   function pick(ev) {
     const r = el.getBoundingClientRect();
@@ -773,13 +785,8 @@ function mountEditor(opts) {
     renderReadout();
   });
   function applyHighlight() {
-    for (const [id, g] of Object.entries(opts.groups)) {
-      const on = isSelected(intent, id);
-      g.traverse((o) => {
-        const mesh = o;
-        const mat = mesh.material;
-        if (mat && mat.emissive) mat.emissive.setHex(on ? 0 : 5579264);
-      });
+    for (const t of targets) {
+      t.mat.emissive.setHex(isSelected(intent, t.id) ? t.orig : 5579264);
     }
   }
   function renderReadout() {

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -1,5 +1,5 @@
 // src/main.ts
-import * as THREE11 from "three";
+import * as THREE12 from "three";
 
 // src/dom.ts
 function byId(id) {
@@ -717,6 +717,80 @@ function foundLabel(m) {
   return `${m.count_found} solution${m.count_found === 1 ? "" : "s"}`;
 }
 
+// src/interaction/editor.ts
+import * as THREE11 from "three";
+
+// src/interaction/selection.ts
+function initialIntent(ctx) {
+  return { selectedPlaneIds: Object.keys(ctx.currentPoses).sort(), priorities: {}, mustPositions: {} };
+}
+function isSelected(intent, id) {
+  return intent.selectedPlaneIds.includes(id);
+}
+function toggleSelection(intent, id) {
+  const selected = isSelected(intent, id);
+  const selectedPlaneIds = selected ? intent.selectedPlaneIds.filter((x) => x !== id) : [...intent.selectedPlaneIds, id].sort();
+  const priorities = { ...intent.priorities };
+  const mustPositions = { ...intent.mustPositions };
+  if (selected) {
+    delete priorities[id];
+    delete mustPositions[id];
+  }
+  return { selectedPlaneIds, priorities, mustPositions };
+}
+
+// src/interaction/editor.ts
+function mountEditor(opts) {
+  let intent = initialIntent(opts.ctx);
+  const ray = new THREE11.Raycaster();
+  const ndc = new THREE11.Vector2();
+  const idByObject = /* @__PURE__ */ new Map();
+  for (const [id, g] of Object.entries(opts.groups)) g.traverse((o) => idByObject.set(o, id));
+  const el = opts.renderer.domElement;
+  function pick(ev) {
+    const r = el.getBoundingClientRect();
+    ndc.set((ev.clientX - r.left) / r.width * 2 - 1, -((ev.clientY - r.top) / r.height) * 2 + 1);
+    ray.setFromCamera(ndc, opts.cam);
+    const hits = ray.intersectObjects(Object.values(opts.groups), true);
+    for (const h of hits) {
+      const id = idByObject.get(h.object);
+      if (id) return id;
+    }
+    return null;
+  }
+  let downX = 0;
+  let downY = 0;
+  el.addEventListener("pointerdown", (ev) => {
+    downX = ev.clientX;
+    downY = ev.clientY;
+  });
+  el.addEventListener("pointerup", (ev) => {
+    if (Math.hypot(ev.clientX - downX, ev.clientY - downY) > 6) return;
+    const id = pick(ev);
+    if (!id) return;
+    intent = toggleSelection(intent, id);
+    applyHighlight();
+    renderReadout();
+  });
+  function applyHighlight() {
+    for (const [id, g] of Object.entries(opts.groups)) {
+      const on = isSelected(intent, id);
+      g.traverse((o) => {
+        const mesh = o;
+        const mat = mesh.material;
+        if (mat && mat.emissive) mat.emissive.setHex(on ? 0 : 5579264);
+      });
+    }
+  }
+  function renderReadout() {
+    const readout = document.getElementById("sel-readout");
+    if (readout) readout.textContent = `selected: ${[...intent.selectedPlaneIds].sort().join(", ")}`;
+  }
+  applyHighlight();
+  renderReadout();
+  return { getIntent: () => intent };
+}
+
 // src/main.ts
 function setReadouts(scene) {
   byId("placeholder").hidden = !scene.placeholder;
@@ -726,7 +800,7 @@ function setReadouts(scene) {
 }
 function buildWorld(scene, data, brand) {
   byId("legend").textContent = "";
-  const group = new THREE11.Group();
+  const group = new THREE12.Group();
   scene.add(group);
   const { groups, labelMeshes, noseMeshes } = addPlanes(group, data, brand);
   const { groups: goGroups } = addGroundObjects(group, data);
@@ -745,7 +819,7 @@ function buildWorld(scene, data, brand) {
     banner("TRANSFORM CHECK ERRORED: " + e.message + " — do not trust this render.");
   }
   const timeline = createTimeline(data, groups, goGroups);
-  return { group, labelMeshes, noseMeshes, setPathsVisible, timeline };
+  return { group, groups, labelMeshes, noseMeshes, setPathsVisible, timeline };
 }
 function wireToggles(wallMeshes, getWorld) {
   const wallsToggle = byId("walls");
@@ -800,6 +874,11 @@ function bootSingle(data, brand) {
     scene: stage.scene,
     cam: stage.cam
   });
+  const ctxEl = document.getElementById("editor-context");
+  if (ctxEl?.textContent) {
+    const ctx = JSON.parse(ctxEl.textContent);
+    mountEditor({ groups: world.groups, renderer: stage.renderer, cam: stage.cam, ctx });
+  }
 }
 function startCompare(manifest, brand) {
   const solutions = manifest.solutions;

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -515,6 +515,11 @@ def build_parser() -> argparse.ArgumentParser:
             "seconds instead of grinding through the full disprove budget."
         ),
     )
+    view.add_argument(
+        "--edit",
+        action="store_true",
+        help="Emit the interactive placement editor (requires --solve; rejects --alternatives).",
+    )
 
     return parser
 
@@ -1144,6 +1149,27 @@ def _resolve_fleet_hangar_refs(args: argparse.Namespace) -> tuple[str, str]:
     return str(fleet_abs), str(hangar_abs)
 
 
+def _raw_scenario_refs(args: argparse.Namespace) -> tuple[str, str]:
+    """Read the raw ``fleet:``/``hangar:`` ref strings from a ``view`` scenario file
+    (verbatim, override-aware) for the editor-context blob echoed into the export.
+
+    Unlike :func:`_resolve_fleet_hangar_refs` (used by ``solve --render-paths`` to
+    write a location-independent layout YAML), this keeps the strings exactly as
+    authored — no path resolution — since the editor's eventual scenario-YAML
+    export re-emits them verbatim next to the original scenario file. It also
+    reads ``args.input`` (the ``view`` subparser's positional), not
+    ``args.scenario`` (``solve``'s), so the two helpers can't be merged without a
+    rename.
+    """
+    import yaml
+
+    with open(args.input, encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    fleet = str(args.fleet) if args.fleet is not None else str(raw.get("fleet", ""))
+    hangar = str(args.hangar) if args.hangar is not None else str(raw.get("hangar", ""))
+    return fleet, hangar
+
+
 def _write_yamls(
     layouts: tuple[Layout, ...],
     pattern: str,
@@ -1329,6 +1355,18 @@ def cmd_view(args: argparse.Namespace) -> int:
     if args.alternatives < 1:
         print("error: view --alternatives must be >= 1.", file=sys.stderr)
         return 2
+    # #442 the editor exports a Scenario (fleet_in/constraints/maintenance), which
+    # only a solved layout carries meaningfully; a hand-authored layout YAML has no
+    # scenario shape to round-trip. It also can't be reconciled with the #666
+    # multi-solution compare container (a different render path entirely, and one
+    # solution to edit doesn't compose with N to switch between) — reject both
+    # up front, before the solve/compare dispatch below.
+    if args.edit and not args.solve:
+        print("error: --edit requires --solve (the editor exports a Scenario).", file=sys.stderr)
+        return 2
+    if args.edit and args.alternatives > 1:
+        print("error: --edit cannot be combined with --alternatives.", file=sys.stderr)
+        return 2
     try:
         fleet_override = load_fleet(args.fleet) if args.fleet is not None else None
         hangar_override = (
@@ -1469,7 +1507,22 @@ def cmd_view(args: argparse.Namespace) -> int:
         layout, moves_plan=moves_plan, check_result=check_result, egress_paths=egress_paths
     )
     try:
-        viewer.render_viewer(scene, args.output)
+        if args.edit:
+            fleet_ref, hangar_ref = _raw_scenario_refs(args)
+            cart_eligible = {
+                p.plane_id: layout.fleet[p.plane_id].movement_mode != "always_own_gear"
+                for p in layout.placements
+            }
+            ctx = viewer.build_editor_context(
+                fleet_ref=fleet_ref,
+                hangar_ref=hangar_ref,
+                maintenance_plane=layout.maintenance_plane,
+                layout=layout,
+                cart_eligible=cart_eligible,
+            )
+            viewer.render_edit_viewer(scene, ctx, args.output)
+        else:
+            viewer.render_viewer(scene, args.output)
     except OSError as e:
         print(f"error: could not write {args.output}: {e}", file=sys.stderr)
         return 2

--- a/src/hangarfit/viewer.py
+++ b/src/hangarfit/viewer.py
@@ -16,6 +16,7 @@ from importlib import resources
 from pathlib import Path
 
 from hangarfit import brand, metrics
+from hangarfit.models import Layout
 
 _ASSETS = "hangarfit._viewer_assets"
 _THREE = "hangarfit._viewer_assets.three"
@@ -63,6 +64,14 @@ def _embed_brand() -> str:
 # scene-contract.ts key-parity guard) stay untouched. The viewer reads it from a
 # separate ``<script id="solutions">`` blob instead of the single-mode ``#scene``.
 _COMPARE_SCHEMA = "hangarfit.viewer-compare/v1"
+
+# The editor-context blob (#442/ADR-0029). Additive alongside the existing
+# ``#scene`` blob (unlike the compare container above, which replaces it): the
+# edit-mode viewer keeps the byte-identical ``#scene`` doc and reads a SECOND
+# ``<script id="editor-context">`` blob for the intent-artifact state the
+# interactive editor needs (current poses, cart eligibility, fleet/hangar refs
+# for the eventual export). Deliberately NOT part of the scene/v2 schema.
+_EDITOR_CONTEXT_SCHEMA = "hangarfit.editor-context/v1"
 
 
 def _assemble_html(*, extra_head: str, hud_html: str, data_scripts: str) -> str:
@@ -114,6 +123,58 @@ def render_viewer(scene: dict, output_path: Path | str) -> None:
     :func:`hangarfit.scene.build_scene`."""
     data = f'<script type="application/json" id="scene">{_embed_json(scene)}</script>\n'
     html = _assemble_html(extra_head="", hud_html=_HUD, data_scripts=data)
+    Path(output_path).write_text(html, encoding="utf-8")
+
+
+def build_editor_context(
+    *,
+    fleet_ref: str,
+    hangar_ref: str,
+    maintenance_plane: str | None,
+    layout: Layout,
+    cart_eligible: dict[str, bool],
+) -> dict:
+    """Build the ``hangarfit.editor-context/v1`` blob for :func:`render_edit_viewer`
+    (#442/ADR-0029).
+
+    ``fleet_ref``/``hangar_ref`` are the raw authored ``fleet:``/``hangar:`` YAML
+    reference strings (the editor's eventual scenario-YAML export re-emits them
+    verbatim; ``Layout`` itself does not retain them). ``currentPoses`` is a
+    scalar copy of each placement's pose fields, keyed by ``plane_id``, sourced
+    from ``layout.placements`` (a ``tuple[Placement, ...]`` — ``Layout`` is not
+    itself iterable). ``cart_eligible`` records, per plane, whether it may ever
+    be placed ``on_carts=True`` (``movement_mode != "always_own_gear"``) — the
+    caller computes this from the fleet since it depends on ``Aircraft`` data
+    the context blob otherwise doesn't carry."""
+    return {
+        "schema": _EDITOR_CONTEXT_SCHEMA,
+        "fleet": fleet_ref,
+        "hangar": hangar_ref,
+        "maintenance": {"plane": maintenance_plane} if maintenance_plane else None,
+        "currentPoses": {
+            p.plane_id: {
+                "x_m": p.x_m,
+                "y_m": p.y_m,
+                "heading_deg": p.heading_deg,
+                "on_carts": p.on_carts,
+            }
+            for p in layout.placements
+        },
+        "cartEligible": dict(cart_eligible),
+    }
+
+
+def render_edit_viewer(scene: dict, context: dict, output_path: Path | str) -> None:
+    """Like :func:`render_viewer`, plus an additive ``#editor-context`` blob and
+    the edit HUD. The ``#scene`` bytes are byte-identical to ``render_viewer``
+    (ADR-0003) — the first line below is verbatim the same as in
+    ``render_viewer``, so nothing about the scene emission changes; the editor
+    context is a second, separate ``<script>`` blob."""
+    data = (
+        f'<script type="application/json" id="scene">{_embed_json(scene)}</script>\n'
+        f'<script type="application/json" id="editor-context">{_embed_json(context)}</script>\n'
+    )
+    html = _assemble_html(extra_head="", hud_html=_HUD_EDIT, data_scripts=data)
     Path(output_path).write_text(html, encoding="utf-8")
 
 
@@ -205,6 +266,17 @@ _HUD = (
     '<label><input id="paths" type="checkbox" checked> paths</label>'
     '<span id="readouts"></span>'
     '<span id="legend"></span>'
+)
+# #442 edit HUD: the standard HUD plus an editor panel (selection readout, priority
+# field, pin/on-carts toggles, export button). Additive — authored as _HUD plus an
+# appended <div>, not a string-hack of _HUD, so single-mode HUD bytes are untouched.
+# Only Task 6 (Chunk 3) wires these controls up; Task 4 just ships the DOM shape.
+_HUD_EDIT = _HUD + (
+    '<div id="editor"><div id="sel-readout"></div>'
+    '<label>priority <input id="prio" type="number" min="0" step="0.5"></label>'
+    '<label><input id="pin-toggle" type="checkbox"> pin here</label>'
+    '<label><input id="carts-toggle" type="checkbox"> on carts</label>'
+    '<button id="export">Export scenario YAML</button></div>'
 )
 # #666 compare HUD: a solution switcher (dropdown, also ←/→ keys) prepended to the
 # standard HUD, plus a per-solution metrics readout. The <select> ships empty —

--- a/tests/test_cli_view.py
+++ b/tests/test_cli_view.py
@@ -406,3 +406,50 @@ def test_view_solve_single_alternative_uses_single_render(tmp_path):
     html = out.read_text(encoding="utf-8")
     assert 'id="scene"' in html
     assert 'id="solutions"' not in html
+
+
+def test_view_edit_requires_solve(tmp_path, capsys):
+    # --edit exports a Scenario, so it only makes sense on a solved layout — a
+    # hand-authored layout YAML has no fleet_in/constraints to round-trip.
+    rc = main(["view", SCENARIO, "--edit", "-o", str(tmp_path / "o.html")])
+    assert rc == 2
+    assert "--edit requires --solve" in capsys.readouterr().err
+
+
+def test_view_edit_rejects_alternatives(tmp_path, capsys):
+    rc = main(
+        [
+            "view",
+            "--solve",
+            SCENARIO,
+            "--edit",
+            "--alternatives",
+            "3",
+            "-o",
+            str(tmp_path / "o.html"),
+        ]
+    )
+    assert rc == 2
+    assert "--edit cannot be combined with --alternatives" in capsys.readouterr().err
+
+
+def test_view_edit_emits_editor_html(tmp_path):
+    out = tmp_path / "o.html"
+    rc = main(
+        [
+            "view",
+            "--solve",
+            SCENARIO,
+            "--edit",
+            "-o",
+            str(out),
+            "--seed",
+            "1",
+            "--budget",
+            "5",
+        ]
+    )
+    assert rc == 0
+    html = out.read_text(encoding="utf-8")
+    assert 'id="editor-context"' in html
+    assert 'id="scene"' in html

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -353,6 +353,54 @@ def test_compare_inlines_committed_bundle(tmp_path):
     assert src in _compare_html(tmp_path)
 
 
+# ── #442/#898: the editor-context blob + edit render path ──────────────────
+
+
+def test_render_edit_viewer_keeps_scene_bytes_and_adds_editor_context(tmp_path):
+    lay = load_layout(LAYOUT)
+    sc = scene.build_scene(lay, moves_plan=plan_fill(lay))
+    ctx = viewer.build_editor_context(
+        fleet_ref="data/fleet.yaml",
+        hangar_ref="data/hangar.yaml",
+        maintenance_plane=lay.maintenance_plane,
+        layout=lay,
+        cart_eligible={p.plane_id: False for p in lay.placements},
+    )
+    edit = tmp_path / "edit.html"
+    plain = tmp_path / "plain.html"
+    viewer.render_edit_viewer(sc, ctx, edit)
+    viewer.render_viewer(sc, plain)
+    e = edit.read_text(encoding="utf-8")
+    p = plain.read_text(encoding="utf-8")
+    assert 'id="editor-context"' in e
+    assert 'id="editor-context"' not in p
+    grab = lambda s: re.search(r'id="scene">(.*?)</script>', s, re.S).group(1)  # noqa: E731
+    assert grab(e) == grab(p)  # #scene bytes identical across modes
+
+
+def test_build_editor_context_shape():
+    lay = load_layout(LAYOUT)
+    ctx = viewer.build_editor_context(
+        fleet_ref="data/fleet.yaml",
+        hangar_ref="data/hangar.yaml",
+        maintenance_plane=lay.maintenance_plane,
+        layout=lay,
+        cart_eligible={
+            p.plane_id: (lay.fleet[p.plane_id].movement_mode != "always_own_gear")
+            for p in lay.placements
+        },
+    )
+    assert ctx["schema"] == "hangarfit.editor-context/v1"
+    assert ctx["fleet"] == "data/fleet.yaml"
+    pid = lay.placements[0].plane_id
+    assert set(ctx["currentPoses"][pid]) == {"x_m", "y_m", "heading_deg", "on_carts"}
+    assert (
+        (ctx["maintenance"] == {"plane": lay.maintenance_plane})
+        if lay.maintenance_plane
+        else (ctx["maintenance"] is None)
+    )
+
+
 def test_brand_module_exports():
     # The single token source (#419) exposes the palettes, status inks, and the
     # 3D viewer token object the BRAND blob is built from.

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -378,6 +378,25 @@ def test_render_edit_viewer_keeps_scene_bytes_and_adds_editor_context(tmp_path):
     assert grab(e) == grab(p)  # #scene bytes identical across modes
 
 
+def test_render_edit_viewer_hud_has_editor_controls(tmp_path):
+    # #442 Chunk 3 wires these control IDs to _HUD_EDIT; guard against a
+    # silent rename in the HUD markup breaking that future hookup.
+    lay = load_layout(LAYOUT)
+    sc = scene.build_scene(lay, moves_plan=plan_fill(lay))
+    ctx = viewer.build_editor_context(
+        fleet_ref="data/fleet.yaml",
+        hangar_ref="data/hangar.yaml",
+        maintenance_plane=lay.maintenance_plane,
+        layout=lay,
+        cart_eligible={p.plane_id: False for p in lay.placements},
+    )
+    out = tmp_path / "edit.html"
+    viewer.render_edit_viewer(sc, ctx, out)
+    html = out.read_text(encoding="utf-8")
+    for control_id in ("sel-readout", "prio", "pin-toggle", "carts-toggle", "export"):
+        assert f'id="{control_id}"' in html, f"missing editor control #{control_id}"
+
+
 def test_build_editor_context_shape():
     lay = load_layout(LAYOUT)
     ctx = viewer.build_editor_context(

--- a/viewer/src/interaction/editor.ts
+++ b/viewer/src/interaction/editor.ts
@@ -1,0 +1,77 @@
+// viewer/src/interaction/editor.ts — the impure raycaster-selection edge (#442
+// Chunk 2). Mounted only when `view --edit` injects an `#editor-context` blob
+// (main.ts gates the call); dormant otherwise. Per the interaction/README's one
+// hard rule, this module may import `three` but must NEVER import `affine.ts`
+// or `anchors.ts` — it never re-derives geometry, only reads the already-built
+// plane Groups the Python-owned transform placed.
+import * as THREE from 'three';
+import { initialIntent, toggleSelection, isSelected } from './selection.ts';
+import type { Intent, EditorContext } from './intent-contract.ts';
+
+export interface EditorHandle {
+  getIntent(): Intent;
+}
+
+export function mountEditor(opts: {
+  groups: Record<string, THREE.Group>;
+  renderer: THREE.WebGLRenderer;
+  cam: THREE.Camera;
+  ctx: EditorContext;
+}): EditorHandle {
+  let intent = initialIntent(opts.ctx);
+  const ray = new THREE.Raycaster();
+  const ndc = new THREE.Vector2();
+  const idByObject = new Map<THREE.Object3D, string>();
+  for (const [id, g] of Object.entries(opts.groups)) g.traverse((o) => idByObject.set(o, id));
+  const el = opts.renderer.domElement;
+
+  function pick(ev: PointerEvent): string | null {
+    const r = el.getBoundingClientRect();
+    ndc.set(((ev.clientX - r.left) / r.width) * 2 - 1, -((ev.clientY - r.top) / r.height) * 2 + 1);
+    ray.setFromCamera(ndc, opts.cam);
+    const hits = ray.intersectObjects(Object.values(opts.groups), true);
+    for (const h of hits) {
+      const id = idByObject.get(h.object);
+      if (id) return id;
+    }
+    return null;
+  }
+
+  // Only a near-stationary pointerdown->up counts as a selection click, so orbiting
+  // the camera (a drag) never toggles selection.
+  let downX = 0;
+  let downY = 0;
+  el.addEventListener('pointerdown', (ev: PointerEvent) => {
+    downX = ev.clientX;
+    downY = ev.clientY;
+  });
+  el.addEventListener('pointerup', (ev: PointerEvent) => {
+    if (Math.hypot(ev.clientX - downX, ev.clientY - downY) > 6) return; // a drag, not a click
+    const id = pick(ev);
+    if (!id) return;
+    intent = toggleSelection(intent, id);
+    applyHighlight();
+    renderReadout();
+  });
+
+  function applyHighlight(): void {
+    // Deselected planes glow amber ("excluded from fleet"); selected keep the default look.
+    for (const [id, g] of Object.entries(opts.groups)) {
+      const on = isSelected(intent, id);
+      g.traverse((o) => {
+        const mesh = o as THREE.Mesh;
+        const mat = mesh.material as THREE.MeshStandardMaterial | undefined;
+        if (mat && mat.emissive) mat.emissive.setHex(on ? 0x000000 : 0x552200);
+      });
+    }
+  }
+
+  function renderReadout(): void {
+    const readout = document.getElementById('sel-readout');
+    if (readout) readout.textContent = `selected: ${[...intent.selectedPlaneIds].sort().join(', ')}`;
+  }
+
+  applyHighlight();
+  renderReadout();
+  return { getIntent: () => intent };
+}

--- a/viewer/src/interaction/editor.ts
+++ b/viewer/src/interaction/editor.ts
@@ -22,7 +22,23 @@ export function mountEditor(opts: {
   const ray = new THREE.Raycaster();
   const ndc = new THREE.Vector2();
   const idByObject = new Map<THREE.Object3D, string>();
-  for (const [id, g] of Object.entries(opts.groups)) g.traverse((o) => idByObject.set(o, id));
+  // Per-mesh highlight targets: clone each emissive material so the editor's highlight
+  // mutation is isolated (gear/pallet materials are SHARED across planes upstream — mutating
+  // the shared instance would bleed the highlight onto every plane). Capture the original
+  // emissive so a selected plane restores its real look instead of being forced to black.
+  const targets: { id: string; mat: THREE.MeshStandardMaterial; orig: number }[] = [];
+  for (const [id, g] of Object.entries(opts.groups)) {
+    g.traverse((o) => {
+      idByObject.set(o, id);
+      const mesh = o as THREE.Mesh;
+      const m = mesh.material;
+      if (m && !Array.isArray(m) && (m as THREE.MeshStandardMaterial).emissive) {
+        const cloned = (m as THREE.MeshStandardMaterial).clone();
+        mesh.material = cloned;
+        targets.push({ id, mat: cloned, orig: cloned.emissive.getHex() });
+      }
+    });
+  }
   const el = opts.renderer.domElement;
 
   function pick(ev: PointerEvent): string | null {
@@ -55,14 +71,9 @@ export function mountEditor(opts: {
   });
 
   function applyHighlight(): void {
-    // Deselected planes glow amber ("excluded from fleet"); selected keep the default look.
-    for (const [id, g] of Object.entries(opts.groups)) {
-      const on = isSelected(intent, id);
-      g.traverse((o) => {
-        const mesh = o as THREE.Mesh;
-        const mat = mesh.material as THREE.MeshStandardMaterial | undefined;
-        if (mat && mat.emissive) mat.emissive.setHex(on ? 0x000000 : 0x552200);
-      });
+    // Selected planes keep their original emissive; deselected planes glow amber ("excluded").
+    for (const t of targets) {
+      t.mat.emissive.setHex(isSelected(intent, t.id) ? t.orig : 0x552200);
     }
   }
 

--- a/viewer/src/main.ts
+++ b/viewer/src/main.ts
@@ -23,13 +23,17 @@ import { checkAnchors } from './anchors.ts';
 import { createTimeline, type Timeline } from './timeline.ts';
 import { startHud } from './hud.ts';
 import { wrapIndex, clampIndex, optionLabels, formatSummary, foundLabel } from './compare.ts';
+import { mountEditor } from './interaction/editor.ts';
 import type { BrandTokens } from './brand-contract.ts';
 import type { CompareManifest, SceneV2 } from './scene-contract.ts';
+import type { EditorContext } from './interaction/intent-contract.ts';
 
 // One solution's dynamic content: the meshes (under one toggleable Group) + its
-// timeline + the label/nose/paths handles the HUD toggles drive.
+// timeline + the label/nose/paths handles the HUD toggles drive, plus the raw
+// per-plane groups (#442) so an `--edit` boot can hand them to the raycaster.
 interface World {
   group: THREE.Group;
+  groups: Record<string, THREE.Group>;
   labelMeshes: THREE.Sprite[];
   noseMeshes: THREE.Mesh[];
   setPathsVisible: (on: boolean) => void;
@@ -85,7 +89,7 @@ function buildWorld(scene: THREE.Scene, data: SceneV2, brand: BrandTokens): Worl
   // Movers (#651) animate from the same timeline as planes, so their Groups are passed
   // alongside the plane Groups (both returned per-id by the add* builders above).
   const timeline = createTimeline(data, groups, goGroups);
-  return { group, labelMeshes, noseMeshes, setPathsVisible, timeline };
+  return { group, groups, labelMeshes, noseMeshes, setPathsVisible, timeline };
 }
 
 // Wire the HUD visibility toggles. `walls` drives the shared hangar; `labels`/`paths`
@@ -154,6 +158,15 @@ function bootSingle(data: SceneV2, brand: BrandTokens): void {
     scene: stage.scene,
     cam: stage.cam,
   });
+
+  // #442: dormant unless `view --edit` injected the `#editor-context` blob (never
+  // emitted by the plain `render_viewer` path) — mirrors the `#solutions` gate
+  // above via the nullable `document.getElementById` (byId THROWS on absence).
+  const ctxEl = document.getElementById('editor-context');
+  if (ctxEl?.textContent) {
+    const ctx = JSON.parse(ctxEl.textContent) as EditorContext;
+    mountEditor({ groups: world.groups, renderer: stage.renderer, cam: stage.cam, ctx });
+  }
 }
 
 function startCompare(manifest: CompareManifest, brand: BrandTokens): void {


### PR DESCRIPTION
## What

Chunk 2 of the v0.18.0 interactive placement editor (#442): `hangarfit view --edit` now emits an interactive placement editor where you can **select which planes are in the fleet** (raycast-click a plane to toggle it) with live highlighting and a selection readout. This wires the Chunk-1 pure core into the running viewer, behind an opt-in flag.

**Python:**
- `viewer.py` — `build_editor_context(...)` + `render_edit_viewer(...)` emit an **additive** `#editor-context` `<script>` blob (`hangarfit.editor-context/v1`) layered over a byte-identical `#scene` blob (mirrors the #666 `viewer-compare/v1` container pattern, but additive — it does **not** replace `#scene`). `currentPoses` carry per-plane pose **scalars** (`x_m/y_m/heading_deg/on_carts`) so the browser does zero geometry (ADR-0002). `_HUD_EDIT` = `_HUD` + an editor panel.
- `cli.py` — `view --edit` flag: requires `--solve` (else exit 2), rejects `--alternatives > 1` (else exit 2). Cart-eligibility derived as `movement_mode != "always_own_gear"`; a `_raw_scenario_refs` helper echoes the authored `fleet:`/`hangar:` refs.

**TypeScript / bundle:**
- `viewer/src/interaction/editor.ts` (new) — the impure raycaster edge: click-vs-drag discrimination (a 6 px threshold so orbiting the camera never toggles selection), per-mesh material-clone highlighting (isolated so it can't bleed across shared gear materials), and the `#sel-readout` update. It mounts only when the `#editor-context` blob is present (dormant otherwise), only in single-scene boot.
- `viewer/src/main.ts` — exposes `groups` on `World` and gates `mountEditor` on a nullable `document.getElementById('editor-context')`; the non-edit and compare boot paths are unchanged.
- `src/hangarfit/_viewer_assets/viewer.js` — rebuilt bundle (drift-clean).

**Invariants held:** `scene.py`/`build_scene` untouched; the `#scene` blob is byte-identical across single and edit modes (ADR-0003); the `editor-context` blob is a viewer-HTML wrapper, not a scene/v2 schema change; `editor.ts` never imports `affine.ts`/`anchors.ts`.

Closes #898

### Notes
- **No `CHANGELOG.md` entry (intentional, consistent with Chunk 1 #901).** `view --edit` isn't end-to-end usable until Chunk 3 (#899) wires the Scenario-YAML export; the single `### Added` editor entry lands there (per the plan's Task 7). The advisory no-CHANGELOG PR warning is expected. Docs (CLAUDE.md / architecture) also land in Chunk 3.
- **Reviews (this branch, pre-PR):** subagent-driven — a spec+quality review after each of Tasks 4/5/6, a fix-and-re-review loop on Task 6 (a real highlight material-bleed bug found & fixed), then a final whole-branch pass with `pr-review-toolkit:code-reviewer` (opus, **ready to merge**) **and `scene-schema-guard` (opus, PASS all 6 contract items)**. Both independently ran the gates (mypy/ruff clean, viewer typecheck/lint/node 59/59, `viewer.js` drift-clean, 85 scene/viewer tests green). Remaining findings are Minor (see inline threads).

## Checklist

- [x] Branched from `develop`
- [x] Tests added/updated and pass locally (59/59 node; `test_viewer`/`test_cli_view`/`test_scene` green; mypy + ruff clean)
- [x] No skipped hooks (no `--no-verify`)
- [x] CLAUDE.md updated if design assumptions changed (n/a this chunk — docs land in Chunk 3)
- [x] pr-review-toolkit run; all threads resolved (code-reviewer opus + scene-schema-guard opus + per-task reviews; 2 inline threads posted & resolved)
- [x] No direct push expected — waiting for review + merge by maintainer
