### PR TITLE
docs(CLAUDE.md): refresh view --edit doc for the v0.19.0 editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,10 +327,16 @@ google-chrome --headless=new --use-gl=angle --use-angle=swiftshader \
 # `#compare` and reading `#banner`.hidden (the viewer exposes state via the DOM).
 hangarfit view tests/fixtures/scenario_minimal.yaml --solve --alternatives 3 -o compare.html
 
-# v0.18.0 interactive placement editor (#442): view --edit turns the viewer into an
-# intent-capture surface — select planes (fleet_in), set priorities, pin at current pose,
-# then "Export scenario YAML" downloads a loader-valid Scenario that `solve` re-runs.
-# Requires --solve; rejects --alternatives. Editor code ships dormant unless --edit is set.
+# Interactive placement editor (#442 v0.18.0 MVP; v0.19.0 redesign #436): view --edit
+# turns the viewer into an intent-capture surface — select planes (fleet_in), set
+# priorities, pin at current pose, rank planes by door proximity (drag-to-order →
+# `door_order`, #907), add planes & movers from a catalog palette (start from an "empty
+# hangar", #910), and override a plane's cart mode for one scenario (`movement_mode` in
+# its constraints block, #909) — then "Export scenario YAML" downloads a loader-valid
+# Scenario that `solve` re-runs. Requires --solve; rejects --alternatives. Editor code
+# ships dormant unless --edit is set. (The #908 absolute door-bias soft term steers
+# `solve` toward a set door_order; it auto-arms when door_order is present, --no-door-bias
+# opts out.)
 hangarfit view tests/fixtures/scenario_minimal.yaml --solve --edit -o edit.html
 
 # #412 staging apron (ADR-0021): with apron_depth_m > 0 each tow path starts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,9 +334,9 @@ hangarfit view tests/fixtures/scenario_minimal.yaml --solve --alternatives 3 -o 
 # hangar", #910), and override a plane's cart mode for one scenario (`movement_mode` in
 # its constraints block, #909) — then "Export scenario YAML" downloads a loader-valid
 # Scenario that `solve` re-runs. Requires --solve; rejects --alternatives. Editor code
-# ships dormant unless --edit is set. (The #908 absolute door-bias soft term steers
-# `solve` toward a set door_order; it auto-arms when door_order is present, --no-door-bias
-# opts out.)
+# ships dormant unless --edit is set. (The #908 absolute door-bias soft term pulls the
+# #1-ranked plane of a set door_order toward the door; it auto-arms when door_order is
+# present, --no-door-bias opts out.)
 hangarfit view tests/fixtures/scenario_minimal.yaml --solve --edit -o edit.html
 
 # #412 staging apron (ADR-0021): with apron_depth_m > 0 each tow path starts


### PR DESCRIPTION
Operational doc catch-up. The `view --edit` command comment in CLAUDE.md's *Useful commands* described only the v0.18.0 capture MVP (#442). develop now carries the v0.19.0 editor additions, so this brings the doc current:

- **#907** door-proximity ranking (drag-to-order → `door_order`)
- **#910** catalog palette (add planes & movers from an empty hangar)
- **#909** per-plane cart-mode override (`movement_mode` in the constraints block)
- **#908** the absolute door-bias soft term that steers `solve` toward a set `door_order` (auto-arms; `--no-door-bias` opts out)

No code or behavior change — a single command-doc comment. Reflects the already-merged #907/#908/#909/#910 (milestone v0.19.0, epic #436); no new issue closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrHcFVwhf2L3wNVQZffMMd