### PR TITLE
feat(viewer): door-proximity ranking in the editor + door_order export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 ### Added
 
 - **Interactive placement editor** — `hangarfit view --solve --edit` turns the 3D viewer into an intent-capture front end: select which planes are in the fleet, set soft priorities and hard pin-at-current-pose must-positions, and export a loader-valid `Scenario` YAML that `hangarfit solve` re-runs. (#442)
-- **Editor door-proximity ranking** — the `--edit` editor gained a drag-to-order "door proximity" list (#1 nearest the door → …): rank an exclusive, partial subset of the selected planes and the exported scenario carries a top-level `door_order: [id, …]` (#614) that `hangarfit solve` honours. The editor-context now also surfaces the door edge so the list can orient itself. No ranking set ⇒ the export is byte-identical (ADR-0003). (#907)
+- **Editor door-proximity ranking** — the `--edit` editor gained a drag-to-order "door proximity" list (#1 nearest the door → …): rank an exclusive, partial subset of the selected planes and the exported scenario carries a top-level `door_order: [id, …]` (#614) that `hangarfit solve` honours. The ranking panel also shows a door-edge hint (which wall, and where along it) from the editor-context. No ranking set ⇒ the export is byte-identical (ADR-0003). (#907)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 ### Added
 
 - **Interactive placement editor** — `hangarfit view --solve --edit` turns the 3D viewer into an intent-capture front end: select which planes are in the fleet, set soft priorities and hard pin-at-current-pose must-positions, and export a loader-valid `Scenario` YAML that `hangarfit solve` re-runs. (#442)
+- **Editor door-proximity ranking** — the `--edit` editor gained a drag-to-order "door proximity" list (#1 nearest the door → …): rank an exclusive, partial subset of the selected planes and the exported scenario carries a top-level `door_order: [id, …]` (#614) that `hangarfit solve` honours. The editor-context now also surfaces the door edge so the list can orient itself. No ranking set ⇒ the export is byte-identical (ADR-0003). (#907)
 
 ### Changed
 

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -722,7 +722,12 @@ import * as THREE11 from "three";
 
 // src/interaction/selection.ts
 function initialIntent(ctx) {
-  return { selectedPlaneIds: Object.keys(ctx.currentPoses).sort(), priorities: {}, mustPositions: {} };
+  return {
+    selectedPlaneIds: Object.keys(ctx.currentPoses).sort(),
+    priorities: {},
+    mustPositions: {},
+    doorOrder: []
+  };
 }
 function isSelected(intent, id) {
   return intent.selectedPlaneIds.includes(id);
@@ -732,11 +737,12 @@ function toggleSelection(intent, id) {
   const selectedPlaneIds = selected ? intent.selectedPlaneIds.filter((x) => x !== id) : [...intent.selectedPlaneIds, id].sort();
   const priorities = { ...intent.priorities };
   const mustPositions = { ...intent.mustPositions };
+  const doorOrder = selected ? intent.doorOrder.filter((x) => x !== id) : intent.doorOrder;
   if (selected) {
     delete priorities[id];
     delete mustPositions[id];
   }
-  return { selectedPlaneIds, priorities, mustPositions };
+  return { selectedPlaneIds, priorities, mustPositions, doorOrder };
 }
 function setPriority(intent, id, priority) {
   const priorities = { ...intent.priorities };
@@ -765,6 +771,22 @@ function setOnCarts(intent, id, onCarts) {
   if (!cur) return intent;
   return { ...intent, mustPositions: { ...intent.mustPositions, [id]: { ...cur, onCarts } } };
 }
+function addToDoorOrder(intent, id) {
+  if (!isSelected(intent, id) || intent.doorOrder.includes(id)) return intent;
+  return { ...intent, doorOrder: [...intent.doorOrder, id] };
+}
+function removeFromDoorOrder(intent, id) {
+  if (!intent.doorOrder.includes(id)) return intent;
+  return { ...intent, doorOrder: intent.doorOrder.filter((x) => x !== id) };
+}
+function moveInDoorOrder(intent, from, to) {
+  const n = intent.doorOrder.length;
+  if (from < 0 || from >= n || to < 0 || to >= n || from === to) return intent;
+  const doorOrder = [...intent.doorOrder];
+  const [item] = doorOrder.splice(from, 1);
+  doorOrder.splice(to, 0, item);
+  return { ...intent, doorOrder };
+}
 
 // src/interaction/export.ts
 function num(n) {
@@ -782,6 +804,8 @@ function intentToScenarioYaml(intent, ctx) {
     lines.push("maintenance:");
     lines.push(`  plane: ${ctx.maintenance.plane}`);
   }
+  const ranked = intent.doorOrder.filter((id) => selected.includes(id));
+  if (ranked.length) lines.push(`door_order: [${ranked.join(", ")}]`);
   const constrained = selected.filter((id) => intent.mustPositions[id] || intent.priorities[id] !== void 0);
   if (constrained.length) {
     lines.push("constraints:");
@@ -847,6 +871,7 @@ function mountEditor(opts) {
     applyHighlight();
     renderReadout();
     syncControls();
+    renderDoorOrder();
   });
   function applyHighlight() {
     for (const t of targets) {
@@ -861,6 +886,8 @@ function mountEditor(opts) {
   const pinToggle = byId("pin-toggle");
   const cartsToggle = byId("carts-toggle");
   const exportBtn = byId("export");
+  const rankAdd = byId("rank-add");
+  const doorList = byId("door-order-list");
   const pinFields = document.createElement("div");
   pinFields.id = "pin-fields";
   pinFields.hidden = true;
@@ -933,9 +960,45 @@ function mountEditor(opts) {
     a.click();
     URL.revokeObjectURL(a.href);
   });
+  function renderDoorOrder() {
+    doorList.textContent = "";
+    intent.doorOrder.forEach((id, index) => {
+      const li = document.createElement("li");
+      li.draggable = true;
+      const label = document.createElement("span");
+      label.textContent = id;
+      const rm = document.createElement("button");
+      rm.type = "button";
+      rm.textContent = "×";
+      rm.title = `unrank ${id}`;
+      rm.addEventListener("click", () => {
+        intent = removeFromDoorOrder(intent, id);
+        renderDoorOrder();
+      });
+      li.append(label, rm);
+      li.addEventListener("dragstart", (ev) => ev.dataTransfer?.setData("text/plain", String(index)));
+      li.addEventListener("dragover", (ev) => ev.preventDefault());
+      li.addEventListener("drop", (ev) => {
+        ev.preventDefault();
+        const from = Number(ev.dataTransfer?.getData("text/plain"));
+        if (Number.isInteger(from)) {
+          intent = moveInDoorOrder(intent, from, index);
+          renderDoorOrder();
+        }
+      });
+      doorList.appendChild(li);
+    });
+    rankAdd.disabled = !(focusedId !== null && isSelected(intent, focusedId) && !intent.doorOrder.includes(focusedId));
+  }
+  rankAdd.addEventListener("click", () => {
+    if (!focusedId) return;
+    intent = addToDoorOrder(intent, focusedId);
+    renderDoorOrder();
+  });
   applyHighlight();
   renderReadout();
   syncControls();
+  renderDoorOrder();
   return { getIntent: () => intent };
 }
 

--- a/src/hangarfit/_viewer_assets/viewer.js
+++ b/src/hangarfit/_viewer_assets/viewer.js
@@ -888,6 +888,12 @@ function mountEditor(opts) {
   const exportBtn = byId("export");
   const rankAdd = byId("rank-add");
   const doorList = byId("door-order-list");
+  const doorHint = byId("door-hint");
+  const door = opts.ctx.door;
+  if (door) {
+    const half = door.width_m / 2;
+    doorHint.textContent = `door: front wall, x ${(door.center_x_m - half).toFixed(1)}–${(door.center_x_m + half).toFixed(1)} m`;
+  }
   const pinFields = document.createElement("div");
   pinFields.id = "pin-fields";
   pinFields.hidden = true;

--- a/src/hangarfit/viewer.py
+++ b/src/hangarfit/viewer.py
@@ -162,8 +162,9 @@ def build_editor_context(
             for p in layout.placements
         },
         "cartEligible": dict(cart_eligible),
-        # The door edge (already in scene/v2) so the door-proximity ranking UI
-        # (#907) can orient its "#1 nearest the door" list.
+        # The door edge (already in scene/v2), so the door-proximity ranking UI
+        # (#907) can show the user which wall — and where along it — the door is
+        # (rendered as a hint in the ranking panel by editor.ts).
         "door": {
             "center_x_m": layout.hangar.door.center_x_m,
             "width_m": layout.hangar.door.width_m,
@@ -250,6 +251,11 @@ _CSS = (
     f"#clock,#active,#readouts,.sw{{font-family:{brand.FONT_MONO};"
     f'font-feature-settings:"tnum" 1,"zero" 1}}'
     f"#readouts{{color:{brand.READOUTS_TEXT};font-variant-numeric:tabular-nums}}"
+    # #907 door-edge hint in the ranking panel: muted mono (it shows a
+    # coordinate span), spaced off the panel title. Editor-only markup, so this
+    # rule is inert in single/compare mode.
+    f"#door-hint{{margin:0 8px;font-family:{brand.FONT_MONO};"
+    f"color:{brand.READOUTS_TEXT};font-variant-numeric:tabular-nums}}"
     "#legend{display:flex;gap:8px;flex-wrap:wrap}"
     ".sw{display:inline-flex;align-items:center;gap:4px}"
     ".sw i{width:11px;height:11px;border-radius:2px;display:inline-block}"
@@ -285,9 +291,11 @@ _HUD_EDIT = _HUD + (
     '<label><input id="carts-toggle" type="checkbox"> on carts</label>'
     # #907 door-proximity ranking: an ordered list (#1 nearest the door), items
     # draggable to reorder; "＋ rank selected" appends the focused plane. The
-    # list is filled/wired by editor.ts; empty markup here keeps it inert until
-    # a plane is ranked.
+    # list + the door-edge hint are filled/wired by editor.ts (the hint reads
+    # the editor-context `door` field); empty markup here keeps it inert until a
+    # plane is ranked.
     '<div id="door-order"><span id="door-order-title">door proximity (#1 nearest)</span>'
+    '<span id="door-hint"></span>'
     '<button id="rank-add" type="button">＋ rank selected</button>'
     '<ol id="door-order-list"></ol></div>'
     '<button id="export">Export scenario YAML</button></div>'

--- a/src/hangarfit/viewer.py
+++ b/src/hangarfit/viewer.py
@@ -162,6 +162,12 @@ def build_editor_context(
             for p in layout.placements
         },
         "cartEligible": dict(cart_eligible),
+        # The door edge (already in scene/v2) so the door-proximity ranking UI
+        # (#907) can orient its "#1 nearest the door" list.
+        "door": {
+            "center_x_m": layout.hangar.door.center_x_m,
+            "width_m": layout.hangar.door.width_m,
+        },
     }
 
 
@@ -277,6 +283,13 @@ _HUD_EDIT = _HUD + (
     '<label>priority <input id="prio" type="number" min="0" step="0.5"></label>'
     '<label><input id="pin-toggle" type="checkbox"> pin here</label>'
     '<label><input id="carts-toggle" type="checkbox"> on carts</label>'
+    # #907 door-proximity ranking: an ordered list (#1 nearest the door), items
+    # draggable to reorder; "＋ rank selected" appends the focused plane. The
+    # list is filled/wired by editor.ts; empty markup here keeps it inert until
+    # a plane is ranked.
+    '<div id="door-order"><span id="door-order-title">door proximity (#1 nearest)</span>'
+    '<button id="rank-add" type="button">＋ rank selected</button>'
+    '<ol id="door-order-list"></ol></div>'
     '<button id="export">Export scenario YAML</button></div>'
 )
 # #666 compare HUD: a solution switcher (dropdown, also ←/→ keys) prepended to the

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -497,3 +497,66 @@ def test_build_editor_context_excludes_maintenance_from_current_poses():
     )
     assert lay.maintenance_plane not in ctx["currentPoses"]
     assert ctx["maintenance"] == {"plane": lay.maintenance_plane}
+
+
+# ── #907: door-proximity ranking (door_order) ──────────────────────────────
+
+
+def test_build_editor_context_includes_door_geometry():
+    # #907: the editor-context carries the door edge so the ranking UI can
+    # orient "#1 nearest the door". Sourced from layout.hangar.door (already in
+    # scene/v2), no signature change.
+    lay = load_layout(LAYOUT)
+    ctx = viewer.build_editor_context(
+        fleet_ref="data/fleet.yaml",
+        hangar_ref="data/hangar.yaml",
+        maintenance_plane=lay.maintenance_plane,
+        layout=lay,
+        cart_eligible={p.plane_id: False for p in lay.placements},
+    )
+    assert ctx["door"] == {
+        "center_x_m": lay.hangar.door.center_x_m,
+        "width_m": lay.hangar.door.width_m,
+    }
+
+
+def test_render_edit_viewer_hud_has_door_order_controls(tmp_path):
+    # #907 wires the door-proximity list DOM; guard the control IDs the editor
+    # hooks up (the ordered list + the "rank selected" affordance).
+    lay = load_layout(LAYOUT)
+    sc = scene.build_scene(lay, moves_plan=plan_fill(lay))
+    ctx = viewer.build_editor_context(
+        fleet_ref="data/fleet.yaml",
+        hangar_ref="data/hangar.yaml",
+        maintenance_plane=lay.maintenance_plane,
+        layout=lay,
+        cart_eligible={p.plane_id: False for p in lay.placements},
+    )
+    out = tmp_path / "edit.html"
+    viewer.render_edit_viewer(sc, ctx, out)
+    html = out.read_text(encoding="utf-8")
+    for control_id in ("door-order-list", "rank-add"):
+        assert f'id="{control_id}"' in html, f"missing editor control #{control_id}"
+
+
+def test_editor_export_with_door_order_loads_via_load_scenario(tmp_path):
+    # #907: the editor emits a top-level `door_order: [id, …]` (rank order,
+    # #1 nearest the door). Prove that shape is loader-valid and round-trips
+    # onto Scenario.door_order (#614).
+    from pathlib import Path
+
+    from hangarfit.loader import load_scenario
+
+    repo = Path(__file__).resolve().parents[1]
+    fleet, hangar = repo / "data" / "fleet.yaml", repo / "data" / "hangar.yaml"
+    yaml = (
+        f"fleet: {fleet}\n"
+        f"hangar: {hangar}\n"
+        "fleet_in: [aviat_husky, ctsl, fuji]\n"
+        "maintenance:\n  plane: fuji\n"
+        "door_order: [ctsl, aviat_husky]\n"
+    )
+    p = tmp_path / "edited.yaml"
+    p.write_text(yaml)
+    sc = load_scenario(p)
+    assert sc.door_order == ("ctsl", "aviat_husky")

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -535,7 +535,7 @@ def test_render_edit_viewer_hud_has_door_order_controls(tmp_path):
     out = tmp_path / "edit.html"
     viewer.render_edit_viewer(sc, ctx, out)
     html = out.read_text(encoding="utf-8")
-    for control_id in ("door-order-list", "rank-add"):
+    for control_id in ("door-order-list", "rank-add", "door-hint"):
         assert f'id="{control_id}"' in html, f"missing editor control #{control_id}"
 
 

--- a/viewer/src/interaction/editor.ts
+++ b/viewer/src/interaction/editor.ts
@@ -15,6 +15,9 @@ import {
   unpin,
   setPinField,
   setOnCarts,
+  addToDoorOrder,
+  removeFromDoorOrder,
+  moveInDoorOrder,
 } from './selection.ts';
 import { intentToScenarioYaml } from './export.ts';
 import { byId } from '../dom.ts';
@@ -85,6 +88,7 @@ export function mountEditor(opts: {
     applyHighlight();
     renderReadout();
     syncControls();
+    renderDoorOrder(); // deselect un-ranks; focus change updates the add-button state
   });
 
   function applyHighlight(): void {
@@ -104,6 +108,8 @@ export function mountEditor(opts: {
   const pinToggle = byId<HTMLInputElement>('pin-toggle');
   const cartsToggle = byId<HTMLInputElement>('carts-toggle');
   const exportBtn = byId<HTMLButtonElement>('export');
+  const rankAdd = byId<HTMLButtonElement>('rank-add');
+  const doorList = byId<HTMLOListElement>('door-order-list');
 
   // Dynamic x/y/heading pin fields — `_HUD_EDIT` (viewer.py) does not carry
   // these, so build them here and hide them until the focused plane is pinned.
@@ -182,8 +188,53 @@ export function mountEditor(opts: {
     URL.revokeObjectURL(a.href);
   });
 
+  // --- Door-proximity ranking list (#907) ---------------------------------
+  // Rebuild the ordered list from intent.doorOrder. Each <li> is drag-reorderable
+  // (HTML5 DnD → moveInDoorOrder by index) and carries a × to unrank. The "＋ rank
+  // selected" button appends the focused plane; it enables only when the focused
+  // plane is selected and not already ranked.
+  function renderDoorOrder(): void {
+    doorList.textContent = '';
+    intent.doorOrder.forEach((id, index) => {
+      const li = document.createElement('li');
+      li.draggable = true;
+      const label = document.createElement('span');
+      label.textContent = id;
+      const rm = document.createElement('button');
+      rm.type = 'button';
+      rm.textContent = '×';
+      rm.title = `unrank ${id}`;
+      rm.addEventListener('click', () => {
+        intent = removeFromDoorOrder(intent, id);
+        renderDoorOrder();
+      });
+      li.append(label, rm);
+      li.addEventListener('dragstart', (ev) => ev.dataTransfer?.setData('text/plain', String(index)));
+      li.addEventListener('dragover', (ev) => ev.preventDefault()); // permit a drop here
+      li.addEventListener('drop', (ev) => {
+        ev.preventDefault();
+        const from = Number(ev.dataTransfer?.getData('text/plain'));
+        if (Number.isInteger(from)) {
+          intent = moveInDoorOrder(intent, from, index);
+          renderDoorOrder();
+        }
+      });
+      doorList.appendChild(li);
+    });
+    rankAdd.disabled = !(
+      focusedId !== null && isSelected(intent, focusedId) && !intent.doorOrder.includes(focusedId)
+    );
+  }
+
+  rankAdd.addEventListener('click', () => {
+    if (!focusedId) return;
+    intent = addToDoorOrder(intent, focusedId);
+    renderDoorOrder();
+  });
+
   applyHighlight();
   renderReadout();
   syncControls();
+  renderDoorOrder();
   return { getIntent: () => intent };
 }

--- a/viewer/src/interaction/editor.ts
+++ b/viewer/src/interaction/editor.ts
@@ -110,6 +110,16 @@ export function mountEditor(opts: {
   const exportBtn = byId<HTMLButtonElement>('export');
   const rankAdd = byId<HTMLButtonElement>('rank-add');
   const doorList = byId<HTMLOListElement>('door-order-list');
+  // Show which wall — and where along it — the door is, from the editor-context
+  // door edge (#907). The door is the front wall (y=0, the coordinate
+  // convention); center_x_m ± width_m/2 is a 1-D span along it (pure display
+  // arithmetic — no geometry transform, so ADR-0002 is untouched).
+  const doorHint = byId<HTMLSpanElement>('door-hint');
+  const door = opts.ctx.door;
+  if (door) {
+    const half = door.width_m / 2;
+    doorHint.textContent = `door: front wall, x ${(door.center_x_m - half).toFixed(1)}–${(door.center_x_m + half).toFixed(1)} m`;
+  }
 
   // Dynamic x/y/heading pin fields — `_HUD_EDIT` (viewer.py) does not carry
   // these, so build them here and hide them until the focused plane is pinned.

--- a/viewer/src/interaction/export.ts
+++ b/viewer/src/interaction/export.ts
@@ -18,6 +18,12 @@ export function intentToScenarioYaml(intent: Intent, ctx: EditorContext): string
   lines.push(`fleet_in: [${fleetIn.join(', ')}]`);
   if (ctx.maintenance) { lines.push('maintenance:'); lines.push(`  plane: ${ctx.maintenance.plane}`); }
 
+  // Door-proximity ranking → Scenario.door_order (#614). Only rank selected
+  // planes (a deselect already un-ranks; filter defensively). Emitted only when
+  // non-empty, so an editor with no ranking exports a byte-identical scenario.
+  const ranked = intent.doorOrder.filter((id) => selected.includes(id));
+  if (ranked.length) lines.push(`door_order: [${ranked.join(', ')}]`);
+
   // Only selected planes may carry constraints (never the maintenance plane).
   const constrained = selected.filter((id) => intent.mustPositions[id] || intent.priorities[id] !== undefined);
   if (constrained.length) {

--- a/viewer/src/interaction/intent-contract.ts
+++ b/viewer/src/interaction/intent-contract.ts
@@ -4,6 +4,10 @@ export interface Intent {
   selectedPlaneIds: string[];
   priorities: Record<string, number>;
   mustPositions: Record<string, MustPosition>;
+  // Door-proximity ranking (#907 → Scenario.door_order, #614): an ordered,
+  // exclusive/partial subset of the selected planes, #1 (index 0) nearest the
+  // door. Empty ⇒ no `door_order` key is exported (byte path unchanged).
+  doorOrder: string[];
 }
 export interface CurrentPose { x_m: number; y_m: number; heading_deg: number; on_carts: boolean; }
 export interface EditorContext {
@@ -12,4 +16,7 @@ export interface EditorContext {
   maintenance: { plane: string } | null;
   currentPoses: Record<string, CurrentPose>;
   cartEligible: Record<string, boolean>;
+  // The door edge (scene/v2 hangar geometry) so the ranking UI can orient the
+  // "#1 nearest the door" list. Absent on older editor-context blobs.
+  door?: { center_x_m: number; width_m: number };
 }

--- a/viewer/src/interaction/intent-contract.ts
+++ b/viewer/src/interaction/intent-contract.ts
@@ -16,7 +16,8 @@ export interface EditorContext {
   maintenance: { plane: string } | null;
   currentPoses: Record<string, CurrentPose>;
   cartEligible: Record<string, boolean>;
-  // The door edge (scene/v2 hangar geometry) so the ranking UI can orient the
-  // "#1 nearest the door" list. Absent on older editor-context blobs.
+  // The door edge (scene/v2 hangar geometry), rendered as a hint in the ranking
+  // panel so the user sees which wall the door is on and where along it. Absent
+  // on older editor-context blobs.
   door?: { center_x_m: number; width_m: number };
 }

--- a/viewer/src/interaction/selection.ts
+++ b/viewer/src/interaction/selection.ts
@@ -75,7 +75,8 @@ export function removeFromDoorOrder(intent: Intent, id: string): Intent {
 }
 
 /** Move the plane at index ``from`` to index ``to`` in the door order. No-op for
- * out-of-range or identical indices (the drag layer clamps to valid slots). */
+ * out-of-range or identical indices — callers pass indices derived from existing
+ * list positions (always in range), so the bounds guard is purely defensive. */
 export function moveInDoorOrder(intent: Intent, from: number, to: number): Intent {
   const n = intent.doorOrder.length;
   if (from < 0 || from >= n || to < 0 || to >= n || from === to) return intent;

--- a/viewer/src/interaction/selection.ts
+++ b/viewer/src/interaction/selection.ts
@@ -2,7 +2,12 @@
 import type { Intent, MustPosition, EditorContext } from './intent-contract.ts';
 
 export function initialIntent(ctx: EditorContext): Intent {
-  return { selectedPlaneIds: Object.keys(ctx.currentPoses).sort(), priorities: {}, mustPositions: {} };
+  return {
+    selectedPlaneIds: Object.keys(ctx.currentPoses).sort(),
+    priorities: {},
+    mustPositions: {},
+    doorOrder: [],
+  };
 }
 
 export function isSelected(intent: Intent, id: string): boolean {
@@ -16,8 +21,11 @@ export function toggleSelection(intent: Intent, id: string): Intent {
     : [...intent.selectedPlaneIds, id].sort();
   const priorities = { ...intent.priorities };
   const mustPositions = { ...intent.mustPositions };
-  if (selected) { delete priorities[id]; delete mustPositions[id]; } // can't constrain an absent plane
-  return { selectedPlaneIds, priorities, mustPositions };
+  // Deselecting drops the plane's constraints AND its door-proximity rank —
+  // you can't rank a plane that isn't in the layout.
+  const doorOrder = selected ? intent.doorOrder.filter((x) => x !== id) : intent.doorOrder;
+  if (selected) { delete priorities[id]; delete mustPositions[id]; }
+  return { selectedPlaneIds, priorities, mustPositions, doorOrder };
 }
 
 export function setPriority(intent: Intent, id: string, priority: number | null): Intent {
@@ -49,4 +57,30 @@ export function setOnCarts(intent: Intent, id: string, onCarts: boolean): Intent
   const cur = intent.mustPositions[id];
   if (!cur) return intent;
   return { ...intent, mustPositions: { ...intent.mustPositions, [id]: { ...cur, onCarts } } };
+}
+
+// --- Door-proximity ranking (#907 → Scenario.door_order) ----------------------
+
+/** Append a selected, not-yet-ranked plane to the end of the door order (least
+ * near the door). No-op for an unselected or already-ranked plane. */
+export function addToDoorOrder(intent: Intent, id: string): Intent {
+  if (!isSelected(intent, id) || intent.doorOrder.includes(id)) return intent;
+  return { ...intent, doorOrder: [...intent.doorOrder, id] };
+}
+
+/** Remove a plane from the door order, preserving the order of the rest. */
+export function removeFromDoorOrder(intent: Intent, id: string): Intent {
+  if (!intent.doorOrder.includes(id)) return intent;
+  return { ...intent, doorOrder: intent.doorOrder.filter((x) => x !== id) };
+}
+
+/** Move the plane at index ``from`` to index ``to`` in the door order. No-op for
+ * out-of-range or identical indices (the drag layer clamps to valid slots). */
+export function moveInDoorOrder(intent: Intent, from: number, to: number): Intent {
+  const n = intent.doorOrder.length;
+  if (from < 0 || from >= n || to < 0 || to >= n || from === to) return intent;
+  const doorOrder = [...intent.doorOrder];
+  const [item] = doorOrder.splice(from, 1);
+  doorOrder.splice(to, 0, item);
+  return { ...intent, doorOrder };
 }

--- a/viewer/test/export.test.ts
+++ b/viewer/test/export.test.ts
@@ -1,7 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { intentToScenarioYaml } from '../src/interaction/export.ts';
-import { initialIntent, setPriority, pinAtCurrent, toggleSelection } from '../src/interaction/selection.ts';
+import {
+  initialIntent, setPriority, pinAtCurrent, toggleSelection, addToDoorOrder,
+} from '../src/interaction/selection.ts';
 import type { EditorContext } from '../src/interaction/intent-contract.ts';
 
 const CTX: EditorContext = {
@@ -55,4 +57,26 @@ test('a plane can carry both a pin and a priority', () => {
     y,
     /^ {2}husky:\n {4}pin: \{ x_m: 2.1, y_m: 14.3, heading_deg: 0.0, on_carts: false \}\n {4}priority: 2.0$/m,
   );
+});
+
+test('door_order is emitted as a top-level list in rank order when set', () => {
+  let i = initialIntent(CTX);
+  i = addToDoorOrder(i, 'ctsl');  // #1 nearest the door
+  i = addToDoorOrder(i, 'husky'); // #2
+  const y = intentToScenarioYaml(i, CTX);
+  assert.match(y, /^door_order: \[ctsl, husky\]$/m);
+});
+
+test('no door_order key is emitted when the ranking is unset (byte path unchanged)', () => {
+  const y = intentToScenarioYaml(initialIntent(CTX), CTX);
+  assert.doesNotMatch(y, /door_order/);
+});
+
+test('door_order never contains a deselected plane', () => {
+  let i = initialIntent(CTX);
+  i = addToDoorOrder(i, 'ctsl');
+  i = addToDoorOrder(i, 'husky');
+  i = toggleSelection(i, 'ctsl'); // deselect ctsl → it drops out of the ranking too
+  const y = intentToScenarioYaml(i, CTX);
+  assert.match(y, /^door_order: \[husky\]$/m);
 });

--- a/viewer/test/export.test.ts
+++ b/viewer/test/export.test.ts
@@ -80,3 +80,12 @@ test('door_order never contains a deselected plane', () => {
   const y = intentToScenarioYaml(i, CTX);
   assert.match(y, /^door_order: \[husky\]$/m);
 });
+
+test('export defensively drops a door_order id that is not in the selection', () => {
+  // toggleSelection normally keeps doorOrder ⊆ selection, so this desynced state
+  // is unreachable through the pure API — construct it directly to exercise the
+  // export's own `selected.includes` guard (the serialization safety net).
+  const i = { ...initialIntent(CTX), doorOrder: ['ctsl', 'ghost'] };
+  const y = intentToScenarioYaml(i, CTX);
+  assert.match(y, /^door_order: \[ctsl\]$/m); // 'ghost' (unselected) is filtered out
+});

--- a/viewer/test/selection.test.ts
+++ b/viewer/test/selection.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   initialIntent, isSelected, toggleSelection, setPriority,
   pinAtCurrent, unpin, setPinField, setOnCarts,
+  addToDoorOrder, removeFromDoorOrder, moveInDoorOrder,
 } from '../src/interaction/selection.ts';
 import type { EditorContext } from '../src/interaction/intent-contract.ts';
 
@@ -89,4 +90,65 @@ test('pin-editing functions do not mutate their input', () => {
   setPinField(pinned, 'husky', 'x', 99);
   setOnCarts(pinned, 'husky', true);
   assert.equal(JSON.stringify(pinned), snapshot);
+});
+
+// --- #907 door-proximity ranking (door_order) ---------------------------------
+
+test('initialIntent starts with an empty doorOrder', () => {
+  assert.deepEqual(initialIntent(CTX).doorOrder, []);
+});
+
+test('addToDoorOrder appends selected, unranked planes in call order', () => {
+  let i = addToDoorOrder(initialIntent(CTX), 'husky');
+  assert.deepEqual(i.doorOrder, ['husky']);
+  i = addToDoorOrder(i, 'ctsl');
+  assert.deepEqual(i.doorOrder, ['husky', 'ctsl']); // #1 nearest the door = first
+});
+
+test('addToDoorOrder never duplicates an already-ranked plane', () => {
+  let i = addToDoorOrder(initialIntent(CTX), 'husky');
+  i = addToDoorOrder(i, 'husky');
+  assert.deepEqual(i.doorOrder, ['husky']);
+});
+
+test('addToDoorOrder ignores an unselected plane', () => {
+  let i = toggleSelection(initialIntent(CTX), 'husky'); // drop husky from the set
+  i = addToDoorOrder(i, 'husky');
+  assert.deepEqual(i.doorOrder, []); // can't rank a plane that isn't in the layout
+});
+
+test('removeFromDoorOrder drops one plane, keeping the rest ordered', () => {
+  let i = addToDoorOrder(initialIntent(CTX), 'husky');
+  i = addToDoorOrder(i, 'ctsl');
+  i = removeFromDoorOrder(i, 'husky');
+  assert.deepEqual(i.doorOrder, ['ctsl']);
+});
+
+test('moveInDoorOrder reorders by index', () => {
+  let i = addToDoorOrder(initialIntent(CTX), 'husky');
+  i = addToDoorOrder(i, 'ctsl'); // [husky, ctsl]
+  i = moveInDoorOrder(i, 1, 0);  // pull ctsl to #1
+  assert.deepEqual(i.doorOrder, ['ctsl', 'husky']);
+});
+
+test('moveInDoorOrder is a no-op for out-of-range or identical indices', () => {
+  const i = addToDoorOrder(initialIntent(CTX), 'husky');
+  assert.deepEqual(moveInDoorOrder(i, 0, 5).doorOrder, ['husky']);
+  assert.deepEqual(moveInDoorOrder(i, -1, 0).doorOrder, ['husky']);
+  assert.deepEqual(moveInDoorOrder(i, 0, 0).doorOrder, ['husky']);
+});
+
+test('deselecting a ranked plane also un-ranks it', () => {
+  let i = addToDoorOrder(initialIntent(CTX), 'husky');
+  i = toggleSelection(i, 'husky');
+  assert.deepEqual(i.doorOrder, []);
+});
+
+test('door-order ops do not mutate their input', () => {
+  const base = addToDoorOrder(initialIntent(CTX), 'husky');
+  const snapshot = JSON.stringify(base);
+  addToDoorOrder(base, 'ctsl');
+  removeFromDoorOrder(base, 'husky');
+  moveInDoorOrder(base, 0, 0);
+  assert.equal(JSON.stringify(base), snapshot);
 });

--- a/viewer/test/selection.test.ts
+++ b/viewer/test/selection.test.ts
@@ -131,6 +131,27 @@ test('moveInDoorOrder reorders by index', () => {
   assert.deepEqual(i.doorOrder, ['ctsl', 'husky']);
 });
 
+test('moveInDoorOrder: forward moves on a 3-element order splice correctly', () => {
+  // A 3-plane context: the remove-then-insert splice seam (a forward move
+  // inserts AFTER the removal shifts the array) only shows up with ≥3 items.
+  const CTX3: EditorContext = {
+    fleet: 'f', hangar: 'h', maintenance: null,
+    currentPoses: {
+      a: { x_m: 0, y_m: 0, heading_deg: 0, on_carts: false },
+      b: { x_m: 1, y_m: 1, heading_deg: 0, on_carts: false },
+      c: { x_m: 2, y_m: 2, heading_deg: 0, on_carts: false },
+    },
+    cartEligible: { a: false, b: false, c: false },
+  };
+  let i = initialIntent(CTX3);
+  i = addToDoorOrder(i, 'a');
+  i = addToDoorOrder(i, 'b');
+  i = addToDoorOrder(i, 'c'); // [a, b, c]
+  assert.deepEqual(moveInDoorOrder(i, 0, 2).doorOrder, ['b', 'c', 'a']); // a → end (forward)
+  assert.deepEqual(moveInDoorOrder(i, 0, 1).doorOrder, ['b', 'a', 'c']); // a → one forward
+  assert.deepEqual(moveInDoorOrder(i, 2, 0).doorOrder, ['c', 'a', 'b']); // c → front (backward)
+});
+
 test('moveInDoorOrder is a no-op for out-of-range or identical indices', () => {
   const i = addToDoorOrder(initialIntent(CTX), 'husky');
   assert.deepEqual(moveInDoorOrder(i, 0, 5).doorOrder, ['husky']);
@@ -142,6 +163,14 @@ test('deselecting a ranked plane also un-ranks it', () => {
   let i = addToDoorOrder(initialIntent(CTX), 'husky');
   i = toggleSelection(i, 'husky');
   assert.deepEqual(i.doorOrder, []);
+});
+
+test('reselecting a deselected plane does not restore its rank', () => {
+  let i = addToDoorOrder(initialIntent(CTX), 'husky'); // [husky]
+  i = toggleSelection(i, 'husky');                     // deselect → un-ranks
+  i = toggleSelection(i, 'husky');                     // reselect
+  assert.ok(isSelected(i, 'husky'));
+  assert.deepEqual(i.doorOrder, []); // rank is NOT restored — the user must re-rank
 });
 
 test('door-order ops do not mutate their input', () => {


### PR DESCRIPTION
Closes #907

## What

Adds the **door-proximity ranking** capability (spec capability C1) to the `hangarfit view --solve --edit` interactive editor. The user can rank an **exclusive, partial** subset of the selected planes ("#1 nearest the door → …"); the export emits a top-level `door_order: [id, …]`, which the loader/solver already honour end-to-end (`Scenario.door_order`, #614). Backend-free — this is entirely viewer-side.

## Changes

- **`intent-contract.ts`** — `Intent` gains `doorOrder: string[]`; `EditorContext` gains an optional `door` edge (`{center_x_m, width_m}`) so the UI can orient the list.
- **`selection.ts`** — `initialIntent` starts `doorOrder: []`; new pure ops `addToDoorOrder` / `removeFromDoorOrder` / `moveInDoorOrder`; deselecting a plane also un-ranks it (mirrors the existing constraint cleanup). Uniqueness holds by construction (a list).
- **`export.ts`** — emits `door_order: [id, …]` (top-level, after `maintenance`) **only when non-empty**, so an editor with no ranking exports a byte-identical scenario (ADR-0003).
- **`editor.ts`** — a drag-to-order `<ol>` wired to the pure ops (HTML5 DnD → `moveInDoorOrder` by index; × to unrank; "＋ rank selected" appends the focused plane, enabled only when it's selected and unranked).
- **`viewer.py`** — `build_editor_context` emits the `door` edge (sourced from `layout.hangar.door`, no signature change); `_HUD_EDIT` gains the door-order panel DOM.
- **`viewer.js`** — rebuilt committed bundle.

## Tests (TDD, red→green)

- **Node** (`selection.test.ts`, `export.test.ts`): the three door-order ops (append / no-dup / unselected-ignored / remove / reorder / out-of-range no-op / deselect-un-ranks / purity) + export emission (rank order, no-key-when-unset, deselected-excluded).
- **Python** (`test_viewer.py`): editor-context `door` geometry; the door-order HUD DOM; and a **loader round-trip** proving the exported `door_order: [ctsl, aviat_husky]` shape loads onto `Scenario.door_order`.

## Verification

- Full node suite (71) + `tests/test_viewer.py` (36) green; ruff / ruff-format / mypy clean; `make test` (two-pass split) green.
- End-to-end: rendered `view --solve --edit`, confirmed the door-order panel + the `door` editor-context field, and a headless swiftshader smoke mounts the editor with no JS errors / no transform banner.

## Out of scope (separate issues)

- Making rank-1 *actively pulled* toward the door (an absolute door-distance soft term) is **#908** — today `door_order` is a post-hoc tiebreak among already-valid basins. C1 ships and relies on that existing relative tiebreak.

## Review

- `scene-schema-guard` (editor-context / viewer.js / `#scene` byte-identity), `code-reviewer`, `comment-analyzer` (docstrings/comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
