### PR TITLE
Remove redundant context7 declaration from .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,10 +6,6 @@
       "headers": {
         "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
-    },
-    "context7": {
-      "type": "http",
-      "url": "https://mcp.context7.com/mcp"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,24 +154,29 @@ The `.claude/` directory holds team-shared Claude Code settings (currently: a Se
 | Server | Transport | Purpose |
 |---|---|---|
 | `github` | HTTP (`https://api.githubcopilot.com/mcp/`) | Issue / PR / release inspection from Claude; complements the existing `gh` CLI. |
-| `context7` | HTTP (`https://mcp.context7.com/mcp`) | Live, version-correct library docs (shapely, matplotlib & other deps) pulled into context on demand, so doc lookups reflect the installed version rather than stale training data. |
 
-**Canonical upstream references (verify before editing `.mcp.json`):**
+**Canonical upstream reference (verify before editing `.mcp.json`):**
 - GitHub MCP: https://github.com/github/github-mcp-server
-- Context7 MCP: https://github.com/upstash/context7
 
-If a URL or env-var name in `.mcp.json` ever stops working, check these first.
+If a URL or env-var name in `.mcp.json` ever stops working, check this first.
+
+### Library docs (Context7) — deliberately *not* repo-declared
+
+`context7` (live, version-correct library docs for shapely, matplotlib & other deps) used to be declared here, and was **removed on purpose**: it is better configured per-developer — as a claude.ai account-level connector or in your own client config — than pinned into shared repo config, so the repo does not dictate which docs provider a contributor uses.
+
+**This means a fresh clone does not get Context7.** If you want it, add it yourself (account-level connector, or a gitignored `.mcp.json` override) using upstream's instructions: https://github.com/upstash/context7. It works keyless under anonymous rate limits; a free key from context7.com/dashboard raises them, read from the `CONTEXT7_API_KEY` request header.
 
 ### Auth requirements
 
 - **GitHub MCP** — Requires `GITHUB_PERSONAL_ACCESS_TOKEN` in your shell environment. Minimum permissions depend on which PAT type you create:
   - **Classic PAT:** `repo` + `read:org` scopes are sufficient for read operations; add `write:discussion` if you want Claude to create issues or PRs via the MCP server rather than `gh`.
   - **Fine-grained PAT:** Repository permissions `Contents: Read`, `Issues: Read`, `Pull requests: Read`; plus Organization permissions `Members: Read` for org-level lookups. Add the corresponding `Write` levels for create operations. Fine-grained PATs use different UI checkboxes from classic — the scope names above are classic-only.
-- **Context7 MCP** — **Works keyless out of the box; no env var required.** The checked-in `.mcp.json` entry carries no auth header on purpose, so a fresh clone connects under Context7's anonymous rate limits with zero setup. A `${CONTEXT7_API_KEY}` header is deliberately *not* committed: Claude Code does not expand `${VAR}` in HTTP `headers` for an unset variable, so an unresolved placeholder would be sent literally and break the keyless default. To raise rate limits, get a free key at context7.com/dashboard and add it locally (not committed) via your own client config or a gitignored override — Context7 reads it from the `CONTEXT7_API_KEY` request header.
+
+**Gotcha when adding any HTTP MCP server here:** Claude Code does **not** expand `${VAR}` in HTTP `headers` when the variable is unset — the unresolved placeholder is sent literally. So only commit a `${VAR}` header for a variable contributors are actually expected to set (as with `GITHUB_PERSONAL_ACCESS_TOKEN` above); for an optional-auth server, commit no auth header at all and let contributors add a key locally.
 
 ### Verifying the servers loaded
 
-After cloning and running `claude`, use the `/mcp` command. The `github` and `context7` servers should appear with status **connected**. If `github` shows **failed**, check that `GITHUB_PERSONAL_ACCESS_TOKEN` is set in your shell environment; `context7` needs no env var and should connect keyless.
+After cloning and running `claude`, use the `/mcp` command. The `github` server should appear with status **connected**. If it shows **failed**, check that `GITHUB_PERSONAL_ACCESS_TOKEN` is set in your shell environment. `context7` will *not* appear unless you added it yourself — see above; that is expected, not a misconfiguration.
 
 ---
 


### PR DESCRIPTION
Closes #972

## What

Removes the `context7` block from `.mcp.json`, leaving only `github` — and updates `CLAUDE.md` in the same change so the documentation stays true.

## Why the doc commit is part of this PR

Review found the original single-file diff would have left the committed `CLAUDE.md` **factually wrong in four places**, each describing a repo-declared context7 that no longer exists:

| Passage | Why it breaks |
|---|---|
| MCP-servers table row | Lists a server the repo no longer declares |
| "Canonical upstream references" | Says "verify before editing `.mcp.json`" for an entry that isn't there |
| Auth-requirements bullet | Asserts "**the checked-in `.mcp.json` entry** carries no auth header on purpose … zero setup" — there is no such entry |
| Post-clone verification step | Instructs contributors that `/mcp` should show `context7` **connected** — it will not, for anyone without their own connector |

The last one is the sharpest: a new contributor following the documented verification step would hit an apparent misconfiguration and have no idea it was intentional.

## Honest note on the trade-off

This *is* a small regression for other contributors — they lose a keyless, zero-setup docs server that previously came free with a clone. Rather than quietly dropping the mention, the rewritten section states that plainly and links upstream instructions for adding it per-developer. The rationale for removing it is that a docs-provider choice belongs to the developer, not to shared repo config.

## Preserved knowledge

The `${VAR}`-not-expanded-when-unset gotcha was rewritten as **general guidance for any future HTTP MCP server** instead of being deleted along with the Context7 bullet. It is a Claude Code behaviour, not a Context7 fact, and is exactly the kind of thing that is painful to rediscover.

## Verification

- `.mcp.json` parses as valid JSON and contains exactly one server (`github`)
- No remaining `CLAUDE.md` passage claims context7 is repo-declared or expected in `/mcp`
- No CHANGELOG entry — contributor-tooling config, not a user-facing library change (matches convention)
