### PR TITLE
feat(viewer,#442): Chunk 3 — editor controls + Scenario-YAML export (closes editor epic #442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- **Interactive placement editor** — `hangarfit view --solve --edit` turns the 3D viewer into an intent-capture front end: select which planes are in the fleet, set soft priorities and hard pin-at-current-pose must-positions, and export a loader-valid `Scenario` YAML that `hangarfit solve` re-runs. (#442)
+
 ### Changed
 
 - The dev/CI `bench` profiling harness gained a `--jobs N|auto` flag that runs the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,12 @@ google-chrome --headless=new --use-gl=angle --use-angle=swiftshader \
 # `#compare` and reading `#banner`.hidden (the viewer exposes state via the DOM).
 hangarfit view tests/fixtures/scenario_minimal.yaml --solve --alternatives 3 -o compare.html
 
+# v0.18.0 interactive placement editor (#442): view --edit turns the viewer into an
+# intent-capture surface — select planes (fleet_in), set priorities, pin at current pose,
+# then "Export scenario YAML" downloads a loader-valid Scenario that `solve` re-runs.
+# Requires --solve; rejects --alternatives. Editor code ships dormant unless --edit is set.
+hangarfit view tests/fixtures/scenario_minimal.yaml --solve --edit -o edit.html
+
 # #412 staging apron (ADR-0021): with apron_depth_m > 0 each tow path starts
 # OUTSIDE the door (y<0) and slides in. Set it on the hangar.yaml or override
 # per run with --apron-depth N|auto (auto = ~max plane length + max turn radius)

--- a/docs/adr/0029-editor-intent-artifact-contract.md
+++ b/docs/adr/0029-editor-intent-artifact-contract.md
@@ -175,8 +175,9 @@ recover from `scene/v2` is supplied by Python via `EditorContext`.
   document — the same pattern as the `viewer-compare/v1` wrapper
   ([ADR-0017](0017-3d-viewer-architecture.md), #666). It is **not** a `scene/v2`
   schema change, so `scene.build_scene()` and its key-parity guard are untouched.
-- Prior intent is **not echoed** on re-open (the editor starts blank); the user's
-  intent persists in the exported YAML. Echoing it is deferred future work.
+- Prior intent is **not echoed** on re-open (the editor starts with the current
+  fleet selected and no saved priorities/pins); the user's intent persists in
+  the exported YAML. Echoing it is deferred future work.
 
 ## Compliance
 

--- a/docs/adr/0029-editor-intent-artifact-contract.md
+++ b/docs/adr/0029-editor-intent-artifact-contract.md
@@ -180,9 +180,9 @@ recover from `scene/v2` is supplied by Python via `EditorContext`.
 
 ## Compliance
 
-The mechanisms below land with **Chunks 1–3** of #442 (this ADR ships in Chunk 0,
-ahead of the code it governs); `render_viewer` and the `scene/v2` byte-identity
-guards it anchors on already exist today.
+The mechanisms below shipped across **Chunks 1–3** of #442 (this ADR was written
+in Chunk 0, ahead of the code it governs); `render_viewer` and the `scene/v2`
+byte-identity guards it anchors on predate them.
 
 - **Grep-able hard rule**: no file under `viewer/src/interaction/` imports
   `affine.ts` or `anchors.ts` (also stated in `interaction/README.md` and the

--- a/docs/adr/0029-editor-intent-artifact-contract.md
+++ b/docs/adr/0029-editor-intent-artifact-contract.md
@@ -1,8 +1,10 @@
 # ADR-0029: The interactive editor captures a pinned pose by copying Python-emitted scalars and exports a full `Scenario` YAML — the browser never composes a transform
 
-- **Status:** Proposed
-  <!-- Proposed at PR-open; Accepted at PR-merge. Records the intent-artifact
-       contract + the ADR-0002 carve-out that Chunks 1–3 of #442 build on. -->
+- **Status:** Accepted
+  <!-- Proposed at PR-open; Accepted with the v0.18.0 delivery of #442 (Chunks
+       1–3 shipped the `interaction/` module this ADR governs). Records the
+       intent-artifact contract + the ADR-0002 carve-out that Chunks 1–3 of
+       #442 build on. -->
 
 - **Date:** 2026-07-02
 - **Deciders:** Patrick Kuhn (DocGerd)

