### PR TITLE
docs(CLAUDE.md): gh pr checks parsing + late-appearing test gate CI gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,12 @@ default "entry per PR" rule still holds for one-at-a-time delivery. GitHub merge
 banner right after a merge/push clears on recompute — `mergeable=MERGEABLE` (and
 `git merge-base --is-ancestor origin/develop <branch>`) is authoritative;
 `mergeStateStatus=BLOCKED` just means required CI is still pending, not a conflict.
+Reading CI state: `gh pr checks <n>` output is **tab-separated** and the #877 fan-out
+check names carry spaces/parens (`test-shard (1 of 3)`, `bench correctness (…)`,
+`serial canaries (determinism)`) — whitespace-split `awk`/`grep` mangles them; use
+`awk -F'\t'` or `gh api repos/DocGerd/hangarfit/commits/<sha>/check-runs`. The required
+`test (Python 3.12)` **gate** appears only once its `test-shard`/`serial-canaries` deps
+finish, so a just-pushed PR shows the shards `pending` with no gate line yet (normal).
 (Mis-based already? `gh api -X PATCH repos/DocGerd/hangarfit/pulls/<n> -f base=develop`,
 then close+reopen the PR to trigger CI.) Wire the stack's order as native issue
 deps: `gh api -X POST repos/DocGerd/hangarfit/issues/<n>/dependencies/blocked_by -F issue_id=<numeric id>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,12 +87,13 @@ default "entry per PR" rule still holds for one-at-a-time delivery. GitHub merge
 banner right after a merge/push clears on recompute — `mergeable=MERGEABLE` (and
 `git merge-base --is-ancestor origin/develop <branch>`) is authoritative;
 `mergeStateStatus=BLOCKED` just means required CI is still pending, not a conflict.
-Reading CI state: `gh pr checks <n>` output is **tab-separated** and the #877 fan-out
-check names carry spaces/parens (`test-shard (1 of 3)`, `bench correctness (…)`,
-`serial canaries (determinism)`) — whitespace-split `awk`/`grep` mangles them; use
-`awk -F'\t'` or `gh api repos/DocGerd/hangarfit/commits/<sha>/check-runs`. The required
-`test (Python 3.12)` **gate** appears only once its `test-shard`/`serial-canaries` deps
-finish, so a just-pushed PR shows the shards `pending` with no gate line yet (normal).
+Reading CI state: `gh pr checks <n>` output is **tab-separated** and many check names
+carry spaces/parens — the #877 fan-out (`test-shard (1 of 3)`, `serial canaries
+(determinism)`) plus the separate `bench correctness (…)` check (#564) — so
+whitespace-split `awk`/`grep` mangles them; use `awk -F'\t'` or
+`gh api repos/DocGerd/hangarfit/commits/<sha>/check-runs`. The required
+`test (Python 3.12)` **gate** appears only once its `static`/`test-shard`/`serial-canaries`
+deps finish, so a just-pushed PR shows the shards `pending` with no gate line yet (normal).
 (Mis-based already? `gh api -X PATCH repos/DocGerd/hangarfit/pulls/<n> -f base=develop`,
 then close+reopen the PR to trigger CI.) Wire the stack's order as native issue
 deps: `gh api -X POST repos/DocGerd/hangarfit/issues/<n>/dependencies/blocked_by -F issue_id=<numeric id>`.


### PR DESCRIPTION
## What

Adds a 6-line **operational** note to CLAUDE.md (next to the existing `mergeStateStatus=BLOCKED` PR/CI-state tip) capturing a recurring `gh`-tooling gotcha surfaced during the #903 auto-merge watch:

- `gh pr checks <n>` output is **tab-separated** and the #877 fan-out check names carry spaces/parens (`test-shard (1 of 3)`, `bench correctness (…)`, `serial canaries (determinism)`) — whitespace-split `awk`/`grep` mangles them; use `awk -F'\t'` or `gh api repos/DocGerd/hangarfit/commits/<sha>/check-runs`.
- The required `test (Python 3.12)` **gate** appears only once its `test-shard`/`serial-canaries` deps finish, so a just-pushed PR shows the shards `pending` with no gate line yet (normal).

Docs-only; no code/behavior change. Not a domain assertion (stays within CLAUDE.md's "how we work" charter).

Closes #905

### Review
Will run `comment-analyzer` (per the subagent guidance for CLAUDE.md doc changes) before flipping ready.

## Checklist

- [x] Branched from `develop`
- [x] No skipped hooks
- [ ] comment-analyzer pass; any threads resolved
- [x] No direct push — waiting for review + merge by maintainer