### PR TITLE
ci: pin codeql-action init and analyze to the same version (v4.37.8)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
         with:
           languages: ${{ matrix.language }}
           # Empty for the Python entry (matrix.config-file is unset there) — the
@@ -47,6 +47,6 @@ jobs:
           config-file: ${{ matrix.config-file }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes #969

## What

Bumps **both** `github/codeql-action/init` and `github/codeql-action/analyze` in `.github/workflows/codeql.yml` from v4.36.2 to **v4.37.8**, in a single commit so the two pins can never skew.

## Why

`init` stamps its own version into the CodeQL config file it writes, and `analyze` refuses to load a config written by a different version. The failure is an exact string comparison:

```
##[error]Loaded a configuration file for version '4.37.6', but running version '4.36.2'
##[error]analyze post-action step failed: Loaded a configuration file for version '4.37.6', but running version '4.36.2'
```

Dependabot treats `init` and `analyze` as two separate actions and opens **one PR per sub-action path**, so each PR bumps only half the pair:

| PR | Bumps | Outcome |
|---|---|---|
| #956 | `analyze` → v4.37.3 | `Analyze (Python)` + `Analyze (JavaScript/TypeScript)` fail |
| #954 | `init` → v4.37.6 | same two checks fail, mirror direction |

`Analyze (Python)` is a **required** check on `develop`, so neither is mergeable. And because the two PRs target *different* versions, merging both would leave `init@v4.37.6` / `analyze@v4.37.3` — still skewed, still failing. Superseding both with one paired bump is the only fix.

Targeting v4.37.8 (latest) rather than either PR's version so the pins land current rather than immediately stale.

## Scope notes

- `scorecard.yml`'s `upload-sarif` (v4.37.3) is **deliberately untouched** — separate workflow, no `init` step, so no config-version check applies. Verified independent.
- SHA resolved by dereferencing the **annotated** tag twice (`git/ref/tags/v4.37.8` → tag object `37f2634a…` → commit `db488dde…`). Method validated against the known-good v4.36.2 pin, which dereferences to `8aad20d1…` exactly as committed today.
- No CHANGELOG entry — CI-only change, matching established convention.

## Verification

The meaningful check is that `Analyze (Python)` and `Analyze (JavaScript/TypeScript)` both go green on this PR, which exercises the paired version end to end.

## Follow-up

The split is structural — dependabot will re-split this pair on every future codeql-action release. Grouping all `github-actions` updates into one PR prevents recurrence; tracked in the Dependabot consolidation issue.