--- a/docs/architecture/05-building-block-view.md
+++ b/docs/architecture/05-building-block-view.md
@@ -535,6 +535,26 @@ it never touches the scene's geometry contract:
   `metrics.PLACEHOLDER_BANNER`); when `scene.readouts` is present (valid layouts
   only) it shows the tightest plan-view gap and smallest wing-over-tail clearance.
 
+**`viewer/src/interaction/` — the placement-editor seam (#442, ADR-0029).** The
+`interaction/` directory [ADR-0020](../adr/0020-viewer-typescript-architecture.md)
+reserved is now active behind `hangarfit view --edit`: `viewer.py` additionally
+injects an `editor-context` blob (`hangarfit.editor-context/v1`, layered over an
+untouched `scene/v2` document, same pattern as the `viewer-compare/v1` wrapper)
+carrying each plane's current pose as plain scalars, and `main.ts` mounts the
+editor only when that blob is present (non-`--edit` renders emit no `#editor-context`
+and stay byte-identical to today). The module is split by purity: `intent-contract.ts`
+(the `Intent`/`EditorContext` type mirror), `selection.ts` (pure selection-state —
+toggle fleet membership, set priority, pin-at-current-pose as a scalar copy of
+`currentPoses[id]`) and `export.ts` (pure `(Intent, EditorContext) → Scenario`-YAML
+serializer, enforcing the ADR-0029 invariants — `fleet_in` = selection ∪ maintenance,
+`priority` omitted when unset, `pin` carries all of `x_m`/`y_m`/`heading_deg`/`on_carts`)
+are node-unit-tested with no THREE/DOM dependency; `editor.ts` is the impure edge —
+the raycaster selection hit-test, highlight, HUD controls, and the "Export scenario
+YAML" `Blob`+`<a download>`. Per [ADR-0002](../adr/0002-determinant-minus-one-transform.md),
+no file under `interaction/` imports `affine.ts` or `anchors.ts`: a pin is a scalar
+copy of Python-computed geometry, never a browser-composed transform, so the
+determinant −1 sign-flip trap cannot recur here by construction.
+
 ### `metrics.py` — read-only render annotations
 
 Pure functions over a `Layout` that annotate (never gate) renders: whether any

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -738,10 +738,72 @@ function toggleSelection(intent, id) {
   }
   return { selectedPlaneIds, priorities, mustPositions };
 }
