### PR TITLE
chore: install current graphify 0.9.25 PreToolUse hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "path=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"tool_input\",{}).get(\"file_path\",\"\"))'); case \"$(basename \"$path\")\" in requirements-*.txt) echo \"[hangarfit guard] $path is a hash-pinned lockfile — do not hand-edit. Regenerate it with the matching pip-compile command in CLAUDE.md (Useful commands); the *-lockfile-drift CI jobs enforce this.\" >&2; exit 2 ;; *) exit 0 ;; esac",
+            "command": "path=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"tool_input\",{}).get(\"file_path\",\"\"))'); case \"$(basename \"$path\")\" in requirements-*.txt) echo \"[hangarfit guard] $path is a hash-pinned lockfile \u2014 do not hand-edit. Regenerate it with the matching pip-compile command in CLAUDE.md (Useful commands); the *-lockfile-drift CI jobs enforce this.\" >&2; exit 2 ;; *) exit 0 ;; esac",
             "timeout": 10
           }
         ]
@@ -29,6 +29,24 @@
             "type": "command",
             "command": "cmd=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"tool_input\",{}).get(\"command\",\"\"))'); case \"$cmd\" in *\"gh pr create\"*) if ! git diff origin/develop...HEAD --name-only 2>/dev/null | grep -Fxq CHANGELOG.md; then echo \"[hangarfit hook] no CHANGELOG.md diff vs origin/develop on this branch. If this PR has a user-facing change, add a CHANGELOG.md [Unreleased] entry before opening it. EXCEPTIONS (no entry needed): dev-tooling/.claude changes; and for >=2 parallel PRs the CHANGELOG entries go in ONE separate CHANGELOG-only PR (see CLAUDE.md), so a missing entry here may be intentional. Advisory only; not blocking.\" >&2; fi ;; *) : ;; esac; exit 0",
             "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/pkuhn/.local/bin/graphify hook-guard search"
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/pkuhn/.local/bin/graphify hook-guard read"
           }
         ]
       }
@@ -49,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -n \"$HANGARFIT_SKIP_VIEWER_HOOK\" ]; then cat > /dev/null; exit 0; fi; path=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"tool_input\",{}).get(\"file_path\",\"\"))'); case \"$path\" in */viewer/src/*.ts) echo \"[hangarfit hook] edited $path — rebuild the committed bundle (npm --prefix viewer/ run build) and commit src/hangarfit/_viewer_assets/viewer.js in the SAME change; the viewer-build-drift CI guard (ADR-0020) rebuilds and diffs it.\" ;; *) : ;; esac; exit 0",
+            "command": "if [ -n \"$HANGARFIT_SKIP_VIEWER_HOOK\" ]; then cat > /dev/null; exit 0; fi; path=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"tool_input\",{}).get(\"file_path\",\"\"))'); case \"$path\" in */viewer/src/*.ts) echo \"[hangarfit hook] edited $path \u2014 rebuild the committed bundle (npm --prefix viewer/ run build) and commit src/hangarfit/_viewer_assets/viewer.js in the SAME change; the viewer-build-drift CI guard (ADR-0020) rebuilds and diffs it.\" ;; *) : ;; esac; exit 0",
             "timeout": 15
           }
         ]
@@ -59,7 +77,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -n \"$HANGARFIT_SKIP_LOCKFILE_HOOK\" ]; then cat > /dev/null; exit 0; fi; path=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"tool_input\",{}).get(\"file_path\",\"\"))'); case \"$(basename \"$path\")\" in pyproject.toml) echo \"[hangarfit hook] edited $path — if you changed [project] dependencies or an optional extra, regenerate the four hash-pinned lockfiles (pip-compile recipes in CLAUDE.md / docs/dev/lockfiles.md); the dev/build/fuzz *-lockfile-drift CI jobs enforce drift (pip-tools has none).\" ;; *) : ;; esac; exit 0",
+            "command": "if [ -n \"$HANGARFIT_SKIP_LOCKFILE_HOOK\" ]; then cat > /dev/null; exit 0; fi; path=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get(\"tool_input\",{}).get(\"file_path\",\"\"))'); case \"$(basename \"$path\")\" in pyproject.toml) echo \"[hangarfit hook] edited $path \u2014 if you changed [project] dependencies or an optional extra, regenerate the four hash-pinned lockfiles (pip-compile recipes in CLAUDE.md / docs/dev/lockfiles.md); the dev/build/fuzz *-lockfile-drift CI jobs enforce drift (pip-tools has none).\" ;; *) : ;; esac; exit 0",
             "timeout": 10
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,3 +441,13 @@ graphify is an **optional, per-developer** tool — it is *not* required to work
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
 
 If graphify is not installed, ignore this section.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).


### PR DESCRIPTION
## Summary

Installs the maintained graphify 0.9.25 hook payload via `graphify claude install`, replacing hangarfit's old/absent PreToolUse hook wiring:

- The new `PreToolUse` entries call the real `graphify hook-guard` entrypoint (`search` / `read` subcommands) instead of inline bash, fixing a substring-matching bug in the old inline approach.
- Matcher is `Bash|Grep` per upstream #1986, so content searches routed through the Grep tool are covered — the old `Bash`-only matcher missed those.
- Per-file staleness checking is softened and the hooks fail open on error, so a broken/missing graph never blocks a tool call.
- `CLAUDE.md` gains the installer's canonical `## graphify` section (exact-line matched); the existing hand-written `## graphify (optional)` section was left untouched since its heading text differs and survives outside the matched block.

`Bash(graphify query:*)` and sibling subcommands were added to the global allowlist in DocGerd/claude-config#1, so the graphify nudge in this hook payload points at commands that don't prompt for permission.

## Verification

- Backed up the pre-install `.claude/settings.json` / `CLAUDE.md` before running the installer.
- Read the full diff: no unrelated top-level key was lost (`jq -S 'del(.hooks)'` before/after identical) and `PostToolUse` is semantically unchanged (only JSON re-serialization of pre-existing em dashes, confirmed via `jq -S` decode-and-diff).
- `jq empty .claude/settings.json` passes.
- No secret-like strings introduced (checked via grep on the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgt9kWWhLVE4qpWff4ryGh
