### PR TITLE
ci(#933): move coverage to its own workflow; drop @serial from coverage pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,12 @@ jobs:
   #                         single-process, OUTSIDE the xdist pool
   #   * `test`            — the aggregator gate; keeps the exact required-check
   #                         name so branch protection needs no change (#880)
-  #   * `coverage`        — NON-required; the Codecov signal, off the critical
-  #                         path (#879)
+  #
+  # The NON-required Codecov signal used to run here as a `coverage` job. It now
+  # lives in its OWN workflow (.github/workflows/coverage.yml, #933) so a
+  # wall-clock flake in its C-tracer test run can no longer fail THIS workflow's
+  # run conclusion and redden the README CI badge: #879 took coverage off the
+  # required (merge) path; #933 takes it off the badge too. See that file.
   # ─────────────────────────────────────────────────────────────────────────
 
   static:
@@ -63,8 +67,9 @@ jobs:
 
       - name: Run test shard ${{ matrix.group }}/3 (no coverage)
         # Required path runs WITHOUT --cov (#879): coverage is produced by the
-        # separate, non-required `coverage` job below, off the merge-critical
-        # path. pytest-split balances the three shards by recorded per-test
+        # separate, non-required Coverage workflow (.github/workflows/coverage.yml,
+        # #933), off the merge-critical path. pytest-split balances the three shards
+        # by recorded per-test
         # duration (the committed `.test_durations`) so each runner does ~equal
         # wall-clock; `-n auto` then parallelizes within the runner. `@serial` is
         # excluded here and run single-process in `serial-canaries` (the
@@ -121,40 +126,6 @@ jobs:
             echo "::error::a required test job did not succeed — see the per-job results above"
             exit 1
           fi
-
-  coverage:
-    # NON-required (NOT in branch protection): produces the Codecov signal off
-    # the merge-critical path (#879). `codecov/patch` is already non-required, so
-    # the merge gate never waits on this. Runs the SAME two-pass split as the old
-    # combined job (bulk + serial via --cov-append) so combined coverage
-    # semantics — including branch coverage (`branch = true` in pyproject.toml) —
-    # are exactly the signal we had before, just no longer on the critical path.
-    #
-    # NB: COVERAGE_CORE=sysmon is deliberately NOT used. We keep branch coverage
-    # on (`branch = true` in pyproject.toml), and sys.monitoring branch coverage
-    # requires Python 3.14+ (coverage added it in 7.7.0). On our Python 3.12
-    # (the single supported interpreter, ADR-0009) coverage warns and falls back
-    # to the default C tracer, so sysmon would buy nothing here. Revisit when the
-    # project moves to Python 3.14+ — NOT on a coverage upgrade (branch+sysmon
-    # support already exists upstream). See #878.
-    name: coverage (Codecov, non-required)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: ./.github/actions/setup-python-env
-
-      - name: Run tests with coverage (two-pass; bulk + serial via --cov-append)
-        run: |
-          pytest -n auto -m "not slow and not serial" --cov=hangarfit --cov-report=xml
-          pytest -m "serial and not slow" --cov=hangarfit --cov-append --cov-report=xml --cov-report=term-missing
-
-      - name: Upload coverage to Codecov
-        if: always()
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
-        with:
-          files: ./coverage.xml
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   dependency-review:
     # PR-time supply-chain gate (#463): fails a PR that introduces a dependency

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,78 @@
+name: Coverage
+
+on:
+  # Same triggers as ci.yml (PRs into, and pushes to, the integration/release
+  # branches) so the Codecov signal is produced on exactly the same events it
+  # always was. The job lives HERE, in its own workflow, rather than in ci.yml
+  # (#933): it is non-required for merge (#879), but while it ran inside ci.yml a
+  # wall-clock flake in its C-tracer test run failed ci.yml's *run conclusion* and
+  # reddened the README CI badge (which tracks that conclusion, not just the
+  # required jobs). #879 took coverage off the required path; #933 finishes the job
+  # by taking it off the badge. The `codecov` badge tracks codecov.io — not this
+  # workflow's conclusion — so it is unaffected by the move.
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  # Distinct from ci.yml's group (keyed on github.workflow = "Coverage"), so a
+  # coverage run and a CI run for the same ref never cancel each other.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  coverage:
+    # NON-required — and NOT in branch protection. Produces the Codecov signal off
+    # BOTH the merge-critical path (#879) and — since #933 — the ci.yml run
+    # conclusion / README CI badge. `codecov/patch` is already non-required, so the
+    # merge gate never waits on this.
+    #
+    # Do NOT add this job to branch protection: staying non-required is what lets
+    # it live in its own workflow and fail open. And do NOT add a "Coverage" status
+    # badge to the README — that would re-introduce exactly the red-badge symptom
+    # #933 removes (this run can still go red on a transient coverage-tooling
+    # hiccup; the codecov.io badge is the coverage signal, not this workflow's
+    # conclusion).
+    #
+    # There is deliberately NO `paths:` filter (unlike the sibling viewer.yml):
+    # coverage measures the whole suite, so it must run on every change.
+    #
+    # Runs the bulk (non-slow, non-@serial) suite once under the branch-coverage
+    # C-tracer (`branch = true` in pyproject.toml). The `@serial` wall-clock
+    # determinism canaries are EXCLUDED here on purpose (#933): under the ~2–3×
+    # slower C-tracer their budgets flaked (the CPU-starvation class in
+    # docs/dev/test-flakes-and-ci-gotchas.md §1–§2), and they add ~no unique
+    # coverage — they re-solve a fixed seed to assert byte-identity, so their code
+    # paths are already covered by their non-serial siblings, and two of them spawn
+    # fresh subprocesses coverage.py cannot even measure (§4). Their determinism is
+    # still asserted by the REQUIRED `serial-canaries` job in ci.yml, which runs
+    # them WITHOUT `--cov` (no tracer, no flake). Excluding them shifts the coverage
+    # number negligibly and the codecov statuses are informational anyway (§5).
+    #
+    # NB: COVERAGE_CORE=sysmon is deliberately NOT used. We keep branch coverage
+    # on (`branch = true` in pyproject.toml), and sys.monitoring branch coverage
+    # requires Python 3.14+ (coverage added it in 7.7.0). On our Python 3.12
+    # (the single supported interpreter, ADR-0009) coverage warns and falls back
+    # to the default C tracer, so sysmon would buy nothing here. Revisit when the
+    # project moves to Python 3.14+ — NOT on a coverage upgrade (branch+sysmon
+    # support already exists upstream). See #878.
+    name: coverage (Codecov, non-required)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: ./.github/actions/setup-python-env
+
+      - name: Run tests with coverage (bulk suite; @serial canaries excluded, #933)
+        run: pytest -n auto -m "not slow and not serial" --cov=hangarfit --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,11 +44,11 @@ jobs:
     # Runs the bulk (non-slow, non-@serial) suite once under the branch-coverage
     # C-tracer (`branch = true` in pyproject.toml). The `@serial` wall-clock
     # determinism canaries are EXCLUDED here on purpose (#933): under the ~2–3×
-    # slower C-tracer their budgets flaked (the CPU-starvation class in
+    # slower C-tracer the budget-based ones flaked (the CPU-starvation class in
     # docs/dev/test-flakes-and-ci-gotchas.md §1–§2), and they add ~no unique
-    # coverage — they re-solve a fixed seed to assert byte-identity, so their code
-    # paths are already covered by their non-serial siblings, and two of them spawn
-    # fresh subprocesses coverage.py cannot even measure (§4). Their determinism is
+    # coverage — each re-solves a fixed seed to assert byte-identity, so its code
+    # paths are already covered by non-serial siblings, and two of them spawn fresh
+    # subprocesses coverage.py cannot even measure (§4). Their determinism is
     # still asserted by the REQUIRED `serial-canaries` job in ci.yml, which runs
     # them WITHOUT `--cov` (no tracer, no flake). Excluding them shifts the coverage
     # number negligibly and the codecov statuses are informational anyway (§5).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Fixed
 
+- CI: the non-required Codecov coverage run moved out of `ci.yml` into its own
+  `coverage.yml` workflow, and the wall-clock `@serial` determinism canaries were
+  dropped from the coverage pass. Together these stop an intermittent coverage-run
+  flake — the canaries' budgets exhausting under the ~2–3× slower branch-coverage
+  C-tracer — from failing `ci.yml`'s run conclusion and reddening the README CI
+  badge. Branch-protection required checks are unchanged, the `@serial` canaries
+  still run for determinism in the required `serial-canaries` job, and the
+  `codecov` badge (fed by the relocated upload) is unaffected. (#933)
+
 ## [0.17.0] — 2026-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,9 @@ All notable changes to this project are documented here. Format follows [Keep a 
 - CI: the non-required Codecov coverage run moved out of `ci.yml` into its own
   `coverage.yml` workflow, and the wall-clock `@serial` determinism canaries were
   dropped from the coverage pass. Together these stop an intermittent coverage-run
-  flake — the canaries' budgets exhausting under the ~2–3× slower branch-coverage
-  C-tracer — from failing `ci.yml`'s run conclusion and reddening the README CI
+  flake — the wall-clock-budgeted `@serial` canaries exhausting their budgets under
+  the ~2–3× slower branch-coverage C-tracer — from failing `ci.yml`'s run conclusion
+  and reddening the README CI
   badge. Branch-protection required checks are unchanged, the `@serial` canaries
   still run for determinism in the required `serial-canaries` job, and the
   `codecov` badge (fed by the relocated upload) is unaffected. (#933)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,9 +226,9 @@ make test-fast   # parallel bulk only (skips the serial canaries — faster iter
 # Read it before treating a determinism/coverage CI failure as a regression: the
 # `serial` wall-clock double-solve canaries (run OUTSIDE `-n auto`, #492); the same
 # fragility in non-serial smokes + the wall-clock bench `--gate` speed ceilings
-# (re-baseline on a deliberate determinism re-base, don't chase a phantom); two-pass
-# coverage (@slow drops from the combined run — keep >=1 non-slow test per new
-# path); and the ProcessPool/spawn worker coverage blind spot (#561).
+# (re-baseline on a deliberate determinism re-base, don't chase a phantom); coverage
+# (a single non-slow pass in coverage.yml since #933 — @slow still drops, keep >=1
+# non-slow test per new path); and the ProcessPool/spawn worker coverage blind spot (#561).
 
 # Lint + format check (CI also runs these)
 ruff check src/ tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,8 +264,13 @@ pip-compile --generate-hashes --no-strip-extras --extra dev -o requirements-dev.
 #                          explicit result check, so it is never silently skipped);
 #                          it keeps the exact required-check NAME, so branch
 #                          protection is unchanged
-#   * coverage           — a SEPARATE, NON-required job (today's two-pass C-tracer
-#                          branch coverage + Codecov), off the merge-critical path
+#   * coverage           — a SEPARATE, NON-required job that now lives in its OWN
+#                          workflow (.github/workflows/coverage.yml, #933): the bulk
+#                          (non-@serial) suite under the C-tracer for branch coverage
+#                          + Codecov, off BOTH the merge-critical path (#879) AND the
+#                          ci.yml run conclusion / README CI badge — so a wall-clock
+#                          coverage flake can no longer redden the badge (the @serial
+#                          canaries run WITHOUT --cov in serial-canaries; #933)
 # The shared hash-pinned PEP-517 install (dev deps from `requirements-dev.txt` +
 # build toolchain from `requirements-build.txt`, both `--require-hashes`, then
 # editable `--no-deps --no-build-isolation` reusing the hash-verified host

--- a/docs/dev/test-flakes-and-ci-gotchas.md
+++ b/docs/dev/test-flakes-and-ci-gotchas.md
@@ -60,20 +60,32 @@ ceiling #524; #544's per-restart-index reseed→spread-off ceiling 20→45 s) ra
 than chase a phantom regression; the bench's validity/path/determinism verdicts
 bind on `max_restarts` and stay reproducible.
 
-## 3. Two-pass coverage
+## 3. Coverage runs in its own workflow (single non-slow pass)
 
-CI runs the suite in two passes (#492) —
+Coverage is produced by the separate **`coverage.yml`** workflow (#933), NOT by
+`ci.yml` — so a wall-clock flake in the coverage run can no longer fail `ci.yml`'s
+run conclusion and redden the README CI badge (#879 took coverage off the required
+*merge* path; #933 took it off the *badge*). It runs the bulk suite once under the
+branch-coverage C-tracer:
 
 ```bash
-pytest -n auto -m "not slow and not serial"
-pytest -m "serial and not slow" --cov-append
+pytest -n auto -m "not slow and not serial" --cov=hangarfit
 ```
 
-— and derives coverage from the **combined** run, so marking a test `@slow` drops
-it from coverage too. If a `@slow` test is the only one covering a new code path,
-the `codecov/patch` number dips for that path (the check is *informational* since
-#589 — it reports, never fails; see §5) — still keep **≥ 1 non-slow test per new
-path** so the signal stays honest.
+The `@serial` wall-clock determinism canaries are deliberately **excluded** from the
+coverage run (#933): under the ~2–3× slower C-tracer their budgets flaked (the §1–§2
+CPU-starvation class), and they add ~no unique coverage — each re-solves a fixed seed
+to assert byte-identity, so its paths are already covered by non-serial siblings, and
+two of them spawn fresh subprocesses coverage.py cannot measure (§4). Their
+determinism is still asserted by the **required** `serial-canaries` job, which runs
+them WITHOUT `--cov` (no tracer, no flake). Excluding them shifts the coverage number
+negligibly and the codecov statuses are informational anyway (§5).
+
+Coverage still excludes `@slow`, so marking a test `@slow` drops it from coverage
+too. If a `@slow` test is the only one covering a new code path, the `codecov/patch`
+number dips for that path (the check is *informational* since #589 — it reports,
+never fails; see §5) — still keep **≥ 1 non-slow test per new path** so the signal
+stays honest.
 
 ## 4. ProcessPool/spawn workers are a coverage blind spot
 

--- a/docs/dev/test-flakes-and-ci-gotchas.md
+++ b/docs/dev/test-flakes-and-ci-gotchas.md
@@ -73,10 +73,10 @@ pytest -n auto -m "not slow and not serial" --cov=hangarfit
 ```
 
 The `@serial` wall-clock determinism canaries are deliberately **excluded** from the
-coverage run (#933): under the ~2–3× slower C-tracer their budgets flaked (the §1–§2
-CPU-starvation class), and they add ~no unique coverage — each re-solves a fixed seed
-to assert byte-identity, so its paths are already covered by non-serial siblings, and
-two of them spawn fresh subprocesses coverage.py cannot measure (§4). Their
+coverage run (#933): under the ~2–3× slower C-tracer the budget-based ones flaked (the
+§1–§2 CPU-starvation class), and they add ~no unique coverage — each re-solves a fixed
+seed to assert byte-identity, so its paths are already covered by non-serial siblings,
+and two of them spawn fresh subprocesses coverage.py cannot measure (§4). Their
 determinism is still asserted by the **required** `serial-canaries` job, which runs
 them WITHOUT `--cov` (no tracer, no flake). Excluding them shifts the coverage number
 negligibly and the codecov statuses are informational anyway (§5).

--- a/docs/openssf-best-practices-badge-silver.md
+++ b/docs/openssf-best-practices-badge-silver.md
@@ -168,7 +168,7 @@ also [`SECURITY.md`](../SECURITY.md) and [`security-posture.md`](security-postur
 | `interfaces_current` (SHOULD) | **Met** | Targets current Python (3.12); deps kept current via Dependabot. |
 | `automated_integration_testing` (MUST) | **Met** | [`ci.yml`](../.github/workflows/ci.yml) runs the full `pytest` suite on every PR into develop/main. |
 | `regression_tests_added50` (MUST) | **Met** (self-attest) | Per-PR test policy ([`CONTRIBUTING.md`](../CONTRIBUTING.md): tests for any behaviour change); bug fixes ship with regression fixtures in `tests/fixtures/`. |
-| `test_statement_coverage80` (MUST) | **Met** | ~97% statement coverage (full suite; `ci.yml` uploads to [Codecov](https://codecov.io/gh/DocGerd/hangarfit)) — well above ≥ 80%. |
+| `test_statement_coverage80` (MUST) | **Met** | ~97% statement coverage (full suite; the [`coverage.yml`](../.github/workflows/coverage.yml) workflow uploads to [Codecov](https://codecov.io/gh/DocGerd/hangarfit)) — well above ≥ 80%. |
 | `test_policy_mandated` (MUST) | **Met** | [`CONTRIBUTING.md`](../CONTRIBUTING.md) §Pull request requirements mandates tests for behaviour changes. |
 | `tests_documented_added` (MUST) | **Met** | The add-a-fixture policy is documented in [`CONTRIBUTING.md`](../CONTRIBUTING.md). |
 | `warnings_strict` (MUST) | **Met** | `mypy` strict (`disallow_untyped_defs` on `hangarfit.*`) + `ruff` lint and format `--check` enforced in CI (merge-blocking). |


### PR DESCRIPTION
Closes #933

## Problem

The README **CI badge** (`ci.yml/badge.svg?branch=develop`) intermittently showed **failing** even though every merge-critical check passed. The non-required `coverage` job lived **inside `ci.yml`**, so when its C-tracer test run flaked, the whole `ci.yml` **run conclusion** went `failure` and the badge (which tracks the run conclusion, not just the required jobs) turned red. #879 took coverage off the **required** path; it left it **inside `ci.yml`**, so the badge still tracked it.

## Fix (A + C — panel-selected)

A four-lens judge panel (GitHub Actions architecture, Codecov tooling, repo-fit, and an adversary tasked to refute) unanimously landed on **A, improved with C**, web-grounded against GitHub/Codecov docs.

**A — decouple the badge (move the job).** New `.github/workflows/coverage.yml` holds the `coverage (Codecov, non-required)` job (same `pull_request`/`push` triggers, own concurrency group). `ci.yml`'s run conclusion — and the README CI badge — now reflects only merge-critical jobs. Mirrors the existing `viewer.yml` precedent (a non-required concern in its own workflow). *Why not `continue-on-error` (option B):* its effect on the run conclusion is disputed across GitHub's own docs vs. practitioner reports, it leaves a red sub-check under a green CI (the documented "looks broken but isn't" antipattern), and it masks genuine coverage-tooling breakage.

**C — cure the flake at source.** The coverage run now executes a **single non-`@serial` bulk pass**; the six `@serial` wall-clock determinism canaries are excluded. They were the flake source under the ~2–3× slower C-tracer and add **~no unique coverage** — each re-solves a fixed seed to assert byte-identity (paths already covered by non-serial siblings), and two spawn fresh subprocesses `coverage.py` cannot even measure. Their determinism is still asserted by the **required** `serial-canaries` job (which runs them without `--cov`, so no tracer, no flake). Without C, A would only *relocate* the red X onto the Coverage workflow; with C, `coverage.yml` stays green.

## Acceptance (from the issue)

- [x] A non-required coverage flake no longer reddens the README CI badge (`ci.yml` no longer runs coverage).
- [x] The `codecov` badge still reflects coverage (upload moved with the job; posts on token + commit SHA — independent of workflow).
- [x] No change to branch-protection required checks (`coverage` was already non-required; the required set — `test (Python 3.12)` gate, 3 lockfile-drift jobs, `Analyze`, `bench correctness` — is untouched).

## Docs synced

`ci.yml` header + test-shard comment · CLAUDE.md fan-out bullet · `docs/dev/test-flakes-and-ci-gotchas.md` §3 · `docs/openssf-best-practices-badge-silver.md` (the `test_statement_coverage80` upload reference) · CHANGELOG `[Unreleased] → Fixed`.

## Notes

- Deliberately **no** `paths:` filter on `coverage.yml` (unlike `viewer.yml`): coverage measures the whole suite, so it must run on every change. A header comment records this + "do not add to branch protection / do not add a Coverage badge" so the fail-open invariant survives future edits.
- Coverage-number shift from C is negligible and `codecov/patch`/`project` are `informational: true`, so non-blocking either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nVZPfDc6Qxa9Wd7ZNESFu