+function setPriority(intent, id, priority) {
+  const priorities = { ...intent.priorities };
+  if (priority === null) delete priorities[id];
+  else priorities[id] = priority;
+  return { ...intent, priorities };
+}
+function pinAtCurrent(intent, id, ctx) {
+  const c = ctx.currentPoses[id];
+  if (!c) return intent;
+  const mp = { x: c.x_m, y: c.y_m, heading: c.heading_deg, onCarts: c.on_carts };
+  return { ...intent, mustPositions: { ...intent.mustPositions, [id]: mp } };
+}
+function unpin(intent, id) {
+  const mustPositions = { ...intent.mustPositions };
+  delete mustPositions[id];
+  return { ...intent, mustPositions };
+}
+function setPinField(intent, id, field, value) {
+  const cur = intent.mustPositions[id];
+  if (!cur) return intent;
+  return { ...intent, mustPositions: { ...intent.mustPositions, [id]: { ...cur, [field]: value } } };
+}
+function setOnCarts(intent, id, onCarts) {
+  const cur = intent.mustPositions[id];
+  if (!cur) return intent;
+  return { ...intent, mustPositions: { ...intent.mustPositions, [id]: { ...cur, onCarts } } };
+}
+
+// src/interaction/export.ts
+function num(n) {
+  const r = Math.round(n * 1e4) / 1e4;
+  return Number.isInteger(r) ? `${r}.0` : `${r}`;
+}
+function intentToScenarioYaml(intent, ctx) {
+  const selected = [...intent.selectedPlaneIds].sort();
+  const fleetIn = [...new Set(ctx.maintenance ? [...selected, ctx.maintenance.plane] : selected)].sort();
+  const lines = [];
+  lines.push(`fleet: ${ctx.fleet}`);
+  lines.push(`hangar: ${ctx.hangar}`);
+  lines.push(`fleet_in: [${fleetIn.join(", ")}]`);
+  if (ctx.maintenance) {
+    lines.push("maintenance:");
+    lines.push(`  plane: ${ctx.maintenance.plane}`);
+  }
+  const constrained = selected.filter((id) => intent.mustPositions[id] || intent.priorities[id] !== void 0);
+  if (constrained.length) {
+    lines.push("constraints:");
+    for (const id of constrained) {
+      lines.push(`  ${id}:`);
+      const mp = intent.mustPositions[id];
+      if (mp) {
+        lines.push(
+          `    pin: { x_m: ${num(mp.x)}, y_m: ${num(mp.y)}, heading_deg: ${num(mp.heading)}, on_carts: ${mp.onCarts} }`
+        );
+      }
+      const p = intent.priorities[id];
+      if (p !== void 0) lines.push(`    priority: ${num(p)}`);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
 
 // src/interaction/editor.ts
 function mountEditor(opts) {
   let intent = initialIntent(opts.ctx);
+  let focusedId = null;
   const ray = new THREE11.Raycaster();
   const ndc = new THREE11.Vector2();
   const idByObject = /* @__PURE__ */ new Map();
@@ -781,8 +843,10 @@ function mountEditor(opts) {
     const id = pick(ev);
     if (!id) return;
     intent = toggleSelection(intent, id);
+    focusedId = isSelected(intent, id) ? id : null;
     applyHighlight();
     renderReadout();
+    syncControls();
   });
   function applyHighlight() {
     for (const t of targets) {
@@ -793,8 +857,85 @@ function mountEditor(opts) {
     const readout = document.getElementById("sel-readout");
     if (readout) readout.textContent = `selected: ${[...intent.selectedPlaneIds].sort().join(", ")}`;
   }
+  const prio = byId("prio");
+  const pinToggle = byId("pin-toggle");
+  const cartsToggle = byId("carts-toggle");
+  const exportBtn = byId("export");
+  const pinFields = document.createElement("div");
+  pinFields.id = "pin-fields";
+  pinFields.hidden = true;
+  function mkPinInput(label, field) {
+    const wrap = document.createElement("label");
+    wrap.textContent = `${label} `;
+    const inp = document.createElement("input");
+    inp.type = "number";
+    inp.step = "0.1";
+    inp.addEventListener("input", () => {
+      if (focusedId && inp.value !== "") intent = setPinField(intent, focusedId, field, Number(inp.value));
+    });
+    wrap.appendChild(inp);
+    pinFields.appendChild(wrap);
+    return inp;
+  }
+  const xIn = mkPinInput("x_m", "x");
+  const yIn = mkPinInput("y_m", "y");
+  const hIn = mkPinInput("heading_deg", "heading");
+  exportBtn.parentElement?.insertBefore(pinFields, exportBtn);
+  function syncControls() {
+    const id = focusedId;
+    const active = id !== null && isSelected(intent, id);
+    prio.disabled = !active;
+    pinToggle.disabled = !active;
+    if (!active || id === null) {
+      prio.value = "";
+      pinToggle.checked = false;
+      pinFields.hidden = true;
+      cartsToggle.disabled = true;
+      cartsToggle.checked = false;
+    } else {
+      const p = intent.priorities[id];
+      prio.value = p !== void 0 ? String(p) : "";
+      const mp = intent.mustPositions[id];
+      pinToggle.checked = mp !== void 0;
+      pinFields.hidden = mp === void 0;
+      if (mp) {
+        xIn.value = String(mp.x);
+        yIn.value = String(mp.y);
+        hIn.value = String(mp.heading);
+        cartsToggle.disabled = !opts.ctx.cartEligible[id];
+        cartsToggle.checked = mp.onCarts;
+      } else {
+        cartsToggle.disabled = true;
+        cartsToggle.checked = false;
+      }
+    }
+    exportBtn.disabled = intent.selectedPlaneIds.length === 0;
+  }
+  prio.addEventListener("input", () => {
+    if (!focusedId) return;
+    intent = setPriority(intent, focusedId, prio.value === "" ? null : Math.max(0, Number(prio.value)));
+  });
+  pinToggle.addEventListener("change", () => {
+    if (!focusedId) return;
+    intent = pinToggle.checked ? pinAtCurrent(intent, focusedId, opts.ctx) : unpin(intent, focusedId);
+    syncControls();
+  });
+  cartsToggle.addEventListener("change", () => {
+    if (!focusedId) return;
+    intent = setOnCarts(intent, focusedId, cartsToggle.checked);
+  });
+  exportBtn.addEventListener("click", () => {
+    const yaml = intentToScenarioYaml(intent, opts.ctx);
+    const blob = new Blob([yaml], { type: "text/yaml" });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "scenario.edited.yaml";
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
   applyHighlight();
   renderReadout();
+  syncControls();
   return { getIntent: () => intent };
 }
 

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -1149,6 +1149,14 @@ def _resolve_fleet_hangar_refs(args: argparse.Namespace) -> tuple[str, str]:
     return str(fleet_abs), str(hangar_abs)
 
 
+def _cart_eligible_map(layout: Layout) -> dict[str, bool]:
+    """Which placed planes the editor may let the user TOGGLE ``on_carts`` for.
+    Only ``cart_eligible`` planes have a free choice; ``always_cart`` (locked True)
+    and ``always_own_gear`` (locked False) are fixed to the single value the loader
+    enforces, so their toggle stays disabled. Mirrors ``Aircraft.is_cart_eligible``."""
+    return {p.plane_id: layout.fleet[p.plane_id].is_cart_eligible for p in layout.placements}
+
+
 def _raw_scenario_refs(args: argparse.Namespace) -> tuple[str, str]:
     """Read the raw ``fleet:``/``hangar:`` ref strings from a ``view`` scenario file
     (verbatim, override-aware) for the editor-context blob echoed into the export.
@@ -1509,10 +1517,7 @@ def cmd_view(args: argparse.Namespace) -> int:
     try:
         if args.edit:
             fleet_ref, hangar_ref = _raw_scenario_refs(args)
-            cart_eligible = {
-                p.plane_id: layout.fleet[p.plane_id].movement_mode != "always_own_gear"
-                for p in layout.placements
-            }
+            cart_eligible = _cart_eligible_map(layout)
             ctx = viewer.build_editor_context(
                 fleet_ref=fleet_ref,
                 hangar_ref=hangar_ref,

--- a/src/hangarfit/viewer.py
+++ b/src/hangarfit/viewer.py
@@ -142,10 +142,11 @@ def build_editor_context(
     verbatim; ``Layout`` itself does not retain them). ``currentPoses`` is a
     scalar copy of each placement's pose fields, keyed by ``plane_id``, sourced
     from ``layout.placements`` (a ``tuple[Placement, ...]`` — ``Layout`` is not
-    itself iterable). ``cart_eligible`` records, per plane, whether it may ever
-    be placed ``on_carts=True`` (``movement_mode != "always_own_gear"``) — the
-    caller computes this from the fleet since it depends on ``Aircraft`` data
-    the context blob otherwise doesn't carry."""
+    itself iterable). ``cart_eligible`` records, per plane, whether the editor
+    may let the user TOGGLE ``on_carts`` — only ``cart_eligible`` planes have a
+    free choice; ``always_cart``/``always_own_gear`` are locked to their single
+    legal value. The caller computes this from the fleet since it depends on
+    ``Aircraft`` data the context blob otherwise doesn't carry."""
     return {
         "schema": _EDITOR_CONTEXT_SCHEMA,
         "fleet": fleet_ref,

--- a/tests/test_cli_view.py
+++ b/tests/test_cli_view.py
@@ -453,3 +453,20 @@ def test_view_edit_emits_editor_html(tmp_path):
     html = out.read_text(encoding="utf-8")
     assert 'id="editor-context"' in html
     assert 'id="scene"' in html
+
+
+def test_cart_eligible_map_only_true_for_cart_eligible():
+    from hangarfit.cli import _cart_eligible_map
+    from hangarfit.loader import load_layout
+
+    lay = load_layout("examples/layouts/example.yaml")
+    m = _cart_eligible_map(lay)
+    # matches the strict property for every placed plane
+    for p in lay.placements:
+        assert m[p.plane_id] == (lay.fleet[p.plane_id].movement_mode == "cart_eligible")
+    # an always_cart plane (locked on-carts) must NOT be toggle-eligible
+    always_cart = [
+        p.plane_id for p in lay.placements if lay.fleet[p.plane_id].movement_mode == "always_cart"
+    ]
+    for pid in always_cart:
+        assert m[pid] is False

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -449,3 +449,51 @@ def test_brand_module_exports():
         "labelConflictChip",
     ):
         assert key in tokens
+
+
+def test_editor_export_shape_loads_via_load_scenario(tmp_path):
+    # #442 Chunk 3: the authoritative guard that the editor's exported
+    # scenario-YAML shape (intentToScenarioYaml in export.ts) is loader-valid.
+    # Mirrors tests/fixtures/scenario_with_pin.yaml's proven-valid shape (real
+    # catalog ids, maintenance plane included in fleet_in) extended with a
+    # `priority` constraint sub-key.
+    from pathlib import Path
+
+    from hangarfit.loader import load_scenario
+
+    repo = Path(__file__).resolve().parents[1]  # tests/ -> repo root
+    fleet, hangar = repo / "data" / "fleet.yaml", repo / "data" / "hangar.yaml"
+    yaml = (
+        f"fleet: {fleet}\n"
+        f"hangar: {hangar}\n"
+        "fleet_in: [aviat_husky, ctsl, fuji]\n"  # maintenance plane fuji IS in fleet_in
+        "maintenance:\n  plane: fuji\n"
+        "constraints:\n"
+        "  aviat_husky:\n"
+        "    pin: { x_m: 2.1, y_m: 14.3, heading_deg: 0.0, on_carts: false }\n"
+        "  ctsl:\n"
+        "    priority: 3.0\n"
+    )
+    p = tmp_path / "edited.yaml"
+    p.write_text(yaml)
+    sc = load_scenario(p)
+    assert "fuji" in sc.fleet_in  # maintenance ∈ fleet_in invariant
+    assert sc.constraints["aviat_husky"].pin is not None
+    assert sc.constraints["ctsl"].priority == 3.0
+
+
+def test_build_editor_context_excludes_maintenance_from_current_poses():
+    # By Layout invariant the maintenance plane never appears in
+    # layout.placements, so build_editor_context's currentPoses (sourced from
+    # layout.placements) must not carry it either.
+    lay = load_layout("examples/layouts/example.yaml")
+    assert lay.maintenance_plane is not None  # guard: fixture actually has one
+    ctx = viewer.build_editor_context(
+        fleet_ref="data/fleet.yaml",
+        hangar_ref="data/hangar.yaml",
+        maintenance_plane=lay.maintenance_plane,
+        layout=lay,
+        cart_eligible={p.plane_id: False for p in lay.placements},
+    )
+    assert lay.maintenance_plane not in ctx["currentPoses"]
+    assert ctx["maintenance"] == {"plane": lay.maintenance_plane}

--- a/viewer/src/interaction/README.md
+++ b/viewer/src/interaction/README.md
@@ -34,7 +34,7 @@ instead of a file. **Python stays the solver authority in every stage.**
 | `intent-contract.ts` | types | `Intent`, `MustPosition`, `CurrentPose`, `EditorContext` — the typed mirror of the exported artifact. | Chunk 1 |
 | `selection.ts` | **pure** | Selection-state machine (toggle/priority/pin-at-current/edit); pose lookup reads `EditorContext.currentPoses` scalars. No THREE/DOM, no affine math. | Chunk 1 |
 | `export.ts` | **pure** | `(Intent, EditorContext) → Scenario-YAML string`; enforces the ADR-0029 serializer invariants. No THREE/DOM. | Chunk 1 |
-| `editor.ts` | impure edge | THREE.Raycaster over `planes` groups, selection highlight, `controls.enabled` gating, HUD wiring, `Blob` + `<a download>` export. Reads `scene-contract.ts`. | Chunks 2–3 |
+| `editor.ts` | impure edge | THREE.Raycaster over `planes` groups, selection highlight, a click-vs-drag pointer-move threshold, HUD control wiring, `Blob` + `<a download>` export. | Chunks 2–3 |
 
 The `Intent` the browser builds mirrors `Scenario.constraints`:
 

--- a/viewer/src/interaction/README.md
+++ b/viewer/src/interaction/README.md
@@ -6,16 +6,16 @@ Stage 2 of the roadmap in [ADR-0020](../../../docs/adr/0020-viewer-typescript-ar
 Its contract is recorded in
 [ADR-0029](../../../docs/adr/0029-editor-intent-artifact-contract.md).
 
-**The seam is now activated** — its contract is recorded (ADR-0029) and its
-modules land across #442; at this exact commit the directory is still
-README-only (esbuild bundles nothing, `viewer.js` byte-unchanged).
+**The seam is now activated and shipped** — its contract is recorded (ADR-0029)
+and its modules landed across #442 Chunks 1–3 (below).
 [ADR-0020](../../../docs/adr/0020-viewer-typescript-architecture.md) reserved this
-directory (previously inert — README-only); ADR-0029 activates it. The modules
-below land across #442 in
-small, independently reviewable chunks — the bundle stays byte-identical until a
-module is actually imported by `main.ts` (the `viewer-build-drift` guard tracks
-that hand-off), so Chunk 1's pure modules ship with an **unchanged** `viewer.js`
-and only Chunk 2's `main.ts` wiring rebuilds it.
+directory (previously inert — README-only); ADR-0029 activates it, and `main.ts`
+mounts `editor.ts` whenever the Python-emitted `#editor-context` blob is present
+(`hangarfit view --edit`). The modules landed in small, independently reviewable
+chunks — the bundle stayed byte-identical until a module was actually imported by
+`main.ts` (the `viewer-build-drift` guard tracked that hand-off), so Chunk 1's
+pure modules shipped with an **unchanged** `viewer.js` and only Chunk 2's
+`main.ts` wiring rebuilt it.
 
 ## What the editor does
 

--- a/viewer/src/interaction/editor.ts
+++ b/viewer/src/interaction/editor.ts
@@ -1,11 +1,23 @@
 // viewer/src/interaction/editor.ts — the impure raycaster-selection edge (#442
-// Chunk 2). Mounted only when `view --edit` injects an `#editor-context` blob
-// (main.ts gates the call); dormant otherwise. Per the interaction/README's one
-// hard rule, this module may import `three` but must NEVER import `affine.ts`
-// or `anchors.ts` — it never re-derives geometry, only reads the already-built
+// Chunk 2) plus the intent-capture controls + Scenario-YAML export (Chunk 3).
+// Mounted only when `view --edit` injects an `#editor-context` blob (main.ts
+// gates the call); dormant otherwise. Per the interaction/README's one hard
+// rule, this module may import `three` but must NEVER import `affine.ts` or
+// `anchors.ts` — it never re-derives geometry, only reads the already-built
 // plane Groups the Python-owned transform placed.
 import * as THREE from 'three';
-import { initialIntent, toggleSelection, isSelected } from './selection.ts';
+import {
+  initialIntent,
+  toggleSelection,
+  isSelected,
+  setPriority,
+  pinAtCurrent,
+  unpin,
+  setPinField,
+  setOnCarts,
+} from './selection.ts';
+import { intentToScenarioYaml } from './export.ts';
+import { byId } from '../dom.ts';
 import type { Intent, EditorContext } from './intent-contract.ts';
 
 export interface EditorHandle {
@@ -19,6 +31,9 @@ export function mountEditor(opts: {
   ctx: EditorContext;
 }): EditorHandle {
   let intent = initialIntent(opts.ctx);
+  // The last-selected plane. The HUD controls (priority/pin/on_carts) always
+  // act on this plane; deselecting it (or nothing being selected) disables them.
+  let focusedId: string | null = null;
   const ray = new THREE.Raycaster();
   const ndc = new THREE.Vector2();
   const idByObject = new Map<THREE.Object3D, string>();
@@ -66,8 +81,10 @@ export function mountEditor(opts: {
     const id = pick(ev);
     if (!id) return;
     intent = toggleSelection(intent, id);
+    focusedId = isSelected(intent, id) ? id : null;
     applyHighlight();
     renderReadout();
+    syncControls();
   });
 
   function applyHighlight(): void {
@@ -82,7 +99,91 @@ export function mountEditor(opts: {
     if (readout) readout.textContent = `selected: ${[...intent.selectedPlaneIds].sort().join(', ')}`;
   }
 
+  // --- Intent-capture controls (priority / pin / on_carts) + export --------
+  const prio = byId<HTMLInputElement>('prio');
+  const pinToggle = byId<HTMLInputElement>('pin-toggle');
+  const cartsToggle = byId<HTMLInputElement>('carts-toggle');
+  const exportBtn = byId<HTMLButtonElement>('export');
+
+  // Dynamic x/y/heading pin fields — `_HUD_EDIT` (viewer.py) does not carry
+  // these, so build them here and hide them until the focused plane is pinned.
+  const pinFields = document.createElement('div');
+  pinFields.id = 'pin-fields';
+  pinFields.hidden = true;
+  function mkPinInput(label: string, field: 'x' | 'y' | 'heading'): HTMLInputElement {
+    const wrap = document.createElement('label');
+    wrap.textContent = `${label} `;
+    const inp = document.createElement('input');
+    inp.type = 'number';
+    inp.step = '0.1';
+    inp.addEventListener('input', () => {
+      if (focusedId && inp.value !== '') intent = setPinField(intent, focusedId, field, Number(inp.value));
+    });
+    wrap.appendChild(inp);
+    pinFields.appendChild(wrap);
+    return inp;
+  }
+  const xIn = mkPinInput('x_m', 'x');
+  const yIn = mkPinInput('y_m', 'y');
+  const hIn = mkPinInput('heading_deg', 'heading');
+  exportBtn.parentElement?.insertBefore(pinFields, exportBtn);
+
+  function syncControls(): void {
+    const id = focusedId;
+    const active = id !== null && isSelected(intent, id);
+    prio.disabled = !active;
+    pinToggle.disabled = !active;
+    if (!active || id === null) {
+      prio.value = '';
+      pinToggle.checked = false;
+      pinFields.hidden = true;
+      cartsToggle.disabled = true;
+      cartsToggle.checked = false;
+    } else {
+      const p = intent.priorities[id];
+      prio.value = p !== undefined ? String(p) : '';
+      const mp = intent.mustPositions[id];
+      pinToggle.checked = mp !== undefined;
+      pinFields.hidden = mp === undefined;
+      if (mp) {
+        xIn.value = String(mp.x);
+        yIn.value = String(mp.y);
+        hIn.value = String(mp.heading);
+        cartsToggle.disabled = !opts.ctx.cartEligible[id];
+        cartsToggle.checked = mp.onCarts;
+      } else {
+        cartsToggle.disabled = true;
+        cartsToggle.checked = false;
+      }
+    }
+    exportBtn.disabled = intent.selectedPlaneIds.length === 0;
+  }
+
+  prio.addEventListener('input', () => {
+    if (!focusedId) return;
+    intent = setPriority(intent, focusedId, prio.value === '' ? null : Math.max(0, Number(prio.value)));
+  });
+  pinToggle.addEventListener('change', () => {
+    if (!focusedId) return;
+    intent = pinToggle.checked ? pinAtCurrent(intent, focusedId, opts.ctx) : unpin(intent, focusedId);
+    syncControls();
+  });
+  cartsToggle.addEventListener('change', () => {
+    if (!focusedId) return;
+    intent = setOnCarts(intent, focusedId, cartsToggle.checked);
+  });
+  exportBtn.addEventListener('click', () => {
+    const yaml = intentToScenarioYaml(intent, opts.ctx);
+    const blob = new Blob([yaml], { type: 'text/yaml' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'scenario.edited.yaml';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+
   applyHighlight();
   renderReadout();
+  syncControls();
   return { getIntent: () => intent };
 }


### PR DESCRIPTION
## What

Chunk 3 — the **final** chunk of the v0.18.0 interactive placement editor (#442). It completes the MVP: `hangarfit view --solve --edit` is now a full intent-capture front door.

- **`editor.ts`** — the intent-capture controls: `#prio` → soft `priority`; `#pin-toggle` → pin-at-current-pose with **dynamic x/y/heading number inputs** (bound to `setPinField`); `#carts-toggle` → `on_carts` (enabled only for genuinely cart-eligible planes); **Export scenario YAML** → `intentToScenarioYaml` + a Blob download (disabled on empty selection). A `syncControls()` keeps the HUD reflecting the focused plane. Rebuilt `viewer.js`.
- **`tests/test_viewer.py`** — the authoritative **round-trip test** (the exported YAML shape loads via `load_scenario` and yields the expected `PlaneConstraint`s) + a maintenance-plane-excluded-from-`currentPoses` guard.
- **`tests/test_cli_view.py`** — a `_cart_eligible_map` unit test (see the cart fix below).
- **Docs:** the single `CHANGELOG.md` `### Added` editor entry (deferred from Chunks 1–2 to here, where the feature becomes user-facing), `CLAUDE.md` `--edit` usage, the `docs/architecture/05-building-block-view.md` `interaction/` block, `docs/adr/0029-...` flipped **Proposed → Accepted**, and `viewer/src/interaction/README.md` finalized.

**Invariants held:** `scene.py`/`build_scene` untouched; `#scene` bytes unchanged; the `editor-context` blob stays a viewer-HTML wrapper (ADR-0002/0003/0017); `editor.ts` never imports `affine.ts`/`anchors.ts` — a pin is a scalar copy of the Python-emitted pose. `viewer.js` is drift-clean.

Closes #899
Closes #442

### Reviews (this branch, pre-PR)
Subagent-driven: a spec+quality review after each of 7a/7b/7c, then a final whole-branch pass with **`code-reviewer` (opus)**, **`scene-schema-guard` (opus, PASS all 6 contract items)**, and **`comment-analyzer` (opus)**. Three **Important** findings were caught and fixed on-branch, then re-reviewed clean:
- **Cart-toggle correctness bug** — the eligibility gate used `movement_mode != "always_own_gear"`, which also enabled the toggle for `always_cart` planes (locked to `on_carts=True` by the loader); a user could uncheck it and export a pin `load_scenario` then rejects. Fixed to the strict `Aircraft.is_cart_eligible` (via a new tested `_cart_eligible_map` helper). The added test (with `example.yaml`'s `always_cart` `zlin_savage`/`wild_thing`) would have caught the original bug.
- Two stale doc claims in `interaction/README.md`'s `editor.ts` row (`controls.enabled` gating; "reads `scene-contract.ts`") corrected to the shipped mechanism.

### Known limitation (candidate fast-follow, not blocking)
Per the plan's chosen model, a click **toggles** fleet membership and `focusedId` is the last-*selected* plane — so configuring an already-selected plane's priority/pin currently requires a deselect→reselect (which transiently drops its constraints). This is the plan-mandated MVP interaction; a nicer model (click = focus, with a separate deselect affordance) is a reasonable post-v0.18.0 UX follow-up. See the inline thread.

## Checklist

- [x] Branched from `develop`
- [x] Tests added/updated and pass locally (59/59 node; 117 py across viewer/cli/scene; mypy + ruff clean; `viewer.js` drift-clean)
- [x] No skipped hooks
- [x] CLAUDE.md updated (— `--edit` usage added)
- [ ] pr-review-toolkit run; all threads resolved
- [x] No direct push expected — waiting for review + merge by maintainer
