### PR TITLE
feat(solver): absolute door-distance steering term (#908)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 - **Interactive placement editor** — `hangarfit view --solve --edit` turns the 3D viewer into an intent-capture front end: select which planes are in the fleet, set soft priorities and hard pin-at-current-pose must-positions, and export a loader-valid `Scenario` YAML that `hangarfit solve` re-runs. (#442)
 - **Editor door-proximity ranking** — the `--edit` editor gained a drag-to-order "door proximity" list (#1 nearest the door → …): rank an exclusive, partial subset of the selected planes and the exported scenario carries a top-level `door_order: [id, …]` (#614) that `hangarfit solve` honours. The ranking panel also shows a door-edge hint (which wall, and where along it) from the editor-context. No ranking set ⇒ the export is byte-identical (ADR-0003). (#907)
+- **Absolute door-proximity steering** — when a scenario sets `door_order`, `hangarfit solve` now actively pulls the #1 (door-nearest) plane toward the door during the spread post-pass, not just as a post-hoc tiebreak (which is inert for a lone #1). Opt out with `--no-door-bias`. Off unless `door_order` is set; the library default (`SearchConfig.door_bias_weight=0.0`) and every plan without `door_order` are byte-identical (ADR-0003). (#908)
 
 ### Changed
 

--- a/docs/adr/0008-inter-plane-spread-soft-preference.md
+++ b/docs/adr/0008-inter-plane-spread-soft-preference.md
@@ -403,3 +403,50 @@ so it can never make an invalid layout selectable. With `door_order` unset (the
 default) every candidate's `door_deviation` is a constant `0.0`, so the key
 reduces to this ADR's original `(−min_gap, energy, restart_index)` ordering
 **byte-for-byte** (ADR-0003) — verified by the 6-plane determinism canaries.
+
+### 2026-07-03 — absolute door-attraction steering term (#908)
+
+The #614 `door_order` tie-break is purely *relative* (a Kendall-tau inversion
+count) and *post-hoc* (a selection key over already-found basins) — it never
+*steers* placement and is provably inert for a lone `#1` (an order needs ≥2
+placed bodies to express an inversion). #908 adds the missing *absolute* steering:
+a fourth soft term folded into the `_spread` hill-climb's energy, alongside the
+spread repulsion, the #320 back-bias, and the #604 region term:
+
+```
+E_total = Σ_{i<j} w_i·w_j·exp(−gap_ij/scale) + back_bias_weight·Σ_{p≠r} (L−y_p)/L
+          + Σ_{o∈prefs} w_o·d_o/W + door_bias_weight·(y_r / L)
+          └── spread ──┘ └──── back bias (r exempt) ────┘ └─ region ─┘ └ door bias (#908) ┘
+```
+
+where `r = door_order[0]` is the rank-1 (door-nearest) plane. The door term
+`solver._door_bias_energy = y_r / length_m` is the sign-flipped mirror of the
+back-bias: minimized when `r` sits AT the door (`y = 0`), so the hill-climb
+actively pulls the top-priority plane doorward. **Only rank-1 is steered**
+(rank1_only) — ranks 2..N keep the relative `_door_order_deviation` selection
+tie-break, giving a clean split: absolute steer for the top pick, relative select
+for the tail. To stop the two door mechanisms fighting, `r` is **exempted from the
+back-bias sum** while door-bias is active (`_back_bias_energy(..., exclude=r)`) —
+otherwise `r`'s own deep-pull would cancel its doorward pull; unranked planes
+still back-fill, vacating the door end and *helping* `r` reach it. Like the
+back-bias, this re-ranks candidates *within* a basin's hill-climb; `−min_gap`
+stays the primary basin-selection key.
+
+**Default & toggle.** `SearchConfig.door_bias_weight` defaults to **0.0** — the
+term is not even summed, so every library caller and determinism canary is
+byte-identical to the pre-#908 solver. The CLI auto-arms `_DOOR_BIAS_DEFAULT_WEIGHT`
+only when the scenario sets `door_order` (`--no-door-bias` forces 0.0; no effect
+under `--no-spread`). The `<2 planes` no-op guard is relaxed so a lone `#1` is
+still pulled.
+
+**Determinism.** The term is RNG-free re-ranking and **division-only** (no
+`math.exp` — cross-machine byte-safe, unlike the spread repulsion). Integration is
+byte-identical to pre-#908 whenever `door_bias_weight = 0`, so no
+determinism-guard / ADR-0003 amendment is required (same reasoning as the #320
+back-bias and #604 region terms); a new door_order-steering determinism canary
+covers the armed path the pre-#908 canaries never exercised.
+
+**Known limitation.** Best-effort "if possible": in dense fills, validity and
+inter-plane repulsion dominate, so the doorward pull is cosmetic-within-slack —
+the weight is deliberately *not* cranked high enough to force it (that would
+collapse spread and congest the door).

--- a/docs/superpowers/plans/2026-07-03-908-door-bias-absolute-term.md
+++ b/docs/superpowers/plans/2026-07-03-908-door-bias-absolute-term.md
@@ -1,0 +1,545 @@
+# #908 Absolute Door-Distance Soft Term — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an absolute door-attraction soft term so the rank-1 plane in `Scenario.door_order` is actively pulled toward the door (`y=0`) during the spread hill-climb — best-effort, byte-identical by default.
+
+**Architecture:** A new `_door_bias_energy` (sign-flipped mirror of `_back_bias_energy`) folded into `_spread`'s `_energy` closure, gated on a new `SearchConfig.door_bias_weight` (default `0.0` ⇒ inert). The `solve` CLI auto-arms a baked default weight when the scenario sets `door_order` (`--no-door-bias` opts out), mirroring the `--back-fill` lever exactly. To avoid a deep-vs-doorward tug-of-war, the rank-1 id is exempted from the back-fill sum while door-bias is active.
+
+**Tech Stack:** Python 3.12, existing `hangarfit.solver` / `hangarfit.models` / `hangarfit.cli`; pytest.
+
+**Design spec:** `docs/superpowers/specs/2026-07-03-908-door-bias-absolute-term-design.md`
+
+## Global Constraints
+
+- **ADR-0003 determinism:** same scenario + seed ⇒ byte-identical plan. New term is RNG-free, wall-clock-free, **division-only** (no `math.exp` — cross-machine byte-safe). Default `door_bias_weight=0.0` ⇒ term never summed ⇒ every `SearchConfig()`-default caller (canaries, `ml/`, `bench`) bit-identical.
+- **`determinism-guard` review required** (touches `solver.py` scoring surface).
+- **Mirror the `--back-fill` precedent** (`_BACK_FILL_DEFAULT_WEIGHT=1.0` cli.py:51; `--no-back-fill` argparse cli.py:255; `back_bias_weight: float = 0.0` + `>= 0` validation models.py:1846/1968).
+- **Weight = rank1_only** (pull only `door_order[0]`); the shipped relative `_door_order_deviation` tiebreak stays untouched for the tail.
+- Run `pytest`, `ruff check src/ tests/`, `ruff format`, `mypy src/hangarfit/` before each commit's completion.
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/hangarfit/solver.py` | `_door_bias_energy` (new); `_back_bias_energy` `exclude` param; `_spread._energy` gate + guard relax | Modify |
+| `src/hangarfit/models.py` | `SearchConfig.door_bias_weight` field + `__post_init__` validation | Modify |
+| `src/hangarfit/cli.py` | `--no-door-bias` argparse; `_DOOR_BIAS_DEFAULT_WEIGHT`; auto-arm at the `solve` SearchConfig site | Modify |
+| `tests/test_solver_door_order.py` | unit tests for the energy term, steering, back-fill exemption, determinism canary | Modify |
+| `tests/test_cli_solve.py` (or the existing solve-CLI test module) | `--no-door-bias` + auto-arm CLI tests | Modify |
+| `docs/adr/0008-inter-plane-spread-soft-preference.md` | amend to record the door-bias steering term | Modify |
+| `CHANGELOG.md` | `[Unreleased]` entry | Modify |
+
+---
+
+### Task 1: `_door_bias_energy` energy term
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` (add function next to `_back_bias_energy` ~1343)
+- Test: `tests/test_solver_door_order.py`
+
+**Interfaces:**
+- Produces: `_door_bias_energy(placements: Mapping[str, Placement], scenario: Scenario) -> float` — returns `y_{door_order[0]} / hangar.length_m` when `door_order` is truthy and `door_order[0]` is placed; else `0.0`. Weight is applied by the caller (mirrors `_back_bias_energy`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_solver_door_order.py` (import `_door_bias_energy` from `hangarfit.solver` in the existing import block):
+
+```python
+# --- _door_bias_energy absolute-attraction term (#908) ---------------------
+
+def test_door_bias_energy_unset_is_zero():
+    s = _scenario()  # door_order is None
+    assert _door_bias_energy({"a": _pl("a", 5.0)}, s) == 0.0  # inert ⇒ byte-identical
+
+
+def test_door_bias_energy_empty_order_is_zero():
+    s = _scenario(door_order=())
+    assert _door_bias_energy({"a": _pl("a", 5.0)}, s) == 0.0
+
+
+def test_door_bias_energy_rank1_absent_is_zero():
+    s = _scenario(door_order=("a", "b"))
+    assert _door_bias_energy({"b": _pl("b", 5.0)}, s) == 0.0  # rank-1 'a' not placed
+
+
+def test_door_bias_energy_is_rank1_y_over_length():
+    s = _scenario(door_order=("a", "b"))  # only rank-1 'a' matters
+    # length_m = 40.0 (see _hangar); a at y=10 ⇒ 10/40 = 0.25, independent of 'b'.
+    assert _door_bias_energy({"a": _pl("a", 10.0), "b": _pl("b", 2.0)}, s) == 0.25
+
+
+def test_door_bias_energy_minimized_at_the_door():
+    s = _scenario(door_order=("a",))
+    near = _door_bias_energy({"a": _pl("a", 1.0)}, s)
+    far = _door_bias_energy({"a": _pl("a", 30.0)}, s)
+    assert near < far  # smaller y (nearer the door at y=0) ⇒ lower energy
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_solver_door_order.py -k door_bias_energy -v`
+Expected: FAIL — `ImportError: cannot import name '_door_bias_energy'`.
+
+- [ ] **Step 3: Implement `_door_bias_energy`**
+
+Add immediately after `_back_bias_energy` (~line 1343) in `src/hangarfit/solver.py`:
+
+```python
+def _door_bias_energy(placements: Mapping[str, Placement], scenario: Scenario) -> float:
+    """Absolute door-attraction bias ``D = y_{rank1} / length_m`` (#908).
+
+    The sign-flipped mirror of :func:`_back_bias_energy`: minimized when the
+    rank-1 ``door_order`` body sits AT the door (``y = 0``), so the spread
+    hill-climb actively pulls the top-priority plane doorward (the absolute
+    steering the relative :func:`_door_order_deviation` tiebreak never supplies —
+    it is provably inert for a lone ``#1``).
+
+    Only ``door_order[0]`` is steered (rank1_only); ranks 2..N are left to the
+    relative selection tiebreak. Returns ``0.0`` when ``door_order`` is falsy
+    (``None`` or the loader-permitted empty ``()``) or the rank-1 body is not
+    placed (e.g. a maintenance-away plane) — skipped exactly like
+    ``_back_bias_energy`` / ``_region_energy`` / ``_door_order_deviation``.
+    Division-only (no ``exp``) ⇒ cross-machine byte-safe. RNG-free. The
+    ``door_bias_weight`` multiplier is applied at the ``_spread._energy`` call
+    site (mirrors ``back_bias_weight * _back_bias_energy``).
+    """
+    order = scenario.door_order
+    if not order:
+        return 0.0
+    rank1 = order[0]
+    if rank1 not in placements:
+        return 0.0
+    return placements[rank1].y_m / scenario.hangar.length_m
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_solver_door_order.py -k door_bias_energy -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_door_order.py
+git commit -m "feat(solver): _door_bias_energy absolute door-attraction term (#908)"
+```
+
+---
+
+### Task 2: `SearchConfig.door_bias_weight` field + validation
+
+**Files:**
+- Modify: `src/hangarfit/models.py` (`SearchConfig` field near `back_bias_weight:1846`; validation near `back_bias_weight` check :1968)
+- Test: `tests/test_models.py` (or the module holding the existing `SearchConfig` validation tests)
+
+**Interfaces:**
+- Produces: `SearchConfig.door_bias_weight: float = 0.0` (validated `>= 0`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the module that tests `SearchConfig` validation (mirror the existing `back_bias_weight` tests; find them with `grep -rn back_bias_weight tests/`):
+
+```python
+def test_search_config_door_bias_weight_default_is_zero():
+    assert SearchConfig().door_bias_weight == 0.0  # inert default ⇒ byte-identical
+
+
+def test_search_config_negative_door_bias_weight_rejected():
+    import pytest
+    with pytest.raises(ValueError, match="door_bias_weight must be >= 0"):
+        SearchConfig(door_bias_weight=-1.0)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/ -k door_bias_weight -v`
+Expected: FAIL — `TypeError: ... unexpected keyword argument 'door_bias_weight'`.
+
+- [ ] **Step 3: Add the field + validation**
+
+In `src/hangarfit/models.py`, add the field immediately after `back_bias_weight`'s docstring block (~after line 1875), before `spread_stall_restarts`:
+
+```python
+    door_bias_weight: float = 0.0
+    """Strength of the absolute door-attraction bias folded into the spread
+    post-pass (#908, ADR-0008 amendment). ``0.0`` (default) ⇒ no door steering —
+    byte-identical to the pre-#908 solver (ADR-0003); the term is not even
+    summed. When ``> 0`` AND ``scenario.door_order`` is set, the spread hill-climb
+    additionally minimizes ``D = y_{door_order[0]} / hangar.length_m``, pulling
+    the rank-1 (door-nearest) plane toward the door at ``y = 0``; the ``<2 planes``
+    no-op guard is relaxed so a lone ``#1`` is still pulled. Only the rank-1 body
+    is steered (rank1_only) — ranks 2..N keep the relative ``_door_order_deviation``
+    selection tiebreak. While active, the rank-1 id is EXEMPTED from the
+    back-of-hangar fill bias (:func:`_back_bias_energy`) so its own deep-pull does
+    not cancel the doorward pull. Same dimensionless-weight semantics as
+    ``back_bias_weight`` (``~1.0`` operating point); ``0.0`` is the exact identity
+    of ``weight · D``, so — like ``back_bias_weight`` — it is ``float = 0.0`` not
+    ``float | None``. No effect when ``spread=False`` (the bias lives in the spread
+    post-pass). The CLI auto-arms it when ``door_order`` is set (``--no-door-bias``
+    opts out)."""
+```
+
+Add the validation immediately after the `back_bias_weight < 0.0` check (~line 1971):
+
+```python
+        if self.door_bias_weight < 0.0:
+            raise ValueError(
+                f"SearchConfig.door_bias_weight must be >= 0 "
+                f"(0 disables the absolute door-attraction bias), got {self.door_bias_weight}"
+            )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/ -k door_bias_weight -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/models.py tests/
+git commit -m "feat(models): SearchConfig.door_bias_weight (#908)"
+```
+
+---
+
+### Task 3: `_back_bias_energy` rank-1 exemption
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` (`_back_bias_energy` ~1327)
+- Test: `tests/test_solver_door_order.py`
+
+**Interfaces:**
+- Produces: `_back_bias_energy(placements, scenario, *, exclude: str | None = None) -> float` — same value as before when `exclude is None` (byte-identical default); skips `exclude` from the sum when given.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_solver_door_order.py`:
+
+```python
+def test_back_bias_energy_exclude_skips_one_id():
+    from hangarfit.solver import _back_bias_energy
+    s = _scenario()  # length_m = 40.0
+    pls = {"a": _pl("a", 10.0), "b": _pl("b", 30.0)}
+    # default: Σ (40−y)/40 = (30/40) + (10/40) = 1.0
+    assert _back_bias_energy(pls, s) == 1.0
+    # exclude 'a' ⇒ only 'b': (40−30)/40 = 0.25
+    assert _back_bias_energy(pls, s, exclude="a") == 0.25
+    # excluding an absent id is a no-op
+    assert _back_bias_energy(pls, s, exclude="zzz") == 1.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_solver_door_order.py -k back_bias_energy_exclude -v`
+Expected: FAIL — `TypeError: _back_bias_energy() got an unexpected keyword argument 'exclude'`.
+
+- [ ] **Step 3: Add the `exclude` param**
+
+Replace `_back_bias_energy`'s signature and its `return` (src/hangarfit/solver.py ~1327/1342). Keep the existing docstring; append one sentence about `exclude`:
+
+```python
+def _back_bias_energy(
+    placements: dict[str, Placement], scenario: Scenario, *, exclude: str | None = None
+) -> float:
+```
+
+Append to the docstring (before the closing `"""`):
+
+```
+    ``exclude`` (default ``None``) drops one plane id from the sum — used by the
+    #908 door-bias to exempt the rank-1 door-seeker from the deep-pull while it is
+    steered toward the door; ``None`` sums every placement (byte-identical to the
+    pre-#908 signature, ADR-0003).
+```
+
+Change the return to:
+
+```python
+    return sum(
+        (length - placements[pid].y_m) / length
+        for pid in sorted(placements)
+        if pid != exclude
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_solver_door_order.py -k back_bias_energy_exclude -v`
+Expected: PASS.
+Run the back-fill regression net (byte-identity of the default path): `pytest tests/ -k back_bias -v`
+Expected: PASS (existing back-fill tests unchanged — `exclude=None` default).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_door_order.py
+git commit -m "feat(solver): _back_bias_energy exclude param for #908 rank-1 exemption"
+```
+
+---
+
+### Task 4: Wire the term into `_spread` (gate + exemption + guard relax) + steering tests
+
+**Files:**
+- Modify: `src/hangarfit/solver.py` (`_spread` gate block ~1566; `_energy` closure ~1587)
+- Test: `tests/test_solver_door_order.py`
+
+**Interfaces:**
+- Consumes: `_door_bias_energy` (Task 1), `SearchConfig.door_bias_weight` (Task 2), `_back_bias_energy(..., exclude=...)` (Task 3).
+
+- [ ] **Step 1: Write the failing steering tests**
+
+Add to `tests/test_solver_door_order.py` (helper + two tests):
+
+```python
+def _rank1_y(res, pid="a"):
+    lay = res.layouts[0]
+    return next(p.y_m for p in lay.placements if p.plane_id == pid)
+
+
+def test_door_bias_pulls_rank1_toward_the_door():
+    # Roomy 40x40 hangar (see _hangar) ⇒ door-side slack for rank-1 'a'.
+    s = _scenario(door_order=("a",))
+    off = SearchConfig(max_restarts=4, spread=True)                       # weight 0
+    on = SearchConfig(max_restarts=4, spread=True, door_bias_weight=1.0)  # armed
+    y_off = _rank1_y(solve(s, search=off, seed=0, budget_s=120.0, plan_paths=False))
+    y_on = _rank1_y(solve(s, search=on, seed=0, budget_s=120.0, plan_paths=False))
+    assert y_on < y_off  # 'a' parks strictly nearer the door with the term on
+
+
+def test_door_bias_overcomes_back_fill_for_rank1():
+    # With back-fill ON (pulls everyone deep), the rank-1 exemption + door-bias
+    # still land 'a' nearer the door than with door-bias off.
+    s = _scenario(door_order=("a",))
+    off = SearchConfig(max_restarts=4, spread=True, back_bias_weight=1.0)
+    on = SearchConfig(max_restarts=4, spread=True, back_bias_weight=1.0, door_bias_weight=1.0)
+    y_off = _rank1_y(solve(s, search=off, seed=0, budget_s=120.0, plan_paths=False))
+    y_on = _rank1_y(solve(s, search=on, seed=0, budget_s=120.0, plan_paths=False))
+    assert y_on < y_off
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_solver_door_order.py -k "door_bias_pulls or overcomes" -v`
+Expected: FAIL — `y_on == y_off` (door_bias_weight is accepted by SearchConfig but not yet consumed by `_spread`).
+
+- [ ] **Step 3: Wire the term into `_spread`**
+
+In `src/hangarfit/solver.py`, in `_spread`, extend the gate block (~1566-1573). After `region_active = bool(scenario.region_preferences)` add:
+
+```python
+    door_active = search.door_bias_weight > 0.0 and bool(scenario.door_order)
+    # rank1_only (#908): exempt the door-seeker from the deep-pull so its own
+    # back-bias does not cancel the doorward pull. None ⇒ no exemption.
+    door_rank1 = scenario.door_order[0] if door_active else None
+```
+
+Extend the early-bail guard so a lone `#1` is still pulled:
+
+```python
+    if not movable or (
+        len(placements) < 2 and not back_fill and not region_active and not door_active
+    ):
+        ...
+        return placements
+```
+
+In the `_energy` closure (~1587-1592), change the back-fill line to pass the exemption and add the door term:
+
+```python
+        e = _inter_plane_energy(trial, scenario, scale, gap_cache=gap_cache, moved=moved)
+        if back_fill:
+            e += search.back_bias_weight * _back_bias_energy(trial, scenario, exclude=door_rank1)
+        if region_active:
+            e += _region_energy(trial, scenario)
+        if door_active:
+            e += search.door_bias_weight * _door_bias_energy(trial, scenario)
+        return e
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_solver_door_order.py -k "door_bias_pulls or overcomes" -v`
+Expected: PASS.
+Run the whole door-order + spread net: `pytest tests/test_solver_door_order.py tests/test_solver_search.py -v`
+Expected: PASS (existing tests use default `door_bias_weight=0` ⇒ unchanged).
+
+*If a steering assertion fails because spread repulsion swamps the pull, raise the test's `door_bias_weight` (e.g. `2.0`) to confirm direction, then set `_DOOR_BIAS_DEFAULT_WEIGHT` (Task 6) accordingly. Do NOT crank it so high that spread collapses — best-effort "if possible" is intended.*
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/solver.py tests/test_solver_door_order.py
+git commit -m "feat(solver): steer rank-1 doorward via door_bias_weight in _spread (#908)"
+```
+
+---
+
+### Task 5: Determinism canary + default byte-identity
+
+**Files:**
+- Test: `tests/test_solver_door_order.py`
+
+- [ ] **Step 1: Write the failing/guard tests**
+
+```python
+def test_solve_door_bias_active_deterministic():
+    # The steering path (door_bias_weight>0 + door_order) is double-solve identical —
+    # today's determinism canaries never exercise door_order at all.
+    s = _scenario(door_order=("a",))
+    cfg = SearchConfig(max_restarts=4, spread=True, door_bias_weight=1.0)
+    a = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    b = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    assert _key(a.layouts) == _key(b.layouts)
+
+
+def test_solve_door_bias_default_is_byte_identical_to_weight_zero():
+    # door_order set but weight 0 (the SearchConfig default) ⇒ NO steering ⇒
+    # identical to a run that never mentioned door-bias.
+    s = _scenario(door_order=("a",))
+    default_cfg = SearchConfig(max_restarts=4, spread=True)
+    explicit_zero = SearchConfig(max_restarts=4, spread=True, door_bias_weight=0.0)
+    a = solve(s, search=default_cfg, seed=0, budget_s=120.0, plan_paths=False)
+    b = solve(s, search=explicit_zero, seed=0, budget_s=120.0, plan_paths=False)
+    assert _key(a.layouts) == _key(b.layouts)
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pytest tests/test_solver_door_order.py -k "door_bias_active_deterministic or byte_identical" -v`
+Expected: PASS (no new implementation — these guard Task 4's contract).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_solver_door_order.py
+git commit -m "test(solver): #908 door-bias determinism canary + byte-identity guard"
+```
+
+---
+
+### Task 6: CLI `--no-door-bias` + auto-arm on `door_order`
+
+**Files:**
+- Modify: `src/hangarfit/cli.py` (constant near `_BACK_FILL_DEFAULT_WEIGHT`:51; argparse near `--no-back-fill`:255; `solve` SearchConfig construction :823)
+- Test: the solve-CLI test module (find with `grep -rln "back-fill\|back_fill\|def test.*solve" tests/test_cli*.py`)
+
+**Interfaces:**
+- Consumes: `SearchConfig.door_bias_weight` (Task 2), `scenario` (already loaded at cli.py:789 before the construction site).
+
+- [ ] **Step 1: Write the failing CLI test**
+
+Add to the solve-CLI test module (mirror the existing `--no-back-fill` test). Use the module's established fixture/helpers for invoking `cmd_solve` / the CLI on a scenario file; assert on the built `SearchConfig` if the module exposes it, else on solver behavior. Concrete behavioral form:
+
+```python
+def test_solve_auto_arms_door_bias_when_door_order_set(tmp_path, capsys):
+    # A scenario WITH door_order: `solve` arms door-bias by default.
+    # A scenario WITHOUT door_order, or --no-door-bias: weight stays 0.
+    from hangarfit.cli import main
+    # ... write a scenario fixture carrying door_order: [a] into tmp_path ...
+    # Assert (via the module's chosen observation point) that the built
+    # SearchConfig.door_bias_weight == _DOOR_BIAS_DEFAULT_WEIGHT for the
+    # door_order scenario, 0.0 for a no-door_order scenario, and 0.0 when
+    # --no-door-bias is passed.
+```
+
+*Author this against the module's existing pattern for the `--no-back-fill` test (same observation point). If that test asserts on a patched/captured `SearchConfig`, mirror it; if it asserts on rendered output, assert the rank-1 plane lands nearer the door with vs without `--no-door-bias`.*
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cli*.py -k door_bias -v`
+Expected: FAIL — `--no-door-bias` unrecognized / weight not armed.
+
+- [ ] **Step 3: Add the constant, argparse flag, and auto-arm**
+
+In `src/hangarfit/cli.py`, add near `_BACK_FILL_DEFAULT_WEIGHT` (~line 51):
+
+```python
+# #908 absolute door-attraction bias: the SearchConfig.door_bias_weight the CLI
+# bakes when the scenario sets door_order (--no-door-bias forces 0.0). Same tuned
+# operating point as the back-fill weight; the rank-1 exemption keeps them from
+# cancelling.
+_DOOR_BIAS_DEFAULT_WEIGHT = 1.0
+```
+
+Add the argparse flag next to `--no-back-fill` (~after line 262, on the same `solve` subparser):
+
+```python
+    solve.add_argument(
+        "--no-door-bias",
+        action="store_false",
+        dest="door_bias",
+        default=True,
+        help=(
+            "Disable the absolute door-attraction bias (#908). By default, when the "
+            "scenario sets door_order, the spread post-pass pulls the top-ranked "
+            "(#1) plane toward the door; pass this to keep only the relative "
+            "door-order selection tiebreak. (No effect without door_order.)"
+        ),
+    )
+```
+
+At the `solve` SearchConfig construction (~line 823-830) add the argument (after `back_bias_weight=...`):
+
+```python
+                door_bias_weight=(
+                    _DOOR_BIAS_DEFAULT_WEIGHT
+                    if (args.door_bias and scenario.door_order)
+                    else 0.0
+                ),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_cli*.py -k door_bias -v`
+Expected: PASS.
+Run the full CLI suite to confirm no existing solve-CLI test broke: `pytest tests/test_cli*.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hangarfit/cli.py tests/test_cli*.py
+git commit -m "feat(cli): auto-arm door-bias on door_order, --no-door-bias opt-out (#908)"
+```
+
+---
+
+### Task 7: ADR-0008 amendment + CHANGELOG
+
+**Files:**
+- Modify: `docs/adr/0008-inter-plane-spread-soft-preference.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Amend ADR-0008**
+
+Add a subsection recording the door-bias steering term alongside the `back_bias` (#320) and `region` (#604) amendments: what it is (absolute `y_{rank1}/length_m` doorward pull, rank1_only), how it is gated (`door_bias_weight>0 AND door_order`, default inert ⇒ ADR-0003), the rank-1 back-fill exemption, and that it is division-only (cross-machine safe) and complements — does not replace — the relative `_door_order_deviation` selection tiebreak (#614).
+
+- [ ] **Step 2: Add the CHANGELOG entry**
+
+Under `## [Unreleased]` → `### Added`:
+
+```markdown
+- **Absolute door-proximity steering** — when a scenario sets `door_order`, `hangarfit solve` now actively pulls the #1 (door-nearest) plane toward the door during the spread post-pass, not just as a post-hoc tiebreak. Opt out with `--no-door-bias`. Off unless `door_order` is set; the library default (`SearchConfig.door_bias_weight=0.0`) and every plan without `door_order` are byte-identical (ADR-0003). (#908)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/adr/0008-inter-plane-spread-soft-preference.md CHANGELOG.md
+git commit -m "docs: record #908 door-bias steering term (ADR-0008 + CHANGELOG)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** hybrid activation → Task 2 (field) + Task 6 (CLI auto-arm/opt-out); rank1_only energy → Task 1; back-fill exemption → Task 3 + Task 4; `<2 planes` guard relax → Task 4; determinism/byte-identity → Task 5; ADR/CHANGELOG → Task 7. ✓ All spec sections covered.
+
+**Placeholder scan:** Task 6's test body is described against the existing `--no-back-fill` test's observation point rather than shown verbatim, because that module's pattern (patched SearchConfig vs rendered-output assertion) must be matched — the implementer reads the sibling test first. All other steps carry complete code.
+
+**Type consistency:** `_door_bias_energy(placements, scenario) -> float`, `_back_bias_energy(..., *, exclude: str | None = None)`, `door_bias_weight: float`, `_DOOR_BIAS_DEFAULT_WEIGHT: float`, `door_active`/`door_rank1` locals — names consistent across Tasks 1/3/4/6. `door_order[0]` guarded by the truthy check in both `_door_bias_energy` and the `door_active` gate.
+
+**Determinism:** default (`door_bias_weight=0`) never sums the term (Task 4 gate); `exclude=None` default leaves `_back_bias_energy` byte-identical (Task 3); canary added (Task 5). `determinism-guard` review is a merge gate.

--- a/docs/superpowers/specs/2026-07-03-908-door-bias-absolute-term-design.md
+++ b/docs/superpowers/specs/2026-07-03-908-door-bias-absolute-term-design.md
@@ -1,0 +1,101 @@
+# #908 — Absolute door-distance soft term (design)
+
+**Status:** design approved (agent-panel + user decisions, 2026-07-03). Implementation gated on #915 merge + `determinism-guard` review. Capability C2 of the editor redesign spec (`2026-07-03-editor-full-frontend-redesign-design.md`).
+
+## Motivation
+
+`Scenario.door_order` (#614) today is only a *relative*, post-hoc **selection tiebreak**
+(`_door_order_deviation`, a Kendall-tau inversion count) — it orders already-valid basins but
+never *steers* placement, and is provably inert for a lone `#1` (needs ≥2 placed bodies). The
+#907 editor lets a user rank "#1 nearest the door", but the common exclusive single-`#1` export
+therefore does nothing. #908 adds the missing capability: an **absolute** door-attraction term
+that actively pulls the rank-1 plane toward the door (`y=0`) during the spread hill-climb —
+best-effort ("**if possible**"), complementing (not replacing) the relative tiebreak.
+
+## Settled decisions
+
+- **Activation = hybrid** (panel 4/4). `SearchConfig.door_bias_weight: float = 0.0` (verbatim mirror
+  of `back_bias_weight`, `models.py:1846`), so every `SearchConfig()`-constructed caller (determinism
+  canaries, `ml/`, `bench`) is **byte-identical**. The `solve` CLI bakes `_DOOR_BIAS_DEFAULT_WEIGHT`
+  when `scenario.door_order is not None` (mirror of the `--back-fill` bake, `cli.py:826`), with a
+  `--no-door-bias` opt-out. The #907 editor exports through `solve`, so `door_order` steers out-of-box —
+  no silent no-op, and no `float | None` sentinel (the CLI yields the three user states by computing the
+  concrete float before constructing `SearchConfig`, consistent with models.py rejecting `None` for back_bias).
+- **Weight = rank1_only** (panel 3/1). Only `door_order[0]` is pulled doorward; ranks 2..N are left to the
+  shipped relative tiebreak. Clean two-stage split (absolute steer for the top pick + relative select for
+  the tail), N-independent magnitude, cannot fight the primary selection key. `steep_decay` (`0.5**i`) is the
+  reserved, forward-compatible upgrade if multi-VIP graded cascades are ever wanted; `linear` rejected
+  (magnitude couples to N; can manufacture inversions the primary key then penalizes).
+
+## Term
+
+`_door_bias_energy(placements, scenario) -> float`:
+- `y_{rank1} / length_m` when `door_order` is **truthy** (non-`None` **and** non-empty) and
+  `door_order[0] ∈ placements`; else `0.0` (guards both `None` and the loader-permitted empty `()`,
+  and a maintenance-away rank-1). The `search.door_bias_weight` multiplier is applied at the `_energy`
+  call site, mirroring `back_bias_weight * _back_bias_energy`.
+- The sign-flipped mirror of `_back_bias_energy`'s `(length−y)/length`: **minimized when rank-1 sits at the
+  door (`y=0`)**. Division-only — **no `math.exp`** → cross-machine byte-safe (sidesteps the libm caveat).
+- RNG-free; iterate any placed ids in `sorted` order for float-sum order-stability. Skip rank-1 if absent
+  from `placements` (e.g. a maintenance-away plane), exactly like `_back_bias_energy` / `_region_energy` /
+  `_door_order_deviation`. No fallback to rank-2 — simplest deterministic "if possible" semantics.
+
+## Integration (`solver.py`)
+
+Fold into `_spread`'s `_energy` closure (~1587), gated like `back_fill` / `region_active`:
+
+```python
+door_active = search.door_bias_weight > 0.0 and bool(scenario.door_order)  # truthy: non-None AND non-empty
+...
+if door_active:
+    e += search.door_bias_weight * _door_bias_energy(trial, scenario)
+```
+
+Relax the `<2 planes` early-bail guard (~1569) with `and not door_active` so a lone `#1` is still pulled.
+
+### Back-fill tug-of-war (the correctness-critical fix)
+
+`back_bias` (default ON, ~1.0) pulls rank-1 **deep**; door-bias pulls it **doorward**; net gradient
+`(door_w − back_w)/length`. If `door_w ≤ back_w` the feature **silently no-ops**. Fix: **exempt the rank-1
+id from `_back_bias_energy`'s sum while door-bias is active** — "everyone back-fills except the door-seeker."
+Unranked planes vacating the front then *helps* rank-1 reach the door. (Chosen over "calibrate `door_w` above
+`back_w`" — more robust, no fragile weight tuning.)
+
+## Determinism (ADR-0003)
+
+- Library default byte-identical (weight `0.0` ⇒ term never summed; the additive identity, same as back_bias).
+- RNG-free, wall-clock-free, division-only ⇒ `determinism-guard` double-solve stays bit-identical, cross-machine safe.
+- `determinism-guard` review **required** (touches the solver scoring surface).
+- Add a **new determinism canary** on a `door_order` + steering fixture — today's canaries never exercise `door_order`.
+
+## Blast radius
+
+Only `tests/test_solver_door_order.py` + `tests/fixtures/scenario_door_order*.yaml` change behavior (the intended
+#908 effect). Those tests assert **only determinism + validity, not layout coordinates**, so nothing pre-existing
+breaks — only new steering assertions to author. **Zero determinism canaries / shipped examples / `data/` scenarios
+set `door_order`** (verified).
+
+## Testing
+
+1. **Unit** `_door_bias_energy`: rank-1 present / absent (maintenance-away) / single-`#1` / `y`-normalization; the
+   back-fill exemption of rank-1 when door-active.
+2. **Steering (merge gate):** a roomy fixture where rank-1 lands at **strictly smaller `y`** with the term on vs off.
+3. **Determinism canary:** `door_order` + steering double-solve byte-identity (covers the steering path the current
+   canaries miss).
+4. **Byte-identity:** default (`door_bias_weight=0`) plans unchanged; `--no-door-bias` forces off; auto-on when
+   `door_order` set.
+
+## Scope / honesty
+
+Best-effort "**if possible**": in dense fills (Herrenteich all-8) validity + inter-plane repulsion dominate, so the
+term is cosmetic-within-slack. **Do not crank the weight** to force it (collapses spread, congests the door).
+
+## ADR
+
+Amend **ADR-0008** (inter-plane spread soft-preference) to record the door-bias steering term alongside
+`back_bias` / `region` (back_bias amended ADR-0008 the same way), or add a short cross-reference note.
+
+## CLI surface (mirror `--back-fill`)
+
+`--door-bias` / `--no-door-bias` boolean pair; default = auto (on when `door_order` set). Exact flag naming +
+whether to expose an explicit weight override deferred to the implementation plan.

--- a/src/hangarfit/cli.py
+++ b/src/hangarfit/cli.py
@@ -50,6 +50,12 @@ _SOLVE_JSON_SCHEMA = "hangarfit.solve/v1"
 # objective — it does not collapse the inter-plane gap. See ADR-0008 (amended).
 _BACK_FILL_DEFAULT_WEIGHT = 1.0
 
+# #908 absolute door-attraction bias: the SearchConfig.door_bias_weight the CLI
+# bakes when the scenario sets door_order (--no-door-bias forces 0.0). Same tuned
+# operating point as the back-fill weight; the rank-1 exemption from _back_bias_energy
+# keeps the two from cancelling. See ADR-0008 (amended).
+_DOOR_BIAS_DEFAULT_WEIGHT = 1.0
+
 # #398 view-mode fast-degrade cap: the *global* tow-expansion budget the `view`
 # subcommand passes to ``plan_fill`` in layout mode. The default whole-fill
 # budget (towplanner._MAX_FILL_EXPANSIONS, 16000) is tuned to *disprove* a hard
@@ -261,6 +267,18 @@ def build_parser() -> argparse.ArgumentParser:
             "post-pass also biases planes toward the back wall, leaving free space "
             "at the door; pass this to keep the symmetric spread only. (No effect "
             "with --no-spread, since the bias rides on the spread post-pass.)"
+        ),
+    )
+    solve.add_argument(
+        "--no-door-bias",
+        action="store_false",
+        dest="door_bias",
+        default=True,
+        help=(
+            "Disable the absolute door-attraction bias (#908). By default, when the "
+            "scenario sets door_order, the spread post-pass pulls the top-ranked (#1) "
+            "plane toward the door; pass this to keep only the relative door-order "
+            "selection tiebreak. (No effect without door_order, or with --no-spread.)"
         ),
     )
     solve.add_argument(
@@ -824,6 +842,11 @@ def cmd_solve(args: argparse.Namespace) -> int:
                 spread=args.spread,
                 nose_out=args.nose_out,
                 back_bias_weight=_BACK_FILL_DEFAULT_WEIGHT if args.back_fill else 0.0,
+                # #908: auto-arm the door-attraction bias only when the scenario
+                # ranks planes by door proximity; --no-door-bias forces it off.
+                door_bias_weight=(
+                    _DOOR_BIAS_DEFAULT_WEIGHT if (args.door_bias and scenario.door_order) else 0.0
+                ),
                 max_restarts=args.max_restarts,
                 spread_stall_restarts=args.spread_stall_restarts,
                 sat_collisions=args.sat_collisions,

--- a/src/hangarfit/models.py
+++ b/src/hangarfit/models.py
@@ -1870,6 +1870,24 @@ class SearchConfig:
     ``spread_stall_restarts``) stays the only kind of opt-out sentinel in this
     dataclass; see ``max_restarts``."""
 
+    door_bias_weight: float = 0.0
+    """Strength of the absolute door-attraction bias folded into the spread
+    post-pass (#908, ADR-0008 amendment). ``0.0`` (default) ⇒ no door steering —
+    byte-identical to the pre-#908 solver (ADR-0003); the term is not even
+    summed. When ``> 0`` AND ``scenario.door_order`` is set, the spread hill-climb
+    additionally minimizes ``D = y_{door_order[0]} / hangar.length_m``, pulling
+    the rank-1 (door-nearest) plane toward the door at ``y = 0``; the ``<2 planes``
+    no-op guard is relaxed so a lone ``#1`` is still pulled. Only the rank-1 body
+    is steered (rank1_only) — ranks 2..N keep the relative ``door_order`` selection
+    tiebreak (:func:`solver._door_order_deviation`). While active, the rank-1 id is
+    EXEMPTED from the back-of-hangar fill bias (:func:`solver._back_bias_energy`)
+    so its own deep-pull does not cancel the doorward pull. Same
+    dimensionless-weight semantics as ``back_bias_weight`` (``~1.0`` operating
+    point); ``0.0`` is the exact identity of ``weight · D``, so — like
+    ``back_bias_weight`` — it is ``float = 0.0`` not ``float | None``. No effect
+    when ``spread=False`` (the bias lives in the spread post-pass). The CLI
+    auto-arms it when ``door_order`` is set (``--no-door-bias`` opts out)."""
+
     spread_stall_restarts: int | None = None
     """(F7 / #404) Opt-in early-exit for the spread-ON restart loop. ``None``
     (default) preserves the run-to-budget collect-every-basin behaviour, so the
@@ -1969,6 +1987,11 @@ class SearchConfig:
             raise ValueError(
                 f"SearchConfig.back_bias_weight must be >= 0 "
                 f"(0 disables the back-of-hangar fill bias), got {self.back_bias_weight}"
+            )
+        if self.door_bias_weight < 0.0:
+            raise ValueError(
+                f"SearchConfig.door_bias_weight must be >= 0 "
+                f"(0 disables the absolute door-attraction bias), got {self.door_bias_weight}"
             )
         if self.spread_stall_restarts is not None and self.spread_stall_restarts < 1:
             raise ValueError(

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -1342,6 +1342,33 @@ def _back_bias_energy(placements: dict[str, Placement], scenario: Scenario) -> f
     return sum((length - placements[pid].y_m) / length for pid in sorted(placements))
 
 
+def _door_bias_energy(placements: Mapping[str, Placement], scenario: Scenario) -> float:
+    """Absolute door-attraction bias ``D = y_{rank1} / length_m`` (#908).
+
+    The sign-flipped mirror of :func:`_back_bias_energy`: minimized when the
+    rank-1 ``door_order`` body sits AT the door (``y = 0``), so the spread
+    hill-climb actively pulls the top-priority plane doorward (the absolute
+    steering the relative :func:`_door_order_deviation` tiebreak never supplies —
+    it is provably inert for a lone ``#1``).
+
+    Only ``door_order[0]`` is steered (rank1_only); ranks 2..N are left to the
+    relative selection tiebreak. Returns ``0.0`` when ``door_order`` is falsy
+    (``None`` or the loader-permitted empty ``()``) or the rank-1 body is not
+    placed (e.g. a maintenance-away plane) — skipped exactly like
+    :func:`_back_bias_energy` / :func:`_region_energy` / :func:`_door_order_deviation`.
+    Division-only (no ``exp``) ⇒ cross-machine byte-safe. RNG-free. The
+    ``door_bias_weight`` multiplier is applied at the ``_spread._energy`` call
+    site (mirrors ``back_bias_weight * _back_bias_energy``).
+    """
+    order = scenario.door_order
+    if not order:
+        return 0.0
+    rank1 = order[0]
+    if rank1 not in placements:
+        return 0.0
+    return placements[rank1].y_m / scenario.hangar.length_m
+
+
 def _region_energy(placements: Mapping[str, Placement], scenario: Scenario) -> float:
     """Soft right/left wall-alignment bias ``R = Σ wₒ·dₒ / W`` (#604).
 

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -1324,7 +1324,9 @@ def _inter_plane_energy(
     return energy
 
 
-def _back_bias_energy(placements: dict[str, Placement], scenario: Scenario) -> float:
+def _back_bias_energy(
+    placements: dict[str, Placement], scenario: Scenario, *, exclude: str | None = None
+) -> float:
     """Back-of-hangar fill bias ``B = Σ (length_m − y_p) / length_m`` (#320).
 
     Minimized when planes park deep (large ``y``, toward the back wall at
@@ -1333,13 +1335,20 @@ def _back_bias_energy(placements: dict[str, Placement], scenario: Scenario) -> f
     single ``back_bias_weight`` reads consistently across hangar sizes. Summed
     over ALL placements — pinned planes add a constant offset that cannot change
     the per-target argmin. RNG-free. See ADR-0008 (amended) and #320.
+
+    ``exclude`` (default ``None``) drops one plane id from the sum — used by the
+    #908 door-bias to exempt the rank-1 door-seeker from the deep-pull while it is
+    steered toward the door; ``None`` sums every placement (byte-identical to the
+    pre-#908 signature, ADR-0003).
     """
     length = scenario.hangar.length_m
     # Iterate in sorted plane-id order (mirrors _inter_plane_energy /
     # _spread_quality) so this float sum is order-stable even if a future
     # refactor ever builds the placements dict from an unordered source — an
     # ADR-0003 hardening; the dict is currently fleet_in-ordered already.
-    return sum((length - placements[pid].y_m) / length for pid in sorted(placements))
+    return sum(
+        (length - placements[pid].y_m) / length for pid in sorted(placements) if pid != exclude
+    )
 
 
 def _door_bias_energy(placements: Mapping[str, Placement], scenario: Scenario) -> float:

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -1602,7 +1602,15 @@ def _spread(
     movable = sorted(pid for pid in placements if pid not in pinned_planes)
     back_fill = search.back_bias_weight > 0.0
     region_active = bool(scenario.region_preferences)
-    if not movable or (len(placements) < 2 and not back_fill and not region_active):
+    # #908 absolute door-attraction: pull only the rank-1 door_order body toward
+    # the door, and exempt it from the back-fill deep-pull so the two don't cancel
+    # (rank1_only). door_rank1 is None (⇒ door_active False) unless armed.
+    door_order = scenario.door_order
+    door_rank1 = door_order[0] if door_order and search.door_bias_weight > 0.0 else None
+    door_active = door_rank1 is not None
+    if not movable or (
+        len(placements) < 2 and not back_fill and not region_active and not door_active
+    ):
         # Nothing to optimize: no movable target, or <2 planes with neither the
         # back-fill nor the region bias active (inter-plane energy is identically
         # 0.0). With back-fill OR a region preference active a lone body is still
@@ -1622,9 +1630,11 @@ def _spread(
         # the back-bias is a per-plane sum (no pairs) so it is always re-summed.
         e = _inter_plane_energy(trial, scenario, scale, gap_cache=gap_cache, moved=moved)
         if back_fill:
-            e += search.back_bias_weight * _back_bias_energy(trial, scenario)
+            e += search.back_bias_weight * _back_bias_energy(trial, scenario, exclude=door_rank1)
         if region_active:
             e += _region_energy(trial, scenario)
+        if door_active:
+            e += search.door_bias_weight * _door_bias_energy(trial, scenario)
         return e
 
     current_energy = _energy(placements)

--- a/src/hangarfit/solver.py
+++ b/src/hangarfit/solver.py
@@ -1360,8 +1360,10 @@ def _door_bias_energy(placements: Mapping[str, Placement], scenario: Scenario) -
     steering the relative :func:`_door_order_deviation` tiebreak never supplies —
     it is provably inert for a lone ``#1``).
 
-    Only ``door_order[0]`` is steered (rank1_only); ranks 2..N are left to the
-    relative selection tiebreak. Returns ``0.0`` when ``door_order`` is falsy
+    Only ``door_order[0]`` gains this absolute steering (rank1_only) — *on top of*
+    the relative :func:`_door_order_deviation` selection tiebreak, which still ranks
+    every placed ``door_order`` body (``#1`` included); ranks 2..N get only that
+    relative tiebreak. Returns ``0.0`` when ``door_order`` is falsy
     (``None`` or the loader-permitted empty ``()``) or the rank-1 body is not
     placed (e.g. a maintenance-away plane) — skipped exactly like
     :func:`_back_bias_energy` / :func:`_region_energy` / :func:`_door_order_deviation`.
@@ -1611,10 +1613,11 @@ def _spread(
     if not movable or (
         len(placements) < 2 and not back_fill and not region_active and not door_active
     ):
-        # Nothing to optimize: no movable target, or <2 planes with neither the
-        # back-fill nor the region bias active (inter-plane energy is identically
-        # 0.0). With back-fill OR a region preference active a lone body is still
-        # pulled toward its wall, so we do NOT bail there.
+        # Nothing to optimize: no movable target, or <2 planes with none of the
+        # back-fill, region, nor door bias active (inter-plane energy is identically
+        # 0.0). With any of those active a lone body is still pulled — toward its
+        # wall (back-fill/region) or toward the door (#908 door-bias) — so we do
+        # NOT bail there.
         return placements
 
     def _energy(
@@ -1623,11 +1626,12 @@ def _spread(
         gap_cache: dict[tuple[str, str], float] | None = None,
         moved: str | None = None,
     ) -> float:
-        # Spread repulsion, plus the #320 back-of-hangar bias when active. The
-        # back-bias re-ranks candidates *within* this hill-climb; basin selection
-        # stays min-gap-primary (ADR-0008 amended). gap_cache/moved memoize the
-        # unchanged-pair distances within one iteration (#455, byte-identical);
-        # the back-bias is a per-plane sum (no pairs) so it is always re-summed.
+        # Spread repulsion, plus (each when active) the #320 back-of-hangar bias
+        # (with the #908 rank-1 exemption), the #604 region bias, and the #908
+        # door-attraction bias. These re-rank candidates *within* this hill-climb;
+        # basin selection stays min-gap-primary (ADR-0008 amended). gap_cache/moved
+        # memoize the unchanged-pair distances within one iteration (#455,
+        # byte-identical); the per-plane bias sums (no pairs) are always re-summed.
         e = _inter_plane_energy(trial, scenario, scale, gap_cache=gap_cache, moved=moved)
         if back_fill:
             e += search.back_bias_weight * _back_bias_energy(trial, scenario, exclude=door_rank1)

--- a/tests/test_cli_solve.py
+++ b/tests/test_cli_solve.py
@@ -784,6 +784,51 @@ def test_solve_back_fill_defaults_on_and_no_back_fill_opts_out():
     assert build_parser().parse_args(["solve", "s.yaml", "--no-back-fill"]).back_fill is False
 
 
+def test_solve_door_bias_defaults_on_and_no_door_bias_opts_out():
+    """`--no-door-bias` flips the ``door_bias`` namespace default (#908); absent,
+    it defaults ON (the CLI auto-arms door-bias only when door_order is set)."""
+    from hangarfit.cli import build_parser
+
+    assert build_parser().parse_args(["solve", "s.yaml"]).door_bias is True
+    assert build_parser().parse_args(["solve", "s.yaml", "--no-door-bias"]).door_bias is False
+
+
+class _CapturedSolve(Exception):
+    """Sentinel: short-circuit main() once the SearchConfig has been built."""
+
+
+def _door_bias_weight_for(monkeypatch, argv):
+    # Run `solve` far enough to build the SearchConfig, capturing its
+    # door_bias_weight without paying for the actual search.
+    import hangarfit.solver as solver_mod
+    from hangarfit.cli import main
+
+    captured: dict[str, float] = {}
+
+    def _fake_solve(scenario, **kwargs):
+        captured["weight"] = kwargs["search"].door_bias_weight
+        raise _CapturedSolve
+
+    monkeypatch.setattr(solver_mod, "solve", _fake_solve)
+    with pytest.raises(_CapturedSolve):
+        main(argv)
+    return captured["weight"]
+
+
+def test_solve_auto_arms_door_bias_only_when_door_order_set(monkeypatch):
+    from hangarfit.cli import _DOOR_BIAS_DEFAULT_WEIGHT
+
+    door = "tests/fixtures/scenario_door_order.yaml"
+    no_door = "tests/fixtures/scenario_minimal.yaml"
+    base = ["--seed", "42", "--budget", "5"]
+    # door_order set + default flag ⇒ armed at the baked default weight
+    assert _door_bias_weight_for(monkeypatch, ["solve", door, *base]) == _DOOR_BIAS_DEFAULT_WEIGHT
+    # --no-door-bias ⇒ forced off even with door_order
+    assert _door_bias_weight_for(monkeypatch, ["solve", door, "--no-door-bias", *base]) == 0.0
+    # no door_order ⇒ off (nothing to steer)
+    assert _door_bias_weight_for(monkeypatch, ["solve", no_door, *base]) == 0.0
+
+
 def test_solve_nose_out_defaults_on_and_no_nose_out_opts_out():
     """`--no-nose-out` flips the ``nose_out`` namespace default (#263); absent,
     it defaults ON (the solver prefers nose-out parked headings)."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1261,6 +1261,18 @@ class TestSearchConfig:
         assert SearchConfig(back_bias_weight=0.0).back_bias_weight == 0.0
         assert SearchConfig(back_bias_weight=2.5).back_bias_weight == 2.5
 
+    def test_search_config_door_bias_weight_defaults_zero(self) -> None:
+        # Neutral library default (#908): no door steering, byte-identical solver.
+        # The CLI auto-arms it when door_order is set; --no-door-bias opts out.
+        assert SearchConfig().door_bias_weight == 0.0
+
+    def test_search_config_door_bias_weight_rejects_negative(self) -> None:
+        with pytest.raises(ValueError, match="door_bias_weight"):
+            SearchConfig(door_bias_weight=-1.0)
+        # zero (disabled) and positive are accepted
+        assert SearchConfig(door_bias_weight=0.0).door_bias_weight == 0.0
+        assert SearchConfig(door_bias_weight=1.0).door_bias_weight == 1.0
+
     # ── F7 (#404): opt-in spread-stagnation early-exit ──────────────────────
     def test_spread_stall_restarts_default_is_none(self) -> None:
         # Opt-in: None preserves the run-to-budget spread-ON behavior, so the

--- a/tests/test_solver_door_order.py
+++ b/tests/test_solver_door_order.py
@@ -21,6 +21,7 @@ from hangarfit.models import (
     SearchConfig,
 )
 from hangarfit.solver import (
+    _door_bias_energy,
     _door_order_deviation,
     _empty_layout,
     _select_spread_diverse,
@@ -181,3 +182,34 @@ def test_solve_door_order_active_deterministic():
     a = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
     b = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
     assert _key(a.layouts) == _key(b.layouts)
+
+
+# --- _door_bias_energy absolute-attraction term (#908) ---------------------
+
+
+def test_door_bias_energy_unset_is_zero():
+    s = _scenario()  # door_order is None
+    assert _door_bias_energy({"a": _pl("a", 5.0)}, s) == 0.0  # inert ⇒ byte-identical
+
+
+def test_door_bias_energy_empty_order_is_zero():
+    s = _scenario(door_order=())
+    assert _door_bias_energy({"a": _pl("a", 5.0)}, s) == 0.0
+
+
+def test_door_bias_energy_rank1_absent_is_zero():
+    s = _scenario(door_order=("a", "b"))
+    assert _door_bias_energy({"b": _pl("b", 5.0)}, s) == 0.0  # rank-1 'a' not placed
+
+
+def test_door_bias_energy_is_rank1_y_over_length():
+    s = _scenario(door_order=("a", "b"))  # only rank-1 'a' matters
+    # length_m = 40.0 (see _hangar); a at y=10 ⇒ 10/40 = 0.25, independent of 'b'.
+    assert _door_bias_energy({"a": _pl("a", 10.0), "b": _pl("b", 2.0)}, s) == 0.25
+
+
+def test_door_bias_energy_minimized_at_the_door():
+    s = _scenario(door_order=("a",))
+    near = _door_bias_energy({"a": _pl("a", 1.0)}, s)
+    far = _door_bias_energy({"a": _pl("a", 30.0)}, s)
+    assert near < far  # smaller y (nearer the door at y=0) ⇒ lower energy

--- a/tests/test_solver_door_order.py
+++ b/tests/test_solver_door_order.py
@@ -247,6 +247,27 @@ def test_door_bias_makes_the_ranked_plane_the_door_nearest():
     assert ranked_is_door_nearest(("b",), "b")
 
 
+def test_solve_door_bias_active_deterministic():
+    # The steering path (door_bias_weight>0 + door_order) is double-solve identical —
+    # today's determinism canaries never exercise door_order at all.
+    s = _scenario(door_order=("a",))
+    cfg = SearchConfig(max_restarts=4, spread=True, door_bias_weight=1.0)
+    a = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    b = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False)
+    assert _key(a.layouts) == _key(b.layouts)
+
+
+def test_solve_door_bias_default_is_byte_identical_to_weight_zero():
+    # door_order set but weight 0 (the SearchConfig default) ⇒ NO steering ⇒
+    # identical to a run that never mentioned door-bias.
+    s = _scenario(door_order=("a",))
+    default_cfg = SearchConfig(max_restarts=4, spread=True)
+    explicit_zero = SearchConfig(max_restarts=4, spread=True, door_bias_weight=0.0)
+    a = solve(s, search=default_cfg, seed=0, budget_s=120.0, plan_paths=False)
+    b = solve(s, search=explicit_zero, seed=0, budget_s=120.0, plan_paths=False)
+    assert _key(a.layouts) == _key(b.layouts)
+
+
 def test_door_bias_overcomes_back_fill_for_rank1():
     # With back-fill ON (pulls everyone deep), the rank-1 exemption + door-bias
     # still land 'a' nearer the door than with door-bias off.

--- a/tests/test_solver_door_order.py
+++ b/tests/test_solver_door_order.py
@@ -213,3 +213,16 @@ def test_door_bias_energy_minimized_at_the_door():
     near = _door_bias_energy({"a": _pl("a", 1.0)}, s)
     far = _door_bias_energy({"a": _pl("a", 30.0)}, s)
     assert near < far  # smaller y (nearer the door at y=0) ⇒ lower energy
+
+
+def test_back_bias_energy_exclude_skips_one_id():
+    from hangarfit.solver import _back_bias_energy
+
+    s = _scenario()  # length_m = 40.0
+    pls = {"a": _pl("a", 10.0), "b": _pl("b", 30.0)}
+    # default: Σ (40−y)/40 = (30/40) + (10/40) = 1.0
+    assert _back_bias_energy(pls, s) == 1.0
+    # exclude 'a' ⇒ only 'b': (40−30)/40 = 0.25
+    assert _back_bias_energy(pls, s, exclude="a") == 0.25
+    # excluding an absent id is a no-op
+    assert _back_bias_energy(pls, s, exclude="zzz") == 1.0

--- a/tests/test_solver_door_order.py
+++ b/tests/test_solver_door_order.py
@@ -226,3 +226,33 @@ def test_back_bias_energy_exclude_skips_one_id():
     assert _back_bias_energy(pls, s, exclude="a") == 0.25
     # excluding an absent id is a no-op
     assert _back_bias_energy(pls, s, exclude="zzz") == 1.0
+
+
+def _rank1_y(res, pid="a"):
+    lay = res.layouts[0]
+    return next(p.y_m for p in lay.placements if p.plane_id == pid)
+
+
+def test_door_bias_makes_the_ranked_plane_the_door_nearest():
+    # Under door-bias, whichever plane is #1 parks (tied-)nearest the door — it
+    # steers the RELATIVE outcome, not a fixed corner. (Roomy 40x40 hangar.)
+    def ranked_is_door_nearest(order: tuple[str, ...], who: str) -> bool:
+        s = _scenario(door_order=order)
+        cfg = SearchConfig(max_restarts=4, spread=True, door_bias_weight=2.0)
+        lay = solve(s, search=cfg, seed=0, budget_s=120.0, plan_paths=False).layouts[0]
+        ys = {p.plane_id: p.y_m for p in lay.placements}
+        return all(ys[who] <= y for y in ys.values())
+
+    assert ranked_is_door_nearest(("a",), "a")
+    assert ranked_is_door_nearest(("b",), "b")
+
+
+def test_door_bias_overcomes_back_fill_for_rank1():
+    # With back-fill ON (pulls everyone deep), the rank-1 exemption + door-bias
+    # still land 'a' nearer the door than with door-bias off.
+    s = _scenario(door_order=("a",))
+    off = SearchConfig(max_restarts=4, spread=True, back_bias_weight=1.0)
+    on = SearchConfig(max_restarts=4, spread=True, back_bias_weight=1.0, door_bias_weight=1.0)
+    y_off = _rank1_y(solve(s, search=off, seed=0, budget_s=120.0, plan_paths=False))
+    y_on = _rank1_y(solve(s, search=on, seed=0, budget_s=120.0, plan_paths=False))
+    assert y_on < y_off


### PR DESCRIPTION
Closes #908

## What

Adds the **absolute door-attraction steering term** (capability C2 of the editor redesign). Today `Scenario.door_order` (#614) is only a *relative*, post-hoc selection tiebreak (`_door_order_deviation`, a Kendall-tau inversion count) — it orders already-valid basins but never *steers* placement, and is provably inert for a lone `#1`. This makes the #1 (door-nearest) plane actively seek the door (`y=0`) during the spread hill-climb — best-effort, byte-identical by default.

Design was agent-panel-vetted (4 lenses → synthesis) and user-approved. Spec: `docs/superpowers/specs/2026-07-03-908-door-bias-absolute-term-design.md`; plan: `docs/superpowers/plans/2026-07-03-908-door-bias-absolute-term.md`.

## How

- **`_door_bias_energy = y_{rank1}/length_m`** — sign-flipped mirror of `_back_bias_energy`, minimized at the door. **Division-only** (no `math.exp` → cross-machine byte-safe). **rank1_only**: only `door_order[0]` is steered; ranks 2..N keep the relative tiebreak.
- **`SearchConfig.door_bias_weight: float = 0.0`** (validated ≥0, verbatim mirror of `back_bias_weight`). Folded into `_spread._energy` only when `weight > 0 AND door_order` set; the `<2 planes` guard is relaxed so a lone #1 is still pulled.
- **Rank-1 back-fill exemption** (`_back_bias_energy(..., exclude=door_rank1)`) — stops the deep-vs-doorward tug-of-war: `#1` isn't pulled deep by its own back-bias while it's steered doorward; unranked planes still back-fill and vacate the door end.
- **CLI hybrid activation** — `solve` auto-arms `_DOOR_BIAS_DEFAULT_WEIGHT` when the scenario sets `door_order`; `--no-door-bias` opts out (exact `--back-fill` mirror). The #907 editor exports through `solve`, so a ranking steers out-of-box.

## Determinism (ADR-0003)

- Default `door_bias_weight=0.0` ⇒ the term is **not even summed** ⇒ every library caller + determinism canary byte-identical (verified: `test_solve_door_bias_default_is_byte_identical_to_weight_zero`; regression net of the existing spread/door_order/search suites, 89 passed, all use the default weight).
- RNG-free, wall-clock-free, division-only ⇒ double-solve bit-identical (new canary `test_solve_door_bias_active_deterministic` — today's canaries never exercised `door_order`).
- ADR-0008 amended.

## Tests (TDD, 7 tasks, red→green each)

- `_door_bias_energy` units (unset/empty/rank-1-absent/normalization/door-minimized); `SearchConfig` field + validation; `_back_bias_energy` `exclude` (back-fill byte-identity); steering (ranked plane becomes door-nearest; door-bias overcomes back-fill via the exemption); determinism canary + byte-identity guard; CLI auto-arm / `--no-door-bias` / no-door_order.

## Review

- **`determinism-guard` (required — touches `solver.py` scoring surface)**, plus `code-reviewer`, `type-design-analyzer` (`models.py` change), `silent-failure-hunter` is N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
